### PR TITLE
$pages->not() accepts Pages (or other collections) as argument

### DIFF
--- a/core/pages.php
+++ b/core/pages.php
@@ -62,7 +62,7 @@ abstract class PagesAbstract extends Collection {
   public function not() {
     $collection = clone $this;
     foreach(func_get_args() as $uri) {
-      if(is_array($uri)) {
+      if(is_array($uri)  || $uri instanceof Traversable) {
         foreach($uri as $u) {
           $collection = $collection->not($u);
         }


### PR DESCRIPTION
This allow this:

```
  $exclude = page('/foo')->children()->filter(…);
  $keep = page('/foo')->children->not($exclude);
```