### PR TITLE
Refactored Html and Xml classes

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -126,22 +126,19 @@ class Html
     }
 
     /**
-     * Removes all html tags and encoded chars from a string
+     * Removes all HTML tags and encoded chars from a string
      *
-     * <code>
-     *
-     * echo html::decode('some uber <em>crazy</em> stuff');
-     * // output: some uber crazy stuff
-     *
-     * </code>
+     * ```
+     * echo Html::decode('some &uuml;ber <em>crazy</em> stuff');
+     * // output: some über crazy stuff
+     * ```
      *
      * @param string $string
-     * @return string The html string
+     * @return string
      */
-    public static function decode(string $string = null): string
+    public static function decode(string $string): string
     {
-        $string = strip_tags($string);
-        return html_entity_decode($string, ENT_COMPAT, 'utf-8');
+        return Xml::decode($string);
     }
 
     /**

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -184,7 +184,7 @@ class Html
      * @param bool $keepTags If true, existing tags won't be escaped
      * @return string The HTML string
      */
-    public static function encode(string $string = '', bool $keepTags = false): string
+    public static function encode(string $string, bool $keepTags = false): string
     {
         if ($keepTags === true) {
             $list = static::entities();

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -160,23 +160,20 @@ class Xml
     }
 
     /**
-     * Removes all xml entities from a string
-     * and convert them to html entities first
-     * and remove all html entities afterwards.
+     * Removes all XML tags and encoded chars from a string
      *
-     * <code>
-     *
-     * echo xml::decode('some <em>&#252;ber</em> crazy stuff');
-     * // output: some &uuml;ber crazy stuff
-     *
-     * </code>
+     * ```
+     * echo Xml::decode('some &uuml;ber <em>crazy</em> stuff');
+     * // output: some über crazy stuff
+     * ```
      *
      * @param string $string
      * @return string
      */
-    public static function decode(string $string = null): string
+    public static function decode(string $string): string
     {
-        return Html::decode($string);
+        $string = strip_tags($string);
+        return html_entity_decode($string, ENT_COMPAT, 'utf-8');
     }
 
     /**

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -54,6 +54,61 @@ class Xml
     ];
 
     /**
+     * Generates a single attribute or a list of attributes
+     *
+     * @param string|array $name String: A single attribute with that name will be generated.
+     *                           Key-value array: A list of attributes will be generated. Don't pass a second argument in that case.
+     * @param mixed $value If used with a `$name` string, pass the value of the attribute here.
+     *                     If used with a `$name` array, this can be set to `false` to disable attribute sorting.
+     * @return string|null The generated XML attributes string
+     */
+    public static function attr($name, $value = null): ?string
+    {
+        if (is_array($name) === true) {
+            if ($value !== false) {
+                ksort($name);
+            }
+
+            $attributes = [];
+            foreach ($name as $key => $val) {
+                $a = static::attr($key, $val);
+
+                if ($a) {
+                    $attributes[] = $a;
+                }
+            }
+
+            return implode(' ', $attributes);
+        }
+
+        if ($value === null || $value === '' || $value === []) {
+            return null;
+        }
+
+        if ($value === ' ') {
+            return strtolower($name) . '=""';
+        }
+
+        if (is_bool($value) === true) {
+            return $value === true ? strtolower($name) . '="' . strtolower($name) . '"' : null;
+        }
+
+        if (is_array($value) === true) {
+            if (isset($value['value'], $value['escape'])) {
+                $value = $value['escape'] === true ? static::encode($value['value']) : $value['value'];
+            } else {
+                $value = implode(' ', array_filter($value, function ($value) {
+                    return !empty($value) || is_numeric($value);
+                }));
+            }
+        } else {
+            $value = static::encode($value);
+        }
+
+        return strtolower($name) . '="' . $value . '"';
+    }
+
+    /**
      * Creates an XML string from an array
      *
      * @param string $props The source array

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -128,11 +128,11 @@ class Xml
      * @param array|string $props The source array or tag content (used internally)
      * @param string $name The name of the root element
      * @param bool $head Include the XML declaration head or not
-     * @param int $level The indendation level (used internally)
      * @param string $indent Indentation string, defaults to two spaces
+     * @param int $level The indendation level (used internally)
      * @return string The XML string
      */
-    public static function create($props, string $name = 'root', bool $head = true, int $level = 0, string $indent = '  '): string
+    public static function create($props, string $name = 'root', bool $head = true, string $indent = '  ', int $level = 0): string
     {
         if (is_array($props) === true) {
             if (A::isAssociative($props) === true) {
@@ -158,7 +158,7 @@ class Xml
                     $value = [];
                     foreach ($props as $childName => $childItem) {
                         // render the child, but don't include the indentation of the first line
-                        $value[] = trim(static::create($childItem, $childName, false, $level + 1, $indent));
+                        $value[] = trim(static::create($childItem, $childName, false, $indent, $level + 1));
                     }
                 }
 
@@ -168,7 +168,7 @@ class Xml
 
                 $result = [];
                 foreach ($props as $childItem) {
-                    $result[] = static::create($childItem, $name, false, $level, $indent);
+                    $result[] = static::create($childItem, $name, false, $indent, $level);
                 }
 
                 $result = implode(PHP_EOL, $result);

--- a/tests/Cms/KirbyText/KirbyTagsTest.php
+++ b/tests/Cms/KirbyText/KirbyTagsTest.php
@@ -125,7 +125,7 @@ class KirbyTagsTest extends TestCase
 
         $expected = '<figure><a href="' . $doc->url() . '"><img alt="" src="' . $image->url() . '"></a></figure>';
 
-        $this->assertEquals($expected, $page->text()->kt());
+        $this->assertEquals($expected, $page->text()->kt()->value());
     }
 
     public function testFile()
@@ -156,7 +156,7 @@ class KirbyTagsTest extends TestCase
 
         $expected = '<p><a download href="' . $file->url() . '">a.jpg</a></p>';
 
-        $this->assertEquals($expected, $page->text()->kt());
+        $this->assertEquals($expected, $page->text()->kt()->value());
     }
 
     public function testFileWithDisabledDownloadOption()
@@ -187,7 +187,7 @@ class KirbyTagsTest extends TestCase
 
         $expected = '<p><a href="' . $file->url() . '">a.jpg</a></p>';
 
-        $this->assertEquals($expected, $page->text()->kt());
+        $this->assertEquals($expected, $page->text()->kt()->value());
     }
 
     public function testFileWithinFile()
