### PR TITLE
fixes user->isAdmin() by adding the role id

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -317,7 +317,7 @@ class User extends ModelWithContent
      */
     public function isAdmin(): bool
     {
-        return $this->role() === 'admin';
+        return $this->role()->id() === 'admin';
     }
 
     /**


### PR DESCRIPTION
For me `$kirby->user()->isAdmin()` does not work, because `$this->role()` returns an object which is than compared to a string.