### PR TITLE
Fix language path for pattern

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -364,7 +364,7 @@ class Language extends Model
             return $this->code;
         }
 
-        return Url::path($this->url());
+        return Url::path($this->url);
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

The `url()` method provided relative path, instead `url` property was used directly.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2345 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
