### PR TITLE
Add locking feature to structure field

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -51,6 +51,12 @@ return [
             return $limit;
         },
         /**
+         * Locks adding and removing entries.
+         */
+        'lock' => function (bool $lock = false) {
+            return $lock;
+        },
+        /**
          * Maximum allowed entries in the structure. Afterwards the "Add" button will be switched off.
          */
         'max' => function (int $max = null) {

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -4,7 +4,7 @@
     <!-- Add button -->
     <template slot="options">
       <k-button
-        v-if="more && currentIndex === null"
+        v-if="more && currentIndex === null && !lock"
         ref="add"
         :id="_uid"
         icon="add"
@@ -118,7 +118,7 @@
               </template>
             </td>
             <td class="k-structure-table-option">
-              <k-button :tooltip="$t('remove')" icon="remove" @click="confirmRemove(index)" />
+              <k-button :tooltip="$t('remove')" :disabled="lock" icon="remove" @click="confirmRemove(index)" />
             </td>
           </tr>
         </k-draggable>
@@ -167,6 +167,7 @@ export default {
     empty: String,
     fields: Object,
     limit: Number,
+    lock: Boolean,
     max: Number,
     min: Number,
     sortable: {


### PR DESCRIPTION
## Describe the PR

If the structure field data is being loaded by the hook, sometimes we don't want to add new rows or remove existing rows by the end users. The locking feature does exactly that. Locking allows editing rows only, unlike the disabled property.

### Usage

````yaml
fields:
  addresses:
    label: Addresses
    type: structure
    lock: true
    fields:
      street:
        label: Street
        type: text
      zip:
        label: ZIP
        type: text
      city:
        label: City
        type: text
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/312

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
