### PR TITLE
Detect exceeded post_max_size on uploads #1812

### DIFF
--- a/i18n/translations/bg.json
+++ b/i18n/translations/bg.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/ca.json
+++ b/i18n/translations/ca.json
@@ -37,7 +37,7 @@
 
   "error.access.login": "Inici de sessió no vàlid",
   "error.access.panel": "No tens permís per accedir al panell",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "No tens accés a aquesta part del tauler",
 
   "error.avatar.create.fail": "No s'ha pogut carregar la imatge del perfil",
   "error.avatar.delete.fail": "La imatge del perfil no s'ha pogut eliminar",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Convertidor no vàlid \"{converter}\"",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "El nom no pot estar buit",
   "error.file.changeName.permission":
     "No tens permís per canviar el nom de \"{filename}\"",
   "error.file.duplicate": "Ja existeix un fitxer amb el nom \"{filename}\"",
@@ -413,16 +413,17 @@
   "translation.name": "Catalan",
 
   "upload": "Carregar",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "El fitxer carregat no s'ha pogut moure",
+  "upload.error.cantWrite": "No s'ha pogut escriure el fitxer al disc",
+  "upload.error.default": "No s'ha pogut carregar el fitxer",
+  "upload.error.extension": "La càrrega del fitxer s'ha aturat per l'extensió",
+  "upload.error.formSize": "El fitxer carregat supera la directiva MAX_FILE_SIZE especificada en el formulari",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "El fitxer carregat supera la directiva upload_max_filesize especifiada al php.ini",
+  "upload.error.noFile": "No s'ha carregat cap fitxer",
+  "upload.error.noFiles": "No s'ha penjat cap fitxer",
+  "upload.error.partial": "El fitxer carregat només s'ha carregat parcialment",
+  "upload.error.tmpDir": "Falta una carpeta temporal",
   "upload.errors": "Error",
   "upload.progress": "Carregant...",
 

--- a/i18n/translations/cs.json
+++ b/i18n/translations/cs.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/da.json
+++ b/i18n/translations/da.json
@@ -37,7 +37,7 @@
 
   "error.access.login": "Ugyldigt log ind",
   "error.access.panel": "Du har ikke adgang til panelet",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "Du har ikke adgang til denne del af panelet",
 
   "error.avatar.create.fail": "Profilbilledet kunne blev ikke uploadet ",
   "error.avatar.delete.fail": "Profilbilledet kunne ikke slettes",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Ugyldig converter \"{converter}\"",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "Navn kan ikke efterlades tomt",
   "error.file.changeName.permission":
     "Du har ikke tilladelse til at ændre navnet på filen \"{filename}\"",
   "error.file.duplicate": "En fil med navnet \"{filename}\" eksisterer allerede",
@@ -184,9 +184,9 @@
   "error.validation.contains":
     "Indtast venligst en værdi der indeholder \"{needle}\"",
   "error.validation.date": "Indtast venligst en gyldig dato",
-  "error.validation.date.after": "Please enter a date after {date}",
-  "error.validation.date.before": "Please enter a date before {date}",
-  "error.validation.date.between": "Please enter a date between {min} and {max}",
+  "error.validation.date.after": "Indtast venligst en dato efter {date}",
+  "error.validation.date.before": "Indtast venligst en dato før {date}",
+  "error.validation.date.between": "Indtast venligst en dato imellem {min} og {max}",
   "error.validation.denied": "Venligst afvis",
   "error.validation.different": "Værdien må ikke være \"{other}\"",
   "error.validation.email": "Indtast venligst en gyldig email adresse",
@@ -266,7 +266,7 @@
   "language.direction.ltr": "Venstre mod højre",
   "language.direction.rtl": "Højre mod venstre",
   "language.locale": "PHP locale string",
-  "language.locale.warning": "You are using a custom locale set up. Please modify it in the language file in /site/languages",
+  "language.locale.warning": "Du benytter en brugerdefineret sprogopsætning. Rediger venligst dette i sprogfilen i /site/languages",
   "language.name": "Navn",
   "language.updated": "Sproget er blevet opdateret",
 
@@ -413,16 +413,17 @@
   "translation.name": "Dansk",
 
   "upload": "Upload",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "Den uploadede fil kunne ikke flyttes",
