### PR TITLE
Add subpages to the parent collection

### DIFF
--- a/core/children.php
+++ b/core/children.php
@@ -38,7 +38,9 @@ abstract class ChildrenAbstract extends Pages {
    * @param array $data
    */
   public function create($uid, $template, $data = array()) {
-    return page::create($this->page->id() . '/' . $uid, $template, $data);
+    $page = page::create($this->page->id() . '/' . $uid, $template, $data);
+    $this->data[$page->id()] = $page;
+    return $page;
   }
 
   /**


### PR DESCRIPTION
If you currently create a new page and then request the list of child pages of the parent of the new page on the same request again, the new page will be missing.
This fix adds the newly created page to the collection.