### PR TITLE
Travis setup: Require PHPUnit 7 directly from composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,15 @@ php:
 install:
   # Install composer packages, will also trigger dump-autoload
   - composer self-update
-  - composer require phpunit/phpunit ^7
-  - composer require friendsofphp/php-cs-fixer
   - composer install --no-interaction --ignore-platform-reqs
 
   # Install coveralls.phar
   - wget -c -nc --retry-connrefused --tries=0 https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
   - chmod +x php-coveralls.phar
   - php php-coveralls.phar --version
+
+  # Install the CS fixer library
+  - composer require friendsofphp/php-cs-fixer
 
 before_script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "true/punycode": "2.1.1",
     "zendframework/zend-escaper": "2.6.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^7.0"
+  },
   "autoload": {
     "files": ["config/helpers.php", "config/aliases.php", "config/tests.php"],
     "classmap": ["dependencies/"],


### PR DESCRIPTION
This cleans up the setup a bit and updates the CMS testing setup to the one of the `composer-installer`.