### PR TITLE
Add separating semicolon when bundling plugins

### DIFF
--- a/src/Cms/PanelPlugins.php
+++ b/src/Cms/PanelPlugins.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
+use Kirby\Toolkit\Str;
 
 /**
  * The PanelPlugins class takes care of collecting
@@ -78,12 +79,21 @@ class PanelPlugins
         foreach ($this->files() as $file) {
             if (F::extension($file) === $type) {
                 if ($content = F::read($file)) {
+                    if ($type === 'js') {
+                        $content = trim($content);
+
+                        // make sure that each plugin is ended correctly
+                        if (Str::endsWith($content, ';') === false) {
+                            $content .= ';';
+                        }
+                    }
+
                     $dist[] = $content;
                 }
             }
         }
 
-        return implode(PHP_EOL, $dist);
+        return implode(PHP_EOL . PHP_EOL, $dist);
     }
 
     /**

--- a/tests/Cms/Plugins/PanelPluginsTest.php
+++ b/tests/Cms/Plugins/PanelPluginsTest.php
@@ -72,11 +72,11 @@ class PanelPluginsTest extends TestCase
         $plugins = new PanelPlugins();
 
         // css
-        $expected = "a\nb";
+        $expected = "a\n\nb";
         $this->assertEquals($expected, $plugins->read('css'));
 
         // js
-        $expected = "a\nb";
+        $expected = "a;\n\nb;";
         $this->assertEquals($expected, $plugins->read('js'));
     }
 


### PR DESCRIPTION
## Describe the PR
Panel plugin js files are now automatically checked and an semicolon is added when it's missing while bundling the files. 

## Related issues
- Fixes #1931

## Todos
If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it.
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
