### PR TITLE
Improve performance of inventory

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -257,12 +257,13 @@ abstract class PageAbstract {
     );
 
     foreach($items as $item) {
-
-      $root = $this->root . DS . $item;
-
-      if(is_dir($root)) {
+	  //assume that files without dots are folders
+      if(!strpos($item, '.')) {
         $this->cache['inventory']['children'][] = $item;
-      } else if(pathinfo($item, PATHINFO_EXTENSION) == $this->site->options['content.file.extension']) {
+        continue;
+      }
+      
+      if(pathinfo($item, PATHINFO_EXTENSION) == $this->site->options['content.file.extension']) {
         $this->cache['inventory']['content'][] = $item;
       } else if(strpos($item, '.thumb.') !== false and preg_match('!\.thumb\.(jpg|jpeg|png|gif)$!i', $item)) {
         // get the filename of the original image and use it as the array key
@@ -311,8 +312,15 @@ abstract class PageAbstract {
 
     $inventory = $this->inventory();
 
-    foreach($inventory['children'] as $child) {
-      $this->cache['children']->add($child);
+    foreach($inventory['children'] as $i => $child) {
+	// check that found children are indeed folders, otherwise move to files
+      if (is_dir($this->root . DS . $child)) {
+	      $this->cache['children']->add($child);
+      } else {
+	      unset($inventory['children'][$i]);
+	      $this->cache['inventory']['files'][] = $child;
+      }
+      
     }
 
     return $this->cache['children'];


### PR DESCRIPTION
`is_dir` is the most time-intensive function, so it would be worth delaying until it's absolutely necessary. This patch got my response-time down to 1.25s from previously 3.5s on a shared host. I also tried `glob`, `opendir` and `directory_iterator`, but on my environments `scandir` was indeed the fastest solution.

I suspect other performance improvements can be made here and there:
- leveraging `glob` as a way to find pages a few levels down, instead of inventoring every folder in-between
- using `readfile` instead of `file_get_contents`, and perhaps only scan the text files 'lazily' until the required field is found (such as title), resuming further ahead whenever another as yet unfetched field is required

Other ideas welcome, might work further on this when time frees up