### PR TITLE
Fix File::modified #1559

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -368,6 +368,28 @@ class File extends ModelWithContent
     }
 
     /**
+     * Get the file's last modification time.
+     *
+     * @param  string $format
+     * @param  string|null $handler date or strftime
+     * @return mixed
+     */
+    public function modified(string $format = null, string $handler = null)
+    {
+        $file     = F::modified($this->root());
+        $content  = F::modified($this->contentFile());
+        $modified = max($file, $content);
+
+        if (is_null($format) === true) {
+            return $modified;
+        }
+
+        $handler = $handler ?? $this->kirby()->option('date.handler', 'date');
+
+        return $handler($format, $modified);
+    }
+
+    /**
      * Returns the parent Page object
      *
      * @return Page

--- a/tests/Cms/FileTest.php
+++ b/tests/Cms/FileTest.php
@@ -5,7 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Image\Image;
 use Kirby\Toolkit\F;
 
-class FilePropsTest extends TestCase
+class FileTest extends TestCase
 {
     protected function defaults(): array
     {
@@ -114,12 +114,12 @@ class FilePropsTest extends TestCase
     {
         $app = new App([
             'roots' => [
-                'index'   => $index = __DIR__ . '/fixtures/FilePropsTest/modified',
+                'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
                 'content' => $index
             ]
         ]);
 
-        // create a site file
+        // create a file
         F::write($file = $index . '/test.js', 'test');
 
         $modified = filemtime($file);
@@ -135,7 +135,35 @@ class FilePropsTest extends TestCase
         $format = '%d.%m.%Y';
         $this->assertEquals(strftime($format, $modified), $file->modified($format, 'strftime'));
 
-        Dir::remove($index);
+        Dir::remove(dirname($index));
+    }
+
+    public function testModifiedContent()
+    {
+        $app = new App([
+            'roots' => [
+                'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
+                'content' => $index
+            ]
+        ]);
+
+        // create a file
+        F::write($file = $index . '/test.js', 'test');
+
+        // write the content file a bit later
+        usleep(1000000);
+
+        F::write($content = $index . '/test.js.txt', 'test');
+
+        $modifiedFile    = F::modified($file);
+        $modifiedContent = F::modified($content);
+
+        $file = $app->file('test.js');
+
+        $this->assertNotEquals($modifiedFile, $file->modified());
+        $this->assertEquals($modifiedContent, $file->modified());
+
+        Dir::remove(dirname($index));
     }
 
     public function testPanelIconDefault()


### PR DESCRIPTION
**Describe the PR**
Implements dedicated `File::modified()`(instead of using `FileVersion::modified()`) which returns the most recent modification time, either of the actual file or the content file.

@bastianallgeier Do you have a good idea for a stable test? On Travis, the timestamp keeps changing.

**Related issues**
- Fixes #1559

**Todos**
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`

