### PR TITLE
Allow same chars on file rename as on upload #2164

### DIFF
--- a/panel/src/components/Dialogs/FileRenameDialog.vue
+++ b/panel/src/components/Dialogs/FileRenameDialog.vue
@@ -68,7 +68,7 @@ export default {
         });
     },
     sluggify(input) {
-      return this.$helper.slug(input, [this.slugs, this.system.ascii], ".");
+      return this.$helper.slug(input, [this.slugs, this.system.ascii], "@._-");
     },
     submit() {
       // prevent empty name with just spaces


### PR DESCRIPTION
## Describe the PR
On upload: https://github.com/getkirby/kirby/blob/master/src/Toolkit/F.php#L652
`a-z0-9` is automatically allowed by the JS slug helper, so we only need to add the rest.

## Related issues
- Fixes #2164