### PR TITLE
Add thumb object to file image object directly.

### DIFF
--- a/core/file.php
+++ b/core/file.php
@@ -214,6 +214,21 @@ abstract class FileAbstract extends Media {
     return true;
 
   }
+  
+  /**
+   * Add thumb object with jQuery style.
+   * 
+   * @param array $params
+   * @return null|Thumb
+   */
+  public function thumb($params = [])
+  {
+    if ('image' === $this->type()) {
+      return new Thumb($this, $params);
+    } else {
+      return null;
+    }
+  }
 
   /**
    * Converts the entire file object into 


### PR DESCRIPTION
I think the best way for following the jQuery style is add the thumbnail object directly to file image object without need to calling with a simple function. Tested and working fine.

Another way is add the relative thumb() function for leave the double coding, in this case need to pass thumb($this, $params, true) for pass the thumb object for chaining feature (i don't think we need to add object param for the file object call).