### PR TITLE
Fix #285 (tags with accents)

### DIFF
--- a/core/kirbytext.php
+++ b/core/kirbytext.php
@@ -44,7 +44,7 @@ abstract class KirbytextAbstract {
     }
 
     // tagsify
-    $text = preg_replace_callback('!(?=[^\]])\([a-z0-9_-]+:.*?\)!is', array($this, 'tag'), $text);
+    $text = preg_replace_callback('!(?=[^\]])\([\w-]+:.*?\)!isu', array($this, 'tag'), $text);
 
     // smartypantsify
     if(kirby()->option('smartypants')) {


### PR DESCRIPTION
I changed the regex that detects the tags:

* Replaced **a-z0-9_** by **\w**
* Added the flag **u** for unicode support