### PR TITLE
Enable spellchecking in textareas by default

### DIFF
--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -76,7 +76,7 @@ return [
         /**
          * If `false`, spellcheck will be switched off
          */
-        'spellcheck' => function (bool $spellcheck = false) {
+        'spellcheck' => function (bool $spellcheck = true) {
             return $spellcheck;
         },
 


### PR DESCRIPTION
## Describe the PR
FIxes a regression which disabled spellchecking in all textareas

## Related issues
- Fixes #2047