### PR TITLE
Fix additional whitespace output by attr()

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -118,7 +118,9 @@ class Html
             if (isset($value['value']) && isset($value['escape'])) {
                 $value = $value['escape'] === true ? htmlspecialchars($value['value'], ENT_QUOTES, 'UTF-8') : $value['value'];
             } else {
-                $value = implode(' ', $value);
+                $value = implode(' ', array_filter($value, function($value) {
+                    return !empty($value) || is_numeric($value);
+                }));
             }
         } else {
             $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -118,7 +118,7 @@ class Html
             if (isset($value['value']) && isset($value['escape'])) {
                 $value = $value['escape'] === true ? htmlspecialchars($value['value'], ENT_QUOTES, 'UTF-8') : $value['value'];
             } else {
-                $value = implode(' ', array_filter($value, function($value) {
+                $value = implode(' ', array_filter($value, function ($value) {
                     return !empty($value) || is_numeric($value);
                 }));
             }


### PR DESCRIPTION
Passing an array containing empty attribute values to `attr()` results in additional whitespace.

```
<?php
$result = attr(['test' => ['string', '', 0, 0.0, '0', true, false, null]]);
echo addcslashes($result, ' ');
?>
```

The example above will output: `test="string\ \ 0\ 0\ 0\ 1\ \ "`

A filter has been added to only allow non-empty and numeric values before concatenation to prevent the additional whitespace. Each output value will now be separated with a single space.

The modified `attr()` function will output: `test="string\ 0\ 0\ 0\ 1"`