### PR TITLE
Cache improvements (PR 1 of 2): Cache prefix

### DIFF
--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -81,12 +81,16 @@ trait AppCaches
             ];
         }
 
+        $prefix = str_replace('/', '_', $this->system()->indexUrl()) .
+                  '/' .
+                  str_replace('.', '/', $key);
+
         $defaults = [
             'active'    => true,
             'type'      => 'file',
             'extension' => 'cache',
             'root'      => $this->root('cache'),
-            'prefix'    => str_replace('.', '/', $key)
+            'prefix'    => $prefix
         ];
 
         if ($options === true) {

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -85,7 +85,8 @@ trait AppCaches
             'active'    => true,
             'type'      => 'file',
             'extension' => 'cache',
-            'root'      => $this->root('cache') . '/' . str_replace('.', '/', $key)
+            'root'      => $this->root('cache'),
+            'prefix'    => str_replace('.', '/', $key)
         ];
 
         if ($options === true) {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -108,6 +108,29 @@ class System
     }
 
     /**
+     * Returns the app's human-readable
+     * index URL without scheme
+     *
+     * @return string
+     */
+    public function indexUrl(): string
+    {
+        $url = $this->app->url('index');
+
+        if (Url::isAbsolute($url)) {
+            $uri = Url::toObject($url);
+        } else {
+            // index URL was configured without host, use the current host
+            $uri = Uri::current([
+                'path'   => $url,
+                'query'  => null
+            ]);
+        }
+
+        return $uri->setScheme(null)->setSlash(false)->toString();
+    }
+
+    /**
      * Create the most important folders
      * if they don't exist yet
      *
@@ -203,39 +226,16 @@ class System
     }
 
     /**
-     * Returns the app's index URL for
-     * licensing purposes without scheme
-     *
-     * @return string
-     */
-    protected function licenseUrl(): string
-    {
-        $url = $this->app->url('index');
-
-        if (Url::isAbsolute($url)) {
-            $uri = Url::toObject($url);
-        } else {
-            // index URL was configured without host, use the current host
-            $uri = Uri::current([
-                'path'   => $url,
-                'query'  => null
-            ]);
-        }
-
-        return $uri->setScheme(null)->setSlash(false)->toString();
-    }
-
-    /**
      * Normalizes the app's index URL for
      * licensing purposes
      *
      * @param string|null $url Input URL, by default the app's index URL
      * @return string Normalized URL
      */
-    protected function licenseUrlNormalized(string $url = null): string
+    protected function licenseUrl(string $url = null): string
     {
         if ($url === null) {
-            $url = $this->licenseUrl();
+            $url = $this->indexUrl();
         }
 
         // remove common "testing" subdomains as well as www.
@@ -308,7 +308,7 @@ class System
         }
 
         // verify the URL
-        if ($this->licenseUrlNormalized() !== $this->licenseUrlNormalized($license['domain'])) {
+        if ($this->licenseUrl() !== $this->licenseUrl($license['domain'])) {
             return false;
         }
 
@@ -372,7 +372,7 @@ class System
             'data' => [
                 'license' => $license,
                 'email'   => $email,
-                'domain'  => $this->licenseUrl()
+                'domain'  => $this->indexUrl()
             ]
         ]);
 

--- a/tests/Cms/AppCachesTest.php
+++ b/tests/Cms/AppCachesTest.php
@@ -44,6 +44,9 @@ class AppCachesTest extends TestCase
     public function testEnabledCacheWithOptions()
     {
         $kirby = $this->app([
+            'urls' => [
+                'index' => 'https://getkirby.com/test'
+            ],
             'options' => [
                 'cache.pages' => [
                     'type' => 'file',
@@ -56,7 +59,7 @@ class AppCachesTest extends TestCase
         $this->assertEquals(__DIR__ . '/fixtures/cache', $kirby->cache('pages')->options()['root']);
 
         $kirby->cache('pages')->set('home', 'test');
-        $this->assertFileExists(__DIR__ . '/fixtures/cache/pages/home.cache');
+        $this->assertFileExists(__DIR__ . '/fixtures/cache/getkirby.com_test/pages/home.cache');
     }
 
     public function testPluginDefaultCache()

--- a/tests/Cms/AppCachesTest.php
+++ b/tests/Cms/AppCachesTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Cache\FileCache;
 use Kirby\Cache\NullCache;
+use Kirby\Toolkit\Dir;
 
 class AppCachesTest extends TestCase
 {
@@ -14,6 +15,13 @@ class AppCachesTest extends TestCase
                 'index' => __DIR__
             ]
         ], $props));
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Dir::remove(__DIR__ . '/fixtures/cache');
     }
 
     public function testDisabledCache()
@@ -30,6 +38,7 @@ class AppCachesTest extends TestCase
         ]);
 
         $this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
+        $this->assertEquals($kirby->root('cache'), $kirby->cache('pages')->options()['root']);
     }
 
     public function testEnabledCacheWithOptions()
@@ -44,6 +53,10 @@ class AppCachesTest extends TestCase
         ]);
 
         $this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
