### PR TITLE
Improvements to KirbyTag parsing

### DIFF
--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -67,7 +67,7 @@ class KirbyTag
         return (new static(...$arguments))->render();
     }
 
-    public static function parse(string $string, array $data = [], array $options = []): string
+    public static function parse(string $string, array $data = [], array $options = []): self
     {
         // remove the brackets
         $tag  = trim(rtrim(ltrim($string, '('), ')'));
@@ -95,7 +95,7 @@ class KirbyTag
 
         $value = array_shift($attributes);
 
-        return (new static($type, $value, $attributes, $data, $options))->render();
+        return new static($type, $value, $attributes, $data, $options);
     }
 
     public function option(string $key, $default = null)

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -69,30 +69,36 @@ class KirbyTag
 
     public static function parse(string $string, array $data = [], array $options = []): self
     {
-        // remove the brackets
+        // remove the brackets, extract the first attribute (the tag type)
         $tag  = trim(rtrim(ltrim($string, '('), ')'));
         $type = trim(substr($tag, 0, strpos($tag, ':')));
         $attr = static::$types[$type]['attr'] ?? [];
 
+        // the type should be parsed as an attribute, so we add it here
+        // to the list of possible attributes
         array_unshift($attr, $type);
 
         // extract all attributes
-        $search = preg_split('!(' . implode('|', $attr) . '):!i', $tag, false, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        $num    = 0;
+        $regex = sprintf('/\s*(%s):\s*/i', implode('|', $attr));
+        $search = preg_split($regex, $tag, false, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
-        $attributes = [];
+        // $search is now an array with alternating keys and values
+        // convert it to arrays of keys and values
+        $chunks = array_chunk($search, 2);
+        $keys   = array_column($chunks, 0);
+        $values = array_column($chunks, 1);
 
-        foreach ($search as $key) {
-            if (!isset($search[$num + 1])) {
-                break;
-            }
-            $key   = trim($search[$num]);
-            $value = trim($search[$num + 1]);
-
-            $attributes[$key] = $value;
-            $num = $num + 2;
+        // ensure that there is a value for each key
+        // otherwise combining won't work
+        if (count($values) < count($keys)) {
+            $values[] = '';
         }
 
+        // combine the two arrays to an associative array
+        $attributes = array_combine($keys, $values);
+
+        // the first attribute is the type attribute
+        // extract and pass its value separately
         $value = array_shift($attributes);
 
         return new static($type, $value, $attributes, $data, $options);

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -105,8 +105,10 @@ class KirbyTag
 
     public function render()
     {
-        if (is_a(static::$types[$this->type]['html'], 'Closure') === true) {
-            return static::$types[$this->type]['html']($this, $this);
+        $callback = static::$types[$this->type]['html'] ?? null;
+
+        if (is_a($callback, Closure::class) === true) {
+            return $callback($this);
         }
 
         throw new BadMethodCallException('Invalid tag render function in tag: ' . $this->type);

--- a/src/Text/KirbyTags.php
+++ b/src/Text/KirbyTags.php
@@ -18,7 +18,7 @@ class KirbyTags
     {
         return preg_replace_callback('!(?=[^\]])\([a-z0-9_-]+:.*?\)!is', function ($match) use ($data, $options) {
             try {
-                return static::$tagClass::parse($match[0], $data, $options);
+                return static::$tagClass::parse($match[0], $data, $options)->render();
             } catch (Exception $e) {
                 return $match[0];
             }

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -15,6 +15,13 @@ class KirbyTagTest extends TestCase
                 'html' => function () {
                     return 'test';
                 }
+            ],
+            'noHtml' => [
+                'attr' => ['a', 'b']
+            ],
+            'invalidHtml' => [
+                'attr' => ['a', 'b'],
+                'html' => 'some string'
             ]
         ];
     }
@@ -50,6 +57,46 @@ class KirbyTagTest extends TestCase
 
         $this->assertNull($tag->b);
         $this->assertEquals('fallback', $tag->attr('b', 'fallback'));
+    }
+
+    public function testRender()
+    {
+        $tag = new KirbyTag('test', 'test value', [
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ]);
+        $this->assertEquals('test: test value-attrA-attrB', $tag->render());
+
+        $tag = new KirbyTag('test', '', [
+            'a' => 'attrA'
+        ]);
+        $this->assertEquals('test: -attrA-', $tag->render());
+    }
+
+    /**
+     * @expectedException        Kirby\Exception\BadMethodCallException
+     * @expectedExceptionMessage Invalid tag render function in tag: noHtml
+     */
+    public function testRenderNoHtml()
+    {
+        $tag = new KirbyTag('noHtml', 'test value', [
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ]);
+        $tag->render();
+    }
+
+    /**
+     * @expectedException        Kirby\Exception\BadMethodCallException
+     * @expectedExceptionMessage Invalid tag render function in tag: invalidHtml
+     */
+    public function testRenderInvalidHtml()
+    {
+        $tag = new KirbyTag('invalidHtml', 'test value', [
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ]);
+        $tag->render();
     }
 
 }

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -33,7 +33,6 @@ class KirbyTagTest extends TestCase
 
     public function testAttr()
     {
-
         $tag = new KirbyTag('test', 'test value', [
             'a' => 'attrA',
             'b' => 'attrB'
@@ -44,13 +43,12 @@ class KirbyTagTest extends TestCase
         $this->assertEquals('attrB', $tag->b);
 
         // attr helper
-        $this->assertEquals('attrA', $tag->attr('a'));
-        $this->assertEquals('attrB', $tag->attr('b'));
+        $this->assertEquals('attrA', $tag->attr('a', 'fallback'));
+        $this->assertEquals('attrB', $tag->attr('b', 'fallback'));
     }
 
     public function testAttrFallback()
     {
-
         $tag = new KirbyTag('test', 'test value', [
             'a' => 'attrA'
         ]);

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -12,8 +12,8 @@ class KirbyTagTest extends TestCase
         KirbyTag::$types = [
             'test' => [
                 'attr' => ['a', 'b'],
-                'html' => function () {
-                    return 'test';
+                'html' => function ($tag) {
+                    return 'test: ' . $tag->value . '-' . $tag->a . '-' . $tag->b;
                 }
             ],
             'noHtml' => [
@@ -55,6 +55,96 @@ class KirbyTagTest extends TestCase
 
         $this->assertNull($tag->b);
         $this->assertEquals('fallback', $tag->attr('b', 'fallback'));
+    }
+
+    public function testParse()
+    {
+        $tag = KirbyTag::parse('(test: test value)', ['some' => 'data'], ['some' => 'options']);
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals(['some' => 'data'], $tag->data);
+        $this->assertEquals(['some' => 'options'], $tag->options);
+        $this->assertEquals([], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([], $tag->attrs);
+
+        $tag = KirbyTag::parse('test:');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('', $tag->value);
+        $this->assertEquals([], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: ');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('', $tag->value);
+        $this->assertEquals([], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA b: attrB');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test:test value a:attrA b:attrB');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA b:');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => ''
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA b: ');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => ''
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA b: attrB ');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => 'attrB'
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA c: attrC b: attrB');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA c: attrC',
+            'b' => 'attrB'
+        ], $tag->attrs);
+
+        $tag = KirbyTag::parse('test: test value a: attrA b: attrB c: attrC');
+        $this->assertEquals('test', $tag->type);
+        $this->assertEquals('test value', $tag->value);
+        $this->assertEquals([
+            'a' => 'attrA',
+            'b' => 'attrB c: attrC'
+        ], $tag->attrs);
+    }
+
+    /**
+     * @expectedException        Kirby\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Undefined tag type: invalid
+     */
+    public function testParseInvalid()
+    {
+        KirbyTag::parse('invalid: test value a: attrA b: attrB');
     }
 
     public function testRender()


### PR DESCRIPTION
I'm currently working on something similar to KirbyTags for a personal project and took the Kirby code as an inspiration.

While I was coding unit tests for that personal project, I noticed that some edge cases are not handled correctly by the parser. Therefore I refactored it and migrated those improvements and unit tests back to the KirbyTag parser.