### PR TITLE
Translate page title error on creating

### DIFF
--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -110,8 +110,8 @@ export default {
       this.page.title = this.page.title.trim();
 
       if (this.page.title.length === 0) {
-        this.$refs.dialog.error('Please enter a title');
-        return false;
+        this.$refs.dialog.error(this.$t("error.page.changeTitle.empty"));
+        return;
       }
 
       const data = {


### PR DESCRIPTION
## Describe the PR

Added missing translate error page title on create like [PageRenameDialog](https://github.com/getkirby/kirby/blob/3.3.3/panel/src/components/Dialogs/PageRenameDialog.vue#L60)

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2441 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
