### PR TITLE
Fixed content representations in multi language sites.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -132,22 +132,7 @@ return function ($kirby) {
             'method'  => 'ALL',
             'env'     => 'site',
             'action'  => function (string $path) use ($kirby) {
-
-                if ($page = $kirby->page($path)) {
-
-                    $url = $kirby->request()->url([
-                        'query'    => null,
-                        'params'   => null,
-                        'fragment' => null
-                    ]);
-
-                    if ($url->toString() !== $page->url()) {
-                        go($page->url());
-                    }
-
-                    return $page;
-                }
-
+                return $kirby->resolve($path);
             }
         ];
 


### PR DESCRIPTION
This pull request makes content representations working again with multi language sites.

Previously requests to special representations would result in 404 pages as the extension was not handled separately. 

**Important:** This change removes the ability to redirect to the proper page URL. As this is also not used in non multi languages sites, I'm not sure if that is still required.

This might also resolve https://github.com/k-next/kirby/issues/959