+        $this->assertEquals(__DIR__ . '/fixtures/cache', $kirby->cache('pages')->options()['root']);
+
+        $kirby->cache('pages')->set('home', 'test');
+        $this->assertFileExists(__DIR__ . '/fixtures/cache/pages/home.cache');
     }
 
     public function testPluginDefaultCache()

--- a/tests/Cms/PageCacheTest.php
+++ b/tests/Cms/PageCacheTest.php
@@ -13,8 +13,7 @@ class PageCacheTest extends TestCase
     {
         $this->app = new App([
             'roots' => [
-                'index' => '/dev/null',
-                'cache' => $this->fixtures = __DIR__ . '/fixtures/PageCacheTest',
+                'index' => $this->fixtures = __DIR__ . '/fixtures/PageCacheTest'
             ],
             'site' => [
                 'children' => [

--- a/tests/Cms/SystemTest.php
+++ b/tests/Cms/SystemTest.php
@@ -104,7 +104,7 @@ class SystemTest extends TestCase
         $_SERVER['SERVER_ADDR'] = null;
     }
 
-    public function licenseUrlProvider()
+    public function indexUrlProvider()
     {
         return [
             ['http://getkirby.com', 'getkirby.com'],
@@ -117,14 +117,10 @@ class SystemTest extends TestCase
     }
 
     /**
-     * @dataProvider licenseUrlProvider
+     * @dataProvider indexUrlProvider
      */
-    public function testLicenseUrl($indexUrl, $expected)
+    public function testIndexUrl($indexUrl, $expected)
     {
-        $reflector = new ReflectionClass(System::class);
-        $licenseUrl = $reflector->getMethod('licenseUrl');
-        $licenseUrl->setAccessible(true);
-
         $_SERVER['SERVER_ADDR'] = 'example.com';
 
         $system = new System($this->app->clone([
@@ -132,13 +128,13 @@ class SystemTest extends TestCase
                 'url' => $indexUrl
             ]
         ]));
-        $this->assertEquals($expected, $licenseUrl->invoke($system));
+        $this->assertEquals($expected, $system->indexUrl($indexUrl));
 
         // reset SERVER_ADDR
         $_SERVER['SERVER_ADDR'] = null;
     }
 
-    public function licenseUrlNormalizedProvider()
+    public function licenseUrlProvider()
     {
         return [
             [null, 'getkirby.com'],
@@ -157,20 +153,20 @@ class SystemTest extends TestCase
     }
 
     /**
-     * @dataProvider licenseUrlNormalizedProvider
+     * @dataProvider licenseUrlProvider
      */
-    public function testLicenseUrlNormalized($url, $expected)
+    public function testLicenseUrl($url, $expected)
     {
         $reflector = new ReflectionClass(System::class);
-        $licenseUrlNormalized = $reflector->getMethod('licenseUrlNormalized');
-        $licenseUrlNormalized->setAccessible(true);
+        $licenseUrl = $reflector->getMethod('licenseUrl');
+        $licenseUrl->setAccessible(true);
 
         $system = new System($this->app->clone([
             'options' => [
                 'url' => 'https://getkirby.com'
             ]
         ]));
-        $this->assertEquals($expected, $licenseUrlNormalized->invoke($system, $url));
+        $this->assertEquals($expected, $licenseUrl->invoke($system, $url));
     }
 
     public function testIsInstallableOnLocalhost()


### PR DESCRIPTION
## Describe the PR

I have now split up the caching improvements PR into smaller units. Unfortunately it wasn't possible to split this one up further because the unit tests depend on one another. But I've made three separate commits for the separate changes, which are pretty small on their own.

### Fix: Cache prefix for all cache types (#1507)

The `AppCaches` now use the new `prefix` feature of our `Cache` classes instead of only modifying the `root` of the cache directory. With that change, the prefix is used not only for file caches, but also for APCu and MemCached (which don't have a `root` and therefore only a global namespace).

This was a bug and the fix should not have any side effects.

### Feature: Include CMS index URL in cache prefix by default (#1496)

The idea behind this is that separate sites (defined by their index URLs) should not share the same caches. For file caches this is only relevant if the sites are using the same cache directory, but it's definitely relevant for multiple sites that share the same APCu cache or Memcached server.

The feature is implemented via the cache prefix. If sharing the caches (like before) is desired, the prefix can be overridden in the site config by the user to not include the index URL (or the prefix can be set in a completely custom way).

**Open questions**:

- [x] Sites with multi-domain multilang will now also have a separate cache per domain. For page caches this will be irrelevant (the pages are cached separately per language anyway), but for data caches sharing the data may be intended. But on the other hand, the cache prefix is configurable, so in the edge-case of multi-domain multilang (which always needs configuration), this could be fine.
- [ ] Possible side effects?
- [ ] The change leads to cache files that need to be manually cleaned up. We need to add a note about this to the change log.

## Related issues

- Fixes #1507 (bug)
- Fixes #1496 (feature)

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)