### PR TITLE
Unset fields, sections and tabs when extending blueprints

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -503,6 +503,12 @@ class Blueprint
                 $fieldProps = [];
             }
 
+            // unset / remove field if its propperty is false
+            if ($fieldProps === false) {
+                unset($fields[$fieldName]);
+                continue;
+            }
+
             // inject the name
             $fieldProps['name'] = $fieldName;
 
@@ -580,6 +586,12 @@ class Blueprint
     {
         foreach ($sections as $sectionName => $sectionProps) {
 
+            // unset / remove section if its propperty is false
+            if ($sectionProps === false) {
+                unset($sections[$sectionName]);
+                continue;
+            }
+
             // inject all section extensions
             $sectionProps = $this->extend($sectionProps);
 
@@ -647,6 +659,12 @@ class Blueprint
         }
 
         foreach ($tabs as $tabName => $tabProps) {
+
+            // unset / remove tab if its propperty is false
+            if ($tabProps === false) {
+                unset($tabs[$tabName]);
+                continue;
+            }
 
             // inject all tab extensions
             $tabProps = $this->extend($tabProps);

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -87,7 +87,7 @@ class Blueprint
      */
     public function __debuginfo(): array
     {
-        return $this->props;
+        return $this->props ?? [];
     }
 
     /**

--- a/tests/Cms/BlueprintExtendAndUnsetTest.php
+++ b/tests/Cms/BlueprintExtendAndUnsetTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class BlueprintExtendAndUnset extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'blueprints' => [
+                'pages/base' => [
+                    'title'  => 'base',
+                    'model'  => 'page',
+                    'tabs'   => [
+                        'content' => [
+                            'sections' => [
+                                'pages' => [
+                                    'type' => 'pages'
+                                ],
+                                'files' => [
+                                    'type' => 'files'
+                                ]
+                            ]
+                        ],
+                        'seo' => [
+                            'fields' => [
+                                'seoTitle' => [
+                                    'label' => 'SEO Title',
+                                    'type' => 'text'
+                                ],
+                                'seoDescription' => [
+                                    'label' => 'SEO Description',
+                                    'type' => 'text'
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    public function testExtendAndUnsetTab()
+    {
+        $blueprint = new Blueprint([
+            'title'  => 'extended',
+            'model'  => 'page',
+            'extends' => 'pages/base',
+            'tabs'  => [
+                'seo'  => false
+            ]
+        ]);
+
+        $this->assertEquals('extended', $blueprint->title());
+        $this->assertEquals(1, sizeof($blueprint->tabs()));
+        $this->assertEquals(false, is_array($blueprint->tab('seo')));
+        $this->assertEquals(true, is_array($blueprint->tab('content')));
+    }
+
+    public function testExtendAndUnsetSection()
+    {
+        $blueprint = new Blueprint([
+            'title'  => 'extended',
+            'model'  => 'page',
+            'extends' => 'pages/base',
+            'tabs'  => [
+                'content'  => [
+                    'sections' => [
+                        'files' => false
+                    ]
+                ]
+            ]
+        ]);
+
+        try {
+            $sections = $blueprint->tab('content')['columns'][0]['sections'];
+        } catch (\Exception $e) {
+            $this->assertNull($e->getMessage(), 'Failed to getg sections.');
+        }
+
+        $this->assertEquals('extended', $blueprint->title());
+        $this->assertEquals(true, is_array($sections));
+        $this->assertEquals(1, sizeof($sections));
+        $this->assertEquals(true, array_key_exists('pages', $sections));
+        $this->assertEquals(false, array_key_exists('files', $sections));
+    }
+
+    public function testExtendAndUnsetFields()
+    {
+        $blueprint = new Blueprint([
+            'title'  => 'extended',
+            'model'  => 'page',
+            'extends' => 'pages/base',
+            'tabs'  => [
+                'seo' => [
+                    'fields' => [
+                        'seoDescription' => false
+                    ]
+                ]
+            ]
+        ]);
+
+        try {
+            $fields = $blueprint->tab('seo')['columns'][0]['sections']['seo-fields']['fields'];
+        } catch (\Exception $e) {
+            $this->assertNull($e->getMessage(), 'Failed to get fields.');
+        }
+
+        $this->assertEquals('extended', $blueprint->title());
+        $this->assertEquals(true, is_array($fields));
+        $this->assertEquals(1, sizeof($fields));
+        $this->assertEquals(true, array_key_exists('seoTitle', $fields));
+        $this->assertEquals(false, array_key_exists('seoDescription', $fields));
+    }
+}


### PR DESCRIPTION
This PR addresses [idea #169](https://github.com/getkirby/ideas/issues/169).

Kirby allows to reuse `fields`, `sections` or `tabs` (let's call them `components` for the scope of this PR) in blueprints by using the `extend` keyword. When reusing components it might become handy to unset/hide/remove some of the inherited components.

This PR allows to unset `fields`, `sections` and `tabs` by setting the corresponding property to `false`.

### Example usage:
```yaml
#/blueprints/tabs/base.yml
title: base
tabs:
  content: 
    sections: 
      pages: 
        type: pages
      files:
        type: files 
  seo:
    fields:
      seoTitle:
        label: SEO Title
        type: text
      seoDescription:
        label: SEO Description
        type: text
```

* Extent `tabs/base` and unset tab `SEO`
  ```yaml
  title: extended
  extends: tabs/base
  tabs:
    seo: false
  ```

* Extent `tabs/base` and unset section `files`
  ```yaml
  title: extended
  extends: tabs/base
  tabs:
    content:
      sections:
        files: false
  ```

* Extent `tabs/base` and unset field `seoDescription`
  ```yaml
  title: extended
  extends: tabs/base
  tabs:
    seo:
      fields:
        seoDescription: false
  ```

## Todos
- [x] Documented on getkirby.com
