### PR TITLE
Support for custom media folder root & URL

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -16,10 +16,10 @@ use Kirby\Toolkit\View;
 return function ($kirby) {
     $api   = $kirby->option('api.slug', 'api');
     $panel = $kirby->option('panel.slug', 'panel');
-
     $index = $kirby->url('index');
     $media = $kirby->url('media');
-    if (Str::startsWith($media, $index)) {
+
+    if (Str::startsWith($media, $index) === true) {
         $media = Str::after($media, $index);
     } else {
         // media URL is outside of the site, we can't make routing work;

--- a/config/routes.php
+++ b/config/routes.php
@@ -17,6 +17,16 @@ return function ($kirby) {
     $api   = $kirby->option('api.slug', 'api');
     $panel = $kirby->option('panel.slug', 'panel');
 
+    $index = $kirby->url('index');
+    $media = $kirby->url('media');
+    if (Str::startsWith($media, $index)) {
+        $media = Str::after($media, $index);
+    } else {
+        // media URL is outside of the site, we can't make routing work;
+        // fall back to the standard media route
+        $media = 'media';
+    }
+
     /**
      * Before routes are running before the
      * plugin routes and cannot be overwritten by
@@ -43,7 +53,7 @@ return function ($kirby) {
             }
         ],
         [
-            'pattern' => 'media/plugins/index.(css|js)',
+            'pattern' => $media . '/plugins/index.(css|js)',
             'env'     => 'media',
             'action'  => function (string $extension) use ($kirby) {
                 return $kirby
@@ -53,7 +63,7 @@ return function ($kirby) {
             }
         ],
         [
-            'pattern' => 'media/plugins/(:any)/(:any)/(:all).(css|gif|js|jpg|png|svg|webp|woff2|woff)',
+            'pattern' => $media . '/plugins/(:any)/(:any)/(:all).(css|gif|js|jpg|png|svg|webp|woff2|woff)',
             'env'     => 'media',
             'action'  => function (string $provider, string $pluginName, string $filename, string $extension) use ($kirby) {
                 return PluginAssets::resolve($provider . '/' . $pluginName, $filename . '.' . $extension);
@@ -71,28 +81,28 @@ return function ($kirby) {
             }
         ],
         [
-            'pattern' => 'media/pages/(:all)/(:any)/(:any)',
+            'pattern' => $media . '/pages/(:all)/(:any)/(:any)',
             'env'     => 'media',
             'action'  => function ($path, $hash, $filename) use ($kirby) {
                 return Media::link($kirby->page($path), $hash, $filename);
             }
         ],
         [
-            'pattern' => 'media/site/(:any)/(:any)',
+            'pattern' => $media . '/site/(:any)/(:any)',
             'env'     => 'media',
             'action'  => function ($hash, $filename) use ($kirby) {
                 return Media::link($kirby->site(), $hash, $filename);
             }
         ],
         [
-            'pattern' => 'media/users/(:any)/(:any)/(:any)',
+            'pattern' => $media . '/users/(:any)/(:any)/(:any)',
             'env'     => 'media',
             'action'  => function ($id, $hash, $filename) use ($kirby) {
                 return Media::link($kirby->user($id), $hash, $filename);
             }
         ],
         [
-            'pattern' => 'media/assets/(:all)/(:any)/(:any)',
+            'pattern' => $media . '/assets/(:all)/(:any)/(:any)',
             'env'     => 'media',
             'action'  => function ($path, $hash, $filename) use ($kirby) {
                 return Media::thumb($path, $hash, $filename);

--- a/tests/Cms/RouterTest.php
+++ b/tests/Cms/RouterTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Http\Route;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\I18n;
 
@@ -659,5 +660,40 @@ class RouterTest extends TestCase
         $this->assertEquals('xml', $result->body());
         $this->assertEquals('en', $app->language()->code());
         $this->assertEquals('en', I18n::locale());
+    }
+
+    public function testCustomMediaFolder()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'urls' => [
+                'index' => 'https://getkirby.com',
+                'media' => $media = 'https://getkirby.com/thumbs'
+            ]
+        ]);
+
+        $this->assertEquals($media, $app->url('media'));
+
+        // call custom media route
+        $route = $app->router()->find('thumbs/pages/a/b/1234-5678/test.jpg', 'GET');
+        $this->assertContains('thumbs/pages/(.*)', $route->pattern());
+
+        $route = $app->router()->find('thumbs/site/1234-5678/test.jpg', 'GET');
+        $this->assertContains('thumbs/site/([a-z', $route->pattern());
+
+        $route = $app->router()->find('thumbs/users/test@getkirby.com/1234-5678/test.jpg', 'GET');
+        $this->assertContains('thumbs/users/([a-z', $route->pattern());
+
+        // default media route should result in the fallback route
+        $route = $app->router()->find('media/pages/a/b/1234-5678/test.jpg', 'GET');
+        $this->assertEquals('(.*)', $route->pattern());
+
+        $route = $app->router()->find('media/site/1234-5678/test.jpg', 'GET');
+        $this->assertEquals('(.*)', $route->pattern());
+
+        $route = $app->router()->find('media/users/test@getkirby.com/1234-5678/test.jpg', 'GET');
+        $this->assertEquals('(.*)', $route->pattern());
     }
 }


### PR DESCRIPTION
The media routes are now dynamically set based on the configured URL path of the `media` directory. This makes thumbs and other lazy media files work again.

## Related issues

- Fixes #1494.

## Todos
- [ ] Add unit tests for fixed bug/feature
- [ ] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
- [x] Documented on getkirby.com
