### PR TITLE
Normalize greyscale and bw as thumb options #2384

### DIFF
--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -69,6 +69,26 @@ trait FileModifications
     }
 
     /**
+     * Alias for File::bw()
+     *
+     * @return \Kirby\Cms\FileVersion|\Kirby\Cms\File
+     */
+    public function grayscale()
+    {
+        return $this->thumb(['grayscale' => true]);
+    }
+
+    /**
+     * Alias for File::bw()
+     *
+     * @return \Kirby\Cms\FileVersion|\Kirby\Cms\File
+     */
+    public function greyscale()
+    {
+        return $this->thumb(['grayscale' => true]);
+    }
+
+    /**
      * Sets the JPEG compression quality
      *
      * @param int $quality

--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -65,6 +65,18 @@ class Darkroom
             $options['blur'] = 10;
         }
 
+        // normalize the greyscale option
+        if (isset($options['greyscale']) === true) {
+            $options['grayscale'] = $options['greyscale'];
+            unset($options['greyscale']);
+        }
+
+        // normalize the bw option
+        if (isset($options['bw']) === true) {
+            $options['grayscale'] = $options['bw'];
+            unset($options['bw']);
+        }
+
         if ($options['quality'] === null) {
             $options['quality'] = $this->settings['quality'];
         }

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -111,4 +111,32 @@ class DarkroomTest extends TestCase
 
         $this->assertEquals(30, $options['quality']);
     }
+
+    public function testGrayscaleFixes()
+    {
+        $darkroom = new Darkroom();
+
+        // grayscale
+        $options = $darkroom->preprocess($this->file(), [
+            'grayscale' => true
+        ]);
+
+        $this->assertEquals(true, $options['grayscale']);
+
+        // greyscale
+        $options = $darkroom->preprocess($this->file(), [
+            'greyscale' => true
+        ]);
+
+        $this->assertEquals(true, $options['grayscale']);
+        $this->assertEquals(false, isset($options['greyscale']));
+
+        // bw
+        $options = $darkroom->preprocess($this->file(), [
+            'bw' => true
+        ]);
+
+        $this->assertEquals(true, $options['grayscale']);
+        $this->assertEquals(false, isset($options['bw']));
+    }
 }


### PR DESCRIPTION
## Describe the PR

`greyscale` and `bw` will now automatically be corrected to grayscale when using them as thumb options.

## Related issues

- Fixes #2384

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`