### PR TITLE
Fix mailto null linking on email field 

### DIFF
--- a/panel/src/components/Forms/Field/EmailField.vue
+++ b/panel/src/components/Forms/Field/EmailField.vue
@@ -9,9 +9,9 @@
     >
       <k-button
         v-if="link"
-        v-bind:link="mailto()"
         slot="icon"
         :icon="icon"
+        :link="mailto"
         :tooltip="$t('open')"
         class="k-input-icon-button"
         tabindex="-1"
@@ -41,13 +41,15 @@ export default {
       default: "email"
     }
   },
+  computed: {
+    mailto() {
+      return this.value && this.value.length > 0 ? 'mailto:' + this.value : null;
+    }
+  },
   methods: {
     focus() {
       this.$refs.input.focus();
     },
-    mailto() {
-      return this.value && this.value.length > 0 ? 'mailto:' + this.value : null;
-    }
   }
 }
 </script>

--- a/panel/src/components/Forms/Field/EmailField.vue
+++ b/panel/src/components/Forms/Field/EmailField.vue
@@ -46,7 +46,7 @@ export default {
       this.$refs.input.focus();
     },
     mailto() {
-      return this.value !== null && this.value.length > 0 ? 'mailto:' + this.value : null;
+      return this.value && this.value.length > 0 ? 'mailto:' + this.value : null;
     }
   }
 }

--- a/panel/src/components/Forms/Field/EmailField.vue
+++ b/panel/src/components/Forms/Field/EmailField.vue
@@ -9,9 +9,9 @@
     >
       <k-button
         v-if="link"
+        v-bind:link="mailto()"
         slot="icon"
         :icon="icon"
-        :link="'mailto:' + value"
         :tooltip="$t('open')"
         class="k-input-icon-button"
         tabindex="-1"
@@ -44,6 +44,9 @@ export default {
   methods: {
     focus() {
       this.$refs.input.focus();
+    },
+    mailto() {
+      return this.value !== null && this.value.length > 0 ? 'mailto:' + this.value : null;
     }
   }
 }

--- a/panel/src/components/Forms/Previews/EmailFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/EmailFieldPreview.vue
@@ -5,7 +5,7 @@ export default {
   extends: UrlFieldPreview,
   computed: {
     link() {
-      return this.value !== null && this.value.length > 0 ? 'mailto:' + this.value : null;
+      return this.value && this.value.length > 0 ? 'mailto:' + this.value : null;
     }
   }
 }

--- a/panel/src/components/Forms/Previews/EmailFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/EmailFieldPreview.vue
@@ -5,7 +5,7 @@ export default {
   extends: UrlFieldPreview,
   computed: {
     link() {
-      return "mailto:" + this.value;
+      return this.value !== null && this.value.length > 0 ? 'mailto:' + this.value : null;
     }
   }
 }


### PR DESCRIPTION
## Describe the PR

`link` property binded to new `mailto()` method that return only value is not empty

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2254

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
