### PR TITLE
Refactor number field #1748

### DIFF
--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -24,7 +24,7 @@ return [
          * Allowed incremental steps between numbers (i.e `0.5`)
          */
         'step' => function ($step = 1) {
-            return $this->toNumber($step);
+            return (float)$this->toNumber($step);
         },
         'value' => function ($value = null) {
             return $this->toNumber($value);
@@ -36,7 +36,7 @@ return [
                 return null;
             }
 
-            return (float)Str::float($value);
+            return Str::float($value);
         }
     ],
     'validations' => [

--- a/panel/src/components/Forms/Field/NumberField.vue
+++ b/panel/src/components/Forms/Field/NumberField.vue
@@ -20,7 +20,11 @@ export default {
   props: {
     ...Field.props,
     ...Input.props,
-    ...NumberInput.props
+    ...NumberInput.props,
+    icon: {
+      type: String,
+      default: "updown"
+    }
   },
   methods: {
     focus() {

--- a/panel/src/components/Misc/Icons.vue
+++ b/panel/src/components/Misc/Icons.vue
@@ -339,6 +339,12 @@
         <path d="M10,4H2C1.4,4,1,4.4,1,5v10c0,0.6,0.4,1,1,1h8c0.6,0,1-0.4,1-1V5C11,4.4,10.6,4,10,4z" />
         <path d="M14,0H4v2h9v11h2V1C15,0.4,14.6,0,14,0z" />
       </symbol>
+      <symbol id="icon-updown" viewBox="0 0 16 16">
+          <polygon points="8,3 12,7 4,7 "></polygon> 
+          <polygon points="8,13 4,9 12,9 "></polygon> 
+          <rect x="1" width="14" height="2"></rect> 
+          <rect x="1" y="14" width="14" height="2"></rect>
+      </symbol>
     </defs>
   </svg>
 </template>

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -211,7 +211,7 @@ class StructureFieldTest extends TestCase
             ]
         ]);
 
-        $this->assertTrue(is_float($field->data()[0]['number']));
+        $this->assertEquals('3.2', $field->data()[0]['number']);
     }
 
     public function testEmpty()


### PR DESCRIPTION
## Describe the PR
Problem with the existing number field:
Having a step like `0.01` would result in omitted zeros e.g. at `0.1` or `0.2` instead of `0.10` and `0.20`- both in the UI as well as the content file. Especially when using the number field for currencies that behavior is not great.

I could not get any solution working with the HTML5 number input.
So I thought, why not implement it as a normal text field instead with support for arrow keys etc.
Arrow keys get emitted directly, manual input on blur (otherwise user could never finish typing).
Also added rounding to next step.
 

## Related issues
- Fixes #1748