### PR TITLE
Cache improvements (PR 2 of 2): Refactoring & Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 os: linux
 sudo: false
+services:
+  - memcached
 
 php:
   - 7.1

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -59,9 +59,9 @@ class ApcuCache extends Cache
      * needs to return a Value object or null if not found
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    public function retrieve(string $key): ?Value
+    public function retrieve(string $key)
     {
         return Value::fromJson(apcu_fetch($this->key($key)));
     }

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -17,9 +17,9 @@ class ApcuCache extends Cache
 {
 
     /**
-     * Checks if the current key exists in cache
+     * Determines if an item exists in the cache
      *
-     * @param  string  $key
+     * @param string $key
      * @return boolean
      */
     public function exists(string $key): bool
@@ -28,7 +28,8 @@ class ApcuCache extends Cache
     }
 
     /**
-     * Flush the entire cache directory
+     * Flushes the entire cache and returns
+     * whether the operation was successful
      *
      * @return boolean
      */
@@ -42,9 +43,10 @@ class ApcuCache extends Cache
     }
 
     /**
-     * Remove an item from the cache
+     * Removes an item from the cache and returns
+     * whether the operation was successful
      *
-     * @param  string  $key
+     * @param string $key
      * @return boolean
      */
     public function remove(string $key): bool
@@ -53,9 +55,10 @@ class ApcuCache extends Cache
     }
 
     /**
-     * Retrieve an item from the cache.
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found
      *
-     * @param  string  $key
+     * @param string $key
      * @return mixed
      */
     public function retrieve(string $key): ?Value
@@ -64,16 +67,17 @@ class ApcuCache extends Cache
     }
 
     /**
-     * Write an item to the cache for a given number of minutes.
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful
      *
      * <code>
-     *    // Put an item in the cache for 15 minutes
-     *    Cache::set('value', 'my value', 15);
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     public function set(string $key, $value, int $minutes = 0): bool

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -78,6 +78,6 @@ class ApcuCache extends Cache
      */
     public function set(string $key, $value, int $minutes = 0): bool
     {
-        return apcu_store($this->key($key), $this->value($value, $minutes)->toJson(), $this->expiration($minutes));
+        return apcu_store($this->key($key), (new Value($value, $minutes))->toJson(), $this->expiration($minutes));
     }
 }

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -58,7 +58,7 @@ class ApcuCache extends Cache
      * @param  string  $key
      * @return mixed
      */
-    public function retrieve(string $key)
+    public function retrieve(string $key): ?Value
     {
         return Value::fromJson(apcu_fetch($this->key($key)));
     }
@@ -76,7 +76,7 @@ class ApcuCache extends Cache
      * @param  int     $minutes
      * @return boolean
      */
-    public function set(string $key, $value, int $minutes = 0)
+    public function set(string $key, $value, int $minutes = 0): bool
     {
         return apcu_store($this->key($key), $this->value($value, $minutes)->toJson(), $this->expiration($minutes));
     }

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -4,10 +4,9 @@ namespace Kirby\Cache;
 
 /**
  * Cache foundation
- * This class doesn't do anything
- * and is perfect as foundation for
- * other cache drivers and to be used
- * when the cache is disabled
+ * This abstract class is used as
+ * foundation for other cache drivers
+ * by extending it
  *
  * @package   Kirby Cache
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -19,13 +18,13 @@ abstract class Cache
 {
 
     /**
-     * stores all options for the driver
+     * Stores all options for the driver
      * @var array
      */
     protected $options = [];
 
     /**
-     * Set all parameters which are needed to connect to the cache storage
+     * Sets all parameters which are needed to connect to the cache storage
      *
      * @param array $options
      */
@@ -35,16 +34,18 @@ abstract class Cache
     }
 
     /**
-     * Write an item to the cache for a given number of minutes.
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful;
+     * this needs to be defined by the driver
      *
      * <code>
-     *   // Put an item in the cache for 15 minutes
-     *   Cache::set('value', 'my value', 15);
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     abstract public function set(string $key, $value, int $minutes = 0): bool;
@@ -65,27 +66,28 @@ abstract class Cache
     }
 
     /**
-     * Private method to retrieve the cache value
-     * This needs to be defined by the driver
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found;
+     * this needs to be defined by the driver
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     abstract public function retrieve(string $key): ?Value;
 
     /**
-     * Get an item from the cache.
+     * Gets an item from the cache
      *
      * <code>
-     *   // Get an item from the cache driver
-     *   $value = Cache::get('value');
+     *   // get an item from the cache driver
+     *   $value = $cache->get('value');
      *
-     *   // Return a default value if the requested item isn't cached
-     *   $value = Cache::get('value', 'default value');
+     *   // return a default value if the requested item isn't cached
+     *   $value = $cache->get('value', 'default value');
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $default
+     * @param string $key
+     * @param mixed $default
      * @return mixed
      */
     public function get(string $key, $default = null)
@@ -111,7 +113,7 @@ abstract class Cache
     /**
      * Calculates the expiration timestamp
      *
-     * @param  int $minutes
+     * @param int $minutes
      * @return int
      */
     protected function expiration(int $minutes = 0): int
@@ -126,9 +128,11 @@ abstract class Cache
     }
 
     /**
-     * Checks when an item in the cache expires
+     * Checks when an item in the cache expires;
+     * returns the expiry timestamp on success, null if the
+     * item never expires and false if the item does not exist
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function expires(string $key)
@@ -148,7 +152,7 @@ abstract class Cache
     /**
      * Checks if an item in the cache is expired
      *
-     * @param  string   $key
+     * @param string $key
      * @return boolean
      */
     public function expired(string $key): bool
@@ -165,9 +169,11 @@ abstract class Cache
     }
 
     /**
-     * Checks when the cache has been created
+     * Checks when the cache has been created;
+     * returns the creation timestamp on success
+     * and false if the item does not exist
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function created(string $key)
@@ -187,7 +193,7 @@ abstract class Cache
     /**
      * Alternate version for Cache::created($key)
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function modified(string $key)
@@ -196,9 +202,9 @@ abstract class Cache
     }
 
     /**
-     * Determine if an item exists in the cache.
+     * Determines if an item exists in the cache
      *
-     * @param  string  $key
+     * @param string $key
      * @return boolean
      */
     public function exists(string $key): bool
@@ -207,15 +213,19 @@ abstract class Cache
     }
 
     /**
-     * Remove an item from the cache
+     * Removes an item from the cache and returns
+     * whether the operation was successful;
+     * this needs to be defined by the driver
      *
-     * @param  string $key
+     * @param string $key
      * @return boolean
      */
     abstract public function remove(string $key): bool;
 
     /**
-     * Flush the entire cache
+     * Flushes the entire cache and returns
+     * whether the operation was successful;
+     * this needs to be defined by the driver
      *
      * @return boolean
      */

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -94,7 +94,7 @@ abstract class Cache
         $value = $this->retrieve($key);
 
         // check for a valid cache value
