### PR TITLE
Disable FormButtons on locked form

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -2,6 +2,7 @@
   <nav v-if="hasChanges" class="k-form-buttons">
     <k-view>
       <k-button
+        :disabled="isLocked"
         icon="undo"
         class="k-form-button"
         @click="reset"
@@ -9,6 +10,7 @@
         {{ $t("revert") }}
       </k-button>
       <k-button
+        :disabled="isLocked"
         icon="check"
         class="k-form-button"
         @click="save"
@@ -27,6 +29,9 @@ export default {
     },
     id() {
       return this.$store.state.form.current;
+    },
+    isLocked() {
+      return this.$store.getters["form/isLocked"];
     }
   },
   created() {

--- a/panel/src/store/modules/form.js
+++ b/panel/src/store/modules/form.js
@@ -27,7 +27,10 @@ export default {
       }
     },
     isCurrent: (state) => id => {
-      return state.current = id;
+      return state.current === id;
+    },
+    isLocked: (state) => {
+      return state.isLocked === true;
     },
     model: (state, getters) => id => {
       return getters.exists(id)


### PR DESCRIPTION
## Describe the PR
Currently, when an structure field item is open, you can click the FormButtons (save), but the form isn't actually saved due to https://github.com/getkirby/kirby/blob/features/panel/src/store/modules/form.js#L146-L150 . However, since no exception is thrown, the smile notification is shown, even though the form isn't actually saved.

To avoid all this, the PR adds that the buttons in the FormButtons bar are disabled when a form is locked.

## Related issues
- Fixes #1679
