### PR TITLE
Fixed collection sorting error

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -84,7 +84,7 @@ return [
             if ($this->sortBy) {
                 $files = $files->sortBy(...$files::sortArgs($this->sortBy));
             } elseif ($this->sortable === true) {
-                $files = $files->sortBy('sort', 'asc');
+                $files = $files->sortBy('sort', 'asc', 'filename', 'asc');
             }
 
             // apply the default pagination


### PR DESCRIPTION
## Describe the PR
This fix is used for cases when main sorting specified by columns has equal values
Without it it will lead to `Fatal Error: Nesting level too deep - recursive dependency?`

Tested with Kirby 3.2.3

Waiting your reviews.

## Related issues

- Fixes https://github.com/getkirby/kirby/issues/1790

## Reference solution
https://github.com/yiisoft/yii2/commit/78de3157942dcbae43c0f5172bc009b17025e319

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)