### PR TITLE
Fix invalid toStructure() data with validate

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -216,14 +216,12 @@ return function (App $app) {
             $rows = Yaml::decode($field->value);
             $data = [];
 
-            if (is_array($rows) === true) {
-                foreach ($rows as $index => $row) {
-                    if (is_array($row) === false) {
-                        continue;
-                    }
-
-                    $data[] = $row;
+            foreach ($rows as $index => $row) {
+                if (is_array($row) === false) {
+                    continue;
                 }
+
+                $data[] = $row;
             }
 
             return new Structure($data, $field->parent());

--- a/config/methods.php
+++ b/config/methods.php
@@ -213,7 +213,20 @@ return function (App $app) {
          * @return Kirby\Cms\Structure
          */
         'toStructure' => function (Field $field) {
-            return new Structure(Yaml::decode($field->value), $field->parent());
+            $rows = Yaml::decode($field->value);
+            $data = [];
+
+            if (is_array($rows) === true) {
+                foreach ($rows as $index => $row) {
+                    if (is_array($row) === false) {
+                        continue;
+                    }
+
+                    $data[] = $row;
+                }
+            }
+
+            return new Structure($data, $field->parent());
         },
 
         /**

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -360,6 +360,22 @@ class FieldMethodsTest extends TestCase
         $this->assertEquals('a', $structure->first()->title()->value());
         $this->assertEquals('b', $structure->last()->title()->value());
     }
+    
+    public function testToStructureWithInvalidData()
+    {
+        $data = [
+            ['title' => 'a'],
+            'title'
+        ];
+
+        $yaml = Yaml::encode($data);
+
+        $field     = $this->field($yaml);
+        $structure = $field->toStructure();
+
+        $this->assertCount(1, $structure);
+        $this->assertEquals('a', $structure->first()->title()->value());
+    }
 
     public function testToDefaultUrl()
     {


### PR DESCRIPTION
## Describe the PR
Since the Kirby flat file CMS, the data in the txt file may sometimes be invalid. This can be a manual modification in the txt file or an incorrect update with the hook. So I think we need to be sure of the source of structured data.

This PR validating that each value in the data is an `array`.

Actually, we're doing this check elsewhere. Inspired from there, I carried it here.
https://github.com/getkirby/kirby/blob/master/config/fields/structure.php#L128-L141

I open it as a `draft` because it's just a suggestion (_especially about looping data_).
I'll update it `ready `if it's considered appropriate by you.

## Related issues

- Fixes https://github.com/getkirby/kirby/issues/2046

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [ ] Fix code style issues with CS fixer and `composer fix`
- [ ] If needed, in-code documentation (DocBlocks etc.)
