### PR TITLE
Fix index for Collection::find with objects #1544

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -349,6 +349,9 @@ class Collection extends Iterator implements Countable
 
         foreach ($keys as $key) {
             if ($item = $this->findByKey($key)) {
+                if (method_exists($item, 'id') === true) {
+                    $key = $item->id();
+                }
                 $result[$key] = $item;
             }
         }

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -349,7 +349,7 @@ class Collection extends Iterator implements Countable
 
         foreach ($keys as $key) {
             if ($item = $this->findByKey($key)) {
-                if (method_exists($item, 'id') === true) {
+                if (is_object($item) && method_exists($item, 'id') === true) {
                     $key = $item->id();
                 }
                 $result[$key] = $item;

--- a/tests/Cms/PagesTest.php
+++ b/tests/Cms/PagesTest.php
@@ -121,6 +121,25 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
     }
 
+    public function testFindMultiple()
+    {
+        $pages = Pages::factory([
+            [
+                'slug' => 'page',
+                'children' => [
+                    ['slug' => 'a'],
+                    ['slug' => 'b'],
+                    ['slug' => 'c']
+                ]
+            ]
+        ]);
+
+        $collection = $pages->find('page')->children()->find('a', 'c');
+        $page       = $pages->find('page')->children()->last();
+
+        $this->assertTrue($collection->has($page));
+    }
+
     public function testIndex()
     {
         $pages = Pages::factory([


### PR DESCRIPTION
**Describe the PR**
The collection returned by e.g. `$pages->find('a', 'b')` now gets indexed correctly, so it can still be used with `$collection->has()` etc.

**Related issues**
- Fixes #1544

**Todos**
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`

