### PR TITLE
More sensible HTML a methods #1734

### DIFF
--- a/src/Cms/Html.php
+++ b/src/Cms/Html.php
@@ -16,15 +16,15 @@ namespace Kirby\Cms;
 class Html extends \Kirby\Toolkit\Html
 {
     /**
-     * Generates an a tag with an absolute Url
+     * Generates an `a` tag with an absolute Url
      *
      * @param string $href Relative or absolute Url
-     * @param string|array|null $text If null, the link will be used as link text. If an array is passed, each element will be added unencoded
+     * @param string|array|null $text If `null`, the link will be used as link text. If an array is passed, each element will be added unencoded
      * @param array $attr Additional attributes for the a tag.
      * @return string
      */
-    public static function a(string $href = null, $text = null, array $attr = []): string
+    public static function link(string $href = null, $text = null, array $attr = []): string
     {
-        return parent::a(Url::to($href), $text, $attr);
+        return parent::link(Url::to($href), $text, $attr);
     }
 }

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -52,7 +52,7 @@ class Html
     }
 
     /**
-     * Generates an a tag
+     * Generates an `a` tag
      *
      * @param string $href The url for the `a` tag
      * @param mixed $text The optional text. If `null`, the url will be used as text
@@ -61,20 +61,15 @@ class Html
      */
     public static function a(string $href = null, $text = null, array $attr = []): string
     {
-        $attr = array_merge(['href' => $href], $attr);
-
-        if (empty($text) === true) {
-            $text = $attr['href'];
+        if (Str::startsWith($href, 'mailto:')) {
+            return static::email($href, $text, $attr);
         }
 
-        if (is_string($text) === true && Str::isUrl($text) === true) {
-            $text = Url::short($text);
+        if (Str::startsWith($href, 'tel:')) {
+            return static::tel($href, $text, $attr);
         }
 
-        // add rel=noopener to target blank links to improve security
-        $attr['rel'] = static::rel($attr['rel'] ?? null, $attr['target'] ?? null);
-
-        return static::tag('a', $text, $attr);
+        return static::link($href, $text, $attr);
     }
 
     /**
@@ -328,6 +323,32 @@ class Html
     }
 
     /**
+     * Generates an `a` link tag
+     *
+     * @param string $href The url for the `a` tag
+     * @param mixed $text The optional text. If `null`, the url will be used as text
+     * @param array $attr Additional attributes for the tag
+     * @return string the generated html
+     */
+    public static function link(string $href = null, $text = null, array $attr = []): string
+    {
+        $attr = array_merge(['href' => $href], $attr);
+
+        if (empty($text) === true) {
+            $text = $attr['href'];
+        }
+
+        if (is_string($text) === true && Str::isUrl($text) === true) {
+            $text = Url::short($text);
+        }
+
+        // add rel=noopener to target blank links to improve security
+        $attr['rel'] = static::rel($attr['rel'] ?? null, $attr['target'] ?? null);
+
+        return static::tag('a', $text, $attr);
+    }
+
+    /**
      * Add noopeener noreferrer to rels when target is `_blank`
      *
      * @param string $rel
@@ -398,7 +419,7 @@ class Html
             $text = $tel;
         }
 
-        return static::a('tel:' . $number, $text, $attr);
+        return static::link('tel:' . $number, $text, $attr);
     }
 
     /**

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -28,6 +28,16 @@ class HtmlTest extends TestCase
         $expected = '<a href="https://getkirby.com">getkirby.com</a>';
 
         $this->assertEquals($expected, $html);
+
+        $html = Html::a('mailto:mail@company.com');
+        $expected = '!\<a href="mailto\:.*?">.*?\</a>!';
+
+        $this->assertRegExp($expected, $html);
+
+        $html = Html::a('tel:1234');
+        $expected = '<a href="tel:1234">tel:1234</a>';
+
+        $this->assertEquals($expected, $html);
     }
 
     public function testAWithText()
@@ -236,6 +246,14 @@ class HtmlTest extends TestCase
 
         $html = Html::rel('noopener', '_blank');
         $expected = 'noopener';
+
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testTel()
+    {
+        $html = Html::tel('1234');
+        $expected = '<a href="tel:1234">1234</a>';
 
         $this->assertEquals($expected, $html);
     }


### PR DESCRIPTION
## Describe the PR
Since `Html::a` could not handle `mailto` hrefs, even though its name suggests that it could, this PR introduces a new `Html::link` method (with the code of the previous `Html::a`, while `Html::a` now checks whether to use `Html::link`, 'Html::email` or `Html::tel`.

## Related issues
- Fixes  #1734