### PR TITLE
Fix #581: prevent infinite redirect on lang detect

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -258,7 +258,7 @@ class Kirby {
         // build language homepage URL including params and/or query
         $url = $language->url();
         if($params = url::params()) $url .= '/' . url::paramsToString($params);
-        if($query  = url::query())  $url .= '?' . url::queryToString($query);
+        if($query  = url::query())  $url .= '/?' . url::queryToString($query);
 
         // redirect to the language homepage
         if($language && rtrim(url::current(), '/') !== rtrim($url, '/')) {


### PR DESCRIPTION
Since this part only applies to `language.detect=true` on the home page of the site, we have to add a `/` before the `?` of the added query string. 

Otherwise the if-statement part  `trim(url::current(), '/') !== rtrim($url, ‘/‘)`(from line 264) would be `true` since `url::current()` provides the url with the `/` while `$url` has not contained this `/` so far.

And this leads to an infinite redirect which this PR should fix.