### PR TITLE
headers option with wildcard function

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -1025,6 +1025,17 @@ abstract class PageAbstract {
   public function headers() {
 
     $template = $this->template();
+    if(isset($this->kirby->options['headers']['*'])) {
+      $headers = $this->kirby->options['headers']['*'];
+
+      if(is_numeric($headers)) {
+        header::status($headers);
+      } else if(is_callable($headers)) {
+        call($headers, $this);
+      }
+
+    }
+
     if(isset($this->kirby->options['headers'][$template])) {
       $headers = $this->kirby->options['headers'][$template];
 


### PR DESCRIPTION
As discussed in this <http://forum.getkirby.com/t/add-headers-to-the-http-response/1825> forum thread, I have added some wildcard function to the headers option of kirby.
I needed this to add some http response header to all of my pages, but I don´t want to duplicate the code for each template, eventually missing template recently added.