### PR TITLE
Fix dropping multiple files on textarea #1850

### DIFF
--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -147,11 +147,11 @@ export default {
     },
     insertFile(files) {
       if (files && files.length > 0) {
-        this.insert(files[0].dragText);
+        this.insert(files.map(file => file.dragText).join("\n\n"));
       }
     },
     insertUpload(files, response) {
-      this.insert(response[0].dragText);
+      this.insert(response.map(file => file.dragText).join("\n\n"));
       this.$events.$emit("model.update");
     },
     onClick() {


### PR DESCRIPTION
## Describe the PR
Multiple files dropped on a textarea were uploaded, but only the first one was inserted. Now all get inserted separated by an empty line.

**_Question:_**
Currently the insert file dialog is limited to one file at a time. Should we change this as well?

## Related issues
- Fixes #1850