+  "upload.error.cantWrite": "Kunne ikke skrive fil til disk",
+  "upload.error.default": "Filen kunne ikke uploades",
+  "upload.error.extension": "Upload af filen blev stoppet af dens type",
+  "upload.error.formSize": "Filen overskrider MAX_FILE_SIZE direktivet der er specificeret for formularen",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "FIlen overskrider upload_max_filesize direktivet i php.ini",
+  "upload.error.noFile": "Ingen fil blev uploadet",
+  "upload.error.noFiles": "Ingen filer blev uploadet",
+  "upload.error.partial": "Den uploadede fil blev kun delvist uploadet",
+  "upload.error.tmpDir": "Der mangler en midlertidig mappe",
   "upload.errors": "Fejl",
   "upload.progress": "Uploader...",
 

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -418,6 +418,7 @@
   "upload.error.default": "Die Datei konnte nicht hochgeladen werden",
   "upload.error.extension": "Der Dateiupload wurde durch eine Erweiterung verhindert",
   "upload.error.formSize": "Die Datei ist größer als die MAX_FILE_SIZE Einstellung im Formular",
+  "upload.error.iniPostSize": "Die Datei ist größer als die post_max_size Einstellung in der php.ini",
   "upload.error.iniSize": "Die Datei ist größer als die upload_max_filesize Einstellung in der php.ini",
   "upload.error.noFile": "Es wurde keine Datei hochgeladen",
   "upload.error.noFiles": "Es wurden keine Dateien hochgeladen",

--- a/i18n/translations/el.json
+++ b/i18n/translations/el.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/es_419.json
+++ b/i18n/translations/es_419.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/es_ES.json
+++ b/i18n/translations/es_ES.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/fa.json
+++ b/i18n/translations/fa.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/fi.json
+++ b/i18n/translations/fi.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -37,9 +37,9 @@
 
   "error.access.login": "Identifiant incorrect",
   "error.access.panel": "Vous n’êtes pas autorisé à accéder au Panel",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "Vous n’êtes pas autorisé à accéder à cette section du Panel",
 
-  "error.avatar.create.fail": "L’image du profil n’a pas pu être transférée",
+  "error.avatar.create.fail": "L’image du profil n’a pu être transférée",
   "error.avatar.delete.fail": "L’image du profil n’a pu être supprimée",
   "error.avatar.dimensions.invalid":
     "Veuillez choisir une image de profil de largeur et hauteur inférieures à 3000 pixels",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Convertisseur «&nbsp;{converter}&nbsp;» incorrect",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "Le nom ne peut être vide",
   "error.file.changeName.permission":
     "Vous n’êtes pas autorisé à modifier le nom de «&nbsp;{filename}&nbsp;»",
   "error.file.duplicate": "Un fichier nommé «&nbsp;{filename}&nbsp;» existe déjà",
@@ -413,16 +413,17 @@
   "translation.name": "Français",
 
   "upload": "Transférer",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "Le fichier transféré n’a pu être déplacé",
+  "upload.error.cantWrite": "Le fichier n’a pu être écrit sur le disque",
+  "upload.error.default": "Le fichier n’a pu être transféré",
+  "upload.error.extension": "Le transfert de fichier a été stoppé par une extension",
+  "upload.error.formSize": "Le fichier transféré excède la directive MAX_FILE_SIZE spécifiée dans le formulaire",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "Le fichier transféré excède la directive MAX_FILE_SIZE spécifiée dans php.ini",
+  "upload.error.noFile": "Aucun fichier n’a été transféré",
+  "upload.error.noFiles": "Aucun fichier n’a été transféré",
+  "upload.error.partial": "Le fichier n’a été que partiellement transféré",
+  "upload.error.tmpDir": "Un dossier temporaire est manquant",
   "upload.errors": "Erreur",
   "upload.progress": "Transfert en cours…",
 

--- a/i18n/translations/hu.json
+++ b/i18n/translations/hu.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/id.json
+++ b/i18n/translations/id.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/ko.json
+++ b/i18n/translations/ko.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/lt.json
+++ b/i18n/translations/lt.json
@@ -37,7 +37,7 @@
 
   "error.access.login": "Neteisingas prisijungimo vardas",
   "error.access.panel": "Neturite teisės prisijungti prie valdymo pulto",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "Neturite teisės peržiūrėti šios valdymo pulto dalies",
 
   "error.avatar.create.fail": "Nepavyko įkelti profilio nuotraukos",
   "error.avatar.delete.fail": "Nepavyko pašalinti profilio nuotraukos",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Neteisingas konverteris \"{converter}\"",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "Pavadinimas negali būti tuščias",
   "error.file.changeName.permission":
     "Neturite teisės pakeisti failo pavadinimo \"{filename}\"",
   "error.file.duplicate": "Failas su pavadinimu \"{filename}\" jau yra",
@@ -413,16 +413,17 @@
   "translation.name": "Lietuvių",
 
   "upload": "Įkelti",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "Įkeltas failas negali būti perkeltas",
