### PR TITLE
Feature/fresh html helper methods

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -394,7 +394,7 @@ return function (App $app) {
         'inline' => function (Field $field) {
             // List of valid inline elements taken from: https://developer.mozilla.org/de/docs/Web/HTML/Inline_elemente
             // Obsolete elements, script tags, image maps and form elements have
-            // been exluded for safety reasons and as they are most likely not
+            // been excluded for safety reasons and as they are most likely not
             // needed in most cases.
             $field->value = strip_tags($field->value, '<b><i><small><abbr><cite><code><dfn><em><kbd><strong><samp><var><a><bdo><br><img><q><span><sub><sup>');
             return $field;

--- a/config/methods.php
+++ b/config/methods.php
@@ -326,6 +326,17 @@ return function (App $app) {
         },
 
         /**
+         * Converts all line breaks in the field content to `<br>` tags.
+         *
+         * @param \Kirby\Cms\Field $field
+         * @return \Kirby\Cms\Field
+         */
+        'nl2br' => function (Field $field) {
+            $field->value = nl2br($field->value, false);
+            return $field;
+        },
+
+        /**
          * Converts the field content from Markdown/Kirbytext to valid HTML
          *
          * @param \Kirby\Cms\Field $field
@@ -369,6 +380,23 @@ return function (App $app) {
                 'field'  => $field
             ]);
 
+            return $field;
+        },
+
+        /**
+         * Strips all block-level HTML elements from the field value,
+         * it can be safely placed inside of other inline elements
+         * without the risk of breaking the HTML structure.
+         *
+         * @param \Kirby\Cms\Field $field
+         * @return \Kirby\Cms\Field
+         */
+        'inline' => function (Field $field) {
+            // List of valid inline elements taken from: https://developer.mozilla.org/de/docs/Web/HTML/Inline_elemente
+            // Obsolete elements, script tags, image maps and form elements have
+            // been exluded for safety reasons and as they are most likely not
+            // needed in most cases.
+            $field->value = strip_tags($field->value, '<b><i><small><abbr><cite><code><dfn><em><kbd><strong><samp><var><a><bdo><br><img><q><span><sub><sup>');
             return $field;
         },
 

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -483,6 +483,14 @@ class FieldMethodsTest extends TestCase
         $this->assertEquals('&ouml;', $this->field('ö')->html());
     }
 
+    public function testNl2br()
+    {
+        $input = 'Multiline' . PHP_EOL . 'test' . PHP_EOL . 'string';
+        $expected = 'Multiline<br>' . PHP_EOL . 'test<br>' . PHP_EOL . 'string';
+
+        $this->assertEquals($expected, $this->field($input)->nl2br()->value());
+    }
+
     public function testKirbytext()
     {
         $kirbytext = '(link: # text: Test)';
@@ -507,6 +515,14 @@ class FieldMethodsTest extends TestCase
         $expected  = '<a href="#">Test</a>';
 
         $this->assertEquals($expected, $this->field($kirbytext)->kirbytags());
+    }
+
+    public function testInline()
+    {
+        $html = '<div><h1>Headline</h1> <p>Subtitle with <a href="#">link</a>.</p></div>';
+        $expected = 'Headline Subtitle with <a href="#">link</a>.';
+
+        $this->assertEquals($expected, $this->field($html)->inline());
     }
 
     public function testLower()


### PR DESCRIPTION
## Describe the PR

In recent projects, I found myself adding the two field methods as decribed below as a simple plugin over and over again.  I found them very useful and thought, they might be a great addition to the core:

- **`$field->nl2br()`**: A shortcut for PHP’s built-in `nl2br()`-function, with the optional `$xhtml` parameter set to `false` (`true` by default). Use case: there’s often a need for multiline-fields without parsing Kirbytext, e.g. for usage in headlines, subtitles etc. It’s way more convenient to use Kirby’s chainable API (e.g. `<?= $page->subtitle()->html()->nl2br() ?>`), than to write `<?= nl2br($page->subtitle()->html(), false) ?>`.
- **`$field->inline()`**: Strips all HTML tags from the field value, except for a few white-listed inline elements. This method has a similar use-case, than the one described above, but is meant for places in a template, where you want to be able to safely include HTML content, that must not contain block-level elements. This is very useful for elements, such as headings and card components, where simple styling and/or the inclusion of links is desirable. I found the results of `kirbytextinline()` insufficient for these use-cases, as it does not apply filtering to the generated HTML. In contrast, the output of the new `inline()` method can be placed inside of most inline-elements without causing any issues, like breaking the HTML structure. I kept the method rather generic, so it can be applied to both Kirbytext/Markdown output and plain HTML strings. E.g.:

```php
<?php foreach ($page->cards()->toStructure() as $item): ?>
  <div class="card">
    <?php if ($icon = $item->icon()->toFile()): ?>
      <?= $icon->html() ?>
    <?php endif ?>
    <h3><?= $item->title()->html() ?></h3>
    <p><?= $item->text()->kt()->inline() ?></p>
  </div>
<?php endforeach ?>
```

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
