### PR TITLE
Add support for role attribute to link Kirbytag.

### DIFF
--- a/extensions/tags.php
+++ b/extensions/tags.php
@@ -185,6 +185,7 @@ kirbytext::$tags['link'] = array(
     return html::a($link, $text, array(
       'rel'    => $tag->attr('rel'),
       'class'  => $tag->attr('class'),
+      'role'  => $tag->attr('role'),
       'title'  => $tag->attr('title'),
       'target' => $tag->target(),
     ));

--- a/extensions/tags.php
+++ b/extensions/tags.php
@@ -163,6 +163,7 @@ kirbytext::$tags['link'] = array(
   'attr' => array(
     'text',
     'class',
+    'role',
     'title',
     'rel',
     'lang',


### PR DESCRIPTION
This might be helpful if you want to markup a link as a button, but when a button itself would not work without javascript:

`<a role="button" href="somehere">Go here</a>`

I can see that there might be other related changes wanted, but this is supposed to be a simple proposal for a feature request. 