+  "upload.error.cantWrite": "Nepavyko įrašyti failo į diską",
+  "upload.error.default": "Nepavyko įkelti failo",
+  "upload.error.extension": "Neįmanoma įkelti tokio tipo failo",
+  "upload.error.formSize": "Įkeltas failas viršija MAX_FILE_SIZE nustatymą, kuris buvo nurodytas formoje",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "Įkeltas failas viršija upload_max_filesize nustatymą faile php.ini",
+  "upload.error.noFile": "Failas nebuvo įkeltas",
+  "upload.error.noFiles": "Failai nebuvo įkelti",
+  "upload.error.partial": "Failas įkeltas tik iš dalies",
+  "upload.error.tmpDir": "Trūksta laikinojo katalogo",
   "upload.errors": "Klaida",
   "upload.progress": "Įkėlimas…",
 

--- a/i18n/translations/nb.json
+++ b/i18n/translations/nb.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/nl.json
+++ b/i18n/translations/nl.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/pl.json
+++ b/i18n/translations/pl.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/pt_BR.json
+++ b/i18n/translations/pt_BR.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/pt_PT.json
+++ b/i18n/translations/pt_PT.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/ru.json
+++ b/i18n/translations/ru.json
@@ -37,7 +37,7 @@
 
   "error.access.login": "Неправильный логин",
   "error.access.panel": "У вас нет права доступа к панели",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "У вас нет прав доступа к этой части панели",
 
   "error.avatar.create.fail": "Не удалось загрузить фотографию профиля",
   "error.avatar.delete.fail": "\u0410\u0432\u0430\u0442\u0430\u0440 (\u0444\u043e\u0442\u043e) \u043a \u0430\u043a\u043a\u0430\u0443\u043d\u0442\u0443 \u043d\u0435 \u043c\u043e\u0436\u0435\u0442 \u0431\u044b\u0442\u044c \u0443\u0434\u0430\u043b\u0435\u043d",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Неверный конвертер \"{converter}\"",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "Название не может быть пустым",
   "error.file.changeName.permission":
     "У вас нет права поменять название \"{filename}\"",
   "error.file.duplicate": "Файл с названием \"{filename}\" уже есть",
@@ -413,16 +413,17 @@
   "translation.name": "Русский (Russian)",
 
   "upload": "Закачать",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "Загруженный файл не может быть перемещен",
+  "upload.error.cantWrite": "Не получилось записать файл на диск",
+  "upload.error.default": "Не получилось загрузить файл",
+  "upload.error.extension": "Загрузка файла не удалась из за расширения",
+  "upload.error.formSize": "Загруженный файл больше чем MAX_FILE_SIZE настройка в форме",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "Загруженный файл больше чем upload_max_filesize настройка в php.ini",
+  "upload.error.noFile": "Файл не был загружен",
+  "upload.error.noFiles": "Файлы не были загружены",
+  "upload.error.partial": "Файл загружен только частично",
+  "upload.error.tmpDir": "Не хватает временной папки",
   "upload.errors": "Ошибка",
   "upload.progress": "Закачивается...",
 

--- a/i18n/translations/sk.json
+++ b/i18n/translations/sk.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/sv_SE.json
+++ b/i18n/translations/sv_SE.json
@@ -418,6 +418,7 @@
   "upload.error.default": "The file could not be uploaded",
   "upload.error.extension": "File upload stopped by extension",
   "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
   "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
   "upload.error.noFile": "No file was uploaded",
   "upload.error.noFiles": "No files were uploaded",

--- a/i18n/translations/tr.json
+++ b/i18n/translations/tr.json
@@ -37,7 +37,7 @@
 
   "error.access.login": "Geçersiz giriş",
   "error.access.panel": "Panele erişim izniniz yok",
-  "error.access.view": "You are not allowed to access this part of the panel",
+  "error.access.view": "Panelin bu bölümüne erişemezsiniz",
 
   "error.avatar.create.fail": "Profil resmi yüklenemedi",
   "error.avatar.delete.fail": "Profil resmi silinemedi",
@@ -52,7 +52,7 @@
 
   "error.field.converter.invalid": "Geçersiz dönüştürücü \"{converter}\"",
 
-  "error.file.changeName.empty": "The name must not be empty",
+  "error.file.changeName.empty": "İsim boş olmamalıdır",
   "error.file.changeName.permission":
     "\"{filename}\" adını değiştiremezsiniz",
   "error.file.duplicate": "\"{filename}\" isimli bir dosya zaten var",
@@ -413,16 +413,17 @@
   "translation.name": "T\u00fcrk\u00e7e",
 
   "upload": "Yükle",
