### PR TITLE
Load models before plugins

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -654,11 +654,11 @@ class Kirby {
     // load all extensions
     $this->extensions();
 
-    // load all plugins
-    $this->plugins();
-
     // load all models
     $this->models();
+
+    // load all plugins
+    $this->plugins();
 
     // start the router
     $this->router = new Router($this->routes());


### PR DESCRIPTION
My plugin needs the page model to operate.
So kirby must load the models before loading my plugin.