### PR TITLE
Fix replacement of "placeholder" in strings.

### DIFF
--- a/vendors/parsedownextra.php
+++ b/vendors/parsedownextra.php
@@ -503,10 +503,11 @@ class ParsedownExtra extends Parsedown
         }
 
         # because we don't want for markup to get encoded
-        $DOMDocument->documentElement->nodeValue = 'placeholder';
+        $placeholderHash = sha1(microtime(true));
+        $DOMDocument->documentElement->nodeValue = $placeholderHash;
 
         $markup = $DOMDocument->saveHTML($DOMDocument->documentElement);
-        $markup = str_replace('placeholder', $elementText, $markup);
+        $markup = str_replace($placeholderHash, $elementText, $markup);
 
         return $markup;
     }


### PR DESCRIPTION
Parsedown extra replaces every occurance of "placeholder" with well … something else. This is of course some very unexpected and unwanted behavior. This patch uses a random sha1 hash instead of "placeholder", because it is very likely that you use the latter one sooner or later in your HTML code, e.g. the name of a css class or a filename.

Someone already created an issue for that in the parsedown extra repository, but it does not seem, that this is fixed too soon. (https://github.com/erusev/parsedown-extra/issues/63).