### PR TITLE
Add api.allowInsecure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kirby
 
-[![Build Status](https://travis-ci.com/k-next/kirby.svg?branch=master)](https://travis-ci.com/k-next/kirby)
+[![Build Status](https://travis-ci.com/getkirby/kirby.svg?branch=master)](https://travis-ci.com/k-next/kirby)
 
 This is Kirby's core application folder. Get started with one of the following repositories instead:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kirby
 
-[![Build Status](https://travis-ci.com/getkirby/kirby.svg?branch=master)](https://travis-ci.com/k-next/kirby)
+[![Build Status](https://travis-ci.com/getkirby/kirby.svg?branch=master)](https://travis-ci.com/getkirby/kirby)
 
 This is Kirby's core application folder. Get started with one of the following repositories instead:
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -69,8 +69,8 @@ class Auth
             throw new InvalidArgumentException('Invalid authorization header');
         }
 
-        // only allow basic auth when https is enabled
-        if ($request->ssl() === false) {
+        // only allow basic auth when https is enabled or insecure requests permitted
+        if ($request->ssl() === false && $this->kirby->option('api.allowInsecure', false) !== true) {
             throw new PermissionException('Basic authentication is only allowed over HTTPS');
         }
 


### PR DESCRIPTION
Relates to issues  #1386 and #1360

This PR would add the option `api.allowInsecure` which prevents error being thrown in the basic auth API without HTTPS.
