### PR TITLE
Add option for the file tag not to download the contents.

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -39,6 +39,7 @@ return [
     'file' => [
         'attr' => [
             'class',
+            'download',
             'rel',
             'target',
             'text',
@@ -57,7 +58,7 @@ return [
 
             return Html::a($file->url(), $tag->text, [
                 'class'    => $tag->class,
-                'download' => true,
+                'download' => $tag->download !== 'false',
                 'rel'      => $tag->rel,
                 'target'   => $tag->target,
                 'title'    => $tag->title,


### PR DESCRIPTION
## Describe the PR
Add option for the 'file' tag not to download the contents but rather open them. Useful for PDFs, for example.

```
(file: companysecrets.pdf download: false)
```