### PR TITLE
Content representations (implements #167)

### DIFF
--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -183,7 +183,9 @@ class Site extends SiteAbstract {
       // store the representation for $page->representation()
       if($uri !== $baseUri) $this->representation = f::extension($uri);
 
-      if($page = $this->children()->findByURI($baseUri)) {
+      if($baseUri === '') {
+        return $this->page = $this->homePage();
+      } else if($page = $this->children()->findByURI($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -182,6 +182,9 @@ class Site extends SiteAbstract {
       } else if($page = $this->children()->findByURI($uri)) {
         return $this->page = $page;
       } else if($page = $this->children()->findByURI($baseUri)) {
+        // check if the representation exists
+        if(!$page->representation()) return go($page);
+
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -182,9 +182,6 @@ class Site extends SiteAbstract {
       } else if($page = $this->children()->findByURI($uri)) {
         return $this->page = $page;
       } else if($page = $this->children()->findByURI($baseUri)) {
-        // check if the representation exists
-        if(!$page->representation()) return go($page);
-
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -171,9 +171,6 @@ class Site extends SiteAbstract {
     $parent  = dirname($uri);
     if($parent !== '.') $baseUri = $parent . '/' . $baseUri;
 
-    // store the representation for $page->representation()
-    if($uri !== $baseUri) $this->representation = f::extension($uri);
-
     if(empty($uri)) {
       return $this->page = $this->homePage();
     } else {
@@ -181,7 +178,12 @@ class Site extends SiteAbstract {
         return $this->page = $page;
       } else if($page = $this->children()->findByURI($uri)) {
         return $this->page = $page;
-      } else if($page = $this->children()->findByURI($baseUri)) {
+      }
+
+      // store the representation for $page->representation()
+      if($uri !== $baseUri) $this->representation = f::extension($uri);
+
+      if($page = $this->children()->findByURI($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -166,13 +166,22 @@ class Site extends SiteAbstract {
     // clean the uri
     $uri = trim($uri, '/');
 
+    // alternate version without file extension
+    $baseUri = f::name($uri);
+    $parent  = dirname($uri);
+    if($parent !== '.') $baseUri = $parent . '/' . $baseUri;
+
+    // store the representation for $page->representation()
+    if($uri !== $baseUri) $this->representation = f::extension($uri);
+
     if(empty($uri)) {
       return $this->page = $this->homePage();
     } else {
-
       if($lang == $this->defaultLanguage->code and $page = $this->children()->find($uri)) {
         return $this->page = $page;
       } else if($page = $this->children()->findByURI($uri)) {
+        return $this->page = $page;
+      } else if($page = $this->children()->findByURI($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/core/page.php
+++ b/core/page.php
@@ -1482,8 +1482,15 @@ abstract class PageAbstract {
    */
   public function controller($arguments = array()) {
 
-    $controller = $this->kirby->registry->get('controller', $this->template());
-      
+    // first try to get a controller for the representation
+    $controller = null;
+    if($representation = $this->representation()) {
+      $controller = $this->kirby->registry->get('controller', $this->template() . '.' . $representation);
+    }
+
+    // no representation or no special controller: try the normal one
+    if(!$controller) $controller = $this->kirby->registry->get('controller', $this->template());
+
     if(is_a($controller, 'Closure')) {
       return (array)call_user_func_array($controller, array(
         $this->site,

--- a/core/site.php
+++ b/core/site.php
@@ -164,7 +164,9 @@ abstract class SiteAbstract extends Page {
       // store the representation for $page->representation()
       if($uri !== $baseUri) $this->representation = f::extension($uri);
 
-      if($page = $this->children()->find($baseUri)) {
+      if($baseUri === '') {
+        return $this->page = $this->homePage();
+      } else if($page = $this->children()->find($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/core/site.php
+++ b/core/site.php
@@ -163,6 +163,9 @@ abstract class SiteAbstract extends Page {
       if($page = $this->children()->find($uri)) {
         return $this->page = $page;
       } else if($page = $this->children()->find($baseUri)) {
+        // check if the representation exists
+        if(!$page->representation()) return go($page);
+
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/core/site.php
+++ b/core/site.php
@@ -154,15 +154,17 @@ abstract class SiteAbstract extends Page {
     $parent  = dirname($uri);
     if($parent !== '.') $baseUri = $parent . '/' . $baseUri;
 
-    // store the representation for $page->representation()
-    if($uri !== $baseUri) $this->representation = f::extension($uri);
-
     if(empty($uri)) {
       return $this->page = $this->homePage();
     } else {
       if($page = $this->children()->find($uri)) {
         return $this->page = $page;
-      } else if($page = $this->children()->find($baseUri)) {
+      }
+
+      // store the representation for $page->representation()
+      if($uri !== $baseUri) $this->representation = f::extension($uri);
+
+      if($page = $this->children()->find($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/core/site.php
+++ b/core/site.php
@@ -163,9 +163,6 @@ abstract class SiteAbstract extends Page {
       if($page = $this->children()->find($uri)) {
         return $this->page = $page;
       } else if($page = $this->children()->find($baseUri)) {
-        // check if the representation exists
-        if(!$page->representation()) return go($page);
-
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/core/site.php
+++ b/core/site.php
@@ -14,6 +14,9 @@ abstract class SiteAbstract extends Page {
   // the current page
   public $page = null;
 
+  // Content representation (file extension)
+  public $representation = null;
+
   /**
    * Constructor
    *
@@ -146,10 +149,20 @@ abstract class SiteAbstract extends Page {
 
     $uri = trim($uri, '/');
 
+    // alternate version without file extension
+    $baseUri = f::name($uri);
+    $parent  = dirname($uri);
+    if($parent !== '.') $baseUri = $parent . '/' . $baseUri;
+
+    // store the representation for $page->representation()
+    if($uri !== $baseUri) $this->representation = f::extension($uri);
+
     if(empty($uri)) {
       return $this->page = $this->homePage();
     } else {
       if($page = $this->children()->find($uri)) {
+        return $this->page = $page;
+      } else if($page = $this->children()->find($baseUri)) {
         return $this->page = $page;
       } else {
         return $this->page = $this->errorPage();

--- a/kirby.php
+++ b/kirby.php
@@ -297,9 +297,13 @@ class Kirby {
 
     // home redirect
     $routes['homeRedirect'] = array(
-      'pattern' => $this->options['home'],
-      'action'  => function() {
-        redirect::send(site()->homepage()->url(), 307);
+      'pattern' => $this->options['home'] . '(\..*)?',
+      'action'  => function($extension = null) {
+        // ignore invalid extensions
+        if($extension === '.') $extension = '';
+        if($extension) $extension = '/' . $extension;
+
+        redirect::send(site()->homepage()->url() . $extension, 307);
       }
     );
 

--- a/kirby.php
+++ b/kirby.php
@@ -81,6 +81,7 @@ class Kirby {
       'content.file.extension'          => 'txt',
       'content.file.ignore'             => array(),
       'content.file.normalize'          => false,
+      'representations.accept'          => false,
       'email.service'                   => 'mail',
       'email.to'                        => null,
       'email.replyTo'                   => null,

--- a/kirby.php
+++ b/kirby.php
@@ -330,8 +330,8 @@ class Kirby {
         // visit the currently active page
         $page = $site->visit($path);
 
-        // magic file route
-        if($site->representation || $page->isErrorPage() && $page->uri() != $path) {
+        // redirections for files and invalid representations
+        if($site->representation !== null) {
 
           // get the filename
           $filename = rawurldecode(basename($path));
@@ -345,11 +345,11 @@ class Kirby {
             }
           }
 
-        }
+          // prevent invalid representation routes
+          if($site->representation === '' || $site->representation != $page->representation()) {
+            return go($page->url());
+          }
 
-        // prevent invalid representation routes
-        if($site->representation && $site->representation != $page->representation()) {
-          return go($page->url());
         }
 
         return $page;

--- a/kirby.php
+++ b/kirby.php
@@ -574,7 +574,7 @@ class Kirby {
     if($this->options['cache'] and $page->isCachable()) {
 
       // try to read the cache by cid (cache id)
-      $cacheId = md5(url::current());
+      $cacheId = md5(url::current() . $page->representation());
 
       // check for modified content within the content folder
       // and auto-expire the page cache in such a case

--- a/kirby.php
+++ b/kirby.php
@@ -330,24 +330,26 @@ class Kirby {
         // visit the currently active page
         $page = $site->visit($path);
 
-        // react on errors for invalid URLs
-        if($page->isErrorPage() and $page->uri() != $path) {
+        // magic file route
+        if($site->representation || $page->isErrorPage() && $page->uri() != $path) {
 
           // get the filename
           $filename = rawurldecode(basename($path));
           $pagepath = dirname($path);
 
           // check if there's a page for the parent path
-          if($page = $site->find($pagepath)) {
+          if($parent = $site->find($pagepath)) {
             // check if there's a file for the last element of the path
-            if($file = $page->file($filename)) {
-              go($file->url());
+            if($file = $parent->file($filename)) {
+              return go($file->url());
             }
           }
 
-          // return the error page if there's no such page
-          return $site->errorPage();
+        }
 
+        // prevent invalid representation routes
+        if($site->representation && $site->representation != $page->representation()) {
+          return go($page->url());
         }
 
         return $page;

--- a/kirby/component/template.php
+++ b/kirby/component/template.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Component;
 
+use Dir;
 use Exception;
+use F;
 use Page;
 use Tpl;
 
@@ -42,6 +44,21 @@ class Template extends \Kirby\Component {
       'page'  => $page
     ), $data);
 
+  }
+
+  /**
+   * Returns all available template files
+   *
+   * @return array
+   */
+  public function files() {
+    $files = dir::read($this->kirby->roots()->templates());
+    $files = array_filter($files, function($file) {
+      return f::extension($file) === 'php';
+    });
+    return array_map(function($file) {
+      return f::name($file);
+    }, $files);
   }
 
   /**

--- a/kirby/registry/template.php
+++ b/kirby/registry/template.php
@@ -4,6 +4,7 @@ namespace Kirby\Registry;
 
 use A;
 use Exception;
+use Str;
 
 /**
  * Template Registy Entry
@@ -50,16 +51,28 @@ class Template extends Entry {
    * Retrieves a registered template file
    * 
    * @param string $name
-   * @return string
+   * @param boolean $representations If true, returns an array of representations
+   * @return string/array
    */
-  public function get($name) {
-    
-    $file = $this->kirby->component('template')->file($name);
+  public function get($name, $representations = false) {
 
-    if(file_exists($file)) {
-      return $file;
+    if($representations) {
+      $files = array_merge(static::$templates, $this->kirby->component('template')->files());
+
+      $result = [];
+      foreach($files as $file) {
+        if(str::startsWith($file, $name . '.')) $result[] = $file;
+      }
+
+      return $result;
     } else {
-      return a::get(static::$templates, $name);
+      $file = $this->kirby->component('template')->file($name);
+
+      if(file_exists($file)) {
+        return $file;
+      } else {
+        return a::get(static::$templates, $name);
+      }
     }
 
   }


### PR DESCRIPTION
This Happy-Birthday-Kirby-PR (\o/) is an implementation of issue #167 (different content representations using multiple templates).

This feature actually changes 60 lines of code instead of 15 I thought it would change, but it includes fallback mechanisms to choose appropriate fallback templates. I hope the code is still readable. ;)

The code implements two ways to approach the "multiple representations" problem:

1. Like in v1, you can simply add any extension to a page (like `sitemap.xml`) and it will work. It will find the sitemap page and render a totally equal result to the normal URI.
2. The more interesting approach: You can create a template `sitemap.xml.php` with custom code and it will be loaded instead of the normal one. Like I said above, the code contains a fallback to the base template (`sitemap`) and then the `default` template, which makes the first approach possible.

The amazing thing about this implementation: It is actually fully backwards-compatible to the current version. If you create a page with a dot in the URI and the user visits this page, it will be loaded instead of a page without a dot. This code won't even run in this case.

If there is a dedicated template, Kirby will try to set an appropriate MIME type using the file extension, so users won't need to manually do this in their custom templates.

The first commit in this PR is a change to cache IDs to make it possible to cache these different representations. I hope that this will work and doesn't create any issues in other scenarios. Meaning: This feature branch should definitely be heavily tested in a lot of scenarios.

Please also take a look at the commit descriptions. They include some implementation details.