### PR TITLE
Inline version of KirbyText

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -51,12 +51,12 @@ return [
     'file::url' => function (App $kirby, $file) {
         return $file->mediaUrl();
     },
-    'markdown' => function (App $kirby, string $text = null, array $options = []): string {
+    'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
         static $markdown;
 
         $markdown = $markdown ?? new Markdown($options);
 
-        return $markdown->parse($text);
+        return $markdown->parse($text, $inline);
     },
     'smartypants' => function (App $kirby, string $text = null, array $options = []): string {
         static $smartypants;

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -429,6 +429,43 @@ function kirbytext(string $text = null, array $data = []): string
 }
 
 /**
+ * Shortcut for `kirbytext()` helper
+ *
+ * @param string $text
+ * @param array $data
+ * @return string
+ */
+function kt(string $text = null, array $data = []): string
+{
+    return kirbytext($text, $data);
+}
+
+/**
+ * Parses KirbyTags and inline Markdown in the
+ * given string.
+ *
+ * @param string $text
+ * @param array $data
+ * @return string
+ */
+function kirbytextinline(string $text = null, array $data = []): string
+{
+    return App::instance()->kirbytext($text, $data, true);
+}
+
+/**
+ * Shortcut for `kirbytextinline()` helper
+ *
+ * @param string $text
+ * @param array $data
+ * @return string
+ */
+function kti(string $text = null, array $data = []): string
+{
+    return kirbytextinline($text, $data);
+}
+
+/**
  * A super simple class autoloader
  *
  * @param array $classmap

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -429,18 +429,6 @@ function kirbytext(string $text = null, array $data = []): string
 }
 
 /**
- * Shortcut for `kirbytext()` helper
- *
- * @param string $text
- * @param array $data
- * @return string
- */
-function kt(string $text = null, array $data = []): string
-{
-    return kirbytext($text, $data);
-}
-
-/**
  * Parses KirbyTags and inline Markdown in the
  * given string.
  *
@@ -451,6 +439,18 @@ function kt(string $text = null, array $data = []): string
 function kirbytextinline(string $text = null, array $data = []): string
 {
     return App::instance()->kirbytext($text, $data, true);
+}
+
+/**
+ * Shortcut for `kirbytext()` helper
+ *
+ * @param string $text
+ * @param array $data
+ * @return string
+ */
+function kt(string $text = null, array $data = []): string
+{
+    return kirbytext($text, $data);
 }
 
 /**

--- a/config/methods.php
+++ b/config/methods.php
@@ -299,6 +299,18 @@ return function (App $app) {
         },
 
         /**
+         * Converts the field content from inline Markdown/Kirbytext to valid HTML
+         */
+        'kirbytextinline' => function (Field $field) use ($app) {
+            $field->value = $app->kirbytext($field->value, [
+                'parent' => $field->parent(),
+                'field'  => $field
+            ], true);
+
+            return $field;
+        },
+
+        /**
          * Parses all KirbyTags without also parsing Markdown
          */
         'kirbytags' => function (Field $field) use ($app) {

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -610,11 +610,11 @@ class App
      * @param array $data
      * @return string
      */
-    public function kirbytext(string $text = null, array $data = []): string
+    public function kirbytext(string $text = null, array $data = [], bool $inline = false): string
     {
         $text = $this->apply('kirbytext:before', $text);
         $text = $this->kirbytags($text, $data);
-        $text = $this->markdown($text);
+        $text = $this->markdown($text, $inline);
         $text = $this->apply('kirbytext:after', $text);
 
         return $text;
@@ -673,11 +673,12 @@ class App
      *
      * @internal
      * @param string $text
+     * @param bool $inline
      * @return string
      */
-    public function markdown(string $text = null): string
+    public function markdown(string $text = null, bool $inline = false): string
     {
-        return $this->extensions['components']['markdown']($this, $text, $this->options['markdown'] ?? []);
+        return $this->extensions['components']['markdown']($this, $text, $this->options['markdown'] ?? [], $inline);
     }
 
     /**

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -134,7 +134,7 @@ trait AppPlugins
 
     protected function extendFieldMethods(array $methods): array
     {
-        return $this->extensions['fieldMethods'] = Field::$methods = array_merge(Field::$methods, $methods);
+        return $this->extensions['fieldMethods'] = Field::$methods = array_merge(Field::$methods, array_change_key_case($methods));
     }
 
     protected function extendFields(array $fields): array

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -380,6 +380,7 @@ trait AppPlugins
             'h'       => 'html',
             'int'     => 'toInt',
             'kt'      => 'kirbytext',
+            'kti'     => 'kirbytextinline',
             'link'    => 'toLink',
             'md'      => 'markdown',
             'sp'      => 'smartypants',

--- a/src/Cms/Field.php
+++ b/src/Cms/Field.php
@@ -73,6 +73,8 @@ class Field
      */
     public function __call(string $method, array $arguments = [])
     {
+        $method = strtolower($method);
+
         if (isset(static::$methods[$method]) === true) {
             return static::$methods[$method](clone $this, ...$arguments);
         }

--- a/src/Text/Markdown.php
+++ b/src/Text/Markdown.php
@@ -58,9 +58,10 @@ class Markdown
      * Parses the given text and returns the HTML
      *
      * @param  string $text
+     * @param  bool $inline
      * @return string
      */
-    public function parse(string $text): string
+    public function parse(string $text, bool $inline = false): string
     {
         if ($this->options['extra'] === true) {
             $parser = new ParsedownExtra;
@@ -70,7 +71,10 @@ class Markdown
 
         $parser->setBreaksEnabled($this->options['breaks']);
 
-        // we need the @ here, because parsedown has some notice issues :(
-        return @$parser->text($text);
+        if ($inline === true) {
+            return @$parser->line($text);
+        } else {
+            return @$parser->text($text);
+        }
     }
 }

--- a/tests/Cms/FieldMethodsTest.php
+++ b/tests/Cms/FieldMethodsTest.php
@@ -22,6 +22,13 @@ class FieldMethodsTest extends TestCase
         return new Field(null, 'test', $value);
     }
 
+    public function testFieldMethodCaseInsensitivity()
+    {
+        $field = $this->field('test');
+        $this->assertEquals('TEST', $field->upper());
+        $this->assertEquals('TEST', $field->UPPER());
+    }
+
     public function testFieldMethodCombination()
     {
         $field = $this->field('test')->upper()->short(3);

--- a/tests/Cms/FieldMethodsTest.php
+++ b/tests/Cms/FieldMethodsTest.php
@@ -413,6 +413,15 @@ class FieldMethodsTest extends TestCase
         $this->assertEquals($expected, $this->field($kirbytext)->kt());
     }
 
+    public function testKirbytextInline()
+    {
+        $kirbytext = '(link: # text: Test)';
+        $expected  = '<a href="#">Test</a>';
+
+        $this->assertEquals($expected, $this->field($kirbytext)->kirbytextinline());
+        $this->assertEquals($expected, $this->field($kirbytext)->kti());
+    }
+
     public function testKirbytags()
     {
         $kirbytext = '(link: # text: Test)';

--- a/tests/Cms/HelpersTest.php
+++ b/tests/Cms/HelpersTest.php
@@ -373,6 +373,18 @@ class HelpersTest extends TestCase
         $this->assertEquals($expected, $tag);
     }
 
+    public function testKirbyTextHelper()
+    {
+        $text   = 'This is **just** a text.';
+        $normal = '<p>This is <strong>just</strong> a text.</p>';
+        $inline = 'This is <strong>just</strong> a text.';
+
+        $this->assertEquals($normal, kirbytext($text));
+        $this->assertEquals($normal, kt($text));
+        $this->assertEquals($inline, kirbytextinline($text));
+        $this->assertEquals($inline, kti($text));
+    }
+
     public function testMarkdownHelper()
     {
         $tag = markdown('# Kirby');


### PR DESCRIPTION
**Describe the PR**
Adds option for KirbyText to output unwrapped (without wrapping `<p>` tag) string.
`kirbytext($text, false)`
`->kirbytext(false)`

**Related issues**
- Implements getkirby/ideas#93

**Todos**
- [x] Add unit tests for feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [ ] Documented on getkirby.com
