### PR TITLE
Added $pages->notTemplate() method

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -429,6 +429,27 @@ class Pages extends Collection
     }
 
     /**
+     * Filter all pages by excluding the given template
+     *
+     * @param string|array $templates
+     * @return Kirby\Cms\Pages
+     */
+    public function notTemplate($templates)
+    {
+        if (empty($templates) === true) {
+            return $this;
+        }
+
+        if (is_array($templates) === false) {
+            $templates = [$templates];
+        }
+
+        return $this->filter(function ($page) use ($templates) {
+            return !in_array($page->intendedTemplate()->name(), $templates);
+        });
+    }
+
+    /**
      * Returns an array with all page numbers
      *
      * @return array

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -402,6 +402,34 @@ class PagesTest extends TestCase
         $this->assertEquals($expected, $pages->index(true)->keys());
     }
 
+    public function testNotTemplate()
+    {
+        $pages = Pages::factory([
+            [
+                'slug'     => 'a',
+                'template' => 'a'
+            ],
+            [
+                'slug'     => 'b',
+                'template' => 'b'
+            ],
+            [
+                'slug'     => 'c',
+                'template' => 'c'
+            ],
+            [
+                'slug'     => 'd',
+                'template' => 'a'
+            ],
+        ]);
+
+        $this->assertEquals(['a', 'b', 'c', 'd'], $pages->notTemplate(null)->pluck('slug'));
+        $this->assertEquals(['b', 'c'], $pages->notTemplate('a')->pluck('slug'));
+        $this->assertEquals(['c'], $pages->notTemplate(['a', 'b'])->pluck('slug'));
+        $this->assertEquals(['a', 'b', 'c', 'd'], $pages->notTemplate(['z'])->pluck('slug'));
+        $this->assertEquals([], $pages->notTemplate(['a', 'b', 'c'])->pluck('slug'));
+    }
+
     public function testNums()
     {
         $pages = Pages::factory([


### PR DESCRIPTION
By @neildaniels (original PR got automatically closed when we decided to remove the `features` branch and work only with `develop`)

## Describe the PR
Adds `$pages->notTemplate()` to exclude specific templates from a Pages collection.

## Related issues
- Implements https://github.com/getkirby/ideas/issues/392

## Todos
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needeed, in-code documentation (DocBlocks etc.)
