### PR TITLE
Sending email with transport props

### DIFF
--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -40,7 +40,9 @@ class Email
         $this->props = array_merge($this->preset, $props);
 
         // add transport settings
-        $this->props['transport'] = $this->options['transport'] ?? [];
+        if (isset($this->props['transport']) === false) {
+            $this->props['transport'] = $this->options['transport'] ?? [];
+        }
 
         // transform model objects to values
         foreach (static::$transform as $prop => $model) {


### PR DESCRIPTION
## Describe the PR
Allow sending email with transport prop.

**Usage**:

```
$kirby->email([
  'template' => 'media',
  'data' => [
    'name' => 'Peter',
    'text' => 'welcome to our wonderful email list'
  ]
], [
    'transport' => [
        'type' => 'smtp',
        'host' => 'smtp.server.com',
        'port' => 465,
        'security' => true,
        'auth' => true,
        'username' => '...',
        'password' => '...',
    ]
]);
```

## Related issues
- Fixes https://github.com/getkirby/kirby/issues/2009

## Todos
- [ ] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [ ] Fix code style issues with CS fixer and `composer fix`
- [ ] If needeed, in-code documentation (DocBlocks etc.)
