### PR TITLE
Search option for picker fields #2208

### DIFF
--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -54,6 +54,13 @@ return [
         },
 
         /**
+         * Enable/disable the search field in the picker
+         */
+        'search' => function (bool $search = true) {
+            return $search;
+        },
+
+        /**
          * Main text for each item
          */
         'text' => function (string $text = null) {

--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -14,6 +14,7 @@
     <template v-else>
 
       <k-input
+        v-if="options.search"
         :autofocus="true"
         :placeholder="$t('search') + ' …'"
         v-model="search"

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -22,6 +22,7 @@
       </header>
 
       <k-input
+        v-if="options.search"
         :autofocus="true"
         :placeholder="$t('search') + ' …'"
         v-model="search"

--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -14,6 +14,7 @@
     <template v-else>
 
       <k-input
+        v-if="options.search"
         :autofocus="true"
         :placeholder="$t('search') + ' …'"
         v-model="search"

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -31,7 +31,7 @@
         :list="selected"
         :data-size="size"
         :handle="true"
-        :data-invalid="isInvalid" 
+        :data-invalid="isInvalid"
         @end="onInput"
       >
         <component
@@ -58,7 +58,7 @@
     <k-empty
       v-else
       :layout="layout"
-      :data-invalid="isInvalid" 
+      :data-invalid="isInvalid"
       icon="image"
       @click="open"
     >
@@ -105,6 +105,7 @@ export default {
         endpoint: this.endpoints.field,
         max: this.max,
         multiple: this.multiple,
+        search: this.search,
         selected: this.selected.map(file => file.id)
       });
     },

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -16,7 +16,7 @@
         :handle="true"
         :list="selected"
         :data-size="size"
-        :data-invalid="isInvalid" 
+        :data-invalid="isInvalid"
         @end="onInput"
       >
         <component
@@ -42,7 +42,7 @@
     <k-empty
       v-else
       :layout="layout"
-      :data-invalid="isInvalid" 
+      :data-invalid="isInvalid"
       icon="page"
       @click="open"
     >
@@ -67,6 +67,7 @@ export default {
         endpoint: this.endpoints.field,
         max: this.max,
         multiple: this.multiple,
+        search: this.search,
         selected: this.selected.map(page => page.id),
       });
     }

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -17,7 +17,7 @@
         :element="elements.list"
         :list="selected"
         :handle="true"
-        :data-invalid="isInvalid" 
+        :data-invalid="isInvalid"
         @end="onInput"
       >
         <component
@@ -42,7 +42,7 @@
     </template>
     <k-empty
       v-else
-      :data-invalid="isInvalid" 
+      :data-invalid="isInvalid"
       icon="users"
       @click="open"
     >
@@ -67,6 +67,7 @@ export default {
         endpoint: this.endpoints.field,
         max: this.max,
         multiple: this.multiple,
+        search: this.search,
         selected: this.selected.map(user => user.id)
       });
     }

