### PR TITLE
Make session methods more accessible from the outside #2294

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -67,7 +67,7 @@ class App
     protected $routes;
     protected $router;
     protected $server;
-    protected $session;
+    protected $sessionHandler;
     protected $site;
     protected $system;
     protected $urls;
@@ -1105,8 +1105,18 @@ class App
      */
     public function session(array $options = [])
     {
-        $this->session = $this->session ?? new AutoSession($this->root('sessions'), $this->options['session'] ?? []);
-        return $this->session->get($options);
+        return $this->sessionHandler()->get($options);
+    }
+
+    /**
+     * Returns the session handler
+     *
+     * @return \Kirby\Session\AutoSession
+     */
+    public function sessionHandler()
+    {
+        $this->sessionHandler = $this->sessionHandler ?? new AutoSession($this->root('sessions'), $this->option('session', []));
+        return $this->sessionHandler;
     }
 
     /**

--- a/src/Session/AutoSession.php
+++ b/src/Session/AutoSession.php
@@ -145,6 +145,17 @@ class AutoSession
     }
 
     /**
+     * Returns the specified Session object
+     *
+     * @param string $token Session token, either including or without the key
+     * @return \Kirby\Session\Session
+     */
+    public function getManually(string $token)
+    {
+        return $this->sessions->get($token, 'manual');
+    }
+
+    /**
      * Deletes all expired sessions
      *
      * If the `gcInterval` is configured, this is done automatically

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -241,6 +241,18 @@ class AutoSessionTest extends TestCase
     }
 
     /**
+     * @covers ::getManually
+     */
+    public function testGetManually()
+    {
+        $autoSession = new AutoSession($this->store);
+
+        $session = $autoSession->getManually('9999999999.valid.' . $this->store->validKey);
+        $this->assertSame('manual', $session->mode());
+        $this->assertSame('9999999999.valid.' . $this->store->validKey, $session->token());
+    }
+
+    /**
      * @covers ::collectGarbage
      */
     public function testCollectGarbage()


### PR DESCRIPTION
## Describe the PR

- Make session handler (`AutoSession` object) accessible for use in plugins (e.g. manual garbage collection, manual session creation)
- Make it possible to retrieve an arbitrary session object from the outside

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2294

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
