### PR TITLE
Remote: Enhancements to headers #2322

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -22,16 +22,17 @@ class Remote
      * @var array
      */
     public static $defaults = [
-        'agent'    => null,
-        'body'     => true,
-        'data'     => [],
-        'encoding' => 'utf-8',
-        'file'     => null,
-        'headers'  => [],
-        'method'   => 'GET',
-        'progress' => null,
-        'test'     => false,
-        'timeout'  => 10,
+        'agent'     => null,
+        'basicAuth' => null,
+        'body'      => true,
+        'data'      => [],
+        'encoding'  => 'utf-8',
+        'file'      => null,
+        'headers'   => [],
+        'method'    => 'GET',
+        'progress'  => null,
+        'test'      => false,
+        'timeout'   => 10,
     ];
 
     /**
@@ -181,6 +182,11 @@ class Remote
             }
 
             $this->curlopt[CURLOPT_HTTPHEADER] = $headers;
+        }
+
+        // add HTTP Basic authentication
+        if (empty($this->options['basicAuth']) === false) {
+            $this->curlopt[CURLOPT_USERPWD] = $this->options['basicAuth'];
         }
 
         // add the user agent

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -170,7 +170,17 @@ class Remote
 
         // add all headers
         if (empty($this->options['headers']) === false) {
-            $this->curlopt[CURLOPT_HTTPHEADER] = $this->options['headers'];
+            // convert associative arrays to strings
+            $headers = [];
+            foreach ($this->options['headers'] as $key => $value) {
+                if (is_string($key) === true) {
+                    $headers[] = $key . ': ' . $value;
+                } else {
+                    $headers[] = $value;
+                }
+            }
+
+            $this->curlopt[CURLOPT_HTTPHEADER] = $headers;
         }
 
         // add the user agent

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -22,6 +22,20 @@ class RemoteTest extends TestCase
         Remote::$defaults = $this->defaults;
     }
 
+    public function testOptionsHeaders()
+    {
+        $request = Remote::get('https://getkirby.com', [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Accept-Charset: utf8'
+            ]
+        ]);
+        $this->assertSame([
+            'Accept: application/json',
+            'Accept-Charset: utf8'
+        ], $request->curlopt[CURLOPT_HTTPHEADER]);
+    }
+
     public function testContent()
     {
         $request = Remote::put('https://getkirby.com');

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -36,71 +36,79 @@ class RemoteTest extends TestCase
         ], $request->curlopt[CURLOPT_HTTPHEADER]);
     }
 
+    public function testOptionsBasicAuth()
+    {
+        $request = Remote::get('https://getkirby.com', [
+            'basicAuth' => 'user:pw'
+        ]);
+        $this->assertSame('user:pw', $request->curlopt[CURLOPT_USERPWD]);
+    }
+
     public function testContent()
     {
         $request = Remote::put('https://getkirby.com');
-        $this->assertEquals(null, $request->content());
+        $this->assertSame(null, $request->content());
     }
 
     public function testCode()
     {
         $request = Remote::put('https://getkirby.com');
-        $this->assertEquals(null, $request->code());
+        $this->assertSame(null, $request->code());
     }
 
     public function testDelete()
     {
         $request = Remote::delete('https://getkirby.com');
-        $this->assertEquals('DELETE', $request->method());
+        $this->assertSame('DELETE', $request->method());
     }
 
     public function testGet()
     {
         $request = Remote::get('https://getkirby.com');
-        $this->assertEquals('GET', $request->method());
+        $this->assertSame('GET', $request->method());
     }
 
     public function testHead()
     {
         $request = Remote::head('https://getkirby.com');
-        $this->assertEquals('HEAD', $request->method());
+        $this->assertSame('HEAD', $request->method());
     }
 
     public function testHeaders()
     {
         $request = new Remote('https://getkirby.com');
-        $this->assertEquals([], $request->headers());
+        $this->assertSame([], $request->headers());
     }
 
     public function testInfo()
     {
         $request = new Remote('https://getkirby.com');
-        $this->assertEquals([], $request->info());
+        $this->assertSame([], $request->info());
     }
 
     public function testPatch()
     {
         $request = Remote::patch('https://getkirby.com');
-        $this->assertEquals('PATCH', $request->method());
+        $this->assertSame('PATCH', $request->method());
     }
 
     public function testPost()
     {
         $request = Remote::post('https://getkirby.com');
-        $this->assertEquals('POST', $request->method());
+        $this->assertSame('POST', $request->method());
     }
 
     public function testPut()
     {
         $request = Remote::put('https://getkirby.com');
-        $this->assertEquals('PUT', $request->method());
+        $this->assertSame('PUT', $request->method());
     }
 
     public function testRequest()
     {
         $request = new Remote($url = 'https://getkirby.com');
 
-        $this->assertEquals($url, $request->url());
-        $this->assertEquals('GET', $request->method());
+        $this->assertSame($url, $request->url());
+        $this->assertSame('GET', $request->method());
     }
 }


### PR DESCRIPTION
## Describe the PR

- Support associative arrays for the `headers` option (`'Accept' => 'application/json'` becomes `'Accept: application/json'` automatically)
- Add support for the `CURLOPT_USERPWD` option with a new `basicAuth` option

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2322

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if neeed)
