### PR TITLE
Added :move property and event Parameters in draggable component. Fixes #1365

### DIFF
--- a/panel/src/ui/components/Misc/Draggable.vue
+++ b/panel/src/ui/components/Misc/Draggable.vue
@@ -2,6 +2,7 @@
   <draggable
     :element="element"
     :list="list"
+    :move="move"
     :options="dragOptions"
     class="k-draggable"
     v-on="listeners"
@@ -22,24 +23,25 @@ export default {
     element: String,
     handle: [String, Boolean],
     list: [Array, Object],
+    move: Function,
     options: Object
   },
   data() {
     return {
       listeners: {
         ...this.$listeners,
-        start: () => {
+        start: (event) => {
           this.$store.dispatch("drag", {});
 
           if (this.$listeners.start) {
-            this.$listeners.start();
+            this.$listeners.start(event);
           }
         },
-        end: () => {
+        end: (event) => {
           this.$store.dispatch("drag", null);
 
           if (this.$listeners.end) {
-            this.$listeners.end();
+            this.$listeners.end(event);
           }
         }
       }


### PR DESCRIPTION
Basically the same as https://github.com/getkirby/kirby/pull/1366 : It adds the event parameters to the callbacks of the `start` and `end`event

Additionally, this pull request adds the `:move` property to the component. This property is also present in the vuedraggable component and should therefore be available in Kirby's draggable component, since it is described as a wrapper. As pointed out int the [vuedraggable docs](https://github.com/SortableJS/Vue.Draggable#move) "this function will be called in a similar way as Sortable onMove callback." I have no idea why this isn't an event, i.e. is called by @move, but it is how it is.

This property is urgently needed by the builder plugin. A merge would be appreciated.