### PR TITLE
Api routes plugin as callback #1621

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -160,9 +160,17 @@ class App
      */
     public function api(): Api
     {
+        if ($this->api !== null) {
+            return $this->api;
+        }
+
         $root       = static::$root . '/config/api';
         $extensions = $this->extensions['api'] ?? [];
         $routes     = (include $root . '/routes.php')($this);
+
+        if (is_a($extensions['routes'] ?? [], Closure::class) === true) {
+            $extensions['routes'] = $extensions['routes']($this);
+        }
 
         $api = [
             'debug'          => $this->option('debug', false),
@@ -174,7 +182,7 @@ class App
             'kirby'          => $this,
         ];
 
-        return $this->api = $this->api ?? new Api($api);
+        return $this->api = new Api($api);
     }
 
     /**

--- a/tests/Cms/AppPluginsTest.php
+++ b/tests/Cms/AppPluginsTest.php
@@ -104,6 +104,39 @@ class AppPluginsTest extends TestCase
         $this->assertEquals('c', $app->api()->call('c'));
     }
 
+    public function testApiRouteCallbackPlugins()
+    {
+        App::plugin('test/a', [
+            'api' => [
+                'routes' => function ($kirby) {
+                    return [
+                        [
+                            'pattern' => 'a',
+                            'action'  => function () use ($kirby) {
+                                return $kirby->root('index');
+                            }
+                        ]
+                    ];
+                }
+            ]
+        ]);
+
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'api' => [
+                'authentication' => function () {
+                    return true;
+                }
+            ],
+        ]);
+
+        $app->impersonate('kirby');
+
+        $this->assertEquals('/dev/null', $app->api()->call('a'));
+    }
+
     public function testBlueprint()
     {
         $kirby = new App([


### PR DESCRIPTION
## Describe the PR
Allows API routes to be defined as callback (same as with normal routes).

## Related issues
- Fixes #1621

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`