@@ -220,7 +220,7 @@ class KirbyTagsTest extends TestCase
         $b = $kirby->file('a/b.jpg');
         $expected = '<p><a download href="' . $b->url() . '">b.jpg</a></p>';
 
-        $this->assertEquals($expected, (string)$a->caption()->kt());
+        $this->assertEquals($expected, $a->caption()->kt()->value());
     }
 
     public function testLinkWithLangAttribute()

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -160,14 +160,6 @@ class HtmlTest extends TestCase
     }
 
     /**
-     * @covers ::decode
-     */
-    public function testDecode()
-    {
-        $this->assertSame('some über crazy stuff', Html::decode('some &uuml;ber <em>crazy</em> stuff'));
-    }
-
-    /**
      * @covers ::email
      */
     public function testEmail()
@@ -419,9 +411,35 @@ class HtmlTest extends TestCase
         $expected = '<p class="test">test</p>';
         $this->assertSame($expected, $html);
 
+        $html = Html::tag('p', 'täst', ['class' => 'test']);
+        $expected = '<p class="test">t&auml;st</p>';
+        $this->assertSame($expected, $html);
+
         $html = Html::tag('p', ['<i>test</i>']);
         $expected = '<p><i>test</i></p>';
         $this->assertSame($expected, $html);
+    }
+
+    /**
+     * @covers       ::value
+     * @dataProvider valueProvider
+     */
+    public function testValue($input, $expected)
+    {
+        $this->assertSame($expected, Html::value($input));
+    }
+
+    public function valueProvider()
+    {
+        return [
+            [true, 'true'],
+            [false, 'false'],
+            [1, '1'],
+            [null, null],
+            ['', null],
+            ['test', 'test'],
+            ['täst', 't&auml;st'],
+        ];
     }
 
     /**

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -169,7 +169,7 @@ class XmlTest extends TestCase
         $tag = Xml::tag('name', 'content');
         $this->assertSame('<name>content</name>', $tag);
 
-        $tag = Xml::tag('name', 'content', null, 1);
+        $tag = Xml::tag('name', 'content', null, '  ', 1);
         $this->assertSame('  <name>content</name>', $tag);
 
         $tag = Xml::tag('name', 'content', ['foo' => 'bar']);
@@ -181,13 +181,13 @@ class XmlTest extends TestCase
         $tag = Xml::tag('name', 'Süper Önencœded ßtring', ['foo' => 'bar']);
         $this->assertSame('<name foo="bar"><![CDATA[Süper Önencœded ßtring]]></name>', $tag);
 
-        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], 1);
+        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], '  ', 1);
         $this->assertSame('  <name foo="bar">content</name>', $tag);
 
-        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], 1, '    ');
+        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], '    ', 1);
         $this->assertSame('    <name foo="bar">content</name>', $tag);
 
-        $tag = Xml::tag('name', ['Test', 'Test2'], ['foo' => 'bar'], 2, ' ');
+        $tag = Xml::tag('name', ['Test', 'Test2'], ['foo' => 'bar'], ' ', 2);
         $this->assertSame('  <name foo="bar">' . PHP_EOL . '   Test' . PHP_EOL . '   Test2' . PHP_EOL . '  </name>', $tag);
     }
 

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -4,89 +4,217 @@ namespace Kirby\Toolkit;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass Kirby\Toolkit\Xml
+ */
 class XmlTest extends TestCase
 {
-    protected $string;
-
-    protected function setUp(): void
+    /**
+     * @covers       ::attr
+     * @dataProvider attrProvider
+     */
+    public function testAttr($input, $value, $expected)
     {
-        $this->string = 'Süper Önencœded ßtring';
+        $this->assertSame($expected, Xml::attr($input, $value));
     }
 
-    public function testCreateParse()
+    public function attrProvider()
     {
-        $xml = Xml::create($data = [
-            'simpson' => [
+        return [
+            [[],                         null,  ''],
+            [['B' => 'b', 'A' => 'a'],   null,  'a="a" b="b"'],
+            [['B' => 'b', 'A' => 'a'],   true,  'a="a" b="b"'],
+            [['B' => 'b', 'A' => 'a'],   false, 'b="b" a="a"'],
+            [['a' => 'a', 'b' => true],  null,  'a="a" b="b"'],
+            [['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
+            [['a' => 'a', 'b' => ''],    null,  'a="a"'],
+            [['a' => 'a', 'b' => false], null,  'a="a"'],
+            [['a' => 'a', 'b' => null],  null,  'a="a"'],
+            [['a' => 'a', 'b' => []],    null,  'a="a"']
+        ];
+    }
+
+    /**
+     * @covers ::attr
+     */
+    public function testAttrArrayValue()
+    {
+        $result = Xml::attr('a', ['a', 'b']);
+        $this->assertSame('a="a b"', $result);
+
+        $result = Xml::attr('a', ['a', 1]);
+        $this->assertSame('a="a 1"', $result);
+
+        $result = Xml::attr('a', ['a', null]);
+        $this->assertSame('a="a"', $result);
+
+        $result = Xml::attr('a', ['value' => '&', 'escape' => true]);
+        $this->assertSame('a="&#38;"', $result);
+
+        $result = Xml::attr('a', ['value' => '&', 'escape' => false]);
+        $this->assertSame('a="&"', $result);
+    }
+
+    /**
+     * @covers ::parse
+     * @covers ::simplify
+     * @covers ::create
+     */
+    public function testParseSimplifyCreate()
+    {
+        $this->assertSame('<name>Homer</name>', Xml::create('Homer', 'name', false));
+        $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<name>Homer</name>', Xml::create('Homer', 'name', true));
+
+        $this->assertSame('  <name>Homer</name>', Xml::create('Homer', 'name', false, 1));
+        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, 1, '    '));
+        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, 2));
+
+        $data = [
+            '@name' => 'contact',
+            '@attributes' => [
+                'type' => 'husband'
+            ],
+            '@value' => 'Homer'
+        ];
+        $this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/contact.xml')));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contact.xml', Xml::create($data, 'contact'));
+
+        $data = [
+            '@name' => 'contacts',
+            'contact' => $contacts = [
                 [
-                    'name' => 'Homer',
                     '@attributes' => [
-                        'type' => 'father'
-                    ]
+                        'type' => 'husband'
+                    ],
+                    '@value' => 'Homer'
                 ],
                 [
-                    'name' => 'Marge',
+                    '@attributes' => [
+                        'type' => 'daughter'
+                    ],
+                    '@value' => 'Lisa'
+                ]
+            ]
+        ];
+        $this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/contacts.xml')));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contacts_nowrapper.xml', Xml::create($contacts, 'contact', false));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contacts.xml', Xml::create($data, 'contacts'));
+
+        $data = [
+            '@name' => 'simpsons',
+            '@namespaces' => [
+                '' => 'https://example.com/simpsons',
+                'simpson' => 'https://example.com/simpson',
+                'unused' => 'https://example.com/unused'
+            ],
+            'simpson' => [
+                [
+                    '@attributes' => [
+                        'type' => 'father'
+                    ],
+                    'name' => 'Homer'
+                ],
+                [
                     '@attributes' => [
                         'type' => 'mother'
+                    ],
+                    'name' => 'Marge',
+                    'simpson:contacts' => [
+                        'simpson:contact' => [
+                            '@attributes' => [
+                                'simpson:type' => 'husband'
+                            ],
+                            '@value' => 'Homer',
+                        ]
                     ]
                 ]
             ]
-        ], 'simpsons');
+        ];
+        $this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/simpsons.xml')));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'invalid'));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, 0, '    '));
 
