### PR TITLE
Add ErrorPageException, fix pagination overflow

### DIFF
--- a/config/aliases.php
+++ b/config/aliases.php
@@ -32,6 +32,9 @@ return [
     'database'  => 'Kirby\Database\Database',
     'db'        => 'Kirby\Database\Db',
 
+    // exceptions
+    'errorpageexception' => 'Kirby\Exception\ErrorPageException',
+
     // http classes
     'cookie'     => 'Kirby\Http\Cookie',
     'header'     => 'Kirby\Http\Header',

--- a/config/sections/mixins/pagination.php
+++ b/config/sections/mixins/pagination.php
@@ -14,7 +14,7 @@ return [
          * Sets the default page for the pagination. This will overwrite default pagination.
          */
         'page' => function (int $page = null) {
-            return get('page', $page ?? 1);
+            return get('page', $page);
         },
     ],
     'methods' => [

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Email\PHPMailer as Emailer;
+use Kirby\Exception\ErrorPageException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Request;
@@ -586,7 +587,11 @@ class App
 
         // Pages
         if (is_a($input, 'Kirby\Cms\Page')) {
-            $html = $input->render();
+            try {
+                $html = $input->render();
+            } catch (ErrorPageException $e) {
+                return $this->io($e);
+            }
 
             if ($input->isErrorPage() === true) {
                 if ($response->code() === null) {

--- a/src/Cms/Pagination.php
+++ b/src/Cms/Pagination.php
@@ -81,9 +81,9 @@ class Pagination extends BasePagination
         }
 
         if ($params['method'] === 'query') {
-            $params['page'] = $params['page'] ?? $params['url']->query()->get($params['variable'], 1);
+            $params['page'] = $params['page'] ?? $params['url']->query()->get($params['variable']);
         } else {
-            $params['page'] = $params['page'] ?? $params['url']->params()->get($params['variable'], 1);
+            $params['page'] = $params['page'] ?? $params['url']->params()->get($params['variable']);
         }
 
         parent::__construct($params);

--- a/src/Exception/ErrorPageException.php
+++ b/src/Exception/ErrorPageException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kirby\Exception;
+
+/**
+ * ErrorPageException
+ * Thrown to trigger the CMS error page
+ *
+ * @package   Kirby Exception
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://opensource.org/licenses/MIT
+ */
+class ErrorPageException extends Exception
+{
+    protected static $defaultKey = 'errorPage';
+    protected static $defaultFallback = 'Triggered error page';
+    protected static $defaultHttpCode = 404;
+}

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -386,27 +386,27 @@ class Pagination
     public function setProperties(array $params)
     {
         if (isset($params['limit'])) {
-            if (is_int($params['limit']) !== true || $params['limit'] < 1) {
+            if (is_numeric($params['limit']) !== true || $params['limit'] < 1) {
                 throw new Exception('Invalid pagination limit: ' . $params['limit']);
             }
 
-            $this->limit = $params['limit'];
+            $this->limit = (int)$params['limit'];
         }
 
         if (isset($params['total'])) {
-            if (is_int($params['total']) !== true || $params['total'] < 0) {
+            if (is_numeric($params['total']) !== true || $params['total'] < 0) {
                 throw new Exception('Invalid total number of items: ' . $params['total']);
             }
 
-            $this->total = $params['total'];
+            $this->total = (int)$params['total'];
         }
 
         if (isset($params['page'])) {
-            if (is_int($params['page']) !== true || $params['page'] < 0) {
+            if (is_numeric($params['page']) !== true || $params['page'] < 0) {
                 throw new Exception('Invalid page number: ' . $params['page']);
             }
 
-            $this->page = $params['page'];
+            $this->page = (int)$params['page'];
         } elseif ($this->page === null) {
             // generate "default page" based on other params if not set already
             $this->page = $this->firstPage();

--- a/tests/Cms/App/AppIoTest.php
+++ b/tests/Cms/App/AppIoTest.php
@@ -2,7 +2,7 @@
 
 namespace Kirby\Cms;
 
-use Exception;
+use Kirby\Exception\Exception;
 use Kirby\Http\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -12,17 +12,40 @@ class AppIoTest extends TestCase
     {
         return new App([
             'roots' => [
-                'index' => '/dev/null'
+                'index'     => '/dev/null',
+                'templates' => __DIR__ . '/fixtures/AppIoTest/templates'
             ]
         ]);
     }
 
     public function testException()
     {
-        $response = $this->app()->io(new Exception('Nope'));
+        $response = $this->app()->io(new Exception([
+            'fallback' => 'Nope',
+            'httpCode' => 501
+        ]));
+
+        $this->assertEquals(501, $response->code());
+        $this->assertEquals('Nope', $response->body());
+    }
+
+    public function testExceptionErrorPage()
+    {
+        $app = $this->app()->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'error',
+                        'template' => 'error'
+                    ]
+                ]
+            ]
+        ]);
+
+        $response = $app->io(new Exception('Nope'));
 
         $this->assertEquals(500, $response->code());
-        $this->assertEquals('Nope', $response->body());
+        $this->assertEquals('Error: Nope', $response->body());
     }
 
     public function testExceptionWithInvalidHttpCode()
@@ -62,6 +85,56 @@ class AppIoTest extends TestCase
         $response = $this->app()->io($input);
 
         $this->assertEquals($input, $response);
+    }
+
+    public function testPage()
+    {
+        $input = new Page([
+            'slug'     => 'test',
+            'template' => 'test'
+        ]);
+
+        $response = $this->app()->io($input);
+
+        $this->assertEquals(200, $response->code());
+        $this->assertEquals('Test template', $response->body());
+    }
+
+    public function testPageErrorPageException()
+    {
+        $input = new Page([
+            'slug'     => 'test',
+            'template' => 'errorpage-exception'
+        ]);
+
+        $response = $this->app()->io($input);
+
+        $this->assertEquals(403, $response->code());
+        $this->assertEquals('Exception message', $response->body());
+    }
+
+    public function testPageErrorPageExceptionErrorPage()
+    {
+        $app = $this->app()->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'error',
+                        'template' => 'error'
+                    ]
+                ]
+            ]
+        ]);
+
+        $input = new Page([
+            'slug'     => 'test',
+            'template' => 'errorpage-exception'
+        ]);
+
+        $response = $app->io($input);
+
+        $this->assertEquals(403, $response->code());
+        $this->assertEquals('Error: Exception message', $response->body());
     }
 
     public function testString()

