### PR TITLE
Fix content for multilang user::create() #1500

### DIFF
--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -186,7 +186,7 @@ trait UserActions
             $user->writePassword($user->password());
 
             // write the user data
-            return $user->save();
+            return $user->save($user->content()->toArray());
         });
     }
 

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -185,8 +185,15 @@ trait UserActions
 
             $user->writePassword($user->password());
 
+            // always create users in the default language
+            if ($user->kirby()->multilang() === true) {
+                $languageCode = $user->kirby()->defaultLanguage()->code();
+            } else {
+                $languageCode = null;
+            }
+
             // write the user data
-            return $user->save($user->content()->toArray());
+            return $user->save($user->content()->toArray(), $languageCode);
         });
     }
 

--- a/tests/Cms/UserActionsTest.php
+++ b/tests/Cms/UserActionsTest.php
@@ -96,6 +96,19 @@ class UserActionsTest extends TestCase
         $this->assertEquals('editor', $user->role());
     }
 
+    public function testCreateWithContent()
+    {
+        $user = User::create([
+            'email' => 'new@domain.com',
+            'role'  => 'editor',
+            'content' => [
+                'a' => 'Custom A'
+            ],
+        ]);
+
+        $this->assertEquals('Custom A', $user->a()->value());
+    }
+
     public function testCreateWithDefaults()
     {
         $user = User::create([
@@ -145,6 +158,38 @@ class UserActionsTest extends TestCase
 
         $this->assertEquals('Custom A', $user->a()->value());
         $this->assertEquals('B', $user->b()->value());
+    }
+
+    public function testCreateWithContentMultilang()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'default' => true,
+                ],
+                [
+                    'code'    => 'de',
+                ]
+            ]
+        ]);
+
+        $user = User::create([
+            'email' => 'new@domain.com',
+            'role'  => 'editor',
+            'content' => [
+                'a' => 'a',
+                'b' => 'b',
+            ],
+        ]);
+
+        $this->assertTrue($user->exists());
+
+        $this->assertEquals('a', $user->a()->value());
+        $this->assertEquals('b', $user->b()->value());
     }
 
     public function testDelete()


### PR DESCRIPTION
## Describe the PR
In multilang, content did not get saved with `User::create()`

## Related issues
- Fixes #1500

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`