### PR TITLE
Fix users-field-preview when there's no avatar

### DIFF
--- a/panel/src/ui/components/Forms/Previews/UsersFieldPreview.vue
+++ b/panel/src/ui/components/Forms/Previews/UsersFieldPreview.vue
@@ -4,7 +4,7 @@
       <figure>
         <k-link :title="user.email" :to="$api.users.link(user.id)" @click.native.stop>
           <k-image
-            v-if="user.avatar.exists"
+            v-if="user.avatar"
             :src="user.avatar.url"
             class="k-users-field-preview-avatar"
             back="pattern"


### PR DESCRIPTION
Else it'll throw an error: `Cannot read property 'exists' of null`.