--- a/tests/Cms/App/fixtures/AppIoTest/templates/error.php
+++ b/tests/Cms/App/fixtures/AppIoTest/templates/error.php
@@ -1,0 +1,1 @@
+Error: <?= $errorMessage ?>

--- a/tests/Cms/App/fixtures/AppIoTest/templates/errorpage-exception.php
+++ b/tests/Cms/App/fixtures/AppIoTest/templates/errorpage-exception.php
@@ -1,0 +1,6 @@
+<?php
+
+throw new Kirby\Exception\ErrorPageException([
+    'fallback' => 'Exception message',
+    'httpCode' => 403
+]);

--- a/tests/Cms/App/fixtures/AppIoTest/templates/test.php
+++ b/tests/Cms/App/fixtures/AppIoTest/templates/test.php
@@ -1,0 +1,1 @@
+Test template

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -159,6 +159,7 @@ class EmailTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testEmailUserData()
     {

--- a/tests/Exception/ErrorPageExceptionTest.php
+++ b/tests/Exception/ErrorPageExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirby\Exception;
+
+use PHPUnit\Framework\TestCase;
+
+class ErrorPageExceptionTest extends TestCase
+{
+    /**
+     * @coversNothing
+     */
+    public function testDefaults()
+    {
+        $exception = new ErrorPageException();
+        $this->assertEquals('error.errorPage', $exception->getKey());
+        $this->assertEquals('Triggered error page', $exception->getMessage());
+        $this->assertEquals(404, $exception->getHttpCode());
+    }
+}

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -185,6 +185,7 @@ class ResponseTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSend()
     {
@@ -210,6 +211,7 @@ class ResponseTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testToString()
     {

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -21,6 +21,12 @@ class PaginationTest extends TestCase
         $this->assertEquals(2, $pagination->page());
     }
 
+    public function testPageString()
+    {
+        $pagination = new Pagination(['total' => 100, 'page' => '2']);
+        $this->assertEquals(2, $pagination->page());
+    }
+
     public function testTotalDefault()
     {
         $pagination = new Pagination();
@@ -54,11 +60,11 @@ class PaginationTest extends TestCase
         $this->assertEquals(1, $pagination->start());
 
         // go to the second page
-        $pagination->setProperties(['page' => 2]);
+        $pagination = $pagination->clone(['page' => 2]);
         $this->assertEquals(21, $pagination->start());
 
         // set a different limit
-        $pagination->setProperties(['limit' => 10]);
+        $pagination = $pagination->clone(['limit' => 10]);
         $this->assertEquals(11, $pagination->start());
     }
 
@@ -71,11 +77,11 @@ class PaginationTest extends TestCase
         $this->assertEquals(20, $pagination->end());
 
         // go to the second page
-        $pagination->setProperties(['page' => 2]);
+        $pagination = $pagination->clone(['page' => 2]);
         $this->assertEquals(40, $pagination->end());
 
         // set a different limit
-        $pagination->setProperties(['limit' => 10]);
+        $pagination = $pagination->clone(['limit' => 10]);
         $this->assertEquals(20, $pagination->end());
     }
 
@@ -283,59 +289,59 @@ class PaginationTest extends TestCase
         $this->assertEquals(10, $pagination->rangeEnd(12));
     }
 
