### PR TITLE
Allow nested collections (#1400)

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -273,7 +273,7 @@ class App
      */
     public function collections(): Collections
     {
-        return $this->collections = $this->collections ?? Collections::load($this);
+        return $this->collections = $this->collections ?? new Collections;
     }
 
     /**

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Controller;
-use Kirby\Toolkit\Str;
 
 /**
  * Manages and loads all collections

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Controller;
+use Kirby\Toolkit\Str;
 
 /**
  * Manages and loads all collections
@@ -107,11 +108,11 @@ class Collections
         $collections = $app->extensions('collections');
         $root        = $app->root('collections');
 
-        foreach (glob($root . '/*.php') as $file) {
+        foreach (glob($root . '/{,*/}*.php', GLOB_BRACE) as $file) {
             $collection = require $file;
 
             if (is_a($collection, 'Closure')) {
-                $name = pathinfo($file, PATHINFO_FILENAME);
+                $name = Str::between($file, $root . '/', '.php');
                 $collections[$name] = $collection;
             }
         }

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -54,16 +54,6 @@ class Collections
     }
 
     /**
-     * Creates a new Collections set
-     *
-     * @param array $collections
-     */
-    public function __construct(array $collections = [])
-    {
-        $this->collections = $collections;
-    }
-
-    /**
      * Loads a collection by name if registered
      *
      * @param string $name
@@ -72,17 +62,23 @@ class Collections
      */
     public function get(string $name, array $data = [])
     {
-        if (isset($this->cache[$name]) === true) {
-            return $this->cache[$name];
-        }
-
+        // if not yet loaded
         if (isset($this->collections[$name]) === false) {
-            return null;
+            $this->collections[$name] = $this->load($name);
         }
 
-        $controller = new Controller($this->collections[$name]);
+        // if not yet cached
+        if (isset($this->cache[$name]) === false) {
+            $controller = new Controller($this->collections[$name]);
+            $this->cache[$name] = $controller->call(null, $data);
+        }
 
-        return $this->cache[$name] = $controller->call(null, $data);
+        // return cloned object
+        if (is_object($this->cache[$name]) === true) {
+            return clone $this->cache[$name];
+        }
+
+        return $this->cache[$name];
     }
 
     /**
@@ -93,30 +89,47 @@ class Collections
      */
     public function has(string $name): bool
     {
-        return isset($this->collections[$name]) === true;
+        if (isset($this->collections[$name]) === true) {
+            return true;
+        }
+
+        try {
+            $this->load($name);
+            return true;
+        } catch (NotFoundException $e) {
+            return false;
+        }
     }
 
     /**
-     * Loads collections from php files in a
-     * given directory.
-     *
-     * @param  string $root
-     * @return self
-     */
-    public static function load(App $app): self
+    * Loads collection from php file in a
+    * given directory or from plugin extension.
+    *
+    * @param  string $name
+    * @return mixed
+    */
+    public function load(string $name)
     {
-        $collections = $app->extensions('collections');
-        $root        = $app->root('collections');
+        $kirby = App::instance();
 
-        foreach (glob($root . '/{,*/}*.php', GLOB_BRACE) as $file) {
+        // first check for collection file
+        $file = $kirby->root('collections') . '/' . $name . '.php';
+
+        if (file_exists($file)) {
             $collection = require $file;
 
             if (is_a($collection, 'Closure')) {
-                $name = Str::between($file, $root . '/', '.php');
-                $collections[$name] = $collection;
+                return $collection;
             }
         }
 
-        return new static($collections);
+        // fallback to collections from plugins
+        $collections = $kirby->extensions('collections');
+
+        if (isset($collections[$name]) === true) {
+            return $collections[$name];
+        }
+
+        throw new NotFoundException('The collection cannot be found');
     }
 }

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -101,12 +101,12 @@ class Collections
     }
 
     /**
-    * Loads collection from php file in a
-    * given directory or from plugin extension.
-    *
-    * @param  string $name
-    * @return mixed
-    */
+     * Loads collection from php file in a
+     * given directory or from plugin extension.
+     *
+     * @param  string $name
+     * @return mixed
+     */
     public function load(string $name)
     {
         $kirby = App::instance();

--- a/tests/Cms/CollectionsTest.php
+++ b/tests/Cms/CollectionsTest.php
@@ -76,6 +76,6 @@ class CollectionsTest extends TestCase
         $this->assertInstanceOf(Collection::class, $result);
 
         $result = $collections->get('nested/test');
-        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals('a', $result);
     }
 }

--- a/tests/Cms/CollectionsTest.php
+++ b/tests/Cms/CollectionsTest.php
@@ -71,8 +71,11 @@ class CollectionsTest extends TestCase
         ]);
 
         $collections = Collections::load($app);
-        $result      = $collections->get('test');
 
+        $result = $collections->get('test');
+        $this->assertInstanceOf(Collection::class, $result);
+
+        $result = $collections->get('nested/test');
         $this->assertInstanceOf(Collection::class, $result);
     }
 }

