### PR TITLE
Fixed: `idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated` in PHP 7.2

### DIFF
--- a/vendor/getkirby/toolkit/lib/url.php
+++ b/vendor/getkirby/toolkit/lib/url.php
@@ -380,7 +380,8 @@ class Url {
     if(!function_exists('idn_to_utf8')) return $url;
 
     // disassemble the URL, convert the domain name and reassemble
-    $host = idn_to_utf8(static::host($url));
+    $variant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : INTL_IDNA_VARIANT_2003;
+    $host = idn_to_utf8(static::host($url), 0, $variant);
     if($host === false) return $url;
     $url  = static::build(['host' => $host], $url);
 
@@ -400,7 +401,8 @@ class Url {
     if(!function_exists('idn_to_ascii')) return $url;
 
     // disassemble the URL, convert the domain name and reassemble
-    $host = idn_to_ascii(static::host($url));
+    $variant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : INTL_IDNA_VARIANT_2003;
+    $host = idn_to_ascii(static::host($url), 0, $variant);
     if($host === false) return $url;
     $url  = static::build(['host' => $host], $url);
 


### PR DESCRIPTION
This issue exists on a server running PHP 7.2. I've made this mod to support older versions too if `INTL_IDNA_VARIANT_UTS46` is not defined.