### PR TITLE
Support for returning Response obj from API route

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -174,7 +174,7 @@ class Api
 
         $output = $this->route->action()->call($this, ...$this->route->arguments());
 
-        if (is_object($output) === true) {
+        if (is_object($output) === true && is_a($output, 'Kirby\\Http\\Response') !== true) {
             return $this->resolve($output)->toResponse();
         }
 


### PR DESCRIPTION
## Describe the PR

It is now possible to return a completely custom `Response` object from custom API routes. This enables custom HTTP status codes, headers and response bodies.

## Related issues

Implements #2076.

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
