### PR TITLE
Add support for different template engines

### DIFF
--- a/core/site.php
+++ b/core/site.php
@@ -76,7 +76,7 @@ abstract class SiteAbstract extends Page {
    *
    * @return string
    */
-  public function template() {
+  public function template($withExtension = false) {
     return 'site';
   }
 


### PR DESCRIPTION
This adds a hook which allows extensions to use a custom parser or template engine for some or all files. 