### PR TITLE
Enables plugin bundling

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,6 +11,7 @@ load(array(
 
   // kirby class and subclasses
   'kirby'                  => __DIR__ . DS . 'kirby.php',
+  'kirby\\modules'         => __DIR__ . DS . 'kirby' . DS . 'modules.php',
   'kirby\\roots'           => __DIR__ . DS . 'kirby' . DS . 'roots.php',
   'kirby\\urls'            => __DIR__ . DS . 'kirby' . DS . 'urls.php',
   'kirby\\request'         => __DIR__ . DS . 'kirby' . DS . 'request.php',

--- a/core/page.php
+++ b/core/page.php
@@ -968,7 +968,7 @@ abstract class PageAbstract {
 
     // check if the file exists and return the appropriate template name
     return $this->cache['template'] =
-      file_exists($this->kirby->modules()->findFile('templates', $templateName, '.php', $this->kirby->roots()->templates())) ?
+      file_exists($this->kirby->modules()->getFile('templates', $templateName, '.php', $this->kirby->roots()->templates())) ?
         $templateName : 'default';
 
   }
@@ -979,7 +979,7 @@ abstract class PageAbstract {
    * @return string
    */
   public function templateFile() {
-    return $this->kirby->modules()->findFile('templates', $this->template(), '.php', $this->kirby->roots()->templates());
+    return $this->kirby->modules()->getFile('templates', $this->template(), '.php', $this->kirby->roots()->templates());
   }
 
   /**
@@ -1009,7 +1009,7 @@ abstract class PageAbstract {
    * @return string
    */
   public function intendedTemplateFile() {
-    return $this->kirby->modules()->findFile('templates', $this->intendedTemplate(), '.php', $this->kirby->roots()->templates());
+    return $this->kirby->modules()->getFile('templates', $this->intendedTemplate(), '.php', $this->kirby->roots()->templates());
   }
 
   /**

--- a/core/page.php
+++ b/core/page.php
@@ -968,7 +968,7 @@ abstract class PageAbstract {
 
     // check if the file exists and return the appropriate template name
     return $this->cache['template'] =
-      file_exists($this->kirby->roots()->templates() . DS . $templateName . '.php') ?
+      file_exists($this->kirby->modules()->findFile('templates', $templateName, '.php', $this->kirby->roots()->templates())) ?
         $templateName : 'default';
 
   }
@@ -979,7 +979,7 @@ abstract class PageAbstract {
    * @return string
    */
   public function templateFile() {
-    return $this->kirby->roots()->templates() . DS . $this->template() . '.php';
+    return $this->kirby->modules()->findFile('templates', $this->template(), '.php', $this->kirby->roots()->templates());
   }
 
   /**
@@ -1009,7 +1009,7 @@ abstract class PageAbstract {
    * @return string
    */
   public function intendedTemplateFile() {
-    return $this->kirby->roots()->templates() . DS . $this->intendedTemplate() . '.php';
+    return $this->kirby->modules()->findFile('templates', $this->intendedTemplate(), '.php', $this->kirby->roots()->templates());
   }
 
   /**

--- a/helpers.php
+++ b/helpers.php
@@ -11,7 +11,7 @@
 function snippet($file, $data = array(), $return = false) {
   if(is_object($data)) $data = array('item' => $data);
 
-  $file = kirby::instance()->modules()->findFile('snippets', $file, '.php', kirby::instance()->roots()->snippets());
+  $file = kirby::instance()->modules()->getFile('snippets', $file, '.php', kirby::instance()->roots()->snippets());
 
   return tpl::load($file, $data, $return);
 }

--- a/helpers.php
+++ b/helpers.php
@@ -10,7 +10,16 @@
  */
 function snippet($file, $data = array(), $return = false) {
   if(is_object($data)) $data = array('item' => $data);
-  return tpl::load(kirby::instance()->roots()->snippets() . DS . $file . '.php', $data, $return);
+
+  $snippet = kirby::instance()->roots()->snippets() . DS . $file . '.php';
+  if(!f::exists($snippet)) {
+    foreach(kirby::instance()->modules()->snippets() as $dir) {
+      $snippet = $dir . DS . $file . '.php';
+      if(f::exists($snippet)) break;
+    }
+  }
+
+  return tpl::load($snippet, $data, $return);
 }
 
 /**

--- a/helpers.php
+++ b/helpers.php
@@ -11,15 +11,9 @@
 function snippet($file, $data = array(), $return = false) {
   if(is_object($data)) $data = array('item' => $data);
 
-  $snippet = kirby::instance()->roots()->snippets() . DS . $file . '.php';
-  if(!f::exists($snippet)) {
-    foreach(kirby::instance()->modules()->snippets() as $dir) {
-      $snippet = $dir . DS . $file . '.php';
-      if(f::exists($snippet)) break;
-    }
-  }
+  $file = kirby::instance()->modules()->findFile('snippets', $file, '.php', kirby::instance()->roots()->snippets());
 
-  return tpl::load($snippet, $data, $return);
+  return tpl::load($file, $data, $return);
 }
 
 /**
@@ -121,7 +115,7 @@ function pages($data = array()) {
 function excerpt($text, $length = 140, $mode = 'chars') {
 
   if(strtolower($mode) == 'words') {
-    $text = str::excerpt(kirbytext($text), 0);    
+    $text = str::excerpt(kirbytext($text), 0);
 
     if(str_word_count($text, 0) > $length) {
       $words = str_word_count($text, 2);
@@ -131,7 +125,7 @@ function excerpt($text, $length = 140, $mode = 'chars') {
     return $text;
 
   } else {
-    return str::excerpt(kirbytext($text), $length);    
+    return str::excerpt(kirbytext($text), $length);
   }
 
 }
@@ -257,9 +251,9 @@ function thisUrl() {
 }
 
 /**
- * Give this any kind of array 
+ * Give this any kind of array
  * to get some kirby style structure
- * 
+ *
  * @param mixed $data
  * @param mixed $page
  * @param mixed $key
@@ -282,6 +276,6 @@ function structure($data, $page = null, $key = null) {
     return $data;
   } else {
     return new Field($page, $key, $data);
-  } 
+  }
 
 };

--- a/kirby.php
+++ b/kirby.php
@@ -491,10 +491,8 @@ class Kirby extends Obj {
     include_once(__DIR__ . DS . 'extensions' . DS . 'methods.php');
 
     // install additional kirby tags
-    kirbytext::install($this->roots->tags());
-
-    // install kirby tags from registered modules
-    foreach($this->modules()->tags() as $tags) {
+    $roots = $this->modules()->allRoots('tags', $this->roots->tags());
+    foreach($roots as $tags) {
       kirbytext::install($tags);
     }
 
@@ -505,8 +503,7 @@ class Kirby extends Obj {
    */
   public function models() {
 
-    $roots   = $this->modules()->models();
-    $roots[] = $this->roots()->models();
+    $roots   = $this->modules()->allRoots('models', $this->roots()->models());
     $load    = array();
 
     foreach($roots as $root) {
@@ -578,8 +575,7 @@ class Kirby extends Obj {
 
     // additional language variables for multilang sites
     if($site->multilang()) {
-      $roots   = $this->modules()->languages();
-      $roots[] = $this->roots()->languages();
+      $roots   = $this->modules()->allRoots('languages', $this->roots()->languages());
 
       foreach($roots as $root) {
         // path for the language file

--- a/kirby.php
+++ b/kirby.php
@@ -494,7 +494,7 @@ class Kirby extends Obj {
     kirbytext::install($this->roots->tags());
 
     // install kirby tags from registered modules
-    foreach((array)$this->modules()->tags() as $tags) {
+    foreach($this->modules()->tags() as $tags) {
       kirbytext::install($tags);
     }
 

--- a/kirby.php
+++ b/kirby.php
@@ -141,11 +141,14 @@ class Kirby extends Obj {
       // auto template css files
       if($url == '@auto') {
 
-        $file = $kirby->site()->page()->template() . '.css';
-        $root = $kirby->roots()->autocss() . DS . $file;
-        $url  = $kirby->urls()->autocss() . '/' . $file;
+        $file    = $kirby->site()->page()->template() . '.css';
+        $root    = $kirby->roots()->autocss() . DS . $file;
+        $url     = $kirby->urls()->autocss() . '/' . $file;
 
-        if(!file_exists($root)) return false;
+        if(!file_exists($root)) {
+          if(!($url = $kirby->modules()->getAsset('autocss', $file)))
+          return false;
+        }
 
       }
 
@@ -175,7 +178,10 @@ class Kirby extends Obj {
         $root = $kirby->roots()->autojs() . DS . $file;
         $src  = $kirby->urls()->autojs() . '/' . $file;
 
-        if(!file_exists($root)) return false;
+        if(!file_exists($root)) {
+          if(!($url = $kirby->modules()->getAsset('autojs', $file)))
+          return false;
+        }
 
       }
 
@@ -537,7 +543,7 @@ class Kirby extends Obj {
    */
   public function controller($page, $arguments = array()) {
 
-    $file = $this->modules()->findFile('controllers', $page->template(), '.php', $this->roots->controllers());
+    $file = $this->modules()->getFile('controllers', $page->template(), '.php', $this->roots->controllers());
 
     if(file_exists($file)) {
 

--- a/kirby.php
+++ b/kirby.php
@@ -493,6 +493,11 @@ class Kirby extends Obj {
     // install additional kirby tags
     kirbytext::install($this->roots->tags());
 
+    // install kirby tags from registered modules
+    foreach($this->modules()->tags() as $tags) {
+      kirbytext::install($tags);
+    }
+
   }
 
   /**
@@ -757,11 +762,11 @@ class Kirby extends Obj {
     // set the timezone for all date functions
     date_default_timezone_set($this->options['timezone']);
 
-    // load all extensions
-    $this->extensions();
-
     // load all plugins
     $this->plugins();
+
+    // load all extensions
+    $this->extensions();
 
     // load all models
     $this->models();

--- a/kirby.php
+++ b/kirby.php
@@ -146,8 +146,7 @@ class Kirby extends Obj {
         $url     = $kirby->urls()->autocss() . '/' . $file;
 
         if(!file_exists($root)) {
-          if(!($url = $kirby->modules()->getAsset('autocss', $file)))
-          return false;
+          if(!($url = $kirby->modules()->getAsset('autocss', $file))) return false;
         }
 
       }
@@ -179,8 +178,7 @@ class Kirby extends Obj {
         $src  = $kirby->urls()->autojs() . '/' . $file;
 
         if(!file_exists($root)) {
-          if(!($url = $kirby->modules()->getAsset('autojs', $file)))
-          return false;
+          if(!($url = $kirby->modules()->getAsset('autojs', $file))) return false;
         }
 
       }
@@ -510,6 +508,7 @@ class Kirby extends Obj {
   public function models() {
 
     $roots   = $this->modules()->allRoots('models', $this->roots()->models());
+    if(empty($roots)) return false;
     $load    = array();
 
     foreach($roots as $root) {
@@ -531,6 +530,8 @@ class Kirby extends Obj {
     // start the autoloader
     if(!empty($load)) {
       load($load);
+    } else {
+      return false;
     }
 
   }

--- a/kirby.php
+++ b/kirby.php
@@ -2,6 +2,7 @@
 
 use Kirby\Roots;
 use Kirby\Urls;
+use Kirby\Modules;
 use Kirby\Request;
 
 class Kirby extends Obj {
@@ -21,6 +22,7 @@ class Kirby extends Obj {
   public $route;
   public $site;
   public $page;
+  public $modules;
   public $plugins;
   public $response;
   public $request;
@@ -37,6 +39,7 @@ class Kirby extends Obj {
   public function __construct($options = array()) {
     $this->roots   = new Roots(dirname(__DIR__));
     $this->urls    = new Urls();
+    $this->modules = new Modules();
     $this->options = array_merge($this->defaults(), $options);
     $this->path    = implode('/', (array)url::fragments(detect::path()));
 
@@ -282,6 +285,12 @@ class Kirby extends Obj {
     }
 
   }
+
+
+  public function modules() {
+    return $this->modules;
+  }
+
 
   /**
    * Registers all routes

--- a/kirby.php
+++ b/kirby.php
@@ -578,10 +578,17 @@ class Kirby extends Obj {
 
     // additional language variables for multilang sites
     if($site->multilang()) {
-      // path for the language file
-      $file = $this->roots()->languages() . DS . $site->language()->code() . '.php';
-      // load the file if it exists
-      if(file_exists($file)) include_once($file);
+      $roots   = $this->modules()->languages();
+      $roots[] = $this->roots()->languages();
+
+      foreach($roots as $root) {
+        // path for the language file
+        $file =  $root . DS . $site->language()->code() . '.php';
+
+        // load the file if it exists
+        if(file_exists($file)) include_once($file);
+      }
+
     }
 
   }

--- a/kirby.php
+++ b/kirby.php
@@ -494,7 +494,7 @@ class Kirby extends Obj {
     kirbytext::install($this->roots->tags());
 
     // install kirby tags from registered modules
-    foreach($this->modules()->tags() as $tags) {
+    foreach((array)$this->modules()->tags() as $tags) {
       kirbytext::install($tags);
     }
 

--- a/kirby.php
+++ b/kirby.php
@@ -536,7 +536,7 @@ class Kirby extends Obj {
    */
   public function controller($page, $arguments = array()) {
 
-    $file = $this->roots->controllers() . DS . $page->template() . '.php';
+    $file = $this->modules()->findFile('controllers', $page->template(), '.php', $this->roots->controllers());
 
     if(file_exists($file)) {
 

--- a/kirby.php
+++ b/kirby.php
@@ -505,20 +505,24 @@ class Kirby extends Obj {
    */
   public function models() {
 
-    if(!is_dir($this->roots()->models())) return false;
+    $roots   = $this->modules()->models();
+    $roots[] = $this->roots()->models();
+    $load    = array();
 
-    $root  = $this->roots()->models();
-    $files = dir::read($root);
-    $load  = array();
+    foreach($roots as $root) {
+      if(!is_dir($root)) continue;
 
-    foreach($files as $file) {
-      if(f::extension($file) != 'php') continue;
-      $name      = f::name($file);
-      $classname = str_replace(array('.', '-', '_'), '', $name . 'page');
-      $load[$classname] = $root . DS . $file;
+      $files = dir::read($root);
 
-      // register the model
-      page::$models[$name] = $classname;
+      foreach($files as $file) {
+        if(f::extension($file) != 'php') continue;
+        $name      = f::name($file);
+        $classname = str_replace(array('.', '-', '_'), '', $name . 'page');
+        $load[$classname] = $root . DS . $file;
+
+        // register the model
+        page::$models[$name] = $classname;
+      }
     }
 
     // start the autoloader

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -2,6 +2,8 @@
 
 namespace Kirby;
 
+use F;
+
 class Modules {
 
   public $modules = array();
@@ -12,6 +14,18 @@ class Modules {
     } else {
       $this->modules[$type] = array($dir);
     }
+  }
+
+  public function findFile($type, $file, $extension, $default) {
+    $dirs = $this->{$type}();
+    array_unshift($dirs, $default);
+
+    foreach($dirs as $dir) {
+      $return = $dir . DS . $file . $extension;
+      if(f::exists($return)) break;
+    }
+
+    return f::exists($return) ? $return : $default . DS . $file . $extension;
   }
 
   public function __call($method, $arguments) {

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kirby;
+
+class Modules {
+
+  public $modules = array();
+
+  public function register($type, $dir) {
+    if(isset($this->modules[$type])) {
+      $this->modules[$type][] = $dir;
+    } else {
+      $this->modules[$type] = array($dir);
+    }
+  }
+
+  public function __call($method, $arguments) {
+    if(isset($this->modules[$method])) {
+      return $this->modules[$method];
+    }
+  }
+
+}

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -33,9 +33,7 @@ class Modules {
   }
 
   public function __call($method, $arguments) {
-    if(isset($this->modules[$method])) {
-      return $this->modules[$method] ? $this->modules[$method] : array();
-    }
+    return a::get($this->modules, $method, array());
   }
 
 }

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -45,12 +45,13 @@ class Modules {
     }
 
     array_push($this->{$module}, $dir);
+    return true;
   }
 
   /**
    * Creates route for plugin assets
    */
-  public function route($route, $root) {
+   public function assets($route, $root) {
     if($page = page($route)) return false;
 
     return kirby()->routes(array(
@@ -67,10 +68,6 @@ class Modules {
         }
       )
     ));
-  }
-
-  public function assets($route, $root) {
-    return $this->route($route, $root);
   }
 
 

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -17,7 +17,7 @@ class Modules {
   }
 
   public function findFile($type, $file, $extension, $default) {
-    $dirs = $this->{$type}();
+    $dirs = (array)$this->{$type}();
     array_unshift($dirs, $default);
 
     foreach($dirs as $dir) {

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -49,14 +49,18 @@ class Modules {
     return f::exists($return) ? $return : $default . DS . $file . $exts[0];
   }
 
-  public function allFiles($type, $default = null) {
+  public function allFiles($type, $default = null, $sort = false) {
     $files = array();
 
     foreach($this->allRoots($type, $default) as $dir) {
-      $files = a::merge($files, dir::read($dir));
+      foreach(dir::read($dir) as $file){
+        $files[] = $file;
+      }
     }
 
-    return $files;
+    if($sort) sort($files);
+
+    return array_unique($files);
   }
 
   public function allRoots($type, $default = null) {

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -2,6 +2,7 @@
 
 namespace Kirby;
 
+use A;
 use F;
 
 class Modules {
@@ -16,21 +17,24 @@ class Modules {
     }
   }
 
-  public function findFile($type, $file, $extension, $default) {
-    $dirs = (array)$this->{$type}();
+  public function findFile($type, $file, $extensions, $default) {
+    $extensions = array_map(function($ext) {
+      return ltrim($ext, '.');
+    }, (array)$extensions);
+
+    $dirs = a::get($this->modules, $type, array());
     array_unshift($dirs, $default);
 
     foreach($dirs as $dir) {
-      $return = $dir . DS . $file . $extension;
-      if(f::exists($return)) break;
+      if($return = f::resolve($dir . DS . $file, $extensions)) break;
     }
 
-    return f::exists($return) ? $return : $default . DS . $file . $extension;
+    return f::exists($return) ? $return : $default . DS . $file . $extensions[0];
   }
 
   public function __call($method, $arguments) {
     if(isset($this->modules[$method])) {
-      return $this->modules[$method];
+      return (array)$this->modules[$method];
     }
   }
 

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -47,12 +47,16 @@ class Modules {
     array_push($this->modules[$type], $dir);
   }
 
+  public function assets($route, $dir) {
+    return $this->route($route, $dir);
+  }
+
   /**
    * Creates route for plugin assets
    * @param  [string] $dir   plugin directory with assets
    * @param  [type] $route   route to point to $dir
    */
-  public function assets($dir, $route) {
+  public function route($route, $dir) {
     if($page = page($route)) return false;
 
     return kirby()->routes(array(

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -7,33 +7,51 @@ use F;
 
 class Modules {
 
-  public $modules = array();
+  public $modules;
 
-  public function register($type, $dir) {
-    if(isset($this->modules[$type])) {
-      $this->modules[$type][] = $dir;
-    } else {
-      $this->modules[$type] = array($dir);
-    }
+  public function __construct() {
+    $this->modules = array(
+      // core
+      'controllers' => array(),
+      'languages'   => array(),
+      'models'      => array(),
+      'snippets'    => array(),
+      'tags'        => array(),
+      'templates'   => array(),
+
+      // panel
+      'blueprints'  => array(),
+      'fields'      => array(),
+    );
   }
 
-  public function findFile($type, $file, $extensions, $default) {
-    $extensions = array_map(function($ext) {
-      return ltrim($ext, '.');
-    }, (array)$extensions);
-
-    $dirs = a::get($this->modules, $type, array());
-    array_unshift($dirs, $default);
-
-    foreach($dirs as $dir) {
-      if($return = f::resolve($dir . DS . $file, $extensions)) break;
-    }
-
-    return f::exists($return) ? $return : $default . DS . $file . $extensions[0];
+  public function register($type, $dir) {
+    if(!isset($this->modules[$type])) return false;
+    array_push($this->modules[$type], $dir);
   }
 
   public function __call($method, $arguments) {
-    return a::get($this->modules, $method, array());
+    return a::get($this->modules, $method, null);
+  }
+
+  public function findFile($type, $file, $extensions, $default) {
+    if(!isset($this->modules[$type])) return null;
+
+    $dirs = a::get($this->modules, $type);
+    $exts = $this->extensions($extensions);
+    array_unshift($dirs, $default);
+
+    foreach($dirs as $dir) {
+      if($return = f::resolve($dir . DS . $file, $exts)) break;
+    }
+
+    return f::exists($return) ? $return : $default . DS . $file . $exts[0];
+  }
+
+  protected function extensions($extensions = array()) {
+    return array_map(function($ext) {
+      return ltrim($ext, '.');
+    }, (array)$extensions);
   }
 
 }

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -41,7 +41,7 @@ class Modules {
     if(in_array($type, array('autocss', 'autojs'))) {
       $route = 'assets/modules/' . sha1($dir);
       $dir   = array($dir, $route);
-      $this->assets($dir, $route);
+      $this->assets($route, $dir);
     }
 
     array_push($this->modules[$type], $dir);

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -39,11 +39,9 @@ class Modules {
 
     // prepare for auto-assets
     if(in_array($type, array('autocss', 'autojs'))) {
-      while (true) {
-        $route = 'assets/module_' . sha1($dir);
-        if($this->assets($dir, $route)) break;
-      }
-      $dir = array($dir, $route);
+      $route = 'assets/modules/' . sha1($dir);
+      $dir   = array($dir, $route);
+      $this->assets($dir, $route);
     }
 
     array_push($this->modules[$type], $dir);

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -34,17 +34,17 @@ class Modules {
   /**
    * Registers a plugin directory for a module type
    */
-  public function register($module, $dir) {
+  public function register($module, $root) {
     if(!isset($this->{$module})) return false;
 
     // prepare for auto-assets
     if($module === 'autocss' or $module === 'autojs') {
-      $route = 'assets/modules/' . sha1($dir);
-      $dir   = array($dir, $route);
-      $this->assets($route, $dir);
+      $route = 'assets/modules/' . sha1($root);
+      $this->assets($route, $root);
+      $root  = compact('root', 'route');
     }
 
-    array_push($this->{$module}, $dir);
+    array_push($this->{$module}, $root);
     return true;
   }
 
@@ -57,7 +57,7 @@ class Modules {
     return kirby()->routes(array(
       array(
         'pattern' => trim($route, '/') . '/(:all)',
-        'action'  => function($file) use($route, $root) {
+        'action'  => function($file) use($root) {
           $path = $root . DS . $file;
           if(is_file($path)) {
             $extension = substr(strchr($path, '.'), 1);
@@ -75,8 +75,8 @@ class Modules {
 
     if($dirs = $this->{$module}()) {
       foreach($dirs as $dir) {
-        $root = $dir[0] . DS . $file;
-        $url  = $dir[1] . DS . $file;
+        $root = $dir['root'] . DS . $file;
+        $url  = $dir['route'] . DS . $file;
         if(f::exists($root)) return $url;
       }
     }

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -9,61 +9,55 @@ use Response;
 
 class Modules {
 
-  public $modules;
+  // core
+  public $controllers = array();
+  public $languages   = array();
+  public $models      = array();
+  public $snippets    = array();
+  public $tags        = array();
+  public $templates   = array();
+  public $autocss     = array();
+  public $autojs      = array();
 
-  public function __construct() {
-    $this->modules = array(
-      // core
-      'controllers' => array(),
-      'languages'   => array(),
-      'models'      => array(),
-      'snippets'    => array(),
-      'tags'        => array(),
-      'templates'   => array(),
-      'autocss'     => array(),
-      'autojs'      => array(),
+  // panel
+  public $blueprints  = array();
+  public $fields      = array();
 
-      // panel
-      'blueprints'  => array(),
-      'fields'      => array(),
-    );
+
+  /**
+   * Magic getter for module arrays
+   */
+  public function __call($method, $arguments) {
+    return isset($this->{$method}) ? $this->{$method} : null;
   }
 
   /**
    * Registers a plugin directory for a module type
-   * @param  [string] $type module type
-   * @param  [string] $dir  directory to be included as source
    */
-  public function register($type, $dir) {
-    if(!isset($this->modules[$type])) return false;
+  public function register($module, $dir) {
+    if(!isset($this->{$module})) return false;
 
     // prepare for auto-assets
-    if(in_array($type, array('autocss', 'autojs'))) {
+    if($module === 'autocss' or $module === 'autojs') {
       $route = 'assets/modules/' . sha1($dir);
       $dir   = array($dir, $route);
       $this->assets($route, $dir);
     }
 
-    array_push($this->modules[$type], $dir);
-  }
-
-  public function assets($route, $dir) {
-    return $this->route($route, $dir);
+    array_push($this->{$module}, $dir);
   }
 
   /**
    * Creates route for plugin assets
-   * @param  [string] $dir   plugin directory with assets
-   * @param  [type] $route   route to point to $dir
    */
-  public function route($route, $dir) {
+  public function route($route, $root) {
     if($page = page($route)) return false;
 
     return kirby()->routes(array(
       array(
         'pattern' => trim($route, '/') . '/(:all)',
-        'action'  => function($file) use($dir, $route) {
-          $path = $dir . DS . $file;
+        'action'  => function($file) use($route, $root) {
+          $path = $root . DS . $file;
           if(is_file($path)) {
             $extension = substr(strchr($path, '.'), 1);
             return new Response(f::read($path), $extension);
@@ -75,70 +69,63 @@ class Modules {
     ));
   }
 
-  public function __call($method, $arguments) {
-    return a::get($this->modules, $method, null);
+  public function assets($route, $root) {
+    return $this->route($route, $root);
   }
 
 
-  public function getAsset($type, $file) {
+  public function getAsset($module, $file) {
 
-    if($dirs = $this->{$type}()) {
+    if($dirs = $this->{$module}()) {
       foreach($dirs as $dir) {
         $root = $dir[0] . DS . $file;
         $url  = $dir[1] . DS . $file;
         if(f::exists($root)) return $url;
       }
-
-    } else {
-      return null;
     }
+
+    return null;
 
   }
 
-  public function getFile($type, $file, $extensions, $default = null) {
+  public function getFile($module, $file, $ext, $default = null) {
 
-    if($dirs = $this->{$type}()) {
-      // $extensions as array without dots
-      $extensions = array_map(function($ext) {
-        return ltrim($ext, '.');
-      }, (array)$extensions);
+    if($dirs = $this->{$module}()) {
+      // $ext as array without dots
+      $ext = array_map(function($e) {
+        return ltrim($e, '.');
+      }, (array)$ext);
 
       // add default location as possible source
-      if(!is_null($default)) {
-        array_unshift($dirs, $default);
-      }
+      if(!is_null($default)) array_unshift($dirs, $default);
 
       foreach($dirs as $dir) {
-        $root = f::resolve($dir . DS . $file, $extensions);
+        $root = f::resolve($dir . DS . $file, $ext);
         if($root) return $root;
       }
 
-      return $default . DS . $file . $extensions[0];
-
-    } else {
-      return null;
     }
+
+    return !is_null($default) ? $default . DS . $file . $ext[0] : null;
 
   }
 
-  public function allFiles($type, $default = null, $sort = false) {
+  public function allFiles($module, $default = null, $sort = false) {
     $files = array();
 
-    foreach($this->allRoots($type, $default) as $dir) {
+    foreach($this->allRoots($module, $default) as $dir) {
       foreach(dir::read($dir) as $file){
         $files[] = $file;
       }
     }
 
-    if($sort === true) {
-      sort($files);
-    }
+    if($sort === true) sort($files);
 
     return array_unique($files);
   }
 
-  public function allRoots($type, $default = null) {
-    $dirs = $this->{$type}();
+  public function allRoots($module, $default = null) {
+    $dirs = $this->{$module}();
     if(is_null($dirs)) $dirs = array();
     if($default) $dirs[] = $default;
     return $dirs;

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -4,6 +4,7 @@ namespace Kirby;
 
 use A;
 use F;
+use Dir;
 
 class Modules {
 
@@ -46,6 +47,22 @@ class Modules {
     }
 
     return f::exists($return) ? $return : $default . DS . $file . $exts[0];
+  }
+
+  public function allFiles($type, $default = null) {
+    $files = array();
+
+    foreach($this->allRoots($type, $default) as $dir) {
+      $files = a::merge($files, dir::read($dir));
+    }
+
+    return $files;
+  }
+
+  public function allRoots($type, $default = null) {
+    $dirs  = $this->{$type}();
+    if($default) $dirs[] = $default;
+    return $dirs;
   }
 
   protected function extensions($extensions = array()) {

--- a/kirby/modules.php
+++ b/kirby/modules.php
@@ -34,7 +34,7 @@ class Modules {
 
   public function __call($method, $arguments) {
     if(isset($this->modules[$method])) {
-      return (array)$this->modules[$method];
+      return $this->modules[$method] ? $this->modules[$method] : array();
     }
   }
 


### PR DESCRIPTION
I have started the path towards plugin bundles, packages, modules – whatever we want to call them. Basically, having the possibility to put tags, fields, snippets, plugins... all together in one plugin folder.

This PR enables plugin modules/bundles so far for:
- [x] Tags
- [x] Snippets
- [x] Templates
- [x] Controllers
- [x] Models
- [x] Languages
- [x] autocss/autojs

To register these tags/fields/... that come with the plugin, there is a simple syntax:

```php
kirby()->modules()->register('snippets',    __DIR__ . DS . 'snippets');
kirby()->modules()->register('templates',   __DIR__ . DS . 'templates');
kirby()->modules()->register('tags',        __DIR__ . DS . 'tags');
kirby()->modules()->register('controllers', __DIR__ . DS . 'controllers');
kirby()->modules()->register('models',      __DIR__ . DS . 'models');
kirby()->modules()->register('languages',   __DIR__ . DS . 'languages');
kirby()->modules()->register('autocss', __DIR__ . DS . 'assets' . DS . 'css' . DS . 'templates');
kirby()->modules()->register('autojs', __DIR__ . DS . 'assets' . DS . 'js' . DS . 'templates');
```

<img width="1044" alt="screen shot 2016-02-23 at 21 50 06" src="https://cloud.githubusercontent.com/assets/3788865/13266362/0de3679a-da78-11e5-9172-1275fdffcfbb.png">

The PR also adds an easy helper to set up routes for plugin assets:
```php
kirby()->modules()->assets('assets/plugins/veryUniquePluginName', __DIR__ . DS . 'assets');
kirby()->modules()->assets('WhateverYourRouteBaseShoudLookLike', __DIR__ . DS . 'assets');
a
// and then use, e.g. in site/snippets/footer.php
<?= js('assets/plugins/veryUniquePluginName/plugin.js') ?>
<?= js('WhateverYourRouteBaseShoudLookLike/magic.js') ?>
```

Lots of thanks already to the community in the forum for all the concepts, ideas, remarks...