### PR TITLE
Replace email placeholder in lock notification correctly #2134

### DIFF
--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -102,7 +102,7 @@ export default {
 
         // restrict actions if page is locked
         if (response.locked && ["preview"].includes(action) === false) {
-          this.$store.dispatch('notification/error', this.$t("lock.page.isLocked", { email: response.email }));
+          this.$store.dispatch('notification/error', this.$t("lock.page.isLocked", { email: response.locked.email }));
           return;
         }
 


### PR DESCRIPTION
## Describe the PR

The email placeholder in the lock error dialog was not replaced correctly.  

## Related issues

- Fixes #2134