### PR TITLE
Fix structure field sortBy

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -143,6 +143,7 @@ import Vue from "vue";
 import Field from "../Field.vue";
 
 Array.prototype.sortBy = function(sortBy) {
+  const sort = Vue.prototype.$helper.sort();
   const options = sortBy.split(" ");
   const field = options[0];
   const direction = options[1] || "asc";
@@ -152,9 +153,9 @@ Array.prototype.sortBy = function(sortBy) {
     const valueB = String(b[field]).toLowerCase();
 
     if (direction === "desc") {
-      return this.$helper.sort(valueB, valueA);
+      return sort(valueB, valueA);
     } else {
-      return this.$helper.sort(valueA, valueB);
+      return sort(valueA, valueB);
     }
   });
 };


### PR DESCRIPTION
## Describe the PR

The following line did not work because `this` was called in the callback.

````js
this.$helper.sort(valueB, valueA);
````

I try to write inline as follows, but it doesn't work, so i assigned it to const.

````js
return Vue.prototype.$helper.sort(valueB, valueA);
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2279 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
