### PR TITLE
Add references to Vue and Vuex in panel object

### DIFF
--- a/panel/src/main.js
+++ b/panel/src/main.js
@@ -3,6 +3,7 @@ import Directives from "./config/directives.js";
 import Filters from "./config/filters.js";
 import Events from "./config/events.js";
 import Vue from "vue";
+import Vuex from "vuex";
 import Vuelidate from "vuelidate";
 
 Vue.use(Directives);
@@ -12,6 +13,9 @@ Vue.use(Vuelidate);
 
 Vue.config.productionTip = false;
 Vue.config.devtools = true;
+
+window.panel.Vue = Vue;
+window.panel.Vuex = Vuex;
 
 import "./config/components.js";
 import "./config/api.js";


### PR DESCRIPTION
Adds references to Vue and Vuex for plugin authors to utilize, especially when needing to use a Vuex store for their plugin.

If this PR relates to one or several issues in the `kirby` or `idea` repo, please reference them here:
- Fixes https://github.com/getkirby/ideas/issues/219


