### PR TITLE
Translate custom locale setup text (Fix #1897)

### DIFF
--- a/i18n/translations/bg.json
+++ b/i18n/translations/bg.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Отляво надясно",
   "language.direction.rtl": "Отдясно наляво",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Име",
   "language.updated": "Езикът беше обновен",
 

--- a/i18n/translations/ca.json
+++ b/i18n/translations/ca.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Esquerra a dreta",
   "language.direction.rtl": "De dreta a esquerra",
   "language.locale": "Cadena local de PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nom",
   "language.updated": "S'ha actualitzat l'idioma",
 

--- a/i18n/translations/cs.json
+++ b/i18n/translations/cs.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Zleva doprava",
   "language.direction.rtl": "Zprava doleva",
   "language.locale": "Řetězec lokalizace PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Jméno",
   "language.updated": "Jazyk byl aktualizován",
 

--- a/i18n/translations/da.json
+++ b/i18n/translations/da.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Venstre mod højre",
   "language.direction.rtl": "Højre mod venstre",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Navn",
   "language.updated": "Sproget er blevet opdateret",
 

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Von links nach rechts",
   "language.direction.rtl": "Von rechts nach links",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "Du nutzt ein angepasstes Setup for PHP Locales. Bitte bearbeite dieses direkt in der entsprechenden Sprachdatei in /site/languages",
   "language.name": "Name",
   "language.updated": "Die Sprache wurde gespeichert",
 

--- a/i18n/translations/el.json
+++ b/i18n/translations/el.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Αριστερά προς τα δεξιά",
   "language.direction.rtl": "Δεξιά προς τα αριστερά",
   "language.locale": "Συμβολοσειρά τοπικής γλώσσας PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Ονομασία",
   "language.updated": "Η γλώσσα έχει ενημερωθεί",
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Left to right",
   "language.direction.rtl": "Right to left",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Name",
   "language.updated": "The language has been updated",
 

--- a/i18n/translations/es_419.json
+++ b/i18n/translations/es_419.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "De Izquierda a derecha",
   "language.direction.rtl": "De derecha a izquierda",
   "language.locale": "Cadena de localización PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nombre",
   "language.updated": "El idioma a sido actualizado",
 

--- a/i18n/translations/es_ES.json
+++ b/i18n/translations/es_ES.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "De izquierda a derecha",
   "language.direction.rtl": "De derecha a izquierda",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nombre",
   "language.updated": "El idioma ha sido actualizado",
 

--- a/i18n/translations/fa.json
+++ b/i18n/translations/fa.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "چپ به راست",
   "language.direction.rtl": "راست به چپ",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "پارسی",
   "language.updated": "زبان به روز شد",
 

--- a/i18n/translations/fi.json
+++ b/i18n/translations/fi.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Vasemmalta oikealle",
   "language.direction.rtl": "Oikealta vasemmalle",
   "language.locale": "PHP-lokaalin tunniste",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nimi",
   "language.updated": "Kieli on päivitetty",
 

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "De gauche à droite",
   "language.direction.rtl": "De droite à gauche",
   "language.locale": "Locales PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nom",
   "language.updated": "La langue a été mise à jour",
 

--- a/i18n/translations/hu.json
+++ b/i18n/translations/hu.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Balról jobbra",
   "language.direction.rtl": "Jobbról balra",
   "language.locale": "PHP locale sztring",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Név",
   "language.updated": "A nyelv frissítve lett",
 

--- a/i18n/translations/id.json
+++ b/i18n/translations/id.json
@@ -183,9 +183,9 @@
   "error.validation.contains":
     "Masukkan nilai yang mengandung \"{needle}\"",
   "error.validation.date": "Masukkan tanggal yang valid",
-  "error.validation.date.after": "Please enter a date after {date}",
-  "error.validation.date.before": "Please enter a date before {date}",
-  "error.validation.date.between": "Please enter a date between {min} and {max}",
+  "error.validation.date.after": "Masukkan tanggal setelah {date}",
+  "error.validation.date.before": "Masukkan tanggal sebelum {date}",
+  "error.validation.date.between": "Masukkan tanggal antara {min} dan {max}",
   "error.validation.denied": "Mohon tolak",
   "error.validation.different": "Nilai harus selain \"{other}\"",
   "error.validation.email": "Masukkan surel yang valid",
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Kiri ke kanan",
   "language.direction.rtl": "Kanan ke kiri",
   "language.locale": "String \"PHP locale\"",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nama",
   "language.updated": "Bahasa sudah diperbaharui",
 

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Sinistra a destra",
   "language.direction.rtl": "Destra a sinistra",
   "language.locale": "Stringa \"PHP locale\"",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nome",
   "language.updated": "La lingua è stata aggiornata",
 

--- a/i18n/translations/ko.json
+++ b/i18n/translations/ko.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "왼쪽에서 오른쪽",
   "language.direction.rtl": "오른쪽에서 왼쪽",
   "language.locale": "PHP 로캘 문자열",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "이름",
   "language.updated": "언어를 변경했습니다.",
 

--- a/i18n/translations/nb.json
+++ b/i18n/translations/nb.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Venstre til høyre",
   "language.direction.rtl": "Høyre til venstre",
   "language.locale": "PHP locale streng",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Navn",
   "language.updated": "Språk har blitt oppdatert",
 

--- a/i18n/translations/nl.json
+++ b/i18n/translations/nl.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Links naar rechts",
   "language.direction.rtl": "Rechts naar links",
   "language.locale": "PHP-locale regel",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Naam",
   "language.updated": "De taal is geüpdatet",
 

--- a/i18n/translations/pl.json
+++ b/i18n/translations/pl.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Od lewej do prawej",
   "language.direction.rtl": "Od prawej do lewej",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nazwa",
   "language.updated": "Język został zaktualizowany",
 

--- a/i18n/translations/pt_BR.json
+++ b/i18n/translations/pt_BR.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Esquerda para direita",
   "language.direction.rtl": "Direita para esquerda",
   "language.locale": "String de localização do PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nome",
   "language.updated": "Idioma atualizado",
 

--- a/i18n/translations/pt_PT.json
+++ b/i18n/translations/pt_PT.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Esquerda para direita",
   "language.direction.rtl": "Direita para esquerda",
   "language.locale": "String de localização do PHP",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Nome",
   "language.updated": "Idioma atualizado",
 

--- a/i18n/translations/sk.json
+++ b/i18n/translations/sk.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Zľava doprava",
   "language.direction.rtl": "Zprava doľava",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Názov",
   "language.updated": "Jazyk bol aktualizovaný",
 

--- a/i18n/translations/sv_SE.json
+++ b/i18n/translations/sv_SE.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Vänster till höger",
   "language.direction.rtl": "Höger till vänster",
   "language.locale": "PHP locale string",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "Namn",
   "language.updated": "Språket har uppdaterats",
 

--- a/i18n/translations/tr.json
+++ b/i18n/translations/tr.json
@@ -265,6 +265,7 @@
   "language.direction.ltr": "Soldan sağa",
   "language.direction.rtl": "Sağdan sola",
   "language.locale": "PHP yerel dizesi",
+  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
   "language.name": "İsim",
   "language.updated": "Dil güncellendi",
 

--- a/panel/src/components/Dialogs/LanguageUpdateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageUpdateDialog.vue
@@ -29,7 +29,7 @@ export default {
         fields.locale = {
           label: fields.locale.label,
           type: "info",
-          text: "You are using a custom locale set up. Please modify it in the language file in /site/languages"
+          text: this.$t("language.locale.warning")
         };
       }
 


### PR DESCRIPTION
## Describe the PR
Added a new translation string for the multi locale setup warning in the language dialog. 

## Related issues
- Fixes #1897