### PR TITLE
Unset lock on altering model #1810

### DIFF
--- a/panel/src/components/Dialogs/FileRemoveDialog.vue
+++ b/panel/src/components/Dialogs/FileRemoveDialog.vue
@@ -36,14 +36,19 @@ export default {
         });
     },
     submit() {
+      // unlock old file id
+      this.$api.delete(this.$route.path + "/lock");
+
       this.$api.files
         .delete(this.parent, this.filename)
         .then(() => {
           // remove data from cache
           this.$store.dispatch("form/remove", "files/" + this.id);
+
           this.$store.dispatch("notification/success", ":)");
           this.$events.$emit("file.delete", this.id);
           this.$emit("success");
+
           this.$refs.dialog.close();
         })
         .catch(error => {

--- a/panel/src/components/Dialogs/FileRenameDialog.vue
+++ b/panel/src/components/Dialogs/FileRenameDialog.vue
@@ -72,6 +72,9 @@ export default {
       return slug(input, [this.slugs, this.system.ascii], "\.");
     },
     submit() {
+      // unlock old file id
+      this.$api.delete(this.$route.path + "/lock");
+
       this.$api.files
         .rename(this.parent, this.file.filename, this.file.name)
         .then(file => {

--- a/panel/src/components/Dialogs/PageUrlDialog.vue
+++ b/panel/src/components/Dialogs/PageUrlDialog.vue
@@ -93,6 +93,9 @@ export default {
         return;
       }
 
+      // unlock old page id
+      this.$api.delete(this.$route.path + "/lock");
+
       this.$api.pages
         .slug(this.page.id, this.slug)
         .then(page => {


### PR DESCRIPTION
## Describe the PR
To make sure we don't leave behind "dead" lock file entries, we have to send unlock API requests on certain model changes.

## Related issues
- Fixes #1810
