### PR TITLE
Trim titles/names before saving #1836

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -51,6 +51,7 @@
 
   "error.field.converter.invalid": "Invalid converter \"{converter}\"",
 
+  "error.file.changeName.empty": "The name must not be empty",
   "error.file.changeName.permission":
     "You are not allowed to change the name of \"{filename}\"",
   "error.file.duplicate": "A file with the name \"{filename}\" already exists",

--- a/panel/src/components/Dialogs/FileRenameDialog.vue
+++ b/panel/src/components/Dialogs/FileRenameDialog.vue
@@ -72,6 +72,14 @@ export default {
       return slug(input, [this.slugs, this.system.ascii], ".");
     },
     submit() {
+      // prevent empty name with just spaces
+      this.file.name = this.file.name.trim();
+
+      if (this.file.name.length === 0) {
+        this.$refs.dialog.error(this.$t("error.file.changeName.empty"));
+        return;
+      }
+
       this.$api.files
         .rename(this.parent, this.file.filename, this.file.name)
         .then(file => {

--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -107,6 +107,8 @@ export default {
 
     },
     submit() {
+      // prevent empty title with just spaces
+      this.page.title = this.page.title.trim();
 
       if (this.page.title.length === 0) {
         this.$refs.dialog.error('Please enter a title');

--- a/panel/src/components/Dialogs/PageRenameDialog.vue
+++ b/panel/src/components/Dialogs/PageRenameDialog.vue
@@ -53,6 +53,8 @@ export default {
         });
     },
     submit() {
+      // prevent empty title with just spaces
+      this.page.title = this.page.title.trim();
 
       if (this.page.title.length === 0) {
         this.$refs.dialog.error(this.$t("error.page.changeTitle.empty"));

--- a/panel/src/components/Dialogs/UserRenameDialog.vue
+++ b/panel/src/components/Dialogs/UserRenameDialog.vue
@@ -52,6 +52,8 @@ export default {
         });
     },
     submit() {
+      this.user.name = this.user.name.trim();
+
       this.$api.users
         .changeName(this.user.id, this.user.name)
         .then(() => {


### PR DESCRIPTION
## Describe the PR
- Trims whitespace n title at page create and rename, file rename and user rename
- Does not allow filenames to be empty (bug in existing versions)
- Adds translation string for empty filename


## Related issues
- Fixes #1836
