### PR TITLE
Fix missing file in api response and new F::relativepath() method (#1937)

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -540,50 +540,19 @@ class Api
         try {
             $result = $this->call($path, $method, $requestData);
         } catch (Throwable $e) {
-            if (is_a($e, 'Kirby\Exception\Exception') === true) {
-                $result = [
-                    'status' => 'error',
-                    'route'  => ($this->route)? $this->route->pattern() : null
-                ] + $e->toArray();
-            } else {
-                // remove the document root from the file path
-                $file = $e->getFile();
-                if (empty($_SERVER['DOCUMENT_ROOT']) === false) {
-                    $file = ltrim(Str::after($file, $_SERVER['DOCUMENT_ROOT']), '/');
-                }
-
-                $result = [
-                    'status'    => 'error',
-                    'exception' => get_class($e),
-                    'message'   => $e->getMessage(),
-                    'file'      => $file,
-                    'line'      => $e->getLine(),
-                    'code'      => empty($e->getCode()) === false ? $e->getCode() : 500,
-                    'route'     => $this->route ? $this->route->pattern() : null
-                ];
-            }
+            $result = $this->responseForException($e);
         }
 
-        if ($result === null) {
-            $result = [
-                'status'  => 'error',
-                'message' => 'not found',
-                'code'    => 404,
-            ];
-        }
-
-        if ($result === true) {
-            $result = [
-                'status' => 'ok',
-            ];
-        }
-
-        if ($result === false) {
-            $result = [
-                'status'  => 'error',
-                'message' => 'bad request',
-                'code'    => 400,
-            ];
+        switch (true) {
+            case $result === null:
+                $result = $this->responseFor404();
+                break;
+            case $result === false:
+                $result = $this->responseFor400();
+                break;
+            case $result === true:
+                $result = $this->responseFor200();
+                break;
         }
 
         if (is_array($result) === false) {
@@ -592,17 +561,6 @@ class Api
 
         // pretty print json data
         $pretty = (bool)($requestData['query']['pretty'] ?? false) === true;
-
-        // remove critical info from the result set if
-        // debug mode is switched off
-        if ($this->debug !== true) {
-            unset(
-                $result['file'],
-                $result['exception'],
-                $result['line'],
-                $result['route']
-            );
-        }
 
         if (($result['status'] ?? 'ok') === 'error') {
             $code = $result['code'] ?? 400;
@@ -616,6 +574,69 @@ class Api
         }
 
         return Response::json($result, 200, $pretty);
+    }
+
+    public function responseFor200(): array
+    {
+        return [
+            'status'  => 'ok',
+            'message' => 'ok',
+            'code'    => 200
+        ];
+    }
+
+    public function responseFor400(): array
+    {
+        return [
+            'status'  => 'error',
+            'message' => 'bad request',
+            'code'    => 400,
+        ];
+    }
+
+    public function responseFor404(): array
+    {
+        return [
+            'status'  => 'error',
+            'message' => 'not found',
+            'code'    => 404,
+        ];
+    }
+
+    public function responseForException($e): array
+    {
+        // prepare the result array for all exception types
+        $result = [
+            'status'    => 'error',
+            'message'   => $e->getMessage(),
+            'code'      => empty($e->getCode()) === true ? 500 : $e->getCode(),
+            'exception' => get_class($e),
+            'key'       => null,
+            'file'      => F::relativepath($e->getFile(), $_SERVER['DOCUMENT_ROOT'] ?? null),
+            'line'      => $e->getLine(),
+            'details'   => [],
+            'route'     => $this->route ? $this->route->pattern() : null
+        ];
+
+        // extend the information for Kirby Exceptions
+        if (is_a($e, 'Kirby\Exception\Exception') === true) {
+            $result['key']     = $e->getKey();
+            $result['details'] = $e->getDetails();
+            $result['code']    = $e->getHttpCode();
+        }
+
+        // remove critical info from the result set if
+        // debug mode is switched off
+        if ($this->debug !== true) {
+            unset(
+                $result['file'],
+                $result['exception'],
+                $result['line'],
+                $result['route']
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -543,16 +543,12 @@ class Api
             $result = $this->responseForException($e);
         }
 
-        switch (true) {
-            case $result === null:
-                $result = $this->responseFor404();
-                break;
-            case $result === false:
-                $result = $this->responseFor400();
-                break;
-            case $result === true:
-                $result = $this->responseFor200();
-                break;
+        if ($result === null) {
+            $result = $this->responseFor404();
+        } elseif ($result === false) {
+            $result = $this->responseFor400();
+        } elseif ($result === true) {
+            $result = $this->responseFor200();
         }
 
         if (is_array($result) === false) {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -576,6 +576,12 @@ class Api
         return Response::json($result, 200, $pretty);
     }
 
+    /**
+     * Returns a 200 - ok
+     * response array.
+     *
+     * @return array
+     */
     public function responseFor200(): array
     {
         return [
@@ -585,6 +591,12 @@ class Api
         ];
     }
 
+    /**
+     * Returns a 400 - bad request
+     * response array.
+     *
+     * @return array
+     */
     public function responseFor400(): array
     {
         return [
@@ -594,6 +606,12 @@ class Api
         ];
     }
 
+    /**
+     * Returns a 404 - not found
+     * response array.
+     *
+     * @return array
+     */
     public function responseFor404(): array
     {
         return [
@@ -603,6 +621,14 @@ class Api
         ];
     }
 
+    /**
+     * Creates the response array for
+     * an exception. Kirby exceptions will
+     * have more information
+     *
+     * @param Exception $e
+     * @return array
+     */
     public function responseForException($e): array
     {
         // prepare the result array for all exception types

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -584,7 +584,7 @@ class F
     public static function relativepath(string $file, string $in = null): string
     {
         if (empty($in) === true) {
-            return $file;
+            return basename($file);
         }
 
         // windows
@@ -592,7 +592,7 @@ class F
         $in   = str_replace('\\', '/', $in);
 
         if (Str::contains($file, $in) === false) {
-            return $file;
+            return basename($file);
         }
 
         return Str::after($file, $in);

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -574,6 +574,31 @@ class F
     }
 
     /**
+     * Returns the relative path of the file
+     * starting after $in
+     *
+     * @param string $file
+     * @param string $in
+     * @return string
+     */
+    public static function relativepath(string $file, string $in = null): string
+    {
+        if (empty($in) === true) {
+            return $file;
+        }
+
+        // windows
+        $file = str_replace('\\', '/', $file);
+        $in   = str_replace('\\', '/', $in);
+
+        if (Str::contains($file, $in) === false) {
+            return $file;
+        }
+
+        return Str::after($file, $in);
+    }
+
+    /**
      * Deletes a file
      *
      * <code>

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -312,8 +312,14 @@ class ApiTest extends TestCase
 
         $result = $api->render('test', 'POST');
 
+        $expected = [
+            'status' => 'ok',
+            'message' => 'ok',
+            'code' => 200
+        ];
+
         $this->assertInstanceOf('Kirby\Http\Response', $result);
-        $this->assertEquals(json_encode(['status' => 'ok']), $result->body());
+        $this->assertEquals(json_encode($expected), $result->body());
     }
 
     public function testRenderFalse()
@@ -385,13 +391,53 @@ class ApiTest extends TestCase
         $result = $api->render('test', 'POST');
 
         $expected = [
-            'status'  => 'error',
-            'message' => 'nope',
-            'code'    => 500,
+            'status'   => 'error',
+            'message'  => 'nope',
+            'code'     => 500,
+            'key'      => null,
+            'details'  => []
         ];
 
         $this->assertInstanceOf('Kirby\Http\Response', $result);
         $this->assertEquals(json_encode($expected), $result->body());
+    }
+
+    public function testRenderExceptionWithDebugging()
+    {
+        $api = new Api([
+            'debug' => true,
+            'routes' => [
+                [
+                    'pattern' => 'test',
+                    'method'  => 'POST',
+                    'action'  => function () {
+                        throw new \Exception('nope');
+                    }
+                ]
+            ]
+        ]);
+
+        // simulate the document root to test relative file paths
+        $_SERVER['DOCUMENT_ROOT'] = __DIR__;
+
+        $result = $api->render('test', 'POST');
+
+        $expected = [
+            'status'    => 'error',
+            'message'   => 'nope',
+            'code'      => 500,
+            'exception' => 'Exception',
+            'key'       => null,
+            'file'      => '/' . basename(__FILE__),
+            'line'      => __LINE__ - 18,
+            'details'   => [],
+            'route'     => 'test'
+        ];
+
+        $this->assertInstanceOf('Kirby\Http\Response', $result);
+        $this->assertEquals(json_encode($expected), $result->body());
+
+        unset($_SERVER['DOCUMENT_ROOT']);
     }
 
     public function testRenderKirbyException()
@@ -419,13 +465,57 @@ class ApiTest extends TestCase
         $expected = [
             'status'  => 'error',
             'message' => 'Test',
+            'code'    => 404,
             'key'     => 'error.test',
             'details' => ['a' => 'A'],
-            'code'    => 404,
         ];
 
         $this->assertInstanceOf('Kirby\Http\Response', $result);
         $this->assertEquals(json_encode($expected), $result->body());
+    }
+
+    public function testRenderKirbyExceptionWithDebugging()
+    {
+        $api = new Api([
+            'debug' => true,
+            'routes' => [
+                [
+                    'pattern' => 'test',
+                    'method'  => 'POST',
+                    'action'  => function () {
+                        throw new \Kirby\Exception\NotFoundException([
+                            'key'      => 'test',
+                            'fallback' => 'Test',
+                            'details'  => [
+                                'a' => 'A'
+                            ]
+                        ]);
+                    }
+                ]
+            ]
+        ]);
+
+        // simulate the document root to test relative file paths
+        $_SERVER['DOCUMENT_ROOT'] = __DIR__;
+
+        $result = $api->render('test', 'POST');
+
+        $expected = [
+            'status'    => 'error',
+            'message'   => 'Test',
+            'code'      => 404,
+            'exception' => 'Kirby\\Exception\\NotFoundException',
+            'key'       => 'error.test',
+            'file'      => '/' . basename(__FILE__),
+            'line'      => __LINE__ - 24,
+            'details'   => ['a' => 'A'],
+            'route'     => 'test',
+        ];
+
+        $this->assertInstanceOf('Kirby\Http\Response', $result);
+        $this->assertEquals(json_encode($expected), $result->body());
+
+        unset($_SERVER['DOCUMENT_ROOT']);
     }
 
     public function testRenderWithSanitizedErrorCode()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -162,16 +162,16 @@ class FTest extends TestCase
     public function testRelativePathWithEmptyBase()
     {
         $path = F::relativepath(__FILE__, '');
-        $this->assertEquals(__FILE__, $path);
+        $this->assertEquals(basename(__FILE__), $path);
 
         $path = F::relativepath(__FILE__, null);
-        $this->assertEquals(__FILE__, $path);
+        $this->assertEquals(basename(__FILE__), $path);
     }
 
     public function testRelativePathWithUnrelatedBase()
     {
         $path = F::relativepath(__FILE__, '/something/something');
-        $this->assertEquals(__FILE__, $path);
+        $this->assertEquals(basename(__FILE__), $path);
     }
 
     public function testRelativePathOnWindows()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -153,6 +153,36 @@ class FTest extends TestCase
         F::realpath($file, $parent);
     }
 
+    public function testRelativePath()
+    {
+        $path = F::relativepath(__FILE__, __DIR__);
+        $this->assertEquals('/' . basename(__FILE__), $path);
+    }
+
+    public function testRelativePathWithEmptyBase()
+    {
+        $path = F::relativepath(__FILE__, '');
+        $this->assertEquals(__FILE__, $path);
+
+        $path = F::relativepath(__FILE__, null);
+        $this->assertEquals(__FILE__, $path);
+    }
+
+    public function testRelativePathWithUnrelatedBase()
+    {
+        $path = F::relativepath(__FILE__, '/something/something');
+        $this->assertEquals(__FILE__, $path);
+    }
+
+    public function testRelativePathOnWindows()
+    {
+        $file = 'C:\xampp\htdocs\index.php';
+        $in   = 'C:/xampp/htdocs';
+
+        $path = F::relativepath($file, $in);
+        $this->assertEquals('/index.php', $path);
+    }
+
     public function testSymlink()
     {
         $src  = $this->fixtures . '/a.txt';


### PR DESCRIPTION
## Describe the PR
Makes sure to always include a proper relative file path in API responses. `F::relativepath()` is new to help with the task of creating reliable relative file paths. 

## Related issues
- Fixes #1937

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
