### PR TITLE
Remove deprecated methods

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -122,6 +122,21 @@ function css($url, $options = null): ?string
 }
 
 /**
+ * Triggers a deprecation warning if debug mode is active
+ *
+ * @param string $message
+ * @return bool Whether the warning was triggered
+ */
+function deprecated(string $message): bool
+{
+    if (App::instance()->option('debug') === true) {
+        return trigger_error($message, E_USER_DEPRECATED) === true;
+    }
+
+    return false;
+}
+
+/**
  * Simple object and variable dumper
  * to help with debugging.
  *

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -363,6 +363,8 @@ class File extends ModelWithContent
      */
     public function meta()
     {
+        deprecated('$file->meta() is deprecated, use $file->content() instead. $file->meta() will be removed in Kirby 3.5.0.');
+
         return $this->content();
     }
 

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -256,6 +256,8 @@ trait FileActions
      */
     public function rename(string $name, bool $sanitize = true)
     {
+        deprecated('$file->rename() is deprecated, use $file->changeName() instead. $file->rename() will be removed in Kirby 3.5.0.');
+
         return $this->changeName($name, $sanitize);
     }
 

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -175,11 +175,13 @@ trait HasChildren
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasUnlistedChildren` instead
+     * @deprecated 3.0.0 Use `Page::hasUnlistedChildren()` instead
      * @return bool
      */
     public function hasInvisibleChildren(): bool
     {
+        deprecated('$page->hasInvisibleChildren() is deprecated, use $page->hasUnlistedChildren() instead. $page->hasInvisibleChildren() will be removed in Kirby 3.5.0.');
+
         return $this->hasUnlistedChildren();
     }
 
@@ -204,11 +206,13 @@ trait HasChildren
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasListedChildren` instead
+     * @deprecated 3.0.0 Use `Page::hasListedChildren()` instead
      * @return bool
      */
     public function hasVisibleChildren(): bool
     {
+        deprecated('$page->hasVisibleChildren() is deprecated, use $page->hasListedChildren() instead. $page->hasVisibleChildren() will be removed in Kirby 3.5.0.');
+
         return $this->hasListedChildren();
     }
 

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -72,11 +72,13 @@ class Languages extends Collection
     }
 
     /**
-     * @deprecated 3.0.0  Use `Languages::default()`instead
+     * @deprecated 3.0.0  Use `Languages::default()` instead
      * @return \Kirby\Cms\Language|null
      */
     public function findDefault()
     {
+        deprecated('$languages->findDefault() is deprecated, use $languages->default() instead. $languages->findDefault() will be removed in Kirby 3.5.0.');
+
         return $this->default();
     }
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -733,11 +733,13 @@ class Page extends ModelWithContent
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::isUnlisted()` intead
+     * @deprecated 3.0.0 Use `Page::isUnlisted()` instead
      * @return bool
      */
     public function isInvisible(): bool
     {
+        deprecated('$page->isInvisible() is deprecated, use $page->isUnlisted() instead. $page->isInvisible() will be removed in Kirby 3.5.0.');
+
         return $this->isUnlisted();
     }
 
@@ -794,11 +796,13 @@ class Page extends ModelWithContent
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::isListed()` intead
+     * @deprecated 3.0.0 Use `Page::isListed()` instead
      * @return bool
      */
     public function isVisible(): bool
     {
+        deprecated('$page->isVisible() is deprecated, use $page->isListed() instead. $page->isVisible() will be removed in Kirby 3.5.0.');
+
         return $this->isListed();
     }
 

