### PR TITLE
Fixed return type of option() helper

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -453,7 +453,7 @@ function markdown(string $text = null): string
  *
  * @param string $key
  * @param mixed $default
- * @return void
+ * @return mixed
  */
 function option(string $key, $default = null)
 {


### PR DESCRIPTION
Return type of option() helper is mixed according to [App::option()](https://github.com/k-next/kirby/blob/master/src/Cms/App.php#L641)