### PR TITLE
Cache blueprint extends

### DIFF
--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -111,7 +111,7 @@ class BlueprintFieldTest extends TestCase
     {
         $this->app = $this->app->clone([
             'blueprints' => [
-                'fields/test' => [
+                'fields/another-test' => [
                     'name'  => 'test',
                     'label' => 'Test',
                     'type'  => 'textarea',
@@ -125,7 +125,7 @@ class BlueprintFieldTest extends TestCase
 
 
         $props = Blueprint::fieldProps([
-            'extends' => 'fields/test',
+            'extends' => 'fields/another-test',
             'buttons' => [
                 'li'
             ]


### PR DESCRIPTION
## Describe the PR

Blueprint extends are now cached by their name.

However, since the `Blueprint` class is statically called in the tests (_tests/Cms/Blueprints/BlueprintFieldTest.php_), it does not match the data in the cache and the test fails. But in my local test on panel ui works great! Should we refactor the test class (BlueprintFieldTest) or the cache system I wrote was faulty 😇?
I'm creating thr PR as a draft because I'm not sure and waiting your feedback please.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2364 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
