### PR TITLE
Update isCachable()

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -245,7 +245,13 @@ abstract class PageAbstract {
    * @return boolean
    */
   public function isCachable() {
-    return !in_array($this->uri(), kirby()->option('cache.ignore'));
+    foreach (kirby()->option('cache.ignore') as $pattern) {
+      if (fnmatch($pattern, $this->uri()) === true) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
See issue: https://github.com/getkirby/kirby/issues/146

Updated `isCachable` function to be able to use patterns in `cache.ignore` as follows:

```PHP
c::set('cache.ignore', array(
    'projects/*'
));
```