### PR TITLE
Support for passwordless login

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -181,9 +181,38 @@ abstract class UserAbstract {
     return sha1($this->username() . $key);
   }
 
+  /**
+   * Log in with password
+   *
+   * @param  string $password
+   * @return boolean
+   */
   public function login($password) {
 
+    if(!$this->password) return false;
     if(!password::match($password, $this->password)) return false;
+
+    return $this->_login();
+
+  }
+
+  /**
+   * Log in without password
+   *
+   * @return boolean
+   */
+  public function loginPasswordless() {
+
+    return $this->_login();
+
+  }
+
+  /**
+   * Processes the successful login
+   *
+   * @return boolean
+   */
+  protected function _login() {
 
     $data = array();
     if(static::current()) {
@@ -256,10 +285,6 @@ abstract class UserAbstract {
 
       if(empty($data['username'])) {
         throw new Exception('Invalid username');
-      }
-
-      if(empty($data['password'])) {
-        throw new Exception('Invalid password');
       }
 
     }


### PR DESCRIPTION
Users now don’t need to have passwords to be valid.

A user without password can’t login but there is a new $user->loginPasswordless() method for that.

Passwordless login allows the developer to log users in based on other kinds of authentication (OAuth, email, SMS etc.).