### PR TITLE
Fix icon option for tags field

### DIFF
--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -98,9 +98,11 @@ export default {
       selected: null,
       newTag: null,
       tagOptions: this.options.map(tag => {
-        tag.icon = "tag";
+        if (this.icon && this.icon.length > 0) {
+          tag.icon = this.icon;
+        }
         return tag;
-      })
+      }, this)
     };
   },
   computed: {


### PR DESCRIPTION
## Describe the PR

1. If icon is not defined, default tag icon is shown
2. If icon is a string, the defined icon is displayed
3. If true or false is defined, icon is not shown

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2438 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
