### PR TITLE
Fix timezone bug in date field

### DIFF
--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -67,7 +67,7 @@ return [
     'methods' => [
         'toDate' => function ($value) {
             if ($timestamp = timestamp($value, $this->time['step'] ?? 5)) {
-                return date(DATE_W3C, $timestamp);
+                return date('Y-m-d H:i:s', $timestamp);
             }
 
             return null;

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -30,9 +30,9 @@ class DateFieldTest extends TestCase
     public function valueProvider()
     {
         return [
-            ['12.12.2012', date(DATE_W3C, strtotime('2012-12-12'))],
-            ['2016-11-21', date(DATE_W3C, strtotime('2016-11-21'))],
-            ['2016-11-21 12:12:12', date(DATE_W3C, strtotime('2016-11-21 12:10:00')), 5],
+            ['12.12.2012', date('Y-m-d H:i:s', strtotime('2012-12-12'))],
+            ['2016-11-21', date('Y-m-d H:i:s', strtotime('2016-11-21'))],
+            ['2016-11-21 12:12:12', date('Y-m-d H:i:s', strtotime('2016-11-21 12:10:00')), 5],
             ['something', null],
         ];
     }


### PR DESCRIPTION
This issue has been very annoying for quite some time. I'm working on an event calendar plugin and it will be almost impossible for it to work correctly without fixing this issue.

The cause for this bug is: let's say a date field in the content file contains `2019-12-09 10:00`. PHP assumes that the server timezone is UTC and sends `2019-12-09T10:00:00+00:00` to the browser. Because dayjs receives the date including a timezone, it tries to be smart by offsetting the date with my system's timezone. Because I'm in Brazil (GMT-03:00) I see time as 07:00 in the date field. In some cases, you even see a different day. If I set the time to 15:00, It is saved correctly. When I refresh the page it shows 12:00 because dayjs offsets the date once again.

If I set the server timezone to be the same as in my system, it works fine. The problem would be solved if panel users were always in the same timezone. But we can do better and not try to guess panel users' timezone.

## Describe the PR

The solution is to send dates without timezone to the browser in the [`/config/fields/date.php`](https://github.com/getkirby/kirby/blob/21ebebda6bdde9aee62140f81f658f0852ea4e60/config/fields/date.php#L70) file. This changes makes the browser displays the exact same datetime as in the content file.

No change is required in the front-end because the date I see when hitting "save" is being stored correctly to the content file.

## Related issues

- Fixes #1813 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
