### PR TITLE
Fix pages section `templates` option

### DIFF
--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -68,6 +68,12 @@ return [
             return $status;
         },
         /**
+         * Filters the list by templates and sets template options when adding new pages to the section.
+         */
+        'templates' => function ($templates = null) {
+            return A::wrap($templates ?? $this->template);
+        },
+        /**
          * Setup for the main text in the list or cards. By default this will display the page title.
          */
         'text' => function (string $text = '{{ page.title }}') {
@@ -77,9 +83,6 @@ return [
     'computed' => [
         'dragTextType' => function () {
             return option('panel.kirbytext', true) ? 'kirbytext' : 'markdown';
-        },
-        'templates' => function () {
-            return A::wrap($this->templates ?? $this->template);
         },
         'parent' => function () {
             return $this->parentModel();

--- a/tests/Cms/PagesSectionTest.php
+++ b/tests/Cms/PagesSectionTest.php
@@ -110,4 +110,35 @@ class PagesSectionTest extends TestCase
         // non-existing covers
         $this->assertNull($data[2]['image']['url'] ?? null);
     }
+
+    public function testTemplates()
+    {
+
+        // single template
+        $section = new Section('pages', [
+            'name'      => 'test',
+            'model'     => new Page(['slug' => 'test']),
+            'templates' => 'blog'
+        ]);
+
+        $this->assertEquals(['blog'], $section->templates());
+
+        // multiple templates
+        $section = new Section('pages', [
+            'name'      => 'test',
+            'model'     => new Page(['slug' => 'test']),
+            'templates' => ['blog', 'notes']
+        ]);
+
+        $this->assertEquals(['blog', 'notes'], $section->templates());
+
+        // template via alias
+        $section = new Section('pages', [
+            'name'     => 'test',
+            'model'    => new Page(['slug' => 'test']),
+            'template' => 'blog'
+        ]);
+
+        $this->assertEquals(['blog'], $section->templates());
+    }
 }


### PR DESCRIPTION
**Describe the PR**
Deprecates `template` option in favour of `templates` option. `template` option still can be used as fallback. Adding `templates` as explicit prop to be documented on website.

**Related issues**
- getkirby/getkirby.com#197
- getkirby/getkirby.com#266

**Todos**
- [x] Add unit tests for fixed bug
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`