### PR TITLE
i18n: better fallbacks #1876

### DIFF
--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -116,7 +116,7 @@ class I18n
                 return $key[$locale];
             }
             if (is_array($fallback)) {
-                return $fallback[$locale] ?? null;
+                return $fallback[$locale] ?? $fallback['en'] ?? reset($fallback);
             }
             return $fallback;
         }

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -130,6 +130,16 @@ class I18nTest extends TestCase
         ], 'fallback'));
     }
 
+    public function testTranslateArrayWithArrayFallback()
+    {
+        // use the english translation as fallback if available
+        $this->assertEquals('Save', I18n::translate(['de' => 'Speichern'], ['en' => 'Save']));
+
+        // use the first value if there's no english translation
+        $this->assertEquals('Fallback', I18n::translate(['de' => 'Speichern'], ['first' => 'Fallback']));
+    }
+
+
     public function testTranslateArrayWithDifferentLocale()
     {
         I18n::$locale = 'de';


### PR DESCRIPTION
## Describe the PR
If we pass an array of fallbacks (which we pass e.g. for all panel translations), return
1. the fallback for the current language (old)
2. the fallback for English (new)
3. the first defined fallback (new)

## Related issues
- Fixes #1876