### PR TITLE
Forbidden user roles no longer appear in the dialogs #1917

### DIFF
--- a/config/api/routes/roles.php
+++ b/config/api/routes/roles.php
@@ -8,7 +8,14 @@ return [
         'pattern' => 'roles',
         'method'  => 'GET',
         'action'  => function () {
-            return $this->kirby()->roles();
+            switch (get('canBe')) {
+                case 'changed':
+                    return $this->kirby()->roles()->canBeChanged();
+                case 'created':
+                    return $this->kirby()->roles()->canBeCreated();
+                default:
+                    return $this->kirby()->roles();
+            }
         }
     ],
     [

--- a/panel/src/api/roles.js
+++ b/panel/src/api/roles.js
@@ -2,14 +2,14 @@ import Vue from "vue";
 import api from "./api.js";
 
 export default {
-  list() {
-    return api.get("roles");
+  list(params) {
+    return api.get("roles", params);
   },
   get(name) {
     return api.get("roles/" + name);
   },
-  options() {
-    return this.list().then(roles => {
+  options(params) {
+    return this.list(params).then(roles => {
       return roles.data.map(role => {
         return {
           info: role.description || `(${Vue.i18n.translate("role.description.placeholder")})`,

--- a/panel/src/components/Dialogs/UserCreateDialog.vue
+++ b/panel/src/components/Dialogs/UserCreateDialog.vue
@@ -91,9 +91,9 @@ export default {
     },
     open() {
       // load and filter roles
-      const roles = this.$api.roles.options().then(roles => {
+      const roles = this.$api.roles.options({ canBe: "created" }).then(roles => {
         this.roles = roles;
-        
+
         // don't let non-admins create admins
         if (this.$user.role.name !== "admin") {
           this.roles = this.roles.filter(role => {
@@ -103,14 +103,14 @@ export default {
       }).catch(error => {
         this.$store.dispatch('notification/error', error);
       });
-      
+
       // load all translations
       const translations = this.$api.translations.options().then(languages => {
         this.languages = languages;
       }).catch (error => {
         this.$store.dispatch('notification/error', error);
       });
-      
+
       // open dialog when all API requests finished
       Promise.all([roles, translations]).then(() => {
         this.$refs.dialog.open();

--- a/panel/src/components/Dialogs/UserRoleDialog.vue
+++ b/panel/src/components/Dialogs/UserRoleDialog.vue
@@ -47,16 +47,16 @@ export default {
 
       this.$api.users.get(id)
         .then(user => {
-          this.$api.roles.options().then(roles => {
+          this.$api.roles.options({ canBe: "changed" }).then(roles => {
             this.roles = roles;
-            
+
             // don't let non-admins promote anyone to admin
             if (this.$user.role.name !== "admin") {
               this.roles = this.roles.filter(role => {
                 return role.value !== "admin";
               });
             }
-            
+
             this.user = user;
             this.user.role = this.user.role.name;
             this.$refs.dialog.open();

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -22,6 +22,52 @@ class Roles extends Collection
 {
 
     /**
+     * Returns a filtered list of all
+     * roles that can be created by the
+     * current user
+     *
+     * @return self
+     */
+    public function canBeChanged()
+    {
+        if ($user = App::instance()->user()) {
+            return $this->filter(function ($role) use ($user) {
+                $newUser = new User([
+                    'email' => 'test@getkirby.com',
+                    'role'  => $role->id()
+                ]);
+
+                return $newUser->permissions()->can('changeRole');
+            });
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns a filtered list of all
+     * roles that can be created by the
+     * current user
+     *
+     * @return self
+     */
+    public function canBeCreated()
+    {
+        if ($user = App::instance()->user()) {
+            return $this->filter(function ($role) use ($user) {
+                $newUser = new User([
+                    'email' => 'test@getkirby.com',
+                    'role'  => $role->id()
+                ]);
+
+                return $newUser->permissions()->can('create');
+            });
+        }
+
+        return $this;
+    }
+
+    /**
      * @param array $roles
      * @param array $inject
      * @return self

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -38,6 +38,21 @@ class UserPermissions extends ModelPermissions
         return $this->model->isLastAdmin() !== true;
     }
 
+    protected function canCreate(): bool
+    {
+        // the admin can always create new users
+        if ($this->user->isAdmin() === true) {
+            return true;
+        }
+
+        // users who are not admins cannot create admins
+        if ($this->model->isAdmin() === true) {
+            return false;
+        }
+
+        return true;
+    }
+
     protected function canDelete(): bool
     {
         return $this->model->isLastAdmin() !== true;


### PR DESCRIPTION
## Describe the PR
Forbidden user roles no longer appear in the dialogs.

New Roles::canBeChanged and Roles::canBeCreated methods help to filter roles by those that can be created or changed by the current user. This is now also implemented in the API and used by the dialogs to filter the list of allowed roles.

## Related issues
- Fixes #1917

## Todos
- [ ] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
