### PR TITLE
Add missing since information

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -122,6 +122,7 @@ function css($url, $options = null): ?string
 
 /**
  * Triggers a deprecation warning if debug mode is active
+ * @since 3.3.0
  *
  * @param string $message
  * @return bool Whether the warning was triggered

--- a/config/methods.php
+++ b/config/methods.php
@@ -327,6 +327,7 @@ return function (App $app) {
 
         /**
          * Converts all line breaks in the field content to `<br>` tags.
+         * @since 3.3.0
          *
          * @param \Kirby\Cms\Field $field
          * @return \Kirby\Cms\Field
@@ -387,6 +388,7 @@ return function (App $app) {
          * Strips all block-level HTML elements from the field value,
          * it can be safely placed inside of other inline elements
          * without the risk of breaking the HTML structure.
+         * @since 3.3.0
          *
          * @param \Kirby\Cms\Field $field
          * @return \Kirby\Cms\Field

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -784,6 +784,7 @@ class App
     /**
      * Returns the nonce, which is used
      * in the panel for inline scripts
+     * @since 3.3.0
      *
      * @return string
      */

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -405,6 +405,7 @@ abstract class ModelWithContent extends Model
      * Returns an array of all actions
      * that can be performed in the Panel
      * This also checks for the lock status
+     * @since 3.3.0
      *
      * @param array $unlock An array of options that will be force-unlocked
      * @return array

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -438,6 +438,7 @@ class Pages extends Collection
 
     /**
      * Filter all pages by excluding the given template
+     * @since 3.3.0
      *
      * @param string|array $templates
      * @return \Kirby\Cms\Pages

--- a/src/Exception/ErrorPageException.php
+++ b/src/Exception/ErrorPageException.php
@@ -5,6 +5,7 @@ namespace Kirby\Exception;
 /**
  * ErrorPageException
  * Thrown to trigger the CMS error page
+ * @since 3.3.0
  *
  * @package   Kirby Exception
  * @author    Lukas Bestle <lukas@getkirby.com>

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -180,6 +180,7 @@ class Visitor
     /**
      * Returns the MIME type from the provided list that
      * is most accepted (= preferred) by the visitor
+     * @since 3.3.0
      *
      * @param string ...$mimeTypes MIME types to query for
      * @return string|null Preferred MIME type
@@ -206,6 +207,7 @@ class Visitor
     /**
      * Returns true if the visitor prefers a JSON response over
      * an HTML response based on the `Accept` request header
+     * @since 3.3.0
      *
      * @return bool
      */

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -544,6 +544,7 @@ class Collection extends Iterator implements Countable
 
     /**
      * Returns a Collection with the intersection of the given elements
+     * @since 3.3.0
      *
      * @param \Kirby\Toolkit\Collection $other
      * @return \Kirby\Toolkit\Collection
@@ -555,6 +556,7 @@ class Collection extends Iterator implements Countable
 
     /**
      * Checks if there is an intersection between the given collection and this collection
+     * @since 3.3.0
      *
      * @param \Kirby\Toolkit\Collection $other
      * @return bool
@@ -1060,6 +1062,7 @@ class Collection extends Iterator implements Countable
      * is true. If the first parameter is false, the Closure will not be executed.
      * You may pass another Closure as the third parameter to the when method.
      * This Closure will execute if the first parameter evaluates as false
+     * @since 3.3.0
      *
      * @param mixed $condition
      * @param Closure $callback

--- a/src/Toolkit/Mime.php
+++ b/src/Toolkit/Mime.php
@@ -242,6 +242,7 @@ class Mime
     /**
      * Tests if a MIME wildcard pattern from an `Accept` header
      * matches a given type
+     * @since 3.3.0
      *
      * @param string $test
      * @param string $wildcard


### PR DESCRIPTION
## Describe the PR

Adds missing `@since` info to new 3.3.0 methods

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
