### PR TITLE
Added initial composer file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "getkirby/kirby",
+  "description": "The Kirby 2 core.",
+  "keywords": ["core", "kirby"],
+  "homepage": "https://getkirby.com",
+  "license": "https://getkirby.com/license",
+  "authors": [
+    {
+      "name": "Bastian Allgeier",
+      "email": "bastian@getkirby.com",
+      "homepage": "http://bastianallgeier.com"
+    }
+  ],
+  "support": {
+    "email": "support@getkirby.com",
+    "issues": "https://github.com/getkirby/toolkit/issues",
+    "forum": "http://forum.getkirby.com",
+    "source": "https://github.com/getkirby/toolkit"
+  },
+  "autoload": {
+    "files": ["bootstrap.php"]
+  },
+  "require": {
+    "php": ">=5.4.0"
+  },
+  "archive": {
+    "exclude": ["/.gitmodules", "/.gitignore", "/.travis.yml", "/test"]
+  }
+}


### PR DESCRIPTION
This would make it possible to install kirby via composer. 

As described in [How to use Composer to install Kirby, Toolkit, Panel](https://forum.getkirby.com/t/how-to-use-composer-to-install-kirby-toolkit-panel/2850) [composer-custom-directory-installer](https://github.com/mnsami/composer-custom-directory-installer) could be used to install the files in a directory everyone might prefer. 

If you have questions, suggestions or issues with this pull request, just let me know. I really would like to fix the possible outstanding issues to be able to use kirby releases through composer.

Thanks.