### PR TITLE
Fix issue with session cache

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -420,7 +420,7 @@ class User extends ModelWithContent
     /**
      * Logs the user in without checking the password
      *
-     * @param SKirby\Session\Session|array $session Session options or session object to set the user in
+     * @param Kirby\Session\Session|array $session Session options or session object to set the user in
      * @return void
      */
     public function loginPasswordless($session = null): void

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -469,6 +469,9 @@ class Session
         } else {
             $this->needsRetransmission = true;
         }
+
+        // update cache of the Sessions instance with the new token
+        $this->sessions->updateCache($this);
     }
 
     /**

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -243,6 +243,18 @@ class Sessions
     }
 
     /**
+     * Updates the instance cache with a newly created
+     * session or a session with a regenerated token
+     *
+     * @internal
+     * @param Kirby\Session\Session $session Session instance to push to the cache
+     */
+    public function updateCache(Session $session)
+    {
+        $this->cache[$session->token()] = $session;
+    }
+
+    /**
      * Returns the auth token from the cookie
      *
      * @return string|null

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -276,6 +276,29 @@ class SessionsTest extends TestCase
     }
 
     /**
+     * @covers ::updateCache
+     */
+    public function testUpdateCache()
+    {
+        $sessionsReflector = new ReflectionClass(Sessions::class);
+        $cache = $sessionsReflector->getProperty('cache');
+        $cache->setAccessible(true);
+
+        $sessionReflector = new ReflectionClass(Session::class);
+        $tokenKey = $sessionReflector->getProperty('tokenKey');
+        $tokenKey->setAccessible(true);
+
+        $sessions = new Sessions($this->store, ['mode' => 'header']);
+        $session = $sessions->get('9999999999.valid.' . $this->store->validKey);
+        $tokenKey->setValue($session, 'new-key');
+
+        $this->assertArrayNotHasKey('9999999999.valid.new-key', $cache->getValue($sessions));
+        $sessions->updateCache($session);
+        $this->assertArrayHasKey('9999999999.valid.new-key', $cache->getValue($sessions));
+        $this->assertEquals($session, $cache->getValue($sessions)['9999999999.valid.new-key']);
+    }
+
+    /**
      * @covers ::tokenFromCookie
      */
     public function testTokenFromCookie()


### PR DESCRIPTION
If session data is modified in the same request where the session token has been regenerated (for example after user login), the old (regenerated) session is now no longer discarded and overwritten by an entirely new session.

## Related issues
Fixes #1932.

## Todos
If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it.
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