-        $output = Xml::parse($xml);
+        unset($data['@name']);
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'simpsons'));
 
-        $this->assertEquals($output, $data);
+        $this->assertNull(Xml::parse('<this>is invalid</that>'));
     }
 
+    /**
+     * @covers ::encode
+     * @covers ::decode
+     */
     public function testEncodeDecode()
     {
         $expected = 'S&#252;per &#214;nenc&#339;ded &#223;tring';
+        $this->assertSame($expected, Xml::encode('Süper Önencœded ßtring'));
+        $this->assertSame('Süper Önencœded ßtring', Xml::decode($expected));
 
-        $this->assertEquals($expected, Xml::encode($this->string));
-        $this->assertEquals($this->string, Xml::decode($expected));
+        $this->assertSame('S&#252;per Täst', Xml::encode('S&uuml;per Täst', false));
     }
 
+    /**
+     * @covers ::entities
+     */
     public function testEntities()
     {
-        $this->assertTrue(is_array(Xml::entities()));
+        $this->assertSame(Xml::$entities, Xml::entities());
     }
 
+    /**
+     * @covers ::tag
+     */
     public function testTag()
     {
         $tag = Xml::tag('name', 'content');
-        $this->assertEquals('<name>content</name>', $tag);
-    }
+        $this->assertSame('<name>content</name>', $tag);
 
