### PR TITLE
Fixes the cache prefix for urls containing a port

### DIFF
--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -81,7 +81,7 @@ trait AppCaches
             ];
         }
 
-        $prefix = str_replace('/', '_', $this->system()->indexUrl()) .
+        $prefix = str_replace(['/', ':'], '_', $this->system()->indexUrl()) .
                   '/' .
                   str_replace('.', '/', $key);
 

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -62,6 +62,27 @@ class AppCachesTest extends TestCase
         $this->assertFileExists($root . '/getkirby.com_test/pages/home.cache');
     }
 
+    public function testEnabledCacheWithOptionsAndPortPrefix()
+    {
+        $kirby = $this->app([
+            'urls' => [
+                'index' => 'http://127.0.0.0:8000'
+            ],
+            'options' => [
+                'cache.pages' => [
+                    'type' => 'file',
+                    'root' => $root = __DIR__ . '/fixtures/AppCachesTest/cache'
+                ]
+            ]
+        ]);
+
+        $this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
+        $this->assertEquals($root, $kirby->cache('pages')->options()['root']);
+
+        $kirby->cache('pages')->set('home', 'test');
+        $this->assertFileExists($root . '/127.0.0.0_8000/pages/home.cache');
+    }
+
     public function testPluginDefaultCache()
     {
         App::plugin('developer/plugin', [

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -66,7 +66,7 @@ class AppCachesTest extends TestCase
     {
         $kirby = $this->app([
             'urls' => [
-                'index' => 'http://127.0.0.0:8000'
+                'index' => 'http://127.0.0.1:8000'
             ],
             'options' => [
                 'cache.pages' => [
@@ -80,7 +80,7 @@ class AppCachesTest extends TestCase
         $this->assertEquals($root, $kirby->cache('pages')->options()['root']);
 
         $kirby->cache('pages')->set('home', 'test');
-        $this->assertFileExists($root . '/127.0.0.0_8000/pages/home.cache');
+        $this->assertFileExists($root . '/127.0.0.1_8000/pages/home.cache');
     }
 
     public function testPluginDefaultCache()


### PR DESCRIPTION
## Describe the PR
After updating to 3.2.2 I got following error in the panel and frontend.

```
mkdir(): Not a directory
```

I traced it down and my local development url `127.0.0.1:8000` in combination with file caching is the problem here. Because the `:` does not get replaced the cache directory can not be created properly.

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests *
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)

----

\* I had a problem with a markdown and the APCu tests locally. APCu is not available in my enviroment and the markdown thing is probably related to Windows as my OS. Other than that all tests passed.

```
1) Kirby\Cms\AppComponentsTest::testMarkdownCachedInstance
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<p>1st line<br />\r\n
+'<p>1st line<br />\n

tests\Cms\App\AppComponentsTest.php:34
```