### PR TITLE
Fixes #1422

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -146,6 +146,8 @@ class Form
                 $strings[$key] = null;
             } elseif (is_array($value) === true) {
                 $strings[$key] = Yaml::encode($value);
+            } elseif (is_float($value) === true) {
+                $strings[$key] = str_replace(',', '.', $value);
             } else {
                 $strings[$key] = (string)$value;
             }


### PR DESCRIPTION
Casting float values to strings like `(string) 4.5` will result in `"4,5"` for locales using `,` as decimal point like `de_DE` otherwise.