### PR TITLE
Enhance srcset method

### DIFF
--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -122,15 +122,22 @@ trait FileModifications
         $set = [];
 
         foreach ($sizes as $key => $value) {
-            if (is_string($value) === true) {
-                $size = $key;
-                $attr = $value;
+            if (is_array($value)) {
+                $options = $value;
+                $condition = $key;
+            } elseif (is_string($value) === true) {
+                $options = [
+                    'width' => $key
+                ];
+                $condition = $value;
             } else {
-                $size = $value;
-                $attr = $value . 'w';
+                $options = [
+                    'width' => $value
+                ];
+                $condition = $value . 'w';
             }
 
-            $set[] = $this->resize($size)->url() . ' ' . $attr;
+            $set[] = $this->thumb($options)->url() . ' ' . $condition;
         }
 
         return implode(', ', $set);

--- a/src/Cms/HasPanelImage.php
+++ b/src/Cms/HasPanelImage.php
@@ -59,23 +59,27 @@ trait HasPanelImage
             // for lists
             $settings['list'] = [
                 'url' => $image->thumb([
-                    'width'  => 38,
-                    'height' => 38,
-                    'crop' => 'center'
-                ])->url(true) . $modified,
-                'srcset' => $image->thumb([
                     'width' => 38,
                     'height' => 38,
                     'crop' => 'center'
-                ])->url(true) . $modified . ' 1x, ' . $image->thumb([
-                    'width' => 76,
-                    'height' => 76,
-                    'crop' => 'center'
-                ])->url(true) . $modified . ' 2x, ' . $image->thumb([
-                    'width' => 152,
-                    'height' => 152,
-                    'crop' => 'center'
-                ])->url(true) . $modified . ' 3x'
+                ])->url(true) . $modified,
+                'srcset' => $image->srcset([
+                    '1x' => [
+                        'width' => 38,
+                        'height' => 38,
+                        'crop' => 'center'
+                    ],
+                    '2x' => [
+                        'width' => 76,
+                        'height' => 76,
+                        'crop' => 'center'
+                    ],
+                    '3x' => [
+                        'width' => 152,
+                        'height' => 152,
+                        'crop' => 'center'
+                    ]
+                ])
             ];
 
             unset($settings['query']);


### PR DESCRIPTION
## Describe the PR
When discussing #1520 with @distantnative, I noticed that Kirby's `srcset` method is limited to resizing and doesn't take additional options for cropping or other image manipulations. This pull request intends to add this by switching from the `resize` to the `thumb` method for url generation.

The `$sizes` variable now accepts a new array structure moving the image condition to the key and the image options to the value:

```php
$image->srcset([
    '1x' => [
        'width' => 38,
        'height' => 38,
        'crop' => 'center'
    ],
    '2x' => [
        'width' => 76,
        'height' => 76,
        'crop' => 'center'
    ],
    '3x' => [
        'width' => 152,
        'height' => 152,
        'crop' => 'center'
    ]
]);
```

The old condition syntax

```php
$image->srcset([
  800  => '1x',
  1600 => '1.5x'
]);
```

still works for compatibility reasons but should be replaced in the docs with the more powerful proposed syntax in this pull request in my eyes.

The simple syntax of defining a plain array of widths has not been changed.

## Related issues
- https://github.com/getkirby/kirby/issues/1520
- https://github.com/getkirby/ideas/issues/242

## Todos
- [ ] Add unit tests for fixed bug/feature
- [ ] Pass all unit tests
- [ ] Fix code style issues with CS fixer and `composer fix`
- [ ] If needeed, in-code documentation (DocBlocks etc.)

👆 I have no idea what is really needed from this list and how it's done.