### PR TITLE
 Use return value of route:after hook

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -174,7 +174,7 @@ class App
     }
 
     /**
-     * Apply a hook to the given value;
+     * Applies a hook to the given value;
      * the value that gets modified by the hooks
      * is always the last argument
      *
@@ -195,7 +195,12 @@ class App
                 $hookArgs[] = $value;
 
                 // bind the App object to the hook
-                $value = $function->call($this, ...$hookArgs);
+                $newValue = $function->call($this, ...$hookArgs);
+
+                // update value if one was returned
+                if ($newValue !== null) {
+                    $value = $newValue;
+                }
             }
         }
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -174,19 +174,28 @@ class App
     }
 
     /**
-     * Apply a hook to the given value
+     * Apply a hook to the given value;
+     * the value that gets modified by the hooks
+     * is always the last argument
      *
      * @internal
-     * @param string $name
-     * @param mixed $value
-     * @return mixed
+     * @param string $name Hook name
+     * @param mixed $args Arguments to pass to the hooks
+     * @return mixed Resulting value as modified by the hooks
      */
-    public function apply(string $name, $value)
+    public function apply(string $name, ...$args)
     {
+        // split up args into "passive" args and the value
+        $value = array_pop($args);
+
         if ($functions = $this->extension('hooks', $name)) {
             foreach ($functions as $function) {
+                // re-assemble args
+                $hookArgs   = $args;
+                $hookArgs[] = $value;
+
                 // bind the App object to the hook
-                $value = $function->call($this, $value);
+                $value = $function->call($this, ...$hookArgs);
             }
         }
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -276,7 +276,7 @@ class App
         };
 
         $router::$afterEach = function ($route, $path, $method, $result) {
-            $this->trigger('route:after', $route, $path, $method, $result);
+            return $this->apply('route:after', $route, $path, $method, $result);
         };
 
         return $router->call($path ?? $this->path(), $method ?? $this->request()->method());

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -113,7 +113,7 @@ class Router
             }
 
             if (is_a(static::$afterEach, 'Closure') === true) {
-                (static::$afterEach)($route, $path, $method, $result);
+                $result = (static::$afterEach)($route, $path, $method, $result);
             }
         }
 

--- a/tests/Cms/AppTest.php
+++ b/tests/Cms/AppTest.php
@@ -6,6 +6,9 @@ use Kirby\Data\Data;
 use Kirby\Http\Route;
 use Kirby\Toolkit\F;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\App
+ */
 class AppTest extends TestCase
 {
     public function setUp(): void
@@ -16,6 +19,51 @@ class AppTest extends TestCase
     public function tearDown(): void
     {
         Dir::remove($this->fixtures);
+    }
+
+    /**
+     * @covers ::apply
+     */
+    public function testApply()
+    {
+        $app = new App([
+            'options' => [
+                'hooks' => [
+                    'singleParam' => [
+                        function ($value) {
+                            if (func_num_args() !== 1) {
+                                throw new \Exception();
+                            }
+
+                            return $value * 2;
+                        },
+                        function ($value) {
+                            return $value + 1;
+                        },
+                    ],
+                    'multiParams' => [
+                        function ($arg1, $arg2, $value) {
+                            if (func_num_args() !== 3 || $arg1 !== 'arg1' || $arg2 !== 'arg2') {
+                                throw new \Exception();
+                            }
+
+                            return $value * 2;
+                        },
+                        function ($arg1, $arg2, $value) {
+                            return $value + 1;
+                        },
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertEquals(5, $app->apply('singleParam', 2));
+        $this->assertEquals(21, $app->apply('singleParam', 10));
+
+        $this->assertEquals(5, $app->apply('multiParams', 'arg1', 'arg2', 2));
+        $this->assertEquals(21, $app->apply('multiParams', 'arg1', 'arg2', 10));
+
+        $this->assertEquals(2, $app->apply('does-not-exist', 2));
     }
 
     public function testDefaultRoles()

--- a/tests/Cms/AppTest.php
+++ b/tests/Cms/AppTest.php
@@ -29,6 +29,15 @@ class AppTest extends TestCase
         $app = new App([
             'options' => [
                 'hooks' => [
+                    'noModify' => [
+                        function ($value) {
+                            // don't return anything
+                        },
+                        function ($value) {
+                            // explicitly return null (should be the same internally)
+                            return null;
+                        }
+                    ],
                     'singleParam' => [
                         function ($value) {
                             if (func_num_args() !== 1) {
@@ -36,6 +45,9 @@ class AppTest extends TestCase
                             }
 
                             return $value * 2;
+                        },
+                        function ($value) {
+                            // don't return anything
                         },
                         function ($value) {
                             return $value + 1;
@@ -50,12 +62,25 @@ class AppTest extends TestCase
                             return $value * 2;
                         },
                         function ($arg1, $arg2, $value) {
+                            if (func_num_args() !== 3 || $arg1 !== 'arg1' || $arg2 !== 'arg2') {
+                                throw new \Exception();
+                            }
+
+                            // don't return anything
+                        },
+                        function ($arg1, $arg2, $value) {
+                            if (func_num_args() !== 3 || $arg1 !== 'arg1' || $arg2 !== 'arg2') {
+                                throw new \Exception();
+                            }
+
                             return $value + 1;
                         },
                     ]
                 ]
             ]
         ]);
+
+        $this->assertEquals(10, $app->apply('noModify', 10));
 
         $this->assertEquals(5, $app->apply('singleParam', 2));
         $this->assertEquals(21, $app->apply('singleParam', 10));

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -121,9 +121,11 @@ class RouterTest extends TestCase
             $this->assertEquals('/', $path);
             $this->assertEquals('GET', $method);
             $this->assertEquals('test', $result);
+
+            return $result . ':after';
         };
 
-        $router->call('/', 'GET');
+        $this->assertEquals('test:after', $router->call('/', 'GET'));
     }
 
     public function testNext()


### PR DESCRIPTION
## Describe the PR

It is now possible to modify the router's `$result` using hooks as already documented on the site.

## Related issues

Fixes #1605.

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)