### PR TITLE
Add $visitor->preferredMimeType() and $visitor->prefersJson(), remove deprecated methods

### DIFF
--- a/config/roots.php
+++ b/config/roots.php
@@ -11,17 +11,10 @@ return [
         return $roots['kirby'] . '/i18n';
     },
     'i18n:translations' => function (array $roots) {
-        return $roots['translations'];
+        return $roots['i18n'] . '/translations';
     },
     'i18n:rules' => function (array $roots) {
         return $roots['i18n'] . '/rules';
-    },
-    /**
-     * @deprecated 3.2.0 Use `i18n:translations` instead
-     * @TODO move logic over to i18n:translations before removing
-     */
-    'translations' => function (array $roots) {
-        return $roots['i18n'] . '/translations';
     },
 
     // index

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -29,15 +29,12 @@ trait AppErrors
 
     protected function handleErrors()
     {
-        $request = $this->request();
-
-        // TODO: implement acceptance
-        if ($request->ajax()) {
-            return $this->handleJsonErrors();
+        if ($this->request()->cli() === true) {
+            return $this->handleCliErrors();
         }
 
-        if ($request->cli()) {
-            return $this->handleCliErrors();
+        if ($this->visitor()->prefersJson() === true) {
+            return $this->handleJsonErrors();
         }
 
         return $this->handleHtmlErrors();

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -158,7 +158,7 @@ trait AppTranslations
         $inject = $this->extensions['translations'][$locale] ?? [];
 
         // load from disk instead
-        return Translation::load($locale, $this->root('translations') . '/' . $locale . '.json', $inject);
+        return Translation::load($locale, $this->root('i18n:translations') . '/' . $locale . '.json', $inject);
     }
 
     /**
@@ -172,6 +172,6 @@ trait AppTranslations
             return $this->translations;
         }
 
-        return Translations::load($this->root('translations'), $this->extensions['translations'] ?? []);
+        return Translations::load($this->root('i18n:translations'), $this->extensions['translations'] ?? []);
     }
 }

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -357,16 +357,6 @@ class File extends ModelWithContent
     }
 
     /**
-     * @deprecated 3.0.0 Use `File::content()` instead
-     *
-     * @return \Kirby\Cms\Content
-     */
-    public function meta()
-    {
-        return $this->content();
-    }
-
-    /**
      * Get the file's last modification time.
      *
      * @param string $format

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -248,18 +248,6 @@ trait FileActions
     }
 
     /**
-     * @deprecated 3.0.0 Use `File::changeName()` instead
-     *
-     * @param string $name
-     * @param bool $sanitize
-     * @return self
-     */
-    public function rename(string $name, bool $sanitize = true)
-    {
-        return $this->changeName($name, $sanitize);
-    }
-
-    /**
      * Replaces the file. The source must
      * be an absolute path to a file or a Url.
      * The store handles the replacement so it

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -175,15 +175,6 @@ trait HasChildren
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasUnlistedChildren` instead
-     * @return bool
-     */
-    public function hasInvisibleChildren(): bool
-    {
-        return $this->hasUnlistedChildren();
-    }
-
-    /**
      * Checks if the page has any listed children
      *
      * @return bool
@@ -201,15 +192,6 @@ trait HasChildren
     public function hasUnlistedChildren(): bool
     {
         return $this->children()->unlisted()->count() > 0;
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::hasListedChildren` instead
-     * @return bool
-     */
-    public function hasVisibleChildren(): bool
-    {
-        return $this->hasListedChildren();
     }
 
     /**

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -72,15 +72,6 @@ class Languages extends Collection
     }
 
     /**
-     * @deprecated 3.0.0  Use `Languages::default()`instead
-     * @return \Kirby\Cms\Language|null
-     */
-    public function findDefault()
-    {
-        return $this->default();
-    }
-
-    /**
      * Convert all defined languages to a collection
      *
      * @internal

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -733,15 +733,6 @@ class Page extends ModelWithContent
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::isUnlisted()` intead
-     * @return bool
-     */
-    public function isInvisible(): bool
-    {
-        return $this->isUnlisted();
-    }
-
-    /**
      * Checks if the page has a sorting number
      *
      * @return bool
@@ -791,15 +782,6 @@ class Page extends ModelWithContent
     public function isUnlisted(): bool
     {
         return $this->isListed() === false;
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::isListed()` intead
-     * @return bool
-     */
-    public function isVisible(): bool
-    {
-        return $this->isListed();
     }
 
     /**

--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -14,15 +14,6 @@ namespace Kirby\Cms;
 trait PageSiblings
 {
     /**
-     * @deprecated 3.0.0 Use `Page::hasNextUnlisted` instead
-     * @return bool
-     */
-    public function hasNextInvisible(): bool
-    {
-        return $this->hasNextUnlisted();
-    }
-
-    /**
      * Checks if there's a next listed
      * page in the siblings collection
      *
@@ -42,24 +33,6 @@ trait PageSiblings
     public function hasNextUnlisted(): bool
     {
         return $this->nextUnlisted() !== null;
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::hasNextListed` instead
-     * @return bool
-     */
-    public function hasNextVisible(): bool
-    {
-        return $this->hasNextListed();
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::hasPrevUnlisted` instead
-     * @return bool
-     */
-    public function hasPrevInvisible(): bool
-    {
-        return $this->hasPrevUnlisted();
     }
 
     /**
@@ -85,24 +58,6 @@ trait PageSiblings
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasPrevListed instead`
-     * @return bool
-     */
-    public function hasPrevVisible(): bool
-    {
-        return $this->hasPrevListed();
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::nextUnlisted()` instead
-     * @return self|null
-     */
-    public function nextInvisible()
-    {
-        return $this->nextUnlisted();
-    }
-
-    /**
      * Returns the next listed page if it exists
      *
      * @return \Kirby\Cms\Page|null
@@ -123,24 +78,6 @@ trait PageSiblings
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::prevListed()` instead
-     * @return self|null
-     */
-    public function nextVisible()
-    {
-        return $this->nextListed();
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::prevUnlisted()` instead
-     * @return self|null
-     */
-    public function prevInvisible()
-    {
-        return $this->prevUnlisted();
-    }
-
-    /**
      * Returns the previous listed page
      *
      * @return \Kirby\Cms\Page|null
@@ -158,15 +95,6 @@ trait PageSiblings
     public function prevUnlisted()
     {
         return $this->prevAll()->unlisted()->first();
-    }
-
-    /**
-     * @deprecated 3.0.0 Use `Page::prevListed()` instead
-     * @return self|null
-     */
-    public function prevVisible()
-    {
-        return $this->prevListed();
     }
 
     /**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -143,16 +143,6 @@ class Request
     }
 
     /**
-     * Detects ajax requests
-     * @deprecated 3.1.0 No longer reliable, especially with the fetch api.
-     * @return bool
-     */
-    public function ajax(): bool
-    {
-        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
-    }
-
-    /**
      * Returns the Auth object if authentication is set
      *
      * @return \Kirby\Http\Request\Auth\BasicAuth|\Kirby\Http\Request\Auth\BearerAuth|null

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -178,6 +178,43 @@ class Visitor
     }
 
     /**
+     * Returns the MIME type from the provided list that
+     * is most accepted (= preferred) by the visitor
+     *
+     * @param string ...$mimeTypes MIME types to query for
+     * @return string|null Preferred MIME type
+     */
+    public function preferredMimeType(string ...$mimeTypes): ?string
+    {
+        foreach ($this->acceptedMimeTypes() as $acceptedMime) {
+            // look for direct matches
+            if (in_array($acceptedMime->type(), $mimeTypes)) {
+                return $acceptedMime->type();
+            }
+
+            // test each option against wildcard `Accept` values
+            foreach ($mimeTypes as $expectedMime) {
+                if (Mime::matchWildcard($acceptedMime->type(), $expectedMime) === true) {
+                    return $expectedMime;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true if the visitor prefers a JSON response over
+     * an HTML response based on the `Accept` request header
+     *
+     * @return bool
+     */
+    public function prefersJson(): bool
+    {
+        return $this->preferredMimeType('application/json', 'text/html') === 'application/json';
+    }
+
+    /**
      * Sets the ip address if provided
      * or returns the ip of the current
      * visitor otherwise

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -6,7 +6,7 @@ use SimpleXMLElement;
 
 /**
  * The `Mime` class provides method
- * for mime type detection or guessing
+ * for MIME type detection or guessing
  * from different criteria like
  * extensions etc.
  *
@@ -19,7 +19,7 @@ use SimpleXMLElement;
 class Mime
 {
     /**
-     * Extension to mime type map
+     * Extension to MIME type map
      *
      * @var array
      */
@@ -112,7 +112,7 @@ class Mime
     ];
 
     /**
-     * Fixes an invalid mime type guess for the given file
+     * Fixes an invalid MIME type guess for the given file
      *
      * @param string $file
      * @param string $mime
@@ -153,7 +153,7 @@ class Mime
     }
 
     /**
-     * Guesses a mime type by extension
+     * Guesses a MIME type by extension
      *
      * @param string $extension
      * @return string|null
@@ -165,7 +165,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @return string|false
@@ -183,7 +183,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @return string|false
@@ -198,7 +198,7 @@ class Mime
     }
 
     /**
-     * Tries to detect a valid SVG and returns the mime type accordingly
+     * Tries to detect a valid SVG and returns the MIME type accordingly
      *
      * @param string $file
      * @return string|false
@@ -219,7 +219,8 @@ class Mime
     }
 
     /**
-     * Undocumented function
+     * Tests if a given MIME type is matched by an `Accept` header
+     * pattern; returns true if the MIME type is contained at all
      *
      * @param string $mime
      * @param string $pattern
@@ -252,7 +253,7 @@ class Mime
     }
 
     /**
-     * Returns the extension for a given mime type
+     * Returns the extension for a given MIME type
      *
      * @param string|null $mime
      * @return string|false
@@ -273,7 +274,7 @@ class Mime
     }
 
     /**
-     * Returns all available extensions for a given mime type
+     * Returns all available extensions for a given MIME type
      *
      * @param string|null $mime
      * @return array
@@ -298,7 +299,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @param string $extension
@@ -327,7 +328,7 @@ class Mime
     }
 
     /**
-     * Returns all detectable mime types
+     * Returns all detectable MIME types
      *
      * @return array
      */

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -230,12 +230,25 @@ class Mime
         $accepted = Str::accepted($pattern);
 
         foreach ($accepted as $m) {
-            if (fnmatch($m['value'], $mime, FNM_PATHNAME) === true) {
+            if (static::matchWildcard($m['value'], $mime) === true) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Tests if a MIME wildcard pattern from an `Accept` header
+     * matches a given type
+     *
+     * @param string $wildcard
+     * @param string $test
+     * @return bool
+     */
+    public static function matchWildcard(string $wildcard, string $test): bool
+    {
+        return fnmatch($wildcard, $test, FNM_PATHNAME) === true;
     }
 
     /**

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -67,7 +67,6 @@ class LanguagesTest extends TestCase
     public function testDefault()
     {
         $this->assertEquals('en', $this->languages->default()->code());
-        $this->assertEquals('en', $this->languages->findDefault()->code());
     }
 
     public function testMultipleDefault()

--- a/tests/Cms/Pages/PageChildrenTest.php
+++ b/tests/Cms/Pages/PageChildrenTest.php
@@ -62,7 +62,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertTrue($page->hasListedChildren());
-        $this->assertTrue($page->hasVisibleChildren());
     }
 
     public function testHasNoListedChildren()
@@ -75,7 +74,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertFalse($page->hasListedChildren());
-        $this->assertFalse($page->hasVisibleChildren());
     }
 
     public function testHasUnlistedChildren()
@@ -88,7 +86,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertTrue($page->hasUnlistedChildren());
-        $this->assertTrue($page->hasInvisibleChildren());
     }
 
     public function testHasNoUnlistedChildren()
@@ -101,7 +98,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertFalse($page->hasUnlistedChildren());
-        $this->assertFalse($page->hasInvisibleChildren());
     }
 
     public function testHasDrafts()

--- a/tests/Cms/Pages/PageSiblingsTest.php
+++ b/tests/Cms/Pages/PageSiblingsTest.php
@@ -59,9 +59,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertTrue($collection->first()->hasNextListed());
-        $this->assertTrue($collection->first()->hasNextVisible());
         $this->assertFalse($collection->last()->hasNextListed());
-        $this->assertFalse($collection->last()->hasNextVisible());
     }
 
     public function testHasNextUnlisted()
@@ -74,9 +72,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertTrue($collection->first()->hasNextUnlisted());
-        $this->assertTrue($collection->first()->hasNextInvisible());
         $this->assertFalse($collection->last()->hasNextUnlisted());
-        $this->assertFalse($collection->last()->hasNextInvisible());
     }
 
     public function testHasPrev()
@@ -97,9 +93,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertFalse($collection->first()->hasPrevListed());
-        $this->assertFalse($collection->first()->hasPrevVisible());
         $this->assertTrue($collection->last()->hasPrevListed());
-        $this->assertTrue($collection->last()->hasPrevVisible());
     }
 
     public function testHasPrevUnlisted()
@@ -112,9 +106,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertFalse($collection->first()->hasPrevUnlisted());
-        $this->assertFalse($collection->first()->hasPrevInvisible());
         $this->assertTrue($collection->last()->hasPrevUnlisted());
-        $this->assertTrue($collection->last()->hasPrevInvisible());
     }
 
     public function testIndexOf()
@@ -178,7 +170,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('listed', $collection->first()->nextListed()->slug());
-        $this->assertEquals('listed', $collection->first()->nextVisible()->slug());
     }
 
     public function testNextUnlisted()
@@ -190,7 +181,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('unlisted', $collection->first()->nextUnlisted()->slug());
-        $this->assertEquals('unlisted', $collection->first()->nextInvisible()->slug());
     }
 
     public function testPrev()
@@ -220,7 +210,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('listed', $collection->last()->prevListed()->slug());
-        $this->assertEquals('listed', $collection->last()->prevVisible()->slug());
     }
 
     public function testPrevUnlisted()
@@ -232,7 +221,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('unlisted', $collection->last()->prevUnlisted()->slug());
-        $this->assertEquals('unlisted', $collection->last()->prevInvisible()->slug());
     }
 
     public function testSiblings()

--- a/tests/Cms/Pages/PageStatesTest.php
+++ b/tests/Cms/Pages/PageStatesTest.php
@@ -125,14 +125,12 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertTrue($page->isListed());
-        $this->assertTrue($page->isVisible());
 
         $page = new Page([
             'slug' => 'test',
         ]);
 
         $this->assertFalse($page->isListed());
-        $this->assertFalse($page->isVisible());
     }
 
     public function testIsUnlisted()
@@ -142,7 +140,6 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertTrue($page->isUnlisted());
-        $this->assertTrue($page->isInvisible());
 
         $page = new Page([
             'slug' => 'test',
@@ -150,7 +147,6 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertFalse($page->isUnlisted());
-        $this->assertFalse($page->isInvisible());
     }
 
     public function testIsDraft()

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -471,6 +471,7 @@ class RouterTest extends TestCase
 
         // set the accepted visitor language
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;
+        $app = $app->clone();
 
         $response = $app->call('/');
 

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -50,13 +50,54 @@ class VisitorTest extends TestCase
         $this->assertEquals('Kirby', $visitor->userAgent());
     }
 
-    public function testAccepts()
+    public function testAcceptsMimeType()
     {
         $visitor = new Visitor();
         $this->assertFalse($visitor->acceptsMimeType('text/html'));
 
         $visitor = new Visitor(['acceptedMimeType' => 'text/html']);
         $this->assertTrue($visitor->acceptsMimeType('text/html'));
+        $this->assertFalse($visitor->acceptsMimeType('application/json'));
+    }
+
+    public function testPreferredMimeType()
+    {
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json,text/plain;q=0.9,text/*;q=0.7']);
+
+        $this->assertSame('text/html', $visitor->preferredMimeType('text/html'));
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/plain'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('application/json'));
+        $this->assertSame('text/xml', $visitor->preferredMimeType('text/xml'));
+        $this->assertNull($visitor->preferredMimeType('application/yaml'));
+
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/html', 'text/plain'));
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/plain', 'text/xml'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/plain', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/xml', 'application/json'));
+
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'text/plain', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'text/plain', 'application/json', 'text/xml'));
+
+        $this->assertSame('application/json', $visitor->preferredMimeType('application/yaml', 'application/json'));
+    }
+
+    public function testPrefersJson()
+    {
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json']);
+        $this->assertTrue($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'application/json']);
+        $this->assertTrue($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html,application/json;q=0.8']);
+        $this->assertFalse($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html']);
+        $this->assertFalse($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/xml']);
+        $this->assertFalse($visitor->prefersJson());
     }
 
     public function testAcceptsLanguage()

--- a/tests/Toolkit/MimeTest.php
+++ b/tests/Toolkit/MimeTest.php
@@ -31,6 +31,33 @@ class MimeTest extends TestCase
         $this->assertEquals('text/x-php', $mime);
     }
 
+    public function testIsAccepted()
+    {
+        $pattern = 'text/html,text/plain;q=0.8,application/*;q=0.7';
+
+        $this->assertTrue(Mime::isAccepted('text/html', $pattern));
+        $this->assertTrue(Mime::isAccepted('text/plain', $pattern));
+        $this->assertTrue(Mime::isAccepted('application/json', $pattern));
+        $this->assertTrue(Mime::isAccepted('application/yaml', $pattern));
+
+        $this->assertFalse(Mime::isAccepted('text/xml', $pattern));
+    }
+
+    public function testMatchWildcard()
+    {
+        $this->assertTrue(Mime::matchWildcard('text/plain', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('text/*', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('text/*', 'text/xml'));
+        $this->assertTrue(Mime::matchWildcard('*/plain', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/plain', 'application/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/*', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/*', 'application/json'));
+
+        $this->assertFalse(Mime::matchWildcard('text/plain', 'text/xml'));
+        $this->assertFalse(Mime::matchWildcard('text/*', 'application/json'));
+        $this->assertFalse(Mime::matchWildcard('*/plain', 'text/xml'));
+    }
+
     public function testToExtension()
     {
         $extension = Mime::toExtension('image/jpeg');


### PR DESCRIPTION
This PR **removes**:

1. the methods that have been renamed in 3.0.0 and have been deprecated since,
2. the `$request->ajax()` method (deprecated in 3.1.0, can be replaced with `$visitor->prefersJson()`) and
3. the `translations` root that has been renamed to `i18n:translations` in 3.2.0.

It also **adds** new `$visitor->preferredMimeType()` and `$visitor->prefersJson()` methods as a replacement for the removed AJAX check.

We should explicitly name all removed methods (and the respective new methods) in the changelog so that users that haven't migrated to the new names yet can do so without much work.