### PR TITLE
Fix #271 (rewrite=false for multi-language)

### DIFF
--- a/branches/multilang/site.php
+++ b/branches/multilang/site.php
@@ -55,7 +55,7 @@ class Site extends SiteAbstract {
       // return the specific language url
       return $this->languages->find($lang)->url();
     } else {
-      return $this->kirby->urls()->index();
+      return parent::url();
     }
   }
 


### PR DESCRIPTION
Right now, the `/index.php` part of the URL for `rewrite=false` setups is not being used for multi-language setups. Using the proper URL determined by SiteAbstract::__construct() solves this issue.