### PR TITLE
Use default lang for page num query #2256

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -506,10 +506,14 @@ trait PageActions
 
                 return $num;
             default:
+                // get instance with default lanuage
+                $app = $this->kirby()->clone();
+                $app->setCurrentLanguage();
+
                 $template = Str::template($mode, [
-                    'kirby' => $this->kirby(),
-                    'page'  => $this,
-                    'site'  => $this->site(),
+                    'kirby' => $app,
+                    'page'  => $app->page($this->id()),
+                    'site'  => $app->site(),
                 ]);
 
                 return (int)$template;

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -380,27 +380,89 @@ class PageSortTest extends TestCase
     public function testCreateCustomNum()
     {
         // valid
-        $page = new Page([
-            'slug' => 'test',
-            'blueprint' => [
-                'num' => '{{ page.year }}'
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
             ],
-            'content' => [
-                'year' => 2016
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'blueprint' => [
+                            'num' => '{{ page.year }}'
+                        ],
+                        'content' => [
+                            'year' => 2016
+                        ]
+                    ]
+                ]
             ]
         ]);
 
-        $this->assertEquals(2016, $page->createNum());
+        $this->assertEquals(2016, $app->page('test')->createNum());
 
         // invalid
-        $page = new Page([
-            'slug' => 'test',
-            'blueprint' => [
-                'num' => '{{ page.year }}'
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'blueprint' => [
+                            'num' => '{{ page.year }}'
+                        ]
+                    ]
+                ]
             ]
         ]);
 
-        $this->assertEquals(0, $page->createNum());
+        $this->assertEquals(0, $app->page('test')->createNum());
+
+        // multilang with default language fallback
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'blueprint' => [
+                            'num' => '{{ page.year }}'
+                        ],
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => [
+                                    'year' => 2016
+                                ]
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => [
+                                    'year' => 1999
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertEquals(2016, $app->page('test')->createNum());
     }
 
     public function testPublish()


### PR DESCRIPTION
## Describe the PR

Resolve the query for a page's `num` option always with the default language.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2256

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
