### PR TITLE
Fix localized search with case insensitive 

### DIFF
--- a/src/Cms/Search.php
+++ b/src/Cms/Search.php
@@ -56,7 +56,7 @@ class Search
         $collection  = clone $collection;
         $searchwords = preg_replace('/(\s)/u', ',', $query);
         $searchwords = Str::split($searchwords, ',', $options['minlength']);
-        $lowerQuery  = strtolower($query);
+        $lowerQuery  = mb_strtolower($query);
 
         if (empty($options['stopwords']) === false) {
             $searchwords = array_diff($searchwords, $options['stopwords']);
@@ -96,7 +96,7 @@ class Search
                 $score = $options['score'][$key] ?? 1;
                 $value = $data[$key] ?? (string)$item->$key();
 
-                $lowerValue = strtolower($value);
+                $lowerValue = mb_strtolower($value);
 
                 // check for exact matches
                 if ($lowerQuery == $lowerValue) {

--- a/tests/Cms/Collections/SearchTest.php
+++ b/tests/Cms/Collections/SearchTest.php
@@ -54,6 +54,10 @@ class SearchTest extends TestCase
             [
                 'slug'    => 'lisa',
                 'content' => ['firstname' => 'Lisa']
+            ],
+            [
+                'slug'    => 'snowball',
+                'content' => ['firstname' => 'Šnowball']
             ]
         ]);
 
@@ -65,5 +69,38 @@ class SearchTest extends TestCase
 
         $search = Search::collection($collection, 'm', ['minlength' => 1, 'fields' => ['FirstName']]);
         $this->assertCount(3, $search);
+    }
+
+    public function testIgnoreCaseI18n()
+    {
+        $collection = Pages::factory([
+            [
+                'slug'    => 'santa',
+                'content' => ['full' => 'Santa\'s Little Helper']
+            ],
+            [
+                'slug'    => 'snowball',
+                'content' => ['full' => 'Šnowball']
+            ],
+            [
+                'slug'    => 'garfield',
+                'content' => ['full' => 'Garfield']
+            ]
+        ]);
+
+        $search = Search::collection($collection, 's', ['minlength' => 1]);
+        $this->assertCount(2, $search);
+        $search = Search::collection($collection, 'S', ['minlength' => 1]);
+        $this->assertCount(2, $search);
+
+        $search = Search::collection($collection, 'š', ['minlength' => 1]);
+        $this->assertCount(1, $search);
+        $search = Search::collection($collection, 'Š', ['minlength' => 1]);
+        $this->assertCount(1, $search);
+
+        $search = Search::collection($collection, 'g', ['minlength' => 1]);
+        $this->assertCount(1, $search);
+        $search = Search::collection($collection, 'G', ['minlength' => 1]);
+        $this->assertCount(1, $search);
     }
 }


### PR DESCRIPTION
## Describe the PR

Fixed the issue with using `mb_strtolower()` function that support unicode characters.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2408

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