-    public function testTagWithAttributes()
-    {
+        $tag = Xml::tag('name', 'content', null, 1);
+        $this->assertSame('  <name>content</name>', $tag);
+
         $tag = Xml::tag('name', 'content', ['foo' => 'bar']);
-        $this->assertEquals('<name foo="bar">content</name>', $tag);
+        $this->assertSame('<name foo="bar">content</name>', $tag);
+
+        $tag = Xml::tag('name', null, ['foo' => 'bar']);
+        $this->assertSame('<name foo="bar" />', $tag);
+
+        $tag = Xml::tag('name', 'Süper Önencœded ßtring', ['foo' => 'bar']);
+        $this->assertSame('<name foo="bar"><![CDATA[Süper Önencœded ßtring]]></name>', $tag);
+
+        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], 1);
+        $this->assertSame('  <name foo="bar">content</name>', $tag);
+
+        $tag = Xml::tag('name', 'content', ['foo' => 'bar'], 1, '    ');
+        $this->assertSame('    <name foo="bar">content</name>', $tag);
+
+        $tag = Xml::tag('name', ['Test', 'Test2'], ['foo' => 'bar'], 2, ' ');
+        $this->assertSame('  <name foo="bar">' . PHP_EOL . '   Test' . PHP_EOL . '   Test2' . PHP_EOL . '  </name>', $tag);
     }
 
-    public function testTagWithCdata()
+    /**
+     * @covers       ::value
+     * @dataProvider valueProvider
+     */
+    public function testValue($input, $expected)
     {
-        $tag = Xml::tag('name', $this->string, ['foo' => 'bar']);
-        $this->assertEquals('<name foo="bar"><![CDATA[' . Xml::encode($this->string) . ']]></name>', $tag);
+        $this->assertSame($expected, Xml::value($input));
     }
 
     public function valueProvider()
     {
         return [
-            [1, 1],
             [true, 'true'],
             [false, 'false'],
+            [1, '1'],
             [null, null],
             ['', null],
             ['<![CDATA[test]]>', '<![CDATA[test]]>'],
+            ['<![CDATA[töst]]>', '<![CDATA[töst]]>'],
             ['test', 'test'],
-            ['töst', '<![CDATA[t&#246;st]]>']
+            ['töst', '<![CDATA[töst]]>'],
+            ['This is a <![CDATA[test]]> with CDATA', '<![CDATA[This is a <![CDATA[test]]]]><![CDATA[> with CDATA]]>'],
+            ['te]]>st', '<![CDATA[te]]]]><![CDATA[>st]]>'],
+            ['tö]]>st', '<![CDATA[tö]]]]><![CDATA[>st]]>']
         ];
-    }
-
-    /**
-     * @dataProvider valueProvider
-     */
-    public function testValue($input, $expected)
-    {
-        $this->assertEquals($expected, Xml::value($input));
     }
 }

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -65,9 +65,9 @@ class XmlTest extends TestCase
         $this->assertSame('<name>Homer</name>', Xml::create('Homer', 'name', false));
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<name>Homer</name>', Xml::create('Homer', 'name', true));
 
