### PR TITLE
Add hideValue option for multiselect field

### DIFF
--- a/config/fields/multiselect.php
+++ b/config/fields/multiselect.php
@@ -10,7 +10,7 @@ return [
         'accept' => null,
 
         /**
-         * Hide the value of the options in parentheses.
+         * Hides the value of the options in parentheses.
          */
         'hideValue' => function (bool $hideValue = false) {
             return $hideValue;

--- a/config/fields/multiselect.php
+++ b/config/fields/multiselect.php
@@ -10,6 +10,13 @@ return [
         'accept' => null,
 
         /**
+         * Hide the value of the options in parentheses.
+         */
+        'hideValue' => function (bool $hideValue = false) {
+            return $hideValue;
+        },
+
+        /**
          * Custom icon to replace the arrow down.
          */
         'icon' => function (string $icon = null) {

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -56,7 +56,7 @@
           @keydown.native.space.prevent.stop="select(option)"
         >
           <span v-html="option.display" />
-          <span class="k-multiselect-value" v-html="option.info" />
+          <span v-if="!hideValue" class="k-multiselect-value" v-html="option.info" />
         </k-dropdown-item>
       </div>
     </k-dropdown-content>
@@ -71,6 +71,7 @@ export default {
   inheritAttrs: false,
   props: {
     disabled: Boolean,
+    hideValue: Boolean,
     id: [Number, String],
     max: Number,
     min: Number,


### PR DESCRIPTION
![FireShot Capture 781 - Sandbox - Mægazine - http___localhost_test_kirby_127_panel_pages_sandbox](https://user-images.githubusercontent.com/3393422/67098764-6d882100-f1c5-11e9-837d-29e42f331e5d.png)

## Describe the PR

Hides the value of the options in parentheses for multiselect field.

### Usage

````yaml
fields:
  categories:
    label: Categories
    type: multiselect
    hideValue: true
    options:
      design: Design
      architecture: Architecture
      photography: Photography
      3d: 3D
      web: Web

````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/127

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
