### PR TITLE
Adds custom file methods, #372

### DIFF
--- a/core/file.php
+++ b/core/file.php
@@ -11,6 +11,8 @@
  */
 abstract class FileAbstract extends Media {
 
+  static public $methods = array();
+
   public $kirby;
   public $site;
   public $page;
@@ -150,7 +152,15 @@ abstract class FileAbstract extends Media {
    * @return Field
    */
   public function __call($key, $arguments = null) {
-    return $this->meta()->get($key, $arguments);
+    if($meta = $this->meta() and $meta->has($key)) {
+      return $meta->get($key, $arguments);
+    } else if(isset(static::$methods[$key])) {
+      if(!$arguments) $arguments = array();
+      array_unshift($arguments, clone $this);
+      return call(static::$methods[$key], $arguments);
+    } else {
+      return $this;
+    }
   }
 
   /**


### PR DESCRIPTION
Partly fulfils #372 - example for a pretty non-sense but working custom file method:

```php
file::$methods['soshiny'] = function($file) {
  return 'Everthing so shiny: <a href="' . $file->url() . '">' . $file->filename() . '</a>';
};
```

Gets called e.g. `$page->files()->first()->soshiny()`