### PR TITLE
Deactivate content lock for virtual pages

### DIFF
--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -6,18 +6,20 @@ use Kirby\Exception\Exception;
  * Content Lock Routes
  */
 return [
-
     [
         'pattern' => '(:all)/lock',
         'method'  => 'GET',
         'action'  => function (string $path) {
             if ($lock = $this->parent($path)->lock()) {
-                $locked = $lock->get();
+                return [
+                    'supported' => true,
+                    'locked'    => $lock->get()
+                ];
             }
 
             return [
-                'supported' => isset($locked) === true,
-                'locked'    => $locked ?? null
+                'supported' => false,
+                'locked'    => null
             ];
         }
     ],
@@ -30,7 +32,7 @@ return [
             }
 
             throw new Exception([
-                'key' => 'lock.notImplemented',
+                'key'      => 'lock.notImplemented',
                 'httpCode' => 501
             ]);
         }
@@ -44,7 +46,7 @@ return [
             }
 
             throw new Exception([
-                'key' => 'lock.notImplemented',
+                'key'      => 'lock.notImplemented',
                 'httpCode' => 501
             ]);
         }
@@ -54,12 +56,15 @@ return [
         'method'  => 'GET',
         'action'  => function (string $path) {
             if ($lock = $this->parent($path)->lock()) {
-                $unlocked = $lock->isUnlocked();
+                return [
+                    'supported' => true,
+                    'unlocked'  => $lock->isUnlocked()
+                ];
             }
 
             return [
-                'supported' => isset($unlocked) === true,
-                'unlocked'  => $unlocked ?? null
+                'supported' => false,
+                'unlocked'  => null
             ];
         }
     ],
@@ -72,7 +77,7 @@ return [
             }
 
             throw new Exception([
-                'key' => 'lock.notImplemented',
+                'key'      => 'lock.notImplemented',
                 'httpCode' => 501
             ]);
         }
@@ -86,7 +91,7 @@ return [
             }
 
             throw new Exception([
-                'key' => 'lock.notImplemented',
+                'key'      => 'lock.notImplemented',
                 'httpCode' => 501
             ]);
         }

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Exception\Exception;
+
 /**
  * Content Lock Routes
  */
@@ -9,29 +11,55 @@ return [
         'pattern' => '(:all)/lock',
         'method'  => 'GET',
         'action'  => function (string $path) {
-            return $this->parent($path)->lock()->get();
+            if ($lock = $this->parent($path)->lock()) {
+                $locked = $lock->get();
+            }
+
+            return [
+                'supported' => isset($locked) === true,
+                'locked'    => $locked ?? null
+            ];
         }
     ],
     [
         'pattern' => '(:all)/lock',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
-            return $this->parent($path)->lock()->create();
+            if ($lock = $this->parent($path)->lock()) {
+                return $lock->create();
+            }
+
+            throw new Exception([
+                'key' => 'lock.notImplemented',
+                'httpCode' => 501
+            ]);
         }
     ],
     [
         'pattern' => '(:all)/lock',
         'method'  => 'DELETE',
         'action'  => function (string $path) {
-            return $this->parent($path)->lock()->remove();
+            if ($lock = $this->parent($path)->lock()) {
+                return $lock->remove();
+            }
+
+            throw new Exception([
+                'key' => 'lock.notImplemented',
+                'httpCode' => 501
+            ]);
         }
     ],
     [
         'pattern' => '(:all)/unlock',
         'method'  => 'GET',
         'action'  => function (string $path) {
+            if ($lock = $this->parent($path)->lock()) {
+                $unlocked = $lock->isUnlocked();
+            }
+
             return [
-                'isUnlocked' => $this->parent($path)->lock()->isUnlocked()
+                'supported' => isset($unlocked) === true,
+                'unlocked'  => $unlocked ?? null
             ];
         }
     ],
@@ -39,14 +67,28 @@ return [
         'pattern' => '(:all)/unlock',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
-            return $this->parent($path)->lock()->unlock();
+            if ($lock = $this->parent($path)->lock()) {
+                return $lock->unlock();
+            }
+
+            throw new Exception([
+                'key' => 'lock.notImplemented',
+                'httpCode' => 501
+            ]);
         }
     ],
     [
         'pattern' => '(:all)/unlock',
         'method'  => 'DELETE',
         'action'  => function (string $path) {
-            return $this->parent($path)->lock()->resolve();
+            if ($lock = $this->parent($path)->lock()) {
+                return $lock->resolve();
+            }
+
+            throw new Exception([
+                'key' => 'lock.notImplemented',
+                'httpCode' => 501
+            ]);
         }
     ],
 ];