--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -14,11 +14,13 @@ namespace Kirby\Cms;
 trait PageSiblings
 {
     /**
-     * @deprecated 3.0.0 Use `Page::hasNextUnlisted` instead
+     * @deprecated 3.0.0 Use `Page::hasNextUnlisted()` instead
      * @return bool
      */
     public function hasNextInvisible(): bool
     {
+        deprecated('$page->hasNextInvisible() is deprecated, use $page->hasNextUnlisted() instead. $page->hasNextInvisible() will be removed in Kirby 3.5.0.');
+
         return $this->hasNextUnlisted();
     }
 
@@ -45,20 +47,24 @@ trait PageSiblings
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasNextListed` instead
+     * @deprecated 3.0.0 Use `Page::hasNextListed()` instead
      * @return bool
      */
     public function hasNextVisible(): bool
     {
+        deprecated('$page->hasNextVisible() is deprecated, use $page->hasNextListed() instead. $page->hasNextVisible() will be removed in Kirby 3.5.0.');
+
         return $this->hasNextListed();
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasPrevUnlisted` instead
+     * @deprecated 3.0.0 Use `Page::hasPrevUnlisted()` instead
      * @return bool
      */
     public function hasPrevInvisible(): bool
     {
+        deprecated('$page->hasPrevInvisible() is deprecated, use $page->hasPrevUnlisted() instead. $page->hasPrevInvisible() will be removed in Kirby 3.5.0.');
+
         return $this->hasPrevUnlisted();
     }
 
@@ -85,11 +91,13 @@ trait PageSiblings
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::hasPrevListed instead`
+     * @deprecated 3.0.0 Use `Page::hasPrevListed()` instead
      * @return bool
      */
     public function hasPrevVisible(): bool
     {
+        deprecated('$page->hasPrevVisible() is deprecated, use $page->hasPrevListed() instead. $page->hasPrevVisible() will be removed in Kirby 3.5.0.');
+
         return $this->hasPrevListed();
     }
 
@@ -99,6 +107,8 @@ trait PageSiblings
      */
     public function nextInvisible()
     {
+        deprecated('$page->nextInvisible() is deprecated, use $page->nextUnlisted() instead. $page->nextInvisible() will be removed in Kirby 3.5.0.');
+
         return $this->nextUnlisted();
     }
 
@@ -123,11 +133,13 @@ trait PageSiblings
     }
 
     /**
-     * @deprecated 3.0.0 Use `Page::prevListed()` instead
+     * @deprecated 3.0.0 Use `Page::nextListed()` instead
      * @return self|null
      */
     public function nextVisible()
     {
+        deprecated('$page->nextVisible() is deprecated, use $page->nextListed() instead. $page->nextVisible() will be removed in Kirby 3.5.0.');
+
         return $this->nextListed();
     }
 
@@ -137,6 +149,8 @@ trait PageSiblings
      */
     public function prevInvisible()
     {
+        deprecated('$page->prevInvisible() is deprecated, use $page->prevUnlisted() instead. $page->prevInvisible() will be removed in Kirby 3.5.0.');
+
         return $this->prevUnlisted();
     }
 
@@ -166,6 +180,8 @@ trait PageSiblings
      */
     public function prevVisible()
     {
+        deprecated('$page->prevVisible() is deprecated, use $page->prevListed() instead. $page->prevVisible() will be removed in Kirby 3.5.0.');
+
         return $this->prevListed();
     }
 

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -344,13 +344,15 @@ class Pages extends Collection
     }
 
     /**
-     * Deprecated alias for Pages::unlisted()
+     * @deprecated 3.0.0 Use `Pages::unlisted()` instead
      *
      * @return self
      */
     public function invisible()
     {
-        return $this->filterBy('isUnlisted', '==', true);
+        deprecated('$pages->invisible() is deprecated, use $pages->unlisted() instead. $pages->invisible() will be removed in Kirby 3.5.0.');
+
+        return $this->unlisted();
     }
 
     /**
@@ -501,12 +503,14 @@ class Pages extends Collection
     }
 
     /**
-     * Deprecated alias for Pages::listed()
+     * @deprecated 3.0.0 Use `Pages::listed()` instead
      *
      * @return \Kirby\Cms\Pages
      */
     public function visible()
     {
-        return $this->filterBy('isListed', '==', true);
+        deprecated('$pages->visible() is deprecated, use $pages->listed() instead. $pages->visible() will be removed in Kirby 3.5.0.');
+
+        return $this->listed();
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -143,16 +143,6 @@ class Request
     }
 
     /**
-     * Detects ajax requests
-     * @deprecated 3.1.0 No longer reliable, especially with the fetch api.
-     * @return bool
-     */
-    public function ajax(): bool
-    {
-        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
-    }
-
-    /**
      * Returns the Auth object if authentication is set
      *
      * @return \Kirby\Http\Request\Auth\BasicAuth|\Kirby\Http\Request\Auth\BearerAuth|null

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -155,6 +155,23 @@ class HelpersTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testDeprecated()
+    {
+        // with disabled debug mode
+        $this->assertFalse(deprecated('The xyz method is deprecated.'));
+
+        $this->kirby = $this->kirby->clone([
+            'options' => [
+                'debug' => true
+            ]
+        ]);
+
+        // with enabled debug mode
+        $this->expectException('Whoops\Exception\ErrorException');
+        $this->expectExceptionMessage('The xyz method is deprecated.');
+        deprecated('The xyz method is deprecated.');
+    }
+
     public function testDumpHelperOnCli()
     {
         $this->assertEquals("test\n", dump('test', false));

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -70,7 +70,6 @@ class LanguagesTest extends TestCase
     public function testDefault()
     {
         $this->assertEquals('en', $this->languages->default()->code());
-        $this->assertEquals('en', $this->languages->findDefault()->code());
     }
 
     public function testMultipleDefault()

--- a/tests/Cms/Pages/PageChildrenTest.php
+++ b/tests/Cms/Pages/PageChildrenTest.php
@@ -62,7 +62,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertTrue($page->hasListedChildren());
-        $this->assertTrue($page->hasVisibleChildren());
     }
 
     public function testHasNoListedChildren()
@@ -75,7 +74,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertFalse($page->hasListedChildren());
-        $this->assertFalse($page->hasVisibleChildren());
     }
 
     public function testHasUnlistedChildren()
@@ -88,7 +86,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertTrue($page->hasUnlistedChildren());
-        $this->assertTrue($page->hasInvisibleChildren());
     }
 
     public function testHasNoUnlistedChildren()
@@ -101,7 +98,6 @@ class PageChildrenTest extends TestCase
         ]);
 
         $this->assertFalse($page->hasUnlistedChildren());
-        $this->assertFalse($page->hasInvisibleChildren());
     }
 
     public function testHasDrafts()

--- a/tests/Cms/Pages/PageSiblingsTest.php
+++ b/tests/Cms/Pages/PageSiblingsTest.php
@@ -61,9 +61,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertTrue($collection->first()->hasNextListed());
-        $this->assertTrue($collection->first()->hasNextVisible());
         $this->assertFalse($collection->last()->hasNextListed());
-        $this->assertFalse($collection->last()->hasNextVisible());
     }
 
     public function testHasNextUnlisted()
@@ -76,9 +74,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertTrue($collection->first()->hasNextUnlisted());
-        $this->assertTrue($collection->first()->hasNextInvisible());
         $this->assertFalse($collection->last()->hasNextUnlisted());
-        $this->assertFalse($collection->last()->hasNextInvisible());
     }
 
     public function testHasPrev()
@@ -99,9 +95,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertFalse($collection->first()->hasPrevListed());
-        $this->assertFalse($collection->first()->hasPrevVisible());
         $this->assertTrue($collection->last()->hasPrevListed());
-        $this->assertTrue($collection->last()->hasPrevVisible());
     }
 
     public function testHasPrevUnlisted()
@@ -114,9 +108,7 @@ class PageSiblingsTest extends TestCase
         $collection = $site->children();
 
         $this->assertFalse($collection->first()->hasPrevUnlisted());
-        $this->assertFalse($collection->first()->hasPrevInvisible());
         $this->assertTrue($collection->last()->hasPrevUnlisted());
-        $this->assertTrue($collection->last()->hasPrevInvisible());
     }
 
     public function testIndexOf()
@@ -180,7 +172,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('listed', $collection->first()->nextListed()->slug());
-        $this->assertEquals('listed', $collection->first()->nextVisible()->slug());
     }
 
     public function testNextUnlisted()
@@ -192,7 +183,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('unlisted', $collection->first()->nextUnlisted()->slug());
-        $this->assertEquals('unlisted', $collection->first()->nextInvisible()->slug());
     }
 
     public function testPrev()
@@ -222,7 +212,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('listed', $collection->last()->prevListed()->slug());
-        $this->assertEquals('listed', $collection->last()->prevVisible()->slug());
     }
 
     public function testPrevUnlisted()
@@ -234,7 +223,6 @@ class PageSiblingsTest extends TestCase
         ])->children();
 
         $this->assertEquals('unlisted', $collection->last()->prevUnlisted()->slug());
-        $this->assertEquals('unlisted', $collection->last()->prevInvisible()->slug());
     }
 
     public function testSiblings()

--- a/tests/Cms/Pages/PageStatesTest.php
+++ b/tests/Cms/Pages/PageStatesTest.php
@@ -125,14 +125,12 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertTrue($page->isListed());
-        $this->assertTrue($page->isVisible());
 
         $page = new Page([
             'slug' => 'test',
         ]);
 
         $this->assertFalse($page->isListed());
-        $this->assertFalse($page->isVisible());
     }
 
     public function testIsUnlisted()
@@ -142,7 +140,6 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertTrue($page->isUnlisted());
-        $this->assertTrue($page->isInvisible());
 
         $page = new Page([
             'slug' => 'test',
@@ -150,7 +147,6 @@ class PageStatesTest extends TestCase
         ]);
 
         $this->assertFalse($page->isUnlisted());
-        $this->assertFalse($page->isInvisible());
     }
 
     public function testIsDraft()


### PR DESCRIPTION
I'm open for discussion which methods we should remove and which ones we should keep for now.

I think that the `$request->ajax()` method should definitely be removed as it's not really useful anyway and not recommended.

We could probably keep the v2 alias methods, but then we should trigger deprecation warnings when they are called. We could then finally remove them in 3.5.0 or something.