### PR TITLE
Changes the way languages are loaded.

### DIFF
--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -67,7 +67,7 @@ class Languages extends Collection
         $files     = glob(App::instance()->root('languages') . '/*.php');
 
         foreach ($files as $file) {
-            $props = include_once $file;
+            $props = include $file;
 
             if (is_array($props) === true) {
 


### PR DESCRIPTION
Previously multiple calls to the `Languages::load()` function would have loaded the languages only once. The next call would return an empty collection of languages.

Now multiple calls to the load function will load all the languages.

