### PR TITLE
New ready option to inject last-minute configuration #1724

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -128,6 +128,9 @@ class App
         // handle those damn errors
         $this->handleErrors();
 
+        // execute a ready callback from the config
+        $this->optionsFromReadyCallback();
+
         // bake config
         Config::$data = $this->options;
     }
@@ -812,17 +815,6 @@ class App
     }
 
     /**
-     * Inject options from Kirby instance props
-     *
-     * @param array $options
-     * @return array
-     */
-    protected function optionsFromProps(array $options = []): array
-    {
-        return $this->options = array_replace_recursive($this->options, $options);
-    }
-
-    /**
      * Load all options from files in site/config
      *
      * @return array
@@ -841,6 +833,35 @@ class App
         $config = Config::$data;
 
         return $this->options = array_replace_recursive($config, $main, $host, $addr);
+    }
+
+    /**
+     * Inject options from Kirby instance props
+     *
+     * @param array $options
+     * @return array
+     */
+    protected function optionsFromProps(array $options = []): array
+    {
+        return $this->options = array_replace_recursive($this->options, $options);
+    }
+
+    /**
+     * Merge last-minute options from ready callback
+     *
+     * @return array
+     */
+    protected function optionsFromReadyCallback(): array
+    {
+        if (isset($this->options['ready']) === true && is_callable($this->options['ready']) === true) {
+            // fetch last-minute options from the callback
+            $options = (array)$this->options['ready']($this);
+
+            // inject all last-minute options recursively
+            $this->options = array_replace_recursive($this->options, $options);
+        }
+
+        return $this->options;
     }
 
     /**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -210,6 +210,26 @@ class AppTest extends TestCase
         $this->assertEquals($options, $app->options());
     }
 
+    public function testOptionsOnReady()
+    {
+        App::destroy();
+
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'ready' => function ($kirby) {
+                    return [
+                        'test' => $kirby->root('index')
+                    ];
+                }
+            ]
+        ]);
+
+        $this->assertEquals('/dev/null', $app->option('test'));
+    }
+
     public function testRolesFromFixtures()
     {
         $app = new App([


### PR DESCRIPTION
## Describe the PR

The new `ready` option can be used in the config file to inject last-minute options with full access to the Kirby instance. 

## Related issues

- Fixes #1724

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)