### PR TITLE
Allow html markup as k-list-item's info

### DIFF
--- a/panel/src/ui/components/Layout/ListItem.vue
+++ b/panel/src/ui/components/Layout/ListItem.vue
@@ -18,7 +18,7 @@
       </figure>
       <figcaption class="k-list-item-text">
         <em>{{ text }}</em>
-        <small v-if="info">{{ info }}</small>
+        <small v-if="info" v-html="info" />
       </figcaption>
     </k-link>
     <div class="k-list-item-options">


### PR DESCRIPTION
Improves the info's flexibility, plain text will still be rendered as such.

![kirby-pr](https://user-images.githubusercontent.com/14079751/49137688-7b9f2b80-f2ed-11e8-9731-8af1da09904a.jpg)
