### PR TITLE
Caching improvements

### DIFF
--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -141,7 +141,7 @@ class MemCached extends Cache
             }
 
             // only delete keys with the current prefix
-            $keys = array_filter($keys, function($key) {
+            $keys = array_filter($keys, function ($key) {
                 return Str::startsWith($key, $this->options['prefix']);
             });
 

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cache;
 
+use Kirby\Toolkit\Str;
+
 /**
 * Memcached Driver
 *
@@ -132,6 +134,20 @@ class MemCached extends Cache
      */
     public function flush(): bool
     {
-        return $this->connection->flush();
+        if (empty($this->options['prefix']) === false) {
+            $keys = $this->connection->getAllKeys();
+            if (!is_array($keys)) {
+                return false;
+            }
+
+            // only delete keys with the current prefix
+            $keys = array_filter($keys, function($key) {
+                return Str::startsWith($key, $this->options['prefix']);
+            });
+
+            return $this->connection->deleteMulti($keys);
+        } else {
+            return $this->connection->flush();
+        }
     }
 }

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -60,12 +60,16 @@ trait AppCaches
             ];
         }
 
+        $prefix = str_replace('/', '_', $this->system()->indexUrl()) .
+                  '/' .
+                  str_replace('.', '/', $key);
+
         $defaults = [
             'active'    => true,
             'type'      => 'file',
             'extension' => 'cache',
             'root'      => $this->root('cache'),
-            'prefix'    => str_replace('.', '/', $key)
+            'prefix'    => $prefix
         ];
 
         if ($options === true) {

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -64,7 +64,8 @@ trait AppCaches
             'active'    => true,
             'type'      => 'file',
             'extension' => 'cache',
-            'root'      => $this->root('cache') . '/' . str_replace('.', '/', $key)
+            'root'      => $this->root('cache'),
+            'prefix'    => str_replace('.', '/', $key)
         ];
 
         if ($options === true) {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -100,6 +100,29 @@ class System
     }
 
     /**
+     * Returns the app's human-readable
+     * index URL without scheme
+     *
+     * @return string
+     */
+    public function indexUrl(): string
+    {
+        $url = $this->app->url('index');
+
+        if (Url::isAbsolute($url)) {
+            $uri = Url::toObject($url);
+        } else {
+            // index URL was configured without host, use the current host
+            $uri = Uri::current([
+                'path'   => $url,
+                'query'  => null
+            ]);
+        }
+
+        return $uri->setScheme(null)->setSlash(false)->toString();
+    }
+
+    /**
      * Create the most important folders
      * if they don't exist yet
      *
@@ -195,39 +218,16 @@ class System
     }
 
     /**
-     * Returns the app's index URL for
-     * licensing purposes without scheme
-     *
-     * @return string
-     */
-    protected function licenseUrl(): string
-    {
-        $url = $this->app->url('index');
-
-        if (Url::isAbsolute($url)) {
-            $uri = Url::toObject($url);
-        } else {
-            // index URL was configured without host, use the current host
-            $uri = Uri::current([
-                'path'   => $url,
-                'query'  => null
-            ]);
-        }
-
-        return $uri->setScheme(null)->setSlash(false)->toString();
-    }
-
-    /**
      * Normalizes the app's index URL for
      * licensing purposes
      *
      * @param string|null $url Input URL, by default the app's index URL
      * @return string Normalized URL
      */
-    protected function licenseUrlNormalized(string $url = null): string
+    protected function licenseUrl(string $url = null): string
     {
         if ($url === null) {
-            $url = $this->licenseUrl();
+            $url = $this->indexUrl();
         }
 
         // remove common "testing" subdomains as well as www.
@@ -300,7 +300,7 @@ class System
         }
 
         // verify the URL
-        if ($this->licenseUrlNormalized() !== $this->licenseUrlNormalized($license['domain'])) {
+        if ($this->licenseUrl() !== $this->licenseUrl($license['domain'])) {
             return false;
         }
 
@@ -352,7 +352,7 @@ class System
             'data' => [
                 'license' => $license,
                 'email'   => $email,
-                'domain'  => $this->licenseUrl()
+                'domain'  => $this->indexUrl()
             ]
         ]);
 

--- a/tests/Cms/AppCachesTest.php
+++ b/tests/Cms/AppCachesTest.php
@@ -44,6 +44,9 @@ class AppCachesTest extends TestCase
     public function testEnabledCacheWithOptions()
     {
         $kirby = $this->app([
+            'urls' => [
+                'index' => 'https://getkirby.com/test'
+            ],
             'options' => [
                 'cache.pages' => [
                     'type' => 'file',
@@ -56,7 +59,7 @@ class AppCachesTest extends TestCase
         $this->assertEquals(__DIR__ . '/fixtures/cache', $kirby->cache('pages')->options()['root']);
 
         $kirby->cache('pages')->set('home', 'test');
-        $this->assertFileExists(__DIR__ . '/fixtures/cache/pages/home.cache');
+        $this->assertFileExists(__DIR__ . '/fixtures/cache/getkirby.com_test/pages/home.cache');
     }
 
     public function testPluginDefaultCache()

--- a/tests/Cms/AppCachesTest.php
+++ b/tests/Cms/AppCachesTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Cache\Cache;
 use Kirby\Cache\FileCache;
+use Kirby\Toolkit\Dir;
 
 class AppCachesTest extends TestCase
 {
@@ -14,6 +15,13 @@ class AppCachesTest extends TestCase
                 'index' => __DIR__
             ]
         ], $props));
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Dir::remove(__DIR__ . '/fixtures/cache');
     }
 
     public function testDisabledCache()
