### PR TITLE
Cache collections with different data #1542

### DIFF
--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -69,21 +69,21 @@ class Collections
         // if not yet cached
         if (
             isset($this->cache[$name]) === false ||
-            $this->cache[$name]["data"] !== $data
+            $this->cache[$name]['data'] !== $data
         ) {
             $controller = new Controller($this->collections[$name]);
             $this->cache[$name] = [
-                "result" => $controller->call(null, $data),
-                "data"   => $data
+                'result' => $controller->call(null, $data),
+                'data'   => $data
             ];
         }
 
         // return cloned object
-        if (is_object($this->cache[$name]["result"]) === true) {
-            return clone $this->cache[$name]["result"];
+        if (is_object($this->cache[$name]['result']) === true) {
+            return clone $this->cache[$name]['result'];
         }
 
-        return $this->cache[$name]["result"];
+        return $this->cache[$name]['result'];
     }
 
     /**

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -67,17 +67,23 @@ class Collections
         }
 
         // if not yet cached
-        if (isset($this->cache[$name]) === false) {
+        if (
+            isset($this->cache[$name]) === false ||
+            $this->cache[$name]["data"] !== $data
+        ) {
             $controller = new Controller($this->collections[$name]);
-            $this->cache[$name] = $controller->call(null, $data);
+            $this->cache[$name] = [
+                "result" => $controller->call(null, $data),
+                "data"   => $data
+            ];
         }
 
         // return cloned object
-        if (is_object($this->cache[$name]) === true) {
-            return clone $this->cache[$name];
+        if (is_object($this->cache[$name]["result"]) === true) {
+            return clone $this->cache[$name]["result"];
         }
 
-        return $this->cache[$name];
+        return $this->cache[$name]["result"];
     }
 
     /**

--- a/tests/Cms/CollectionsTest.php
+++ b/tests/Cms/CollectionsTest.php
@@ -44,6 +44,23 @@ class CollectionsTest extends TestCase
         $this->assertEquals('ab', $result);
     }
 
+    public function testGetWithDifferentData()
+    {
+        $app = $this->_app();
+
+        $result = $app->collections()->get('string', [
+            'a' => 'a',
+            'b' => 'b'
+        ]);
+        $this->assertEquals('ab', $result);
+
+        $result = $app->collections()->get('string', [
+            'a' => 'c',
+            'b' => 'd'
+        ]);
+        $this->assertEquals('cd', $result);
+    }
+
     public function testGetCloned()
     {
         $app         = $this->_app();


### PR DESCRIPTION
## Describe the PR
Fixes the problem that collections were only cache with the first data passed, never again with new data.

## Related issues
- Fixes #1542

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
