### PR TITLE
Show correct error messages when exceptions are thrown in hooks #2155

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -275,7 +275,7 @@ export default {
             return;
           }
 
-          if (response.details) {
+          if (response.details && response.details.length > 0) {
             this.$store.dispatch("notification/error", {
               message: this.$t("error.form.incomplete"),
               details: response.details


### PR DESCRIPTION
## Describe the PR

The error messages in hooks where not properly displayed when an exception is thrown. The reason is the refactored error handling in the API in 3.2.5, which always returns a details array, even if it is empty. 

## Related issues

- Fixes #2155