### PR TITLE
Session refactoring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "michelf/php-smartypants": "1.8.*",
         "claviska/simpleimage": "3.3.*",
         "phpmailer/phpmailer": "6.0.*",
-        "defuse/php-encryption": "2.2.*",
         "filp/whoops": "2.2.*",
         "true/punycode": "2.1.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "71ba22eae4409369c69350b77985365f",
-    "content-hash": "a6832cd832ead9a21e64493a4f200215",
+    "content-hash": "ee63c6a124aba6917621e76580cb649d",
     "packages": [
         {
             "name": "claviska/simpleimage",
@@ -44,70 +43,7 @@
                 }
             ],
             "description": "A PHP class that makes working with images as simple as possible.",
-            "time": "2017-09-12 09:03:56"
-        },
-        {
-            "name": "defuse/php-encryption",
-            "version": "v2.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/defuse/php-encryption.git",
-                "reference": "0f407c43b953d571421e0020ba92082ed5fb7620"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/0f407c43b953d571421e0020ba92082ed5fb7620",
-                "reference": "0f407c43b953d571421e0020ba92082ed5fb7620",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "paragonie/random_compat": ">= 2",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "nikic/php-parser": "^2.0|^3.0|^4.0",
-                "phpunit/phpunit": "^4|^5"
-            },
-            "bin": [
-                "bin/generate-defuse-key"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Defuse\\Crypto\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Hornby",
-                    "email": "taylor@defuse.ca",
-                    "homepage": "https://defuse.ca/"
-                },
-                {
-                    "name": "Scott Arciszewski",
-                    "email": "info@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "Secure PHP Encryption Library",
-            "keywords": [
-                "aes",
-                "authenticated encryption",
-                "cipher",
-                "crypto",
-                "cryptography",
-                "encrypt",
-                "encryption",
-                "openssl",
-                "security",
-                "symmetric key cryptography"
-            ],
-            "time": "2018-07-24 23:27:56"
+            "time": "2017-09-12T09:03:56+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -153,7 +89,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2018-06-11 18:15:32"
+            "time": "2018-06-11T18:15:32+00:00"
         },
         {
             "name": "erusev/parsedown-extra",
@@ -203,7 +139,7 @@
                 "parsedown",
                 "parser"
             ],
-            "time": "2018-05-08 21:54:32"
+            "time": "2018-05-08T21:54:32+00:00"
         },
         {
             "name": "filp/whoops",
@@ -264,7 +200,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2018-06-30 13:14:06"
+            "time": "2018-06-30T13:14:06+00:00"
         },
         {
             "name": "league/color-extractor",
@@ -318,7 +254,7 @@
                 "image",
                 "palette"
             ],
-            "time": "2016-12-15 09:30:02"
+            "time": "2016-12-15T09:30:02+00:00"
         },
         {
             "name": "michelf/php-smartypants",
@@ -368,7 +304,7 @@
                 "typographer",
                 "typography"
             ],
-            "time": "2016-12-13 01:01:17"
+            "time": "2016-12-13T01:01:17+00:00"
         },
         {
             "name": "mustangostang/spyc",
@@ -418,56 +354,7 @@
                 "yaml",
                 "yml"
             ],
-            "time": "2017-02-24 16:06:33"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.17",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2018-07-04 16:31:37"
+            "time": "2017-02-24T16:06:33+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -531,7 +418,7 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "time": "2017-08-28 11:42:41"
+            "time": "2017-08-28T11:42:41+00:00"
         },
         {
             "name": "psr/log",
@@ -578,7 +465,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-04-03 15:59:15"
+            "time": "2018-04-03T15:59:15+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -637,7 +524,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-05-30 15:56:36"
+            "time": "2018-05-30T15:56:36+00:00"
         },
         {
             "name": "true/punycode",
@@ -683,7 +570,7 @@
                 "idna",
                 "punycode"
             ],
