### PR TITLE
New $fileCache->root() method

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -18,6 +18,7 @@ class FileCache extends Cache
 {
     /**
      * Full root including prefix
+     *
      * @var string
      */
     protected $root;
@@ -47,6 +48,16 @@ class FileCache extends Cache
 
         // try to create the directory
         Dir::make($this->root, true);
+    }
+
+    /**
+     * Returns the full root including prefix
+     *
+     * @return string
+     */
+    public function root(): string
+    {
+        return $this->root;
     }
 
     /**

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -18,6 +18,7 @@ class FileCacheTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::root
      */
     public function testConstruct()
     {
@@ -25,11 +26,13 @@ class FileCacheTest extends TestCase
             'root' => $root = __DIR__ . '/fixtures/file'
         ]);
 
+        $this->assertSame($root, $cache->root());
         $this->assertDirectoryExists($root);
     }
 
     /**
      * @covers ::__construct
+     * @covers ::root
      */
     public function testConstructWithPrefix()
     {
@@ -38,6 +41,7 @@ class FileCacheTest extends TestCase
             'prefix' => 'test'
         ]);
 
+        $this->assertSame($root . '/test', $cache->root());
         $this->assertDirectoryExists($root . '/test');
     }
 


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Makes it possible to store other types of files in the cache folder.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes getkirby/ideas#390.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
