### PR TITLE
Provide option to control session time out

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -317,6 +317,8 @@ abstract class UserAbstract {
 
   static public function current() {
 
+    $timeout  = kirby::instance()->option('session.timeout');
+
     $cookey   = cookie::get('kirby'); 
     $username = s::get('auth.username'); 
 
@@ -335,8 +337,8 @@ abstract class UserAbstract {
       return false;
     }
 
-    // keep logged in for one week max.
-    if(s::get('auth.created') < time() - (60 * 60 * 24 * 7)) {
+    // keep logged in until timeout
+    if(s::get('auth.created') < time() - (60 * $timeout)) {
       static::logout();
       return false;
     }

--- a/kirby.php
+++ b/kirby.php
@@ -93,6 +93,7 @@ class Kirby extends Obj {
       'thumbs.driver'                 => 'gd',
       'thumbs.filename'               => '{safeName}-{hash}.{extension}',
       'thumbs.destination'            => false,
+      'session.timeout'               => (60 * 24 * 7), // one week in minutes
     );
 
     // default markdown parser callback


### PR DESCRIPTION
The session timeout (i.e. the time until a user logged in gets logged out again automatically) is currently hard coded in the User class (one week).

A new option `session.timeout` is implemented to provide better control of this value.