-            "time": "2016-11-16 10:37:54"
+            "time": "2016-11-16T10:37:54+00:00"
         }
     ],
     "packages-dev": [
@@ -747,7 +634,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2017-11-06 09:05:54"
+            "time": "2017-11-06T09:05:54+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -791,7 +678,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-04-11 15:42:36"
+            "time": "2018-04-11T15:42:36+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -859,7 +746,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2018-05-06 10:14:50"
+            "time": "2018-05-06T10:14:50+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -914,7 +801,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2018-03-05 09:41:42"
+            "time": "2018-03-05T09:41:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -971,7 +858,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2018-05-14 15:49:16"
+            "time": "2018-05-14T15:49:16+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -1067,7 +954,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-08-01 07:09:04"
+            "time": "2018-08-01T07:09:04+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1115,7 +1002,56 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11 23:09:50"
+            "time": "2018-06-11T23:09:50+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-04T16:31:37+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1170,7 +1106,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05 18:14:27"
+            "time": "2017-03-05T18:14:27+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1217,7 +1153,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05 17:38:23"
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -1268,7 +1204,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2018-02-15 16:58:55"
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1322,7 +1258,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1373,7 +1309,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30 07:14:17"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1420,7 +1356,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1483,7 +1419,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-07-31 07:47:46"
+            "time": "2018-07-31T07:47:46+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1546,7 +1482,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-07 12:06:18"
+            "time": "2018-04-07T12:06:18+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1593,7 +1529,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27 13:52:08"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1634,7 +1570,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1683,7 +1619,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-01-06 05:27:16"
+            "time": "2018-01-06T05:27:16+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1732,7 +1668,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27 08:47:38"
+            "time": "2017-11-27T08:47:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1740,12 +1676,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5744955af9c0a2de74a5eb5287c50bf025100d39"
+                "reference": "bc49df663c00971dcb1025e396f7283adc105121"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5744955af9c0a2de74a5eb5287c50bf025100d39",
-                "reference": "5744955af9c0a2de74a5eb5287c50bf025100d39",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bc49df663c00971dcb1025e396f7283adc105121",
+                "reference": "bc49df663c00971dcb1025e396f7283adc105121",
                 "shasum": ""
             },
             "require": {
@@ -1816,7 +1752,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-08-03 05:27:14"
+            "time": "2018-08-03T15:43:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1875,7 +1811,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-07-13 03:27:23"
+            "time": "2018-07-13T03:27:23+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1920,7 +1856,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2018-05-15 05:52:48"
+            "time": "2018-05-15T05:52:48+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1984,7 +1920,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01 13:46:46"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2036,7 +1972,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-12-14 11:32:19"
+            "time": "2017-12-14T11:32:19+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -2086,7 +2022,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2018-05-15 05:48:40"
+            "time": "2018-05-15T05:48:40+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2153,7 +2089,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2018-06-28 14:22:04"
+            "time": "2018-06-28T14:22:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2204,7 +2140,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2018-05-15 05:52:33"
+            "time": "2018-05-15T05:52:33+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2251,7 +2187,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2018-05-15 05:52:18"
+            "time": "2018-05-15T05:52:18+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -2296,7 +2232,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2018-05-15 05:50:44"
+            "time": "2018-05-15T05:50:44+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -2349,7 +2285,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2018-05-15 05:52:05"
+            "time": "2018-05-15T05:52:05+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2391,7 +2327,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-05-15 05:53:02"
+            "time": "2018-05-15T05:53:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2434,7 +2370,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/console",
@@ -2503,7 +2439,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 11:25:51"
+            "time": "2018-07-26T11:25:51+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -2560,7 +2496,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2018-07-13 17:06:58"
+            "time": "2018-07-13T17:06:58+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2624,7 +2560,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 09:13:01"
+            "time": "2018-07-26T09:13:01+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2674,7 +2610,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 11:25:51"
+            "time": "2018-07-26T11:25:51+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2723,7 +2659,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 11:25:51"
+            "time": "2018-07-26T11:25:51+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2777,7 +2713,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-07-26 08:59:12"
+            "time": "2018-07-26T08:59:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2835,7 +2771,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-05-17 18:32:56"
+            "time": "2018-05-17T18:32:56+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2894,7 +2830,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26 10:06:28"
+            "time": "2018-04-26T10:06:28+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -2949,7 +2885,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-07-01 15:19:55"
+            "time": "2018-07-01T15:19:55+00:00"
         },
         {
             "name": "symfony/process",
@@ -2998,7 +2934,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-03 11:20:06"
+            "time": "2018-08-03T11:20:06+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -3048,7 +2984,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 11:01:15"
+            "time": "2018-07-26T11:01:15+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3088,7 +3024,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07 12:08:54"
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3138,7 +3074,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-05-29 14:25:02"
+            "time": "2018-05-29T14:25:02+00:00"
         }
     ],
     "aliases": [],

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -233,7 +233,7 @@ class Session
     {
         if (is_int($duration)) {
             // verify that the duration is at least 1 second
-            if ($duration <= 0) {
+            if ($duration < 1) {
                 throw new InvalidArgumentException([
                     'data'      => ['method' => 'Session::duration', 'argument' => '$duration'],
                     'translate' => false
@@ -259,7 +259,7 @@ class Session
     {
         if (is_int($timeout) || $timeout === false) {
             // verify that the timeout is at least 1 second
-            if (is_int($timeout) && $timeout <= 0) {
+            if (is_int($timeout) && $timeout < 1) {
                 throw new InvalidArgumentException([
                     'data'      => ['method' => 'Session::timeout', 'argument' => '$timeout'],
                     'translate' => false
@@ -715,7 +715,7 @@ class Session
         $this->renewable    = $data['renewable'];
 
         // reload data into existing object to avoid breaking memory references
-        if ($this->data) {
+        if (is_a($this->data, SessionData::class)) {
             $this->data()->reload($data['data']);
         } else {
             $this->data = new SessionData($this, $data['data']);


### PR DESCRIPTION
As discussed previously, I have refactored the main `Session` class.

Main change: No longer uses encryption, so I was able to get rid of the `php-encryption` library. This has the following effects:

- Because encryption is no longer used, the loading time of a session is decreased by a few milliseconds.
- #398 is no longer needed.

A **side-effect** is that the session is now read-only in the short period of time (less than a second) between the regeneration of the session ID and the moment when the client starts using the new session ID. This happens every few hours and with every privilege change, but shouldn't be a problem as that timespan is very short and sessions are not often written to.

We should however look out if anyone reports the following Exception:

> Session "{token}" is currently read-only because it was accessed via an old session token

If this change turns out to be an issue, we can rollback to an intermediate version I have made a backup of. This intermediate version also doesn't use encryption, but it still has the #398 issue. Please assign any issue that is related to the Exception above to me. But let's hope there won't be any. :)