### PR TITLE
Flip option for pages and files sections

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -16,6 +16,12 @@ return [
     ],
     'props' => [
         /**
+         * Enables/disables reverse sorting
+         */
+        'flip' => function (bool $flip = false) {
+            return $flip;
+        },
+        /**
          * Image options to control the source and look of file previews
          */
         'image' => function ($image = null) {
@@ -81,6 +87,11 @@ return [
                 $files = $files->sortBy(...$files::sortArgs($this->sortBy));
             } elseif ($this->sortable === true) {
                 $files = $files->sortBy('sort', 'asc', 'filename', 'asc');
+            }
+
+            // flip
+            if ($this->flip === true) {
+                $files = $files->flip();
             }
 
             // apply the default pagination

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -179,6 +179,10 @@ return [
                 return false;
             }
 
+            if ($this->flip === true) {
+                return false;
+            }
+
             return true;
         },
         'upload' => function () {

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -23,6 +23,12 @@ return [
             return A::wrap($add);
         },
         /**
+         * Enables/disables reverse sorting
+         */
+        'flip' => function (bool $flip = false) {
+            return $flip;
+        },
+        /**
          * Image options to control the source and look of page previews
          */
         'image' => function ($image = null) {
@@ -120,6 +126,11 @@ return [
             // sort
             if ($this->sortBy) {
                 $pages = $pages->sortBy(...$pages::sortArgs($this->sortBy));
+            }
+
+            // flip
+            if ($this->flip === true) {
+                $pages = $pages->flip();
             }
 
             // pagination

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -233,6 +233,10 @@ return [
                 return false;
             }
 
+            if ($this->flip === true) {
+                return false;
+            }
+
             return true;
         }
     ],

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -230,7 +230,6 @@ class FilesSectionTest extends TestCase
 
     public function testHelp()
     {
-
         // single help
         $section = new Section('files', [
             'name'  => 'test',
@@ -345,5 +344,33 @@ class FilesSectionTest extends TestCase
         ]);
 
         $this->assertFalse($section->sortable());
+    }
+
+    public function testFlip()
+    {
+        $model = new Page([
+            'slug'  => 'test',
+            'files' => [
+                [
+                    'filename' => 'c.jpg'
+                ],
+                [
+                    'filename' => 'a.jpg'
+                ],
+                [
+                    'filename' => 'b.jpg'
+                ]
+            ]
+        ]);
+
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => $model,
+            'flip'  => true
+        ]);
+
+        $this->assertEquals('c.jpg', $section->data()[0]['filename']);
+        $this->assertEquals('b.jpg', $section->data()[1]['filename']);
+        $this->assertEquals('a.jpg', $section->data()[2]['filename']);
     }
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -241,6 +241,28 @@ class PagesSectionTest extends TestCase
         $this->assertFalse($section->sortable());
     }
 
+    public function testFlip()
+    {
+        $page = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-1', 'content' => ['title' => 'C']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'A']],
+                ['slug' => 'subpage-3', 'content' => ['title' => 'B']]
+            ]
+        ]);
+
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => $page,
+            'flip'  => true
+        ]);
+
+        $this->assertEquals('B', $section->data()[0]['text']);
+        $this->assertEquals('A', $section->data()[1]['text']);
+        $this->assertEquals('C', $section->data()[2]['text']);
+    }
+
     public function sortableStatusProvider()
     {
         return [


### PR DESCRIPTION
## Describe the PR

Enable/disable reverse sorting for pages and files sections

**Usage**

````yaml
sections:

  gallery:
    headline: Gallery
    type: files
    template: gallery
    flip: true

  drafts:
    headline: Drafts
    type: pages
    status: draft
    templates: article
    flip: true

````

## Related idea

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/97 [Low-hanging fruits]

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