--- a/panel/src/mixins/picker/dialog.js
+++ b/panel/src/mixins/picker/dialog.js
@@ -12,6 +12,7 @@ export default {
         multiple: true,
         parent: null,
         selected: [],
+        search: true
       },
       search: null,
       pagination: {

--- a/panel/src/mixins/picker/field.js
+++ b/panel/src/mixins/picker/field.js
@@ -10,6 +10,7 @@ export default {
     max: Number,
     multiple: Boolean,
     parent: String,
+    search: Boolean,
     size: String,
     text: String,
     value: {
@@ -47,15 +48,15 @@ export default {
       if (this.required && this.selected.length === 0) {
         return true;
       }
-      
+
       if (this.min && this.selected.length < this.min) {
         return true;
       }
-      
+
       if (this.max && this.selected.length > this.max) {
         return true;
       }
-      
+
       return false;
     },
     more() {

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -15,64 +15,27 @@ use Kirby\Exception\InvalidArgumentException;
  * @copyright Bastian Allgeier GmbH
  * @license   https://getkirby.com/license
  */
-class FilePicker
+class FilePicker extends Picker
 {
     /**
-     * @var \Kirby\Cms\App
-     */
-    protected $kirby;
-
-    /**
-     * @var array
-     */
-    protected $options;
-
-    /**
-     * @var \Kirby\Cms\Site
-     */
-    protected $site;
-
-    /**
-     * Creates a new FilePicker instance
+     * Extends the basic defaults
      *
-     * @param array $params
+     * @return array
      */
-    public function __construct(array $params = [])
+    public function defaults(): array
     {
-        // default params
-        $defaults = [
-            // image settings (ratio, cover, etc.)
-            'image' => [],
-            // query template for the file info field
-            'info' => false,
-            // number of pages displayed per pagination page
-            'limit' => 20,
-            // optional mapping function for the pages array
-            'map' => null,
-            // the reference model (site, page, file or user)
-            'model' => site(),
-            // current page when paginating
-            'page' => 1,
-            // a query string to fetch specific pages
-            'query' => null,
-            // search query
-            'search' => null,
-            // query template for the file text field
-            'text' => '{{ file.filename }}'
-        ];
+        $defaults = parent::defaults();
+        $defaults['text'] = '{{ file.filename }}';
 
-        $this->options = array_merge($defaults, $params);
-        $this->kirby   = $this->options['model']->kirby();
-        $this->site    = $this->kirby->site();
+        return $defaults;
     }
-
 
     /**
      * Search all files for the picker
      *
      * @return \Kirby\Cms\Files|null
      */
-    public function files()
+    public function items()
     {
         $model = $this->options['model'];
 
@@ -101,82 +64,10 @@ class FilePicker
             throw new InvalidArgumentException('Your query must return a set of files');
         }
 
+        // search
+        $files = $this->search($files);
 
-        if (empty($this->options['search']) === false) {
-            $files = $files->search($this->options['search']);
-        }
-
-        // paginate the result
-        $files = $files->paginate([
-            'limit' => $this->options['limit'],
-            'page'  => $this->options['page']
-        ]);
-
-        return $files;
-    }
-
-    /**
-     * Converts all given files to an associative
-     * array that is already optimized for the
-     * panel picker component.
-     *
-     * @param \Kirby\Cms\Files|null $files
-     * @return array
-     */
-    public function filesToArray($files = null): array
-    {
-        if ($files === null) {
-            return [];
-        }
-
-        $result = [];
-
-        foreach ($files as $index => $file) {
-            if (empty($this->options['map']) === false) {
-                $result[] = $this->options['map']($file);
-            } else {
-                $result[] = $file->panelPickerData([
-                    'image' => $this->options['image'],
-                    'info'  => $this->options['info'],
-                    'model' => $this->options['model'],
-                    'text'  => $this->options['text'],
-                ]);
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Return the most relevant pagination
-     * info as array
-     *
-     * @param \Kirby\Cms\Pagination $pagination
-     * @return array
-     */
-    public function paginationToArray(Pagination $pagination): array
-    {
-        return [
-            'limit' => $pagination->limit(),
-            'page'  => $pagination->page(),
-            'total' => $pagination->total()
-        ];
-    }
-
-    /**
-     * Returns an associative array
-     * with all information for the picker.
-     * This will be passed directly to the API.
-     *
-     * @return array
-     */
-    public function toArray(): array
-    {
-        $files = $this->files();
-
-        return [
-            'data'       => $this->filesToArray($files),
-            'pagination' => $this->paginationToArray($files->pagination())
-        ];
+        // paginate
+        return $this->paginate($files);
     }
 }

--- a/src/Cms/Picker.php
+++ b/src/Cms/Picker.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Exception\InvalidArgumentException;
+
+/**
+ * The Picker abstract is the foundation
+ * for the UserPicker, PagePicker and FilePicker
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+abstract class Picker
+{
+    /**
+     * @var \Kirby\Cms\App
+     */
+    protected $kirby;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var \Kirby\Cms\Site
+     */
+    protected $site;
+
+    /**
+     * Creates a new Picker instance
+     *
+     * @param array $params
+     */
+    public function __construct(array $params = [])
+    {
+        $this->options = array_merge($this->defaults(), $params);
+        $this->kirby   = $this->options['model']->kirby();
+        $this->site    = $this->kirby->site();
+    }
+
+    /**
+     * Return the array of default values
+     *
+     * @return array
+     */
+    protected function defaults(): array
+    {
+        // default params
+        return [
+            // image settings (ratio, cover, etc.)
+            'image' => [],
+            // query template for the info field
+            'info' => false,
+            // number of users displayed per pagination page
+            'limit' => 20,
+            // optional mapping function for the result array
+            'map' => null,
+            // the reference model
+            'model' => site(),
+            // current page when paginating
+            'page' => 1,
+            // a query string to fetch specific items
+            'query' => null,
+            // search query
+            'search' => null,
+            // query template for the text field
+            'text' =>  null
+        ];
+    }
+
+    /**
+     * Fetches all items for the picker
+     *
+     * @return \Kirby\Cms\Collection|null
+     */
+    abstract public function items();
+
+    /**
+     * Converts all given items to an associative
+     * array that is already optimized for the
+     * panel picker component.
+     *
+     * @param \Kirby\Cms\Collection|null $items
+     * @return array
+     */
+    public function itemsToArray($items = null): array
+    {
+        if ($items === null) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($items as $index => $item) {
+            if (empty($this->options['map']) === false) {
+                $result[] = $this->options['map']($item);
+            } else {
+                $result[] = $item->panelPickerData([
+                    'image' => $this->options['image'],
+                    'info'  => $this->options['info'],
+                    'model' => $this->options['model'],
+                    'text'  => $this->options['text'],
+                ]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Apply pagination to the collection
+     * of items according to the options.
+     *
+     * @param \Kirby\Cms\Collection $items
+     * @return \Kirby\Cms\Collection
+     */
+    public function paginate($items)
+    {
+        return $items->paginate([
+            'limit' => $this->options['limit'],
+            'page'  => $this->options['page']
+        ]);
+    }
+
+    /**
+     * Return the most relevant pagination
+     * info as array
+     *
+     * @param \Kirby\Cms\Pagination $pagination
+     * @return array
+     */
+    public function paginationToArray(Pagination $pagination): array
+    {
+        return [
+            'limit' => $pagination->limit(),
+            'page'  => $pagination->page(),
+            'total' => $pagination->total()
+        ];
+    }
+
+    /**
+     * Search through the collection of items
+     * if not deactivate in the options
+     *
+     * @param \Kirby\Cms\Collection $items
+     * @return \Kirby\Cms\Collection
+     */
+    public function search($items)
+    {
+        if (empty($this->options['search']) === false) {
+            return $items->search($this->options['search']);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Returns an associative array
+     * with all information for the picker.
+     * This will be passed directly to the API.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $items = $this->items();
+
+        return [
+            'data'       => $this->itemsToArray($items),
+            'pagination' => $this->paginationToArray($items->pagination()),
+        ];
+    }
+}

--- a/tests/Cms/Files/FilePickerTest.php
+++ b/tests/Cms/Files/FilePickerTest.php
@@ -30,7 +30,7 @@ class FilePickerTest extends TestCase
     {
         $picker = new FilePicker();
 
-        $this->assertCount(3, $picker->files());
+        $this->assertCount(3, $picker->items());
     }
 
     public function testQuery()
@@ -39,6 +39,6 @@ class FilePickerTest extends TestCase
             'query' => 'site.files.offset(1)'
         ]);
 
-        $this->assertCount(2, $picker->files());
+        $this->assertCount(2, $picker->items());
     }
 }

--- a/tests/Cms/Pages/PagePickerTest.php
+++ b/tests/Cms/Pages/PagePickerTest.php
@@ -41,8 +41,8 @@ class PagePickerTest extends TestCase
         $picker = new PagePicker();
 
         $this->assertEquals($this->app->site(), $picker->model());
-        $this->assertCount(1, $picker->pages());
-        $this->assertEquals('grandmother', $picker->pages()->first()->id());
+        $this->assertCount(1, $picker->items());
+        $this->assertEquals('grandmother', $picker->items()->first()->id());
     }
 
     public function testParent()
@@ -51,8 +51,8 @@ class PagePickerTest extends TestCase
             'parent' => 'grandmother'
         ]);
 
-        $this->assertCount(1, $picker->pages());
-        $this->assertEquals('grandmother/mother', $picker->pages()->first()->id());
+        $this->assertCount(1, $picker->items());
+        $this->assertEquals('grandmother/mother', $picker->items()->first()->id());
         $this->assertEquals('grandmother', $picker->model()->id());
     }
 
@@ -71,9 +71,9 @@ class PagePickerTest extends TestCase
             'query' => 'site.find("grandmother/mother").children'
         ]);
 
