### PR TITLE
Make search default to users on users page

### DIFF
--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -62,7 +62,7 @@ export default {
       items: [],
       q: null,
       selected: -1,
-      currentType: "pages"
+      currentType: this.$store.state.view === "users" ? "users" : "pages"
     }
   },
   computed: {


### PR DESCRIPTION
## Describe the PR

Now it's easier to search for users while on the users page.
Since it was from the idea repository, I opened it as a draft.

## Related idea

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/355

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