--- a/tests/Cms/CollectionsTest.php
+++ b/tests/Cms/CollectionsTest.php
@@ -12,6 +12,7 @@ class CollectionsTest extends TestCase
             ]
         ]);
     }
+
     public function testGet()
     {
         $app        = $this->_app();
@@ -57,6 +58,13 @@ class CollectionsTest extends TestCase
         $result = $app->collections()->load('test');
         $this->assertInstanceOf(Collection::class, $result());
 
+        $result = $app->collections()->load('nested/test');
+        $this->assertEquals('a', $result());
+    }
+
+    public function testLoadNested()
+    {
+        $app = $this->_app();
         $result = $app->collections()->load('nested/test');
         $this->assertEquals('a', $result());
     }

--- a/tests/Cms/CollectionsTest.php
+++ b/tests/Cms/CollectionsTest.php
@@ -4,29 +4,27 @@ namespace Kirby\Cms;
 
 class CollectionsTest extends TestCase
 {
+    protected function _app()
+    {
+        return new App([
+            'roots' => [
+                'collections' => __DIR__ . '/fixtures/collections'
+            ]
+        ]);
+    }
     public function testGet()
     {
-        $collection  = new Collection();
-        $collections = new Collections([
-            'test' => function () use ($collection) {
-                return $collection;
-            }
-        ]);
-
-        $result = $collections->get('test');
+        $app        = $this->_app();
+        $collection = new Collection();
+        $result     = $app->collections()->get('test');
 
         $this->assertEquals($collection, $result);
     }
 
     public function testGetWithData()
     {
-        $collections = new Collections([
-            'test' => function ($a, $b) {
-                return $a . $b;
-            }
-        ]);
-
-        $result = $collections->get('test', [
+        $app    = $this->_app();
+        $result = $app->collections()->get('string', [
             'a' => 'a',
             'b' => 'b'
         ]);
@@ -36,13 +34,8 @@ class CollectionsTest extends TestCase
 
     public function testGetWithRearrangedData()
     {
-        $collections = new Collections([
-            'test' => function ($b, $a) {
-                return $a . $b;
-            }
-        ]);
-
-        $result = $collections->get('test', [
+        $app    = $this->_app();
+        $result = $app->collections()->get('rearranged', [
             'a' => 'a',
             'b' => 'b'
         ]);
@@ -52,30 +45,19 @@ class CollectionsTest extends TestCase
 
     public function testHas()
     {
-        $collections = new Collections([
-            'test' => function ($b, $a) {
-                return $a . $b;
-            }
-        ]);
-
-        $this->assertTrue($collections->has('test'));
-        $this->assertFalse($collections->has('does-not-exist'));
+        $app= $this->_app();
+        $this->assertTrue($app->collections()->has('test'));
+        $this->assertFalse($app->collections()->has('does-not-exist'));
+        $this->assertTrue($app->collections()->has('test'));
     }
 
     public function testLoad()
     {
-        $app = new App([
-            'roots' => [
-                'collections' => __DIR__ . '/fixtures/collections'
-            ]
-        ]);
+        $app = $this->_app();
+        $result = $app->collections()->load('test');
+        $this->assertInstanceOf(Collection::class, $result());
 
-        $collections = Collections::load($app);
-
-        $result = $collections->get('test');
-        $this->assertInstanceOf(Collection::class, $result);
-
-        $result = $collections->get('nested/test');
-        $this->assertEquals('a', $result);
+        $result = $app->collections()->load('nested/test');
+        $this->assertEquals('a', $result());
     }
 }

--- a/tests/Cms/fixtures/collections/nested/test.php
+++ b/tests/Cms/fixtures/collections/nested/test.php
@@ -1,0 +1,7 @@
+<?php
+
+use Kirby\Cms\Collection;
+
+return function () {
+    return new Collection();
+};

--- a/tests/Cms/fixtures/collections/nested/test.php
+++ b/tests/Cms/fixtures/collections/nested/test.php
@@ -3,5 +3,5 @@
 use Kirby\Cms\Collection;
 
 return function () {
-    return new Collection();
+    return 'a';
 };

--- a/tests/Cms/fixtures/collections/rearranged.php
+++ b/tests/Cms/fixtures/collections/rearranged.php
@@ -1,0 +1,5 @@
+<?php
+
+return function ($b, $a) {
+    return $a . $b;
+};

--- a/tests/Cms/fixtures/collections/string.php
+++ b/tests/Cms/fixtures/collections/string.php
@@ -1,0 +1,5 @@
+<?php
+
+return function ($a, $b) {
+    return $a . $b;
+};


### PR DESCRIPTION
## Describe the PR
Allows collection files to be placed inside the collections folder as well as one subdirectory lower:

```
collections/
∟ folder/
  ∟ name.php
```

to be called by `$kirby->collection('folder/name')`.

## Related issues
- Fixes #1400