### PR TITLE
Added support for language reading direction

### DIFF
--- a/branches/multilang/language.php
+++ b/branches/multilang/language.php
@@ -9,12 +9,13 @@ class Language extends Obj {
 
   public function __construct($site, $lang) {
 
-    $this->site    = $site;
-    $this->code    = $lang['code'];
-    $this->name    = $lang['name'];
-    $this->locale  = $lang['locale'];
-    $this->default = (isset($lang['default']) and $lang['default']);
-    $this->url     = isset($lang['url']) ? $lang['url'] : $lang['code'];
+    $this->site       = $site;
+    $this->code       = $lang['code'];
+    $this->name       = $lang['name'];
+    $this->locale     = $lang['locale'];
+    $this->default    = (isset($lang['default']) and $lang['default']);
+    $this->direction  = (isset($lang['direction']) and $lang['direction'] == 'rtl') ? 'rtl' : 'ltr';
+    $this->url        = isset($lang['url']) ? $lang['url'] : $lang['code'];
 
   }
 


### PR DESCRIPTION
When setting up languages now, you can specify the reading direction (`ltr` or `rtl`) for the language:

```php
c::set('languages', array(
  array(
    'code'    => 'en',
    'name'    => 'English',
    'default' => true,
    'locale'  => 'en_US',
    'url'     => '/',
    'direction' => 'rtl'
  )
));
```

This can help you to apply the right body class in the snippet to apply the respective CSS:
```php
<body class="<?php echo $site->language()->direction() ?>">
```