### PR TITLE
User and users methods, user models, file models

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -63,6 +63,7 @@ trait AppPlugins
         'templates' => [],
         'translations' => [],
         'userMethods' => [],
+        'userModels' => [],
         'usersMethods' => [],
         'validators' => []
     ];
@@ -271,6 +272,10 @@ trait AppPlugins
         return $this->extensions['userMethods'] = User::$methods = array_merge(User::$methods, $methods);
     }
 
+    protected function extendUserModels(array $models): array
+    {
+        return $this->extensions['userModels'] = User::$models = array_merge(User::$models, $models);
+    }
 
     protected function extendUsersMethods(array $methods): array
     {

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -48,13 +48,14 @@ trait AppPlugins
         'fieldMethods' => [],
         'fileMethods' => [],
         'filesMethods' => [],
+        'fileModels' => [],
         'fields' => [],
         'hooks' => [],
         'options' => [],
         'pages' => [],
         'pageMethods' => [],
-        'pageModels' => [],
         'pagesMethods' => [],
+        'pageModels' => [],
         'routes' => [],
         'sections' => [],
         'siteMethods' => [],
@@ -146,6 +147,11 @@ trait AppPlugins
     protected function extendFilesMethods(array $methods): array
     {
         return $this->extensions['filesMethods'] = Files::$methods = array_merge(Files::$methods, $methods);
+    }
+
+    protected function extendFileModels(array $models): array
+    {
+        return $this->extensions['fileModels'] = File::$models = array_merge(File::$models, $models);
     }
 
     protected function extendFieldMethods(array $methods): array

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -62,6 +62,8 @@ trait AppPlugins
         'tags' => [],
         'templates' => [],
         'translations' => [],
+        'userMethods' => [],
+        'usersMethods' => [],
         'validators' => []
     ];
 
@@ -262,6 +264,17 @@ trait AppPlugins
     protected function extendTranslations(array $translations): array
     {
         return $this->extensions['translations'] = array_replace_recursive($this->extensions['translations'], $translations);
+    }
+
+    protected function extendUserMethods(array $methods): array
+    {
+        return $this->extensions['userMethods'] = User::$methods = array_merge(User::$methods, $methods);
+    }
+
+
+    protected function extendUsersMethods(array $methods): array
+    {
+        return $this->extensions['usersMethods'] = Users::$methods = array_merge(Users::$methods, $methods);
     }
 
     protected function extendValidators(array $validators): array

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -75,6 +75,14 @@ class File extends ModelWithContent
     public static $methods = [];
 
     /**
+     * Registry with all File models
+     *
+     * @var array
+     */
+    public static $models = [];
+
+
+    /**
      * The parent object
      *
      * @var Model
@@ -262,6 +270,22 @@ class File extends ModelWithContent
     }
 
     /**
+     * Constructs a File object and also
+     * takes File models into account.
+     *
+     * @internal
+     * @return self
+     */
+    public static function factory($props): self
+    {
+        if (empty($props['model']) === false) {
+            return static::model($props['model'], $props);
+        }
+
+        return new static($props);
+    }
+
+    /**
      * Returns the filename with extension
      *
      * @return string
@@ -356,16 +380,24 @@ class File extends ModelWithContent
     }
 
     /**
-     * Returns the parent model.
-     * This is normally the parent page
-     * or the site object.
+     * Creates a file model if it has been registered
      *
      * @internal
-     * @return Site|Page
+     * @param string $name
+     * @param array $props
+     * @return User
      */
