### PR TITLE
Added $options arg in Json::encode() #2111

### DIFF
--- a/src/Data/Json.php
+++ b/src/Data/Json.php
@@ -19,11 +19,12 @@ class Json extends Handler
      * Converts an array to an encoded JSON string
      *
      * @param  mixed  $data
+     * @param  int $options
      * @return string
      */
-    public static function encode($data): string
+    public static function encode($data, int $options = 0): string
     {
-        return json_encode($data);
+        return json_encode($data, $options);
     }
 
     /**

--- a/tests/Data/JsonTest.php
+++ b/tests/Data/JsonTest.php
@@ -28,6 +28,17 @@ class JsonTest extends TestCase
     }
 
     /**
+     * @covers ::encode
+     */
+    public function testEncodeUnicode()
+    {
+        $string  = 'здравей';
+        $encoded = '\u0437\u0434\u0440\u0430\u0432\u0435\u0439';
+        $this->assertEquals('"' . $encoded . '"', Json::encode($string));
+        $this->assertEquals('"' . $string . '"', Json::encode($string, JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
      * @covers ::decode
      */
     public function testDecodeCorrupted1()


### PR DESCRIPTION
## Describe the PR
You can now pass encoding options to the `Json::encode()` method. 

## Related issues
- Fixes #2111

## Todos
If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it.
- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
