### PR TITLE
Bugfix: kirbytag.php

### DIFF
--- a/core/kirbytag.php
+++ b/core/kirbytag.php
@@ -106,7 +106,7 @@ abstract class KirbytagAbstract {
     if(preg_match('!(http|https)\:\/\/!i', $url)) return false;
 
     // skip urls without extensions
-    if(!preg_match('!\.[a-z]+$!',$url)) return false;
+    if(!preg_match('!\.[a-z]+$!i',$url)) return false;
 
     // try to get all files for the current page
     $files = $this->files();


### PR DESCRIPTION
Fixed a bug where upper case url extensions were ignored. e.g. `(image: my-image.JPG)` didn't work.