### PR TITLE
Provide the field to the parser components.

### DIFF
--- a/core/kirbytext.php
+++ b/core/kirbytext.php
@@ -49,10 +49,10 @@ abstract class KirbytextAbstract {
     $text = preg_replace_callback('!(?=[^\]])\([a-z0-9_-]+:.*?\)!is', array($this, 'tag'), $text);
 
     // markdownify
-    $text = kirby::instance()->component('markdown')->parse($text);
+    $text = kirby::instance()->component('markdown')->parse($text, $this->field);
 
     // smartypantsify
-    $text = kirby::instance()->component('smartypants')->parse($text);
+    $text = kirby::instance()->component('smartypants')->parse($text, false, $this->field);
 
     // post filters
     foreach(static::$post as $filter) {

--- a/kirby/component/markdown.php
+++ b/kirby/component/markdown.php
@@ -4,6 +4,7 @@ namespace Kirby\Component;
 
 use Parsedown;
 use ParsedownExtra;
+use Field;
 
 /**
  * Kirby Markdown Parser Component
@@ -34,9 +35,10 @@ class Markdown extends \Kirby\Component {
    * transforms the given markdown to HTML
    * 
    * @param string $markdown
+   * @param Field $text
    * @return string
    */
-  public function parse($markdown) {
+  public function parse($markdown, Field $field) {
 
     if(!$this->kirby->options['markdown']) {
       return $markdown;

--- a/kirby/component/smartypants.php
+++ b/kirby/component/smartypants.php
@@ -3,6 +3,7 @@
 namespace Kirby\Component;
 
 use \Michelf\SmartyPantsTypographer;
+use Field;
 
 /**
  * Kirby Smartypants Parser Component
@@ -60,9 +61,10 @@ class Smartypants extends \Kirby\Component {
    * 
    * @param string $text
    * @param boolean $force
+   * @param Field $text
    * @return string
    */
-  public function parse($text, $force = false) {
+  public function parse($text, $force = false, Field $field) {
     if($this->kirby->options['smartypants'] === true || $force === true) {
 
       // prepare the text


### PR DESCRIPTION
I did replace the Markdown parser in a project and needed the context of the current field.

This pull request updates the Kirbytext->parse() method to pass the current field to the parser. With this the parse method inside the component can base decisions on the current context the parser is in.

This closes #529 as it's no longer available. 