### PR TITLE
Fix KirbyText in image KirbyTag caption #1501

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kirby\Cms\App;
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
 
@@ -124,6 +123,11 @@ return [
 
             if ($tag->kirby()->option('kirbytext.image.figure', true) === false) {
                 return $link($image);
+            }
+
+            // render KirbyText in caption
+            if ($tag->caption) {
+                $tag->caption = [$tag->kirby()->kirbytext($tag->caption, [], true)];
             }
 
             return Html::figure([ $link($image) ], $tag->caption, [

--- a/tests/Cms/KirbyTagsTest.php
+++ b/tests/Cms/KirbyTagsTest.php
@@ -80,6 +80,19 @@ class KirbyTagsTest extends TestCase
         $this->assertEquals($expected, $kirby->kirbytext('(image: https://test.com/something.jpg)'));
     }
 
+    public function testImageWithCaption()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $expected = '<figure><img alt="" src="/myimage.jpg"><figcaption>This is an <em>awesome</em> image and this a <a href="">link</a></figcaption></figure>';
+
+        $this->assertEquals($expected, $kirby->kirbytext('(image: myimage.jpg caption: This is an *awesome* image and this a <a href="">link</a>)'));
+    }
+
     public function testFileWithinFile()
     {
         $kirby = new App([


### PR DESCRIPTION
## Describe the PR
Makes this work:

```
(image: myimage.jpg caption: This is an *awesome* image and this a <a href="">link</a>)
```

## Related issues
- Fixes #1501

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`