-  "upload.error.cantMove": "The uploaded file could not be moved",
-  "upload.error.cantWrite": "Failed to write file to disk",
-  "upload.error.default": "The file could not be uploaded",
-  "upload.error.extension": "File upload stopped by extension",
-  "upload.error.formSize": "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the form",
-  "upload.error.iniSize": "The uploaded file exceeds the upload_max_filesize directive in php.ini",
-  "upload.error.noFile": "No file was uploaded",
-  "upload.error.noFiles": "No files were uploaded",
-  "upload.error.partial": "The uploaded file was only partially uploaded",
-  "upload.error.tmpDir": "Missing a temporary folder",
+  "upload.error.cantMove": "Yüklenen dosya taşınamadı",
+  "upload.error.cantWrite": "Dosya diske yazılamadı",
+  "upload.error.default": "Dosya yüklenemedi",
+  "upload.error.extension": "Dosya yükleme uzantısı tarafından durduruldu",
+  "upload.error.formSize": "Yüklenen dosya, formda belirtilen MAX_FILE_SIZE yönergesini aşıyor",
+  "upload.error.iniPostSize": "The uploaded file exceeds the post_max_size directive in php.ini",
+  "upload.error.iniSize": "Yüklenen dosya php.ini içindeki upload_max_filesize yönergesini aşıyor",
+  "upload.error.noFile": "Dosya yüklenmedi",
+  "upload.error.noFiles": "Dosyalar yüklenmedi",
+  "upload.error.partial": "Yüklenen dosya sadece kısmen yüklendi",
+  "upload.error.tmpDir": "Geçici klasör eksik",
   "upload.errors": "Hata",
   "upload.progress": "Yükleniyor...",
 

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -690,7 +690,14 @@ class Api
         ];
 
         if (empty($files) === true) {
-            throw new Exception(t('upload.error.noFiles'));
+            $postMaxSize       = 1024 * 1024 * (int)ini_get('post_max_size');
+            $uploadMaxFileSize = 1024 * 1024 * (int)ini_get('upload_max_filesize');
+
+            if ($postMaxSize < $uploadMaxFileSize) {
+                throw new Exception(t('upload.error.iniPostSize'));
+            } else {
+                throw new Exception(t('upload.error.noFiles'));
+            }
         }
 
         foreach ($files as $upload) {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -690,8 +690,8 @@ class Api
         ];
 
         if (empty($files) === true) {
-            $postMaxSize       = 1024 * 1024 * (int)ini_get('post_max_size');
-            $uploadMaxFileSize = 1024 * 1024 * (int)ini_get('upload_max_filesize');
+            $postMaxSize       = Str::toBytes(ini_get('post_max_size'));
+            $uploadMaxFileSize = Str::toBytes(ini_get('upload_max_filesize'));
 
             if ($postMaxSize < $uploadMaxFileSize) {
                 throw new Exception(t('upload.error.iniPostSize'));

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -897,6 +897,32 @@ class Str
     }
 
     /**
+     * Converts a filesize string with shortcuts
+     * like M, G or K to an integer value
+     *
+     * @return int
+     */
+    public static function toBytes($size): int
+    {
+        $size = trim($size);
+        $last = strtolower($size[strlen($size)-1] ?? null);
+        $size = (int)$size;
+
+        switch ($last) {
+            case 'g':
+                $size *= 1024;
+                // no break
+            case 'm':
+                $size *= 1024;
+                // no break
+            case 'k':
+                $size *= 1024;
+        }
+
+        return $size;
+    }
+
+    /**
      * Convert the string to the given type
      *
      * @param string $string

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -621,6 +621,26 @@ EOT;
         $this->assertEquals('homer says: hi', $template);
     }
 
+    public function testToBytes()
+    {
+        $this->assertEquals(0, Str::toBytes(0));
+        $this->assertEquals(0, Str::toBytes(''));
+        $this->assertEquals(0, Str::toBytes(null));
+        $this->assertEquals(0, Str::toBytes(false));
+        $this->assertEquals(0, Str::toBytes('x'));
+        $this->assertEquals(0, Str::toBytes('K'));
+        $this->assertEquals(0, Str::toBytes('M'));
+        $this->assertEquals(0, Str::toBytes('G'));
+        $this->assertEquals(2, Str::toBytes(2));
+        $this->assertEquals(2, Str::toBytes('2'));
+        $this->assertEquals(2 * 1024, Str::toBytes('2K'));
+        $this->assertEquals(2 * 1024, Str::toBytes('2k'));
+        $this->assertEquals(2 * 1024 * 1024, Str::toBytes('2M'));
+        $this->assertEquals(2 * 1024 * 1024, Str::toBytes('2m'));
+        $this->assertEquals(2 * 1024 * 1024 * 1024, Str::toBytes('2G'));
+        $this->assertEquals(2 * 1024 * 1024 * 1024, Str::toBytes('2g'));
+    }
+
     public function testToType()
     {
         // string to string


### PR DESCRIPTION
## Describe the PR
After all the additional upload checks, the exceeded post_max_size setting is now also caught and followed by a useful error message. 

## Related issues
- Fixes #1812