@@ -30,6 +38,7 @@ class AppCachesTest extends TestCase
         ]);
 
         $this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
+        $this->assertEquals($kirby->root('cache'), $kirby->cache('pages')->options()['root']);
     }
 
     public function testEnabledCacheWithOptions()
@@ -44,6 +53,10 @@ class AppCachesTest extends TestCase
         ]);
 
         $this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
+        $this->assertEquals(__DIR__ . '/fixtures/cache', $kirby->cache('pages')->options()['root']);
+
+        $kirby->cache('pages')->set('home', 'test');
+        $this->assertFileExists(__DIR__ . '/fixtures/cache/pages/home.cache');
     }
 
     public function testPluginDefaultCache()

--- a/tests/Cms/PageCacheTest.php
+++ b/tests/Cms/PageCacheTest.php
@@ -13,8 +13,7 @@ class PageCacheTest extends TestCase
     {
         $this->app = new App([
             'roots' => [
-                'index' => '/dev/null',
-                'cache' => $this->fixtures = __DIR__ . '/fixtures/PageCacheTest',
+                'index' => $this->fixtures = __DIR__ . '/fixtures/PageCacheTest'
             ],
             'site' => [
                 'children' => [

--- a/tests/Cms/SystemTest.php
+++ b/tests/Cms/SystemTest.php
@@ -104,7 +104,7 @@ class SystemTest extends TestCase
         $_SERVER['SERVER_ADDR'] = null;
     }
 
-    public function licenseUrlProvider()
+    public function indexUrlProvider()
     {
         return [
             ['http://getkirby.com', 'getkirby.com'],
@@ -117,14 +117,10 @@ class SystemTest extends TestCase
     }
 
     /**
-     * @dataProvider licenseUrlProvider
+     * @dataProvider indexUrlProvider
      */
-    public function testLicenseUrl($indexUrl, $expected)
+    public function testIndexUrl($indexUrl, $expected)
     {
-        $reflector = new ReflectionClass(System::class);
-        $licenseUrl = $reflector->getMethod('licenseUrl');
-        $licenseUrl->setAccessible(true);
-
         $_SERVER['SERVER_ADDR'] = 'example.com';
 
         $system = new System($this->app->clone([
@@ -132,13 +128,13 @@ class SystemTest extends TestCase
                 'url' => $indexUrl
             ]
         ]));
-        $this->assertEquals($expected, $licenseUrl->invoke($system));
+        $this->assertEquals($expected, $system->indexUrl($indexUrl));
 
         // reset SERVER_ADDR
         $_SERVER['SERVER_ADDR'] = null;
     }
 
-    public function licenseUrlNormalizedProvider()
+    public function licenseUrlProvider()
     {
         return [
             [null, 'getkirby.com'],
@@ -157,20 +153,20 @@ class SystemTest extends TestCase
     }
 
     /**
-     * @dataProvider licenseUrlNormalizedProvider
+     * @dataProvider licenseUrlProvider
      */
-    public function testLicenseUrlNormalized($url, $expected)
+    public function testLicenseUrl($url, $expected)
     {
         $reflector = new ReflectionClass(System::class);
-        $licenseUrlNormalized = $reflector->getMethod('licenseUrlNormalized');
-        $licenseUrlNormalized->setAccessible(true);
+        $licenseUrl = $reflector->getMethod('licenseUrl');
+        $licenseUrl->setAccessible(true);
 
         $system = new System($this->app->clone([
             'options' => [
                 'url' => 'https://getkirby.com'
             ]
         ]));
-        $this->assertEquals($expected, $licenseUrlNormalized->invoke($system, $url));
+        $this->assertEquals($expected, $licenseUrl->invoke($system, $url));
     }
 
     public function testIsInstallableOnLocalhost()


### PR DESCRIPTION
The `AppCaches` now use the `prefix` feature of our `Cache` classes instead of only modifying the `root` of the cache directory. With that change, the prefix is used not only for file caches, but also for APCu and MemCached (which don't have a `root`).

The prefix now includes:

- The cache key (like previously)
- The index URL of the current site (so that caches are not shared by multiple sites on the same server by default)

If sharing between sites is desired, the prefix can be set manually to something else.

Also the MemCached cache is now flushed based on the current prefix only (not the entire cache). This is in line with the other two caching adapters File and APCu that do this already.

## Related issues

- Fixes #1496
- Fixes #1507

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [ ] Documented on getkirby.com