-    public function testSetProperties()
+    public function testClone()
     {
         $pagination = new Pagination();
-        $pagination->setProperties(['limit' => 3, 'total' => 5, 'page' => 2]);
+        $pagination = $pagination->clone(['limit' => 3, 'total' => 5, 'page' => 2]);
 
         $this->assertSame(3, $pagination->limit());
         $this->assertSame(5, $pagination->total());
         $this->assertSame(2, $pagination->page());
     }
 
-    public function testSetPropertiesInvalid1()
+    public function testCloneInvalid1()
     {
         $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Invalid pagination limit: 0');
 
         $pagination = new Pagination();
-        $pagination->setProperties(['limit' => 0]);
+        $pagination = $pagination->clone(['limit' => 0]);
     }
 
-    public function testSetPropertiesInvalid2()
+    public function testCloneInvalid2()
     {
         $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Invalid total number of items: -1');
 
         $pagination = new Pagination();
-        $pagination->setProperties(['total' => -1]);
+        $pagination = $pagination->clone(['total' => -1]);
     }
 
-    public function testSetPropertiesInvalid3()
+    public function testCloneInvalid3()
     {
         $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Invalid page number: -1');
 
         $pagination = new Pagination();
-        $pagination->setProperties(['page' => -1]);
+        $pagination = $pagination->clone(['page' => -1]);
     }
 
-    public function testSetPropertiesOutOfBounds1()
+    public function testCloneOutOfBounds1()
     {
         $this->expectException('Kirby\Exception\ErrorPageException');
         $this->expectExceptionMessage('Pagination page 3 is out of bounds, expected 1-2');
 
         $pagination = new Pagination();
-        $pagination->setProperties(['page' => 3, 'total' => 10, 'limit' => 5]);
+        $pagination = $pagination->clone(['page' => 3, 'total' => 10, 'limit' => 5]);
     }
 
