### PR TITLE
Fix reverting page titles #1727

### DIFF
--- a/panel/src/store/modules/form.js
+++ b/panel/src/store/modules/form.js
@@ -132,6 +132,12 @@ export default {
 
       // fetch from api
       return Api.get(model.api, { select: "content" }).then(response => {
+
+        if (id.startsWith("pages/") || id.startsWith("site")) {
+          // remove title from response content
+          delete response.content.title;
+        }
+
         context.commit("SET_ORIGINALS", [id, response.content]);
         context.commit("SET_VALUES", [id, response.content]);
         context.commit("DELETE_CHANGES", id);


### PR DESCRIPTION
## Describe the PR
On `$store.dispatch("form/revert")` the field values are re-added to the store. So we need to make sure to exclude the page and site title here as well.

## Related issues
- Fixes #1727
