### PR TITLE
Allow linking an (image:) to a file

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -106,8 +106,15 @@ return [
                 if (empty($tag->link) === true) {
                     return $img;
                 }
+                
+                if($link = $tag->file($tag->link)) {
+                    $link = $link->url();
+                }
+                else {
+                    $link = $tag->link === 'self' ? $tag->src : $tag->link;
+                }
 
-                return Html::a($tag->link === 'self' ? $tag->src : $tag->link, [$img], [
+                return Html::a($link, [$img], [
                     'rel'    => $tag->rel,
                     'class'  => $tag->linkclass,
                     'target' => $tag->target

--- a/config/tags.php
+++ b/config/tags.php
@@ -107,10 +107,9 @@ return [
                     return $img;
                 }
                 
-                if($link = $tag->file($tag->link)) {
+                if ($link = $tag->file($tag->link)) {
                     $link = $link->url();
-                }
-                else {
+                } else {
                     $link = $tag->link === 'self' ? $tag->src : $tag->link;
                 }
 


### PR DESCRIPTION
## Describe the PR
Not much but currently there's no way to get an `image` tag to open a different file by specifying its filename in the `link:` attribute, ends up on an error. This commit fixes it.  

```markdown
(image: file-1.jpg link: file-2.pdf)
```
