### PR TITLE
.htaccess: Do not redirect for non-existing assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -38,11 +38,14 @@ RewriteRule ^(kirby|panel\/app|panel\/tests)/(.*) index.php [L]
 # make panel links work
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI} !^/panel/assets
 RewriteRule ^panel/(.*) panel/index.php [L]
 
 # make site links work
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI} !^/panel
+RewriteCond %{REQUEST_URI} !^/assets
 RewriteRule ^(.*) index.php [L]
 
 </IfModule>


### PR DESCRIPTION
Do not redirect to panel/index.php or index.php when assets are trying to be accessed that do not exist.

Fixes k-next/starterkit#321

@bastianallgeier I have no experience with htaccess, this seems to work but maybe you know a more elegant way.