### PR TITLE
Add smartypants for languages

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1187,7 +1187,15 @@ class App
         if ($options === true) {
             $options = [];
         }
-
+        
+        if ($this->multilang() === true) {
+            $languageSmartypants = $this->language()->smartypants() ?? [];
+        
+            if (empty($languageSmartypants) === false) {
+                $options = array_merge($options, $languageSmartypants);
+            }
+        }
+        
         return $this->component('smartypants')($this, $text, $options);
     }
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1184,18 +1184,20 @@ class App
     {
         $options = $this->option('smartypants', []);
 
-        if ($options === true) {
+        if ($options === false) {
+            return $text;
+        } elseif (is_array($options) === false) {
             $options = [];
         }
-        
+
         if ($this->multilang() === true) {
             $languageSmartypants = $this->language()->smartypants() ?? [];
-        
+
             if (empty($languageSmartypants) === false) {
                 $options = array_merge($options, $languageSmartypants);
             }
         }
-        
+
         return $this->component('smartypants')($this, $text, $options);
     }
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -57,7 +57,7 @@ class Language extends Model
      * @var array|null
      */
     protected $slugs;
-    
+
     /**
      * @var array|null
      */
@@ -493,7 +493,7 @@ class Language extends Model
         $this->slugs = $slugs ?? [];
         return $this;
     }
-    
+
     /**
      * @param array $smartypants
      * @return self
@@ -533,9 +533,9 @@ class Language extends Model
     {
         return $this->slugs;
     }
-    
+
     /**
-     * Returns the custom smartypants for this language
+     * Returns the custom SmartyPants options for this language
      *
      * @return array
      */

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -57,6 +57,11 @@ class Language extends Model
      * @var array|null
      */
     protected $slugs;
+    
+    /**
+     * @var array|null
+     */
+    protected $smartypants;
 
     /**
      * @var array|null
@@ -85,6 +90,7 @@ class Language extends Model
             'locale',
             'name',
             'slugs',
+            'smartypants',
             'translations',
             'url',
         ]);
@@ -487,6 +493,16 @@ class Language extends Model
         $this->slugs = $slugs ?? [];
         return $this;
     }
+    
+    /**
+     * @param array $smartypants
+     * @return self
+     */
+    protected function setSmartypants(array $smartypants = null)
+    {
+        $this->smartypants = $smartypants ?? [];
+        return $this;
+    }
 
     /**
      * @param array $translations
@@ -516,6 +532,16 @@ class Language extends Model
     public function slugs(): array
     {
         return $this->slugs;
+    }
+    
+    /**
+     * Returns the custom smartypants for this language
+     *
+     * @return array
+     */
+    public function smartypants(): array
+    {
+        return $this->smartypants;
     }
 
     /**

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -45,6 +45,44 @@ class AppComponentsTest extends TestCase
 
         $this->assertEquals($expected, $this->kirby->smartypants($text));
     }
+    
+    public function testLanguageSmartypants()
+    {
+        $this->kirby = $this->kirby->clone([
+            'options' => [
+                'languages'     => true,
+                'smartypants'   => true
+            ],
+            'languages' => [
+                [
+                    'code'          => 'en',
+                    'name'          => 'English',
+                    'default'       => true,
+                    'locale'        => 'en_US',
+                    'url'           => '/',
+                    'smartypants'   => [
+                        'doublequote.open'  => '<',
+                        'doublequote.close' => '>'
+                    ]
+                ],
+                [
+                    'code'          => 'de',
+                    'name'          => 'Deutsch',
+                    'locale'        => 'de_DE',
+                    'url'           => '/de',
+                    'smartypants'   => [
+                        'doublequote.open'  => '<<',
+                        'doublequote.close' => '>>'
+                    ]
+                ]
+            ]
+        ]);
+
+        $text     = '"Test"';
+        $expected = '<Test>';
+
+        $this->assertSame($expected, $this->kirby->smartypants($text));
+    }
 
     public function testSmartypantsCachedInstance()
     {

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -45,8 +45,22 @@ class AppComponentsTest extends TestCase
 
         $this->assertEquals($expected, $this->kirby->smartypants($text));
     }
-    
-    public function testLanguageSmartypants()
+
+    public function testSmartypantsDisabled()
+    {
+        $this->kirby = $this->kirby->clone([
+            'options' => [
+                'smartypants'   => false
+            ]
+        ]);
+
+        $text     = '"Test"';
+        $expected = '"Test"';
+
+        $this->assertSame($expected, $this->kirby->smartypants($text));
+    }
+
+    public function testSmartypantsMultiLang()
     {
         $this->kirby = $this->kirby->clone([
             'options' => [
@@ -80,6 +94,36 @@ class AppComponentsTest extends TestCase
 
         $text     = '"Test"';
         $expected = '<Test>';
+
+        $this->assertSame($expected, $this->kirby->smartypants($text));
+    }
+
+    public function testSmartypantsDefaultOptionsOnMultiLang()
+    {
+        $this->kirby = $this->kirby->clone([
+            'options' => [
+                'languages'     => true,
+                'smartypants'   => true
+            ],
+            'languages' => [
+                [
+                    'code'          => 'en',
+                    'name'          => 'English',
+                    'default'       => true,
+                    'locale'        => 'en_US',
+                    'url'           => '/'
+                ],
+                [
+                    'code'          => 'de',
+                    'name'          => 'Deutsch',
+                    'locale'        => 'de_DE',
+                    'url'           => '/de'
+                ]
+            ]
+        ]);
+
+        $text     = '"Test"';
+        $expected = '&#8220;Test&#8221;';
 
         $this->assertSame($expected, $this->kirby->smartypants($text));
     }


### PR DESCRIPTION
## Describe the PR

If smartypants are defined in the languages, it merges with default smartypants. If there is no default smartypants, it must be enabled as `true` in the config.

In addition, when `smartypants` were disabled as `false`, would give an error when called `smartypants()`, this error is also fixed.

### Usage

````php
<?php

return [
    'code' => 'en',
    'default' => true,
    'direction' => 'ltr',
    'locale' => 'en_US',
    'name' => 'English',
    'translations' => [],
    'url' => NULL,
    'smartypants' => [
        'doublequote.open'  => '<',
        'doublequote.close' => '>'
    ],
];
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes #2037 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
