### PR TITLE
Account/User files: change to .yml format

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -20,7 +20,7 @@ abstract class UserAbstract {
     $this->username = str::slug(basename($username));
 
     // check if the account file exists
-    if(!file_exists($this->file())) {
+    if(!$this->exists()) {
       throw new Exception('The user account could not be found');
     }
 
@@ -134,11 +134,11 @@ abstract class UserAbstract {
   }
 
   protected function file() {
-    return kirby::instance()->roots()->accounts() . DS . $this->username() . '.php';
+    return f::resolve(kirby::instance()->roots()->accounts() . DS . $this->username(), array('yml', 'php', 'yaml'));
   }
 
   public function exists() {
-    return file_exists($this->file());
+    return f::exists($this->file());
   }
 
   public function generateKey() {
@@ -285,7 +285,7 @@ abstract class UserAbstract {
     static::validate($data, 'insert');
 
     // create the file root
-    $file = kirby::instance()->roots()->accounts() . DS . $data['username'] . '.php';
+    $file = kirby::instance()->roots()->accounts() . DS . $data['username'] . '.yml';
 
     // check for an existing username
     if(file_exists($file)) {
@@ -306,10 +306,7 @@ abstract class UserAbstract {
 
   static protected function save($file, $data) {
 
-    $yaml  = '<?php if(!defined(\'KIRBY\')) exit ?>' . PHP_EOL . PHP_EOL;
-    $yaml .= data::encode($data, 'yaml');
-
-    if(!f::write($file, $yaml)) {
+    if(!data::write($file, $data, 'yaml')) {
       throw new Exception('The user account could not be saved');
     } else {
       return true;

--- a/core/user.php
+++ b/core/user.php
@@ -235,8 +235,18 @@ abstract class UserAbstract {
       if(is_null($value)) unset($this->data[$key]);
     }
 
+    // get filename and rename it to .yml if .php
+    $file = $this->file();
+    if(f::extension($file) === 'php') {
+      $old = $file;
+      $file = f::dirname($file) . DS . f::extension($file, 'yml');
+      if(!f::move($old, $file)) {
+        throw new Exception('The account file could not be renamed');
+      }
+    }
+
     // save the new user data
-    static::save($this->file(), $this->data);
+    static::save($file, $this->data);
 
     // return the updated user project
     return $this;

--- a/core/users.php
+++ b/core/users.php
@@ -18,7 +18,7 @@ abstract class UsersAbstract extends Collection {
     foreach(dir::read($root) as $file) {
 
       // skip invalid account files
-      if(f::extension($file) != 'php') continue;
+      if(!in_array(f::extension($file), array('yml', 'php', 'yaml'))) continue;
 
       $user = new User(f::name($file));
       $this->append($user->username(), $user);

--- a/test/UsersTest.php
+++ b/test/UsersTest.php
@@ -1,0 +1,64 @@
+<?php
+
+require_once('lib/bootstrap.php');
+
+class UsersTest extends KirbyTestCase {
+
+  public function testConstruction() {
+    $site  = $this->siteInstance();
+
+    $this->assertInstanceOf('Users', $site->users());
+    $this->assertEquals(1, $site->users()->count());
+    $this->assertInstanceOf('User', $site->users()->first());
+  }
+
+  public function testCreate() {
+    $site  = $this->siteInstance();
+
+    try {
+      $site->users()->create(array(
+        'username'  => 'john',
+        'email'     => 'john@doe.com',
+        'password'  => 'secretpasswordwillbeencrypted',
+        'firstName' => 'John',
+        'lastName'  => 'Doe'
+      ));
+    } catch(Exception $e) {
+      echo $e->getMessage();
+    }
+    $this->assertInstanceOf('User', $site->user('john'));
+    $this->assertEquals(2, $site->users()->count());
+    $this->assertEquals('john@doe.com', $site->user('john')->email());
+    $this->assertEquals('John', $site->user('john')->firstName());
+    $this->assertEquals('Doe', $site->user('john')->lastName());
+
+  }
+
+  public function testUpdate() {
+    $site  = $this->siteInstance();
+
+    $this->assertInstanceOf('User', $site->user('john'));
+    try {
+      $site->user('john')->update(array(
+        'username'  => 'john',
+        'email'     => 'jane@doe.com',
+        'firstName' => 'Jane',
+      ));
+    } catch(Exception $e) {
+      echo $e->getMessage();
+    }
+    $this->assertEquals('jane@doe.com', $site->user('john')->email());
+    $this->assertEquals('Jane', $site->user('john')->firstName());
+  }
+
+  public function testDelete() {
+    $site  = $this->siteInstance();
+    try {
+      $site->user('john')->delete();
+    } catch(Exception $e) {
+      echo $e->getMessage();
+    }
+    $this->assertEquals(1, $site->users()->count());
+  }
+
+}

--- a/test/lib/testcase.php
+++ b/test/lib/testcase.php
@@ -6,8 +6,9 @@ class KirbyTestCase extends PHPUnit_Framework_TestCase {
 
     c::$data = array();
 
-    $kirby = new Kirby($options);    
-    $kirby->roots->content = TEST_ROOT_ETC . DS . 'content';
+    $kirby = new Kirby($options);
+    $kirby->roots->content  = TEST_ROOT_ETC . DS . 'content';
+    $kirby->roots->accounts = TEST_ROOT_ETC . DS . 'site' . DS . 'accounts';
     return $kirby;
 
   }


### PR DESCRIPTION
with `.php` and `.yaml` working as well as fallback. But Kirby itself will write out `.yml` for new account files.

Fixes #377 