### PR TITLE
Fix minor typo in a comment

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -506,7 +506,7 @@ trait PageActions
 
                 return $num;
             default:
-                // get instance with default lanuage
+                // get instance with default language
                 $app = $this->kirby()->clone();
                 $app->setCurrentLanguage();
 


### PR DESCRIPTION
## Describe the PR

Fix spelling of `language` in a comment introduced in https://github.com/getkirby/kirby/issues/2256.

## Related issues

None.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if neeed)
