### PR TITLE
Fetch the last insert ID only with INSERT statements.

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -369,7 +369,7 @@ class Database
             $this->statement->execute($bindings);
 
             $this->affected  = $this->statement->rowCount();
-            $this->lastId    = $this->connection->lastInsertId();
+            $this->lastId    = substr($query, 0, 7 ) == 'INSERT ' ? $this->connection->lastInsertId() : null;
             $this->lastError = null;
 
             // store the final sql to add it to the trace later


### PR DESCRIPTION
## Describe the PR

I did implement a Postgresql Adapter for Kirby. PostgreSQL does not seem to like when the last insert ID is requested, but it was for example a `SELECT` query.

This PULL request changes the call to `lastInsertId` on `INSERT` queries.

I'm aware that this is not a nice solution, but based on the context that is available at that given point, it seems to be the only one.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
