### PR TITLE
Fix clickable disabled fields

### DIFF
--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -99,8 +99,11 @@ export default {
 .k-field[data-disabled] {
   cursor: not-allowed;
 }
-.k-field[data-disabled] *:not(.k-text[data-theme=help]) {
+.k-field[data-disabled] * {
   pointer-events: none;
+}
+.k-field[data-disabled] .k-text[data-theme=help] * {
+  pointer-events: initial;
 }
 .k-field-counter {
   display: none;


### PR DESCRIPTION
## Describe the PR

Reverted `[data-disabled] *` selector and add new selector for `[data-theme=help] *` in disabled fields

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2170 

Tested on 3.2.5 with Chrome, Firefox and Edge

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
