### PR TITLE
Add $pagination->hasCurrentPage() method #1887

### DIFF
--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -123,11 +123,11 @@ class Pagination
     {
         if ($page === null) {
             if ($this->page > $this->pages()) {
-                $this->page = $this->lastPage();
+                return $this->lastPage();
             }
 
             if ($this->page < 1) {
-                $this->page = $this->firstPage();
+                return $this->firstPage();
             }
 
             return $this->page;

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -254,6 +254,18 @@ class Pagination
     }
 
     /**
+     * Checks if the current page exists
+     * (returns false if the provided page has
+     * overflowed the range of pages)
+     *
+     * @return boolean
+     */
+    public function hasCurrentPage(): bool
+    {
+        return $this->hasPage($this->page);
+    }
+
+    /**
      * Checks if the given page exists
      *
      * @return boolean

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -181,6 +181,30 @@ class PaginationTest extends TestCase
         $this->assertEquals(10, $pagination->offset());
     }
 
+    public function testHasCurrentPage()
+    {
+        $pagination = new Pagination([
+            'page'  => 5,
+            'limit' => 1,
+            'total' => 10
+        ]);
+        $this->assertTrue($pagination->hasCurrentPage());
+
+        $pagination = new Pagination([
+            'page'  => 42,
+            'limit' => 1,
+            'total' => 10
+        ]);
+        $this->assertFalse($pagination->hasCurrentPage());
+
+        $pagination = new Pagination([
+            'page'  => 0,
+            'limit' => 1,
+            'total' => 10
+        ]);
+        $this->assertFalse($pagination->hasCurrentPage());
+    }
+
     public function testHasPage()
     {
         $pagination = new Pagination([


### PR DESCRIPTION
## Describe the PR

New `$pagination->hasCurrentPage()` method that can be used in the controller to check if an overflow happened and to react accordingly (e.g. redirect to error page, render custom error, redirect to last existing page).

## Related issues

- Fixes #1887

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
