### PR TITLE
Languages can now use their own domains again #1382

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,12 +1,12 @@
 <?php
 
+use Kirby\Cms\LanguageRoutes;
 use Kirby\Cms\Media;
 use Kirby\Cms\Panel;
 use Kirby\Cms\PanelPlugins;
 use Kirby\Cms\PluginAssets;
 use Kirby\Http\Response\Redirect;
 use Kirby\Http\Router\Route;
-use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 
 return function ($kirby) {
@@ -110,73 +110,7 @@ return function ($kirby) {
 
     // Multi-language setup
     if ($kirby->multilang() === true) {
-
-        // Multi-language home
-        $after[] = [
-            'pattern' => '',
-            'method'  => 'ALL',
-            'env'     => 'site',
-            'action'  => function () use ($kirby) {
-                $home = $kirby->site()->homePage();
-
-                // language detection on the home page with / as URL
-                if ($home && $kirby->url() !== $home->url()) {
-                    if ($kirby->option('languages.detect') === true) {
-                        return $kirby
-                            ->response()
-                            ->redirect($kirby->detectedLanguage()->url());
-                    } else {
-                        return $kirby
-                            ->response()
-                            ->redirect($kirby->site()->url());
-                    }
-
-                    // default home page
-                } else {
-                    return $kirby->defaultLanguage()->router()->call();
-                }
-            }
-        ];
-
-        foreach ($kirby->languages() as $language) {
-            $after[] = [
-                'pattern' => trim($language->pattern() . '/(:all?)', '/'),
-                'method'  => 'ALL',
-                'env'     => 'site',
-                'action'  => function ($path = null) use ($language) {
-                    return $language->router()->call($path);
-                }
-            ];
-        }
-
-        // fallback route for unprefixed default language URLs.
-        $after[] = [
-            'pattern' => '(:all)',
-            'method'  => 'ALL',
-            'env'     => 'site',
-            'action'  => function (string $path) use ($kirby) {
-
-                // check for content representations or files
-                $extension = F::extension($path);
-
-                // try to redirect prefixed pages
-                if (empty($extension) === true && $page = $kirby->page($path)) {
-                    $url = $kirby->request()->url([
-                        'query'    => null,
-                        'params'   => null,
-                        'fragment' => null
-                    ]);
-
-                    if ($url->toString() !== $page->url()) {
-                        return $kirby
-                            ->response()
-                            ->redirect($page->url());
-                    }
-                }
-
-                return $kirby->defaultLanguage()->router()->call($path);
-            }
-        ];
+        $after = LanguageRoutes::create($kirby);
     } else {
 
         // Single-language home

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -118,6 +118,17 @@ class Language extends Model
     }
 
     /**
+     * Returns the base Url for the language
+     * without the path or other cruft
+     *
+     * @return string
+     */
+    public function baseUrl(): string
+    {
+        return Url::base($this->url()) ?? $this->kirby()->url();
+    }
+
+    /**
      * Returns the language code/id.
      * The language code is used in
      * text file names as appendix.
@@ -332,17 +343,33 @@ class Language extends Model
     }
 
     /**
+     * Returns the URL path for the language
+     *
+     * @return string
+     */
+    public function path(): string
+    {
+        if ($this->url === null) {
+            return $this->code;
+        }
+
+        return Url::path($this->url());
+    }
+
+    /**
      * Returns the routing pattern for the language
      *
      * @return string
      */
     public function pattern(): string
     {
-        if (empty($this->url) === true) {
-            return $this->code;
+        $path = $this->path();
+
+        if (empty($path) === true) {
+            return '(:all?)';
         }
 
-        return trim($this->url, '/');
+        return $path . '/(:all?)';
     }
 
     /**
@@ -580,7 +607,11 @@ class Language extends Model
      */
     public function url(): string
     {
-        return Url::makeAbsolute($this->pattern(), $this->kirby()->url());
+        if ($this->url === null) {
+            $this->url = '/' . $this->code;
+        }
+
+        return Url::makeAbsolute($this->url, $this->kirby()->url());
     }
 
     /**

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -366,7 +366,7 @@ class Language extends Model
         $path = $this->path();
 
         if (empty($path) === true) {
-            return '(:all?)';
+            return '(:all)';
         }
 
         return $path . '/(:all?)';

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -7,8 +7,7 @@ use Kirby\Toolkit\F;
 class LanguageRoutes
 {
     /**
-     * Inject all language routes into
-     * the given routes array
+     * Creates all multi-language routes
      *
      * @param App $kirby
      * @return array

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -20,7 +20,6 @@ class LanguageRoutes
         $baseurl = $kirby->url();
 
         foreach ($kirby->languages() as $language) {
-
             // ignore languages with a different base url
             if ($language->baseurl() !== $baseurl) {
                 continue;
@@ -31,7 +30,13 @@ class LanguageRoutes
                 'method'  => 'ALL',
                 'env'     => 'site',
                 'action'  => function ($path = null) use ($language) {
-                    return $language->router()->call($path);
+                    if ($result = $language->router()->call($path)) {
+                        return $result;
+                    }
+
+                    // jump through to the fallback if nothing
+                    // can be found for this language
+                    $this->next();
                 }
             ];
         }

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -9,11 +9,14 @@ class LanguageRoutes
     /**
      * Creates all multi-language routes
      *
-     * @param App $kirby
+     * @param \Kirby\Cms\App $kirby
      * @return array
      */
     public static function create(App $kirby): array
     {
+        $routes = [];
+
+        // add the route for the home page
         $routes[] = static::home($kirby);
 
         // Kirby's base url
@@ -51,7 +54,7 @@ class LanguageRoutes
      * Create the fallback route
      * for unprefixed default language URLs.
      *
-     * @param App $kirby
+     * @param \Kirby\Cms\App $kirby
      * @return array
      */
     public static function fallback(App $kirby): array
@@ -88,7 +91,7 @@ class LanguageRoutes
     /**
      * Create the multi-language home page route
      *
-     * @param App $kirby
+     * @param \Kirby\Cms\App $kirby
      * @return array
      */
     public static function home(App $kirby): array

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Toolkit\F;
+
+class LanguageRoutes
+{
+    /**
+     * Inject all language routes into
+     * the given routes array
+     *
+     * @param App $kirby
+     * @return array
+     */
+    public static function create(App $kirby): array
+    {
+        $routes[] = static::home($kirby);
+
+        // Kirby's base url
+        $baseurl = $kirby->url();
+
+        foreach ($kirby->languages() as $language) {
+
+            // ignore languages with a different base url
+            if ($language->baseurl() !== $baseurl) {
+                continue;
+            }
+
+            $routes[] = [
+                'pattern' => $language->pattern(),
+                'method'  => 'ALL',
+                'env'     => 'site',
+                'action'  => function ($path = null) use ($language) {
+                    return $language->router()->call($path);
+                }
+            ];
+        }
+
+        $routes[] = static::fallback($kirby);
+
+        return $routes;
+    }
+
+
+    /**
+     * Create the fallback route
+     * for unprefixed default language URLs.
+     *
+     * @param App $kirby
+     * @return array
+     */
+    public static function fallback(App $kirby): array
+    {
+        return [
+            'pattern' => '(:all)',
+            'method'  => 'ALL',
+            'env'     => 'site',
+            'action'  => function (string $path) use ($kirby) {
+
+                // check for content representations or files
+                $extension = F::extension($path);
+
+                // try to redirect prefixed pages
+                if (empty($extension) === true && $page = $kirby->page($path)) {
+                    $url = $kirby->request()->url([
+                        'query'    => null,
+                        'params'   => null,
+                        'fragment' => null
+                    ]);
+
+                    if ($url->toString() !== $page->url()) {
+                        return $kirby
+                            ->response()
+                            ->redirect($page->url());
+                    }
+                }
+
+                return $kirby->defaultLanguage()->router()->call($path);
+            }
+        ];
+    }
+
+    /**
+     * Create the multi-language home page route
+     *
+     * @param App $kirby
+     * @return array
+     */
+    public static function home(App $kirby): array
+    {
+        // Multi-language home
+        return [
+            'pattern' => '',
+            'method'  => 'ALL',
+            'env'     => 'site',
+            'action'  => function () use ($kirby) {
+
+                // find all languages with the same base url as the current installation
+                $languages = $kirby->languages()->filterBy('baseurl', $kirby->url());
+
+                // if there's no language with a matching base url,
+                // redirect to the default language
+                if ($languages->count() === 0) {
+                    return $kirby
+                        ->response()
+                        ->redirect($kirby->defaultLanguage()->url());
+                }
+
+                // if there's just one language, we take that to render the home page
+                if ($languages->count() === 1) {
+                    $currentLanguage = $languages->first();
+                } else {
+                    $currentLanguage = $kirby->defaultLanguage();
+                }
+
+                // language detection on the home page with / as URL
+                if ($kirby->url() !== $currentLanguage->url()) {
+                    if ($kirby->option('languages.detect') === true) {
+                        return $kirby
+                            ->response()
+                            ->redirect($kirby->detectedLanguage()->url());
+                    }
+
+                    return $kirby
+                        ->response()
+                        ->redirect($currentLanguage->url());
+                }
+
+                // render the home page of the current language
+                return $currentLanguage->router()->call();
+            }
+        ];
+    }
+}

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -338,4 +338,103 @@ class LanguageTest extends TestCase
 
         $this->assertEquals($fixtures . '/site/languages/de.php', $language->root());
     }
+
+    public function pathProvider()
+    {
+        return [
+            [null, 'en'],
+            ['/', ''],
+            ['/en', 'en'],
+            ['/en/', 'en'],
+            ['https://getkirby.com/en', 'en'],
+            ['https://getkirby.com/en/', 'en'],
+            ['https://getkirby.com/sub/sub', 'sub/sub'],
+            ['https://getkirby.com/sub/sub/', 'sub/sub'],
+        ];
+    }
+
+    /**
+     * @dataProvider pathProvider
+     */
+    public function testPath($input, $expected)
+    {
+        $language = new Language([
+            'code' => 'en',
+            'url'  => $input
+        ]);
+
+        $this->assertEquals($expected, $language->path());
+    }
+
+    public function patternProvider()
+    {
+        return [
+            [null, 'en/(:all?)'],
+            ['/', '(:all?)'],
+            ['/en', 'en/(:all?)'],
+            ['/en/', 'en/(:all?)'],
+            ['https://getkirby.com', '(:all?)'],
+            ['https://getkirby.com/', '(:all?)'],
+            ['https://getkirby.com/en', 'en/(:all?)'],
+            ['https://getkirby.com/en/', 'en/(:all?)'],
+            ['https://getkirby.com/sub/sub', 'sub/sub/(:all?)'],
+            ['https://getkirby.com/sub/sub/', 'sub/sub/(:all?)'],
+        ];
+    }
+
+    /**
+     * @dataProvider patternProvider
+     */
+    public function testPattern($input, $expected)
+    {
+        $language = new Language([
+            'code' => 'en',
+            'url'  => $input
+        ]);
+
+        $this->assertEquals($expected, $language->pattern());
+    }
+
+    public function testBaseUrl()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'urls' => [
+                'index' => 'https://getkirby.com'
+            ]
+        ]);
+
+        // default
+        $language = new Language([
+            'code' => 'en',
+        ]);
+
+        $this->assertEquals('https://getkirby.com', $language->baseUrl());
+
+        // with path
+        $language = new Language([
+            'code' => 'en',
+            'url'  => '/en'
+        ]);
+
+        $this->assertEquals('https://getkirby.com', $language->baseUrl());
+
+        // different domain
+        $language = new Language([
+            'code' => 'en',
+            'url'  => 'https://getkirby.de'
+        ]);
+
+        $this->assertEquals('https://getkirby.de', $language->baseUrl());
+
+        // different domain with path
+        $language = new Language([
+            'code' => 'en',
+            'url'  => 'https://getkirby.de/en'
+        ]);
+
+        $this->assertEquals('https://getkirby.de', $language->baseUrl());
+    }
 }

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -370,11 +370,11 @@ class LanguageTest extends TestCase
     {
         return [
             [null, 'en/(:all?)'],
-            ['/', '(:all?)'],
+            ['/', '(:all)'],
             ['/en', 'en/(:all?)'],
             ['/en/', 'en/(:all?)'],
-            ['https://getkirby.com', '(:all?)'],
-            ['https://getkirby.com/', '(:all?)'],
+            ['https://getkirby.com', '(:all)'],
+            ['https://getkirby.com/', '(:all)'],
             ['https://getkirby.com/en', 'en/(:all?)'],
             ['https://getkirby.com/en/', 'en/(:all?)'],
             ['https://getkirby.com/sub/sub', 'sub/sub/(:all?)'],

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -410,7 +410,8 @@ class RouterTest extends TestCase
                 ],
                 [
                     'code' => 'en',
-                ]
+                    'url'  => '/en'
+                ],
             ]
         ]);
 

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -431,6 +431,100 @@ class RouterTest extends TestCase
         $this->assertEquals('en', I18n::locale());
     }
 
