### PR TITLE
Add pagination to all pickers #1632

### DIFF
--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -99,9 +99,11 @@ return [
                     $field = $this->field();
 
                     return $field->filepicker([
-                        'query' => $field->query(),
                         'image' => $field->image(),
                         'info'  => $field->info(),
+                        'limit' => $field->limit(),
+                        'page'  => $this->requestQuery('page'),
+                        'query' => $field->query(),
                         'text'  => $field->text()
                     ]);
                 }

--- a/config/fields/mixins/filepicker.php
+++ b/config/fields/mixins/filepicker.php
@@ -1,40 +1,14 @@
 <?php
 
+use Kirby\Cms\FilePicker;
+
 return [
     'methods' => [
         'filepicker' => function (array $params = []) {
-
             // fetch the parent model
-            $model = $this->model();
+            $params['model'] = $this->model();
 
-            // find the right default query
-            if (empty($params['query']) === false) {
-                $query = $params['query'];
-            } elseif (is_a($model, 'Kirby\Cms\File') === true) {
-                $query = 'file.siblings';
-            } else {
-                $query = $model::CLASS_ALIAS . '.files';
-            }
-
-            // fetch all files for the picker
-            $files = $model->query($query, 'Kirby\Cms\Files');
-            $data  = [];
-
-            // prepare the response for each file
-            foreach ($files as $index => $file) {
-                if (empty($params['map']) === false) {
-                    $data[] = $params['map']($file);
-                } else {
-                    $data[] = $file->panelPickerData([
-                        'image' => $params['image'] ?? [],
-                        'info'  => $params['info'] ?? false,
-                        'model' => $model,
-                        'text'  => $params['text'] ?? '{{ file.filename }}',
-                    ]);
-                }
-            }
-
-            return $data;
+            return (new FilePicker($params))->toArray();
         }
     ]
 ];

--- a/config/fields/mixins/userpicker.php
+++ b/config/fields/mixins/userpicker.php
@@ -1,44 +1,13 @@
 <?php
 
+use Kirby\Cms\UserPicker;
+
 return [
     'methods' => [
         'userpicker' => function (array $params = []) {
+            $params['model'] = $this->model();
 
-            // fetch the parent model
-            $model = $this->model();
-
-            // find the right default query
-            if (empty($params['query']) === false) {
-                $query = $params['query'];
-            } elseif (is_a($model, 'Kirby\Cms\User') === true) {
-                $query = 'user.siblings';
-            } else {
-                $query = 'kirby.users';
-            }
-
-            // fetch all users for the picker
-            $users = $model->query($query, 'Kirby\Cms\Users');
-            $data  = [];
-
-            if (!$users) {
-                return [];
-            }
-
-            // prepare the response for each user
-            foreach ($users->sortBy('username', 'asc') as $index => $user) {
-                if (empty($params['map']) === false) {
-                    $data[] = $params['map']($user);
-                } else {
-                    $data[] = $user->panelPickerData([
-                        'image' => $params['image'] ?? [],
-                        'info'  => $params['info'] ?? false,
-                        'model' => $model,
-                        'text'  => $params['text'] ?? '{{ user.username }}',
-                    ]);
-                }
-            }
-
-            return $data;
+            return (new UserPicker($params))->toArray();
         }
     ]
 ];

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -75,9 +75,11 @@ return [
                     $field = $this->field();
 
                     return $field->userpicker([
-                        'query' => $field->query(),
                         'image' => $field->image(),
                         'info'  => $field->info(),
+                        'limit' => $field->limit(),
+                        'page'  => $this->requestQuery('page'),
+                        'query' => $field->query(),
                         'text'  => $field->text()
                     ]);
                 }

--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -12,34 +12,42 @@
     </template>
 
     <template v-else>
