### PR TITLE
Fix SelectInput in Edge browser #1712

### DIFF
--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -8,7 +8,7 @@
       :id="id"
       :name="name"
       :required="required"
-      v-model="selected"
+      :value="selected"
       class="k-select-input-native"
       v-on="listeners"
     >
@@ -67,7 +67,8 @@ export default {
       listeners: {
         ...this.$listeners,
         click: (event) => this.onClick(event),
-        input: (event) => this.onInput(event.target.value),
+        change: (event) => this.onInput(event.target.value),
+        input: (event) => {}
       }
     };
   },


### PR DESCRIPTION
## Describe the PR
Edge/IE does not work well with the `@input` event on `select` elements. Thus `v-model` also has problems. This PR replaces the use with a pair of `:value` and `@change`.

## Related issues
- Fixes #1712