### PR TITLE
Reimplement basic options aliases

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -88,6 +88,22 @@ class Options
             case 'query':
                 $options = static::query($props['query'], $model);
                 break;
+            case 'children':
+            case 'grandChildren':
+            case 'siblings':
+            case 'index':
+            case 'files':
+            case 'images':
+            case 'documents':
+            case 'videos':
+            case 'audio':
+            case 'code':
+            case 'archives':
+                $options = static::query('page.' . $options, $model);
+                break;
+            case 'pages':
+                $options = static::query('site.index', $model);
+                break;
         }
 
         if (is_array($options) === false) {


### PR DESCRIPTION
As in https://getkirby.com/docs/cheatsheet/panel-fields/select

I did not reimplement things like `visibleChildren` - I think this is rather used rarely and in this case it could be a breaking change from v2 to v3, forcing developers to use the query syntax for these cases.
