### PR TITLE
Add support for computed content fields.

### DIFF
--- a/core/content.php
+++ b/core/content.php
@@ -53,6 +53,11 @@ abstract class ContentAbstract {
       $this->data[$key]->value = trim(substr($field, $pos+1));
     }
 
+    // include computed fields function
+    if (file_exists(kirby::instance()->roots()->computed() . DS . $this->name . '.php')) {
+      include_once(kirby::instance()->roots()->computed() . DS . $this->name . '.php');
+    }
+
   }
 
   /**
@@ -124,6 +129,15 @@ abstract class ContentAbstract {
     if(isset($this->data[$key])) {
       return $this->data[$key];
     } else {
+      if (function_exists($this->name . 'Computed')) {
+        $func = $this->name . 'Computed';
+
+        $return = $func($key, $this->data);
+
+        if (!is_null($return)) {
+          return $return;
+        }
+      }
 
       // return an empty field on demand
       $field        = new Field();

--- a/core/content.php
+++ b/core/content.php
@@ -11,12 +11,13 @@
  */
 abstract class ContentAbstract {
 
-  public $page   = null;
-  public $root   = null;
-  public $raw    = null;
-  public $data   = array();
-  public $fields = array();
-  public $name   = null;
+  public $page     = null;
+  public $root     = null;
+  public $raw      = null;
+  public $data     = array();
+  public $fields   = array();
+  public $computed = array();
+  public $name     = null;
 
   /**
    * Constructor
@@ -55,7 +56,7 @@ abstract class ContentAbstract {
 
     // include computed fields function
     if (file_exists(kirby::instance()->roots()->computed() . DS . $this->name . '.php')) {
-      include_once(kirby::instance()->roots()->computed() . DS . $this->name . '.php');
+      $this->computed = include(kirby::instance()->roots()->computed() . DS . $this->name . '.php');
     }
 
   }
@@ -128,16 +129,9 @@ abstract class ContentAbstract {
 
     if(isset($this->data[$key])) {
       return $this->data[$key];
+    } elseif (isset($this->computed[$key])) {
+      return $this->computed[$key]($this->page);
     } else {
-      if (function_exists($this->name . 'Computed')) {
-        $func = $this->name . 'Computed';
-
-        $return = $func($key, $this->data);
-
-        if (!is_null($return)) {
-          return $return;
-        }
-      }
 
       // return an empty field on demand
       $field        = new Field();

--- a/kirby/roots.php
+++ b/kirby/roots.php
@@ -72,6 +72,10 @@ class Roots extends Obj {
     return $this->site() . DS . 'fields';
   }
 
+  public function computed() {
+    return $this->site() . DS . 'computed';
+  }
+
   public function widgets() {
     return $this->site() . DS . 'widgets';
   }


### PR DESCRIPTION
While we have the ability to sort pages based on a custom date format, I noticed that if you want to use the panel, you're limited to either a date format or a time format, not a combination. This is due no "datetime" field in the panel. I considered creating a custom field for that purpose but I came back to an idea I had when using Kirby v1, `computed fields`. I've had a few instances where I'd like to have the value of a field computed somehow rather than just set in the content file.

This pull request contains the ability to create a custom computed field function for each template. Inside that function you can do what you need to do to get the value you want for the field. I've included an example below. You don't have to use it but I figured it might help someone else.

Create a `site\computed\article.php` file. Put the following in it:

```php
<?php
/**
 * Custom computed field values for a template.
 *
 * Function name is comprised of the name of the template (article) and the word Computed.
 *
 * $field is the name of the field we're after.
 * $data is the currently loaded content of the file.
 *
 * You should return 'null' if you don't want to handle the field.
 */
function articleComputed($field, $data) {
  switch ($field) {
    case 'created':
      return $data['date'] . ' ' . $data['time'];
    case 'updated':
      return $data['update'] . ' ' . $data['uptime'];
    default:
      return null;
  }
}
```

Edit your blueprint for the article template with the following:

```
fields:
  date:
    label: Created
    type: date
    default: today
    width: 1/2
    required: true
  time:
    label: Time
    type: time
    interval: 5
    width: 1/2
  update:
    label: Updated
    type: date
    default: today
    width: 1/2
  uptime:
    label: Time
    type: time
    interval: 5
    width: 1/2
```

Then, edit you parent blueprint to sort on the following:

```
pages:
  num:
    mode: date
    field: created
    format: YmdHi
```