### PR TITLE
Fix jump when clicking/focus on checkboxes #1657

### DIFF
--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <label class="k-checkbox-input">
+  <label class="k-checkbox-input" @click.stop>
     <input
       ref="input"
       :checked="value"
@@ -64,7 +64,7 @@ export default {
       this.$emit("invalid", this.$v.$invalid, this.$v);
     },
     select() {
-      this.$refs.input.focus();
+      this.focus();
     }
   },
   validations() {


### PR DESCRIPTION
## Describe the PR
Stopping click propagation from checkbox input, so the focus event of checkboxes field isn't constantly triggered when checking/unchecking one input (which then caused the viewport jumping).

## Related issues
- Fixes #1657
