### PR TITLE
Fix smartypants php7 deprecated warning

### DIFF
--- a/vendors/smartypants.php
+++ b/vendors/smartypants.php
@@ -72,7 +72,7 @@ class SmartyPants_Parser {
 	var $do_stupefy   = 0;
 	var $convert_quot = 0; # should we translate &quot; entities into normal quotes?
 
-	function SmartyPants_Parser($attr = SMARTYPANTS_ATTR) {
+	function __construct($attr = SMARTYPANTS_ATTR) {
 	#
 	# Initialize a SmartyPants_Parser with certain attributes.
 	#
@@ -542,7 +542,7 @@ class SmartyPantsTypographer_Parser extends SmartyPants_Parser {
 
 	
 
-	function SmartyPantsTypographer_Parser($attr = SMARTYPANTS_ATTR) {
+	function __construct($attr = SMARTYPANTS_ATTR) {
 	#
 	# Initialize a SmartyPantsTypographer_Parser with certain attributes.
 	#
@@ -578,8 +578,8 @@ class SmartyPantsTypographer_Parser extends SmartyPants_Parser {
 	#    sign to completly remove any space present)
 	#
 		# Initialize inherited SmartyPants parser.
-		parent::SmartyPants_Parser($attr);
 				
+		parent::__construct($attr);
 		if ($attr == "1" || $attr == "2" || $attr == "3") {
 			# Do everything, turn all options on.
 			$this->do_comma_quotes      = 1;


### PR DESCRIPTION
SmartyPants throws a deprecated warning when using php 7, because the C++/ Java style syntax for the constructor is not supported any more.