### PR TITLE
Cross-domain multilang

### DIFF
--- a/branches/multilang/language.php
+++ b/branches/multilang/language.php
@@ -22,6 +22,18 @@ class Language extends Obj {
   public function url() {
     return url::makeAbsolute($this->url, $this->site->url());
   }
+  
+  public function path() {
+    return url::path($this->url);
+  }
+  
+  public function isRoot() {
+    return $this->path() === '';
+  }
+  
+  public function host() {
+    return (url::isAbsolute($this->url))? url::host($this->url) : false;
+  }
 
   public function isDefault() {
     return $this->default;    

--- a/kirby.php
+++ b/kirby.php
@@ -237,17 +237,52 @@ class Kirby {
     $kirby  = $this;
     $site   = $this->site();
 
+    // fallback route for both single and multilang branches
+    $otherRoute = function($path = null) use($site, $kirby) {
+
+      // get the language code from the route
+      $lang = ($kirby->route->lang)? $kirby->route->lang->code() : false;
+
+      // visit the currently active page
+      $page = ($lang)? $site->visit($path, $lang) : $site->visit($path);
+
+      // react on errors for invalid URLs
+      if($page->isErrorPage() and $page->uri() != $path) {
+
+        // get the filename
+        $filename = rawurldecode(basename($path));
+        $pagepath = dirname($path);
+
+        // check if there's a page for the parent path
+        if($page = $site->find($pagepath)) {
+          // check if there's a file for the last element of the path
+          if($file = $page->file($filename)) {
+            go($file->url());
+          }
+        }
+
+        // return the error page if there's no such page
+        return $site->errorPage();
+
+      }
+
+      return $page;
+
+    };
+
     if($site->multilang()) {
 
-      foreach($site->languages() as $lang) {
-
+      // first register all languages that are not at the root of the domain
+      // otherwise they would capture all requests
+      foreach($site->languages()->sortBy('isRoot', 'asc') as $lang) {
+        
+        $pattern = ($lang->path())? $lang->path() . '/(:all?)' : '(:all)';
         $routes[] = array(
-          'pattern' => ltrim($lang->url . '/(:all?)', '/'),
+          'pattern' => $pattern,
+          'host'    => $lang->host(),
           'method'  => 'ALL',
           'lang'    => $lang,
-          'action'  => function($path = null) use($kirby, $site) {
-            return $site->visit($path, $kirby->route->lang->code());
-          }
+          'action'  => $otherRoute
         );
 
       }
@@ -324,35 +359,8 @@ class Kirby {
     $routes['others'] = array(
       'pattern' => '(:all)',
       'method'  => 'ALL',
-      'action'  => function($path = null) use($site, $kirby) {
-
-        // visit the currently active page
-        $page = $site->visit($path);
-
-        // react on errors for invalid URLs
-        if($page->isErrorPage() and $page->uri() != $path) {
-
-          // get the filename
-          $filename = rawurldecode(basename($path));
-          $pagepath = dirname($path);
-
-          // check if there's a page for the parent path
-          if($page = $site->find($pagepath)) {
-            // check if there's a file for the last element of the path
-            if($file = $page->file($filename)) {
-              go($file->url());
-            }
-          }
-
-          // return the error page if there's no such page
-          return $site->errorPage();
-
-        }
-
-        return $page;
-
-      }
-
+      'lang'    => false,
+      'action'  => $otherRoute
     );
 
     return $routes;


### PR DESCRIPTION
This change (together with getkirby/toolkit#178) allows to use a different language per domain out of the box.

Example:

```php
c::set('languages', [
	[
		'code'    => 'en',
		'name'    => 'English',
		'default' => true,
		'locale'  => 'en_US',
		'url'     => 'https://example.com',
	],
	[
		'code'    => 'de',
		'name'    => 'Deutsch',
		'locale'  => 'de_DE',
		'url'     => 'https://example.de',
	]
]);
```

Non-absolute language URLs like `/de`, `/` or `de` will continue to work. You can even combine them like `https://example.com/kirby` in case the languages are on a sub-folder.

---

Since this change only touches routes, it shouldn't break the Panel.
However it would make sense to add support for this in the Panel too, so that the correct language would be pre-selected per domain, that would just be an enhancement.