-    public function model()
+    public static function model(string $name, array $props = [])
     {
-        return $this->parent();
+        if ($class = (static::$models[$name] ?? null)) {
+            $object = new $class($props);
+
+            if (is_a($object, 'Kirby\Cms\File') === true) {
+                return $object;
+            }
+        }
+
+        return new static($props);
     }
 
     /**

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -135,8 +135,10 @@ trait FileActions
         // prefer the filename from the props
         $props['filename'] = F::safeName($props['filename'] ?? basename($props['source']));
 
+        $props['model'] = strtolower($props['template'] ?? 'default');
+
         // create the basic file and a test upload object
-        $file   = new static($props);
+        $file = File::factory($props);
         $upload = new Image($props['source']);
 
         // create a form for the file

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -90,7 +90,7 @@ class Files extends Collection
             $props['kirby']      = $kirby;
             $props['parent']     = $parent;
 
-            $file = new File($props);
+            $file = File::factory($props);
 
             $collection->data[$file->id()] = $file;
         }

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -28,6 +28,7 @@ class User extends ModelWithContent
     const CLASS_ALIAS = 'user';
 
     use HasFiles;
+    use HasMethods;
     use HasSiblings;
     use UserActions;
 
@@ -72,6 +73,13 @@ class User extends ModelWithContent
     protected $language;
 
     /**
+     * All registered user methods
+     *
+     * @var array
+     */
+    public static $methods = [];
+
+    /**
      * @var string
      */
     protected $name;
@@ -101,6 +109,11 @@ class User extends ModelWithContent
         // public property access
         if (isset($this->$method) === true) {
             return $this->$method;
+        }
+
+        // user methods
+        if ($this->hasMethod($method)) {
+            return $this->callMethod($method, $arguments);
         }
 
         // return site content otherwise

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -80,6 +80,13 @@ class User extends ModelWithContent
     public static $methods = [];
 
     /**
+     * Registry with all User models
+     *
+     * @var array
+     */
+    public static $models = [];
+
+    /**
      * @var string
      */
     protected $name;
@@ -249,6 +256,22 @@ class User extends ModelWithContent
     public function exists(): bool
     {
         return is_file($this->contentFile('default')) === true;
+    }
+
+    /**
+     * Constructs a User object and also
+     * takes User models into account.
+     *
+     * @internal
+     * @return self
+     */
+    public static function factory($props): self
+    {
+        if (empty($props['model']) === false) {
+            return static::model($props['model'], $props);
+        }
+
+        return new static($props);
     }
 
     /**
@@ -455,6 +478,27 @@ class User extends ModelWithContent
     public function mediaUrl(): string
     {
         return $this->kirby()->url('media') . '/users/' . $this->id();
+    }
+
+    /**
+     * Creates a user model if it has been registered
+     *
+     * @internal
+     * @param string $name
+     * @param array $props
+     * @return User
+     */
+    public static function model(string $name, array $props = [])
+    {
+        if ($class = (static::$models[$name] ?? null)) {
+            $object = new $class($props);
+
+            if (is_a($object, 'Kirby\Cms\User') === true) {
+                return $object;
+            }
+        }
+
+        return new static($props);
     }
 
     /**

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -173,7 +173,9 @@ trait UserActions
             $data['password'] = static::hashPassword($props['password']);
         }
 
-        $user = new static($data);
+        $props['role'] = $props['model'] = strtolower($props['role'] ?? 'default');
+
+        $user = User::factory($data);
 
         // create a form for the user
         $form = Form::for($user, [

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -71,7 +71,7 @@ class Users extends Collection
 
         // read all user blueprints
         foreach ($users as $props) {
-            $user = new User($props + $inject);
+            $user = User::factory($props + $inject);
             $collection->set($user->id(), $user);
         }
 

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -19,6 +19,14 @@ use Kirby\Toolkit\Str;
  */
 class Users extends Collection
 {
+
+    /**
+     * All registered users methods
+     *
+     * @var array
+     */
+    public static $methods = [];
+
     public function create(array $data)
     {
         return User::create($data);

--- a/tests/Cms/AppPluginsTest.php
+++ b/tests/Cms/AppPluginsTest.php
@@ -416,6 +416,26 @@ class AppPluginsTest extends TestCase
         Page::$methods = [];
     }
 
+    public function testPagesMethod()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'pagesMethods' => [
+                'test' => function () {
+                    return 'test';
+                }
+            ]
+        ]);
+
+        $pages = new Pages([]);
+        $this->assertEquals('test', $pages->test());
+
+        // reset methods
+        Pages::$methods = [];
+    }
+
     public function testPageModel()
     {
         $kirby = new App([
@@ -674,5 +694,48 @@ class AppPluginsTest extends TestCase
         I18n::$locale = 'de';
 
         $this->assertEquals('Deutscher Test', I18n::translate('test'));
+    }
+
+    public function testUserMethod()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'userMethods' => [
+                'test' => function () {
+                    return 'test';
+                }
+            ]
+        ]);
+
+        $user = new User([
+            'email' => 'test@getkirby.com',
+            'name'  => 'Test User'
+        ]);
+        $this->assertEquals('test', $user->test());
+
+        // reset methods
+        User::$methods = [];
+    }
+
+    public function testUsersMethod()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'usersMethods' => [
+                'test' => function () {
+                    return 'test';
+                }
+            ]
+        ]);
+
+        $users = new Users([]);
+        $this->assertEquals('test', $users->test());
+
+        // reset methods
+        Users::$methods = [];
     }
 }