-    public function testSetPropertiesOutOfBounds2()
+    public function testCloneOutOfBounds2()
     {
         $this->expectException('Kirby\Exception\ErrorPageException');
         $this->expectExceptionMessage('Pagination page 0 is out of bounds, expected 1-2');
 
         $pagination = new Pagination();
-        $pagination->setProperties(['page' => 0, 'total' => 10, 'limit' => 5]);
+        $pagination = $pagination->clone(['page' => 0, 'total' => 10, 'limit' => 5]);
     }
 
     public function testToArray()

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -305,46 +305,19 @@ class PaginationTest extends TestCase
     public function testSetPropertiesInvalid2()
     {
         $this->expectException('Kirby\Exception\Exception');
-        $this->expectExceptionMessage('Invalid pagination limit: 1');
-
-        $pagination = new Pagination();
-        $pagination->setProperties(['limit' => '1']);
-    }
-
-    public function testSetPropertiesInvalid3()
-    {
-        $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Invalid total number of items: -1');
 
         $pagination = new Pagination();
         $pagination->setProperties(['total' => -1]);
     }
 
-    public function testSetPropertiesInvalid4()
-    {
-        $this->expectException('Kirby\Exception\Exception');
-        $this->expectExceptionMessage('Invalid total number of items: 1');
-
-        $pagination = new Pagination();
-        $pagination->setProperties(['total' => '1']);
-    }
-
-    public function testSetPropertiesInvalid5()
+    public function testSetPropertiesInvalid3()
     {
         $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Invalid page number: -1');
 
         $pagination = new Pagination();
         $pagination->setProperties(['page' => -1]);
-    }
-
-    public function testSetPropertiesInvalid6()
-    {
-        $this->expectException('Kirby\Exception\Exception');
-        $this->expectExceptionMessage('Invalid page number: 1');
-
-        $pagination = new Pagination();
-        $pagination->setProperties(['page' => '1']);
     }
 
     public function testSetPropertiesOutOfBounds1()

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -15,17 +15,10 @@ class PaginationTest extends TestCase
         $this->assertEquals(1, $pagination->page());
     }
 
-    public function testPageSetter()
+    public function testPage()
     {
-        $pagination = new Pagination();
-        $this->assertInstanceOf(Pagination::class, $pagination->page(12));
-    }
-
-    public function testPageGetter()
-    {
-        $pagination = new Pagination();
-        $pagination->page(12);
-        $this->assertEquals(0, $pagination->page());
+        $pagination = new Pagination(['total' => 100, 'page' => 2]);
+        $this->assertEquals(2, $pagination->page());
     }
 
     public function testTotalDefault()
@@ -34,26 +27,10 @@ class PaginationTest extends TestCase
         $this->assertEquals(0, $pagination->total());
     }
 
-    public function testTotalSetter()
+    public function testTotal()
     {
-        $pagination = new Pagination();
-        $this->assertInstanceOf(Pagination::class, $pagination->total(12));
-    }
-
-    public function testTotalGetter()
-    {
-        $pagination = new Pagination();
-        $pagination->total(12);
+        $pagination = new Pagination(['total' => 12]);
         $this->assertEquals(12, $pagination->total());
-    }
-
-    public function testTotalInvalid()
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Invalid total number of items: -1');
-
-        $pagination = new Pagination();
-        $pagination->total(-1);
     }
 
     public function testLimitDefault()
@@ -62,26 +39,10 @@ class PaginationTest extends TestCase
         $this->assertEquals(20, $pagination->limit());
     }
 
-    public function testLimitSetter()
+    public function testLimit()
     {
-        $pagination = new Pagination();
-        $this->assertInstanceOf(Pagination::class, $pagination->limit(100));
-    }
-
-    public function testLimitGetter()
-    {
-        $pagination = new Pagination();
-        $pagination->limit(100);
+        $pagination = new Pagination(['limit' => 100]);
         $this->assertEquals(100, $pagination->limit());
-    }
-
-    public function testLimitInvalid()
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Invalid pagination limit: -1');
-
-        $pagination = new Pagination();
-        $pagination->limit(-1);
     }
 
     public function testStart()
@@ -93,11 +54,11 @@ class PaginationTest extends TestCase
         $this->assertEquals(1, $pagination->start());
 
         // go to the second page
-        $pagination->page(2);
+        $pagination->setProperties(['page' => 2]);
         $this->assertEquals(21, $pagination->start());
 
         // set a different limit
-        $pagination->limit(10);
+        $pagination->setProperties(['limit' => 10]);
         $this->assertEquals(11, $pagination->start());
     }
 