-        $this->assertCount(3, $picker->pages());
-        $this->assertEquals('grandmother/mother/child-a', $picker->pages()->first()->id());
-        $this->assertEquals('grandmother/mother/child-c', $picker->pages()->last()->id());
+        $this->assertCount(3, $picker->items());
+        $this->assertEquals('grandmother/mother/child-a', $picker->items()->first()->id());
+        $this->assertEquals('grandmother/mother/child-c', $picker->items()->last()->id());
     }
 
     public function testQueryAndParent()
@@ -83,9 +83,9 @@ class PagePickerTest extends TestCase
             'parent' => 'grandmother/mother'
         ]);
 
-        $this->assertCount(3, $picker->pages());
-        $this->assertEquals('grandmother/mother/child-a', $picker->pages()->first()->id());
-        $this->assertEquals('grandmother/mother/child-c', $picker->pages()->last()->id());
+        $this->assertCount(3, $picker->items());
+        $this->assertEquals('grandmother/mother/child-a', $picker->items()->first()->id());
+        $this->assertEquals('grandmother/mother/child-c', $picker->items()->last()->id());
     }
 
     public function testQueryStart()

--- a/tests/Cms/Users/UserPickerTest.php
+++ b/tests/Cms/Users/UserPickerTest.php
@@ -28,7 +28,7 @@ class UserPickerTest extends TestCase
     {
         $picker = new UserPicker();
 
-        $this->assertCount(3, $picker->users());
+        $this->assertCount(3, $picker->items());
     }
 
     public function testQuery()
@@ -37,6 +37,6 @@ class UserPickerTest extends TestCase
             'query' => 'kirby.users.offset(1)'
         ]);
 
-        $this->assertCount(2, $picker->users());
+        $this->assertCount(2, $picker->items());
     }
 }


### PR DESCRIPTION
## Describe the PR

Each picker field now has a search option, which can be used to switch off the search input in the dialog. 

The PHP Picker classes are also refactored to extend a single Picker abstract class for all the basic stuff that the pickers have in common. 

## Related issues

- Fixes #2208