### PR TITLE
Fix "Class 'I18n' not found" error

### DIFF
--- a/config/api/authentication.php
+++ b/config/api/authentication.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kirby\Cms\Auth;
 use Kirby\Exception\PermissionException;
 
 return function () {

--- a/config/api/collections.php
+++ b/config/api/collections.php
@@ -1,12 +1,5 @@
 <?php
 
-use Kirby\Cms\Files;
-use Kirby\Cms\Languages;
-use Kirby\Cms\Pages;
-use Kirby\Cms\Roles;
-use Kirby\Cms\Translations;
-use Kirby\Cms\Users;
-
 /**
  * Api Collection Definitions
  */

--- a/config/api/routes/system.php
+++ b/config/api/routes/system.php
@@ -1,5 +1,8 @@
 <?php
 
+use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
+
 /**
  * System Routes
  */
@@ -54,11 +57,11 @@ return [
             }
 
             if ($system->isInstallable() === false) {
-                throw new Exception('The panel cannot be installed');
+                throw new Exception('The Panel cannot be installed');
             }
 
             if ($system->isInstalled() === true) {
-                throw new Exception('The panel is already installed');
+                throw new Exception('The Panel is already installed');
             }
 
             // create the first user

--- a/config/fields/email.php
+++ b/config/fields/email.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\I18n;
+
 return [
     'extends' => 'text',
     'props' => [

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Data\Yaml;
 use Kirby\Toolkit\A;
 
 return [

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Toolkit\I18n;
 
 return [
     'props' => [

--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\Api;
 use Kirby\Cms\File;
+use Kirby\Exception\Exception;
 
 return [
     'props' => [

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\Str;
+
 return [
     'props' => [
         /**

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Data\Yaml;
 use Kirby\Toolkit\A;
 
 return [

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -1,6 +1,8 @@
 <?php
 
 use Kirby\Cms\Form;
+use Kirby\Data\Yaml;
+use Kirby\Toolkit\I18n;
 
 return [
     'mixins' => ['min'],

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -1,5 +1,9 @@
 <?php
 
+use Kirby\Toolkit\A;
+use Kirby\Toolkit\Str;
+use Kirby\Toolkit\V;
+
 return [
     'mixins' => ['min', 'options'],
     'props' => [

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\I18n;
 
 return [
     'props' => [

--- a/config/fields/url.php
+++ b/config/fields/url.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\I18n;
+
 return [
     'extends' => 'text',
     'props' => [

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -1,5 +1,8 @@
 <?php
 
+use Kirby\Data\Yaml;
+use Kirby\Toolkit\A;
+
 return [
     'mixins' => ['min', 'picker', 'userpicker'],
     'props' => [

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -9,6 +9,8 @@ use Kirby\Http\Server;
 use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
+use Kirby\Toolkit\V;
 
 /**
  * Helper to create an asset object

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\File;
+use Kirby\Toolkit\I18n;
 
 return [
     'mixins' => [

--- a/config/sections/mixins/empty.php
+++ b/config/sections/mixins/empty.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\I18n;
+
 return [
     'props' => [
         /**

--- a/config/sections/mixins/parent.php
+++ b/config/sections/mixins/parent.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Exception\Exception;
+
 return [
     'props' => [
         /**

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\Blueprint;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\I18n;
 
 return [
     'mixins' => [

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -173,7 +173,7 @@ class Api
             // set PHP locales based on *user* language
             // so that e.g. strftime() gets formatted correctly
             if (is_a($user, 'Kirby\Cms\User') === true) {
-                $locale = $user->language();
+                $locale = $language = $user->language();
 
                 // if it's not already a full locale, "fake" one
                 // and assume that the country equals the language
@@ -188,6 +188,7 @@ class Api
                     $locale . '.UTF-8',
                     $locale . '.UTF8',
                     $locale . '.ISO8859-1',
+                    $language,
                     setlocale(LC_ALL, 0) // fall back to the previously defined locale
                 ];
 

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -183,13 +183,19 @@ class Api
 
                 // provide some variants as fallbacks to be
                 // compatible with as many systems as possible
-                setlocale(LC_ALL, [
+                $locales = [
                     $locale,
                     $locale . '.UTF-8',
                     $locale . '.UTF8',
                     $locale . '.ISO8859-1',
                     setlocale(LC_ALL, 0) // fall back to the previously defined locale
-                ]);
+                ];
+
+                // set the locales that are relevant for string formatting
+                // *don't* set LC_CTYPE to avoid breaking other parts of the system
+                setlocale(LC_MONETARY, $locales);
+                setlocale(LC_NUMERIC, $locales);
+                setlocale(LC_TIME, $locales);
             }
         }
 

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -117,6 +117,8 @@ class ApiTest extends TestCase
 
     public function testCallLocale()
     {
+        $originalLocale = setlocale(LC_CTYPE, 0);
+
         $language = 'de';
 
         $api = new Api([
@@ -135,11 +137,17 @@ class ApiTest extends TestCase
         ]);
 
         $this->assertEquals('something', $api->call('foo'));
-        $this->assertTrue(in_array(setlocale(LC_ALL, 0), ['de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_TIME, 0), ['de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
+        $this->assertEquals($originalLocale, setlocale(LC_CTYPE, 0));
 
         $language = 'pt_BR';
         $this->assertEquals('something', $api->call('foo'));
-        $this->assertTrue(in_array(setlocale(LC_ALL, 0), ['pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
+        $this->assertTrue(in_array(setlocale(LC_TIME, 0), ['pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
+        $this->assertEquals($originalLocale, setlocale(LC_CTYPE, 0));
     }
 
     public function testCollections()


### PR DESCRIPTION
## Describe the PR

Fixes errors that occur because of the wrong locale set for `LC_CTYPE` (introduced in 3.2.5-rc.1).

Also two other minor improvements to the code:

- Also pass language code as locale fallback for the new `Api` locale feature
- Add missing `use` declaration in the file that caused the error originally

## Related issues

- Fixes #2128

## Todos

- [x] Add unit tests for fixed bug/feature
- [x] Pass all unit tests
- [x] Fix code style issues with CS fixer and `composer fix`
- [x] If needed, in-code documentation (DocBlocks etc.)
