### PR TITLE
prev/next sortBy on multiple fields

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -435,11 +435,10 @@ abstract class PageAbstract {
    *
    * @param object $siblings Children A collection of siblings to search in
    * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  protected function _next(Children $siblings, $sort = false, $direction = 'asc', $visibility = false) {
-    if($sort) $siblings = $siblings->sortBy($sort, $direction);
+  protected function _next(Children $siblings, $sort = array(), $visibility = false) {
+    if($sort) $siblings = call(array($siblings, 'sortBy'), $sort);
     $index = $siblings->indexOf($this);
     if($index === false) return null;
     if($visibility) {
@@ -456,11 +455,10 @@ abstract class PageAbstract {
    *
    * @param object $siblings Children A collection of siblings to search in
    * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  protected function _prev(Children $siblings, $sort = false, $direction = 'asc', $visibility = false) {
-    if($sort) $siblings = $siblings->sortBy($sort, $direction);
+  protected function _prev(Children $siblings, $sort = array(), $visibility = false) {
+    if($sort) $siblings = call(array($siblings, 'sortBy'), $sort);
     $index = $siblings->indexOf($this);
     if($index === false or $index === 0) return null;
     if($visibility) {
@@ -477,71 +475,61 @@ abstract class PageAbstract {
    *
    * @return Page
    */
-  public function next($sort = false, $direction = 'asc') {
-    return $this->_next($this->parent->children(), $sort, $direction);
+  public function next() {
+    return $this->_next($this->parent->children(), func_get_args());
   }
 
   /**
    * Checks if there's a next page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasNext($sort = false, $direction = 'asc') {
-    return $this->next($sort, $direction) != null;
+  public function hasNext() {
+    return $this->next(func_get_args()) != null;
   }
 
   /**
    * Returns the next visible page in the current collection if available
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  public function nextVisible($sort = false, $direction = 'asc') {
+  public function nextVisible() {
     if(!$this->parent) {
       return null;
     } else {
-      return $this->_next($this->parent->children(), $sort, $direction, 'visible');      
+      return $this->_next($this->parent->children(), func_get_args(), 'visible');      
     }
   }
 
   /**
    * Checks if there's a next visible page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasNextVisible($sort = false, $direction = 'asc') {
-    return $this->nextVisible($sort, $direction) != null;
+  public function hasNextVisible() {
+    return $this->nextVisible(func_get_args()) != null;
   }
 
   /**
    * Returns the next invisible page in the current collection if available
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  public function nextInvisible($sort = false, $direction = 'asc') {
+  public function nextInvisible() {
     if(!$this->parent) {
       return null;
     } else {
-      return $this->_next($this->parent->children(), $sort, $direction, 'invisible');
+      return $this->_next($this->parent->children(), func_get_args(), 'invisible');
     }
   }
 
   /**
    * Checks if there's a next invisible page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasNextInvisible($sort = false, $direction = 'asc') {
-    return $this->nextInvisible($sort, $direction) != null;
+  public function hasNextInvisible() {
+    return $this->nextInvisible(func_get_args()) != null;
   }
 
   /**
@@ -549,71 +537,61 @@ abstract class PageAbstract {
    *
    * @return Page
    */
-  public function prev($sort = false, $direction = 'asc') {
-    return $this->_prev($this->parent->children(), $sort, $direction);
+  public function prev() {
+    return $this->_prev($this->parent->children(), func_get_args());
   }
 
   /**
    * Checks if there's a previous page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasPrev($sort = false, $direction = 'asc') {
-    return $this->prev($sort, $direction) != null;
+  public function hasPrev() {
+    return $this->prev(func_get_args()) != null;
   }
 
   /**
    * Returns the previous visible page in the current collection if available
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  public function prevVisible($sort = false, $direction = 'asc') {
+  public function prevVisible() {
     if(!$this->parent) {
       return null;
     } else {
-      return $this->_prev($this->parent->children(), $sort, $direction, 'visible');
+      return $this->_prev($this->parent->children(), func_get_args(), 'visible');
     }
   }
 
   /**
    * Checks if there's a previous visible page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasPrevVisible($sort = false, $direction = 'asc') {
-    return $this->prevVisible($sort, $direction) != null;
+  public function hasPrevVisible() {
+    return $this->prevVisible(func_get_args()) != null;
   }
 
   /**
    * Returns the previous invisible page in the current collection if available
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return mixed Page or null
    */
-  public function prevInvisible($sort = false, $direction = 'asc') {
+  public function prevInvisible() {
     if(!$this->parent) {
       return null;
     } else {
-      return $this->_prev($this->parent->children(), $sort, $direction, 'invisible');
+      return $this->_prev($this->parent->children(), func_get_args(), 'invisible');
     }
   }
 
   /**
    * Checks if there's a previous invisible page
    *
-   * @param string $sort An optional sort field for the siblings
-   * @param string $direction An optional sort direction
    * @return boolean
    */
-  public function hasPrevInvisible($sort = false, $direction = 'asc') {
-    return $this->prevInvisible($sort, $direction) != null;
+  public function hasPrevInvisible() {
+    return $this->prevInvisible(func_get_args()) != null;
   }
 
   /**


### PR DESCRIPTION
Enabled the use of multiple sort fields vor prev/next. More or less related to https://github.com/getkirby/panel/pull/354.
I often use a date and time field for articles. When articles are posted on the same date, and only have a differen time, this update enables the `prev` and `next` functions to return the correct previous and next article: `$article->prevVisible('date', 'asc', 'time', 'asc');`. Up till now I solved this with code in a controller but it would make more sense to be able to use the default prev/next functions.