### PR TITLE
Make tags in image caption work by providing an array as parameter

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -126,7 +126,7 @@ return [
                 return $link($image);
             }
 
-            return Html::figure([ $link($image) ], $tag->caption, [
+            return Html::figure([ $link($image) ], [$tag->caption], [
                 'class' => $tag->class
             ]);
         }


### PR DESCRIPTION
This PR is supposed to fix the second part of part of issue https://github.com/getkirby/kirby/issues/1501, i.e. HTML tags being stripped from captions.