### PR TITLE
Fix smartypants usage #1686

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -650,6 +650,11 @@ class App
         $text = $this->apply('kirbytext:before', $text);
         $text = $this->kirbytags($text, $data);
         $text = $this->markdown($text, $inline);
+
+        if ($this->option('smartypants', false) !== false) {
+            $text = $this->smartypants($text);
+        }
+
         $text = $this->apply('kirbytext:after', $text);
 
         return $text;
@@ -1126,7 +1131,13 @@ class App
      */
     public function smartypants(string $text = null): string
     {
-        return $this->component('smartypants')($this, $text, $this->options['smartypants'] ?? []);
+        $options = $this->option('smartypants', []);
+
+        if ($options === true) {
+            $options = [];
+        }
+
+        return $this->component('smartypants')($this, $text, $options);
     }
 
     /**

--- a/tests/Cms/FieldMethodsTest.php
+++ b/tests/Cms/FieldMethodsTest.php
@@ -476,6 +476,23 @@ class FieldMethodsTest extends TestCase
         $this->assertEquals($expected, $this->field($text)->smartypants());
     }
 
+    public function testSmartypantsWithKirbytext()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'smartypants' => true
+            ]
+        ]);
+
+        $text     = '"Test"';
+        $expected = '&#8220;Test&#8221;';
+
+        $this->assertEquals($expected, $this->field($text)->kti());
+    }
+
     public function testSlug()
     {
         $text     = 'Ä--Ö--Ü';

--- a/tests/Cms/HelpersTest.php
+++ b/tests/Cms/HelpersTest.php
@@ -519,6 +519,23 @@ class HelpersTest extends TestCase
         $this->assertEquals($expected, $text);
     }
 
+    public function testSmartypantsWithKirbytext()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'smartypants' => true
+            ]
+        ]);
+
+        $text     = kirbytextinline('"Test"');
+        $expected = '&#8220;Test&#8221;';
+
+        $this->assertEquals($expected, $text);
+    }
+
     public function testSnippet()
     {
         $app = $this->kirby->clone([


### PR DESCRIPTION
## Describe the PR
Option `"smartypants" => true` works as described in docs now.
Also Kirby now checks if smartypants is activated when using kirbytext and applies it if so.

## Related issues
- Fixes #1686

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
