### PR TITLE
 Add `content.locking` option and lower frequency #2000

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -113,8 +113,8 @@ export default {
       // if user started to make changes,
       // start setting lock on each heartbeat
       if (previous === false && current === true) {
-        this.$store.dispatch("heartbeat/remove", this.getLock);
-        this.$store.dispatch("heartbeat/add", [this.setLock, 30]);
+        this.$store.dispatch("heartbeat/remove", [this.getLock, 15]);
+        this.$store.dispatch("heartbeat/add", [this.setLock, 40]);
         return;
       }
 
@@ -136,7 +136,7 @@ export default {
 
       // start listening for content lock
       if (this.hasChanges === false) {
-        this.$store.dispatch("heartbeat/add", this.getLock);
+        this.$store.dispatch("heartbeat/add", [this.getLock, 15]);
       }
     }
   },
@@ -191,7 +191,7 @@ export default {
           // listen to concurrent lock
           this.$store.dispatch("form/revert", this.id);
           this.$store.dispatch("heartbeat/remove", this.setLock);
-          this.$store.dispatch("heartbeat/add", this.getLock);
+          this.$store.dispatch("heartbeat/add", [this.getLock, 15]);
         });
       }
     },
@@ -202,7 +202,7 @@ export default {
 
         this.$api.delete(...this.api.lock).then(() => {
           this.$store.dispatch("form/lock", null);
-          this.$store.dispatch("heartbeat/add", this.getLock);
+          this.$store.dispatch("heartbeat/add", [this.getLock, 15]);
         });
       }
     },
@@ -213,7 +213,7 @@ export default {
 
         this.$api.patch(...this.api.unlock).then(() => {
           this.$store.dispatch("form/lock", null);
-          this.$store.dispatch("heartbeat/add", this.getLock);
+          this.$store.dispatch("heartbeat/add", [this.getLock, 15]);
         });
       }
     },
@@ -224,7 +224,7 @@ export default {
 
         this.$api.delete(...this.api.unlock).then(() => {
           this.$store.dispatch("form/unlock", null);
-          this.$store.dispatch("heartbeat/add", this.getLock);
+          this.$store.dispatch("heartbeat/add", [this.getLock, 15]);
         });
       }
     },

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -86,7 +86,7 @@ class ContentLock
                 'user'       => $user->id(),
                 'email'      => $user->email(),
                 'time'       => $time,
-                'unlockable' => $time + $this->kirby()->option('lock.duration', 60 * 2) <= time()
+                'unlockable' => ($time + 200) <= time()
             ];
         }
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -269,7 +269,11 @@ abstract class ModelWithContent extends Model
     {
         $dir = $this->contentFileDirectory();
 
-        if (is_string($dir) === true && file_exists($dir) === true) {
+        if (
+            $this->kirby()->option('content.locking', true) &&
+            is_string($dir) === true &&
+            file_exists($dir) === true
+        ) {
             return new ContentLock($this);
         }
     }


### PR DESCRIPTION
## Describe the PR
As reported, pinging the API every 5 seconds could cause heavy loads with many tabs open. I think we are fine by just checking every 15 seconds and setting the lock every 40 seconds. Protected period now would be 200 seconds.

## Related issues
- Fixes #2000