-      <k-list v-if="models.length">
-        <k-list-item
-          v-for="file in models"
-          :key="file.filename"
-          :text="file.text"
-          :info="file.info"
-          :image="file.image"
-          :icon="file.icon"
-          @click="toggle(file)"
-        >
-          <k-button
-            v-if="isSelected(file)"
-            slot="options"
-            :autofocus="true"
-            :icon="checkedIcon"
-            :tooltip="$t('remove')"
-            theme="positive"
-          />
-          <k-button
-            v-else
-            slot="options"
-            :autofocus="true"
-            :tooltip="$t('select')"
-            icon="circle-outline"
-          />
-        </k-list-item>
-      </k-list>
-
+      <template v-if="models.length">
+        <k-list>
+          <k-list-item
+            v-for="file in models"
+            :key="file.filename"
+            :text="file.text"
+            :info="file.info"
+            :image="file.image"
+            :icon="file.icon"
+            @click="toggle(file)"
+          >
+            <k-button
+              v-if="isSelected(file)"
+              slot="options"
+              :autofocus="true"
+              :icon="checkedIcon"
+              :tooltip="$t('remove')"
+              theme="positive"
+            />
+            <k-button
+              v-else
+              slot="options"
+              :autofocus="true"
+              :tooltip="$t('select')"
+              icon="circle-outline"
+            />
+          </k-list-item>
+        </k-list>
+        <k-pagination
+          :details="true"
+          :dropdown="false"
+          v-bind="pagination"
+          align="center"
+          @paginate="paginate"
+        />
+      </template>
       <k-empty v-else icon="image">
         {{ $t("dialog.files.empty") }}
       </k-empty>
