### PR TITLE
Fix for Blueprint Datetime Usage #1424

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -380,7 +380,7 @@ trait PageActions
                 return 0;
             case 'date':
             case 'datetime':
-                $format = 'date' ? 'Ymd' : 'YmdHi';
+                $format = 'date' == $mode ? 'Ymd' : 'YmdHi';
                 $date   = $this->content()->get('date')->value();
                 $time   = empty($date) === true ? time() : strtotime($date);
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -380,7 +380,7 @@ trait PageActions
                 return 0;
             case 'date':
             case 'datetime':
-                $format = 'date' == $mode ? 'Ymd' : 'YmdHi';
+                $format = $mode === 'date' ? 'Ymd' : 'YmdHi';
                 $date   = $this->content()->get('date')->value();
                 $time   = empty($date) === true ? time() : strtotime($date);
 


### PR DESCRIPTION
This PR resolves https://github.com/getkirby/kirby/issues/1424. The previous code treated `datetime` as `date`.