### PR TITLE
plugin returns callback or false

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -315,7 +315,7 @@ class Kirby extends Obj {
    */
   public function plugin($name, $mode = 'dir') {
 
-    if(isset($this->plugins[$name])) return true;
+    if(isset($this->plugins[$name])) return $this->plugins[$name];
 
     if($mode == 'dir') {
       $file = $this->roots->plugins() . DS . $name . DS . $name . '.php';
@@ -325,6 +325,7 @@ class Kirby extends Obj {
 
     if(file_exists($file)) return $this->plugins[$name] = include_once($file);
 
+    return false;
   }
 
   /**


### PR DESCRIPTION
Suspect this is a typo, as it doesn't seem to make much sense that the function would never return false, but return true if the plugin was cached, or a callback if it wasn't. I suspect this is what you intended.