### PR TITLE
Session fixes

### DIFF
--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -24,11 +24,6 @@ return [
         'auth'    => false,
         'action'  => function () {
 
-            // logout previous users
-            // if ($user = $this->kirby()->user()) {
-            //     $user->logout();
-            // }
-
             // session options
             $options = [
                 'createMode' => 'cookie',
@@ -48,7 +43,7 @@ return [
 
             // sleep for a random amount of milliseconds
             // to make automated attacks harder
-            usleep(rand(1000, 2000000));
+            usleep(random_int(1000, 2000000));
 
             throw new InvalidArgumentException('Invalid email or password');
 

--- a/src/Session/AutoSession.php
+++ b/src/Session/AutoSession.php
@@ -111,10 +111,18 @@ class AutoSession
         // always use the less strict value for compatibility with features
         // that depend on the less strict behavior
         if ($duration > $session->duration()) {
+            // the duration needs to be extended
             $session->duration($duration);
         }
-        if (($timeout === false && $session->timeout() !== false) || $timeout > $session->timeout()) {
-            $session->timeout($timeout);
+        if ($session->timeout() !== false) {
+            // a timeout exists
+            if ($timeout === false) {
+                // it needs to be completely disabled
+                $session->timeout(false);
+            } elseif (is_int($timeout) && $timeout > $session->timeout()) {
+                // it needs to be extended
+                $session->timeout($timeout);
+            }
         }
 
         // if the session has been created and was not yet initialized,

--- a/src/Session/FileSessionStore.php
+++ b/src/Session/FileSessionStore.php
@@ -77,8 +77,10 @@ class FileSessionStore extends SessionStore
         // very unlikely scenario!
         $contents = $this->get($expiryTime, $id);
         if ($contents !== '') {
+            // @codeCoverageIgnoreStart
             $this->unlock($expiryTime, $id);
             return $this->createId($expiryTime);
+            // @codeCoverageIgnoreEnd
         }
 
         return $id;
@@ -128,12 +130,14 @@ class FileSessionStore extends SessionStore
         if ($result === true) {
             $this->isLocked[$name] = true;
         } else {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -167,12 +171,14 @@ class FileSessionStore extends SessionStore
         if ($result === true) {
             unset($this->isLocked[$name]);
         } else {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -197,12 +203,14 @@ class FileSessionStore extends SessionStore
             $result = flock($handle, LOCK_SH);
 
             if ($result !== true) {
+                // @codeCoverageIgnoreStart
                 throw new Exception([
                     'key'       => 'session.filestore.unexpectedFilesystemError',
                     'fallback'  => 'Unexpected file system error',
                     'translate' => false,
                     'httpCode'  => 500
                 ]);
+                // @codeCoverageIgnoreEnd
             }
         }
 
@@ -222,12 +230,14 @@ class FileSessionStore extends SessionStore
             $result = flock($handle, LOCK_UN);
 
             if ($result !== true) {
+                // @codeCoverageIgnoreStart
                 throw new Exception([
                     'key'       => 'session.filestore.unexpectedFilesystemError',
                     'fallback'  => 'Unexpected file system error',
                     'translate' => false,
                     'httpCode'  => 500
                 ]);
+                // @codeCoverageIgnoreEnd
             }
         }
 
@@ -264,23 +274,27 @@ class FileSessionStore extends SessionStore
 
         // delete all file contents first
         if (rewind($handle) !== true || ftruncate($handle, 0) !== true) {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
 
         // write the new contents
         $result = fwrite($handle, $data);
         if (!is_int($result) || $result === 0) {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -312,12 +326,14 @@ class FileSessionStore extends SessionStore
 
         // file still exists, delete it
         if (@unlink($path) !== true) {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -456,12 +472,14 @@ class FileSessionStore extends SessionStore
         $result = fclose($handle);
 
         if ($result !== true) {
+            // @codeCoverageIgnoreStart
             throw new Exception([
                 'key'       => 'session.filestore.unexpectedFilesystemError',
                 'fallback'  => 'Unexpected file system error',
                 'translate' => false,
                 'httpCode'  => 500
             ]);
+            // @codeCoverageIgnoreEnd
         }
     }
 }

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -205,6 +205,21 @@ class AutoSessionTest extends TestCase
         $this->assertEquals('awesome session', $session->data()->get('id'));
         $this->assertEquals(7300, $session->duration());
         $this->assertEquals(false, $session->timeout());
+        Cookie::remove('kirby_session');
+
+        // timeout for the first time: shouldn't change anything
+        $autoSession = new AutoSession($this->store);
+        $session = $autoSession->get(['long' => true]);
+        $this->assertEquals(1209600, $session->duration());
+        $this->assertEquals(false, $session->timeout());
+        $session->data()->set('id', 'awesome session');
+        $session->commit();
+        Cookie::set('kirby_session', $session->token());
+        $session = $autoSession->get();
+        $this->assertEquals('awesome session', $session->data()->get('id'));
+        $this->assertEquals(1209600, $session->duration());
+        $this->assertEquals(false, $session->timeout());
+        $session->commit();
     }
 
     public function testCreateManually()


### PR DESCRIPTION
Should hopefully finally fix #472.

The issue was that the `csrf()` helper requests a session object but doesn't tell Kirby whether it wants a "long" or normal session. Intended behavior is that the existing state is kept, but there was a logic error in the `AutoSession` class, so the timeout is being reset to the default (half an hour).

I have also made some other enhancements to auth/session handling like support for serialization (#1070).