### PR TITLE
Support for locale arrays (backend part)

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -406,7 +406,7 @@ class App
         $visitor   = $this->visitor();
 
         foreach ($visitor->acceptedLanguages() as $lang) {
-            if ($language = $languages->findBy('locale', $lang->locale())) {
+            if ($language = $languages->findBy('locale', $lang->locale(LC_ALL))) {
                 return $language;
             }
         }

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -46,7 +46,7 @@ class Language extends Model
     protected $direction;
 
     /**
-     * @var string
+     * @var array
      */
     protected $locale;
 
@@ -293,13 +293,18 @@ class Language extends Model
     }
 
     /**
-     * Returns the PHP locale setting string
+     * Returns the PHP locale setting array
      *
-     * @return string
+     * @param int $category If passed, returns the locale for the specified category (e.g. LC_ALL) as string
+     * @return array|string
      */
-    public function locale(): string
+    public function locale(int $category = null)
     {
-        return $this->locale;
+        if ($category !== null) {
+            return $this->locale[$category] ?? $this->locale[LC_ALL] ?? null;
+        } else {
+            return $this->locale;
+        }
     }
 
     /**
@@ -401,12 +406,21 @@ class Language extends Model
     }
 
     /**
-     * @param string $locale
+     * @param string|array $locale
      * @return self
      */
-    protected function setLocale(string $locale = null): self
+    protected function setLocale($locale = null): self
     {
-        $this->locale = $locale ?? $this->code;
+        if (is_array($locale)) {
+            $this->locale = $locale;
+        } elseif (is_string($locale)) {
+            $this->locale = [LC_ALL => $locale];
+        } elseif ($locale === null) {
+            $this->locale = [LC_ALL => $this->code];
+        } else {
+            throw new InvalidArgumentException('Locale must be string or array');
+        }
+
         return $this;
     }
 

--- a/tests/Cms/LanguageTest.php
+++ b/tests/Cms/LanguageTest.php
@@ -76,7 +76,57 @@ class LanguageTest extends TestCase
             'locale' => 'en_US'
         ]);
 
-        $this->assertEquals('en_US', $language->locale());
+        $this->assertEquals([
+            LC_ALL => 'en_US'
+        ], $language->locale());
+        $this->assertEquals('en_US', $language->locale(LC_ALL));
+    }
+
+    public function testLocaleArray1()
+    {
+        $language = new Language([
+            'code' => 'en',
+            'locale' => [
+                LC_ALL   => 'en_US',
+                LC_CTYPE => 'en_US.utf8'
+            ]
+        ]);
+
+        $this->assertEquals([
+            LC_ALL   => 'en_US',
+            LC_CTYPE => 'en_US.utf8'
+        ], $language->locale());
+        $this->assertEquals('en_US', $language->locale(LC_ALL));
+        $this->assertEquals('en_US.utf8', $language->locale(LC_CTYPE));
+        $this->assertEquals('en_US', $language->locale(LC_MONETARY));
+    }
+
+    public function testLocaleArray2()
+    {
+        $language = new Language([
+            'code' => 'en',
+            'locale' => [
+                LC_CTYPE => 'en_US.utf8'
+            ]
+        ]);
+
+        $this->assertEquals([
+            LC_CTYPE => 'en_US.utf8'
+        ], $language->locale());
+        $this->assertEquals(null, $language->locale(LC_ALL));
+        $this->assertEquals('en_US.utf8', $language->locale(LC_CTYPE));
+        $this->assertEquals(null, $language->locale(LC_MONETARY));
+    }
+
+    /**
+     * @expectedException Kirby\Exception\InvalidArgumentException
+     */
+    public function testLocaleInvalid()
+    {
+        $language = new Language([
+            'code' => 'en',
+            'locale' => 123
+        ]);
     }
 
     public function testLocaleDefault()
@@ -85,7 +135,7 @@ class LanguageTest extends TestCase
             'code' => 'en',
         ]);
 
-        $this->assertEquals('en', $language->locale());
+        $this->assertEquals('en', $language->locale(LC_ALL));
     }
 
     public function testName()
@@ -169,7 +219,7 @@ class LanguageTest extends TestCase
         $this->assertEquals('de', $data['code']);
         $this->assertEquals(false, $data['default']);
         $this->assertEquals('ltr', $data['direction']);
-        $this->assertEquals('de', $data['locale']);
+        $this->assertEquals([LC_ALL => 'de'], $data['locale']);
         $this->assertEquals('de', $data['name']);
         $this->assertEquals([], $data['translations']);
         $this->assertEquals(null, $data['url'] ?? null);


### PR DESCRIPTION
This is the backend part of the locale array feature (#1387).

Locales that are configured entirely in the Panel with locale strings are still supported and seem to work just fine. If a locale array is configured manually in the language file, the Panel will however currently try to cast the array it gets from the API to a string for the locale string field. I think we should have some frontend logic in place that will then make that field read-only.

## Related issues

Fixes #1387.

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
- [x] Documented on getkirby.com