-        if (!is_a($value, 'Kirby\Cache\Value')) {
+        if (!is_a($value, Value::class)) {
             return $default;
         }
 
@@ -140,7 +140,7 @@ abstract class Cache
         $value = $this->retrieve($key);
 
         // check for a valid Value object
-        if (!is_a($value, 'Kirby\Cache\Value')) {
+        if (!is_a($value, Value::class)) {
             return false;
         }
 
@@ -179,7 +179,7 @@ abstract class Cache
         $value = $this->retrieve($key);
 
         // check for a valid Value object
-        if (!is_a($value, 'Kirby\Cache\Value')) {
+        if (!is_a($value, Value::class)) {
             return false;
         }
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -71,9 +71,9 @@ abstract class Cache
      * this needs to be defined by the driver
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    abstract public function retrieve(string $key): ?Value;
+    abstract public function retrieve(string $key);
 
     /**
      * Gets an item from the cache
@@ -133,7 +133,7 @@ abstract class Cache
      * item never expires and false if the item does not exist
      *
      * @param string $key
-     * @return mixed
+     * @return int|null|false
      */
     public function expires(string $key)
     {
@@ -174,7 +174,7 @@ abstract class Cache
      * and false if the item does not exist
      *
      * @param string $key
-     * @return mixed
+     * @return int|false
      */
     public function created(string $key)
     {
@@ -194,7 +194,7 @@ abstract class Cache
      * Alternate version for Cache::created($key)
      *
      * @param string $key
-     * @return mixed
+     * @return int|false
      */
     public function modified(string $key)
     {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -15,7 +15,7 @@ namespace Kirby\Cache;
  * @copyright Bastian Allgeier GmbH
  * @license   https://opensource.org/licenses/MIT
  */
-class Cache
+abstract class Cache
 {
 
     /**
@@ -45,12 +45,9 @@ class Cache
      * @param  string  $key
      * @param  mixed   $value
      * @param  int     $minutes
-     * @return null
+     * @return boolean
      */
-    public function set(string $key, $value, int $minutes = 0)
-    {
-        return null;
-    }
+    abstract public function set(string $key, $value, int $minutes = 0): bool;
 
     /**
      * Adds the prefix to the key if given
@@ -74,10 +71,7 @@ class Cache
      * @param  string $key
      * @return mixed
      */
-    public function retrieve(string $key)
-    {
-        return null;
-    }
+    abstract public function retrieve(string $key): ?Value;
 
     /**
      * Get an item from the cache.
@@ -225,20 +219,14 @@ class Cache
      * @param  string $key
      * @return boolean
      */
-    public function remove(string $key): bool
-    {
-        return true;
-    }
+    abstract public function remove(string $key): bool;
 
     /**
      * Flush the entire cache
      *
      * @return boolean
      */
-    public function flush(): bool
-    {
-        return true;
-    }
+    abstract public function flush(): bool;
 
     /**
      * Returns all passed cache options

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -191,18 +191,6 @@ abstract class Cache
     }
 
     /**
-     * Returns Value object
-     *
-     * @param  mixed  $value    The value, which should be cached
-     * @param  int    $minutes  The number of minutes before expiration
-     * @return Kirby\Cache\Value
-     */
-    protected function value($value, int $minutes)
-    {
-        return new Value($value, $minutes);
-    }
-
-    /**
      * Determine if an item exists in the cache.
      *
      * @param  string  $key

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -104,11 +104,8 @@ abstract class Cache
             return $default;
         }
 
-        // get the pure value
-        $cache = $value->value();
-
-        // return the cache value or the default
-        return $cache ?? $default;
+        // return the pure value
+        return $value->value();
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -99,7 +99,7 @@ abstract class Cache
         }
 
         // remove the item if it is expired
-        if (time() >= $value->expires()) {
+        if ($value->expires() > 0 && time() >= $value->expires()) {
             $this->remove($key);
             return $default;
         }
@@ -119,9 +119,9 @@ abstract class Cache
      */
     protected function expiration(int $minutes = 0): int
     {
-        // keep forever if minutes are not defined
+        // 0 = keep forever
         if ($minutes === 0) {
-            $minutes = 2628000;
+            return 0;
         }
 
         // calculate the time
@@ -156,7 +156,15 @@ abstract class Cache
      */
     public function expired(string $key): bool
     {
-        return $this->expires($key) <= time();
+        $expires = $this->expires($key);
+
+        if ($expires === null) {
+            return false;
+        } elseif (!is_int($expires)) {
+            return true;
+        } else {
+            return time() >= $expires;
+        }
     }
 
     /**
@@ -198,7 +206,7 @@ abstract class Cache
      */
     public function exists(string $key): bool
     {
-        return !$this->expired($key);
+        return $this->expired($key) === false;
     }
 
     /**

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -26,9 +26,11 @@ class FileCache extends Cache
     /**
      * Sets all parameters which are needed for the file cache
      *
-     * @param array $params
+     * @param array $options 'root' (required)
+     *                       'prefix' (default: none)
+     *                       'extension' (file extension for cache files, default: none)
      */
-    public function __construct(array $params)
+    public function __construct(array $options)
     {
         $defaults = [
             'root'      => null,
@@ -36,7 +38,7 @@ class FileCache extends Cache
             'extension' => null
         ];
 
-        parent::__construct(array_merge($defaults, $params));
+        parent::__construct(array_merge($defaults, $options));
 
         // build the full root including prefix
         $this->root = $this->options['root'];
@@ -51,7 +53,7 @@ class FileCache extends Cache
     /**
      * Returns the full path to a file for a given key
      *
-     * @param  string $key
+     * @param string $key
      * @return string
      */
     protected function file(string $key): string
@@ -66,16 +68,17 @@ class FileCache extends Cache
     }
 
     /**
-     * Write an item to the cache for a given number of minutes.
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful
      *
      * <code>
-     *    // Put an item in the cache for 15 minutes
-     *    Cache::set('value', 'my value', 15);
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     public function set(string $key, $value, int $minutes = 0): bool
@@ -86,9 +89,10 @@ class FileCache extends Cache
     }
 
     /**
-     * Retrieve an item from the cache.
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found
      *
-     * @param  string  $key
+     * @param string $key
      * @return mixed
      */
     public function retrieve(string $key): ?Value
@@ -99,10 +103,12 @@ class FileCache extends Cache
     }
 
     /**
-     * Checks when the cache has been created
+     * Checks when the cache has been created;
+     * returns the creation timestamp on success
+     * and false if the item does not exist
      *
      * @param string $key
-     * @return int
+     * @return mixed
      */
     public function created(string $key)
     {
@@ -116,9 +122,10 @@ class FileCache extends Cache
     }
 
     /**
-     * Remove an item from the cache
+     * Removes an item from the cache and returns
+     * whether the operation was successful
      *
-     * @param  string $key
+     * @param string $key
      * @return boolean
      */
     public function remove(string $key): bool
@@ -133,7 +140,8 @@ class FileCache extends Cache
     }
 
     /**
-     * Flush the entire cache directory
+     * Flushes the entire cache and returns
+     * whether the operation was successful
      *
      * @return boolean
      */

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -60,8 +60,9 @@ class FileCache extends Cache
      * @param  string  $key
      * @param  mixed   $value
      * @param  int     $minutes
+     * @return boolean
      */
-    public function set(string $key, $value, int $minutes = 0)
+    public function set(string $key, $value, int $minutes = 0): bool
     {
         return F::write($this->file($key), $this->value($value, $minutes)->toJson());
     }
@@ -72,7 +73,7 @@ class FileCache extends Cache
      * @param  string  $key
      * @return mixed
      */
-    public function retrieve(string $key)
+    public function retrieve(string $key): ?Value
     {
         return Value::fromJson(F::read($this->file($key)));
     }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -104,7 +104,7 @@ class FileCache extends Cache
      * @param string $key
      * @return int
      */
-    public function created(string $key): int
+    public function created(string $key)
     {
         // use the modification timestamp
         // as indicator when the cache has been created/overwritten
@@ -112,7 +112,7 @@ class FileCache extends Cache
 
         // get the file for this cache key
         $file = $this->file($key);
-        return file_exists($file) ? filemtime($this->file($key)) : 0;
+        return file_exists($file) ? filemtime($this->file($key)) : false;
     }
 
     /**
@@ -123,7 +123,13 @@ class FileCache extends Cache
      */
     public function remove(string $key): bool
     {
-        return F::remove($this->file($key));
+        $file = $this->file($key);
+
+        if (is_file($file) === true) {
+            return F::remove($file);
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -93,9 +93,9 @@ class FileCache extends Cache
      * needs to return a Value object or null if not found
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    public function retrieve(string $key): ?Value
+    public function retrieve(string $key)
     {
         $file = $this->file($key);
 

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -64,7 +64,9 @@ class FileCache extends Cache
      */
     public function set(string $key, $value, int $minutes = 0): bool
     {
-        return F::write($this->file($key), $this->value($value, $minutes)->toJson());
+        $file = $this->file($key);
+
+        return F::write($file, (new Value($value, $minutes))->toJson());
     }
 
     /**

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -151,6 +151,6 @@ class FileCache extends Cache
             return true;
         }
 
-        return false;
+        return false; // @codeCoverageIgnore
     }
 }

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -65,9 +65,9 @@ class MemCached extends Cache
      * needs to return a Value object or null if not found
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    public function retrieve(string $key): ?Value
+    public function retrieve(string $key)
     {
         return Value::fromJson($this->connection->get($this->key($key)));
     }

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -59,22 +59,11 @@ class MemCached extends Cache
     }
 
     /**
-     * Returns the full keyname
-     * including the prefix (if set)
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found
      *
      * @param  string $key
-     * @return string
-     */
-    public function key(string $key): string
-    {
-        return $this->options['prefix'] . $key;
-    }
-
-    /**
-     * Retrieve the CacheValue object from the cache.
-     *
-     * @param  string  $key
-     * @return object  CacheValue
+     * @return mixed
      */
     public function retrieve(string $key): ?Value
     {
@@ -90,39 +79,6 @@ class MemCached extends Cache
     public function remove(string $key): bool
     {
         return $this->connection->delete($this->key($key));
-    }
-
-    /**
-     * Checks when an item in the cache expires
-     *
-     * @param  string $key
-     * @return int
-     */
-    public function expires(string $key): int
-    {
-        return parent::expires($this->key($key));
-    }
-
-    /**
-     * Checks if an item in the cache is expired
-     *
-     * @param  string $key
-     * @return boolean
-     */
-    public function expired(string $key): bool
-    {
-        return parent::expired($this->key($key));
-    }
-
-    /**
-     * Checks when the cache has been created
-     *
-     * @param  string $key
-     * @return int
-     */
-    public function created(string $key): int
-    {
-        return parent::created($this->key($key));
     }
 
     /**

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -51,9 +51,9 @@ class MemCached extends Cache
      * @param  string  $key
      * @param  mixed   $value
      * @param  int     $minutes
-     * @return void
+     * @return boolean
      */
-    public function set(string $key, $value, int $minutes = 0)
+    public function set(string $key, $value, int $minutes = 0): bool
     {
         return $this->connection->set($this->key($key), $this->value($value, $minutes)->toJson(), $this->expiration($minutes));
     }
@@ -76,7 +76,7 @@ class MemCached extends Cache
      * @param  string  $key
      * @return object  CacheValue
      */
-    public function retrieve(string $key)
+    public function retrieve(string $key): ?Value
     {
         return Value::fromJson($this->connection->get($this->key($key)));
     }

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -55,7 +55,7 @@ class MemCached extends Cache
      */
     public function set(string $key, $value, int $minutes = 0): bool
     {
-        return $this->connection->set($this->key($key), $this->value($value, $minutes)->toJson(), $this->expiration($minutes));
+        return $this->connection->set($this->key($key), (new Value($value, $minutes))->toJson(), $this->expiration($minutes));
     }
 
     /**

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -21,12 +21,13 @@ class MemCached extends Cache
     protected $connection;
 
     /**
-     * Set all parameters which are needed for the memcache client
-     * see defaults for available parameters
+     * Sets all parameters which are needed to connect to Memcached
      *
-     * @param array $params
+     * @param array $options 'host'   (default: localhost)
+     *                       'port'   (default: 11211)
+     *                       'prefix' (default: null)
      */
-    public function __construct(array $params = [])
+    public function __construct(array $options = [])
     {
         $defaults = [
             'host'    => 'localhost',
@@ -34,23 +35,24 @@ class MemCached extends Cache
             'prefix'  => null,
         ];
 
-        parent::__construct(array_merge($defaults, $params));
+        parent::__construct(array_merge($defaults, $options));
 
         $this->connection = new \Memcached();
         $this->connection->addServer($this->options['host'], $this->options['port']);
     }
 
     /**
-     * Write an item to the cache for a given number of minutes.
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful
      *
      * <code>
-     *    // Put an item in the cache for 15 minutes
-     *    Cache::set('value', 'my value', 15);
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     public function set(string $key, $value, int $minutes = 0): bool
@@ -62,7 +64,7 @@ class MemCached extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function retrieve(string $key): ?Value
@@ -71,9 +73,10 @@ class MemCached extends Cache
     }
 
     /**
-     * Remove an item from the cache
+     * Removes an item from the cache and returns
+     * whether the operation was successful
      *
-     * @param  string  $key
+     * @param string $key
      * @return boolean
      */
     public function remove(string $key): bool
@@ -82,7 +85,9 @@ class MemCached extends Cache
     }
 
     /**
-     * Flush the entire cache directory
+     * Flushes the entire cache and returns
+     * whether the operation was successful;
+     * WARNING: Memcached only supports flushing the whole cache at once!
      *
      * @return boolean
      */

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -45,9 +45,9 @@ class MemoryCache extends Cache
      * needs to return a Value object or null if not found
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    public function retrieve(string $key): ?Value
+    public function retrieve(string $key)
     {
         return $this->store[$key] ?? null;
     }

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Kirby\Cache;
+
+/**
+ * Memory Cache Driver (cache in memory for current request only)
+ *
+ * @package   Kirby Cache
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      http://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   MIT
+ */
+class MemoryCache extends Cache
+{
+
+    /**
+     * Cache data
+     * @var array
+     */
+    protected $store = [];
+
+    /**
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful
+     *
+     * <code>
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
+     * </code>
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  int     $minutes
+     * @return boolean
+     */
+    public function set(string $key, $value, int $minutes = 0): bool
+    {
+        $this->store[$key] = new Value($value, $minutes);
+        return true;
+    }
+
+    /**
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function retrieve(string $key): ?Value
+    {
+        return $this->store[$key] ?? null;
+    }
+
+    /**
+     * Removes an item from the cache and returns
+     * whether the operation was successful
+     *
+     * @param  string $key
+     * @return boolean
+     */
+    public function remove(string $key): bool
+    {
+        if (isset($this->store[$key])) {
+            unset($this->store[$key]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Flushes the entire cache and returns
+     * whether the operation was successful
+     *
+     * @return boolean
+     */
+    public function flush(): bool
+    {
+        $this->store = [];
+        return true;
+    }
+}

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -7,9 +7,9 @@ namespace Kirby\Cache;
  *
  * @package   Kirby Cache
  * @author    Lukas Bestle <lukas@getkirby.com>
- * @link      http://getkirby.com
- * @copyright Bastian Allgeier
- * @license   MIT
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://opensource.org/licenses/MIT
  */
 class MemoryCache extends Cache
 {
@@ -29,9 +29,9 @@ class MemoryCache extends Cache
      *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     public function set(string $key, $value, int $minutes = 0): bool
@@ -44,7 +44,7 @@ class MemoryCache extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function retrieve(string $key): ?Value
@@ -56,7 +56,7 @@ class MemoryCache extends Cache
      * Removes an item from the cache and returns
      * whether the operation was successful
      *
-     * @param  string $key
+     * @param string $key
      * @return boolean
      */
     public function remove(string $key): bool

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kirby\Cache;
+
+/**
+ * Dummy Cache Driver (does not do any caching)
+ *
+ * @package   Kirby Cache
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      http://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   MIT
+ */
+class NullCache extends Cache
+{
+
+    /**
+     * Writes an item to the cache for a given number of minutes and
+     * returns whether the operation was successful
+     *
+     * <code>
+     *   // put an item in the cache for 15 minutes
+     *   $cache->set('value', 'my value', 15);
+     * </code>
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  int     $minutes
+     * @return boolean
+     */
+    public function set(string $key, $value, int $minutes = 0): bool
+    {
+        return true;
+    }
+
+    /**
+     * Internal method to retrieve the raw cache value;
+     * needs to return a Value object or null if not found
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function retrieve(string $key): ?Value
+    {
+        return null;
+    }
+
+    /**
+     * Removes an item from the cache and returns
+     * whether the operation was successful
+     *
+     * @param  string $key
+     * @return boolean
+     */
+    public function remove(string $key): bool
+    {
+        return true;
+    }
+
+    /**
+     * Flushes the entire cache and returns
+     * whether the operation was successful
+     *
+     * @return boolean
+     */
+    public function flush(): bool
+    {
+        return true;
+    }
+}

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -7,9 +7,9 @@ namespace Kirby\Cache;
  *
  * @package   Kirby Cache
  * @author    Lukas Bestle <lukas@getkirby.com>
- * @link      http://getkirby.com
- * @copyright Bastian Allgeier
- * @license   MIT
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://opensource.org/licenses/MIT
  */
 class NullCache extends Cache
 {
@@ -23,9 +23,9 @@ class NullCache extends Cache
      *   $cache->set('value', 'my value', 15);
      * </code>
      *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param string $key
+     * @param mixed $value
+     * @param int $minutes
      * @return boolean
      */
     public function set(string $key, $value, int $minutes = 0): bool
@@ -37,7 +37,7 @@ class NullCache extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
-     * @param  string $key
+     * @param string $key
      * @return mixed
      */
     public function retrieve(string $key): ?Value
@@ -49,7 +49,7 @@ class NullCache extends Cache
      * Removes an item from the cache and returns
      * whether the operation was successful
      *
-     * @param  string $key
+     * @param string $key
      * @return boolean
      */
     public function remove(string $key): bool

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -38,9 +38,9 @@ class NullCache extends Cache
      * needs to return a Value object or null if not found
      *
      * @param string $key
-     * @return mixed
+     * @return Kirby\Cache\Value|null
      */
-    public function retrieve(string $key): ?Value
+    public function retrieve(string $key)
     {
         return null;
     }

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -45,11 +45,6 @@ class Value
      */
     public function __construct($value, int $minutes = 0, $created = null)
     {
-        // keep forever if minutes are not defined
-        if ($minutes === 0) {
-            $minutes = 2628000;
-        }
-
         $this->value   = $value;
         $this->minutes = $minutes;
         $this->created = $created ?? time();
@@ -66,12 +61,18 @@ class Value
     }
 
     /**
-     * Returns the expiration date as UNIX timestamp
+     * Returns the expiration date as UNIX timestamp or
+     * null if the value never expires
      *
      * @return int
      */
-    public function expires(): int
+    public function expires(): ?int
     {
+        // 0 = keep forever
+        if ($this->minutes === 0) {
+            return null;
+        }
+
         return $this->created + ($this->minutes * 60);
     }
 

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -25,10 +25,10 @@ class Value
     protected $value;
 
     /**
-     * the expiration timestamp
+     * the number of minutes until the value expires
      * @var int
      */
-    protected $expires;
+    protected $minutes;
 
     /**
      * the creation timestamp
@@ -43,10 +43,10 @@ class Value
      * @param int   $minutes the number of minutes until the value expires
      * @param int   $created the unix timestamp when the value has been created
      */
-    public function __construct($value, int $minutes = 0, $created = null)
+    public function __construct($value, int $minutes = 0, int $created = null)
     {
         $this->value   = $value;
-        $this->minutes = $minutes;
+        $this->minutes = $minutes ?? 0;
         $this->created = $created ?? time();
     }
 

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -64,7 +64,7 @@ class Value
      * Returns the expiration date as UNIX timestamp or
      * null if the value never expires
      *
-     * @return int
+     * @return int|null
      */
     public function expires(): ?int
     {
@@ -80,7 +80,7 @@ class Value
      * Creates a value object from an array
      *
      * @param array $array
-     * @return Kirby\Cache\Value
+     * @return self
      */
     public static function fromArray(array $array)
     {
@@ -92,7 +92,7 @@ class Value
      * returns null on error
      *
      * @param string $json
-     * @return Kirby\Cache\Value|null
+     * @return self|null
      */
     public static function fromJson(string $json)
     {

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -91,17 +91,21 @@ class Value
      * Creates a value object from a json string
      *
      * @param string $json
-     * @return self
+     * @return Value|null
      */
-    public static function fromJson($json)
+    public static function fromJson(string $json)
     {
         try {
-            $array = json_decode($json, true) ?? [];
-        } catch (Throwable $e) {
-            $array = [];
-        }
+            $array = json_decode($json, true);
 
-        return static::fromArray($array);
+            if (is_array($array)) {
+                return static::fromArray($array);
+            } else {
+                return null;
+            }
+        } catch (Throwable $e) {
+            return null;
+        }
     }
 
     /**

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -7,7 +7,7 @@ use Throwable;
 /**
  * Cache Value
  * Stores the value, creation timestamp and expiration timestamp
- * and makes it possible to store all three with a single cache key.
+ * and makes it possible to store all three with a single cache key
  *
  * @package   Kirby Cache
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -19,7 +19,7 @@ class Value
 {
 
     /**
-     * the cached value
+     * Cached value
      * @var mixed
      */
     protected $value;
@@ -31,7 +31,7 @@ class Value
     protected $minutes;
 
     /**
-     * the creation timestamp
+     * Creation timestamp
      * @var int
      */
     protected $created;
@@ -40,8 +40,8 @@ class Value
      * Constructor
      *
      * @param mixed $value
-     * @param int   $minutes the number of minutes until the value expires
-     * @param int   $created the unix timestamp when the value has been created
+     * @param int $minutes the number of minutes until the value expires
+     * @param int $created the unix timestamp when the value has been created
      */
     public function __construct($value, int $minutes = 0, int $created = null)
     {
@@ -80,7 +80,7 @@ class Value
      * Creates a value object from an array
      *
      * @param array $array
-     * @return self
+     * @return Kirby\Cache\Value
      */
     public static function fromArray(array $array)
     {
@@ -88,10 +88,11 @@ class Value
     }
 
     /**
-     * Creates a value object from a json string
+     * Creates a value object from a JSON string;
+     * returns null on error
      *
      * @param string $json
-     * @return Value|null
+     * @return Kirby\Cache\Value|null
      */
     public static function fromJson(string $json)
     {
@@ -109,7 +110,7 @@ class Value
     }
 
     /**
-     * Convert the object to a json string
+     * Converts the object to a JSON string
      *
      * @return string
      */
@@ -119,7 +120,7 @@ class Value
     }
 
     /**
-     * Convert the object to an array
+     * Converts the object to an array
      *
      * @return array
      */
@@ -133,7 +134,7 @@ class Value
     }
 
     /**
-     * Returns the value
+     * Returns the pure value
      *
      * @return mixed
      */

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Cache\Cache;
+use Kirby\Cache\NullCache;
 use Kirby\Exception\InvalidArgumentException;
 
 /**
@@ -34,7 +35,8 @@ trait AppCaches
         $options = $this->cacheOptions($key);
 
         if ($options['active'] === false) {
-            return $this->caches[$key] = new Cache;
+            // use a dummy cache that does nothing
+            return $this->caches[$key] = new NullCache;
         }
 
         $type  = strtolower($options['type']);

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -50,7 +50,17 @@ trait AppCaches
         $className = $types[$type];
 
         // initialize the cache class
-        return $this->caches[$key] = new $className($options);
+        $cache = new $className($options);
+
+        // check if it is a useable cache object
+        if (is_a($cache, Cache::class) !== true) {
+            throw new InvalidArgumentException([
+                'key'  => 'app.invalid.cacheType',
+                'data' => ['type' => $type]
+            ]);
+        }
+
+        return $this->caches[$key] = $cache;
     }
 
     /**

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -613,6 +613,7 @@ trait AppPlugins
             'apcu'      => 'Kirby\Cache\ApcuCache',
             'file'      => 'Kirby\Cache\FileCache',
             'memcached' => 'Kirby\Cache\MemCached',
+            'memory'    => 'Kirby\Cache\MemoryCache',
         ]);
 
         $this->extendComponents(include static::$root . '/config/components.php');

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -3,26 +3,30 @@
 namespace Kirby\Cache;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
+use ReflectionMethod;
 
 class TestCache extends Cache
 {
-    protected $store = [];
+    public $store = [];
 
-    public function set(string $key, $value, int $minutes = 0, int $created = null)
+    public function set(string $key, $value, int $minutes = 0, int $created = null): bool
     {
         $value = new Value($value, $minutes, $created);
         $this->store[$key] = $value;
+        return true;
     }
-    public function retrieve(string $key)
+
+    public function retrieve(string $key): ?Value
     {
         return $this->store[$key] ?? null;
     }
+
     public function remove(string $key): bool
     {
         unset($this->store[$key]);
         return true;
     }
+
     public function flush(): bool
     {
         $this->store = [];
@@ -30,86 +34,146 @@ class TestCache extends Cache
     }
 }
 
+/**
+ * @coversDefaultClass \Kirby\Cache\NullCache
+ */
 class CacheTest extends TestCase
 {
+    /**
+     * @covers ::__construct
+     * @covers ::options
+     */
     public function testConstruct()
     {
-        $driver = new TestCache();
-        $this->assertInstanceOf(TestCache::class, $driver);
+        $cache = new TestCache(['some' => 'options']);
+        $this->assertEquals(['some' => 'options'], $cache->options());
     }
 
+    /**
+     * @covers ::key
+     */
+    public function testKey()
+    {
+        $method = new ReflectionMethod(Cache::class, 'key');
+        $method->setAccessible(true);
+
+        $cache = new TestCache();
+        $this->assertEquals('foo', $method->invoke($cache, 'foo'));
+
+        $cache = new TestCache([
+            'prefix' => 'test'
+        ]);
+        $this->assertEquals('test/foo', $method->invoke($cache, 'foo'));
+    }
+
+    /**
+     * @covers ::get
+     */
     public function testGet()
     {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo');
-        $this->assertEquals('foo', $driver->get('foo'));
+        $cache = new TestCache();
+
+        $cache->set('foo', 'foo');
+        $this->assertEquals('foo', $cache->get('foo'));
+
+        $cache->set('foo', ['this is' => 'an array']);
+        $this->assertEquals(['this is' => 'an array'], $cache->get('foo'));
+
+        $cache->set('foo', 1234);
+        $this->assertEquals(1234, $cache->get('foo'));
+
+        $cache->set('foo', null);
+        $this->assertEquals(null, $cache->get('foo', 'default'));
+
+        $this->assertEquals('default', $cache->get('doesnotexist', 'default'));
+
+        $cache->set('notyetexpired', 'foo', 60, time());
+        $this->assertEquals('foo', $cache->get('notyetexpired'));
+
+        $cache->set('expired', 'foo', 60, 0);
+        $this->assertTrue(isset($cache->store['expired']));
+        $this->assertEquals('default', $cache->get('expired', 'default'));
+        $this->assertFalse(isset($cache->store['expired']));
     }
 
-    public function testGetDefault()
-    {
-        $driver = new TestCache();
-        $this->assertEquals('default', $driver->get('foo', 'default'));
-    }
-
-    public function testGetExpired()
-    {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo', 60, 0);
-        $this->assertEquals('none', $driver->get('foo', 'none'));
-        $this->assertFalse($driver->exists('foo'));
-    }
-
+    /**
+     * @covers ::expiration
+     */
     public function testExpiration()
     {
-        $driver = new TestCache();
-        $ref = new ReflectionClass($driver);
-        $expiration = $ref->getMethod('expiration');
-        $expiration->setAccessible(true);
+        $method = new ReflectionMethod(Cache::class, 'expiration');
+        $method->setAccessible(true);
 
-        $this->assertEquals(time() + (60 * 2628000), $expiration->invoke($driver));
-        $this->assertEquals(time() + 600, $expiration->invoke($driver, 10));
+        $cache = new TestCache();
+        $this->assertEquals(0, $method->invoke($cache));
+        $this->assertEquals(0, $method->invoke($cache, 0));
+        $this->assertEquals(time() + 600, $method->invoke($cache, 10));
     }
 
+    /**
+     * @covers ::expires
+     */
     public function testExpires()
     {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo', 12);
-        $this->assertEquals(time() + 720, $driver->expires('foo'));
+        $cache = new TestCache();
+
+        $cache->set('foo', 'foo', 12);
+        $this->assertEquals(time() + 720, $cache->expires('foo'));
+
+        $cache->set('foo', 'foo');
+        $this->assertEquals(null, $cache->expires('foo'));
+
+        $this->assertFalse($cache->expires('doesnotexist'));
     }
 
-    public function testExpiresNonValue()
-    {
-        $driver = new TestCache();
-        $this->assertfalse($driver->expires('missing'));
-    }
-
+    /**
+     * @covers ::expired
+     */
     public function testExpired()
     {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo');
-        $this->assertFalse($driver->expired('foo'));
+        $cache = new TestCache();
+
+        $cache->set('foo', 'foo');
+        $this->assertFalse($cache->expired('foo'));
+
+        $cache->set('foo', 'foo', 60, 0);
+        $this->assertTrue($cache->expired('foo'));
+
+        $cache->set('foo', 'foo', 60);
+        $this->assertFalse($cache->expired('foo'));
+
+        $this->assertTrue($cache->expired('doesnotexist'));
     }
 
+    /**
+     * @covers ::created
+     * @covers ::modified
+     */
     public function testCreated()
     {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo');
-        $this->assertEquals(time(), $driver->created('foo'));
-        $this->assertEquals(time(), $driver->modified('foo'));
+        $cache = new TestCache();
+
+        $cache->set('foo', 'foo', 60, 1234);
+        $this->assertEquals(1234, $cache->created('foo'));
+        $this->assertEquals(1234, $cache->modified('foo'));
+
+        $this->assertFalse($cache->created('doesnotexist'));
+        $this->assertFalse($cache->modified('doesnotexist'));
     }
 
-    public function testCreatedNonValue()
-    {
-        $driver = new TestCache();
-        $this->assertFalse($driver->created('missing'));
-        $this->assertFalse($driver->modified('missing'));
-    }
-
+    /**
+     * @covers ::exists
+     */
     public function testExists()
     {
-        $driver = new TestCache();
-        $driver->set('foo', 'foo');
-        $this->assertTrue($driver->exists('foo'));
-        $this->assertFalse($driver->exists('missing'));
+        $cache = new TestCache();
+
+        $cache->set('foo', 'foo');
+        $this->assertTrue($cache->exists('foo'));
+
+        $cache->set('foo', 'foo', 60, 0);
+        $this->assertFalse($cache->exists('foo'));
+
+        $this->assertFalse($cache->exists('doesnotexist'));
     }
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -3,97 +3,222 @@
 namespace Kirby\Cache;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Kirby\Toolkit\Dir;
 
-class FileTest extends TestCase
+/**
+ * @coversDefaultClass \Kirby\Cache\FileCache
+ */
+class FileCacheTest extends TestCase
 {
-    public function testSetGetRemove()
+    public function tearDown()
     {
-        $file = new FileCache([
+        Dir::remove(__DIR__ . '/fixtures/file');
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testConstruct()
+    {
+        $cache = new FileCache([
             'root' => $root = __DIR__ . '/fixtures/file'
         ]);
 
-        $file->set('foo', 'A basic value');
-        $this->assertTrue(file_exists($root . '/foo'));
-
-        $this->assertEquals('A basic value', $file->get('foo'));
-        $this->assertEquals(time(), $file->created('foo'));
-
-        $file->remove('foo');
-        $this->assertFalse(file_exists($root . '/foo'));
+        $this->assertDirectoryExists($root);
     }
 
-    public function testSetGetRemoveWithExtension()
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructWithPrefix()
     {
-        $root = __DIR__ . '/fixtures/file';
-        $file = new FileCache([
-            'root'      => $root,
-            'extension' => 'cache'
-        ]);
-
-        $file->set('foo', 'A basic value');
-        $this->assertTrue(file_exists($root . '/foo.cache'));
-
-        $this->assertEquals('A basic value', $file->get('foo'));
-        $this->assertEquals(time(), $file->created('foo'));
-
-        $file->remove('foo');
-        $this->assertFalse(file_exists($root . '/foo.cache'));
-    }
-
-    public function testSetGetRemoveWithPrefix()
-    {
-        $root = __DIR__ . '/fixtures/file';
-        $file = new FileCache([
-            'root'   => $root,
-            'prefix' => 'test'
-        ]);
-
-        $file->set('foo', 'A basic value');
-        $this->assertTrue(file_exists($root . '/test/foo'));
-
-        $this->assertEquals('A basic value', $file->get('foo'));
-        $this->assertEquals(time(), $file->created('foo'));
-
-        $file->remove('foo');
-        $this->assertFalse(file_exists($root . '/test/foo'));
-    }
-
-    public function testFlush()
-    {
-        $file = new FileCache([
-            'root' => $root = __DIR__ . '/fixtures/file'
-        ]);
-
-        $file->set('a', 'A basic value');
-        $file->set('b', 'A basic value');
-        $file->set('c', 'A basic value');
-        $this->assertTrue(file_exists($root . '/a'));
-        $this->assertTrue(file_exists($root . '/b'));
-        $this->assertTrue(file_exists($root . '/c'));
-
-        $file->flush();
-        $this->assertFalse(file_exists($root . '/a'));
-        $this->assertFalse(file_exists($root . '/b'));
-        $this->assertFalse(file_exists($root . '/c'));
-    }
-
-    public function testFlushWithPrefix()
-    {
-        $file = new FileCache([
+        $cache = new FileCache([
             'root'   => $root = __DIR__ . '/fixtures/file',
             'prefix' => 'test'
         ]);
 
-        $file->set('a', 'A basic value');
-        $file->set('b', 'A basic value');
-        $file->set('c', 'A basic value');
-        $this->assertTrue(file_exists($root . '/test/a'));
-        $this->assertTrue(file_exists($root . '/test/b'));
-        $this->assertTrue(file_exists($root . '/test/c'));
+        $this->assertDirectoryExists($root . '/test');
+    }
 
-        $file->flush();
-        $this->assertFalse(file_exists($root . '/test/a'));
-        $this->assertFalse(file_exists($root . '/test/b'));
-        $this->assertFalse(file_exists($root . '/test/c'));
+    /**
+     * @covers ::file
+     */
+    public function testFile()
+    {
+        $method = new ReflectionMethod(FileCache::class, 'file');
+        $method->setAccessible(true);
+
+        $cache = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file'
+        ]);
+        $this->assertEquals($root . '/test', $method->invoke($cache, 'test'));
+
+        $cache = new FileCache([
+            'root'      => $root = __DIR__ . '/fixtures/file',
+            'extension' => 'cache'
+        ]);
+        $this->assertEquals($root . '/test.cache', $method->invoke($cache, 'test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+            'prefix' => 'test1'
+        ]);
+        $this->assertEquals($root . '/test1/test', $method->invoke($cache, 'test'));
+
+        $cache = new FileCache([
+            'root'      => $root = __DIR__ . '/fixtures/file',
+            'prefix'    => 'test1',
+            'extension' => 'cache'
+        ]);
+        $this->assertEquals($root . '/test1/test.cache', $method->invoke($cache, 'test'));
+    }
+
+    /**
+     * @covers ::set
+     * @covers ::created
+     * @covers ::retrieve
+     * @covers ::remove
+     */
+    public function testOperations()
+    {
+        $cache = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file'
+        ]);
+
+        $time = time();
+        $this->assertTrue($cache->set('foo', 'A basic value', 10));
+
+        $this->assertFileExists($root . '/foo');
+        $this->assertTrue($cache->exists('foo'));
+        $this->assertEquals('A basic value', $cache->retrieve('foo')->value());
+        $this->assertEquals($time, $cache->created('foo'));
+        $this->assertEquals($time + 600, $cache->expires('foo'));
+
+        $this->assertTrue($cache->remove('foo'));
+        $this->assertFileNotExists($root . '/foo');
+        $this->assertFalse($cache->exists('foo'));
+        $this->assertNull($cache->retrieve('foo'));
+
+        $this->assertFalse($cache->remove('doesnotexist'));
+    }
+
+    /**
+     * @covers ::set
+     * @covers ::created
+     * @covers ::retrieve
+     * @covers ::remove
+     */
+    public function testOperationsWithExtension()
+    {
+        $cache = new FileCache([
+            'root'      => $root = __DIR__ . '/fixtures/file',
+            'extension' => 'cache'
+        ]);
+
+        $time = time();
+        $this->assertTrue($cache->set('foo', 'A basic value', 10));
+
+        $this->assertFileExists($root . '/foo.cache');
+        $this->assertTrue($cache->exists('foo'));
+        $this->assertEquals('A basic value', $cache->retrieve('foo')->value());
+        $this->assertEquals($time, $cache->created('foo'));
+        $this->assertEquals($time + 600, $cache->expires('foo'));
+
+        $this->assertTrue($cache->remove('foo'));
+        $this->assertFileNotExists($root . '/foo.cache');
+        $this->assertFalse($cache->exists('foo'));
+        $this->assertNull($cache->retrieve('foo'));
+    }
+
+    /**
+     * @covers ::set
+     * @covers ::created
+     * @covers ::retrieve
+     * @covers ::remove
+     */
+    public function testOperationsWithPrefix()
+    {
+        $cache1 = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file',
+            'prefix' => 'test1'
+        ]);
+        $cache2 = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file',
+            'prefix' => 'test2'
+        ]);
+
+        $time = time();
+        $this->assertTrue($cache1->set('foo', 'A basic value', 10));
+
+        $this->assertFileExists($root . '/test1/foo');
+        $this->assertTrue($cache1->exists('foo'));
+        $this->assertFalse($cache2->exists('foo'));
+        $this->assertEquals('A basic value', $cache1->retrieve('foo')->value());
+        $this->assertEquals($time, $cache1->created('foo'));
+        $this->assertEquals($time + 600, $cache1->expires('foo'));
+
+        $this->assertTrue($cache2->set('foo', 'Another basic value'));
+        $this->assertTrue($cache2->exists('foo'));
+
+        $this->assertEquals('A basic value', $cache1->retrieve('foo')->value());
+        $this->assertTrue($cache1->remove('foo'));
+        $this->assertFileNotExists($root . '/test1/foo');
+        $this->assertFalse($cache1->exists('foo'));
+        $this->assertNull($cache1->retrieve('foo'));
+        $this->assertTrue($cache2->exists('foo'));
+        $this->assertEquals('Another basic value', $cache2->retrieve('foo')->value());
+    }
+
+    /**
+     * @covers ::flush
+     */
+    public function testFlush()
+    {
+        $cache = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file'
+        ]);
+
+        $cache->set('a', 'A basic value');
+        $cache->set('b', 'A basic value');
+        $cache->set('c', 'A basic value');
+        $this->assertFileExists($root . '/a');
+        $this->assertFileExists($root . '/b');
+        $this->assertFileExists($root . '/c');
+
+        $this->assertTrue($cache->flush());
+        $this->assertFileNotExists($root . '/a');
+        $this->assertFileNotExists($root . '/b');
+        $this->assertFileNotExists($root . '/c');
+    }
+
+    /**
+     * @covers ::flush
+     */
+    public function testFlushWithPrefix()
+    {
+        $cache1 = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file',
+            'prefix' => 'test1'
+        ]);
+        $cache2 = new FileCache([
+            'root' => $root = __DIR__ . '/fixtures/file',
+            'prefix' => 'test2'
+        ]);
+
+        $cache1->set('a', 'A basic value');
+        $cache1->set('b', 'A basic value');
+        $cache2->set('a', 'A basic value');
+        $cache2->set('b', 'A basic value');
+        $this->assertFileExists($root . '/test1/a');
+        $this->assertFileExists($root . '/test1/b');
+        $this->assertFileExists($root . '/test2/a');
+        $this->assertFileExists($root . '/test2/b');
+
+        $this->assertTrue($cache1->flush());
+        $this->assertFileNotExists($root . '/test1/a');
+        $this->assertFileNotExists($root . '/test1/b');
+        $this->assertFileExists($root . '/test2/a');
+        $this->assertFileExists($root . '/test2/b');
     }
 }

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -9,7 +9,14 @@ use PHPUnit\Framework\TestCase;
  */
 class MemCachedTest extends TestCase
 {
-    public function tearDown()
+    public function setUp(): void
+    {
+        if (class_exists('Memcached') === false) {
+            $this->markTestSkipped('The Memcached extension is not available.');
+        }
+    }
+
+    public function tearDown(): void
     {
         $connection = new \Memcached();
         $connection->addServer('localhost', 11211);

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -13,6 +13,13 @@ class MemCachedTest extends TestCase
     {
         if (class_exists('Memcached') === false) {
             $this->markTestSkipped('The Memcached extension is not available.');
+            return;
+        }
+
+        $connection = new \Memcached();
+        $connection->addServer('localhost', 11211);
+        if (is_array($connection->getStats()) !== true) {
+            $this->markTestSkipped('The Memcached server is not running.');
         }
     }
 

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -3,21 +3,22 @@
 namespace Kirby\Cache;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Kirby\Toolkit\Dir;
 
 /**
- * @coversDefaultClass \Kirby\Cache\ApcuCache
+ * @coversDefaultClass \Kirby\Cache\MemoryCache
  */
-class ApcuCacheTest extends TestCase
+class MemoryCacheTest extends TestCase
 {
     /**
      * @covers ::set
-     * @covers ::exists
      * @covers ::retrieve
      * @covers ::remove
      */
     public function testOperations()
     {
-        $cache = new ApcuCache([]);
+        $cache = new MemoryCache();
 
         $time = time();
         $this->assertTrue($cache->set('foo', 'A basic value', 10));
@@ -36,18 +37,13 @@ class ApcuCacheTest extends TestCase
 
     /**
      * @covers ::set
-     * @covers ::exists
      * @covers ::retrieve
      * @covers ::remove
      */
-    public function testOperationsWithPrefix()
+    public function testOperationsWithMultipleInstances()
     {
-        $cache1 = new ApcuCache([
-            'prefix' => 'test1'
-        ]);
-        $cache2 = new ApcuCache([
-            'prefix' => 'test2'
-        ]);
+        $cache1 = new MemoryCache();
+        $cache2 = new MemoryCache();
 
         $time = time();
         $this->assertTrue($cache1->set('foo', 'A basic value', 10));
@@ -74,7 +70,7 @@ class ApcuCacheTest extends TestCase
      */
     public function testFlush()
     {
-        $cache = new ApcuCache([]);
+        $cache = new MemoryCache();
 
         $cache->set('a', 'A basic value');
         $cache->set('b', 'A basic value');
@@ -92,14 +88,10 @@ class ApcuCacheTest extends TestCase
     /**
      * @covers ::flush
      */
-    public function testFlushWithPrefix()
+    public function testFlushWithMultipleInstances()
     {
-        $cache1 = new ApcuCache([
-            'prefix' => 'test1'
-        ]);
-        $cache2 = new ApcuCache([
-            'prefix' => 'test2'
-        ]);
+        $cache1 = new MemoryCache();
+        $cache2 = new MemoryCache();
 
         $cache1->set('a', 'A basic value');
         $cache1->set('b', 'A basic value');

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kirby\Cache;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Kirby\Toolkit\Dir;
+
+/**
+ * @coversDefaultClass \Kirby\Cache\NullCache
+ */
+class NullCacheTest extends TestCase
+{
+    /**
+     * @covers ::set
+     * @covers ::retrieve
+     * @covers ::remove
+     */
+    public function testOperations()
+    {
+        $cache = new NullCache();
+
+        $this->assertTrue($cache->set('foo', 'A basic value', 10));
+        $this->assertFalse($cache->exists('foo'));
+        $this->assertNull($cache->retrieve('foo'));
+        $this->assertTrue($cache->remove('foo'));
+    }
+
+    /**
+     * @covers ::flush
+     */
+    public function testFlush()
+    {
+        $cache = new NullCache();
+
+        $this->assertTrue($cache->flush());
+    }
+}

--- a/tests/Cache/ValueTest.php
+++ b/tests/Cache/ValueTest.php
@@ -4,51 +4,176 @@ namespace Kirby\Cache;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Cache\Value
+ */
 class ValueTest extends TestCase
 {
-    public function testSetup()
+    /**
+     * @covers ::__construct
+     * @covers ::created
+     */
+    public function testCreated()
+    {
+        $value = new Value('foo');
+        $this->assertEquals(time(), $value->created());
+
+        $value = new Value('foo', 0, 1000);
+        $this->assertEquals(1000, $value->created());
+    }
+
+    /**
+     * @covers ::expires
+     */
+    public function testExpires()
+    {
+        $value = new Value('foo');
+        $this->assertNull($value->expires());
+
+        $value = new Value('foo', 0, 10000);
+        $this->assertNull($value->expires());
+
+        $value = new Value('foo', 1000, 0);
+        $this->assertEquals(1000 * 60, $value->expires());
+
+        $value = new Value('foo', 1000, 10000);
+        $this->assertEquals(10000 + 1000 * 60, $value->expires());
+    }
+
+    /**
+     * @covers ::fromArray
+     * @covers ::toArray
+     */
+    public function testArrayConversion()
+    {
+        $data = [
+            'created' => 10000,
+            'minutes' => 0,
+            'value'   => 'foo'
+        ];
+        $value = Value::fromArray($data);
+        $this->assertEquals(10000, $value->created());
+        $this->assertNull($value->expires());
+        $this->assertEquals('foo', $value->value());
+        $this->assertEquals($data, $value->toArray());
+
+        $time = time();
+        $data = [
+            'created' => null,
+            'minutes' => 1000,
+            'value'   => ['this is' => 'an array']
+        ];
+        $value = Value::fromArray($data);
+        $this->assertEquals($time, $value->created());
+        $this->assertEquals($time + 1000 * 60, $value->expires());
+        $this->assertEquals(['this is' => 'an array'], $value->value());
+        $this->assertEquals([
+            'created' => $time,
+            'minutes' => 1000,
+            'value'   => ['this is' => 'an array']
+        ], $value->toArray());
+
+        $data = [
+            'created' => 10000,
+            'minutes' => null,
+            'value'   => 'foo'
+        ];
+        $value = Value::fromArray($data);
+        $this->assertEquals(10000, $value->created());
+        $this->assertNull($value->expires());
+        $this->assertEquals('foo', $value->value());
+        $this->assertEquals([
+            'created' => 10000,
+            'minutes' => 0,
+            'value'   => 'foo'
+        ], $value->toArray());
+    }
+
+    /**
+     * @covers ::fromArray
+     */
+    public function testFromArrayInvalid()
+    {
+        $this->expectException(\TypeError::class);
+
+        $data = [
+            'created' => 'invalid',
+            'minutes' => 'invalid',
+            'value'   => 'foo'
+        ];
+        $value = Value::fromArray($data);
+    }
+
+    /**
+     * @covers ::fromJson
+     * @covers ::toJson
+     */
+    public function testJsonConversion()
+    {
+        $data = json_encode([
+            'created' => 10000,
+            'minutes' => 0,
+            'value'   => 'foo'
+        ]);
+        $value = Value::fromJson($data);
+        $this->assertEquals(10000, $value->created());
+        $this->assertNull($value->expires());
+        $this->assertEquals('foo', $value->value());
+        $this->assertEquals($data, $value->toJson());
+
+        $time = time();
+        $data = json_encode([
+            'created' => null,
+            'minutes' => 1000,
+            'value'   => ['this is' => 'an array']
+        ]);
+        $value = Value::fromJson($data);
+        $this->assertEquals($time, $value->created());
+        $this->assertEquals($time + 1000 * 60, $value->expires());
+        $this->assertEquals(['this is' => 'an array'], $value->value());
+        $this->assertEquals(json_encode([
+            'created' => $time,
+            'minutes' => 1000,
+            'value'   => ['this is' => 'an array']
+        ]), $value->toJson());
+
+        $data = json_encode([
+            'created' => 10000,
+            'minutes' => null,
+            'value'   => 'foo'
+        ]);
+        $value = Value::fromJson($data);
+        $this->assertEquals(10000, $value->created());
+        $this->assertNull($value->expires());
+        $this->assertEquals('foo', $value->value());
+        $this->assertEquals(json_encode([
+            'created' => 10000,
+            'minutes' => 0,
+            'value'   => 'foo'
+        ]), $value->toJson());
+
+        $this->assertNull(Value::fromJson('gibberish'));
+
+        $data = json_encode([
+            'created' => 'invalid',
+            'minutes' => 'invalid',
+            'value'   => 'foo'
+        ]);
+        $this->assertNull(Value::fromJson($data));
+    }
+
+    /**
+     * @covers ::value
+     */
+    public function testValue()
     {
         $value = new Value('foo');
         $this->assertEquals('foo', $value->value());
-        $this->assertEquals(time(), $value->created());
-        $this->assertEquals(time() + (2628000 * 60), $value->expires());
-    }
 
-    public function testSetupCustomDuration()
-    {
-        $value = new Value('foo', 100);
-        $this->assertEquals(time() + (100 * 60), $value->expires());
-    }
+        $value = new Value(['this is' => 'an array']);
+        $this->assertEquals(['this is' => 'an array'], $value->value());
 
-    public function testFromArray()
-    {
-        $value = Value::fromArray([
-            'value'   => 'foo',
-            'minutes' => 1,
-            'created' => 0
-        ]);
-
-        $this->assertEquals('foo', $value->value());
-        $this->assertEquals(0, $value->created());
-        $this->assertEquals(60, $value->expires());
-    }
-
-    public function testFromJson()
-    {
-        $value = Value::fromJson(json_encode([
-            'value'   => 'foo',
-            'minutes' => 1,
-            'created' => 0
-        ]));
-
-        $this->assertEquals('foo', $value->value());
-        $this->assertEquals(0, $value->created());
-        $this->assertEquals(60, $value->expires());
-    }
-
-    public function testFromInvalidJson()
-    {
-        $value = Value::fromJson('foo');
-        $this->assertNull($value->value());
+        $value = new Value(12345);
+        $this->assertEquals(12345, $value->value());
     }
 }

--- a/tests/Cms/AppCachesTest.php
+++ b/tests/Cms/AppCachesTest.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Cache\Cache;
 use Kirby\Cache\FileCache;
+use Kirby\Cache\NullCache;
 
 class AppCachesTest extends TestCase
 {
@@ -18,7 +18,7 @@ class AppCachesTest extends TestCase
 
     public function testDisabledCache()
     {
-        $this->assertEquals(Cache::class, get_class($this->app()->cache('pages')));
+        $this->assertEquals(NullCache::class, get_class($this->app()->cache('pages')));
     }
 
     public function testEnabledCacheWithoutOptions()

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,4 +1,5 @@
 # extension="apcu.so"
+extension="memcached.so"
 
 apc.enabled=1
 apc.enable_cli=1


### PR DESCRIPTION
## Describe the PR

The original goal was "just" to reach 100 % code coverage for the `Cache` package, but while writing unit tests, I noticed a few bugs in the existing implementation, so I refactored the package.

There are a lot of changes, so it's probably best to look at the commits one by one. :)

**Fixed bugs**:

- Cache items that never expire now actually never expire (before: after 5 years)
- Support for deliberately empty cache values (before: treated like not existing at all)
- Behavior between different cache drivers is now consistent

**New features**:

- The `AppCaches` class now checks if the cache instances extend the `Cache` class as other objects are invalid
- New `NullCache` and `MemoryCache` drivers

**Other changes**:

- Code cleanup, more consistent doc blocks
- Code coverage of the `Cache` package up from 78 % to 100 %, in total up from 82 % to 83 %

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)