### PR TITLE
Fix api basic auth usage for local env

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -69,8 +69,8 @@ class Auth
             throw new InvalidArgumentException('Invalid authorization header');
         }
 
-        // only allow basic auth when https is enabled
-        if ($request->ssl() === false) {
+        // only allow basic auth when https is enabled or when in local environment
+        if (!$this->kirby->system()->isLocal() && $request->ssl() === false) {
             throw new PermissionException('Basic authentication is only allowed over HTTPS');
         }
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -70,7 +70,7 @@ class Auth
         }
 
         // only allow basic auth when https is enabled or when in local environment
-        if (!$this->kirby->system()->isLocal() && $request->ssl() === false) {
+        if (!System::isLocalEnv($this->kirby->server()) && $request->ssl() === false) {
             throw new PermissionException('Basic authentication is only allowed over HTTPS');
         }
 

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -7,6 +7,7 @@ use Kirby\Data\Json;
 use Kirby\Exception\Exception;
 use Kirby\Exception\PermissionException;
 use Kirby\Http\Remote;
+use Kirby\Http\Server;
 use Kirby\Http\Uri;
 use Kirby\Http\Url;
 use Kirby\Toolkit\Dir;
@@ -154,12 +155,12 @@ class System
     /**
      * Check if this is a local installation
      *
+     * @param Server $server
      * @return boolean
      */
-    public function isLocal(): bool
+    public static function isLocalEnv(Server $server): bool
     {
-        $server = $this->app->server();
-        $host   = $server->host();
+        $host = $server->host();
 
         if ($host === 'localhost') {
             return true;
@@ -182,6 +183,15 @@ class System
         }
 
         return false;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isLocal(): bool
+    {
+        $server = $this->app->server();
+        return static::isLocalEnv($server);
     }
 
     /**


### PR DESCRIPTION
Using basic auth for api endpoints requires an ssl connection atm, which is not typical for a localhost/dev env