### PR TITLE
Fix opening multiselect via keys #2187

### DIFF
--- a/panel/src/components/Forms/Field/MultiselectField.vue
+++ b/panel/src/components/Forms/Field/MultiselectField.vue
@@ -6,6 +6,7 @@
     class="k-multiselect-field"
     @blur="blur"
     @keydown.native.enter.prevent="focus"
+    @keydown.native.space.prevent="focus"
   >
     <k-input
       ref="input"

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -51,8 +51,8 @@
             'disabled': !addable
           }"
           @click.prevent="select(option)"
-          @keydown.native.enter.prevent="select(option)"
-          @keydown.native.space.prevent="select(option)"
+          @keydown.native.enter.prevent.stop="select(option)"
+          @keydown.native.space.prevent.stop="select(option)"
         >
           <span v-html="option.display" />
           <span class="k-multiselect-value" v-html="option.info" />


### PR DESCRIPTION
## Describe the PR
I think this solves it. Opening works now with enter and space, selecting an item still works with enter and space as well.

## Related issues
- Fixes #2187