### PR TITLE
$pages->find for arrays

### DIFF
--- a/core/children.php
+++ b/core/children.php
@@ -78,7 +78,11 @@ abstract class ChildrenAbstract extends Pages {
 
     if(!count($args)) {
       return false;
-    } else if(count($args) > 1) {
+    } else if (count($args) === 1 and is_array($args[0])) {
+      $args = $args[0];
+    }
+
+    if(count($args) > 1) {
       $collection = new Children($this->page);
       foreach($args as $id) {
         if($page = $this->find($id)) {

--- a/core/pages.php
+++ b/core/pages.php
@@ -86,7 +86,11 @@ abstract class PagesAbstract extends Collection {
 
     if(!count($args)) {
       return false;
-    } else if(count($args) > 1) {
+    } else if(count($array) === 1 and is_array($args[0])) {
+      $args = $args[0];
+    }
+
+    if(count($args) > 1) {
       $pages = new static();
       foreach($args as $id) {
         if($page = $this->find($id)) {

--- a/extensions/methods.php
+++ b/extensions/methods.php
@@ -172,20 +172,19 @@ field::$methods['toPage'] = function($field) {
 };
 
 /**
- * Returns all page objects from a yaml list in a field
+ * Returns all page objects from a yaml list or a $sep separated string in a field
  * @param Field $field The calling Kirby Field instance
  * @return Collection
  */
-field::$methods['pages'] = field::$methods['toPages'] = function($field) {
+field::$methods['pages'] = field::$methods['toPages'] = function($field, $sep = null) {
 
-  $related = array();
-
-  foreach($field->yaml() as $r) {
-    // make sure to only add found related pages
-    if($rel = page($r)) $related[$rel->id()] = $rel;
+  if($sep !== null) {
+    $array = $field->split($sep);
+  } else {
+    $array = $field->yaml();
   }
 
-  return new Collection($related);
+  return $field->site()->pages()->find($array);
 
 };
 


### PR DESCRIPTION
for $pages and $children. Solves #392 .

also adds $field->toPages(',') for fields that return a string with separated uris (pass separator as parameter)