### PR TITLE
Remove the name field from the installer to set the focus on the email address #1802

### DIFF
--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -101,12 +101,6 @@ export default {
     },
     fields() {
       return {
-        name: {
-          label: this.$t("name"),
-          type: "text",
-          icon: "user",
-          autofocus: true
-        },
         email: {
           label: this.$t("email"),
           type: "email",


### PR DESCRIPTION
## Describe the PR

I understand that the name field in the installer can be mistaken as a username field, which can get quite confusing. IMHO the most simple first step is to remove it entirely from the installer. It's not required to get up and running and I think less fields == less friction. How do you feel about it? 

## Related issues

- Fixes #1802