### PR TITLE
Fix excerpt method with support unicode chars #2420

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -361,7 +361,7 @@ class Str
             return $string;
         }
 
-        return static::substr($string, 0, strrpos(static::substr($string, 0, $chars), ' ')) . ' ' . $rep;
+        return static::substr($string, 0, mb_strrpos(static::substr($string, 0, $chars), ' ')) . ' ' . $rep;
     }
 
     /**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -157,6 +157,15 @@ class StrTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testExcerptWithUnicodeChars()
+    {
+        $string   = 'Hellö Wörld text<br>with some html';
+        $expected = 'Hellö Wörld text …';
+        $result   = Str::excerpt($string, 20);
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testFloat()
     {
         $this->assertEquals('0', Str::float(false));

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -159,7 +159,7 @@ class StrTest extends TestCase
 
     public function testExcerptWithUnicodeChars()
     {
-        $string   = 'Hellö Wörld text<br>with some html';
+        $string   = 'Hellö Wörld text<br>with söme htmäl';
         $expected = 'Hellö Wörld text …';
         $result   = Str::excerpt($string, 20);
 


### PR DESCRIPTION
## Describe the PR

Fixed the issue with using `mb_strrpos` method to support unicode chars suggested by @frankrausch

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2420

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
