### PR TITLE
Fix csp issues by introducing a new $kirby->nonce() method #1527

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -57,6 +57,7 @@ class App
     protected $languages;
     protected $locks;
     protected $multilang;
+    protected $nonce;
     protected $options;
     protected $path;
     protected $request;
@@ -775,6 +776,17 @@ class App
         }
 
         return $this->multilang = $this->languages()->count() !== 0;
+    }
+
+    /**
+     * Returns the nonce, which is used
+     * in the panel for inline scripts
+     *
+     * @return string
+     */
+    public function nonce(): string
+    {
+        return $this->nonce = $this->nonce ?? base64_encode(random_bytes(20));
     }
 
     /**

--- a/src/Cms/Panel.php
+++ b/src/Cms/Panel.php
@@ -107,6 +107,7 @@ class Panel
             'pluginCss' => $plugins->url('css'),
             'pluginJs'  => $plugins->url('js'),
             'panelUrl'  => $uri->path()->toString(true) . '/',
+            'nonce'     => $kirby->nonce(),
             'options'   => [
                 'url'         => $url,
                 'site'        => $kirby->url('index'),

--- a/views/panel.php
+++ b/views/panel.php
@@ -7,20 +7,20 @@
 
   <title>Kirby Panel</title>
 
-  <link rel="stylesheet" href="<?= $assetUrl ?>/css/app.css">
-  <link rel="stylesheet" href="<?= $pluginCss ?>">
+  <link nonce="<?= $nonce ?>" rel="stylesheet" href="<?= $assetUrl ?>/css/app.css">
+  <link nonce="<?= $nonce ?>" rel="stylesheet" href="<?= $pluginCss ?>">
 
   <?php if ($customCss) : ?>
-  <link rel="stylesheet" href="<?= $customCss ?>">
+  <link nonce="<?= $nonce ?>" rel="stylesheet" href="<?= $customCss ?>">
   <?php endif ?>
 
-  <link rel="apple-touch-icon" href="<?= $assetUrl ?>/apple-touch-icon.png" />
-  <link rel="shortcut icon" href="<?= $assetUrl ?>/favicon.png">
+  <link nonce="<?= $nonce ?>" rel="apple-touch-icon" href="<?= $assetUrl ?>/apple-touch-icon.png" />
+  <link nonce="<?= $nonce ?>" rel="shortcut icon" href="<?= $assetUrl ?>/favicon.png">
 
   <base href="<?= $panelUrl ?>">
 </head>
 <body>
-  <svg aria-hidden="true" class="k-icons" xmlns="http://www.w3.org/2000/svg" overflow="hidden">
+  <svg aria-hidden="true" class="k-icons" xmlns="http://www.w3.org/2000/svg" overflow="hidden" nonce="<?= $nonce ?>">
     <defs />
   </svg>
 
@@ -32,15 +32,14 @@
 
   <?= $icons ?>
 
-  <script>window.panel = <?= json_encode($options, JSON_UNESCAPED_SLASHES) ?></script>
-
-  <script src="<?= $assetUrl ?>/js/plugins.js" defer></script>
-  <script src="<?= $assetUrl ?>/js/vendor.js" defer></script>
-  <script src="<?= $pluginJs ?>" defer></script>
+  <script nonce="<?= $nonce ?>">window.panel = <?= json_encode($options, JSON_UNESCAPED_SLASHES) ?></script>
+  <script nonce="<?= $nonce ?>" src="<?= $assetUrl ?>/js/plugins.js" defer></script>
+  <script nonce="<?= $nonce ?>" src="<?= $assetUrl ?>/js/vendor.js" defer></script>
+  <script nonce="<?= $nonce ?>" src="<?= $pluginJs ?>" defer></script>
   <?php if (isset($config['js'])) : ?>
-    <script src="<?= Url::to($config['js']) ?>" defer></script>
+    <script nonce="<?= $nonce ?>" src="<?= Url::to($config['js']) ?>" defer></script>
   <?php endif ?>
-  <script src="<?= $assetUrl ?>/js/app.js" defer></script>
+  <script nonce="<?= $nonce ?>" src="<?= $assetUrl ?>/js/app.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Describe the PR

The Kirby class now has a new `$kirby->nonce()` which returns the nonce used for all external and inline scripts + svg + stylesheets). You can use this to set your own CSP and the panel will still work

## Related issues

- Fixes #1527