### PR TITLE
Fix store overwriting changed titles (#1497)

### DIFF
--- a/panel/src/store/modules/form.js
+++ b/panel/src/store/modules/form.js
@@ -105,6 +105,9 @@ export default {
         model.id = context.getters.id(model.id);
       }
 
+      // remove title from model content
+      delete model.content.title;
+
       context.commit("CREATE", model);
       context.commit("CURRENT", model.id);
 


### PR DESCRIPTION
## Describe the PR
Fixes the bug described as follows: In the Panel, if you have pending content changes on a page, rename the page, then save the pending content changes, the title will actually be saved as the original title and the page header will be disconnected from what is actually saved.

## Related issues
- Fixes #1497