-        $this->assertSame('  <name>Homer</name>', Xml::create('Homer', 'name', false, 1));
-        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, 1, '    '));
-        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, 2));
+        $this->assertSame('  <name>Homer</name>', Xml::create('Homer', 'name', false, '  ', 1));
+        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '    ', 1));
+        $this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '  ', 2));
 
         $data = [
             '@name' => 'contact',
@@ -132,7 +132,7 @@ class XmlTest extends TestCase
         ];
         $this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/simpsons.xml')));
         $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'invalid'));
-        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, 0, '    '));
+        $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
 
         unset($data['@name']);
         $this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'simpsons'));

--- a/tests/Toolkit/fixtures/xml/contact.xml
+++ b/tests/Toolkit/fixtures/xml/contact.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contact type="husband">Homer</contact>

--- a/tests/Toolkit/fixtures/xml/contacts.xml
+++ b/tests/Toolkit/fixtures/xml/contacts.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contacts>
+  <contact type="husband">Homer</contact>
+  <contact type="daughter">Lisa</contact>
+</contacts>

--- a/tests/Toolkit/fixtures/xml/contacts_nowrapper.xml
+++ b/tests/Toolkit/fixtures/xml/contacts_nowrapper.xml
@@ -1,0 +1,2 @@
+<contact type="husband">Homer</contact>
+<contact type="daughter">Lisa</contact>

--- a/tests/Toolkit/fixtures/xml/simpsons.xml
+++ b/tests/Toolkit/fixtures/xml/simpsons.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simpsons xmlns="https://example.com/simpsons" xmlns:simpson="https://example.com/simpson" xmlns:unused="https://example.com/unused">
+  <simpson type="father">
+    <name>Homer</name>
+  </simpson>
+  <simpson type="mother">
+    <name>Marge</name>
+    <simpson:contacts>
+      <simpson:contact simpson:type="husband">Homer</simpson:contact>
+    </simpson:contacts>
+  </simpson>
+</simpsons>

--- a/tests/Toolkit/fixtures/xml/simpsons_4spaces.xml
+++ b/tests/Toolkit/fixtures/xml/simpsons_4spaces.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simpsons xmlns="https://example.com/simpsons" xmlns:simpson="https://example.com/simpson" xmlns:unused="https://example.com/unused">
+    <simpson type="father">
+        <name>Homer</name>
+    </simpson>
+    <simpson type="mother">
+        <name>Marge</name>
+        <simpson:contacts>
+            <simpson:contact simpson:type="husband">Homer</simpson:contact>
+        </simpson:contacts>
+    </simpson>
+</simpsons>


### PR DESCRIPTION
## Describe the PR

- Made relevant methods from the `Toolkit\Html` class available in the `Toolkit\Xml` class
- Full refactoring of the `Html` and `Xml` classes including tests with 100 % code coverage
  - Improve reliability and consistency of XML parsing and creation (the previous implementation lacked many features and didn't generate correct indentation)
  - `Html` now inherits from `Xml` to enable code sharing and access to the parsing and document creation methods in the Html class
  - Correct and improve information in doc blocks
  - Fix email and tel link generation in `Html::a()`
  - `Html::email()`: Fix link generation when called without text (the email address was previously not made the link text even though that is what was supposed to happen)
  - `Html::tag()`: Support for passing `null` as the `$content` to explicitly generate a void tag (was already documented like this but not supported)
  - `Xml::value()`: Proper CDATA support including edge-cases
  - Improve consistency of method arguments

**Note:** Some methods in both classes previously had completely optional arguments, even in cases where it didn't really make sense (like `Html::breaks()`). I have changed the type hints for those methods to better fit the use-case. @bastianallgeier Please check if there was a valid reason why the type hints have previously been so lax. Maybe I'm missing something.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