@@ -58,5 +66,11 @@ export default {
 <style lang="scss">
 .k-files-dialog .k-list-item {
   cursor: pointer;
+}
+.k-files-dialog .k-pagination {
+  margin-bottom: -1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -64,7 +64,7 @@
           :dropdown="false"
           v-bind="pagination"
           align="center"
-          @paginate="onPaginate"
+          @paginate="paginate"
         />
       </template>
       <k-empty v-else icon="page">
@@ -87,11 +87,6 @@ export default {
         title: null,
         parent: null
       },
-      pagination: {
-        limit: 20,
-        page: 1,
-        total: 0
-      },
       options: {
         ...mixin.options,
         parent: null,
@@ -102,7 +97,6 @@ export default {
     fetchData() {
       return {
         parent: this.options.parent,
-        page: this.pagination.page,
       };
     }
   },
@@ -117,18 +111,9 @@ export default {
       this.pagination.page = 1;
       this.fetch();
     },
-    onClose() {
-      this.pagination.page = 1;
-    },
     onFetched(response) {
-      this.model      = response.model;
-      this.pagination = response.pagination;
+      this.model = response.model;
     },
-    onPaginate(pagination) {
-      this.pagination.page  = pagination.page;
-      this.pagination.limit = pagination.limit;
-      this.fetch();
-    }
   }
 };
 </script>

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -5,7 +5,6 @@
     size="medium"
     @cancel="$emit('cancel')"
     @submit="submit"
-    @close="onClose"
   >
     <template v-if="issue">
       <k-box :text="issue" theme="negative" />

--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -12,33 +12,41 @@
     </template>
 
     <template v-else>
-      <k-list v-if="models.length">
-        <k-list-item
-          v-for="user in models"
-          :key="user.email"
-          :text="user.username"
-          :image="user.image"
-          :icon="user.icon"
-          @click="toggle(user)"
-        >
-          <k-button
-            v-if="isSelected(user)"
-            slot="options"
-            :autofocus="true"
-            :icon="checkedIcon"
-            :tooltip="$t('remove')"
-            theme="positive"
-          />
-          <k-button
-            v-else
-            slot="options"
-            :autofocus="true"
-            :tooltip="$t('select')"
-            icon="circle-outline"
-          />
-        </k-list-item>
-      </k-list>
-
+      <template v-if="models.length">
+        <k-list>
+          <k-list-item
+            v-for="user in models"
+            :key="user.email"
+            :text="user.username"
+            :image="user.image"
+            :icon="user.icon"
+            @click="toggle(user)"
+          >
+            <k-button
+              v-if="isSelected(user)"
+              slot="options"
+              :autofocus="true"
+              :icon="checkedIcon"
+              :tooltip="$t('remove')"
+              theme="positive"
+            />
+            <k-button
+              v-else
+              slot="options"
+              :autofocus="true"
+              :tooltip="$t('select')"
+              icon="circle-outline"
+            />
+          </k-list-item>
+        </k-list>
+        <k-pagination
+          :details="true"
+          :dropdown="false"
+          v-bind="pagination"
+          align="center"
+          @paginate="paginate"
+        />
+      </template>
       <k-empty v-else icon="users">
         {{ $t("dialog.users.empty") }}
       </k-empty>
@@ -57,5 +65,11 @@ export default {
 <style lang="scss">
 .k-users-dialog .k-list-item {
   cursor: pointer;
+}
+.k-users-dialog .k-pagination {
+  margin-bottom: -1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/panel/src/mixins/picker/dialog.js
+++ b/panel/src/mixins/picker/dialog.js
@@ -10,6 +10,11 @@ export default {
         multiple: true,
         parent: null,
         selected: [],
+      },
+      pagination: {
+        limit: 20,
+        page: 1,
+        total: 0
       }
     }
   },
@@ -23,10 +28,16 @@ export default {
   },
   methods: {
     fetch() {
+      const params = {
+        page: this.pagination.page,
+        ...this.fetchData || {}
+      };
+
       return this.$api
-        .get(this.options.endpoint, this.fetchData || {})
+        .get(this.options.endpoint, params)
         .then(response => {
-          this.models = response.data || response.pages || response;
+          this.models     = response.data;
+          this.pagination = response.pagination;
 
           if (this.onFetched) {
             this.onFetched(response);
@@ -38,6 +49,9 @@ export default {
         });
     },
     open(files, options) {
+
+      // reset pagination
+      this.pagination.page = 0;
 
       let fetch = true;
 
@@ -69,6 +83,11 @@ export default {
       } else {
         this.$refs.dialog.open();
       }
+    },
+    paginate(pagination) {
+      this.pagination.page  = pagination.page;
+      this.pagination.limit = pagination.limit;
+      this.fetch();
     },
     submit() {
       this.$emit("submit", Object.values(this.selected));

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -90,11 +90,11 @@ class FilePicker
         // by converting site and page objects to proper
         // pages by returning their children
         if (is_a($files, 'Kirby\Cms\Site') === true) {
-            $files = $files->children();
+            $files = $files->files();
         } elseif (is_a($files, 'Kirby\Cms\Page') === true) {
-            $files = $files->children();
+            $files = $files->files();
         } elseif (is_a($files, 'Kirby\Cms\User') === true) {
-            $files = $files->children();
+            $files = $files->files();
         } elseif (is_a($files, 'Kirby\Cms\Files') === false) {
             throw new InvalidArgumentException('Your query must return a set of files');
         }

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -116,7 +116,7 @@ class FilePicker
      * @param \Kirby\Cms\Files|null $files
      * @return array
      */
-    public function filesToArray($files): array
+    public function filesToArray($files = null): array
     {
         if ($files === null) {
             return [];

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Exception\InvalidArgumentException;
+
+/**
+ * The FilePicker class helps to
+ * fetch the right files for the API calls
+ * for the file picker component in the panel.
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class FilePicker
+{
+    /**
+     * @var \Kirby\Cms\App
+     */
+    protected $kirby;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var \Kirby\Cms\Site
+     */
+    protected $site;
+
+    /**
+     * Creates a new FilePicker instance
+     *
+     * @param array $params
+     */
+    public function __construct(array $params = [])
+    {
+        // default params
+        $defaults = [
+            // image settings (ratio, cover, etc.)
+            'image' => [],
+            // query template for the file info field
+            'info' => false,
+            // number of pages displayed per pagination page
+            'limit' => 20,
+            // optional mapping function for the pages array
+            'map' => null,
+            // the reference model (site, page, file or user)
+            'model' => site(),
+            // current page when paginating
+            'page' => 1,
+            // a query string to fetch specific pages
+            'query' => null,
+            // query template for the file text field
+            'text' => '{{ file.filename }}'
+        ];
+
+        $this->options = array_merge($defaults, $params);
+        $this->kirby   = $this->options['model']->kirby();
+        $this->site    = $this->kirby->site();
+    }
+
+
+    /**
+     * Search all files for the picker
+     *
+     * @return \Kirby\Cms\Files|null
+     */
+    public function files()
+    {
+        $model = $this->options['model'];
+
+        // find the right default query
+        if (empty($this->options['query']) === false) {
+            $query = $this->options['query'];
+        } elseif (is_a($model, 'Kirby\Cms\File') === true) {
+            $query = 'file.siblings';
+        } else {
+            $query = $model::CLASS_ALIAS . '.files';
+        }
+
+        // fetch all files for the picker
+        $files = $model->query($query);
+
+        // help mitigate some typical query usage issues
+        // by converting site and page objects to proper
+        // pages by returning their children
+        if (is_a($files, 'Kirby\Cms\Site') === true) {
+            $files = $files->children();
+        } elseif (is_a($files, 'Kirby\Cms\Page') === true) {
+            $files = $files->children();
+        } elseif (is_a($files, 'Kirby\Cms\User') === true) {
+            $files = $files->children();
+        } elseif (is_a($files, 'Kirby\Cms\Files') === false) {
+            throw new InvalidArgumentException('Your query must return a set of files');
+        }
+
+        // paginate the result
+        $files = $files->paginate([
+            'limit' => $this->options['limit'],
+            'page'  => $this->options['page']
+        ]);
+
+        return $files;
+    }
+
+    /**
+     * Converts all given files to an associative
+     * array that is already optimized for the
+     * panel picker component.
+     *
+     * @param \Kirby\Cms\Files|null $files
+     * @return array
+     */
+    public function filesToArray($files): array
+    {
+        if ($files === null) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($files as $index => $file) {
+            if (empty($this->options['map']) === false) {
+                $result[] = $this->options['map']($file);
+            } else {
+                $result[] = $file->panelPickerData([
+                    'image' => $this->options['image'],
+                    'info'  => $this->options['info'],
+                    'model' => $this->options['model'],
+                    'text'  => $this->options['text'],
+                ]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the most relevant pagination
+     * info as array
+     *
+     * @param \Kirby\Cms\Pagination $pagination
+     * @return array
+     */
+    public function paginationToArray(Pagination $pagination): array
+    {
+        return [
+            'limit' => $pagination->limit(),
+            'page'  => $pagination->page(),
+            'total' => $pagination->total()
+        ];
+    }
+
+    /**
+     * Returns an associative array
+     * with all information for the picker.
+     * This will be passed directly to the API.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $files = $this->files();
+
+        return [
+            'data'       => $this->filesToArray($files),
+            'pagination' => $this->paginationToArray($files->pagination())
+        ];
+    }
+}

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -348,8 +348,8 @@ class PagePicker
         $pages = $this->pages();
 
         return [
+            'data'       => $this->pagesToArray($pages),
             'model'      => $this->modelToArray($this->model()),
-            'pages'      => $this->pagesToArray($pages),
             'pagination' => $this->paginationToArray($pages->pagination())
         ];
     }

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -134,10 +134,10 @@ class PagePicker
      * parent model that is currently selected
      * in the page picker.
      *
-     * @param \Kirby\Cms\Site|\Kirby\Cms\Page
+     * @param \Kirby\Cms\Site|\Kirby\Cms\Page|null
      * @return array|null
      */
-    public function modelToArray($model): ?array
+    public function modelToArray($model = null): ?array
     {
         if ($model === null) {
             return null;
@@ -238,7 +238,6 @@ class PagePicker
         // help mitigate some typical query usage issues
         // by converting site and page objects to proper
         // pages by returning their children
-
         if (is_a($pages, 'Kirby\Cms\Site') === true) {
             $pages = $pages->children();
         } elseif (is_a($pages, 'Kirby\Cms\Page') === true) {
@@ -258,7 +257,7 @@ class PagePicker
      * @param \Kirby\Cms\Pages|null $pages
      * @return array
      */
-    public function pagesToArray($pages): array
+    public function pagesToArray($pages = null): array
     {
         if ($pages === null) {
             return [];

--- a/src/Cms/UserPicker.php
+++ b/src/Cms/UserPicker.php
@@ -33,17 +33,17 @@ class UserPicker
         $defaults = [
             // image settings (ratio, cover, etc.)
             'image' => [],
-            // query template for the page info field
+            // query template for the user info field
             'info' => false,
-            // number of pages displayed per pagination page
+            // number of users displayed per pagination page
             'limit' => 20,
-            // optional mapping function for the pages array
+            // optional mapping function for the users array
             'map' => null,
             // the reference model (user)
             'model' => site(),
             // current page when paginating
             'page' => 1,
-            // a query string to fetch specific pages
+            // a query string to fetch specific users
             'query' => null,
             // query template for the user text field
             'text' => '{{ user.username }}'
@@ -98,7 +98,7 @@ class UserPicker
      * @param \Kirby\Cms\Users|null $users
      * @return array
      */
-    public function usersToArray($users): array
+    public function usersToArray($users = null): array
     {
         if ($users === null) {
             return [];

--- a/src/Cms/UserPicker.php
+++ b/src/Cms/UserPicker.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Exception\InvalidArgumentException;
+
+/**
+ * The UserPicker class helps to
+ * fetch the right files for the API calls
+ * for the user picker component in the panel.
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class UserPicker
+{
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Creates a new UserPicker instance
+     *
+     * @param array $params
+     */
+    public function __construct(array $params = [])
+    {
+        // default params
+        $defaults = [
+            // image settings (ratio, cover, etc.)
+            'image' => [],
+            // query template for the page info field
+            'info' => false,
+            // number of pages displayed per pagination page
+            'limit' => 20,
+            // optional mapping function for the pages array
+            'map' => null,
+            // the reference model (user)
+            'model' => site(),
+            // current page when paginating
+            'page' => 1,
+            // a query string to fetch specific pages
+            'query' => null,
+            // query template for the user text field
+            'text' => '{{ user.username }}'
+        ];
+
+        $this->options = array_merge($defaults, $params);
+    }
+
+    /**
+     * Search all users for the picker
+     *
+     * @return \Kirby\Cms\Users|null
+     */
+    public function users()
+    {
+        $model = $this->options['model'];
+
+        // find the right default query
+        if (empty($this->options['query']) === false) {
+            $query = $this->options['query'];
+        } elseif (is_a($model, 'Kirby\Cms\User') === true) {
+            $query = 'user.siblings';
+        } else {
+            $query = 'kirby.users';
+        }
+
+        // fetch all users for the picker
+        $users = $model->query($query);
+
+        // catch invalid data
+        if (is_a($users, 'Kirby\Cms\Users') === false) {
+            throw new InvalidArgumentException('Your query must return a set of users');
+        }
+
+        // sort users
+        $users = $users->sortBy('username', 'asc');
+
+        // paginate the result
+        $users = $users->paginate([
+            'limit' => $this->options['limit'],
+            'page'  => $this->options['page']
+        ]);
+
+        return $users;
+    }
+
+    /**
+     * Converts all given users to an associative
+     * array that is already optimized for the
+     * panel picker component.
+     *
+     * @param \Kirby\Cms\Users|null $users
+     * @return array
+     */
+    public function usersToArray($users): array
+    {
+        if ($users === null) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($users as $index => $user) {
+            if (empty($this->options['map']) === false) {
+                $result[] = $this->options['map']($user);
+            } else {
+                $result[] = $user->panelPickerData([
+                    'image' => $this->options['image'],
+                    'info'  => $this->options['info'],
+                    'model' => $this->options['model'],
+                    'text'  => $this->options['text'],
+                ]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the most relevant pagination
+     * info as array
+     *
+     * @param \Kirby\Cms\Pagination $pagination
+     * @return array
+     */
+    public function paginationToArray(Pagination $pagination): array
+    {
+        return [
+            'limit' => $pagination->limit(),
+            'page'  => $pagination->page(),
+            'total' => $pagination->total()
+        ];
+    }
+
+    /**
+     * Returns an associative array
+     * with all information for the picker.
+     * This will be passed directly to the API.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $users = $this->users();
+
+        return [
+            'data'       => $this->usersToArray($users),
+            'pagination' => $this->paginationToArray($users->pagination())
+        ];
+    }
+}

--- a/tests/Cms/Files/FilePickerTest.php
+++ b/tests/Cms/Files/FilePickerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class FilePickerTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'files' => [
+                    ['filename' => 'a.jpg'],
+                    ['filename' => 'b.jpg'],
+                    ['filename' => 'c.jpg']
+                ]
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+    }
+
+    public function testDefaults()
+    {
+        $picker = new FilePicker();
+
+        $this->assertCount(3, $picker->files());
+    }
+
+    public function testQuery()
+    {
+        $picker = new FilePicker([
+            'query' => 'site.files.offset(1)'
+        ]);
+
+        $this->assertCount(2, $picker->files());
+    }
+}

--- a/tests/Cms/Users/UserPickerTest.php
+++ b/tests/Cms/Users/UserPickerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class UserPickerTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'users' => [
+                ['email' => 'a@getkirby.com'],
+                ['email' => 'b@getkirby.com'],
+                ['email' => 'c@getkirby.com']
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+    }
+
+    public function testDefaults()
+    {
+        $picker = new UserPicker();
+
+        $this->assertCount(3, $picker->users());
+    }
+
+    public function testQuery()
+    {
+        $picker = new UserPicker([
+            'query' => 'kirby.users.offset(1)'
+        ]);
+
+        $this->assertCount(2, $picker->users());
+    }
+}

--- a/tests/Form/Fields/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/FilePickerMixinTest.php
@@ -16,7 +16,7 @@ class FilePickerMixinTest extends TestCase
                 'mixins'  => ['filepicker'],
                 'methods' => [
                     'files' => function () {
-                        return $this->filepicker();
+                        return $this->filepicker()['data'];
                     }
                 ]
             ]
@@ -50,7 +50,7 @@ class FilePickerMixinTest extends TestCase
                 'mixins'  => ['filepicker'],
                 'methods' => [
                     'files' => function () {
-                        return $this->filepicker();
+                        return $this->filepicker()['data'];
                     }
                 ]
             ]
@@ -84,7 +84,7 @@ class FilePickerMixinTest extends TestCase
                 'mixins'  => ['filepicker'],
                 'methods' => [
                     'files' => function () {
-                        return $this->filepicker();
+                        return $this->filepicker()['data'];
                     }
                 ]
             ]
@@ -118,7 +118,7 @@ class FilePickerMixinTest extends TestCase
                 'mixins'  => ['filepicker'],
                 'methods' => [
                     'files' => function () {
-                        return $this->filepicker();
+                        return $this->filepicker()['data'];
                     }
                 ]
             ]
@@ -158,7 +158,7 @@ class FilePickerMixinTest extends TestCase
                     'files' => function () {
                         return $this->filepicker([
                             'query' => $this->query
-                        ]);
+                        ])['data'];
                     }
                 ]
             ]
@@ -204,7 +204,7 @@ class FilePickerMixinTest extends TestCase
                             'map' => function ($file) {
                                 return $file->id();
                             }
-                        ]);
+                        ])['data'];
                     }
                 ]
             ]

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -53,7 +53,7 @@ class PagePickerMixinTest extends TestCase
         ]);
 
         $response = $field->pages();
-        $pages    = $response['pages'];
+        $pages    = $response['data'];
         $model    = $response['model'];
 
         $this->assertEquals('Test', $model['title']);
@@ -106,7 +106,7 @@ class PagePickerMixinTest extends TestCase
         ]);
 
         $response = $field->pages();
-        $pages    = $response['pages'];
+        $pages    = $response['data'];
         $model    = $response['model'];
 
         $this->assertEquals('a', $model['title']);
@@ -151,22 +151,22 @@ class PagePickerMixinTest extends TestCase
         $field = $this->field('test', [
             'model' => $page
         ]);
-        
+
         $response = $field->pages();
-        $pages    = $response['pages'];
+        $pages    = $response['data'];
         $model    = $response['model'];
-        
+
         $this->assertCount(3, $model);
         $this->assertNull($model['id']);
         $this->assertNull($model['parent']);
         $this->assertSame('test', $model['title']);
-        
+
         $this->assertCount(3, $pages);
         $this->assertSame('test/a', $pages[0]['id']);
         $this->assertSame('test/b', $pages[1]['id']);
         $this->assertSame('test/c', $pages[2]['id']);
     }
-    
+
     public function testPageChildrenWithoutSubpages()
     {
         Field::$types = [
@@ -204,7 +204,7 @@ class PagePickerMixinTest extends TestCase
         ]);
 
         $response = $field->pages();
-        $pages    = $response['pages'];
+        $pages    = $response['data'];
         $model    = $response['model'];
 
         $this->assertNull($model);
@@ -246,7 +246,7 @@ class PagePickerMixinTest extends TestCase
         ]);
 
         $response = $field->pages();
-        $pages    = $response['pages'];
+        $pages    = $response['data'];
 
         $this->assertEquals(['test/a', 'test/b', 'test/c'], $pages);
     }

--- a/tests/Form/Fields/Mixins/UserPickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/UserPickerMixinTest.php
@@ -33,7 +33,7 @@ class UserPickerMixinTest extends TestCase
                 'mixins'  => ['userpicker'],
                 'methods' => [
                     'users' => function () {
-                        return $this->userpicker();
+                        return $this->userpicker()['data'];
                     }
                 ]
             ]
@@ -64,7 +64,7 @@ class UserPickerMixinTest extends TestCase
                     'users' => function () {
                         return $this->userpicker([
                             'query' => 'kirby.users.role("editor")'
-                        ]);
+                        ])['data'];
                     }
                 ]
             ]
@@ -96,7 +96,7 @@ class UserPickerMixinTest extends TestCase
                             'map' => function ($user) {
                                 return $user->email();
                             }
-                        ]);
+                        ])['data'];
                     }
                 ]
             ]


### PR DESCRIPTION
## Describe the PR

Pagination is now implemented for all pickers (pages, users, files) and all pickers have new underlying PHP classes to refactor their spaghetti code from the fields definitions.

## Related issues

- #1632

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