+    public function multiDomainProvider()
+    {
+        return [
+            ['https://getkirby.fr', 'fr'],
+            ['https://getkirby.com', 'en'],
+        ];
+    }
+
+    /**
+     * @dataProvider multiDomainProvider
+     */
+    public function testMultiLangHomeWithDifferentDomains($domain, $language)
+    {
+        $app = $this->app->clone([
+            'urls' => [
+                'index' => $domain
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'home'
+                    ]
+                ]
+            ],
+            'options' => [
+                'languages' => true
+            ],
+            'languages' => [
+                [
+                    'code'    => 'fr',
+                    'default' => true,
+                    'url'     => 'https://getkirby.fr'
+                ],
+                [
+                    'code' => 'en',
+                    'url'  => 'https://getkirby.com'
+                ]
+            ]
+        ]);
+
+        // home
+        $page = $app->call('');
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals('home', $page->id());
+        $this->assertEquals($language, $app->language()->code());
+        $this->assertEquals($language, I18n::locale());
+    }
+
+    /**
+     * @dataProvider multiDomainProvider
+     */
+    public function testMultiLangHomeWithDifferentDomainsAndPath($domain, $language)
+    {
+        $app = $this->app->clone([
+            'urls' => [
+                'index' => $domain
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'home'
+                    ]
+                ]
+            ],
+            'options' => [
+                'languages' => true
+            ],
+            'languages' => [
+                [
+                    'code'    => 'fr',
+                    'default' => true,
+                    'url'     => 'https://getkirby.fr/subfolder'
+                ],
+                [
+                    'code' => 'en',
+                    'url'  => 'https://getkirby.com/subfolder'
+                ]
+            ]
+        ]);
+
+        // redirect
+        $redirect = $app->call('');
+        $this->assertInstanceOf(Responder::class, $redirect);
+
+        // home
+        $page = $app->call('subfolder');
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals('home', $page->id());
+        $this->assertEquals($language, $app->language()->code());
+        $this->assertEquals($language, I18n::locale());
+    }
+
     public function acceptedLanguageProvider()
     {
         return [


### PR DESCRIPTION
## Describe the PR

After 3.0.0 language routing was no longer possible with custom domains for individual languages. This PR finally fixes this regression. 

## Related issues

- Fixes #1382

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)