### PR TITLE
Default page controller, fix #103

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -524,16 +524,22 @@ class Kirby extends Obj {
 
     $file = $this->roots->controllers() . DS . $page->template() . '.php';
 
+    if(!file_exists($file)) {
+      $file = $this->roots->controllers() . DS . 'default.php';
+    }
+
     if(file_exists($file)) {
 
       $callback = include_once($file);
 
-      if(is_callable($callback)) return (array)call_user_func_array($callback, array(
-        $this->site(),
-        $this->site()->children(),
-        $page,
-        $arguments
-      ));
+      if(is_callable($callback)) {
+        return (array)call_user_func_array($callback, array(
+          $this->site(),
+          $this->site()->children(),
+          $page,
+          $arguments
+        ));
+      }
 
     }
 

--- a/kirby.php
+++ b/kirby.php
@@ -525,7 +525,7 @@ class Kirby extends Obj {
     $file = $this->roots->controllers() . DS . $page->template() . '.php';
 
     if(!file_exists($file)) {
-      $file = $this->roots->controllers() . DS . 'default.php';
+      $file = $this->roots->controllers() . DS . 'site.php';
     }
 
     if(file_exists($file)) {


### PR DESCRIPTION
If not template-specific controller exists, Kirby tries to use a `defaul.php` controller instead if present.

ToDo:
- [x] What if we actually want a controller for the default template that should not be applied for any other template? --> changed to `site.php`(based on discussion in #103 )