### PR TITLE
Components: re-initialize when options changed

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -105,8 +105,14 @@ return [
      */
     'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
         static $markdown;
+        static $config;
 
-        $markdown = $markdown ?? new Markdown($options);
+        // if the config options have changed or the component is called for the first time,
+        // (re-)initialize the parser object
+        if ($config !== $options) {
+            $markdown = new Markdown($options);
+            $config   = $options;
+        }
 
         return $markdown->parse($text, $inline);
     },
@@ -121,8 +127,14 @@ return [
      */
     'smartypants' => function (App $kirby, string $text = null, array $options = []): string {
         static $smartypants;
+        static $config;
 
-        $smartypants = $smartypants ?? new Smartypants($options);
+        // if the config options have changed or the component is called for the first time,
+        // (re-)initialize the parser object
+        if ($config !== $options) {
+            $smartypants = new Smartypants($options);
+            $config      = $options;
+        }
 
         return $smartypants->parse($text);
     },

--- a/tests/Cms/AppComponentsTest.php
+++ b/tests/Cms/AppComponentsTest.php
@@ -21,12 +21,37 @@ class AppComponentsTest extends TestCase
         $this->assertEquals($expected, $this->kirby->markdown($text));
     }
 
+    public function testMarkdownCachedInstance()
+    {
+        $text     = '1st line
+2nd line';
+        $expected = '<p>1st line<br />
+2nd line</p>';
+
+        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, []));
+
+        $expected = '<p>1st line
+2nd line</p>';
+        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, ['breaks' => false]));
+    }
+
     public function testSmartypants()
     {
         $text     = '"Test"';
         $expected = '&#8220;Test&#8221;';
 
         $this->assertEquals($expected, $this->kirby->smartypants($text));
+    }
+
+    public function testSmartypantsCachedInstance()
+    {
+        $text     = '"Test"';
+        $expected = '&#8220;Test&#8221;';
+
+        $this->assertEquals($expected, $this->kirby->component('smartypants')($this->kirby, $text, []));
+
+        $expected = 'TestTest&#8221;';
+        $this->assertEquals($expected, $this->kirby->component('smartypants')($this->kirby, $text, ['doublequote.open' => 'Test']));
     }
 
     public function testSnippet()


### PR DESCRIPTION
## Describe the PR
for markdown and smartypants components

## Related issues
- Fixes #1465

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
