### PR TITLE
Modified cache flushing on page update

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -1106,7 +1106,7 @@ abstract class PageAbstract {
       throw new Exception('The page could not be updated');
     }
 
-    $this->kirby->cache()->flush();
+    $this->kirby->cache()->remove(md5($this->url()));
     $this->reset();
     $this->touch();
     return true;


### PR DESCRIPTION
Modified $page->update() so only the corresponding cache file will be removed instead of the entire cache.
I can see why other options like create and move need an entire cache flush, but flushing everything on a single page update seems unnecessary to me.