### PR TITLE
fix: correct default ratio padding for Card

### DIFF
--- a/panel/src/ui/components/Layout/Card.vue
+++ b/panel/src/ui/components/Layout/Card.vue
@@ -76,7 +76,7 @@ export default {
       return this.link ? "k-link" : "div";
     },
     ratioPadding() {
-      return ratioPadding(this.image.ratio);
+      return (this.image && this.image.ratio) ? ratioPadding(this.image.ratio) : ratioPadding('3/2');
     }
   }
 };


### PR DESCRIPTION
ratioPadding is only used if there is no image or no image.src, so it needs a fallback