### PR TITLE
PageStatus: only load siblings when needed #2052

### DIFF
--- a/panel/src/components/Dialogs/PageStatusDialog.vue
+++ b/panel/src/components/Dialogs/PageStatusDialog.vue
@@ -103,7 +103,7 @@ export default {
     open(id) {
       this.$api.pages
         .get(id, {
-          select: ["id", "status", "num", "errors", "siblings", "blueprint"]
+          select: ["id", "status", "num", "errors", "blueprint"]
         })
         .then(page => {
           if (page.blueprint.options.changeStatus === false) {
@@ -118,12 +118,20 @@ export default {
               details: page.errors
             });
           }
-
-          this.states = page.blueprint.status;
+                    
           this.page = page;
+          this.states = page.blueprint.status;
           this.form.status = page.status;
-          this.form.position = page.num || (page.siblings.length + 1);
-          this.$refs.dialog.open();
+          
+          // only load siblings if needed
+          if (page.blueprint.num === "default") {
+            this.$api.pages.get(id, { select: ["siblings"] }).then(response => {
+              this.form.position = page.num || (response.siblings.length + 1);
+              this.$refs.dialog.open();
+            });
+          } else {
+            this.$refs.dialog.open();
+          }
         })
         .catch(error => {
           this.$store.dispatch('notification/error', error);


### PR DESCRIPTION
## Describe the PR
Only load siblings in PageStatus dialog when `num` is `default`.

## Related issues
- Fixes #2052
