### PR TITLE
Add hooks before and after the plugins have been loaded

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -121,6 +121,9 @@ class App
         $this->extensionsFromOptions();
         $this->extensionsFromFolders();
 
+        // trigger hook for use in plugins
+        $this->trigger('system.loadPlugins:after');
+
         // handle those damn errors
         $this->handleErrors();
 

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -701,7 +701,6 @@ trait AppPlugins
     protected function pluginsLoader(): array
     {
         $root   = $this->root('plugins');
-        $kirby  = $this;
         $loaded = [];
 
         foreach (Dir::read($root) as $dirname) {
@@ -709,14 +708,10 @@ trait AppPlugins
                 continue;
             }
 
-            if (is_dir($root . '/' . $dirname) === false) {
-                continue;
-            }
-
             $dir   = $root . '/' . $dirname;
             $entry = $dir . '/index.php';
 
-            if (file_exists($entry) === false) {
+            if (is_dir($dir) !== true || is_file($entry) !== true) {
                 continue;
             }
 

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -26,7 +26,10 @@ class DummyUser extends User
 
 class AppPluginsTest extends TestCase
 {
-    protected $fixtures;
+    public $fixtures;
+
+    // used for testPluginLoader()
+    public static $calledPluginsLoadedHook = false;
 
     public function setUp(): void
     {
@@ -824,5 +827,57 @@ class AppPluginsTest extends TestCase
 
         // reset methods
         Users::$methods = [];
+    }
+
+    public function testPluginLoader()
+    {
+        $phpUnit  = $this;
+        $executed = 0;
+
+        $kirby = new App([
+            'roots' => [
+                'index'   => $this->fixtures = __DIR__ . '/fixtures/AppPluginsTest',
+                'plugins' => $this->fixtures . '/site/plugins-loader'
+            ],
+            'hooks' => [
+                'system.loadPlugins:after' => function () use ($phpUnit, &$executed) {
+                    if (count($this->plugins()) === 2) {
+                        $phpUnit->assertEquals([
+                            'kirby/manual1' => new Plugin('kirby/manual1', []),
+                            'kirby/manual2' => new Plugin('kirby/manual2', [])
+                        ], $this->plugins());
+                    } else {
+                        $phpUnit->assertEquals([
+                            'kirby/test1' => new Plugin('kirby/test1', [
+                                'hooks' => [
+                                    'system.loadPlugins:after' => function () {
+                                        // just a dummy closure to compare against
+                                    }
+                                ],
+                                'root' => $phpUnit->fixtures . '/site/plugins-loader/test1'
+                            ])
+                        ], $this->plugins());
+                    }
+
+                    $executed++;
+                }
+            ]
+        ]);
+
+        // the hook defined inside the test1 plugin should also have been called
+        $this->assertTrue(static::$calledPluginsLoadedHook);
+
+        // try loading again (which should *not* trigger the hooks again)
+        $kirby->plugins();
+
+        // overwrite plugins with a custom array
+        $expected = [
+            'kirby/manual1' => new Plugin('kirby/manual1', []),
+            'kirby/manual2' => new Plugin('kirby/manual2', [])
+        ];
+        $this->assertEquals($expected, $kirby->plugins($expected));
+
+        // hook should have been called only once after the firs initialization
+        $this->assertEquals(1, $executed);
     }
 }

--- a/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/.test4/index.php
+++ b/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/.test4/index.php
@@ -1,0 +1,3 @@
+<?php
+
+Kirby::plugin('kirby/test4', []);

--- a/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/_test3/index.php
+++ b/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/_test3/index.php
@@ -1,0 +1,3 @@
+<?php
+
+Kirby::plugin('kirby/test3', []);

--- a/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/test1/index.php
+++ b/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/test1/index.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirby\Cms\AppPluginsTest;
+
+Kirby::plugin('kirby/test1', [
+    'hooks' => [
+        'system.loadPlugins:after' => function () {
+            AppPluginsTest::$calledPluginsLoadedHook = true;
+        }
+    ]
+]);

--- a/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/test5.php
+++ b/tests/Cms/App/fixtures/AppPluginsTest/site/plugins-loader/test5.php
@@ -1,0 +1,3 @@
+<?php
+
+Kirby::plugin('kirby/test5', []);


### PR DESCRIPTION
## Describe the PR

New `system.loadPlugins:before` and `system.loadPlugins:after` hooks are now triggered right before and after the plugins have been loaded. This makes it possible to hook into other plugins e.g. to extend them with further functionality.

**Open issue:** The tests currently don't pass because a `system.loadPlugins:after` hook defined in a plugin (which is the most important functionality of this feature) won't be triggered. The reason for this is that the `$app->extensionsFromPlugins()` method is called long after the plugins have been loaded – but before the hook would be triggered in `$app->plugins()` – so the hook is not already defined when it's triggered. Unfortunately I haven't found a good solution that doesn't require changing the system loading order. I'm very open for ideas!

## Related issues

- Closes https://github.com/getkirby/ideas/issues/23

## Todos

- [x] Add unit tests for fixed bug/feature
- [ ] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
