### PR TITLE
Fix broken replace action for files #1951

### DIFF
--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -54,7 +54,16 @@ return [
             return $files->nth($index + 1);
         },
         'options' => function (File $file) {
-            return $file->permissions()->toArray();
+            $options = $file->permissions()->toArray();
+            $lock    = $file->lock();
+
+            if ($lock && $lock->isLocked()) {
+                foreach ($options as $key => $value) {
+                    $options[$key] = false;
+                }
+            }
+
+            return $options;
         },
         'panelIcon' => function (File $file) {
             return $file->panelIcon();

--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -54,16 +54,7 @@ return [
             return $files->nth($index + 1);
         },
         'options' => function (File $file) {
-            $options = $file->permissions()->toArray();
-            $lock    = $file->lock();
-
-            if ($lock && $lock->isLocked()) {
-                foreach ($options as $key => $value) {
-                    $options[$key] = false;
-                }
-            }
-
-            return $options;
+            return $file->panelOptions();
         },
         'panelIcon' => function (File $file) {
             return $file->panelIcon();

--- a/config/api/models/Page.php
+++ b/config/api/models/Page.php
@@ -56,7 +56,22 @@ return [
             return $page->num();
         },
         'options' => function (Page $page) {
-            return $page->permissions()->toArray();
+            $options = $page->permissions()->toArray();
+            $lock    = $page->lock();
+
+            if ($lock && $lock->isLocked()) {
+                $allowed = ['preview'];
+
+                foreach ($options as $key => $value) {
+                    if (in_array($key, $allowed)) {
+                        continue;
+                    }
+
+                    $options[$key] = false;
+                }
+            }
+
+            return $options;
         },
         'panelIcon' => function (Page $page) {
             return $page->panelIcon();

--- a/config/api/models/Page.php
+++ b/config/api/models/Page.php
@@ -56,22 +56,7 @@ return [
             return $page->num();
         },
         'options' => function (Page $page) {
-            $options = $page->permissions()->toArray();
-            $lock    = $page->lock();
-
-            if ($lock && $lock->isLocked()) {
-                $allowed = ['preview'];
-
-                foreach ($options as $key => $value) {
-                    if (in_array($key, $allowed)) {
-                        continue;
-                    }
-
-                    $options[$key] = false;
-                }
-            }
-
-            return $options;
+            return $page->panelOptions(['preview']);
         },
         'panelIcon' => function (Page $page) {
             return $page->panelIcon();

--- a/config/api/models/User.php
+++ b/config/api/models/User.php
@@ -39,7 +39,16 @@ return [
             return $user->next();
         },
         'options' => function (User $user) {
-            return $user->permissions()->toArray();
+            $options = $user->permissions()->toArray();
+            $lock    = $user->lock();
+
+            if ($lock && $lock->isLocked()) {
+                foreach ($options as $key => $value) {
+                    $options[$key] = false;
+                }
+            }
+
+            return $options;
         },
         'permissions' => function (User $user) {
             return $user->role()->permissions()->toArray();

--- a/config/api/models/User.php
+++ b/config/api/models/User.php
@@ -39,16 +39,7 @@ return [
             return $user->next();
         },
         'options' => function (User $user) {
-            $options = $user->permissions()->toArray();
-            $lock    = $user->lock();
-
-            if ($lock && $lock->isLocked()) {
-                foreach ($options as $key => $value) {
-                    $options[$key] = false;
-                }
-            }
-
-            return $options;
+            return $user->panelOptions();
         },
         'permissions' => function (User $user) {
             return $user->role()->permissions()->toArray();

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -75,7 +75,7 @@ export default {
       } else {
         return false;
       }
-    }
+    },
   },
   created() {
     this.load();
@@ -86,45 +86,40 @@ export default {
   },
   methods: {
     action(file, action) {
-      // check first if file is locked
-      const url = this.$api.files.url(file.parent, file.filename, "lock");
-      this.$api.get(url).then(response => {
 
-        // restrict actions if file is locked
-        if (response.locked && ["download", "edit"].includes(action) === false) {
-          this.$store.dispatch('notification/error', this.$t("lock.file.isLocked", { email: response.email }));
-          return;
-        }
+      switch (action) {
+        case "edit":
+          this.$router.push(file.link);
+          break;
+        case "download":
+          window.open(file.url);
+          break;
+        case "rename":
+          this.$refs.rename.open(file.parent, file.filename);
+          break;
+        case "replace":
+          this.$refs.upload.open({
+            url: config.api + "/" + this.$api.files.url(file.parent, file.filename),
+            accept: file.mime,
+            multiple: false
+          });
+          break;
+        case "remove":
+          if (this.data.length <= this.options.min) {
+            const number = this.options.min > 1 ? "plural" : "singular";
+            this.$store.dispatch("notification/error", {
+              message: this.$t("error.section.files.min." + number, {
+                section: this.options.headline || this.name,
+                min: this.options.min
+              })
+            });
+            break;
+          }
 
-        switch (action) {
-          case "edit":
-            this.$router.push(file.link);
-            break;
-          case "download":
-            window.open(file.url);
-            break;
-          case "rename":
-            this.$refs.rename.open(file.parent, file.filename);
-            break;
-          case "replace":
-            this.replace(file);
-            break;
-          case "remove":
-            if (this.data.length <= this.options.min) {
-              const number = this.options.min > 1 ? "plural" : "singular";
-              this.$store.dispatch("notification/error", {
-                message: this.$t("error.section.files.min." + number, {
-                  section: this.options.headline || this.name,
-                  min: this.options.min
-                })
-              });
-              break;
-            }
+          this.$refs.remove.open(file.parent, file.filename);
+          break;
+      }
 
-            this.$refs.remove.open(file.parent, file.filename);
-            break;
-        }
-      });
     },
     drop(files) {
       if (this.add === false) {

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -1,4 +1,4 @@
-<template>
+  <template>
   <section v-if="isLoading === false" class="k-pages-section">
 
     <header class="k-section-header">
@@ -95,73 +95,62 @@ export default {
       }
     },
     action(page, action) {
-      // check first if page is locked
-      const url = this.$api.pages.url(page.id, "lock")
 
-      this.$api.get(url).then(response => {
-
-        // restrict actions if page is locked
-        if (response.locked && ["preview"].includes(action) === false) {
-          this.$store.dispatch('notification/error', this.$t("lock.page.isLocked", { email: response.locked.email }));
-          return;
+      switch (action) {
+        case "duplicate": {
+          this.$refs.duplicate.open(page.id);
+          break;
         }
+        case "preview": {
+          let preview = window.open("", "_blank");
+          preview.document.write = "...";
 
-        switch (action) {
-          case "duplicate": {
-            this.$refs.duplicate.open(page.id);
-            break;
-          }
-          case "preview": {
-            let preview = window.open("", "_blank");
-            preview.document.write = "...";
+          this.$api.pages
+            .preview(page.id)
+            .then(url => {
+              preview.location.href = url;
+            })
+            .catch(error => {
+              this.$store.dispatch("notification/error", error);
+            });
 
-            this.$api.pages
-              .preview(page.id)
-              .then(url => {
-                preview.location.href = url;
+          break;
+        }
+        case "rename": {
+          this.$refs.rename.open(page.id);
+          break;
+        }
+        case "url": {
+          this.$refs.url.open(page.id);
+          break;
+        }
+        case "status": {
+          this.$refs.status.open(page.id);
+          break;
+        }
+        case "template": {
+          this.$refs.template.open(page.id);
+          break;
+        }
+        case "remove": {
+          if (this.data.length <= this.options.min) {
+            const number = this.options.min > 1 ? "plural" : "singular";
+            this.$store.dispatch("notification/error", {
+              message: this.$t("error.section.pages.min." + number, {
+                section: this.options.headline || this.name,
+                min: this.options.min
               })
-              .catch(error => {
-                this.$store.dispatch("notification/error", error);
-              });
+            });
+            break;
+          }
 
-            break;
-          }
-          case "rename": {
-            this.$refs.rename.open(page.id);
-            break;
-          }
-          case "url": {
-            this.$refs.url.open(page.id);
-            break;
-          }
-          case "status": {
-            this.$refs.status.open(page.id);
-            break;
-          }
-          case "template": {
-            this.$refs.template.open(page.id);
-            break;
-          }
-          case "remove": {
-            if (this.data.length <= this.options.min) {
-              const number = this.options.min > 1 ? "plural" : "singular";
-              this.$store.dispatch("notification/error", {
-                message: this.$t("error.section.pages.min." + number, {
-                  section: this.options.headline || this.name,
-                  min: this.options.min
-                })
-              });
-              break;
-            }
-
-            this.$refs.remove.open(page.id);
-            break;
-          }
-          default: {
-            throw new Error("Invalid action");
-          }
+          this.$refs.remove.open(page.id);
+          break;
         }
-      });
+        default: {
+          throw new Error("Invalid action");
+        }
+      }
 
     },
     items(data) {

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -247,6 +247,17 @@ abstract class ModelWithContent extends Model
     }
 
     /**
+     * Checks if the model is locked for the current user
+     *
+     * @return bool
+     */
+    public function isLocked(): bool
+    {
+        $lock = $this->lock();
+        return $lock && $lock->isLocked() === true;
+    }
+
+    /**
      * Checks if the data has any errors
      *
      * @return bool
@@ -380,6 +391,31 @@ abstract class ModelWithContent extends Model
         }
 
         return $image;
+    }
+
+    /**
+     * Returns an array of all actions
+     * that can be performed in the Panel
+     * This also checks for the lock status
+     *
+     * @param array $unlock An array of options that will be force-unlocked
+     * @return array
+     */
+    public function panelOptions(array $unlock = []): array
+    {
+        $options = $this->permissions()->toArray();
+
+        if ($this->isLocked()) {
+            foreach ($options as $key => $value) {
+                if (in_array($key, $unlock)) {
+                    continue;
+                }
+
+                $options[$key] = false;
+            }
+        }
+
+        return $options;
     }
 
     /**

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -9,6 +9,14 @@ class FileTestModel extends File
 {
 }
 
+class FileTestForceLocked extends File
+{
+    public function isLocked(): bool
+    {
+        return true;
+    }
+}
+
 class FileTest extends TestCase
 {
     protected function defaults(): array
@@ -272,6 +280,56 @@ class FileTest extends TestCase
         ];
 
         $this->assertEquals($expected, $icon);
+    }
+
+    public function testPanelOptions()
+    {
+        $file = new File([
+            'filename' => 'test.jpg',
+        ]);
+
+        $file->kirby()->impersonate('kirby');
+
+        $expected = [
+            'changeName' => true,
+            'create'     => true,
+            'delete'     => true,
+            'replace'    => true,
+            'update'     => true,
+        ];
+
+        $this->assertEquals($expected, $file->panelOptions());
+    }
+
+    public function testPanelOptionsWithLockedFile()
+    {
+        $file = new FileTestForceLocked([
+            'filename' => 'test.jpg',
+        ]);
+
+        $file->kirby()->impersonate('kirby');
+
+        // without override
+        $expected = [
+            'changeName' => false,
+            'create'     => false,
+            'delete'     => false,
+            'replace'    => false,
+            'update'     => false,
+        ];
+
+        $this->assertEquals($expected, $file->panelOptions());
+
+        // with override
+        $expected = [
+            'changeName' => false,
+            'create'     => false,
+            'delete'     => true,
+            'replace'    => false,
+            'update'     => false,
+        ];
+
+        $this->assertEquals($expected, $file->panelOptions(['delete']));
     }
 
     public function testPanelUrl()

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -8,6 +8,14 @@ class PageTestModel extends Page
 {
 }
 
+class PageTestForceLocked extends Page
+{
+    public function isLocked(): bool
+    {
+        return true;
+    }
+}
+
 
 class PageTest extends TestCase
 {
@@ -844,6 +852,74 @@ class PageTest extends TestCase
         $this->assertEquals($emoji, $icon['type']);
         $this->assertEquals('pattern', $icon['back']);
         $this->assertEquals(null, $icon['ratio']);
+    }
+
+    public function testPanelOptions()
+    {
+        $page = new Page([
+            'slug' => 'test',
+        ]);
+
+        $page->kirby()->impersonate('kirby');
+
+        $expected = [
+            'changeSlug'     => true,
+            'changeStatus'   => true,
+            'changeTemplate' => false, // no other template available in this scenario
+            'changeTitle'    => true,
+            'create'         => true,
+            'delete'         => true,
+            'duplicate'      => true,
+            'read'           => true,
+            'preview'        => true,
+            'sort'           => false, // drafts cannot be sorted
+            'update'         => true,
+        ];
+
+        $this->assertEquals($expected, $page->panelOptions());
+    }
+
+    public function testPanelOptionsWithLockedPage()
+    {
+        $page = new PageTestForceLocked([
+            'slug' => 'test',
+        ]);
+
+        $page->kirby()->impersonate('kirby');
+
+        // without override
+        $expected = [
+            'changeSlug'     => false,
+            'changeStatus'   => false,
+            'changeTemplate' => false,
+            'changeTitle'    => false,
+            'create'         => false,
+            'delete'         => false,
+            'duplicate'      => false,
+            'read'           => false,
+            'preview'        => false,
+            'sort'           => false,
+            'update'         => false,
+        ];
+
+        $this->assertEquals($expected, $page->panelOptions());
+
+        // with override
+        $expected = [
+            'changeSlug'     => false,
+            'changeStatus'   => false,
+            'changeTemplate' => false,
+            'changeTitle'    => false,
+            'create'         => false,
+            'delete'         => false,
+            'duplicate'      => false,
+            'read'           => false,
+            'preview'        => true,
+            'sort'           => false,
+            'update'         => false,
+        ];
+
+        $this->assertEquals($expected, $page->panelOptions(['preview']));
     }
 
     public function testPanelUrl()

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -8,6 +8,14 @@ class UserTestModel extends User
 {
 }
 
+class UserTestForceLocked extends User
+{
+    public function isLocked(): bool
+    {
+        return true;
+    }
+}
+
 class UserTest extends TestCase
 {
     public function testAvatar()
@@ -297,5 +305,64 @@ class UserTest extends TestCase
 
         // each hook needs to be called exactly twice
         $this->assertEquals((1 + 2 + 4 + 8) * 2, $calls);
+    }
+
+    public function testPanelOptions()
+    {
+        $user = new User([
+            'email' => 'test@getkirby.com',
+        ]);
+
+        $user->kirby()->impersonate('kirby');
+
+        $expected = [
+            'create'         => true,
+            'changeEmail'    => true,
+            'changeLanguage' => true,
+            'changeName'     => true,
+            'changePassword' => true,
+            'changeRole'     => false, // just one role
+            'delete'         => true,
+            'update'         => true,
+        ];
+
+        $this->assertEquals($expected, $user->panelOptions());
+    }
+
+    public function testPanelOptionsWithLockedUser()
+    {
+        $user = new UserTestForceLocked([
+            'email' => 'test@getkirby.com',
+        ]);
+
+        $user->kirby()->impersonate('kirby');
+
+        // without override
+        $expected = [
+            'create'         => false,
+            'changeEmail'    => false,
+            'changeLanguage' => false,
+            'changeName'     => false,
+            'changePassword' => false,
+            'changeRole'     => false,
+            'delete'         => false,
+            'update'         => false,
+        ];
+
+        $this->assertEquals($expected, $user->panelOptions());
+
+        // with override
+        $expected = [
+            'create'         => false,
+            'changeEmail'    => true,
+            'changeLanguage' => false,
+            'changeName'     => false,
+            'changePassword' => false,
+            'changeRole'     => false,
+            'delete'         => false,
+            'update'         => false,
+        ];
+
+        $this->assertEquals($expected, $user->panelOptions(['changeEmail']));
     }
 }


### PR DESCRIPTION
## Describe the PR

Content locking added a new layer of requests between the called action in dropdowns and the actual execution. This was no issue for all regular actions, but opening a window or opening the uploader was blocked by this in Safari and Firefox. This is now fixed by removing the additional API request to get the lock. The lock information is now used in the options API calls to disable options right away when the page, file or user is locked. This is a far better approach IMHO, as it makes the option API a lot more useful for other calls as well. 

## Related issues

- Fixes #1951

## Ready?

- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`