--- a/tests/Cms/AppPluginsTest.php
+++ b/tests/Cms/AppPluginsTest.php
@@ -17,6 +17,10 @@ class DummyPage extends Page
 {
 }
 
+class DummyUser extends User
+{
+}
+
 class AppPluginsTest extends TestCase
 {
     public function setUp(): void
@@ -717,6 +721,25 @@ class AppPluginsTest extends TestCase
 
         // reset methods
         User::$methods = [];
+    }
+
+    public function testUserModel()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'userModels' => [
+                'dummy' => DummyUser::class
+            ]
+        ]);
+
+        $user = User::factory([
+            'slug'  => 'test',
+            'model' => 'dummy'
+        ]);
+
+        $this->assertInstanceOf(DummyUser::class, $user);
     }
 
     public function testUsersMethod()

--- a/tests/Cms/AppPluginsTest.php
+++ b/tests/Cms/AppPluginsTest.php
@@ -13,6 +13,10 @@ class DummyCache extends FileCache
 {
 }
 
+class DummyFile extends File
+{
+}
+
 class DummyPage extends Page
 {
 }
@@ -268,6 +272,25 @@ class AppPluginsTest extends TestCase
         ]);
 
         $this->assertEquals(['foo' => 'bar'], $kirby->controller('test'));
+    }
+
+    public function testfileModel()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'fileModels' => [
+                'dummy' => DummyFile::class
+            ]
+        ]);
+
+        $user = File::factory([
+            'filename' => 'test',
+            'model'    => 'dummy'
+        ]);
+
+        $this->assertInstanceOf(DummyFile::class, $user);
     }
 
     public function testFieldMethod()

--- a/tests/Cms/FileTest.php
+++ b/tests/Cms/FileTest.php
@@ -332,4 +332,20 @@ class FileTest extends TestCase
         $this->assertEquals('https://getkirby.com/api/users/test/files/user-file.jpg', $file->apiUrl());
         $this->assertEquals('users/test/files/user-file.jpg', $file->apiUrl(true));
     }
+
+    public function testFileModel()
+    {
+        File::$models = [
+            'dummy' => DummyFile::class
+        ];
+
+        $user = File::factory([
+            'filename' => 'test',
+            'model'    => 'dummy'
+        ]);
+
+        $this->assertInstanceOf(DummyFile::class, $user);
+
+        File::$models = [];
+    }
 }

--- a/tests/Cms/PageTest.php
+++ b/tests/Cms/PageTest.php
@@ -848,7 +848,7 @@ class PageTest extends TestCase
         $this->assertEquals('pages/mother+child', $page->apiUrl(true));
     }
 
-    public function testCustomMethods()
+    public function testPageMethods()
     {
         Page::$methods = [
             'test' => function () {
@@ -861,5 +861,21 @@ class PageTest extends TestCase
         $this->assertEquals('homer', $page->test());
 
         Page::$methods = [];
+    }
+
+    public function testPageModel()
+    {
+        Page::$models = [
+            'dummy' => DummyPage::class
+        ];
+
+        $page = Page::factory([
+            'slug'  => 'test',
+            'model' => 'dummy'
+        ]);
+
+        $this->assertInstanceOf(DummyPage::class, $page);
+
+        Page::$models = [];
     }
 }

--- a/tests/Cms/PageTest.php
+++ b/tests/Cms/PageTest.php
@@ -847,4 +847,19 @@ class PageTest extends TestCase
         $this->assertEquals('https://getkirby.com/api/pages/mother+child', $page->apiUrl());
         $this->assertEquals('pages/mother+child', $page->apiUrl(true));
     }
