### PR TITLE
sortBy in sections: Support sorting constants

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -82,7 +82,16 @@ return [
             $files = $this->parent->files()->template($this->template);
 
             if ($this->sortBy) {
-                $files = $files->sortBy(...Str::split($this->sortBy, ' '));
+                $sortArgs = Str::split($this->sortBy, ' ');
+
+                // fill in PHP constants
+                array_walk($sortArgs, function (string &$value) {
+                    if (Str::startsWith($value, 'SORT_') === true && defined($value) === true) {
+                        $value = constant($value);
+                    }
+                });
+
+                $files = $files->sortBy(...$sortArgs);
             } elseif ($this->sortable === true) {
                 $files = $files->sortBy('sort', 'asc');
             }

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -82,16 +82,7 @@ return [
             $files = $this->parent->files()->template($this->template);
 
             if ($this->sortBy) {
-                $sortArgs = Str::split($this->sortBy, ' ');
-
-                // fill in PHP constants
-                array_walk($sortArgs, function (string &$value) {
-                    if (Str::startsWith($value, 'SORT_') === true && defined($value) === true) {
-                        $value = constant($value);
-                    }
-                });
-
-                $files = $files->sortBy(...$sortArgs);
+                $files = $files->sortBy(...$files::sortArgs($this->sortBy));
             } elseif ($this->sortable === true) {
                 $files = $files->sortBy('sort', 'asc');
             }

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -122,7 +122,16 @@ return [
 
             // sort
             if ($this->sortBy) {
-                $pages = $pages->sortBy(...Str::split($this->sortBy, ' '));
+                $sortArgs = Str::split($this->sortBy, ' ');
+
+                // fill in PHP constants
+                array_walk($sortArgs, function (string &$value) {
+                    if (Str::startsWith($value, 'SORT_') === true && defined($value) === true) {
+                        $value = constant($value);
+                    }
+                });
+
+                $pages = $pages->sortBy(...$sortArgs);
             }
 
             // pagination

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -122,16 +122,7 @@ return [
 
             // sort
             if ($this->sortBy) {
-                $sortArgs = Str::split($this->sortBy, ' ');
-
-                // fill in PHP constants
-                array_walk($sortArgs, function (string &$value) {
-                    if (Str::startsWith($value, 'SORT_') === true && defined($value) === true) {
-                        $value = constant($value);
-                    }
-                });
-
-                $pages = $pages->sortBy(...$sortArgs);
+                $pages = $pages->sortBy(...$pages::sortArgs($this->sortBy));
             }
 
             // pagination

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -849,7 +849,7 @@ class Collection extends Iterator implements Countable
      * @param string $sortBy
      * @return array
      */
-    static public function sortArgs(string $sortBy): array
+    public static function sortArgs(string $sortBy): array
     {
         $sortArgs = Str::split($sortBy, ' ');
 

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -844,6 +844,26 @@ class Collection extends Iterator implements Countable
     }
 
     /**
+     * Get sort arguments from a string
+     *
+     * @param string $sortBy
+     * @return array
+     */
+    static public function sortArgs(string $sortBy): array
+    {
+        $sortArgs = Str::split($sortBy, ' ');
+
+        // fill in PHP constants
+        array_walk($sortArgs, function (string &$value) {
+            if (Str::startsWith($value, 'SORT_') === true && defined($value) === true) {
+                $value = constant($value);
+            }
+        });
+
+        return $sortArgs;
+    }
+
+    /**
      * Sorts the elements by any number of fields
      *
      * @param   $field      string|callable  Field name or value callback to sort by

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -230,7 +230,7 @@ class FilesSectionTest extends TestCase
     public function testSortBy()
     {
         $locale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, 'de_DE');
+        setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
 
         $model = new Page([
             'slug'  => 'test',

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -227,6 +227,68 @@ class FilesSectionTest extends TestCase
         $this->assertEquals('Information', $section->help());
     }
 
+    public function testSortBy()
+    {
+        $locale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, 'de_DE');
+
+        $model = new Page([
+            'slug'  => 'test',
+            'files' => [
+                [
+                    'filename' => 'z.jpg'
+                ],
+                [
+                    'filename' => 'ä.jpg'
+                ],
+                [
+                    'filename' => 'b.jpg'
+                ]
+            ]
+        ]);
+
+        // no settings
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => $model
+        ]);
+        $this->assertEquals('b.jpg', $section->data()[0]['filename']);
+        $this->assertEquals('z.jpg', $section->data()[1]['filename']);
+        $this->assertEquals('ä.jpg', $section->data()[2]['filename']);
+
+        // custom sorting direction
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'sortBy' => 'filename desc'
+        ]);
+        $this->assertEquals('ä.jpg', $section->data()[0]['filename']);
+        $this->assertEquals('z.jpg', $section->data()[1]['filename']);
+        $this->assertEquals('b.jpg', $section->data()[2]['filename']);
+
+        // custom flag
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'sortBy' => 'filename SORT_LOCALE_STRING'
+        ]);
+        $this->assertEquals('ä.jpg', $section->data()[0]['filename']);
+        $this->assertEquals('b.jpg', $section->data()[1]['filename']);
+        $this->assertEquals('z.jpg', $section->data()[2]['filename']);
+
+        // flag & sorting direction
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'sortBy' => 'filename desc SORT_LOCALE_STRING'
+        ]);
+        $this->assertEquals('z.jpg', $section->data()[0]['filename']);
+        $this->assertEquals('b.jpg', $section->data()[1]['filename']);
+        $this->assertEquals('ä.jpg', $section->data()[2]['filename']);
+
+        setlocale(LC_ALL, $locale);
+    }
+
     public function testSortable()
     {
         $section = new Section('files', [

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -156,7 +156,7 @@ class PagesSectionTest extends TestCase
     public function testSortBy()
     {
         $locale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, 'de_DE');
+        setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
 
         $page = new Page([
             'slug'     => 'test',

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -153,6 +153,72 @@ class PagesSectionTest extends TestCase
         $this->assertFalse($section->add());
     }
 
+    public function testSortBy()
+    {
+        $locale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, 'de_DE');
+
+        $page = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-1', 'content' => ['title' => 'Z']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'Ä']],
+                ['slug' => 'subpage-3', 'content' => ['title' => 'B']]
+            ]
+        ]);
+
+        // no settings
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => $page
+        ]);
+        $this->assertEquals('Z', $section->data()[0]['text']);
+        $this->assertEquals('Ä', $section->data()[1]['text']);
+        $this->assertEquals('B', $section->data()[2]['text']);
+
+        // sort by field
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title'
+        ]);
+        $this->assertEquals('B', $section->data()[0]['text']);
+        $this->assertEquals('Z', $section->data()[1]['text']);
+        $this->assertEquals('Ä', $section->data()[2]['text']);
+
+        // custom sorting direction
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title desc'
+        ]);
+        $this->assertEquals('Ä', $section->data()[0]['text']);
+        $this->assertEquals('Z', $section->data()[1]['text']);
+        $this->assertEquals('B', $section->data()[2]['text']);
+
+        // custom flag
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title SORT_LOCALE_STRING'
+        ]);
+        $this->assertEquals('Ä', $section->data()[0]['text']);
+        $this->assertEquals('B', $section->data()[1]['text']);
+        $this->assertEquals('Z', $section->data()[2]['text']);
+
+        // flag & sorting direction
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title desc SORT_LOCALE_STRING'
+        ]);
+        $this->assertEquals('Z', $section->data()[0]['text']);
+        $this->assertEquals('B', $section->data()[1]['text']);
+        $this->assertEquals('Ä', $section->data()[2]['text']);
+
+        setlocale(LC_ALL, $locale);
+    }
+
     public function testSortable()
     {
         $section = new Section('pages', [


### PR DESCRIPTION
Makes it possible to use custom sorting flags in the `sortBy` attribute of the pages and files sections:

```yaml
customSection:
    type: pages
    headline: Custom Section
    sortBy: title asc SORT_LOCALE_STRING
```

## Related issues

Fixes #1913.

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
