### PR TITLE
Fix width and height attributes in video tags (Fix #1875)

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -106,7 +106,7 @@ return [
                 if (empty($tag->link) === true) {
                     return $img;
                 }
-                
+
                 if ($link = $tag->file($tag->link)) {
                     $link = $link->url();
                 } else {
@@ -227,13 +227,15 @@ return [
         'html' => function ($tag) {
             $video = Html::video(
                 $tag->value,
-                $tag->kirby()->option('kirbytext.video.options', [])
+                $tag->kirby()->option('kirbytext.video.options', []),
+                [
+                    'height' => $tag->height ?? $tag->kirby()->option('kirbytext.video.height'),
+                    'width'  => $tag->width  ?? $tag->kirby()->option('kirbytext.video.width'),
+                ]
             );
 
             return Html::figure([$video], $tag->caption, [
-                'class'  => $tag->class  ?? $tag->kirby()->option('kirbytext.video.class', 'video'),
-                'height' => $tag->height ?? $tag->kirby()->option('kirbytext.video.height'),
-                'width'  => $tag->width  ?? $tag->kirby()->option('kirbytext.video.width'),
+                'class' => $tag->class  ?? $tag->kirby()->option('kirbytext.video.class', 'video'),
             ]);
         }
     ],

--- a/tests/Cms/KirbyText/fixtures/kirbytext/video-width-and-height/expected.html
+++ b/tests/Cms/KirbyText/fixtures/kirbytext/video-width-and-height/expected.html
@@ -1,0 +1,1 @@
+<figure class="video"><iframe allowfullscreen height="200" src="https://player.vimeo.com/video/115805751" width="200"></iframe></figure>

--- a/tests/Cms/KirbyText/fixtures/kirbytext/video-width-and-height/test.txt
+++ b/tests/Cms/KirbyText/fixtures/kirbytext/video-width-and-height/test.txt
@@ -1,0 +1,1 @@
+(video: https://vimeo.com/115805751 width: 200 height: 200)


### PR DESCRIPTION
## Describe the PR
The width and height attributes in youtube, vimeo and video Kirbytags are now applied to the iframe instead of the wrapping figure element. 

## Related issues
- Fixes #1875

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`