### PR TITLE
Fix unicode support of regexp escape method #2282

### DIFF
--- a/panel/src/helpers/regex.js
+++ b/panel/src/helpers/regex.js
@@ -1,1 +1,1 @@
-RegExp.escape = s => s.replace(/[\p{L}]|[-\/\\^$*+?.()|[\]{}]+/u, '\\$&');
+RegExp.escape = s => s.replace(new RegExp("[\\p{L}][-/\\\\^$*+?.()|[\\]{}]", "gu"), '\\$&');

--- a/panel/src/helpers/regex.js
+++ b/panel/src/helpers/regex.js
@@ -1,1 +1,1 @@
-RegExp.escape = s => s.replace(new RegExp("[\\p{L}][-/\\\\^$*+?.()|[\\]{}]", "gu"), '\\$&');
+RegExp.escape = s => s.replace(new RegExp("[\\p{L}]|[-/\\\\^$*+?.()[\\]{}]", "gu"), '\\$&');

--- a/panel/tests/unit/Helpers/Slug.spec.js
+++ b/panel/tests/unit/Helpers/Slug.spec.js
@@ -40,6 +40,7 @@ describe("Slug Helper", () => {
   it("applies rules", () => {
     const rules = [
       {"å": "a"},
+      {"á": "a"},
       {"ö": "oe"},
       {"ß": "ss"},
       {"İ": "i"}
@@ -56,6 +57,14 @@ describe("Slug Helper", () => {
 
     const result = slug("1+1", rules);
     expect(result).toBe("1-plus-1");
+  });
+
+  it("handles asterisks", () => {
+    const resultA = slug("***");
+    expect(resultA).toBe("");
+
+    const resultB = slug("***a***b***");
+    expect(resultB).toBe("a-b");
   });
 
 });


### PR DESCRIPTION
## Describe the PR

In the `replace` method, the `u` flag was not rendered properly, converted to the `new RegExp()` method with corrected pattern. 

**Note:** I have to remove `|` pipe char from escape pattern to work with `Str:$ascii` chars. Do you have a solution for this?

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2282 
- Fixes #2293 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
