### PR TITLE
Check if dump function already exists

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -129,19 +129,21 @@ function css($url, $options = null)
  * @param boolean $echo
  * @return string
  */
-function dump($variable, bool $echo = true): string
-{
-    if (Server::cli() === true) {
-        $output = print_r($variable, true) . PHP_EOL;
-    } else {
-        $output = '<pre>' . print_r($variable, true) . '</pre>';
-    }
+if (!function_exists('dump')) {
+    function dump($variable, bool $echo = true): string
+    {
+        if (Server::cli() === true) {
+            $output = print_r($variable, true) . PHP_EOL;
+        } else {
+            $output = '<pre>' . print_r($variable, true) . '</pre>';
+        }
 
-    if ($echo === true) {
-        echo $output;
-    }
+        if ($echo === true) {
+            echo $output;
+        }
 
-    return $output;
+        return $output;
+    }
 }
 
 /**


### PR DESCRIPTION
## Describe the PR

Check whether the dump helper function already exists. Helpful when using Kirby with composer installation + symfony/var-dumper. Vendor extensions get loaded first thus Kirby fails to initialize. This patch fixes this error and adds ability to replace the dump helper with different possible dump utilities.