### PR TITLE
Don’t require email address for user

### DIFF
--- a/core/user.php
+++ b/core/user.php
@@ -157,6 +157,7 @@ abstract class UserAbstract {
   }
 
   public function gravatar($size = 256) {
+    if(!$this->email()) return false;
     return gravatar($this->email(), $size);
   }
 
@@ -261,10 +262,6 @@ abstract class UserAbstract {
         throw new Exception('Invalid password');
       }
 
-    }
-
-    if(!empty($data['email']) and !v::email($data['email'])) {
-      throw new Exception('Invalid email');
     }
 
   }


### PR DESCRIPTION
Sending this as a PR as I’m not sure why this requirement made it into Kirby back then.

As far as I can tell, the email is only used for the „Send email“ button in the Panel. We should add a check there and hide it if there is no valid email.