### PR TITLE
Use textfile path instead of directory

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -921,7 +921,7 @@ abstract class PageAbstract {
    * @return int
    */
   public function modified($format = null, $handler = null) {
-    return f::modified($this->root, $format, $handler ? $handler : $this->kirby->options['date.handler']);
+    return f::modified($this->textFile(), $format, $handler ? $handler : $this->kirby->options['date.handler']);
   }
 
   /**


### PR DESCRIPTION
This commit fixes the modified method of the page model. Instead of
checking the modification date of the enclosing subfolder, it now
checks the timestamp of the actual content file.