### PR TITLE
page->contentUrl without trailing slash, #392

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -184,7 +184,10 @@ abstract class PageAbstract {
    * @return string
    */
   public function contentUrl() {
-    return $this->kirby()->urls()->content() . '/' . $this->diruri();
+    if (!empty($this->diruri()))
+      return $this->kirby()->urls()->content() . '/' . $this->diruri();
+    else
+      return $this->kirby()->urls()->content();
   }
 
   /**


### PR DESCRIPTION
If contentUrl() ist used for $site, no diruri() exists and therefore contentUrl() gets a trailing slash. This results in http://something/content//image.jpg for $site->image()->url()... as the url() method adds another slash between the contentUrl of the page/site and the filename.