### PR TITLE
Media files are not generated on multisite setup (Fix #1901)

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -247,7 +247,7 @@ class Uri
         }
 
         $uri = Server::get('REQUEST_URI');
-        $uri = str_replace(Server::get('HTTP_HOST'), '', $uri);
+        $uri = preg_replace('!^(http|https)\:\/\/' . Server::get('HTTP_HOST') . '!', '', $uri);
         $uri = parse_url('http://getkirby.com' . $uri);
 
         $url = new static(array_merge([

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -57,7 +57,7 @@ class UriTest extends TestCase
     public function testCurrentWithHostInRequestUri()
     {
         $_SERVER['HTTP_HOST'] = 'ktest.loc';
-        $_SERVER['REQUEST_URI'] = '/ktest.loc/';
+        $_SERVER['REQUEST_URI'] = 'http://ktest.loc/';
 
         $uri = Uri::current();
         $this->assertEquals('/', $uri->toString());
@@ -67,7 +67,7 @@ class UriTest extends TestCase
     public function testCurrentWithHostAndPathInRequestUri()
     {
         $_SERVER['HTTP_HOST'] = 'ktest.loc';
-        $_SERVER['REQUEST_URI'] = '/ktest.loc/a/b';
+        $_SERVER['REQUEST_URI'] = 'http://ktest.loc/a/b';
 
         $uri = Uri::current();
         $this->assertEquals('/a/b', $uri->toString());
@@ -77,11 +77,21 @@ class UriTest extends TestCase
     public function testCurrentWithHostAndSchemeInRequestUri()
     {
         $_SERVER['HTTP_HOST'] = 'ktest.loc';
-        $_SERVER['REQUEST_URI'] = '/http://ktest.loc/';
+        $_SERVER['REQUEST_URI'] = 'http://ktest.loc/';
 
         $uri = Uri::current();
         $this->assertEquals('/', $uri->toString());
         $this->assertEquals('', $uri->path());
+    }
+
+    public function testCurrentWithHostInPath()
+    {
+        $_SERVER['HTTP_HOST'] = 'ktest.loc';
+        $_SERVER['REQUEST_URI'] = 'http://ktest.loc/a/b/ktest.loc';
+
+        $uri = Uri::current();
+        $this->assertEquals('/a/b/ktest.loc', $uri->toString());
+        $this->assertEquals('a/b/ktest.loc', $uri->path());
     }
 
     public function testValidScheme()


### PR DESCRIPTION
## Describe the PR
In order to fix a bug before 3.2.0 the host address was removed from the request uri. This helped with virtual domain setups, but broke the media router in multi-domain setups. The removal is now only happening at the beginning of the request uri, which avoids the bug. 

## Related issues
- Fixes #1901

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`