### PR TITLE
Kirbytag detection

### DIFF
--- a/core/kirbytag.php
+++ b/core/kirbytag.php
@@ -37,23 +37,13 @@ abstract class KirbytagAbstract {
         if(isset($tag[$key])) $this->attr[$key] = $tag[$key];
       }
     } else {
-
-      // extract all attributes
-      $search = preg_split('!(' . implode('|', $attributes) . '):!i', $tag, false, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
-      $num    = 0;
-
-      foreach($search AS $key) {
-
-        if(!isset($search[$num+1])) break;
-
-        $key   = trim($search[$num]);
-        $value = trim($search[$num+1]);
-
-        $this->attr[$key] = $value;
-        $num = $num+2;
-
-      }
-
+      // extract any attribute
+      preg_match_all('/([a-z0-9_-]+):((?:\s+(?![a-z0-9_-]+:\s+?)\S+|(?:[^()]*\)))+)/is', $tag, $matches);
+      
+      $attr = array_combine($matches[1], array_map('trim', $matches[2]));
+  
+      // filter on expected attributes
+      $this->attr = array_intersect_key($attr, array_flip($attributes));
     }
 
   }

--- a/core/kirbytext.php
+++ b/core/kirbytext.php
@@ -44,7 +44,7 @@ abstract class KirbytextAbstract {
     }
 
     // tags
-    $text = preg_replace_callback('!(?=[^\]])\([a-z0-9]+:.*?\)!is', array($this, 'tag'), $text);
+    $text = preg_replace_callback('/(?=[^\]])\(([a-z0-9_-]+:((?:[^()]++|\((?2)\))*))\)/is', array($this, 'tag'), $text);
 
     // markdownify
     $text = markdown($text);
@@ -66,7 +66,7 @@ abstract class KirbytextAbstract {
   public function tag($input) {
 
     // remove the brackets
-    $tag  = trim(rtrim(ltrim($input[0], '('), ')'));
+    $tag  = $input[1];
     $name = trim(substr($tag, 0, strpos($tag, ':')));
 
     // if the tag is not installed return the entire string


### PR DESCRIPTION
Tried my hand at changing the way Kirbytags are detected in orde to be able to use parentheses within tags:

```
(image: image.jpg caption: Untitled (2011))
```

It can also be used so that you can use Kirbytags within a text or a caption for instance:

```
(image: image.jpg caption: (link: http://untitled.com/2011 text: Untitled) (2011))
```

Of course the Kirbytag for images should be altered then to pass the `$caption` through `kirbytext()`.