### PR TITLE
Validate language name on update

### DIFF
--- a/panel/src/components/Dialogs/LanguageUpdateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageUpdateDialog.vue
@@ -58,7 +58,12 @@ export default {
           this.$store.dispatch('notification/error', error);
         });
     },
-    submit() {
+    submit() { 
+      if (this.language.name.length === 0) {
+        this.$refs.dialog.error(this.$t("error.language.name"));
+        return;
+      }
+
       this.$api
         .patch("languages/" + this.language.code, {
           name: this.language.name,

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -636,9 +636,17 @@ class Language extends Model
      */
     public function update(array $props = null)
     {
+        // don't change the language code
+        unset($props['code']);
+
+        // make sure the slug is nice and clean
         $props['slug'] = Str::slug($props['slug'] ?? null);
-        $kirby         = App::instance();
-        $updated       = $this->clone($props);
+
+        $kirby   = App::instance();
+        $updated = $this->clone($props);
+
+        // validate the updated language
+        LanguageRules::update($updated);
 
         // convert the current default to a non-default language
         if ($updated->isDefault() === true) {

--- a/src/Cms/LanguageRules.php
+++ b/src/Cms/LanguageRules.php
@@ -19,6 +19,29 @@ class LanguageRules
 {
     public static function create(Language $language): bool
     {
+        static::validLanguageCode($language);
+        static::validLanguageName($language);
+
+        if ($language->exists() === true) {
+            throw new DuplicateException([
+                'key'  => 'language.duplicate',
+                'data' => [
+                    'code' => $language->code()
+                ]
+            ]);
+        }
+
+        return true;
+    }
+
+    public static function update(Language $language)
+    {
+        static::validLanguageCode($language);
+        static::validLanguageName($language);
+    }
+
+    public static function validLanguageCode(Language $language): bool
+    {
         if (Str::length($language->code()) < 2) {
             throw new InvalidArgumentException([
                 'key'  => 'language.code',
@@ -29,21 +52,17 @@ class LanguageRules
             ]);
         }
 
+        return true;
+    }
+
+    public static function validLanguageName(Language $language): bool
+    {
         if (Str::length($language->name()) < 1) {
             throw new InvalidArgumentException([
                 'key'  => 'language.name',
                 'data' => [
                     'code' => $language->code(),
                     'name' => $language->name()
-                ]
-            ]);
-        }
-
-        if ($language->exists() === true) {
-            throw new DuplicateException([
-                'key'  => 'language.duplicate',
-                'data' => [
-                    'code' => $language->code()
                 ]
             ]);
         }

--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -6,6 +6,16 @@ use PHPUnit\Framework\TestCase;
 
 class LanguageRulesTest extends TestCase
 {
+
+    public function setUp(): void
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+    }
+
     public function testCreateWithInvalidCode()
     {
         $language = new Language([
@@ -43,4 +53,29 @@ class LanguageRulesTest extends TestCase
 
         LanguageRules::create($language);
     }
+
+    public function testUpdateWithoutCode()
+    {
+        $language = $this->createMock(Language::class);
+        $language->method('code')->willReturn('');
+        $language->method('name')->willReturn('Deutsch');
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Please enter a valid code for the language');
+
+        LanguageRules::update($language);
+    }
+
+    public function testUpdateWithoutName()
+    {
+        $language = $this->createMock(Language::class);
+        $language->method('code')->willReturn('de');
+        $language->method('name')->willReturn('');
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Please enter a valid name for the language');
+
+        LanguageRules::update($language);
+    }
+
 }


### PR DESCRIPTION
## Describe the PR

Now language name validating on updates.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2436 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
