### PR TITLE
Load role files without subdirectories #2383

### DIFF
--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Toolkit\Dir;
-
 /**
  * Extension of the Collection class that
  * introduces `Roles::factory()` to convert an

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -116,12 +116,14 @@ class Roles extends Collection
 
         // load roles from directory
         if ($root !== null) {
-            foreach (Dir::read($root) as $filename) {
+            foreach (glob($root . '/*.yml') as $file) {
+                $filename = basename($file);
+
                 if ($filename === 'default.yml') {
                     continue;
                 }
 
-                $role = Role::load($root . '/' . $filename, $inject);
+                $role = Role::load($file, $inject);
                 $roles->set($role->id(), $role);
             }
         }


### PR DESCRIPTION
## Describe the PR

With this PR, only .yml files are loaded for roles and subdirectories and other files are ignored. 

## Related issues

- Fixes #2383

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
