### PR TITLE
Fix absolute path on dragText property

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -513,11 +513,12 @@ class File extends ModelWithContent
 
         if (empty($params['model']) === false) {
             $uuid = $this->parent() === $params['model'] ? $this->filename() : $this->id();
+            $absolute = $this->parent() !== $params['model'];
         }
 
         return [
             'filename' => $this->filename(),
-            'dragText' => $this->dragText(),
+            'dragText' => $this->dragText('auto', $absolute ?? false),
             'icon'     => $icon,
             'id'       => $this->id(),
             'image'    => $image,


### PR DESCRIPTION
## Describe the PR

Fixed absolute path on dragText property for files with checking parent model.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2366

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
