### PR TITLE
Update PHP version support checks

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,9 +2,12 @@
 
 /**
  * Validate the PHP version to already
- * stop at older versions
+ * stop at older or too recent versions
  */
-if (version_compare(phpversion(), '7.1.0', '>=') === false) {
+if (
+    version_compare(PHP_VERSION, '7.2.0', '>=') === false ||
+    version_compare(PHP_VERSION, '7.5.0', '<')  === false
+) {
     die(include __DIR__ . '/views/php.php');
 }
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "source": "https://github.com/getkirby/kirby"
   },
   "require": {
-    "php": ">=7.1.0",
+    "php": ">=7.2.0 <7.5.0",
     "ext-mbstring": "*",
     "ext-ctype": "*",
     "getkirby/composer-installer": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd42f7beddf9095ff11eb9c04e511f93",
+    "content-hash": "c2c22d6898201e049bbd0fa9d9906956",
     "packages": [
         {
             "name": "claviska/simpleimage",
@@ -621,7 +621,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0 <7.5.0",
         "ext-mbstring": "*",
         "ext-ctype": "*"
     },

--- a/views/php.php
+++ b/views/php.php
@@ -5,7 +5,7 @@
   </p>
   <p class="admin-advice">
     Advice for developers and administrators:<br>
-    Upgrade PHP to 7.1+
+    Change the PHP version to 7.2, 7.3 or 7.4 (PHP 7.3 is recommended)
   </p>
 
 <?php include __DIR__ . '/snippets/footer.php' ?>


### PR DESCRIPTION
Kirby 3.4.0+ supports PHP 7.2 to 7.4. Versions below 7.2 or above 7.4 (= 7.5.0 or greater) are not supported.