### PR TITLE
Allow symfony var dumper to be used

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -136,18 +136,20 @@ function deprecated(string $message): bool
     return false;
 }
 
-/**
- * Simple object and variable dumper
- * to help with debugging.
- *
- * @param mixed $variable
- * @param bool $echo
- * @return string
- */
-function dump($variable, bool $echo = true): string
-{
-    $kirby = App::instance();
-    return $kirby->component('dump')($kirby, $variable, $echo);
+if (false === function_exists('dump')) {
+    /**
+     * Simple object and variable dumper
+     * to help with debugging.
+     *
+     * @param mixed $variable
+     * @param bool $echo
+     * @return string
+     */
+    function dump($variable, bool $echo = true): string
+    {
+        $kirby = App::instance();
+        return $kirby->component('dump')($kirby, $variable, $echo);
+    }
 }
 
 /**


### PR DESCRIPTION
## Describe the PR

I like the symfony var dumper, but it breaks the base kirby helper. If you add a check if the function exists it can be used in stead of the Simple object and variable dumper.

## Related issues

None, better development

## Ready?

Yes

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