--- a/panel/src/store/modules/form.js
+++ b/panel/src/store/modules/form.js
@@ -153,22 +153,27 @@ export default {
 
       context.commit("CREATE", model);
       context.commit("CURRENT", model.id);
-
+      context.dispatch("load", model);
+    },
+    load(context, model) {
       const stored = localStorage.getItem("kirby$form$" + model.id);
 
       if (stored) {
         const data = JSON.parse(stored);
 
         Api.get(model.api + "/unlock").then(response => {
-          if (response.isUnlocked === true) {
-            context.commit("UNLOCK", data.values);
-
-          } else if (data.values) {
+          if (
+            response.supported === false ||
+            response.unlocked === false
+          ) {
             Object.keys(data.values).forEach(field => {
               const value = data.values[field];
               context.commit("UPDATE", [model.id, field, value]);
             });
+            return;
           }
+
+          context.commit("UNLOCK", data.values);
         });
       }
     },

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -66,12 +66,12 @@ class ContentLock
     }
 
     /**
-     * Returns array  with `locked` flag and,
-     * if needed, `user`, `email`, `time`, `canUnlock`
+     * Returns either `false` or array  with `user`, `email`,
+     * `time` and `unlockable` keys
      *
-     * @return array
+     * @return array|bool
      */
-    public function get(): array
+    public function get()
     {
         $data = $this->data['lock'] ?? [];
 
@@ -83,17 +83,14 @@ class ContentLock
             $time = intval($data['time']);
 
             return [
-                'locked'    => true,
-                'user'      => $user->id(),
-                'email'     => $user->email(),
-                'time'      => $time,
-                'canUnlock' => $time + $this->kirby()->option('lock.duration', 60 * 2) <= time()
+                'user'       => $user->id(),
+                'email'      => $user->email(),
+                'time'       => $time,
+                'unlockable' => $time + $this->kirby()->option('lock.duration', 60 * 2) <= time()
             ];
         }
 
-        return [
-            'locked' => false
-        ];
+        return false;
     }
 
     /**
@@ -105,10 +102,7 @@ class ContentLock
     {
         $lock = $this->get();
 
-        if (
-            $lock['locked'] === true &&
-            $lock['user'] !== $this->user()->id()
-        ) {
+        if ($lock !== false && $lock['user'] !== $this->user()->id()) {
             return true;
         }
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -260,11 +260,18 @@ abstract class ModelWithContent extends Model
     /**
      * Returns the lock object for this model
      *
-     * @return Kirby\Cms\ContentLock
+     * Only if a content firectory exists,
+     * virtual pages will need to overwrite this method
+     *
+     * @return Kirby\Cms\ContentLock|null
      */
     public function lock()
     {
-        return new ContentLock($this);
+        $dir = $this->contentFileDirectory();
+
+        if (is_string($dir) === true && file_exists($dir) === true) {
+            return new ContentLock($this);
+        }
     }
 
     /**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -260,7 +260,7 @@ abstract class ModelWithContent extends Model
     /**
      * Returns the lock object for this model
      *
-     * Only if a content firectory exists,
+     * Only if a content directory exists,
      * virtual pages will need to overwrite this method
      *
      * @return Kirby\Cms\ContentLock|null

--- a/tests/Cms/Content/ContentLockTest.php
+++ b/tests/Cms/Content/ContentLockTest.php
@@ -17,9 +17,8 @@ class ContentLockTest extends TestCase
             ],
             'site' => [
                 'children' => [
-                    [
-                        'slug'  => 'test'
-                    ]
+                    ['slug'  => 'test'],
+                    ['slug'  => 'foo']
                 ]
             ],
             'users' => [

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kirby\Cms;
+
+class MyModel extends ModelWithContent
+{
+    public function blueprint()
+    {
+        return 'test';
+    }
+
+    protected function commit(string $action, array $arguments, \Closure $callback)
+    {
+        return;
+    }
+
+    public function contentFileName(): string
+    {
+        return 'test.txt';
+    }
+
+    public function root(): ?string
+    {
+        return '/tmp';
+    }
+}
+
+class MyFailModel extends MyModel
+{
+    public function root(): ?string
+    {
+        return null;
+    }
+}
+
+class ModelWithContentTest extends TestCase
+{
+
+    public function testContentLock()
+    {
+        $model = new MyModel();
+        $this->assertInstanceOf('Kirby\\Cms\\ContentLock', $model->lock());
+    }
+
+    public function testContentLockWithNoDirectory()
+    {
+        $model = new MyFailModel();
+        $this->assertNull($model->lock());
+    }
+}
+


### PR DESCRIPTION
- Only return a ContentLock object if a content directory in the file system exist
- On API request: check first for a ContentLock object, if none returned just end the request