### PR TITLE
Return date() as Field

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -730,11 +730,12 @@ abstract class PageAbstract {
     if($timestamp = strtotime($this->content()->$field())) {
 
       if(is_null($format)) {
-        return $timestamp;
+        $value = $timestamp;
       } else {
-        return $this->kirby->options['date.handler']($format, $timestamp);
+        $value = $this->kirby->options['date.handler']($format, $timestamp);
       }
 
+      return new Field($this, $field, $value);
     }
 
   }


### PR DESCRIPTION
Return the result of the `$page->date()` as Field object.

So that it can be used with field methods, e.g. `$page->date('n')->int()`.