### PR TITLE
Including subpages feature on pages field

### DIFF
--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -7,34 +7,38 @@ return [
             $subpages = $params['subpages'] ?? true;
             $model    = $this->model();
             $site     = $this->kirby()->site();
-
+            $root     = $site;
+            
             if (empty($query) === false) {
                 if ($subpages === true) {
+                    $root  = $model->query($query, 'Kirby\Cms\Pages');
+                    
                     if ($parent = $site->find($params['parent'] ?? null)) {
                         $pages = $parent->children();
                     } else {
-                        $pages  = $model->query($query, 'Kirby\Cms\Pages');
+                        $pages  = $root;
                         $parent = $pages->parent();
                     }
                 } else {
-                    $pages = $model->query($query, 'Kirby\Cms\Pages');
+                    $pages  = $model->query($query, 'Kirby\Cms\Pages');
+                    $parent = null;
                 }
             } else {
                 if (!$parent = $site->find($params['parent'] ?? null)) {
-                    $parent = $site;
+                    $parent = $root;
                 }
                 
                 $pages = $parent->children();
             }
             
-            if ($subpages === true) {
+            if ($subpages === true && $parent !== null) {
                 $self  = [
-                    'id'     => (empty($parent->id()) === true || empty($params['parent']) === true) ? null : $parent->id(),
+                    'id'     => (empty($parent->id()) === true || $parent->id() === $root->parent()->id()) ? null : $parent->id(),
                     'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
                     'title'  => $parent->title()->value(),
                 ];
             }
-
+            
             $children = [];
 
             foreach ($pages as $index => $page) {

--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -3,42 +3,53 @@
 return [
     'methods' => [
         'pagepicker' => function (array $params = []) {
-            $query    = $params['query'] ?? null;
-            $subpages = $params['subpages'] ?? true;
-            $model    = $this->model();
-            $site     = $this->kirby()->site();
-            $root     = $site;
-            
-            if (empty($query) === false) {
-                if ($subpages === true) {
-                    $root  = $model->query($query, 'Kirby\Cms\Pages');
-                    
-                    if ($parent = $site->find($params['parent'] ?? null)) {
+
+            // default params
+            $params = array_merge([
+                'image'    => [],
+                'info'     => false,
+                'map'      => null,
+                'parent'   => null,
+                'query'    => null,
+                'subpages' => true,
+                'text'     => null
+            ], $params);
+
+
+            $model = $this->model();
+            $site  = $this->kirby()->site();
+            $root  = $site;
+
+            if (empty($params['query']) === false) {
+                if ($params['subpages'] === true) {
+                    $root = $model->query($params['query'], 'Kirby\Cms\Pages');
+
+                    if ($parent = $site->find($params['parent'])) {
                         $pages = $parent->children();
                     } else {
                         $pages  = $root;
                         $parent = $pages->parent();
                     }
                 } else {
-                    $pages  = $model->query($query, 'Kirby\Cms\Pages');
+                    $pages  = $model->query($params['query'], 'Kirby\Cms\Pages');
                     $parent = null;
                 }
             } else {
-                if (!$parent = $site->find($params['parent'] ?? null)) {
+                if (!$parent = $site->find($params['parent'])) {
                     $parent = $root;
                 }
-                
+
                 $pages = $parent->children();
             }
-            
-            if ($subpages === true && $parent !== null) {
-                $self  = [
+
+            if ($params['subpages'] === true && $parent !== null) {
+                $self = [
                     'id'     => (empty($parent->id()) === true || $parent->id() === $root->parent()->id()) ? null : $parent->id(),
                     'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
                     'title'  => $parent->title()->value(),
                 ];
             }
-            
+
             $children = [];
 
             foreach ($pages as $index => $page) {
@@ -47,10 +58,10 @@ return [
                         $children[] = $params['map']($page);
                     } else {
                         $children[] = $page->panelPickerData([
-                            'image' => $params['image'] ?? [],
-                            'info'  => $params['info'] ?? false,
+                            'image' => $params['image'],
+                            'info'  => $params['info'],
                             'model' => $model,
-                            'text'  => $params['text'] ?? null,
+                            'text'  => $params['text'],
                         ]);
                     }
                 }

--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -9,22 +9,21 @@ return [
             $site     = $this->kirby()->site();
 
             if (empty($query) === false) {
-                $pages = $model->query($query, 'Kirby\Cms\Pages');
-                
                 if ($subpages === true) {
-                    $root = $pages->parent();
-                    
                     if ($parent = $site->find($params['parent'] ?? null)) {
                         $pages = $parent->children();
                     } else {
-                        $parent = $root;
+                        $pages  = $model->query($query, 'Kirby\Cms\Pages');
+                        $parent = $pages->parent();
                     }
                     
                     $self  = [
-                        'id'     => (empty($parent->id()) === true || $root->id() === $parent->id()) ? null : $parent->id(),
+                        'id'     => (empty($parent->id()) === true || empty($params['parent']) === true) ? null : $parent->id(),
                         'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
                         'title'  => $parent->title()->value(),
                     ];
+                } else {
+                    $pages = $model->query($query, 'Kirby\Cms\Pages');
                 }
             } else {
                 if (!$parent = $site->find($params['parent'] ?? null)) {

--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -16,12 +16,6 @@ return [
                         $pages  = $model->query($query, 'Kirby\Cms\Pages');
                         $parent = $pages->parent();
                     }
-                    
-                    $self  = [
-                        'id'     => (empty($parent->id()) === true || empty($params['parent']) === true) ? null : $parent->id(),
-                        'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
-                        'title'  => $parent->title()->value(),
-                    ];
                 } else {
                     $pages = $model->query($query, 'Kirby\Cms\Pages');
                 }
@@ -31,14 +25,14 @@ return [
                 }
                 
                 $pages = $parent->children();
-                
-                if ($subpages === true) {
-                    $self  = [
-                        'id'     => empty($parent->id()) === true ? null : $parent->id(),
-                        'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
-                        'title'  => $parent->title()->value(),
-                    ];
-                }
+            }
+            
+            if ($subpages === true) {
+                $self  = [
+                    'id'     => (empty($parent->id()) === true || empty($params['parent']) === true) ? null : $parent->id(),
+                    'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
+                    'title'  => $parent->title()->value(),
+                ];
             }
 
             $children = [];

--- a/config/fields/mixins/pagepicker.php
+++ b/config/fields/mixins/pagepicker.php
@@ -1,76 +1,14 @@
 <?php
 
+use Kirby\Cms\PagePicker;
+
 return [
     'methods' => [
         'pagepicker' => function (array $params = []) {
+            // inject the current model
+            $params['model'] = $this->model();
 
-            // default params
-            $params = array_merge([
-                'image'    => [],
-                'info'     => false,
-                'map'      => null,
-                'parent'   => null,
-                'query'    => null,
-                'subpages' => true,
-                'text'     => null
-            ], $params);
-
-
-            $model = $this->model();
-            $site  = $this->kirby()->site();
-            $root  = $site;
-
-            if (empty($params['query']) === false) {
-                if ($params['subpages'] === true) {
-                    $root = $model->query($params['query'], 'Kirby\Cms\Pages');
-
-                    if ($parent = $site->find($params['parent'])) {
-                        $pages = $parent->children();
-                    } else {
-                        $pages  = $root;
-                        $parent = $pages->parent();
-                    }
-                } else {
-                    $pages  = $model->query($params['query'], 'Kirby\Cms\Pages');
-                    $parent = null;
-                }
-            } else {
-                if (!$parent = $site->find($params['parent'])) {
-                    $parent = $root;
-                }
-
-                $pages = $parent->children();
-            }
-
-            if ($params['subpages'] === true && $parent !== null) {
-                $self = [
-                    'id'     => (empty($parent->id()) === true || $parent->id() === $root->parent()->id()) ? null : $parent->id(),
-                    'parent' => is_a($parent->parent(), 'Kirby\Cms\Page') === true ? $parent->parent()->id() : null,
-                    'title'  => $parent->title()->value(),
-                ];
-            }
-
-            $children = [];
-
-            foreach ($pages as $index => $page) {
-                if ($page->isReadable() === true) {
-                    if (empty($params['map']) === false) {
-                        $children[] = $params['map']($page);
-                    } else {
-                        $children[] = $page->panelPickerData([
-                            'image' => $params['image'],
-                            'info'  => $params['info'],
-                            'model' => $model,
-                            'text'  => $params['text'],
-                        ]);
-                    }
-                }
-            }
-
-            return [
-                'model' => $self ?? null,
-                'pages' => $children
-            ];
+            return (new PagePicker($params))->toArray();
         }
     ]
 ];

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -42,9 +42,9 @@ return [
         'size' => function (string $size = 'auto') {
             return $size;
         },
-        
+
         /**
-         * Optional includes subpages of pages
+         * Optionally include subpages of pages
          */
         'subpages' => function (bool $subpages = true) {
             return $subpages;

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -42,6 +42,13 @@ return [
         'size' => function (string $size = 'auto') {
             return $size;
         },
+        
+        /**
+         * Optional includes subpages of pages
+         */
+        'subpages' => function (bool $subpages = true) {
+            return $subpages;
+        },
 
         'value' => function ($value = null) {
             return $this->toPages($value);
@@ -86,11 +93,12 @@ return [
                     $field = $this->field();
 
                     return $field->pagepicker([
-                        'image'  => $field->image(),
-                        'info'   => $field->info(),
-                        'parent' => $this->requestQuery('parent'),
-                        'query'  => $field->query(),
-                        'text'   => $field->text()
+                        'image'    => $field->image(),
+                        'info'     => $field->info(),
+                        'parent'   => $this->requestQuery('parent'),
+                        'query'    => $field->query(),
+                        'subpages' => $field->subpages(),
+                        'text'     => $field->text()
                     ]);
                 }
             ]

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -831,13 +831,17 @@ class App
     /**
      * Returns any page from the content folder
      *
-     * @param string $id
+     * @param string $id|null
      * @param \Kirby\Cms\Page|\Kirby\Cms\Site|null $parent
      * @param bool $drafts
      * @return \Kirby\Cms\Page|null
      */
-    public function page(string $id, $parent = null, bool $drafts = true)
+    public function page(?string $id = null, $parent = null, bool $drafts = true)
     {
+        if ($id === null) {
+            return null;
+        }
+
         $parent = $parent ?? $this->site();
 
         if ($page = $parent->find($id)) {

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Exception\InvalidArgumentException;
+
+/**
+ * The PagePicker class helps to
+ * fetch the right pages and the parent
+ * model for the API calls for the
+ * page picker component in the panel.
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class PagePicker
+{
+    /**
+     * @var \Kirby\Cms\App
+     */
+    protected $kirby;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var \Kirby\Cms\Pages
+     */
+    protected $pages;
+
+    /**
+     * @var \Kirby\Cms\Page|\Kirby\Cms\Site
+     */
+    protected $parent;
+
+    /**
+     * @var \Kirby\Cms\Site
+     */
+    protected $site;
+
+    /**
+     * Creates a new PagePicker instance
+     *
+     * @param array $params
+     */
+    public function __construct(array $params = [])
+    {
+        // default params
+        $defaults = [
+            // image settings (ratio, cover, etc.)
+            'image' => [],
+            // query template for the page info field
+            'info' => false,
+            // optional mapping function for the pages array
+            'map' => null,
+            // the reference model (site or page)
+            'model' => site(),
+            // Page ID of the selected parent. Used to navigate
+            'parent' => null,
+            // a query string to fetch specific pages
+            'query' => null,
+            // enable/disable subpage navigation
+            'subpages' => true,
+            // query template for the page text field
+            'text' => null
+        ];
+
+        $this->options = array_merge($defaults, $params);
+        $this->kirby   = $this->options['model']->kirby();
+        $this->site    = $this->kirby->site();
+    }
+
+    /**
+     * Returns the parent model object that
+     * is currently selected in the page picker.
+     * It normally starts at the site, but can
+     * also be any subpage. When a query is given
+     * and subpage navigation is deactivated,
+     * there will be no model available at all.
+     *
+     * @return \Kirby\Cms\Page|\Kirby\Cms\Site|null
+     */
+    public function model()
+    {
+        // no subpages navigation = no model
+        if ($this->options['subpages'] === false) {
+            return null;
+        }
+
+        // the model for queries is a bit more tricky to find
+        if (empty($this->options['query']) === false) {
+            return $this->modelForQuery();
+        }
+
+        return $this->parent();
+    }
+
+    /**
+     * Returns a model object for the given
+     * query, depending on the parent and subpages
+     * options.
+     *
+     * @return \Kirby\Cms\Page|\Kirby\Cms\Site|null
+     */
+    public function modelForQuery()
+    {
+        if ($this->options['subpages'] === true && empty($this->options['parent']) === false) {
+            return $this->parent();
+        }
+
+        if ($pages = $this->pages()) {
+            return $pages->parent();
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns basic information about the
+     * parent model that is currently selected
+     * in the page picker.
+     *
+     * @param \Kirby\Cms\Site|\Kirby\Cms\Page
+     * @return array|null
+     */
+    public function modelToArray($model): ?array
+    {
+        if ($model === null) {
+            return null;
+        }
+
+        // the selected model is the site. there's nothing above
+        if (is_a($model, 'Kirby\Cms\Site') === true) {
+            return [
+                'id'     => null,
+                'parent' => null,
+                'title'  => $model->title()->value()
+            ];
+        }
+
+        // the top-most page has been reached
+        // the missing id indicates that there's nothing above
+        if ($model->id() === $this->start()->id()) {
+            return [
+                'id'     => null,
+                'parent' => null,
+                'title'  => $model->title()->value()
+            ];
+        }
+
+        // the model is a regular page
+        return [
+            'id'     => $model->id(),
+            'parent' => $model->parentModel()->id(),
+            'title'  => $model->title()->value()
+        ];
+    }
+
+    /**
+     * Search all pages for the picker
+     *
+     * @return \Kirby\Cms\Pages|null
+     */
+    public function pages()
+    {
+        // cache
+        if ($this->pages !== null) {
+            return $this->pages;
+        }
+
+        // no query? simple parent-based search for pages
+        if (empty($this->options['query']) === true) {
+            return $this->pages = $this->pagesForParent();
+        }
+
+        // when subpage navigation is enabled, a parent
+        // might be passed in addition to the query.
+        // The parent then takes priority.
+        if ($this->options['subpages'] === true && empty($this->options['parent']) === false) {
+            return $this->pages = $this->pagesForParent();
+        }
+
+        // search by query
+        return $this->pages = $this->pagesForQuery();
+    }
+
+    /**
+     * Search for pages by parent
+     *
+     * @return \Kirby\Cms\Pages
+     */
+    public function pagesForParent()
+    {
+        return $this->parent()->children();
+    }
+
+    /**
+     * Search for pages by query string
+     *
+     * @return \Kirby\Cms\Pages
+     */
+    public function pagesForQuery()
+    {
+        $model = $this->options['model'];
+        $pages = $model->query($this->options['query']);
+
+        // help mitigate some typical query usage issues
+        // by converting site and page objects to proper
+        // pages by returning their children
+
+        if (is_a($pages, 'Kirby\Cms\Site') === true) {
+            $pages = $pages->children();
+        } elseif (is_a($pages, 'Kirby\Cms\Page') === true) {
+            $pages = $pages->children();
+        } elseif (is_a($pages, 'Kirby\Cms\Pages') === false) {
+            throw new InvalidArgumentException('Your query must return a set of pages');
+        }
+
+        return $pages;
+    }
+
+    /**
+     * Converts all given pages to an associative
+     * array that is already optimized for the
+     * panel picker component.
+     *
+     * @param \Kirby\Cms\Pages|null $pages
+     * @return array
+     */
+    public function pagesToArray($pages): array
+    {
+        if ($pages === null) {
+            return [];
+        }
+
+        $result = [];
+
+        // create the array result for each individual page
+        foreach ($pages as $index => $page) {
+            if ($page->isReadable() === true) {
+                if (empty($this->options['map']) === false) {
+                    $result[] = $this->options['map']($page);
+                } else {
+                    $result[] = $page->panelPickerData([
+                        'image' => $this->options['image'],
+                        'info'  => $this->options['info'],
+                        'model' => $this->options['model'],
+                        'text'  => $this->options['text'],
+                    ]);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns the parent model.
+     * The model will be used to fetch
+     * subpages unless there's a specific
+     * query to find pages instead.
+     *
+     * @return \Kirby\Cms\Page|\Kirby\Cms\Site
+     */
+    public function parent()
+    {
+        if ($this->parent !== null) {
+            return $this->parent;
+        }
+
+        return $this->parent = $this->kirby->page($this->options['parent']) ?? $this->site;
+    }
+
+    /**
+     * Calculates the top-most model (page or site)
+     * that can be accessed when navigating
+     * through pages.
+     *
+     * @return \Kirby\Cms\Page|\Kirby\Cms\Site
+     */
+    public function start()
+    {
+        if (empty($this->options['query']) === false) {
+            if ($pages = $this->pagesForQuery()) {
+                return $pages->parent();
+            }
+
+            return $this->site;
+        }
+
+        return $this->site;
+    }
+
+    /**
+     * Returns an associative array
+     * with all information for the picker.
+     * This will be passed directly to the API.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'model' => $this->modelToArray($this->model()),
+            'pages' => $this->pagesToArray($this->pages()),
+        ];
+    }
+}

--- a/tests/Cms/Pages/PagePickerTest.php
+++ b/tests/Cms/Pages/PagePickerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class PagePickerTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'grandmother',
+                        'children' => [
+                            [
+                                'slug' => 'mother',
+                                'children' => [
+                                    ['slug' => 'child-a'],
+                                    ['slug' => 'child-b'],
+                                    ['slug' => 'child-c']
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+    }
+
+    public function testDefaults()
+    {
+        $picker = new PagePicker();
+
+        $this->assertEquals($this->app->site(), $picker->model());
+        $this->assertCount(1, $picker->pages());
+        $this->assertEquals('grandmother', $picker->pages()->first()->id());
+    }
+
+    public function testParent()
+    {
+        $picker = new PagePicker([
+            'parent' => 'grandmother'
+        ]);
+
+        $this->assertCount(1, $picker->pages());
+        $this->assertEquals('grandmother/mother', $picker->pages()->first()->id());
+        $this->assertEquals('grandmother', $picker->model()->id());
+    }
+
+    public function testParentStart()
+    {
+        $picker = new PagePicker([
+            'parent' => 'grandmother/mother'
+        ]);
+
+        $this->assertEquals($picker->start(), $this->app->site());
+    }
+
+    public function testQuery()
+    {
+        $picker = new PagePicker([
+            'query' => 'site.find("grandmother/mother").children'
+        ]);
+
+        $this->assertCount(3, $picker->pages());
+        $this->assertEquals('grandmother/mother/child-a', $picker->pages()->first()->id());
+        $this->assertEquals('grandmother/mother/child-c', $picker->pages()->last()->id());
+    }
+
+    public function testQueryAndParent()
+    {
+        $picker = new PagePicker([
+            'query'  => 'site.find("grandmother").children',
+            'parent' => 'grandmother/mother'
+        ]);
+
+        $this->assertCount(3, $picker->pages());
+        $this->assertEquals('grandmother/mother/child-a', $picker->pages()->first()->id());
+        $this->assertEquals('grandmother/mother/child-c', $picker->pages()->last()->id());
+    }
+
+    public function testQueryStart()
+    {
+        $picker = new PagePicker([
+            'query'  => 'site.find("grandmother").children',
+            'parent' => 'grandmother/mother'
+        ]);
+
+        $this->assertEquals('grandmother', $picker->start()->id());
+    }
+}

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -135,7 +135,65 @@ class PagePickerMixinTest extends TestCase
         $page = new Page([
             'slug' => 'test',
             'children' => [
-                ['slug' => 'a'],
+                [
+                    'slug' => 'a',
+                    'children' => [
+                        ['slug' => 'aa'],
+                        ['slug' => 'ab'],
+                        ['slug' => 'ac'],
+                    ]
+                ],
+                ['slug' => 'b'],
+                ['slug' => 'c'],
+            ]
+        ]);
+
+        $field = $this->field('test', [
+            'model' => $page
+        ]);
+        
+        $response = $field->pages();
+        $pages    = $response['pages'];
+        $model    = $response['model'];
+        
+        $this->assertCount(3, $model);
+        $this->assertNull($model['id']);
+        $this->assertNull($model['parent']);
+        $this->assertSame('test', $model['title']);
+        
+        $this->assertCount(3, $pages);
+        $this->assertSame('test/a', $pages[0]['id']);
+        $this->assertSame('test/b', $pages[1]['id']);
+        $this->assertSame('test/c', $pages[2]['id']);
+    }
+    
+    public function testPageChildrenWithoutSubpages()
+    {
+        Field::$types = [
+            'test' => [
+                'mixins'  => ['pagepicker'],
+                'methods' => [
+                    'pages' => function () {
+                        return $this->pagepicker([
+                            'query'    => 'page.children',
+                            'subpages' => false
+                        ]);
+                    }
+                ]
+            ]
+        ];
+
+        $page = new Page([
+            'slug' => 'test',
+            'children' => [
+                [
+                    'slug' => 'a',
+                    'children' => [
+                        ['slug' => 'aa'],
+                        ['slug' => 'ab'],
+                        ['slug' => 'ac'],
+                    ]
+                ],
                 ['slug' => 'b'],
                 ['slug' => 'c'],
             ]
@@ -147,8 +205,9 @@ class PagePickerMixinTest extends TestCase
 
         $response = $field->pages();
         $pages    = $response['pages'];
+        $model    = $response['model'];
 
-        $this->assertNull($response['model']);
+        $this->assertNull($model);
         $this->assertCount(3, $pages);
         $this->assertEquals('test/a', $pages[0]['id']);
         $this->assertEquals('test/b', $pages[1]['id']);


### PR DESCRIPTION
## Describe the PR

Allows you to include sub-pages with using query or not

I didn't want to separate options as `subpages` and `querySubpages` as @lukasbestle suggested. This could create a bit of confusion for users and code
I wanted to make a simpler and more comprehensive (with query or not) implement with one option as `subpages`
Including subpages default option is enabled and to disable set as `subpages: false`

**Usage**:

```yaml
fields:
    testWithDefault:
        type: pages
        multiple: true
        
    testWithoutSubpages:
        type: pages
        multiple: true
        subpages: false
        
    testWithQuerySubpages:
        type: pages
        multiple: true
        query: site.find("test").children
```

**Note**:
@lukasbestle I know i can't write a very effective unit test. I think a different method needs to be applied for child elements. Therefore, it may be necessary to review the `testPageChildren()` test 😇 

**Additional idea**: 
In addition, you can select pages from specific levels by adding depth option. If approval is given, I can implement this idea. For ex:

```yaml
fields:
    testWithDepth:
        type: pages
        multiple: true
        depth: 2

```

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/217

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
