### PR TITLE
Fix `page::sort` hiding pages if called without parameter, Fix #349

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -1196,10 +1196,12 @@ abstract class PageAbstract {
   }
 
   /**
-   * Changes the prepended number for the page
+   * Return the prepended number for the page
+   * or changes it to the number passed as parameter 
    */
-  public function sort($num) {
+  public function sort($num = null) {
 
+    if(!$num) return $this->num();
     if($num === $this->num()) return true;
 
     $dir  = $num . '-' . $this->uid();

--- a/test/PageTest.php
+++ b/test/PageTest.php
@@ -115,4 +115,17 @@ class PageTest extends KirbyTestCase {
 
   }
 
+  public function testSort() {
+    $site  = $this->siteInstance();
+    $page  = new Page($site, '2-b');
+    $this->assertEquals('2', $page->num());
+    $this->assertEquals('2', $page->sort());
+    $this->assertEquals(true, $page->sort(3));
+    $this->assertEquals('3', $page->num());
+    $this->assertEquals('3', $page->sort());
+    $this->assertEquals(true, $page->sort(2));
+    $this->assertEquals('2', $page->num());
+    $this->assertEquals('2', $page->sort());
+  }
+
 }

--- a/test/PageTest.php
+++ b/test/PageTest.php
@@ -119,13 +119,13 @@ class PageTest extends KirbyTestCase {
     $site  = $this->siteInstance();
     $page  = new Page($site, '2-b');
     $this->assertEquals('2', $page->num());
-    $this->assertEquals('2', $page->sort());
-    $this->assertEquals(true, $page->sort(3));
+    $this->assertEquals($page->num(), $page->sort());
+    $this->assertTrue(true, $page->sort(3));
     $this->assertEquals('3', $page->num());
-    $this->assertEquals('3', $page->sort());
-    $this->assertEquals(true, $page->sort(2));
+    $this->assertEquals($page->num(), $page->sort());
+    $this->assertTrue(true, $page->sort(2));
     $this->assertEquals('2', $page->num());
-    $this->assertEquals('2', $page->sort());
+    $this->assertEquals($page->num(), $page->sort());
   }
 
 }


### PR DESCRIPTION
Calling the `page::sort` method so far resulted in hiding the page (removing the prepended number). This seems rather unintended since the core has `page::hide` for this.

Now, this change is prevented and instead `page::num` is returned when no nem `$num` is passed as parameter (also fixing an issue with sortBy calling `page::sort` as possible field, #349).

PHPunit tests have passed (I also added a new one for this) – however, we should check that the core and the panel really never use `page::sort` without a parameter to hide a page.