### PR TITLE
Toggle field preview #2126 

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -99,6 +99,7 @@
                   :value="item[columnName]"
                   :column="column"
                   :field="fields[columnName]"
+                  @input="update(index, columnName, $event)"
                 />
                 <template v-else>
                   <p class="k-structure-table-text">
@@ -551,6 +552,10 @@ export default {
       const b = Number(parts[1]);
 
       return parseFloat(100 / b * a, 2).toFixed(2) + "%";
+    },
+    update(index, column, value) {
+      this.items[index][column] = value;
+      this.onInput();
     }
   }
 };

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -1,0 +1,30 @@
+<template>
+  <k-input
+    v-model="value"
+    :text="field.text"
+    class="k-toggle-field-preview"
+    type="toggle"
+    @input="$emit('input', $event)"
+  />
+</template>
+
+<script>
+export default {
+  props: {
+    field: Object,
+    value: Array,
+  }
+}
+</script>
+
+<style lang="scss">
+.k-toggle-field-preview label {
+  padding: 0 .25rem 0 .75rem;
+  display: flex;
+  height: 38px;
+  cursor: pointer;
+}
+.k-toggle-field-preview .k-toggle-input-label {
+  padding-left: .5rem;
+}
+</style>

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -119,6 +119,7 @@ import ToolbarLinkDialog from "@/components/Forms/Toolbar/LinkDialog.vue";
 import FilesFieldPreview from "@/components/Forms/Previews/FilesFieldPreview.vue";
 import EmailFieldPreview from "@/components/Forms/Previews/EmailFieldPreview.vue";
 import PagesFieldPreview from "@/components/Forms/Previews/PagesFieldPreview.vue";
+import ToggleFieldPreview from "@/components/Forms/Previews/ToggleFieldPreview.vue";
 import UrlFieldPreview from "@/components/Forms/Previews/UrlFieldPreview.vue";
 import UsersFieldPreview from "@/components/Forms/Previews/UsersFieldPreview.vue";
 
@@ -183,6 +184,7 @@ Vue.component("k-toolbar-link-dialog", ToolbarLinkDialog);
 Vue.component("k-email-field-preview", EmailFieldPreview);
 Vue.component("k-files-field-preview", FilesFieldPreview);
 Vue.component("k-pages-field-preview", PagesFieldPreview);
+Vue.component("k-toggle-field-preview", ToggleFieldPreview);
 Vue.component("k-url-field-preview", UrlFieldPreview);
 Vue.component("k-users-field-preview", UsersFieldPreview);
 


### PR DESCRIPTION
## Describe the PR

This PR adds a new toggle field preview for structure fields. It's also the first interactive preview, which can be toggled directly in the table. 

<img width="840" alt="Screenshot 2019-09-27 at 12 13 45" src="https://user-images.githubusercontent.com/24532/65761996-46878380-e120-11e9-874e-61750b86cbe5.png">

## Related issues

- Fixes #2126 