### PR TITLE
Structure displayText method return string always

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -413,7 +413,7 @@ export default {
         return "…";
       }
 
-      return value;
+      return value.toString();
     },
     escape() {
       if (this.currentIndex === "new") {


### PR DESCRIPTION
## Describe the PR

Now `displayText()` method in structure field return string always.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2423 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
