### PR TITLE
New Kirby\Data\Xml class

### DIFF
--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -8,8 +8,8 @@ use Kirby\Toolkit\F;
 /**
  * The `Data` class provides readers and
  * writers for data. The class comes with
- * four handlers for `json`, `php`, `txt`
- * and `yaml` encoded data, but can be
+ * four handlers for `json`, `php`, `txt`,
+ * `xml` and `yaml` encoded data, but can be
  * extended and customized.
  *
  * The read and write methods automatically
@@ -32,6 +32,7 @@ class Data
     public static $aliases = [
         'md'    => 'txt',
         'mdown' => 'txt',
+        'rss'   => 'xml',
         'yml'   => 'yaml',
     ];
 
@@ -44,6 +45,7 @@ class Data
         'json' => 'Kirby\Data\Json',
         'php'  => 'Kirby\Data\PHP',
         'txt'  => 'Kirby\Data\Txt',
+        'xml'  => 'Kirby\Data\Xml',
         'yaml' => 'Kirby\Data\Yaml',
     ];
 

--- a/src/Data/Xml.php
+++ b/src/Data/Xml.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kirby\Data;
+
+use Exception;
+use Kirby\Toolkit\Xml as XmlConverter;
+
+/**
+ * Simple Wrapper around the XML parser of the Toolkit
+ *
+ * @package   Kirby Data
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Xml extends Handler
+{
+    /**
+     * Converts an array to an encoded XML string
+     *
+     * @param mixed $data
+     * @return string
+     */
+    public static function encode($data): string
+    {
+        return XmlConverter::create($data, 'data');
+    }
+
+    /**
+     * Parses an encoded XML string and returns a multi-dimensional array
+     *
+     * @param string $xml
+     * @return array
+     */
+    public static function decode($xml): array
+    {
+        $result = XmlConverter::parse($xml);
+
+        if (is_array($result) === true) {
+            // remove the root's name if it is the default <data> to ensure that
+            // the decoded data is the same as the input to the encode() method
+            if ($result['@name'] === 'data') {
+                unset($result['@name']);
+            }
+
+            return $result;
+        } else {
+            throw new Exception('XML string is invalid');
+        }
+    }
+}

--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -20,11 +20,13 @@ class DataTest extends TestCase
         $this->assertInstanceOf(Json::class, Data::handler('json'));
         $this->assertInstanceOf(PHP::class, Data::handler('php'));
         $this->assertInstanceOf(Txt::class, Data::handler('txt'));
+        $this->assertInstanceOf(Xml::class, Data::handler('xml'));
         $this->assertInstanceOf(Yaml::class, Data::handler('yaml'));
 
         // aliases
         $this->assertInstanceOf(Txt::class, Data::handler('md'));
         $this->assertInstanceOf(Txt::class, Data::handler('mdown'));
+        $this->assertInstanceOf(Xml::class, Data::handler('rss'));
         $this->assertInstanceOf(Yaml::class, Data::handler('yml'));
 
         // different case
@@ -72,7 +74,7 @@ class DataTest extends TestCase
             'email' => 'homer@simpson.com'
         ];
 
-        $handlers = ['json', 'yml', 'txt'];
+        $handlers = ['json', 'yml', 'xml', 'txt'];
 
         foreach ($handlers as $handler) {
             $encoded = Data::encode($data, $handler);

--- a/tests/Data/XmlTest.php
+++ b/tests/Data/XmlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Kirby\Data;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass Kirby\Data\Xml
+ */
+class XmlTest extends TestCase
+{
+    /**
+     * @covers ::encode
+     * @covers ::decode
+     */
+    public function testEncodeDecode()
+    {
+        $array = [
+            'name'     => 'Homer',
+            'children' => ['Lisa', 'Bart', 'Maggie']
+        ];
+
+        $expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<data>\n  <name>Homer</name>\n  " .
+                    "<children>Lisa</children>\n  <children>Bart</children>\n  <children>Maggie</children>\n</data>";
+
+        $data = Xml::encode($array);
+        $this->assertSame($expected, $data);
+
+        $result = Xml::decode($data);
+        $this->assertSame($array, $result);
+
+        // with a custom root name
+        $expected = str_replace('data>', 'custom>', $expected);
+        $array = [
+            '@name'    => 'custom',
+            'name'     => 'Homer',
+            'children' => ['Lisa', 'Bart', 'Maggie']
+        ];
+        $result = Xml::decode($expected);
+        $this->assertSame($array, $result);
+    }
+
+    /**
+     * @covers ::decode
+     */
+    public function testDecodeCorrupted()
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('XML string is invalid');
+
+        Xml::decode('some gibberish');
+    }
+}


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Adds XML support to the `Data` package based on the newly refactored `Toolkit\Xml` class.

**Important:** This PR depends on #2400. Merge that PR first, which will make the duplicate commits disappear here.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
