### PR TITLE
Add support for PHP 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /.idea
 
 # tests
+.phpunit.result.cache
 /panel/cypress
 /tests/coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 install:
   # install Composer packages, will also trigger dump-autoload
-  - composer require -n --ignore-platform-reqs "phwoolcon/ci-pecl-cacher" "phpunit/phpunit:^7" "pcov/clobber" "friendsofphp/php-cs-fixer" "php-coveralls/php-coveralls"
+  - composer require -n --ignore-platform-reqs "phwoolcon/ci-pecl-cacher" "phpunit/phpunit:^8" "friendsofphp/php-cs-fixer" "php-coveralls/php-coveralls"
   - composer install -n --ignore-platform-reqs --no-suggest
 
   # install and cache PHP extensions
@@ -32,7 +32,6 @@ install:
 
 before_script:
   - mkdir -p build/logs
-  - ./vendor/bin/pcov clobber
   - ls -al
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ services:
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
-jobs:
-  allow_failures:
-  - php: 7.4snapshot
+  - 7.4
 
 before_install:
   # set up PHP config

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,13 +2,11 @@
 
 <phpunit
     bootstrap="tests/bootstrap.php"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnFailure="true"
-    stderr="true"
     colors="true"
-    verbose="true">
+    stopOnError="true"
+    stopOnFailure="true"
+    verbose="true"
+    stderr="true">
 
     <filter>
         <whitelist>

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -70,6 +70,13 @@ trait AppPlugins
     ];
 
     /**
+     * Cache for system extensions
+     *
+     * @var array
+     */
+    protected static $systemExtensions = null;
+
+    /**
      * Flag when plugins have been loaded
      * to not load them again
      *
@@ -570,37 +577,69 @@ trait AppPlugins
      */
     protected function extensionsFromSystem()
     {
-        // Form Field Mixins
-        FormField::$mixins['filepicker'] = include static::$root . '/config/fields/mixins/filepicker.php';
-        FormField::$mixins['min']        = include static::$root . '/config/fields/mixins/min.php';
-        FormField::$mixins['options']    = include static::$root . '/config/fields/mixins/options.php';
-        FormField::$mixins['pagepicker'] = include static::$root . '/config/fields/mixins/pagepicker.php';
-        FormField::$mixins['picker']     = include static::$root . '/config/fields/mixins/picker.php';
-        FormField::$mixins['upload']     = include static::$root . '/config/fields/mixins/upload.php';
-        FormField::$mixins['userpicker'] = include static::$root . '/config/fields/mixins/userpicker.php';
+        // load static extensions only once
+        if (static::$systemExtensions === null) {
+            // Form Field Mixins
+            FormField::$mixins['filepicker'] = include static::$root . '/config/fields/mixins/filepicker.php';
+            FormField::$mixins['min']        = include static::$root . '/config/fields/mixins/min.php';
+            FormField::$mixins['options']    = include static::$root . '/config/fields/mixins/options.php';
+            FormField::$mixins['pagepicker'] = include static::$root . '/config/fields/mixins/pagepicker.php';
+            FormField::$mixins['picker']     = include static::$root . '/config/fields/mixins/picker.php';
+            FormField::$mixins['upload']     = include static::$root . '/config/fields/mixins/upload.php';
+            FormField::$mixins['userpicker'] = include static::$root . '/config/fields/mixins/userpicker.php';
 
-        // Tag Aliases
-        KirbyTag::$aliases = [
-            'youtube' => 'video',
-            'vimeo'   => 'video'
-        ];
+            // Tag Aliases
+            KirbyTag::$aliases = [
+                'youtube' => 'video',
+                'vimeo'   => 'video'
+            ];
 
-        // Field method aliases
-        Field::$aliases = [
-            'bool'    => 'toBool',
-            'esc'     => 'escape',
-            'excerpt' => 'toExcerpt',
-            'float'   => 'toFloat',
-            'h'       => 'html',
-            'int'     => 'toInt',
-            'kt'      => 'kirbytext',
-            'kti'     => 'kirbytextinline',
-            'link'    => 'toLink',
-            'md'      => 'markdown',
-            'sp'      => 'smartypants',
-            'v'       => 'isValid',
-            'x'       => 'xml'
-        ];
+            // Field method aliases
+            Field::$aliases = [
+                'bool'    => 'toBool',
+                'esc'     => 'escape',
+                'excerpt' => 'toExcerpt',
+                'float'   => 'toFloat',
+                'h'       => 'html',
+                'int'     => 'toInt',
+                'kt'      => 'kirbytext',
+                'kti'     => 'kirbytextinline',
+                'link'    => 'toLink',
+                'md'      => 'markdown',
+                'sp'      => 'smartypants',
+                'v'       => 'isValid',
+                'x'       => 'xml'
+            ];
+
+            // blueprint presets
+            PageBlueprint::$presets['pages']   = include static::$root . '/config/presets/pages.php';
+            PageBlueprint::$presets['page']    = include static::$root . '/config/presets/page.php';
+            PageBlueprint::$presets['files']   = include static::$root . '/config/presets/files.php';
+
+            // section mixins
+            Section::$mixins['empty']          = include static::$root . '/config/sections/mixins/empty.php';
+            Section::$mixins['headline']       = include static::$root . '/config/sections/mixins/headline.php';
+            Section::$mixins['help']           = include static::$root . '/config/sections/mixins/help.php';
+            Section::$mixins['layout']         = include static::$root . '/config/sections/mixins/layout.php';
+            Section::$mixins['max']            = include static::$root . '/config/sections/mixins/max.php';
+            Section::$mixins['min']            = include static::$root . '/config/sections/mixins/min.php';
+            Section::$mixins['pagination']     = include static::$root . '/config/sections/mixins/pagination.php';
+            Section::$mixins['parent']         = include static::$root . '/config/sections/mixins/parent.php';
+
+            // section types
+            Section::$types['info']            = include static::$root . '/config/sections/info.php';
+            Section::$types['pages']           = include static::$root . '/config/sections/pages.php';
+            Section::$types['files']           = include static::$root . '/config/sections/files.php';
+            Section::$types['fields']          = include static::$root . '/config/sections/fields.php';
+
+            static::$systemExtensions = [
+                'components'   => include static::$root . '/config/components.php',
+                'blueprints'   => include static::$root . '/config/blueprints.php',
+                'fields'       => include static::$root . '/config/fields.php',
+                'fieldMethods' => include static::$root . '/config/methods.php',
+                'tags'         => include static::$root . '/config/tags.php'
+            ];
+        }
 
         // default cache types
         $this->extendCacheTypes([
@@ -610,32 +649,11 @@ trait AppPlugins
             'memory'    => 'Kirby\Cache\MemoryCache',
         ]);
 
-        $this->extendComponents(include static::$root . '/config/components.php');
-        $this->extendBlueprints(include static::$root . '/config/blueprints.php');
-        $this->extendFields(include static::$root . '/config/fields.php');
-        $this->extendFieldMethods((include static::$root . '/config/methods.php')($this));
-        $this->extendTags(include static::$root . '/config/tags.php');
-
-        // blueprint presets
-        PageBlueprint::$presets['pages']   = include static::$root . '/config/presets/pages.php';
-        PageBlueprint::$presets['page']    = include static::$root . '/config/presets/page.php';
-        PageBlueprint::$presets['files']   = include static::$root . '/config/presets/files.php';
-
-        // section mixins
-        Section::$mixins['empty']          = include static::$root . '/config/sections/mixins/empty.php';
-        Section::$mixins['headline']       = include static::$root . '/config/sections/mixins/headline.php';
-        Section::$mixins['help']           = include static::$root . '/config/sections/mixins/help.php';
-        Section::$mixins['layout']         = include static::$root . '/config/sections/mixins/layout.php';
-        Section::$mixins['max']            = include static::$root . '/config/sections/mixins/max.php';
-        Section::$mixins['min']            = include static::$root . '/config/sections/mixins/min.php';
-        Section::$mixins['pagination']     = include static::$root . '/config/sections/mixins/pagination.php';
-        Section::$mixins['parent']         = include static::$root . '/config/sections/mixins/parent.php';
-
-        // section types
-        Section::$types['info']            = include static::$root . '/config/sections/info.php';
-        Section::$types['pages']           = include static::$root . '/config/sections/pages.php';
-        Section::$types['files']           = include static::$root . '/config/sections/files.php';
-        Section::$types['fields']          = include static::$root . '/config/sections/fields.php';
+        $this->extendComponents(static::$systemExtensions['components']);
+        $this->extendBlueprints(static::$systemExtensions['blueprints']);
+        $this->extendFields(static::$systemExtensions['fields']);
+        $this->extendFieldMethods((static::$systemExtensions['fieldMethods'])($this));
+        $this->extendTags(static::$systemExtensions['tags']);
     }
 
     /**

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -319,6 +319,9 @@ class Auth
         $log['by-ip']    = $log['by-ip'] ?? [];
         $log['by-email'] = $log['by-email'] ?? [];
 
+        // remove all elements on the top level with different keys (old structure)
+        $log = array_intersect_key($log, array_flip(['by-ip', 'by-email']));
+
         // remove entries that are no longer needed
         $originalLog = $log;
         $time = time() - $this->kirby->option('auth.timeout', 3600);
@@ -327,9 +330,6 @@ class Auth
                 return $entry['time'] > $time;
             });
         }
-
-        // remove all elements on the top level with different keys (old structure)
-        $log = array_intersect_key($log, array_flip(['by-ip', 'by-email']));
 
         // write new log to the file system if it changed
         if ($read === false || $log !== $originalLog) {

--- a/src/Cms/FileVersion.php
+++ b/src/Cms/FileVersion.php
@@ -15,7 +15,9 @@ use Kirby\Toolkit\Properties;
  */
 class FileVersion
 {
-    use FileFoundation;
+    use FileFoundation {
+        toArray as parentToArray;
+    }
     use Properties;
 
     protected $modifications;
@@ -89,7 +91,7 @@ class FileVersion
      */
     public function toArray(): array
     {
-        $array = array_merge(parent::toArray(), [
+        $array = array_merge($this->parentToArray(), [
             'modifications' => $this->modifications(),
         ]);
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -272,7 +272,8 @@ class User extends ModelWithContent
     }
 
     /**
-     * Hashes user password
+     * Hashes the user's password unless it is `null`,
+     * which will leave it as `null`
      *
      * @internal
      * @param string|null $password
@@ -281,11 +282,7 @@ class User extends ModelWithContent
     public static function hashPassword($password): ?string
     {
         if ($password !== null) {
-            $info = password_get_info($password);
-
-            if ($info['algo'] === 0) {
-                $password = password_hash($password, PASSWORD_DEFAULT);
-            }
+            $password = password_hash($password, PASSWORD_DEFAULT);
         }
 
         return $password;
@@ -773,7 +770,7 @@ class User extends ModelWithContent
     }
 
     /**
-     * Sets and hashes a new user password
+     * Sets the user's password hash
      *
      * @param string $password
      * @return self

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -94,7 +94,7 @@ trait UserActions
     {
         return $this->commit('changePassword', [$this, $password], function ($user, $password) {
             $user = $user->clone([
-                'password' => $password = $user->hashPassword($password)
+                'password' => $password = User::hashPassword($password)
             ]);
 
             $user->writePassword($password);
@@ -165,7 +165,7 @@ trait UserActions
         $data = $props;
 
         if (isset($props['password']) === true) {
-            $data['password'] = static::hashPassword($props['password']);
+            $data['password'] = User::hashPassword($props['password']);
         }
 
         $props['role'] = $props['model'] = strtolower($props['role'] ?? 'default');

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -11,7 +11,7 @@ use ReflectionMethod;
  */
 class FileCacheTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Dir::remove(__DIR__ . '/fixtures/file');
     }

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -84,7 +84,7 @@ class HelpersTest extends TestCase
         // should generate token
         $session->remove('csrf');
         $token = csrf();
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
         $this->assertStringMatchesFormat('%x', $token);
         $this->assertEquals(64, strlen($token));
         $this->assertEquals($session->get('csrf'), $token);

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -121,11 +121,10 @@ class LanguageTest extends TestCase
         $this->assertEquals(null, $language->locale(LC_MONETARY));
     }
 
-    /**
-     * @expectedException Kirby\Exception\InvalidArgumentException
-     */
     public function testLocaleInvalid()
     {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+
         $language = new Language([
             'code' => 'en',
             'locale' => 123

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -779,13 +779,13 @@ class RouterTest extends TestCase
 
         // call custom media route
         $route = $app->router()->find('thumbs/pages/a/b/1234-5678/test.jpg', 'GET');
-        $this->assertContains('thumbs/pages/(.*)', $route->pattern());
+        $this->assertStringContainsString('thumbs/pages/(.*)', $route->pattern());
 
         $route = $app->router()->find('thumbs/site/1234-5678/test.jpg', 'GET');
-        $this->assertContains('thumbs/site/([a-z', $route->pattern());
+        $this->assertStringContainsString('thumbs/site/([a-z', $route->pattern());
 
         $route = $app->router()->find('thumbs/users/test@getkirby.com/1234-5678/test.jpg', 'GET');
-        $this->assertContains('thumbs/users/([a-z', $route->pattern());
+        $this->assertStringContainsString('thumbs/users/([a-z', $route->pattern());
 
         // default media route should result in the fallback route
         $route = $app->router()->find('media/pages/a/b/1234-5678/test.jpg', 'GET');

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -322,7 +322,7 @@ class PagesSectionTest extends TestCase
         $data = $section->data();
 
         // existing covers
-        $this->assertContains('data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw', $data[0]['image']['cards']['url']);
+        $this->assertStringContainsString('data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw', $data[0]['image']['cards']['url']);
 
         // non-existing covers
         $this->assertNull($data[2]['image']['cards']['url'] ?? null);

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -21,7 +21,7 @@ class WillFail
  */
 class ExceptionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_SERVER['DOCUMENT_ROOT']);
     }

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class FieldTest extends TestCase
 {
+    protected $originalMixins;
+
     public function setUp(): void
     {
         new App([
@@ -16,14 +18,17 @@ class FieldTest extends TestCase
             ]
         ]);
 
-        Field::$types  = [];
-        Field::$mixins = [];
+        Field::$types = [];
+
+        // make a backup of the system mixins
+        $this->originalMixins = Field::$mixins;
     }
 
     public function tearDown(): void
     {
-        Field::$types  = [];
-        Field::$mixins = [];
+        Field::$types = [];
+
+        Field::$mixins = $this->originalMixins;
     }
 
     public function testWithoutModel()

--- a/tests/Form/Fields/TestCase.php
+++ b/tests/Form/Fields/TestCase.php
@@ -14,8 +14,7 @@ class TestCase extends BaseTestCase
     public function setUp(): void
     {
         // start with a fresh set of fields
-        Field::$mixins = [];
-        Field::$types  = [];
+        Field::$types = [];
 
         $this->app = new App([
             'roots' => [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -9,14 +9,12 @@ class FieldsTest extends TestCase
 {
     public function setUp(): void
     {
-        Field::$types  = [];
-        Field::$mixins = [];
+        Field::$types = [];
     }
 
     public function tearDown(): void
     {
-        Field::$types  = [];
-        Field::$mixins = [];
+        Field::$types = [];
     }
 
     public function testConstruct()

--- a/tests/Form/ValidationsTest.php
+++ b/tests/Form/ValidationsTest.php
@@ -25,14 +25,11 @@ class ValidationsTest extends TestCase
                 ]
             ]
         ];
-
-        Field::$mixins = [];
     }
 
     public function tearDown(): void
     {
-        Field::$types  = [];
-        Field::$mixins = [];
+        Field::$types = [];
     }
 
     public function testBooleanValid()

--- a/tests/Http/ServerTest.php
+++ b/tests/Http/ServerTest.php
@@ -20,13 +20,13 @@ class ServerTest extends TestCase
 
     public function testGet()
     {
-        $this->assertInternalType('array', Server::get());
-        $this->assertInternalType('string', Server::get('SERVER_ADDR'));
+        $this->assertIsArray(Server::get());
+        $this->assertIsString(Server::get('SERVER_ADDR'));
     }
 
     public function testPort()
     {
-        $this->assertInternalType('int', Server::port());
+        $this->assertIsInt(Server::port());
         $this->assertEquals(0, Server::port());
 
         // SERVER_PORT

--- a/tests/Image/ExifTest.php
+++ b/tests/Image/ExifTest.php
@@ -113,7 +113,7 @@ class ExifTest extends TestCase
     public function testToArray()
     {
         $exif  = $this->_exif();
-        $this->assertInternalType('array', $exif->toArray());
-        $this->assertInternalType('array', $exif->__debugInfo());
+        $this->assertIsArray($exif->toArray());
+        $this->assertIsArray($exif->__debugInfo());
     }
 }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -33,8 +33,8 @@ class ImageTest extends TestCase
     public function testDownload()
     {
         $image  = $this->_image();
-        $this->assertInternalType('string', $image->download());
-        $this->assertInternalType('string', $image->download('meow.jpg'));
+        $this->assertIsString($image->download());
+        $this->assertIsString($image->download('meow.jpg'));
     }
 
     public function testExif()
@@ -140,13 +140,13 @@ class ImageTest extends TestCase
     public function testToArray()
     {
         $image  = $this->_image();
-        $this->assertInternalType('array', $image->toArray());
+        $this->assertIsArray($image->toArray());
     }
 
     public function testToJson()
     {
         $image  = $this->_image();
-        $this->assertInternalType('string', $image->toJson());
+        $this->assertIsString($image->toJson());
     }
 
     public function testToString()
@@ -158,6 +158,6 @@ class ImageTest extends TestCase
     public function testDebuginfo()
     {
         $image  = $this->_image();
-        $this->assertInternalType('array', $image->__debugInfo());
+        $this->assertIsArray($image->__debugInfo());
     }
 }

--- a/tests/Image/LocationTest.php
+++ b/tests/Image/LocationTest.php
@@ -37,7 +37,7 @@ class LocationTest extends TestCase
     public function testToString()
     {
         $camera = new Location($this->_exif());
-        $this->assertContains('50.8190533333', (string)$camera);
-        $this->assertContains('-0.016666666666', (string)$camera);
+        $this->assertStringContainsString('50.8190533333', (string)$camera);
+        $this->assertStringContainsString('-0.016666666666', (string)$camera);
     }
 }

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -107,7 +107,7 @@ class SessionTest extends TestCase
         // but setting a new value should
         $session->data()->set('someKey', 'someValue');
         $this->assertNotNull($session->token());
-        $this->assertInternalType('string', $session->token());
+        $this->assertIsString($session->token());
         $this->assertWriteMode(true, $session);
 
         $token = explode('.', $session->token());

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -250,7 +250,7 @@ class StrTest extends TestCase
         $length = 200;
 
         $this->assertRegexp('/^[[:alnum:]]+$/', Str::random());
-        $this->assertInternalType('string', Str::random());
+        $this->assertIsString(Str::random());
         $this->assertEquals($length, strlen(Str::random($length)));
 
         $this->assertRegexp('/^[[:alpha:]]+$/', Str::random($length, 'alpha'));


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- Make core code compatible with PHP 7.4 (password hashing bug + smaller bugs that now surfaced because of new PHP strict warnings)
- Improve unit testing performance and decrease memory usage by a lot by caching the system extensions in memory between the tests
- Upgrade to PHPUnit 8
- Run Travis tests with PHP 7.4

The performance improvements had to be done to get the tests to run on PHP 7.4, otherwise they would have failed because of not enough memory. Nice side effect: The Travis builds run almost half a minute faster than before.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2335 
