### PR TITLE
TimeInput: Fix dayjs format issue #1574

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -4499,9 +4499,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.6.tgz",
-      "integrity": "sha512-NLhaSS1/wWLRFy0Kn/VmsAExqll2zxRUPmPbqJoeMKQrFxG+RT94VMSE+cVljB6A76/zZkR0Xub4ihTHQ5HgGg=="
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.10.tgz",
+      "integrity": "sha512-U+7kBBkJzPWww0vNeMkaBeJwnkivTACoajm+bTfwparjFcPI6/5JSQN40WVnX6yCsm20oGf1SkMkIIp4m/boAw=="
     },
     "de-indent": {
       "version": "1.0.2",

--- a/panel/package.json
+++ b/panel/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "autosize": "^4.0.2",
-    "dayjs": "^1.8.6",
+    "dayjs": "^1.8.10",
     "npm": "^6.8.0",
     "slugify": "^1.3.4",
     "vue": "^2.6.6",

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -73,7 +73,7 @@ export default {
   },
   computed: {
     date() {
-      return dayjs(`${this.year}-${this.month + 1}-${this.day}`);
+      return dayjs(`${this.year}/${this.month + 1}/${this.day}`);
     },
     numberOfDays() {
       return this.date.daysInMonth();

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -138,7 +138,7 @@ export default {
       const a = this.meridiem || "AM";
 
       const time = this.notation === 24 ? `${h}:${m}:00` : `${h}:${m}:00 ${a}`;
-      const date = dayjs("2000-01-01 " + time);
+      const date = dayjs("2000/01/01 " + time);
 
       this.$emit("input", date.format("HH:mm"));
     },
@@ -166,7 +166,8 @@ export default {
       return Math.floor(minute / this.step) * this.step;
     },
     toObject(time) {
-      const date = dayjs("2001-01-01 " + time + ":00");
+
+      const date = dayjs("2001/01/01 " + time + ":00");
 
       if (!time || date.isValid() === false) {
         return {


### PR DESCRIPTION
**Describe the PR**
`dayjs` cannot deal correctly with `YYYY-mm-dd` formats in e.g. Safari. Solution: go with `YYYY/mm/dd`

**Related issues**
- Fixes #1574