### PR TITLE
Fix decimals on NumberInput #1748

### DIFF
--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -27,7 +27,7 @@ return [
             return $this->toNumber($step);
         },
         'value' => function ($value = null) {
-            return $this->toNumber($value);
+            return $this->toValue($value);
         }
     ],
     'methods' => [
@@ -37,6 +37,11 @@ return [
             }
 
             return (float)Str::float($value);
+        },
+        'toValue' => function ($value) {
+            $decimal = strlen(substr(strrchr($this->step(), '.'), 1));
+
+            return number_format((float)$this->toNumber($value), $decimal, '.', false);
         }
     ],
     'validations' => [


### PR DESCRIPTION
Always save and submit to the Panel the number field value with the same number of decimals as defined by `step`.

Fixes #1748 

**EDIT**
@bastianallgeier just realised that this will keep failing the unit tests... to achieve what's asked in the related issue, the value has to be turned into a string (what this code does) while former it was a number/float. Problematic.