### PR TITLE
New Visitor class methods for preferred MIME type

### DIFF
--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -29,18 +29,17 @@ trait AppErrors
 
     protected function handleErrors()
     {
-        $request = $this->request();
-
-        // TODO: implement acceptance
-        if ($request->ajax()) {
-            return $this->handleJsonErrors();
+        if ($this->request()->cli() === true) {
+            $this->handleCliErrors();
+            return;
         }
 
-        if ($request->cli()) {
-            return $this->handleCliErrors();
+        if ($this->visitor()->prefersJson() === true) {
+            $this->handleJsonErrors();
+            return;
         }
 
-        return $this->handleHtmlErrors();
+        $this->handleHtmlErrors();
     }
 
     protected function handleHtmlErrors()

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -194,7 +194,7 @@ class Visitor
 
             // test each option against wildcard `Accept` values
             foreach ($mimeTypes as $expectedMime) {
-                if (Mime::matchWildcard($acceptedMime->type(), $expectedMime) === true) {
+                if (Mime::matches($expectedMime, $acceptedMime->type()) === true) {
                     return $expectedMime;
                 }
             }

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -178,6 +178,43 @@ class Visitor
     }
 
     /**
+     * Returns the MIME type from the provided list that
+     * is most accepted (= preferred) by the visitor
+     *
+     * @param string ...$mimeTypes MIME types to query for
+     * @return string|null Preferred MIME type
+     */
+    public function preferredMimeType(string ...$mimeTypes): ?string
+    {
+        foreach ($this->acceptedMimeTypes() as $acceptedMime) {
+            // look for direct matches
+            if (in_array($acceptedMime->type(), $mimeTypes)) {
+                return $acceptedMime->type();
+            }
+
+            // test each option against wildcard `Accept` values
+            foreach ($mimeTypes as $expectedMime) {
+                if (Mime::matchWildcard($acceptedMime->type(), $expectedMime) === true) {
+                    return $expectedMime;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true if the visitor prefers a JSON response over
+     * an HTML response based on the `Accept` request header
+     *
+     * @return bool
+     */
+    public function prefersJson(): bool
+    {
+        return $this->preferredMimeType('application/json', 'text/html') === 'application/json';
+    }
+
+    /**
      * Sets the ip address if provided
      * or returns the ip of the current
      * visitor otherwise

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -6,7 +6,7 @@ use SimpleXMLElement;
 
 /**
  * The `Mime` class provides method
- * for mime type detection or guessing
+ * for MIME type detection or guessing
  * from different criteria like
  * extensions etc.
  *
@@ -19,7 +19,7 @@ use SimpleXMLElement;
 class Mime
 {
     /**
-     * Extension to mime type map
+     * Extension to MIME type map
      *
      * @var array
      */
@@ -112,7 +112,7 @@ class Mime
     ];
 
     /**
-     * Fixes an invalid mime type guess for the given file
+     * Fixes an invalid MIME type guess for the given file
      *
      * @param string $file
      * @param string $mime
@@ -153,7 +153,7 @@ class Mime
     }
 
     /**
-     * Guesses a mime type by extension
+     * Guesses a MIME type by extension
      *
      * @param string $extension
      * @return string|null
@@ -165,7 +165,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @return string|false
@@ -183,7 +183,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @return string|false
@@ -198,7 +198,7 @@ class Mime
     }
 
     /**
-     * Tries to detect a valid SVG and returns the mime type accordingly
+     * Tries to detect a valid SVG and returns the MIME type accordingly
      *
      * @param string $file
      * @return string|false
@@ -219,7 +219,8 @@ class Mime
     }
 
     /**
-     * Undocumented function
+     * Tests if a given MIME type is matched by an `Accept` header
+     * pattern; returns true if the MIME type is contained at all
      *
      * @param string $mime
      * @param string $pattern
@@ -252,7 +253,7 @@ class Mime
     }
 
     /**
-     * Returns the extension for a given mime type
+     * Returns the extension for a given MIME type
      *
      * @param string|null $mime
      * @return string|false
@@ -273,7 +274,7 @@ class Mime
     }
 
     /**
-     * Returns all available extensions for a given mime type
+     * Returns all available extensions for a given MIME type
      *
      * @param string|null $mime
      * @return array
@@ -298,7 +299,7 @@ class Mime
     }
 
     /**
-     * Returns the mime type of a file
+     * Returns the MIME type of a file
      *
      * @param string $file
      * @param string $extension
@@ -327,7 +328,7 @@ class Mime
     }
 
     /**
-     * Returns all detectable mime types
+     * Returns all detectable MIME types
      *
      * @return array
      */

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -230,12 +230,25 @@ class Mime
         $accepted = Str::accepted($pattern);
 
         foreach ($accepted as $m) {
-            if (fnmatch($m['value'], $mime, FNM_PATHNAME) === true) {
+            if (static::matchWildcard($m['value'], $mime) === true) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Tests if a MIME wildcard pattern from an `Accept` header
+     * matches a given type
+     *
+     * @param string $wildcard
+     * @param string $test
+     * @return bool
+     */
+    public static function matchWildcard(string $wildcard, string $test): bool
+    {
+        return fnmatch($wildcard, $test, FNM_PATHNAME) === true;
     }
 
     /**

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -231,7 +231,7 @@ class Mime
         $accepted = Str::accepted($pattern);
 
         foreach ($accepted as $m) {
-            if (static::matchWildcard($m['value'], $mime) === true) {
+            if (static::matches($mime, $m['value']) === true) {
                 return true;
             }
         }
@@ -243,11 +243,11 @@ class Mime
      * Tests if a MIME wildcard pattern from an `Accept` header
      * matches a given type
      *
-     * @param string $wildcard
      * @param string $test
+     * @param string $wildcard
      * @return bool
      */
-    public static function matchWildcard(string $wildcard, string $test): bool
+    public static function matches(string $test, string $wildcard): bool
     {
         return fnmatch($wildcard, $test, FNM_PATHNAME) === true;
     }

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -471,6 +471,7 @@ class RouterTest extends TestCase
 
         // set the accepted visitor language
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;
+        $app = $app->clone();
 
         $response = $app->call('/');
 

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -50,13 +50,54 @@ class VisitorTest extends TestCase
         $this->assertEquals('Kirby', $visitor->userAgent());
     }
 
-    public function testAccepts()
+    public function testAcceptsMimeType()
     {
         $visitor = new Visitor();
         $this->assertFalse($visitor->acceptsMimeType('text/html'));
 
         $visitor = new Visitor(['acceptedMimeType' => 'text/html']);
         $this->assertTrue($visitor->acceptsMimeType('text/html'));
+        $this->assertFalse($visitor->acceptsMimeType('application/json'));
+    }
+
+    public function testPreferredMimeType()
+    {
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json,text/plain;q=0.9,text/*;q=0.7']);
+
+        $this->assertSame('text/html', $visitor->preferredMimeType('text/html'));
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/plain'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('application/json'));
+        $this->assertSame('text/xml', $visitor->preferredMimeType('text/xml'));
+        $this->assertNull($visitor->preferredMimeType('application/yaml'));
+
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/html', 'text/plain'));
+        $this->assertSame('text/plain', $visitor->preferredMimeType('text/plain', 'text/xml'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/plain', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/xml', 'application/json'));
+
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'text/plain', 'application/json'));
+        $this->assertSame('application/json', $visitor->preferredMimeType('text/html', 'text/plain', 'application/json', 'text/xml'));
+
+        $this->assertSame('application/json', $visitor->preferredMimeType('application/yaml', 'application/json'));
+    }
+
+    public function testPrefersJson()
+    {
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json']);
+        $this->assertTrue($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'application/json']);
+        $this->assertTrue($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html,application/json;q=0.8']);
+        $this->assertFalse($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/html']);
+        $this->assertFalse($visitor->prefersJson());
+
+        $visitor = new Visitor(['acceptedMimeType' => 'text/xml']);
+        $this->assertFalse($visitor->prefersJson());
     }
 
     public function testAcceptsLanguage()

--- a/tests/Toolkit/MimeTest.php
+++ b/tests/Toolkit/MimeTest.php
@@ -43,19 +43,19 @@ class MimeTest extends TestCase
         $this->assertFalse(Mime::isAccepted('text/xml', $pattern));
     }
 
-    public function testMatchWildcard()
+    public function testMatches()
     {
-        $this->assertTrue(Mime::matchWildcard('text/plain', 'text/plain'));
-        $this->assertTrue(Mime::matchWildcard('text/*', 'text/plain'));
-        $this->assertTrue(Mime::matchWildcard('text/*', 'text/xml'));
-        $this->assertTrue(Mime::matchWildcard('*/plain', 'text/plain'));
-        $this->assertTrue(Mime::matchWildcard('*/plain', 'application/plain'));
-        $this->assertTrue(Mime::matchWildcard('*/*', 'text/plain'));
-        $this->assertTrue(Mime::matchWildcard('*/*', 'application/json'));
+        $this->assertTrue(Mime::matches('text/plain', 'text/plain'));
+        $this->assertTrue(Mime::matches('text/plain', 'text/*'));
+        $this->assertTrue(Mime::matches('text/xml', 'text/*'));
+        $this->assertTrue(Mime::matches('text/plain', '*/plain'));
+        $this->assertTrue(Mime::matches('application/plain', '*/plain'));
+        $this->assertTrue(Mime::matches('text/plain', '*/*'));
+        $this->assertTrue(Mime::matches('application/json', '*/*'));
 
-        $this->assertFalse(Mime::matchWildcard('text/plain', 'text/xml'));
-        $this->assertFalse(Mime::matchWildcard('text/*', 'application/json'));
-        $this->assertFalse(Mime::matchWildcard('*/plain', 'text/xml'));
+        $this->assertFalse(Mime::matches('text/xml', 'text/plain'));
+        $this->assertFalse(Mime::matches('application/json', 'text/*'));
+        $this->assertFalse(Mime::matches('text/xml', '*/plain'));
     }
 
     public function testToExtension()

--- a/tests/Toolkit/MimeTest.php
+++ b/tests/Toolkit/MimeTest.php
@@ -31,6 +31,33 @@ class MimeTest extends TestCase
         $this->assertEquals('text/x-php', $mime);
     }
 
+    public function testIsAccepted()
+    {
+        $pattern = 'text/html,text/plain;q=0.8,application/*;q=0.7';
+
+        $this->assertTrue(Mime::isAccepted('text/html', $pattern));
+        $this->assertTrue(Mime::isAccepted('text/plain', $pattern));
+        $this->assertTrue(Mime::isAccepted('application/json', $pattern));
+        $this->assertTrue(Mime::isAccepted('application/yaml', $pattern));
+
+        $this->assertFalse(Mime::isAccepted('text/xml', $pattern));
+    }
+
+    public function testMatchWildcard()
+    {
+        $this->assertTrue(Mime::matchWildcard('text/plain', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('text/*', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('text/*', 'text/xml'));
+        $this->assertTrue(Mime::matchWildcard('*/plain', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/plain', 'application/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/*', 'text/plain'));
+        $this->assertTrue(Mime::matchWildcard('*/*', 'application/json'));
+
+        $this->assertFalse(Mime::matchWildcard('text/plain', 'text/xml'));
+        $this->assertFalse(Mime::matchWildcard('text/*', 'application/json'));
+        $this->assertFalse(Mime::matchWildcard('*/plain', 'text/xml'));
+    }
+
     public function testToExtension()
     {
         $extension = Mime::toExtension('image/jpeg');


### PR DESCRIPTION
This is the first set of changes from #2148. Removing the deprecated features requires these changes, so I will send the other two PRs once this one is merged.