### PR TITLE
Correct German licence translation

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -13,7 +13,7 @@
   "discard": "Verwerfen",
   "edit": "Bearbeiten",
   "install": "Installieren",
-  "license": "Lizens",
+  "license": "Lizenz",
   "login": "Einloggen",
   "logout": "Ausloggen",
   "more": "More",


### PR DESCRIPTION
`Lizens` to `Lizenz`.

I made that mistake countless times myself. 😄 