### PR TITLE
Fix options in video helpers #2118

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -825,7 +825,7 @@ function video(string $url, array $options = [], array $attr = []): string
  */
 function vimeo(string $url, array $options = [], array $attr = []): string
 {
-    return Html::video($url, $options, $attr);
+    return Html::vimeo($url, $options, $attr);
 }
 
 /**
@@ -851,5 +851,5 @@ function widont(string $string = null): string
  */
 function youtube(string $url, array $options = [], array $attr = []): string
 {
-    return Html::video($url, $options, $attr);
+    return Html::youtube($url, $options, $attr);
 }

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -465,7 +465,7 @@ class Html
         }
 
         // build the options query
-        if (!empty($options)) {
+        if (empty($options) === false) {
             $query = '?' . http_build_query($options);
         } else {
             $query = '';

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -523,7 +523,7 @@ class Html
         }
 
         // build the options query
-        if (!empty($options)) {
+        if (empty($options) === false) {
             $query = '?' . http_build_query($options);
         } else {
             $query = '';

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -693,10 +693,44 @@ class HelpersTest extends TestCase
         $this->assertEquals($expected, $video);
     }
 
+    public function testYoutubeVideoWithOptions()
+    {
+        $video = video('https://www.youtube.com/watch?v=xB3s_f7PzYk', [
+            'youtube' => [
+                'controls' => 0
+            ]
+        ]);
+
+        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
+
+        $this->assertEquals($expected, $video);
+    }
+
+    public function testVimeoVideoWithOptions()
+    {
+        $video = video('https://vimeo.com/335292911', [
+            'vimeo' => [
+                'controls' => 0
+            ]
+        ]);
+
+        $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
+
+        $this->assertEquals($expected, $video);
+    }
+
     public function testVimeo()
     {
-        $video    = video('https://vimeo.com/335292911');
+        $video    = vimeo('https://vimeo.com/335292911');
         $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911"></iframe>';
+
+        $this->assertEquals($expected, $video);
+    }
+
+    public function testVimeoWithOptions()
+    {
+        $video    = vimeo('https://vimeo.com/335292911', ['controls' => 0]);
+        $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
 
         $this->assertEquals($expected, $video);
     }
@@ -713,6 +747,14 @@ class HelpersTest extends TestCase
     {
         $video    = youtube('https://www.youtube.com/watch?v=xB3s_f7PzYk');
         $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
+
+        $this->assertEquals($expected, $video);
+    }
+
+    public function testYoutubeWithOptions()
+    {
+        $video    = youtube('https://www.youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
+        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertEquals($expected, $video);
     }


### PR DESCRIPTION
## Describe the PR

The vimeo and youtube helpers did not pass the options argument correctly to the HTML::video method. 

## Related issues

- Fixes #2118

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`