### PR TITLE
Fix `num: date` with translations #1886

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -463,7 +463,9 @@ trait PageActions
             case 'date':
             case 'datetime':
                 $format = $mode === 'date' ? 'Ymd' : 'YmdHi';
-                $date   = $this->date()->isEmpty() ? 'now' : $this->date();
+                $lang   = $this->kirby()->defaultLanguage() ?? null;
+                $field  = $this->content($lang)->get('date');
+                $date   = $field->isEmpty() ? 'now' : $field;
                 return date($format, strtotime($date));
                 break;
             case 'default':

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -331,6 +331,54 @@ class PageSortTest extends TestCase
         $this->assertEquals(20121212, $page->createNum());
     }
 
+    public function testCreateNumWithTranslations()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        $page = new Page([
+            'slug' => 'test',
+            'blueprint' => [
+                'num' => 'date'
+            ],
+            'translations' => [
+                [
+                    'code' => 'en',
+                    'content' => [
+                        'date' => '2019-01-01',
+                    ]
+                ],
+                [
+                    'code' => 'de',
+                    'content' => [
+                        'date' => '2018-01-01',
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertEquals(20190101, $page->createNum());
+
+        $app->setCurrentLanguage('de');
+        $app->setCurrentTranslation('de');
+
+        $this->assertEquals(20190101, $page->createNum());
+    }
+
     public function testCreateCustomNum()
     {
         // valid


### PR DESCRIPTION
## Describe the PR
Makes sure to always use the default language `date` field value for `num`.

_**Requires #1882 to be merged first.**_

## Related issues
- Fixes #1886

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
