### PR TITLE
Consider custom paths for templates, snippets etc.

### DIFF
--- a/kirby/roots.php
+++ b/kirby/roots.php
@@ -45,7 +45,7 @@ class Roots extends Obj {
   }
 
   public function config() {
-    return $this->site() . DS . 'config';
+    return isset($this->config) ? $this->config : $this->site() . DS . 'config';
   }
 
   public function accounts() {
@@ -53,11 +53,11 @@ class Roots extends Obj {
   }
 
   public function blueprints() {
-    return $this->site() . DS . 'blueprints';
+    return isset($this->blueprints) ? $this->blueprints : $this->site() . DS . 'blueprints';
   }
 
   public function plugins() {
-    return $this->site() . DS . 'plugins';
+    return isset($this->plugins) ? $this->plugins : $this->site() . DS . 'plugins';
   }
 
   public function cache() {
@@ -65,35 +65,35 @@ class Roots extends Obj {
   }
 
   public function tags() {
-    return $this->site() . DS . 'tags';
+    return isset($this->tags) ? $this->tags : $this->site() . DS . 'tags';
   }
 
   public function fields() {
-    return $this->site() . DS . 'fields';
+    return isset($this->fields) ? $this->fields : $this->site() . DS . 'fields';
   }
 
   public function widgets() {
-    return $this->site() . DS . 'widgets';
+    return isset($this->widgets) ? $this->widgets : $this->site() . DS . 'widgets';
   }
 
   public function controllers() {
-    return $this->site() . DS . 'controllers';
+    return isset($this->controllers) ? $this->controllers : $this->site() . DS . 'controllers';
   }
 
   public function models() {
-    return $this->site() . DS . 'models';
+    return isset($this->models) ? $this->models : $this->site() . DS . 'models';
   }
 
   public function templates() {
-    return $this->site() . DS . 'templates';
+    return isset($this->templates) ? $this->templates : $this->site() . DS . 'templates';
   }
 
   public function snippets() {
-    return $this->site() . DS . 'snippets';
+    return isset($this->snippets) ? $this->snippets : $this->site() . DS . 'snippets';
   }
 
   public function languages() {
-    return $this->site() . DS . 'languages';
+    return isset($this->languages) ? $this->languages : $this->site() . DS . 'languages';
   }
 
 }


### PR DESCRIPTION
Until now, the site path was the base for each of its children directories like templates, snippets etc. Only accounts and the cache could be moved elsewhere.

I think it makes sense to allow advanced users to modify the other paths as well.