### PR TITLE
Prevent $pages->add() from silently breaking when adding invalid objects #1890

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\InvalidArgumentException;
+
 /**
  * The `$pages` object refers to a
  * collection of pages. The pages in this
@@ -55,6 +57,10 @@ class Pages extends Collection
         // add a page object
         } elseif (is_a($object, 'Kirby\Cms\Page') === true) {
             $this->__set($object->id(), $object);
+
+        // give a useful error message on invalid objects
+        } elseif (is_object($object) === true) {
+            throw new InvalidArgumentException('You must pass a Page object to the Pages collection');
         }
 
         return $this;

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -58,8 +58,8 @@ class Pages extends Collection
         } elseif (is_a($object, 'Kirby\Cms\Page') === true) {
             $this->__set($object->id(), $object);
 
-        // give a useful error message on invalid objects
-        } elseif (is_object($object) === true) {
+        // give a useful error message on invalid input
+        } elseif (in_array($object, [null, false, true], true) !== true) {
             throw new InvalidArgumentException('You must pass a Page object to the Pages collection');
         }
 

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -78,6 +78,36 @@ class PagesTest extends TestCase
         $this->assertEquals('a/aa', $pages->nth(2)->id());
     }
 
+    public function testAddNull()
+    {
+        $pages = new Pages();
+        $this->assertCount(0, $pages);
+
+        $pages->add(null);
+
+        $this->assertCount(0, $pages);
+    }
+
+    public function testAddFalse()
+    {
+        $pages = new Pages();
+        $this->assertCount(0, $pages);
+
+        $pages->add(false);
+
+        $this->assertCount(0, $pages);
+    }
+
+    public function testAddInvalidObject()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('You must pass a Page object to the Pages collection');
+
+        $site  = new Site();
+        $pages = new Pages();
+        $pages->add($site);
+    }
+
     public function testAudio()
     {
         $pages = Pages::factory([


### PR DESCRIPTION
## Related issues

- Fixes #1890