### PR TITLE
Convert structure field types to page collections

### DIFF
--- a/extensions/methods.php
+++ b/extensions/methods.php
@@ -65,11 +65,17 @@ field::$methods['empty'] = function($field) {
 
 field::$methods['pages'] = function($field) {
 
+  $values = $field->yaml();
   $related = array();
 
-  foreach($field->yaml() as $r) {
-    // make sure to only add found related pages
-    if($rel = page($r)) $related[$rel->id()] = $rel;
+  // Handle structure fields
+  if (is_array(a::first($values))) {
+    $values = a::extract($values, 'uri');
+  }
+
+  foreach($values as $uri) {
+    // Only add existing pages
+    if($rel = page($uri)) $related[$rel->id()] = $rel;
   }
 
   return new Collection($related);


### PR DESCRIPTION
I found your snippet for related pages in the [documentation](http://v2.getkirby.com/docs/solutions/blog/related-articles) and was searching for a way to allow users to add a list of pages within the panel. 

Therefor the structure field type looks like a perfect fit. 

Example blueprint definition for a related page structure:
```yaml
related:
    label: Related Posts
    type: structure
    entry: >
      {{title}} ({{uri}})
    fields:
      title:
        label: Title
        type: text
      uri:
        label: Post
        type: page
```

Example for related post entries in the content file:

```yaml
----
Related:
-
  title: Related Post A
  uri: blog/post-a
-
  title: Related Post B
  uri: blog/post-b
----
``` 

Unfortunately the `pages()` function on the field does only convert plain lists of URIs to a collection of page objects. With this addition structures like the described one would be converted as well, as long as `uri` is used as field name. 