@@ -110,11 +71,11 @@ class PaginationTest extends TestCase
         $this->assertEquals(20, $pagination->end());
 
         // go to the second page
-        $pagination->page(2);
+        $pagination->setProperties(['page' => 2]);
         $this->assertEquals(40, $pagination->end());
 
         // set a different limit
-        $pagination->limit(10);
+        $pagination->setProperties(['limit' => 10]);
         $this->assertEquals(20, $pagination->end());
     }
 
@@ -222,7 +183,7 @@ class PaginationTest extends TestCase
         $pagination = new Pagination(['page' => 2, 'total' => 42]);
         $this->assertEquals(1, $pagination->prevPage());
 
-        $pagination = new Pagination(['page' => 1]);
+        $pagination = new Pagination(['page' => 1, 'total' => 42]);
         $this->assertEquals(null, $pagination->prevPage());
     }
 
@@ -231,7 +192,7 @@ class PaginationTest extends TestCase
         $pagination = new Pagination();
         $this->assertFalse($pagination->hasNextPage());
 
-        $pagination = new Pagination(['total' => 42, 'page' => 5]);
+        $pagination = new Pagination(['total' => 42, 'page' => 3]);
         $this->assertFalse($pagination->hasNextPage());
 
         $pagination = new Pagination(['total' => 42, 'page' => 2]);
@@ -243,7 +204,7 @@ class PaginationTest extends TestCase
         $pagination = new Pagination(['page' => 1, 'total' => 30]);
         $this->assertEquals(2, $pagination->nextPage());
 
-        $pagination = new Pagination(['page' => 3]);
+        $pagination = new Pagination(['page' => 2, 'total' => 30]);
         $this->assertEquals(null, $pagination->nextPage());
     }
 
@@ -320,6 +281,88 @@ class PaginationTest extends TestCase
         $this->assertEquals(range(1, 10), $range);
         $this->assertEquals(1, $pagination->rangeStart(12));
         $this->assertEquals(10, $pagination->rangeEnd(12));
+    }
+
+    public function testSetProperties()
+    {
+        $pagination = new Pagination();
+        $pagination->setProperties(['limit' => 3, 'total' => 5, 'page' => 2]);
+
+        $this->assertSame(3, $pagination->limit());
+        $this->assertSame(5, $pagination->total());
+        $this->assertSame(2, $pagination->page());
+    }
+
+    public function testSetPropertiesInvalid1()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid pagination limit: 0');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['limit' => 0]);
+    }
+
+    public function testSetPropertiesInvalid2()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid pagination limit: 1');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['limit' => '1']);
+    }
+
+    public function testSetPropertiesInvalid3()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid total number of items: -1');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['total' => -1]);
+    }
+
+    public function testSetPropertiesInvalid4()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid total number of items: 1');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['total' => '1']);
+    }
+
+    public function testSetPropertiesInvalid5()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid page number: -1');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['page' => -1]);
+    }
+
+    public function testSetPropertiesInvalid6()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid page number: 1');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['page' => '1']);
+    }
+
+    public function testSetPropertiesOutOfBounds1()
+    {
+        $this->expectException('Kirby\Exception\ErrorPageException');
+        $this->expectExceptionMessage('Pagination page 3 is out of bounds, expected 1-2');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['page' => 3, 'total' => 10, 'limit' => 5]);
+    }
+
+    public function testSetPropertiesOutOfBounds2()
+    {
+        $this->expectException('Kirby\Exception\ErrorPageException');
+        $this->expectExceptionMessage('Pagination page 0 is out of bounds, expected 1-2');
+
+        $pagination = new Pagination();
+        $pagination->setProperties(['page' => 0, 'total' => 10, 'limit' => 5]);
     }
 
     public function testToArray()


### PR DESCRIPTION
## Describe the PR

- Add new `ErrorPageException` that can be thrown while a page is rendered (e.g. from the template or controller) to trigger the error page
- Replace the single setters in the `Pagination` class with a new `setProperties()` method that validates the properties when setting
- Trigger the error page if the pagination page is out of bounds

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #1887

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
