### PR TITLE
Added query including subpages

### DIFF
--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -9,7 +9,19 @@ return [
 
             if ($query) {
                 $pages = $model->query($query, 'Kirby\Cms\Pages');
-                $self  = null;
+                $root = $pages->parent();
+
+                if ($parent = $site->find($params['parent'] ?? null)) {
+                    $pages = $parent->children();
+                } else {
+                    $parent = $root;
+                }
+
+                $self = [
+                    'id' => ($parent->id() == '' or $root == $parent->id()) ? null : $parent->id(),
+                    'title' => $parent->title()->value(),
+                    'parent' => is_a($parent->parent(), Page::class) === true ? $parent->parent()->id() : null,
+                ];
             } else {
                 if (!$parent = $site->find($params['parent'] ?? null)) {
                     $parent = $site;

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -149,8 +149,9 @@ class PagePickerMixinTest extends TestCase
 
         $response = $field->pages();
         $pages    = $response['pages'];
-
-        $this->assertNull($response['model']);
+        $model    = $response['model'];
+        
+        $this->assertEquals('test', $model['title']);
         $this->assertCount(3, $pages);
         $this->assertEquals('test/a', $pages[0]['id']);
         $this->assertEquals('test/b', $pages[1]['id']);


### PR DESCRIPTION
Added "query including subpages" feature as known issue https://github.com/getkirby/ideas/issues/217

Tested on Kirby 3.2.0 with following blueprint:

```
fields:
    categories:
        label: Categories
        type: pages
        multiple: true
        min: 1
        max: 5
        required: true
        placeholder: Select Categories
        options: query
        query: site.find("categories").children
```
## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [ ] Fix code style issues with CS fixer and `composer fix`
- [ ] If needeed, in-code documentation (DocBlocks etc.)