### PR TITLE
Infer section type from name #ideas/120

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -5,7 +5,6 @@ use Kirby\Cms\Asset;
 use Kirby\Cms\Html;
 use Kirby\Cms\Response;
 use Kirby\Cms\Url;
-use Kirby\Http\Server;
 use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\I18n;

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -595,12 +595,17 @@ class Blueprint
                 continue;
             }
 
+            // fallback to default props when true is passed
+            if ($sectionProps === true) {
+                $sectionProps = [];
+            }
+
             // inject all section extensions
             $sectionProps = $this->extend($sectionProps);
 
             $sections[$sectionName] = $sectionProps = array_merge($sectionProps, [
                 'name' => $sectionName,
-                'type' => $type = $sectionProps['type'] ?? null
+                'type' => $type = $sectionProps['type'] ?? $sectionName
             ]);
 
             if (empty($type) === true || is_string($type) === false) {

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -267,4 +267,28 @@ class BlueprintTest extends TestCase
         $this->assertEquals(true, array_key_exists('headline', $sections['main']));
         $this->assertEquals('Invalid section type for section "main"', $sections['main']['headline']);
     }
+
+    public function testSectionTypeFromName()
+    {
+        // with options
+        $blueprint = new Blueprint([
+            'model' => 'test',
+            'sections' => [
+                'info' => [
+                ]
+            ]
+        ]);
+
+        $this->assertEquals('info', $blueprint->sections()['info']->type());
+
+        // by just passing true
+        $blueprint = new Blueprint([
+            'model' => 'test',
+            'sections' => [
+                'info' => true
+            ]
+        ]);
+
+        $this->assertEquals('info', $blueprint->sections()['info']->type());
+    }
 }


### PR DESCRIPTION
## Describe the PR

You can now create sections without specifying the type if the name matches the expected type: 

```
sections: 
  info: 
    text: something
```

Or by simply using `true` to invoke the defaults

```
sections: 
  pages: true
```

## Related issues

- Fixes #https://github.com/getkirby/ideas/issues/120

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)