### PR TITLE
Fixes $page->update() in a multilang enviroment (#1571)

### DIFF
--- a/src/Cms/Form.php
+++ b/src/Cms/Form.php
@@ -21,7 +21,8 @@ class Form extends BaseForm
 
         if ($kirby->multilang() === true) {
             $fields            = $props['fields'] ?? [];
-            $isDefaultLanguage = $kirby->language()->isDefault();
+            $languageCode      = $props['languageCode'] ?? $kirby->language()->code();
+            $isDefaultLanguage = $languageCode === $kirby->defaultLanguage()->code();
 
             foreach ($fields as $fieldName => $fieldProps) {
                 // switch untranslatable fields to readonly

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -413,6 +413,7 @@ abstract class ModelWithContent extends Model
     {
         $form = Form::for($this, [
             'input'          => $input,
+            'languageCode'   => $languageCode,
             'ignoreDisabled' => $validate === false,
         ]);
 


### PR DESCRIPTION
**Describe the PR**
> The $page->update() method fills in the missing fields from its input with empty values or duplicates those of the main language file, ignoring translate: false.

<details>
<summary>Me talking gibberish :wink:</summary>

While creating the PR I realized that the expected functionallity is not documented anywhere. Basically there are two ways this should (can) work:
1. If you do not add the language code the **currently active language** should be used. (Thats how it kinda works right now and how the PR will work)
2. Or if you do not add the language code the **default language** should be updated.

As far as I can tell for option **1** to work properly we would also need to make sure that the currently active language will be saved. Right now if the `$languageCode` is `null` the `Form` class will check the input/fields for the currently active language (which could differ from the default one) but will always save the input to the default language. So option **2** should probably the way to go.

On the other hand I can see that one would expect the currently active language to be updated if no language code is specified.
</details>

It actually works as expcted! If no language is specified the currently active language will be updated. If a language is specified this language will be updated taken `translate: false` into account.

**Related issues**
- Fixes #1571 