### PR TITLE
Fix invalid regex with enhance escape method

### DIFF
--- a/panel/src/helpers/regex.js
+++ b/panel/src/helpers/regex.js
@@ -1,1 +1,1 @@
-RegExp.escape = s => s.replace(/\p[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+RegExp.escape = s => s.replace(/[\p{L}]|[-\/\\^$*+?.()|[\]{}]+/u, '\\$&');


### PR DESCRIPTION
## Describe the PR

I think I've found the right escape method after hundreds of tests on 3.2.5.

**Informations**:
- Learned that the `u` flag should be used for unicode property `\p`
- `/gu` flags together was not working in this case
- Special characters (`-\/\\^$*+?.()|[\]{}`) were not escaped somehow (main reason of this issue) because we added `\p` property in our last commit
- Added condition that escape unicode or special characters to work with unicode and special characters (I'd appreciate it if you have a better regex syntax)
- `\p{L}` mean is escape only unicode letters as `{L}`

In summary, the PR does: escaping only unicode letters and defined special characters.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2138 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
