### PR TITLE
Extensible email templates

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1,9 +1,9 @@
 <?php
 
 use Kirby\Cms\App;
-use Kirby\Cms\Model;
 use Kirby\Cms\Filename;
 use Kirby\Cms\FileVersion;
+use Kirby\Cms\Model;
 use Kirby\Cms\Response;
 use Kirby\Cms\Template;
 use Kirby\Data\Data;
@@ -80,8 +80,8 @@ return [
 
         return Snippet::load($file, $data);
     },
-    'template' => function (App $kirby, string $name, string $type = 'html') {
-        return new Template($name, $type);
+    'template' => function (App $kirby, string $name, string $type = 'html', string $defaultType = 'html') {
+        return new Template($name, $type, $defaultType);
     },
     'thumb' => function (App $kirby, string $src, string $dst, array $options) {
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1043,9 +1043,9 @@ class App
      *
      * @return Template
      */
-    public function template(string $name, string $type = 'html'): Template
+    public function template(string $name, string $type = 'html', string $defaultType = 'html'): Template
     {
-        return $this->extensions['components']['template']($this, $name, $type);
+        return $this->extensions['components']['template']($this, $name, $type, $defaultType);
     }
 
     /**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -439,7 +439,6 @@ class App
 
         // any direct exception will be turned into an error page
         if (is_a($input, 'Throwable') === true) {
-
             $code    = $input->getCode();
             $message = $input->getMessage();
 

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -91,7 +91,7 @@ class Email
 
     protected function getTemplate(string $name, string $type = null)
     {
-        return App::instance()->template("emails/{$name}", $type, 'text');
+        return App::instance()->template('emails/' . $name, $type, 'text');
     }
 
     public function toArray(): array

--- a/src/Cms/Template.php
+++ b/src/Cms/Template.php
@@ -3,19 +3,53 @@
 namespace Kirby\Cms;
 
 use Exception;
-use Throwable;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Tpl;
 use Kirby\Toolkit\View;
+use Throwable;
 
+/**
+ * Represents a Kirby template and takes care
+ * of loading the correct file.
+ */
 class Template
 {
+
+    /**
+     * Global template data
+     *
+     * @var array
+     */
     public static $data = [];
 
+    /**
+     * The name of the template
+     *
+     * @var string
+     */
     protected $name;
+
+    /**
+     * Template type (html, json, etc.)
+     *
+     * @var string
+     */
     protected $type;
+
+    /**
+     * Default template type if no specific type is set
+     *
+     * @var string
+     */
     protected $defaultType;
 
+    /**
+     * Creates a new template object
+     *
+     * @param string $name
+     * @param string $type
+     * @param string $defaultType
+     */
     public function __construct(string $name, string $type = 'html', string $defaultType = 'html')
     {
         $this->name = strtolower($name);
@@ -23,37 +57,70 @@ class Template
         $this->defaultType = $defaultType;
     }
 
+    /**
+     * Converts the object to a simple string
+     * This is used in template filters for example
+     *
+     * @return string
+     */
     public function __toString(): string
     {
         return $this->name;
     }
 
+    /**
+     * Checks if the template exists
+     *
+     * @return boolean
+     */
     public function exists(): bool
     {
         return file_exists($this->file());
     }
 
+    /**
+     * Returns the expected template file extension
+     *
+     * @return string
+     */
     public function extension(): string
     {
         return 'php';
     }
 
+    /**
+     * Returns the default template type
+     *
+     * @return string
+     */
     public function defaultType(): string
     {
         return $this->defaultType;
     }
 
+    /**
+     * Returns the place where templates are located
+     * in the site folder and and can be found in extensions
+     *
+     * @return string
+     */
     public function store(): string
     {
         return 'templates';
     }
 
+    /**
+     * Detects the location of the template file
+     * if it exists.
+     *
+     * @return string|null
+     */
     public function file(): ?string
     {
-        if ($this->hasDefaultType()) {
+        if ($this->hasDefaultType() === true) {
             try {
                 // Try the default template in the default template directory.
-                return F::realpath("{$this->root()}/{$this->name()}.{$this->extension()}", $this->root());
+                return F::realpath($this->root() . '/' . $this->name() . '.' . $this->extension(), $this->root());
             } catch (Exception $e) {
                 //
             }
@@ -61,16 +128,16 @@ class Template
             // Look for the default template provided by an extension.
             $path = App::instance()->extension($this->store(), $this->name());
 
-            if (!is_null($path)) {
+            if ($path !== null) {
                 return $path;
             }
         }
 
-        $name = "{$this->name()}.{$this->type()}";
+        $name = $this->name() . '.' . $this->type();
 
         try {
             // Try the template with type extension in the default template directory.
-            return F::realpath("{$this->root()}/{$name}.{$this->extension()}", $this->root());
+            return F::realpath($this->root() . '/' . $name . '.' . $this->extension(), $this->root());
         } catch (Exception $e) {
             // Look for the template with type extension provided by an extension.
             // This might be null if the template does not exist.
@@ -78,6 +145,11 @@ class Template
         }
     }
 
+    /**
+     * Returns the template name
+     *
+     * @return string
+     */
     public function name(): string
     {
         return $this->name;
@@ -92,16 +164,31 @@ class Template
         return Tpl::load($this->file(), $data);
     }
 
+    /**
+     * Returns the root to the templates directory
+     *
+     * @return string
+     */
     public function root(): string
     {
         return App::instance()->root($this->store());
     }
 
+    /**
+     * Returns the template type
+     *
+     * @return string
+     */
     public function type(): string
     {
         return $this->type;
     }
 
+    /**
+     * Checks if the template uses the default type
+     *
+     * @return boolean
+     */
     public function hasDefaultType(): bool
     {
         $type = $this->type();

--- a/src/Cms/Template.php
+++ b/src/Cms/Template.php
@@ -14,11 +14,13 @@ class Template
 
     protected $name;
     protected $type;
+    protected $defaultType;
 
-    public function __construct(string $name, string $type = 'html')
+    public function __construct(string $name, string $type = 'html', string $defaultType = 'html')
     {
         $this->name = strtolower($name);
         $this->type = $type;
+        $this->defaultType = $defaultType;
     }
 
     public function __toString(): string
@@ -38,7 +40,7 @@ class Template
 
     public function defaultType(): string
     {
-        return 'html';
+        return $this->defaultType;
     }
 
     public function store(): string
@@ -56,6 +58,7 @@ class Template
                 //
             }
 
+            // Look for the default template provided by an extension.
             $path = App::instance()->extension($this->store(), $this->name());
 
             if (!is_null($path)) {
@@ -69,7 +72,8 @@ class Template
             // Try the template with type extension in the default template directory.
             return F::realpath("{$this->root()}/{$name}.{$this->extension()}", $this->root());
         } catch (Exception $e) {
-            // Finally look for the template with type extension provided by an extension.
+            // Look for the template with type extension provided by an extension.
+            // This might be null if the template does not exist.
             return App::instance()->extension($this->store(), $name);
         }
     }

--- a/tests/Cms/EmailTest.php
+++ b/tests/Cms/EmailTest.php
@@ -50,8 +50,8 @@ class EmailTest extends TestCase
     public function testEmailTemplate()
     {
         $app = new App([
-            'roots' => [
-                'emails' => __DIR__ . '/fixtures/emails'
+            'templates' => [
+                'emails/contact' => __DIR__ . '/fixtures/emails/contact.php'
             ]
         ]);
         $email = new Email([
@@ -66,13 +66,12 @@ class EmailTest extends TestCase
     public function testEmailTemplateHtml()
     {
         $app = new App([
-            'roots' => [
-                'emails' => __DIR__ . '/fixtures/emails'
+            'templates' => [
+                'emails/media.html' => __DIR__ . '/fixtures/emails/media.html.php',
+                'emails/media.text' => __DIR__ . '/fixtures/emails/media.text.php',
             ]
         ]);
-        $email = new Email([
-            'template' => 'media'
-        ]);
+        $email = new Email(['template' => 'media']);
         $this->assertEquals([
             'html' => '<b>Image:</b> <img src=""/>',
             'text' => 'Image: Description'

--- a/tests/Cms/EmailTest.php
+++ b/tests/Cms/EmailTest.php
@@ -156,8 +156,8 @@ class EmailTest extends TestCase
         $this->markTestIncomplete();
 
         $app = new App([
-            'roots' => [
-                'emails' => __DIR__ . '/fixtures/emails'
+            'templates' => [
+                'emails/user-info' => __DIR__ . '/fixtures/emails/user-info.php'
             ]
         ]);
 


### PR DESCRIPTION
**Edit:** Also see my comment below.

I wanted to replace the email snippet feature of my Uniform plugin with the new email templates. However, I noticed that it is not possible to define email templates in a plugin.

This PR implements extensible email templates that work just like extensible templates. I implemented a `$kirby->emailTemplate()` function which is used by the Email class. Plugins can define email templates in the usual way:

```php
Kirby::plugin('test/test', [
   'emails' => [
      'contact' => __DIR__ . '/emails/contact.php',
   ],
]);
```

Note that email templates are defined with the `email` key but the function to call them is `emailTemplate`. Do you want to change this?

I encountered one issue with this, though. Email templates are always defined without their type extension (`text`/`html`). Whether both templates exist was automatically determined. This was incompatible with the way (email-)templates are loaded with the extension system. So I updated the template lookup procedure for the default template type. I think it might be useful in other scenarios as well.

Old behavior (assuming `html` is the default template type):

1. Look for `site/templates/{$name}.php`
2. Look for template `$name` in the extensions

New behavior:

1. Look for `site/templates/{$name}.php`
2. Look for template `$name` in the extensions
3. Look for `site/templates/{$name}.html.php`
2. Look for template `{$name}.html` in the extensions

The behavior of loading a template with a non-default type stays the same.

CI failed because the CS fixer complained of a previous unrelated commit. I included these fixes here as well.