### PR TITLE
added snippet subfolder support

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -10,6 +10,7 @@
  */
 function snippet($file, $data = array(), $return = false) {
   if(is_object($data)) $data = array('item' => $data);
+  $file = implode(DS, explode('.', $file));
   return tpl::load(kirby::instance()->roots()->snippets() . DS . $file . '.php', $data, $return);
 }
 


### PR DESCRIPTION
Snippets can be placed in subfolders within the snippets folder. They can be called via `snippet("folder.filename")` as known from Laravel.

`snippet("filename")` is still working - so it does not break compatibility.