### PR TITLE
Add option to load fatal error template from config

### DIFF
--- a/kirby/errorhandling.php
+++ b/kirby/errorhandling.php
@@ -2,6 +2,7 @@
 
 namespace Kirby;
 
+use C;
 use Kirby;
 use R;
 use Response;
@@ -102,7 +103,7 @@ class ErrorHandling {
     } else {
 
       $handler = new CallbackHandler(function($exception, $inspector, $run) {
-        $html = tpl::load(dirname(__DIR__) . DS . 'views' . DS . 'fatal.php');
+        $html = tpl::load(c::get('fatal', dirname(__DIR__) . DS . 'views' . DS . 'fatal.php'));
         echo new Response($html, 'html', 500);
         return Handler::QUIT;
       });


### PR DESCRIPTION
This change would allow the setting of custom fatal error pages. Obviously we don't want fatal errors in production, but it would be nice to include site logos and custom messaging just in case.