### PR TITLE
Escape regex for Panel slugs #1946

### DIFF
--- a/panel/src/helpers/slug.js
+++ b/panel/src/helpers/slug.js
@@ -13,7 +13,7 @@ export default (string, rules = [], allowed = "") => {
         const isTrimmed = rule.substr(0,1) !== "/";
         const trimmed   = rule.substring(1, rule.length - 1);
         const regex     = isTrimmed ? rule : trimmed;
-        string = string.replace(new RegExp(regex, "g"), ruleset[rule]);
+        string = string.replace(new RegExp(RegExp.escape(regex), "g"), ruleset[rule]);
       });
     }
   });


### PR DESCRIPTION
## Describe the PR
Escape the regex string to allow for replacement mappings such as `'+' => 'plus'`.

## Related issues
- Fixes #1946