### PR TITLE
Add fallbacks for grab cursor CSS #2354

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -761,6 +761,8 @@ $structure-item-height: 38px;
     box-shadow: rgba($color-dark, 0.25) 0 5px 10px;
     outline: 2px solid $color-focus;
     margin-bottom: 2px;
+    cursor: grabbing;
+    cursor: -moz-grabbing;
     cursor: -webkit-grabbing;
   }
 }

--- a/panel/src/components/Misc/SortHandle.vue
+++ b/panel/src/components/Misc/SortHandle.vue
@@ -8,6 +8,9 @@
 
 <style lang="scss">
 .k-sort-handle {
+  cursor: move;
+  cursor: grab;
+  cursor: -moz-grab;
   cursor: -webkit-grab;
   line-height: 0;
   color: $color-dark;
@@ -25,6 +28,8 @@
   width: 1rem;
 }
 .k-sort-handle:active {
+  cursor: grabbing;
+  cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
 }
 </style>


### PR DESCRIPTION
## Describe the PR

Add CSS fallbacks for grab cursor for non-webkit browsers.

## Related issues

- Fixes #2354
