### PR TITLE
Use `site()->homepage()->url()` for redirect

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -298,7 +298,7 @@ class Kirby {
     $routes['homeRedirect'] = array(
       'pattern' => $this->options['home'],
       'action'  => function() {
-        redirect::send(page('home')->url(), 307);
+        redirect::send(site()->homepage()->url(), 307);
       }
     );
 


### PR DESCRIPTION
Use `site()->homepage()->url()` for redirect instead of `page('home')->url()`. Ran into this issue while having a custom homepage defined in `config.php` as follows:

```
c::set('home', 'projects');
```

Going to the url `/projects` gave me the following error:

```
Fatal error: Call to a member function url() on boolean in /kirby/kirby.php on line 301
```

Apparently because I’ve set a custom homepage the function `page('home')` returns nothing whereas `site()->homepage()->url()` works as expected.