### PR TITLE
Select field: Disable or hide empty option if required

### DIFF
--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -14,5 +14,11 @@ return [
         'icon' => function (string $icon = null) {
             return $icon;
         },
+        /**
+         * Custom placeholder string for empty option.
+         */
+        'placeholder' => function (string $placeholder = '—') {
+            return $placeholder;
+        },
     ]
 ];

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -12,7 +12,7 @@
       class="k-select-input-native"
       v-on="listeners"
     >
-      <option v-if="empty !== false" value="">{{ empty }}</option>
+      <option :disabled="required" value="">{{ placeholder }}</option>
       <option
         v-for="option in options"
         :disabled="option.disabled"
@@ -38,10 +38,6 @@ export default {
     id: [Number, String],
     name: [Number, String],
     placeholder: String,
-    empty: {
-      type: [String, Boolean],
-      default: "—"
-    },
     options: {
       type: Array,
       default: () => {
@@ -69,7 +65,7 @@ export default {
       const label = this.text(this.selected);
 
       if (this.selected === "" || this.selected === null || label === null) {
-        return this.placeholder || "—";
+        return this.placeholder;
       }
 
       return label;

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -12,7 +12,13 @@
       class="k-select-input-native"
       v-on="listeners"
     >
-      <option :disabled="required" value="">{{ placeholder }}</option>
+      <option
+        v-if="hasEmpty"
+        :disabled="required"
+        value=""
+      >
+        {{ placeholder }}
+      </option>
       <option
         v-for="option in options"
         :disabled="option.disabled"
@@ -34,6 +40,7 @@ export default {
   props: {
     autofocus: Boolean,
     ariaLabel: String,
+    default: String,
     disabled: Boolean,
     id: [Number, String],
     name: [Number, String],
@@ -61,6 +68,9 @@ export default {
     };
   },
   computed: {
+    hasEmpty() {
+      return !(this.required && this.default);
+    },
     label() {
       const label = this.text(this.selected);
 


### PR DESCRIPTION
## Describe the PR
Disable empty option when field is required and no default is set, so the empty option is preselected but cannot be re-selected.
Hide empty option when field is required and default is set.

## Related issues
- Fixes #1664