### PR TITLE
Improve a11n of status title in ListItem #566

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -23,6 +23,7 @@
 
   "delete": "Delete",
   "dimensions": "Dimensions",
+  "disabled": "Disabled",
   "discard": "Discard",
   "download": "Download",
   "duplicate": "Duplicate",

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -18,11 +18,16 @@
     </k-link>
     <nav class="k-list-item-options">
       <slot name="options">
-        <k-button
+        <span 
           v-if="flag"
-          v-bind="flag"
-          @click="flag.click"
-        />
+          :title="flag.tooltip" 
+          class="k-button k-list-item-status"
+        >
+          <k-button
+            v-bind="flag"
+            @click="flag.click"
+          />
+        </span>
         <k-button
           v-if="options"
           :tooltip="$t('options')"
@@ -171,6 +176,9 @@ $list-item-height: 38px;
   @media screen and (min-width: $breakpoint-small) {
     display: block;
   }
+}
+.k-list-item-status {
+  height: auto !important;
 }
 .k-list-item-options {
   position: relative;

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -18,16 +18,12 @@
     </k-link>
     <nav class="k-list-item-options">
       <slot name="options">
-        <span 
+        <k-button
           v-if="flag"
-          :title="flag.tooltip" 
-          class="k-button k-list-item-status"
-        >
-          <k-button
-            v-bind="flag"
-            @click="flag.click"
-          />
-        </span>
+          v-bind="flag"
+          class="k-list-item-status"
+          @click="flag.click"
+        />
         <k-button
           v-if="options"
           :tooltip="$t('options')"

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -1,42 +1,16 @@
 <template>
   <component
-    v-tab
     ref="button"
-    :aria-current="current"
-    :autofocus="autofocus"
-    :id="id"
     :is="component"
-    :disabled="disabled"
-    :data-tabbed="tabbed"
-    :data-theme="theme"
-    :data-responsive="responsive"
-    :role="role"
-    :tabindex="tabindex"
-    :target="target"
-    :title="tooltip"
-    :to="link"
-    :type="link ? null : type"
-    class="k-button"
+    v-bind="$props"
     v-on="$listeners"
   >
-    <k-icon
-      v-if="icon"
-      :type="icon"
-      :alt="tooltip"
-      class="k-button-icon"
-    />
-    <span v-if="$slots.default" class="k-button-text"><slot /></span>
+    <slot />
   </component>
 </template>
 
 <script>
-/* Directives */
-import TabDirective from "@/directives/tab.js";
-
 export default {
-  directives: {
-    "tab": TabDirective,
-  },
   inheritAttrs: false,
   props: {
     autofocus: Boolean,
@@ -46,6 +20,7 @@ export default {
     id: [String, Number],
     link: String,
     responsive: Boolean,
+    rel: String,
     role: String,
     target: String,
     tabindex: String,
@@ -56,37 +31,30 @@ export default {
       default: "button"
     }
   },
-  data() {
-    return {
-      tabbed: false
-    };
-  },
   computed: {
     component() {
-      return this.link ? "k-link" : "button";
-    },
-    imageUrl() {
-      if (!this.image) {
-        return null;
+      if (this.disabled === true) {
+        return "k-button-disabled";
       }
 
-      if (typeof this.image === "object") {
-        return this.image.url;
-      }
-
-      return this.image;
+      return this.link ? "k-button-link" : "k-button-native";
     },
   },
   methods: {
     focus() {
-      this.$refs.button.focus();
+      if (this.$refs.button.focus) {
+        this.$refs.button.focus();
+      }
     },
     tab() {
-      this.focus();
-      this.tabbed = true;
+      if (this.$refs.button.tab) {
+        this.$refs.button.tab();
+      }
     },
     untab() {
-      this.tabbed = false;
+      if (this.$refs.button.untab) {
+        this.$refs.button.untab();
+      }
     }
   }
 };
@@ -105,11 +73,6 @@ button {
 button::-moz-focus-inner {
   padding: 0;
   border: 0;
-}
-.k-button[disabled],
-.k-button[data-disabled] {
-  pointer-events: none;
-  opacity: 0.5;
 }
 
 .k-button {

--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -1,0 +1,42 @@
+<template>
+  <span
+    :id="id"
+    :data-disabled="true"
+    :data-responsive="responsive"
+    :data-theme="theme"
+    :title="tooltip"
+    class="k-button"
+  >
+    <k-icon
+      v-if="icon"
+      :type="icon"
+      :alt="tooltip"
+      class="k-button-icon"
+    />
+    <span v-if="$slots.default" class="k-button-text"><slot /></span>
+  </span>
+</template>
+
+<script>
+export default {
+  inheritAttrs: false,
+  props: {
+    icon: String,
+    id: [String, Number],
+    responsive: Boolean,
+    theme: String,
+    tooltip: String,
+  }
+};
+</script>
+
+<style lang="scss">
+.k-button[data-disabled] {
+  opacity: 0.5;
+  cursor: default;
+}
+.k-button[data-disabled]:focus .k-button-text,
+.k-button[data-disabled]:hover .k-button-text {
+  opacity: 0.75;
+}
+</style>

--- a/panel/src/components/Navigation/ButtonLink.vue
+++ b/panel/src/components/Navigation/ButtonLink.vue
@@ -1,0 +1,48 @@
+<template>
+  <k-link
+    :aria-current="current"
+    :autofocus="autofocus"
+    :id="id"
+    :data-theme="theme"
+    :data-responsive="responsive"
+    :rel="rel"
+    :role="role"
+    :tabindex="tabindex"
+    :target="target"
+    :title="tooltip"
+    :to="link"
+    class="k-button"
+    v-on="$listeners"
+  >
+    <k-icon
+      v-if="icon"
+      :type="icon"
+      :alt="tooltip"
+      class="k-button-icon"
+    />
+    <span v-if="$slots.default" class="k-button-text"><slot /></span>
+  </k-link>
+</template>
+
+<script>
+import tab from "@/mixins/tab.js";
+
+export default {
+  mixins: [tab],
+  inheritAttrs: false,
+  props: {
+    autofocus: Boolean,
+    current: [String, Boolean],
+    icon: String,
+    id: [String, Number],
+    link: String,
+    rel: String,
+    responsive: Boolean,
+    role: String,
+    target: String,
+    tabindex: String,
+    theme: String,
+    tooltip: String,
+  }
+};
+</script>

--- a/panel/src/components/Navigation/ButtonNative.vue
+++ b/panel/src/components/Navigation/ButtonNative.vue
@@ -1,0 +1,47 @@
+<template>
+  <button
+    :aria-current="current"
+    :autofocus="autofocus"
+    :id="id"
+    :data-theme="theme"
+    :data-responsive="responsive"
+    :role="role"
+    :tabindex="tabindex"
+    :title="tooltip"
+    :type="type"
+    class="k-button"
+    v-on="$listeners"
+  >
+    <k-icon
+      v-if="icon"
+      :type="icon"
+      :alt="tooltip"
+      class="k-button-icon"
+    />
+    <span v-if="$slots.default" class="k-button-text"><slot /></span>
+  </button>
+</template>
+
+<script>
+import tab from "@/mixins/tab.js";
+
+export default {
+  mixins: [tab],
+  inheritAttrs: false,
+  props: {
+    autofocus: Boolean,
+    current: [String, Boolean],
+    icon: String,
+    id: [String, Number],
+    responsive: Boolean,
+    role: String,
+    tabindex: String,
+    theme: String,
+    tooltip: String,
+    type: {
+      type: String,
+      default: "button"
+    }
+  }
+};
+</script>

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -155,12 +155,13 @@ export default {
     },
     items(data) {
       return data.map(page => {
+        const isEnabled = page.permissions.changeStatus !== false;
+        
         page.flag = {
           class: "k-status-flag k-status-flag-" + page.status,
-          tooltip: this.$t("page.status"),
-          icon:
-            page.permissions.changeStatus === false ? "protected" : "circle",
-          disabled: page.permissions.changeStatus === false,
+          tooltip: isEnabled ? this.$t("page.status") : `${this.$t("page.status")} (${this.$t("disabled")})`,
+          icon: isEnabled ? "circle" : "protected",
+          disabled: !isEnabled,
           click: () => {
             this.action(page, "status");
           }

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -27,6 +27,7 @@
           :disabled="!permissions.changeStatus || isLocked"
           :icon="!permissions.changeStatus || isLocked ? 'protected' : 'circle'"
           :responsive="true"
+          :tooltip="status.label"
           @click="action('status')"
         >
           {{ status.label }}

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -245,7 +245,10 @@ Vue.component("k-text", Text);
 
 /* Navigation */
 import Button from "@/components/Navigation/Button.vue";
+import ButtonDisabled from "@/components/Navigation/ButtonDisabled.vue";
 import ButtonGroup from "@/components/Navigation/ButtonGroup.vue";
+import ButtonLink from "@/components/Navigation/ButtonLink.vue";
+import ButtonNative from "@/components/Navigation/ButtonNative.vue";
 import Dropdown from "@/components/Navigation/Dropdown.vue";
 import DropdownContent from "@/components/Navigation/DropdownContent.vue";
 import DropdownItem from "@/components/Navigation/DropdownItem.vue";
@@ -258,7 +261,10 @@ import Tag from "@/components/Navigation/Tag.vue";
 import Topbar from "@/components/Navigation/Topbar.vue";
 
 Vue.component("k-button", Button);
+Vue.component("k-button-disabled", ButtonDisabled);
 Vue.component("k-button-group", ButtonGroup);
+Vue.component("k-button-link", ButtonLink);
+Vue.component("k-button-native", ButtonNative);
 Vue.component("k-dropdown", Dropdown);
 Vue.component("k-dropdown-content", DropdownContent);
 Vue.component("k-dropdown-item", DropdownItem);

--- a/panel/src/config/directives.js
+++ b/panel/src/config/directives.js
@@ -1,8 +1,0 @@
-import tab from "@/directives/tab.js";
-
-export default {
-  install(Vue) {
-    // tab directive
-    Vue.directive("tab", tab);
-  }
-};

--- a/panel/src/main.js
+++ b/panel/src/main.js
@@ -1,5 +1,4 @@
 import App from "./App.vue";
-import Directives from "./config/directives.js";
 import Filters from "./config/filters.js";
 import Events from "./config/events.js";
 import Vue from "vue";
@@ -16,7 +15,6 @@ import "./config/i18n.js";
 import "./config/libraries.js";
 import "./config/plugins.js";
 
-Vue.use(Directives);
 Vue.use(Events);
 Vue.use(Filters);
 Vue.use(Vuelidate);

--- a/panel/src/mixins/tab.js
+++ b/panel/src/mixins/tab.js
@@ -1,0 +1,32 @@
+export default {
+  mounted() {
+    this.$el.addEventListener("keyup", this.onTab);
+    this.$el.addEventListener("blur", this.onUntab);
+  },
+  destroyed() {
+    this.$el.removeEventListener("keyup", this.onTab);
+    this.$el.removeEventListener("blur", this.onUntab);
+  },
+  methods: {
+    focus() {
+      if (this.$el.focus) {
+        this.$el.focus();
+      }
+    },
+    onTab(e) {
+      if (e.keyCode === 9) {
+        this.$el.dataset.tabbed = true;
+      }
+    },
+    onUntab() {
+      delete this.$el.dataset.tabbed;
+    },
+    tab() {
+      this.$el.focus();
+      this.$el.dataset.tabbed = true;
+    },
+    untab() {
+      delete this.$el.dataset.tabbed;
+    },
+  }
+};


### PR DESCRIPTION
## Describe the PR
The title of the status button was not shown when disabled due to `pointer-events: none`. Solved by wrapping with another element. Tbd if ideal because of additional markup or if we decide not to fix.

## Related issues
- Fixes #566
