### PR TITLE
Textarea: close dropdowns on interaction (#1283)

### DIFF
--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -25,8 +25,10 @@
         class="k-textarea-input-native"
         @focus="onFocus"
         @input="onInput"
+        @click="onInteraction"
         @keydown.meta.enter="onSubmit"
         @keydown.meta="onShortcut"
+        @keydown.exact="onInteraction"
         @dragover="onOver"
         @dragleave="onOut"
         @drop="onDrop"
@@ -170,6 +172,13 @@ export default {
     },
     onInput($event) {
       this.$emit("input", $event.target.value);
+    },
+    onInteraction($event) {
+      if (this.$refs.toolbar) {
+        Object.keys(this.$refs.toolbar.$refs).forEach(dropdown => {
+          this.$refs.toolbar.$refs[dropdown][0].close();
+        });
+      }
     },
     onInvalid() {
       this.$emit("invalid", this.$v.$invalid, this.$v);


### PR DESCRIPTION
## Describe the PR
Textare toolbar dropdowns are all closed if textarea get clicked again or typed into.

## Related issues
- Fixes #1283