+
+    public function testCustomMethods()
+    {
+        Page::$methods = [
+            'test' => function () {
+                return 'homer';
+            }
+        ];
+
+        $page = new Page(['slug' => 'test']);
+
+        $this->assertEquals('homer', $page->test());
+
+        Page::$methods = [];
+    }
 }

--- a/tests/Cms/PagesTest.php
+++ b/tests/Cms/PagesTest.php
@@ -277,4 +277,32 @@ class PagesTest extends TestCase
         $result = $pages->search('mountain');
         $this->assertCount(2, $result);
     }
+
+    public function testCustomMethods()
+    {
+        Pages::$methods = [
+            'test' => function () {
+                $slugs = '';
+                foreach ($this as $page) {
+                    $slugs .= $page->slug();
+                }
+                return $slugs;
+            }
+        ];
+
+        $pages = Pages::factory([
+            [
+                'slug' => 'page',
+                'children' => [
+                    ['slug' => 'a'],
+                    ['slug' => 'b']
+                ]
+            ]
+        ]);
+
+        $pages = $pages->find('page')->children();
+        $this->assertEquals('ab', $pages->test());
+
+        Pages::$methods = [];
+    }
 }

--- a/tests/Cms/UserTest.php
+++ b/tests/Cms/UserTest.php
@@ -201,4 +201,22 @@ class UserTest extends TestCase
         $this->assertEquals('Test User', $user->query('user.name'));
         $this->assertEquals('test@getkirby.com', $user->query('user.email'));
     }
+
+    public function testCustomMethods()
+    {
+        User::$methods = [
+            'test' => function () {
+                return 'homer';
+            }
+        ];
+
+        $user = new User([
+            'email' => 'test@getkirby.com',
+            'name'  => 'Test User'
+        ]);
+
+        $this->assertEquals('homer', $user->test());
+
+        User::$methods = [];
+    }
 }

--- a/tests/Cms/UserTest.php
+++ b/tests/Cms/UserTest.php
@@ -202,7 +202,7 @@ class UserTest extends TestCase
         $this->assertEquals('test@getkirby.com', $user->query('user.email'));
     }
 
-    public function testCustomMethods()
+    public function testUserMethods()
     {
         User::$methods = [
             'test' => function () {
@@ -218,5 +218,21 @@ class UserTest extends TestCase
         $this->assertEquals('homer', $user->test());
 
         User::$methods = [];
+    }
+
+    public function testUserModel()
+    {
+        User::$models = [
+            'dummy' => DummyUser::class
+        ];
+
+        $user = User::factory([
+            'slug'  => 'test',
+            'model' => 'dummy'
+        ]);
+
+        $this->assertInstanceOf(DummyUser::class, $user);
+
+        User::$models = [];
     }
 }

--- a/tests/Cms/UsersTest.php
+++ b/tests/Cms/UsersTest.php
@@ -32,4 +32,26 @@ class UsersTest extends TestCase
         $this->assertEquals('b@getkirby.com', $users->find('B@getkirby.com')->email());
         $this->assertEquals('b@getkirby.com', $users->find('b@getkirby.com')->email());
     }
+
+    public function testCustomMethods()
+    {
+        Users::$methods = [
+            'test' => function () {
+                $i = 0;
+                foreach ($this as $user) {
+                    $i++;
+                }
+                return $i;
+            }
+        ];
+
+        $users = new Users([
+            new User(['email' => 'a@getkirby.com']),
+            new User(['email' => 'B@getKirby.com']),
+        ]);
+
+        $this->assertEquals(2, $users->test());
+
+        Users::$methods = [];
+    }
 }


### PR DESCRIPTION
## Describe the PR
Adds custom user methods and users methods.
Adds user models based on their role.
Adds file models based on their template.

Important: Removes previous `File::model` calls for `File::parent` to keep consistency across main object classes.

## Related issues
- Implements  #1636

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)