### PR TITLE
Use semantic versioning for Composer installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": ">=7.1.0",
     "ext-mbstring": "*",
     "ext-ctype": "*",
-    "getkirby/composer-installer": "*",
+    "getkirby/composer-installer": "^1.0",
     "mustangostang/spyc": "0.6.2",
     "michelf/php-smartypants": "1.8.1",
     "claviska/simpleimage": "3.3.3",


### PR DESCRIPTION
Otherwise installation of old Kirby releases may break once we need to make a breaking change to the installer.