### PR TITLE
Add feature user login/logout hooks

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -426,10 +426,16 @@ class User extends ModelWithContent
      */
     public function loginPasswordless($session = null): void
     {
+        $kirby = $this->kirby();
+
         $session = $this->sessionFromOptions($session);
+
+        $kirby->trigger('user.login:before', $this, $session);
 
         $session->regenerateToken(); // privilege change
         $session->data()->set('user.id', $this->id());
+
+        $kirby->trigger('user.login:after', $this, $session);
     }
 
     /**
@@ -440,6 +446,8 @@ class User extends ModelWithContent
      */
     public function logout($session = null): void
     {
+        $kirby = $this->kirby();
+
         $session = $this->sessionFromOptions($session);
 
         $session->data()->remove('user.id');
@@ -447,9 +455,13 @@ class User extends ModelWithContent
         if ($session->data()->get() === []) {
             // session is now empty, we might as well destroy it
             $session->destroy();
+            
+            $kirby->trigger('user.logout:after', $this, null);
         } else {
             // privilege change
             $session->regenerateToken();
+            
+            $kirby->trigger('user.logout:after', $this, $session);
         }
     }
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -446,21 +446,22 @@ class User extends ModelWithContent
      */
     public function logout($session = null): void
     {
-        $kirby = $this->kirby();
-
+        $kirby   = $this->kirby();
         $session = $this->sessionFromOptions($session);
+
+        $kirby->trigger('user.logout:before', $this, $session);
 
         $session->data()->remove('user.id');
 
         if ($session->data()->get() === []) {
             // session is now empty, we might as well destroy it
             $session->destroy();
-            
+
             $kirby->trigger('user.logout:after', $this, null);
         } else {
             // privilege change
             $session->regenerateToken();
-            
+
             $kirby->trigger('user.logout:after', $this, $session);
         }
     }

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -239,4 +239,56 @@ class UserTest extends TestCase
 
         User::$models = [];
     }
+    
+    public function testLoginHooks()
+    {
+        $phpUnit = $this;
+        
+        $app = new App([
+            'users' => [
+                ['email' => 'test@getkirby.com']
+            ],
+            'hooks' => [
+                'user.login:before' => function ($user, $session) use ($phpUnit) {
+                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
+                    $phpUnit->assertEquals($session, S::instance());
+                },
+                'user.login:after' => function ($user, $session) use ($phpUnit) {
+                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
+                    $phpUnit->assertEquals($session, S::instance());
+                }
+            ]
+        ]);
+
+        $user = $app->user('test@getkirby.com');
+        $user->loginPasswordless();
+        $user->logout();
+    }
+
+    public function testLogoutHooks()
+    {
+        $phpUnit = $this;
+        
+        $app = new App([
+            'users' => [
+                ['email' => 'test@getkirby.com']
+            ],
+            'hooks' => [
+                'user.logout:before' => function ($user, $session) use ($phpUnit) {
+                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
+                    $phpUnit->assertEquals($session, S::instance());
+                },
+                'user.logout:after' => function ($user, $session) use ($phpUnit) {
+                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
+                    if ($session !== null) {
+                        $phpUnit->assertEquals($session, S::instance());
+                    }
+                }
+            ]
+        ]);
+
+        $user = $app->user('test@getkirby.com');
+        $user->loginPasswordless();
+        $user->logout();
+    }
 }

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -239,56 +239,63 @@ class UserTest extends TestCase
 
         User::$models = [];
     }
-    
-    public function testLoginHooks()
+
+    public function testLoginLogoutHooks()
     {
-        $phpUnit = $this;
-        
+        $phpunit = $this;
+
+        $calls         = 0;
+        $logoutSession = false;
         $app = new App([
             'users' => [
                 ['email' => 'test@getkirby.com']
             ],
             'hooks' => [
-                'user.login:before' => function ($user, $session) use ($phpUnit) {
-                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
-                    $phpUnit->assertEquals($session, S::instance());
-                },
-                'user.login:after' => function ($user, $session) use ($phpUnit) {
-                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
-                    $phpUnit->assertEquals($session, S::instance());
-                }
-            ]
-        ]);
+                'user.login:before' => function ($user, $session) use ($phpunit, &$calls) {
+                    $phpunit->assertEquals('test@getkirby.com', $user->email());
+                    $phpunit->assertEquals($session, S::instance());
 
-        $user = $app->user('test@getkirby.com');
-        $user->loginPasswordless();
-        $user->logout();
-    }
-
-    public function testLogoutHooks()
-    {
-        $phpUnit = $this;
-        
-        $app = new App([
-            'users' => [
-                ['email' => 'test@getkirby.com']
-            ],
-            'hooks' => [
-                'user.logout:before' => function ($user, $session) use ($phpUnit) {
-                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
-                    $phpUnit->assertEquals($session, S::instance());
+                    $calls += 1;
                 },
-                'user.logout:after' => function ($user, $session) use ($phpUnit) {
-                    $phpUnit->assertEquals('test@getkirby.com', $user->email());
-                    if ($session !== null) {
-                        $phpUnit->assertEquals($session, S::instance());
+                'user.login:after' => function ($user, $session) use ($phpunit, &$calls) {
+                    $phpunit->assertEquals('test@getkirby.com', $user->email());
+                    $phpunit->assertEquals($session, S::instance());
+
+                    $calls += 2;
+                },
+                'user.logout:before' => function ($user, $session) use ($phpunit, &$calls) {
+                    $phpunit->assertEquals('test@getkirby.com', $user->email());
+                    $phpunit->assertEquals($session, S::instance());
+
+                    $calls += 4;
+                },
+                'user.logout:after' => function ($user, $session) use ($phpunit, &$calls, &$logoutSession) {
+                    $phpunit->assertEquals('test@getkirby.com', $user->email());
+
+                    if ($logoutSession === true) {
+                        $phpunit->assertEquals($session, S::instance());
+                        $phpunit->assertEquals('value', S::instance()->get('some'));
+                    } else {
+                        $phpunit->assertNull($session);
                     }
+
+                    $calls += 8;
                 }
             ]
         ]);
 
+        // without prepopulated session
         $user = $app->user('test@getkirby.com');
         $user->loginPasswordless();
         $user->logout();
+
+        // with a session with another value
+        S::instance()->set('some', 'value');
+        $logoutSession = true;
+        $user->loginPasswordless();
+        $user->logout();
+
+        // each hook needs to be called exactly twice
+        $this->assertEquals((1 + 2 + 4 + 8) * 2, $calls);
     }
 }


### PR DESCRIPTION
## Describe the PR
A total of 4 hooks have been added when users log in and out.

- user.login:before
- user.login:after
- user.logout:before
- user.logout:after

## Related feature

- Closes https://github.com/getkirby/ideas/issues/350

**Usage**

```
return [
    'hooks' => [
        'user.login:before' => function ($user, $session) {
            // your code goes here
        },
        'user.login:after' => function ($user, $session) {
            // your code goes here
        },
        'user.logout:before' => function ($user, $session) {
            // your code goes here
        },
        'user.logout:after' => function ($user, $session) {
            // your code goes here
        }
    ]
];
```

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [ ] If needeed, in-code documentation (DocBlocks etc.)

Btw, sorry for the PR branch as `develop`, i missed that :(