### PR TITLE
Add help text for sections

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -8,6 +8,7 @@ return [
     'mixins' => [
         'empty',
         'headline',
+        'help',
         'layout',
         'min',
         'max',

--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -4,7 +4,8 @@ use Kirby\Toolkit\I18n;
 
 return [
     'mixins' => [
-        'headline'
+        'headline',
+        'help'
     ],
     'props' => [
         'text' => function ($text = null) {

--- a/config/sections/mixins/help.php
+++ b/config/sections/mixins/help.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'props' => [
+        /**
+         * Sets the help text
+         */
+        'help' => function ($help = null) {
+            return I18n::translate($help, $help);
+        }
+    ]
+];

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -10,6 +10,7 @@ return [
     'mixins' => [
         'empty',
         'headline',
+        'help',
         'layout',
         'min',
         'max',

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -51,6 +51,14 @@
 
     </template>
 
+    <footer v-if="help">
+      <k-text
+        theme="help"
+        class="k-section-help"
+        v-html="help"
+      />
+    </footer>
+
   </section>
 
 </template>

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -69,4 +69,7 @@ export default {
     left: 0;
   }
 }
+.k-section-help {
+  padding-top: 0.5rem;
+}
 </style>

--- a/panel/src/mixins/section.js
+++ b/panel/src/mixins/section.js
@@ -1,8 +1,9 @@
 export default {
   props: {
-    parent: String,
     blueprint: String,
-    name: String
+    help: String,
+    name: String,
+    parent: String
   },
   methods: {
     load() {

--- a/panel/src/mixins/section/collection.js
+++ b/panel/src/mixins/section/collection.js
@@ -1,7 +1,8 @@
 export default {
   props: {
-    parent: String,
     blueprint: String,
+    parent: String,
+    help: String,
     name: String
   },
   data() {

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -404,6 +404,7 @@ trait AppPlugins
         // section mixins
         Section::$mixins['empty']          = include static::$root . '/config/sections/mixins/empty.php';
         Section::$mixins['headline']       = include static::$root . '/config/sections/mixins/headline.php';
+        Section::$mixins['help']           = include static::$root . '/config/sections/mixins/help.php';
         Section::$mixins['layout']         = include static::$root . '/config/sections/mixins/layout.php';
         Section::$mixins['max']            = include static::$root . '/config/sections/mixins/max.php';
         Section::$mixins['min']            = include static::$root . '/config/sections/mixins/min.php';

--- a/tests/Cms/FilesSectionTest.php
+++ b/tests/Cms/FilesSectionTest.php
@@ -199,4 +199,29 @@ class FilesSectionTest extends TestCase
         $data = $section->data();
         $this->assertEquals('(image: a/a.jpg)', $data[0]['dragText']);
     }
+
+    public function testHelp()
+    {
+
+        // single help
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'help'  => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->help());
+
+        // translated help
+        $section = new Section('files', [
+            'name'     => 'test',
+            'model'    => new Page(['slug' => 'test']),
+            'help' => [
+                'en' => 'Information',
+                'de' => 'Informationen'
+            ]
+        ]);
+
+        $this->assertEquals('Information', $section->help());
+    }
 }

--- a/tests/Cms/InfoSectionTest.php
+++ b/tests/Cms/InfoSectionTest.php
@@ -33,12 +33,12 @@ class InfoSectionTest extends TestCase
             'name'     => 'test',
             'model'    => new Page(['slug' => 'test']),
             'headline' => [
-                'en' => 'Informations',
+                'en' => 'Information',
                 'de' => 'Informationen'
             ]
         ]);
 
-        $this->assertEquals('Informations', $section->headline());
+        $this->assertEquals('Information', $section->headline());
     }
 
     public function testText()
@@ -58,11 +58,49 @@ class InfoSectionTest extends TestCase
             'name'  => 'test',
             'model' => new Page(['slug' => 'test']),
             'text'  => [
-                'en' => 'Informations',
+                'en' => 'Information',
                 'de' => 'Informationen'
             ]
         ]);
 
-        $this->assertEquals('<p>Informations</p>', $section->text());
+        $this->assertEquals('<p>Information</p>', $section->text());
+    }
+
+    public function testTheme()
+    {
+
+        // single help
+        $section = new Section('info', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'theme' => 'notice'
+        ]);
+
+        $this->assertEquals('notice', $section->theme());
+    }
+
+    public function testHelp()
+    {
+
+        // single help
+        $section = new Section('info', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'help'  => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->help());
+
+        // translated help
+        $section = new Section('info', [
+            'name'     => 'test',
+            'model'    => new Page(['slug' => 'test']),
+            'help' => [
+                'en' => 'Information',
+                'de' => 'Informationen'
+            ]
+        ]);
+
+        $this->assertEquals('Information', $section->help());
     }
 }

--- a/tests/Cms/PagesSectionTest.php
+++ b/tests/Cms/PagesSectionTest.php
@@ -113,7 +113,6 @@ class PagesSectionTest extends TestCase
 
     public function testTemplates()
     {
-
         // single template
         $section = new Section('pages', [
             'name'      => 'test',
@@ -162,5 +161,30 @@ class PagesSectionTest extends TestCase
         ]);
 
         $this->assertEquals('Test', $section->empty());
+    }
+
+    public function testHelp()
+    {
+
+        // single help
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'help'  => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->help());
+
+        // translated help
+        $section = new Section('pages', [
+            'name'     => 'test',
+            'model'    => new Page(['slug' => 'test']),
+            'help' => [
+                'en' => 'Information',
+                'de' => 'Informationen'
+            ]
+        ]);
+
+        $this->assertEquals('Information', $section->help());
     }
 }


### PR DESCRIPTION
**Describe the PR**
PR adds an `help` option to the info, pages and files sections, which is displayed as help text below the section when defined.

**Related issues**
- Fixes getkirby/ideas#11

**Todos**
- [x] Human-readable commit messages
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] Add unit tests for feature
- [x] Pass all unit tests
- [x] Documented on getkirby.com