### PR TITLE
Email: Don’t require text with HTML template #1557

### DIFF
--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -75,12 +75,16 @@ class Email
             $html = $this->getTemplate($this->props['template'], 'html');
             $text = $this->getTemplate($this->props['template'], 'text');
 
-            if ($html->exists() && $text->exists()) {
+            if ($html->exists()) {
                 $this->props['body'] = [
-                    'html' => $html->render($data),
-                    'text' => $text->render($data),
+                    'html' => $html->render($data)
                 ];
-            // fallback to single email text template
+
+                if ($text->exists()) {
+                    $this->props['body']['text'] = $text->render($data);
+                }
+
+                // fallback to single email text template
             } elseif ($text->exists()) {
                 $this->props['body'] = $text->render($data);
             } else {

--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -32,7 +32,7 @@ class Body
         return $this->html;
     }
 
-    public function text(): string
+    public function text()
     {
         return $this->text;
     }
@@ -43,7 +43,7 @@ class Body
         return $this;
     }
 
-    protected function setText(string $text)
+    protected function setText(string $text = null)
     {
         $this->text = $text;
         return $this;

--- a/tests/Cms/EmailTest.php
+++ b/tests/Cms/EmailTest.php
@@ -64,6 +64,19 @@ class EmailTest extends TestCase
     {
         $app = new App([
             'templates' => [
+                'emails/media.html' => __DIR__ . '/fixtures/emails/media.html.php'
+            ]
+        ]);
+        $email = new Email(['template' => 'media']);
+        $this->assertEquals([
+            'html' => '<b>Image:</b> <img src=""/>'
+        ], $email->toArray()['body']);
+    }
+
+    public function testEmailTemplateHtmlText()
+    {
+        $app = new App([
+            'templates' => [
                 'emails/media.html' => __DIR__ . '/fixtures/emails/media.html.php',
                 'emails/media.text' => __DIR__ . '/fixtures/emails/media.text.php',
             ]

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -98,6 +98,21 @@ class EmailTest extends TestCase
         $this->assertTrue($email->isHtml());
     }
 
+    public function testBodyHtmlOnly()
+    {
+        $email = $this->_email([
+            'body' => $body = [
+                'html' => 'HTML is even <b>better</b>'
+            ]
+        ]);
+
+        $this->assertInstanceOf(Body::class, $email->body());
+        $this->assertEquals(null, $email->body()->text());
+        $this->assertEquals($body['html'], $email->body()->html());
+
+        $this->assertTrue($email->isHtml());
+    }
+
     public function testAttachments()
     {
         $email = $this->_email([


### PR DESCRIPTION
**Describe the PR**
With this PR, emails with HTML templates, do not require a text fallback anymore.

**Related issues**
- Fixes #1557

**Todos**
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`

