### PR TITLE
Fix falsely translating field options #1548

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -121,7 +121,9 @@ class Options
             }
 
             // translate the option text
-            $option['text'] = I18n::translate($option['text'], $option['text']);
+            if (is_array($option['text']) === true) {
+                $option['text'] = I18n::translate($option['text'], $option['text']);
+            }
 
             // add the option to the list
             $result[] = $option;

--- a/tests/Form/OptionsTest.php
+++ b/tests/Form/OptionsTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Data\Data;
 use Kirby\Data\Yaml;
 use Kirby\Toolkit\Dir;
+use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase;
 
 class OptionsTest extends TestCase
@@ -157,5 +158,46 @@ class OptionsTest extends TestCase
         ];
 
         $this->assertEquals($expected, $result);
+    }
+
+    public function testTranslated()
+    {
+        I18n::$locale = 'en';
+
+        $options = Options::factory([
+            'a' => ['en' => 'A (en)', 'de' => 'A (de)'],
+            'b' => ['en' => 'B (en)', 'de' => 'B (de)']
+        ]);
+
+        $this->assertEquals('A (en)', $options[0]['text']);
+        $this->assertEquals('B (en)', $options[1]['text']);
+
+        I18n::$locale = 'de';
+
+        $options = Options::factory([
+            'a' => ['en' => 'A (en)', 'de' => 'A (de)'],
+            'b' => ['en' => 'B (en)', 'de' => 'B (de)']
+        ]);
+
+        $this->assertEquals('A (de)', $options[0]['text']);
+        $this->assertEquals('B (de)', $options[1]['text']);
+    }
+
+    public function testUntranslated()
+    {
+        I18n::$translations = [
+            'en' => [
+                'language' => 'Language'
+            ],
+            'de' => [
+                'language' => 'Sprache'
+            ]
+        ];
+
+        $options = Options::factory([
+            'language' => 'language',
+        ]);
+
+        $this->assertEquals('language', $options[0]['text']);
     }
 }


### PR DESCRIPTION
**Describe the PR**
Only translation option text if it actually is an array of translations.

**Related issues**
- Fixes #1548

**Todos**
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`

