### PR TITLE
Fix Page:: blueprints for non-array values of options()['changeTemplate']

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -247,10 +247,10 @@ class Page extends ModelWithContent
         }
 
         $blueprints      = [];
-		$templates       = $this->blueprint()->options()['changeTemplate'] ?? [];
-		if (!is_array($templates)) {
-			$templates = [];
-		}
+        $templates       = $this->blueprint()->options()['changeTemplate'] ?? [];
+        if (!is_array($templates)) {
+            $templates = [];
+        }
         $currentTemplate = $this->intendedTemplate()->name();
 
         // add the current template to the array

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -247,7 +247,10 @@ class Page extends ModelWithContent
         }
 
         $blueprints      = [];
-        $templates       = $this->blueprint()->options()['changeTemplate'] ?? false;
+		$templates       = $this->blueprint()->options()['changeTemplate'] ?? [];
+		if (!is_array($templates)) {
+			$templates = [];
+		}
         $currentTemplate = $this->intendedTemplate()->name();
 
         // add the current template to the array


### PR DESCRIPTION
The Kirby\Cms\Page::blueprints() method was assuming that the $templates variable was an array, but it could have been a boolean in two different situation: 

- ```$this->blueprint()->options()['changeTemplate']``` can return ```true```, not only an array
- if that option was not defined, it was falling back to ```false``` instead of empty array.

In some real world situations this issue was actually happening, and the panel was failing to edit a page raising the error "Cannot use a scalar value as an array".

I think there is no need to make a separate test for the fix because there are no side effects, the rest of the method was already assuming that $templates was always an array, I just made sure that this is really happening.

