### PR TITLE
Fix unicode support

### DIFF
--- a/panel/src/helpers/regex.js
+++ b/panel/src/helpers/regex.js
@@ -1,1 +1,1 @@
-RegExp.escape = s => s.replace(new RegExp("[\\p{L}]|[-/\\\\^$*+?.()[\\]{}]", "gu"), '\\$&');
+RegExp.escape = s => s.replace(new RegExp("[-/\\\\^$*+?.()[\\]{}]", "gu"), '\\$&');


### PR DESCRIPTION
## Describe the PR

You won't believe it, but it's just enough to add the `u` flag or my eyes see it wrong 😲 🎉 
We no longer need the `\p{L}` pattern.
We couldn't use `u` flag in `replace()` method directly when didn't support that flag, but since we can use it directly in `RegExp`, the problem seems to have been solved without the need for anything additional 🕺 

**Was not working on first pattern:**
````js
s.replace(/[-/\\^$*+?.()|[\]{}]/gu, '\\$&');
````

**Now working with RegExp:**
````js
s.replace(new RegExp("[-/\\\\^$*+?.()[\\]{}]", "gu"), '\\$&')
````

Can you please test and review?

**Note again**: I have to remove `|` pipe char from escape pattern to work with `Str:$ascii` chars that contains `|` char.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2313 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
