### PR TITLE
Fix min for fields

### DIFF
--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -4,7 +4,7 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
 return [
-    'mixins' => ['options'],
+    'mixins' => ['min', 'options'],
     'props' => [
         /**
          * Unset inherited props

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -3,6 +3,7 @@
 use Kirby\Toolkit\A;
 
 return [
+    'mixins' => ['min'],
     'props' => [
         /**
          * Unset inherited props

--- a/config/fields/mixins/min.php
+++ b/config/fields/mixins/min.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'computed' => [
+        'min' => function () {
+            // set min to at least 1, if required
+            if ($this->required === true) {
+                return $this->min ?? 1;
+            }
+
+            return $this->min;
+        },
+        'required' => function () {
+            // set required to true if min is set
+            if ($this->min) {
+                return true;
+            }
+
+            return $this->required;
+        }
+    ]
+];

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -4,6 +4,7 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 
 return [
+    'mixins' => ['min'],
     'props' => [
         /**
          * Unset inherited props

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -4,6 +4,7 @@ use Kirby\Cms\Form;
 use Kirby\Cms\Blueprint;
 
 return [
+    'mixins' => ['min'],
     'props' => [
         /**
          * Unset inherited props
@@ -121,7 +122,7 @@ return [
             }
 
             return $columns;
-        },
+        }
     ],
     'methods' => [
         'rows' => function ($value) {

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'mixins' => ['options'],
+    'mixins' => ['min', 'options'],
     'props' => [
 
         /**

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'mixins' => ['min'],
     'props' => [
         /**
          * Unset inherited props

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -363,6 +363,7 @@ trait AppPlugins
     protected function extensionsFromSystem()
     {
         // Form Field Mixins
+        FormField::$mixins['min']     = include static::$root . '/config/fields/mixins/min.php';
         FormField::$mixins['options'] = include static::$root . '/config/fields/mixins/options.php';
 
         // Tag Aliases

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -71,6 +71,11 @@ class V
             $value = $params[$index] ?? null;
 
             if (is_array($value) === true) {
+                foreach ($value as $index => $item) {
+                    if (is_array($item) === true) {
+                        $value[$index] = implode('|', $item);
+                    }
+                }
                 $value = implode(', ', $value);
             }
 

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -398,6 +398,47 @@ class FieldTest extends TestCase
         $this->assertEquals('en', $field->label);
     }
 
+    public function testMixinMin()
+    {
+        Field::$mixins['min'] = include kirby()->root('kirby') . '/config/fields/mixins/min.php';
+
+        Field::$types = [
+            'test' => ['mixins' => ['min']]
+        ];
+
+        $field = new Field('test', [
+            'model' => new Page(['slug' => 'test']),
+        ]);
+
+        $this->assertFalse($field->isRequired());
+        $this->assertNull($field->min());
+
+        $field = new Field('test', [
+            'model' => new Page(['slug' => 'test']),
+            'min'   => 5
+        ]);
+
+        $this->assertTrue($field->isRequired());
+        $this->assertEquals(5, $field->min());
+
+        $field = new Field('test', [
+            'model' => new Page(['slug' => 'test']),
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->isRequired());
+        $this->assertEquals(1, $field->min());
+
+        $field = new Field('test', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true,
+            'min'      => 5
+        ]);
+
+        $this->assertTrue($field->isRequired());
+        $this->assertEquals(5, $field->min());
+    }
+
     public function testModel()
     {
         Field::$types = [

--- a/tests/Form/Fields/CheckboxesFieldTest.php
+++ b/tests/Form/Fields/CheckboxesFieldTest.php
@@ -90,6 +90,7 @@ class CheckboxesFieldTest extends TestCase
             'min'     => 2
         ]);
 
+        $this->assertTrue($field->required());
         $this->assertFalse($field->isValid());
         $this->assertArrayHasKey('min', $field->errors());
     }
@@ -104,5 +105,38 @@ class CheckboxesFieldTest extends TestCase
 
         $this->assertFalse($field->isValid());
         $this->assertArrayHasKey('max', $field->errors());
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('checkboxes', [
+            'options'  => ['a', 'b', 'c'],
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('checkboxes', [
+            'options'  => ['a', 'b', 'c'],
+            'value'    => null,
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('checkboxes', [
+            'options'  => ['a', 'b', 'c'],
+            'required' => true,
+            'value'    => 'a'
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -109,6 +109,8 @@ class FilesFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(3, $field->min());
+        $this->assertTrue($field->required());
         $this->assertArrayHasKey('min', $field->errors());
     }
 
@@ -124,6 +126,7 @@ class FilesFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(1, $field->max());
         $this->assertArrayHasKey('max', $field->errors());
     }
 
@@ -194,5 +197,39 @@ class FilesFieldTest extends TestCase
         ]);
 
         $this->assertEquals('Test', $field->empty());
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('files', [
+            'model'    => $this->model(),
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('files', [
+            'model'    => $this->model(),
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('files', [
+            'model'    => $this->model(),
+            'required' => true,
+            'value' => [
+                'a.jpg',
+            ],
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -89,6 +89,8 @@ class PagesFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(3, $field->min());
+        $this->assertTrue($field->required());
         $this->assertArrayHasKey('min', $field->errors());
     }
 
@@ -104,6 +106,7 @@ class PagesFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(1, $field->max());
         $this->assertArrayHasKey('max', $field->errors());
     }
 
@@ -125,5 +128,39 @@ class PagesFieldTest extends TestCase
         ]);
 
         $this->assertEquals('Test', $field->empty());
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('pages', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('pages', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('pages', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true,
+            'value' => [
+                'a/aa',
+            ],
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -91,6 +91,8 @@ class StructureFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(2, $field->min());
+        $this->assertTrue($field->required());
         $this->assertArrayHasKey('min', $field->errors());
     }
 
@@ -110,6 +112,7 @@ class StructureFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(1, $field->max());
         $this->assertArrayHasKey('max', $field->errors());
     }
 
@@ -294,5 +297,51 @@ class StructureFieldTest extends TestCase
         ]);
 
         $this->assertEquals($data, $field->data(true));
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('structure', [
+            'fields' => [
+                'title' => [
+                    'type' => 'text'
+                ]
+            ],
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('structure', [
+            'fields' => [
+                'title' => [
+                    'type' => 'text'
+                ]
+            ],
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('structure', [
+            'fields' => [
+                'title' => [
+                    'type' => 'text'
+                ]
+            ],
+            'value' => [
+                ['title' => 'a'],
+            ],
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }

--- a/tests/Form/Fields/TagsFieldTest.php
+++ b/tests/Form/Fields/TagsFieldTest.php
@@ -114,6 +114,8 @@ class TagsFieldTest extends TestCase
 
         $this->assertFalse($field->isValid());
         $this->assertArrayHasKey('min', $field->errors());
+        $this->assertEquals(2, $field->min());
+        $this->assertTrue($field->required());
     }
 
     public function testMax()
@@ -125,6 +127,40 @@ class TagsFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(1, $field->max());
         $this->assertArrayHasKey('max', $field->errors());
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('tags', [
+            'options'  => ['a', 'b', 'c'],
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('tags', [
+            'options'  => ['a', 'b', 'c'],
+            'value'    => null,
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('tags', [
+            'options'  => ['a', 'b', 'c'],
+            'required' => true,
+            'value'    => 'a'
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }

--- a/tests/Form/Fields/UsersFieldTest.php
+++ b/tests/Form/Fields/UsersFieldTest.php
@@ -119,6 +119,8 @@ class UsersFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(3, $field->min());
+        $this->assertTrue($field->required());
         $this->assertArrayHasKey('min', $field->errors());
     }
 
@@ -134,6 +136,7 @@ class UsersFieldTest extends TestCase
         ]);
 
         $this->assertFalse($field->isValid());
+        $this->assertEquals(1, $field->max());
         $this->assertArrayHasKey('max', $field->errors());
     }
 
@@ -155,5 +158,39 @@ class UsersFieldTest extends TestCase
         ]);
 
         $this->assertEquals('Test', $field->empty());
+    }
+
+    public function testRequiredProps()
+    {
+        $field = new Field('users', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true
+        ]);
+
+        $this->assertTrue($field->required());
+        $this->assertEquals(1, $field->min());
+    }
+
+    public function testRequiredInvalid()
+    {
+        $field = new Field('users', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true
+        ]);
+
+        $this->assertFalse($field->isValid());
+    }
+
+    public function testRequiredValid()
+    {
+        $field = new Field('tags', [
+            'model'    => new Page(['slug' => 'test']),
+            'required' => true,
+            'value' => [
+                'leonardo@getkirby.com',
+            ],
+        ]);
+
+        $this->assertTrue($field->isValid());
     }
 }


### PR DESCRIPTION
**Describe the PR**

- For checkboxes, files, pages, structure, tags and users fields:
  - If min is set, required is implied as true.
  - If required is set to true, min is implied as at least 1.
- Fixes `V::message` for nested arrays (as with the structure field)

**Related issues**
- Fixes #1546

**Todos**
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`