### PR TITLE
Add missing parent to `page dialog's` API and consume it correctly in the panel

### DIFF
--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -113,12 +113,16 @@ return [
                     } else {
                         if (!$parent = $this->site()->find($this->requestQuery('parent'))) {
                             $parent = $this->site();
+                            $modelParent = null;
+                        } else {
+                            $modelParent = $parent->parent() ? $parent->parent()->id() : null;
                         }
 
                         $pages = $parent->children();
                         $model = [
-                            'id'    => $parent->id() == '' ? null : $parent->id(),
-                            'title' => $parent->title()->value()
+                            'id'     => $parent->id() == '' ? null : $parent->id(),
+                            'title'  => $parent->title()->value(),
+                            'parent' => $modelParent
                         ];
                     }
 

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -90,7 +90,7 @@ export default {
   },
   methods: {
     back() {
-      this.options.parent = this.model.parent ? this.model.parent.id : null;
+      this.options.parent = this.model.parent ? this.model.parent : null;
       this.fetch();
     },
     go(page) {


### PR DESCRIPTION
## Describe the PR

According to https://github.com/getkirby/kirby/blob/0885e295788aadac1bd11fbbd28502d3119d2959/panel/src/components/Dialogs/PagesDialog.vue#L108 the API should provide the models parent to the `pages dialog` if available.

Seen the code in https://github.com/steirico/kirby/blob/d250d832888f15c1b08a056c131bb8602784afe5/config/fields/pages.php#L102-L139 that's never the case.

This PR modifies the API to set the model's parent `id` if available and consumes it in the `pages dialog` accordingly.

## Related issues

PR relates to issues in the `kirby` repo:
- Fixes #1841

## Todos
If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it.
- [ ] Add unit tests for fixed bug/feature
- [ ] Pass all unit tests
- [ ] Fix code style issues with CS fixer and `composer fix`
- [ ] If needeed, in-code documentation (DocBlocks etc.)
