### PR TITLE
Allow name phpmailer functions

### DIFF
--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -25,7 +25,9 @@ class Email
     protected $bcc;
     protected $cc;
     protected $from;
+    protected $fromName;
     protected $replyTo;
+    protected $replyToName;
     protected $isSent = false;
     protected $subject;
     protected $to;
@@ -75,6 +77,11 @@ class Email
         return $this->from;
     }
 
+    public function fromName(): ?string
+    {
+        return $this->fromName;
+    }
+
     public function isHtml()
     {
         return $this->body()->html() !== null;
@@ -90,6 +97,11 @@ class Email
         return $this->replyTo;
     }
 
+    public function replyToName(): ?string
+    {
+        return $this->replyToName;
+    }
+
     protected function resolveEmail($email = null, bool $multiple = true)
     {
         if ($email === null) {
@@ -97,16 +109,27 @@ class Email
         }
 
         if (is_array($email) === false) {
-            $email = [$email];
+            $email = [$email => null];
         }
 
-        foreach ($email as $address) {
+        $result = [];
+        foreach ($email as $address => $name) {
+            // convert simple email arrays to associative arrays
+            if (is_int($address) === true) {
+                // the value is the address, there is no name
+                $address = $name;
+                $result[$address] = null;
+            } else {
+                $result[$address] = $name;
+            }
+
+            // ensure that the address is valid
             if (V::email($address) === false) {
                 throw new Exception(sprintf('"%s" is not a valid email address', $address));
             }
         }
 
-        return $multiple === true ? $email : $email[0];
+        return $multiple === true ? $result : array_keys($result)[0];
     }
 
     public function send(): bool
@@ -148,9 +171,21 @@ class Email
         return $this;
     }
 
+    protected function setFromName(string $fromName = null)
+    {
+        $this->fromName = $fromName;
+        return $this;
+    }
+
     protected function setReplyTo(string $replyTo = null)
     {
         $this->replyTo = $this->resolveEmail($replyTo, false);
+        return $this;
+    }
+
+    protected function setReplyToName(string $replyToName = null)
+    {
+        $this->replyToName = $replyToName;
         return $this;
     }
 

--- a/src/Email/PHPMailer.php
+++ b/src/Email/PHPMailer.php
@@ -21,22 +21,22 @@ class PHPMailer extends Email
         $mailer = new Mailer(true);
 
         // set sender's address
-        $mailer->setFrom($this->from());
+        $mailer->setFrom($this->from(), $this->fromName() ?? '');
 
         // optional reply-to address
         if ($replyTo = $this->replyTo()) {
-            $mailer->addReplyTo($replyTo);
+            $mailer->addReplyTo($replyTo, $this->replyToName() ?? '');
         }
 
         // add (multiple) recepient, CC & BCC addresses
-        foreach ($this->to() as $to) {
-            $mailer->addAddress($to);
+        foreach ($this->to() as $email => $name) {
+            $mailer->addAddress($email, $name ?? '');
         }
-        foreach ($this->cc() as $cc) {
-            $mailer->addCC($cc);
+        foreach ($this->cc() as $email => $name) {
+            $mailer->addCC($email, $name ?? '');
         }
-        foreach ($this->bcc() as $bcc) {
-            $mailer->addBCC($bcc);
+        foreach ($this->bcc() as $email => $name) {
+            $mailer->addBCC($email, $name ?? '');
         }
 
         $mailer->Subject = $this->subject();

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -12,24 +12,33 @@ class EmailTest extends TestCase
     public function testProperties()
     {
         $email = $this->_email([
-            'from' => $form = 'no-reply@supercompany.com',
+            'from' => $from = 'no-reply@supercompany.com',
+            'fromName' => $fromName = 'Super Company NoReply',
             'to' => $to = 'someone@gmail.com',
-            'replyTo' => $replyTo = 'no-reply@supercompany.com',
+            'replyTo' => $replyTo = 'reply@supercompany.com',
+            'replyToName' => $replyToName = 'Super Company Reply',
             'subject' => $subject = 'Thank you for your contact request',
             'body' => $body = 'We will never reply',
             'cc' => $cc = [
                 'marketing@supercompany.com',
-                'sales@supercompany.com'
+                'sales@supercompany.com' => 'Super Company Sales'
             ],
             'bcc' => $cc
         ]);
 
-        $this->assertEquals($form, $email->from());
-        $this->assertEquals([$to], $email->to());
+        $expectedCc = [
+            'marketing@supercompany.com' => null,
+            'sales@supercompany.com'     => 'Super Company Sales'
+        ];
+
+        $this->assertEquals($from, $email->from());
+        $this->assertEquals($fromName, $email->fromName());
+        $this->assertEquals([$to => null], $email->to());
         $this->assertEquals($replyTo, $email->replyTo());
+        $this->assertEquals($replyToName, $email->replyToName());
         $this->assertEquals($subject, $email->subject());
-        $this->assertEquals($cc, $email->cc());
-        $this->assertEquals($cc, $email->bcc());
+        $this->assertEquals($expectedCc, $email->cc());
+        $this->assertEquals($expectedCc, $email->bcc());
 
         $this->assertInstanceOf(Body::class, $email->body());
         $this->assertEquals($body, $email->body()->text());


### PR DESCRIPTION
## Describe the PR

This PR allow name on phpmailer functions that `from`, `replyTo`, `to`, `cc`, `bcc`.

The current syntax supported only one layer (just emails).
As for the name option, it changed the definition syntax. 
I think this implement is the correct syntax usage. 
If you're thinking of a better syntax, we can close the PR. 
Therefore, it was opened as a draft because of this is just an idea 👍 

### Syntax

**1. Single email**

    'from' => 'no-reply@supercompany.com',

**2. Single email with name**

    'from' => ['no-reply@supercompany.com', 'Super Company'],

**3. Multiple email**

    'to' => [
        'john@doe.com', 
        'mark@otto.com'
    ],

**4. Multiple email with name**

    'to' => [
        ['john@doe.com', 'John Doe'],
        ['mark@otto.com', 'Mark Otto']
    ],

### Usage

````php
$kirby->email([
    'from' => ['no-reply@supercompany.com', 'Super Company'],
    'replyTo' => ['no-reply@supercompany.com', 'Super Company'],
    'to' => [
        ['john@doe.com', 'John Doe'],
        ['mark@otto.com', 'Mark Otto']
    ],
    'cc' => [
        ['anotherone@gmail.com', 'Another One']
    ],
    'bcc' => [
        ['secret@foo.com', 'Secret Foo'],
        ['secret@bar.com', 'Secret Bar']
    ],
    'subject' => 'Welcome!',
    'body'=> 'It\'s great to have you with us',
]);
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/42

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
