### PR TITLE
Accessing with default language slug on multilang

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -243,11 +243,11 @@ class Pages extends Collection
         $query      = $startAt;
 
         foreach ($path as $key) {
-            $query = ltrim($query . '/' . $key, '/');
-            $item  = $collection->get($query) ?? null;
-
-            if ($item === null && $multiLang === true) {
+            if ($multiLang === true) {
                 $item = $collection->findBy('slug', $key);
+            } else {
+                $query = ltrim($query . '/' . $key, '/');
+                $item  = $collection->get($query);
             }
 
             if ($item === null) {


### PR DESCRIPTION
## Describe the PR

Fixed the issue with separated finding page in collection based on multilingual option.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2257 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
