### PR TITLE
Clear lock if user not found for locked page #2333

### DIFF
--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -45,7 +45,7 @@ class ContentLock
      *
      * @return bool
      */
-    public function clear(): bool
+    protected function clearLock(): bool
     {
         // if no lock exists, skip
         if (isset($this->data['lock']) === false) {
@@ -105,7 +105,7 @@ class ContentLock
             }
 
             // clear lock if user not found
-            $this->clear();
+            $this->clearLock();
         }
 
         return false;
@@ -169,10 +169,7 @@ class ContentLock
             ]);
         }
 
-        // remove lock
-        unset($this->data['lock']);
-
-        return $this->kirby()->locks()->set($this->model, $this->data);
+        return $this->clearLock();
     }
 
     /**
@@ -212,10 +209,7 @@ class ContentLock
         $this->data['unlock']   = $this->data['unlock'] ?? [];
         $this->data['unlock'][] = $this->data['lock']['user'];
 
-        // remove lock
-        unset($this->data['lock']);
-
-        return $this->kirby()->locks()->set($this->model, $this->data);
+        return $this->clearLock();
     }
 
     /**

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -41,7 +41,7 @@ class ContentLock
     }
 
     /**
-     * Clear lock
+     * Clears the lock unconditionally
      *
      * @return bool
      */

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -41,6 +41,24 @@ class ContentLock
     }
 
     /**
+     * Clear lock
+     *
+     * @return bool
+     */
+    public function clear(): bool
+    {
+        // if no lock exists, skip
+        if (isset($this->data['lock']) === false) {
+            return true;
+        }
+
+        // remove lock
+        unset($this->data['lock']);
+
+        return $this->kirby()->locks()->set($this->model, $this->data);
+    }
+
+    /**
      * Sets lock with the current user
      *
      * @return bool
@@ -74,19 +92,20 @@ class ContentLock
     {
         $data = $this->data['lock'] ?? [];
 
-        if (
-            empty($data) === false &&
-            $data['user'] !== $this->user()->id() &&
-            $user = $this->kirby()->user($data['user'])
-        ) {
-            $time = (int)($data['time']);
+        if (empty($data) === false && $data['user'] !== $this->user()->id()) {
+            if ($user = $this->kirby()->user($data['user'])) {
+                $time = (int)($data['time']);
 
-            return [
-                'user'       => $user->id(),
-                'email'      => $user->email(),
-                'time'       => $time,
-                'unlockable' => ($time + 60) <= time()
-            ];
+                return [
+                    'user'       => $user->id(),
+                    'email'      => $user->email(),
+                    'time'       => $time,
+                    'unlockable' => ($time + 60) <= time()
+                ];
+            }
+
+            // clear lock if user not found
+            $this->clear();
         }
 
         return false;

--- a/tests/Cms/Content/ContentLockTest.php
+++ b/tests/Cms/Content/ContentLockTest.php
@@ -17,8 +17,8 @@ class ContentLockTest extends TestCase
             ],
             'site' => [
                 'children' => [
-                    ['slug'  => 'test'],
-                    ['slug'  => 'foo']
+                    ['slug' => 'test'],
+                    ['slug' => 'foo']
                 ]
             ],
             'users' => [
@@ -38,6 +38,28 @@ class ContentLockTest extends TestCase
     public function tearDown(): void
     {
         Dir::remove($this->fixtures);
+    }
+
+    public function testClearLock()
+    {
+        $app = $this->app;
+        $page = $app->page('test');
+
+        $app->impersonate('test@getkirby.com');
+        $page->lock()->create();
+        $oldData = $page->lock()->get();
+        $app->users()->remove($app->user()->id());
+
+        $app->impersonate('homer@simpson.com');
+        $page->lock()->get();
+        $page->lock()->create();
+        $newData = $page->lock()->get();
+
+        $this->assertTrue(empty($oldData));
+        $this->assertFalse(empty($newData));
+        $this->assertFalse($newData['unlockable']);
+        $this->assertEquals('homer@simpson.com', $newData['email']);
+        $this->assertArrayHasKey('time', $newData);
     }
 
     public function testCreate()


### PR DESCRIPTION
## Describe the PR

I think the issue is because the page locked by another user that cannot find the user.
If you think the issue  is not caused by this, I must say that this PR definitely resolves a bug :))

Fixed the issue with clearing lock data if user not found for that page. 
I could not see the appropriate method for remove/clear all lock data and created a new `clear` method that remove `lock` data without any conditions.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2333 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
