### PR TITLE
Fix "undefined index" bug in structure

### DIFF
--- a/lib/structure.php
+++ b/lib/structure.php
@@ -11,7 +11,7 @@ class Structure extends Collection {
     } else {
       $lowerkeys = array_change_key_case($this->data, CASE_LOWER);
       if(isset($lowerkeys[strtolower($key)])) {
-        return $lowerkeys[$key];
+        return $lowerkeys[strtolower($key)];
       }
     }
 


### PR DESCRIPTION
When the key has a different case between the collection and the `get` call, it will now return the correct item (if I didn't miss something).