### PR TITLE
Format numbers when translating counts

### DIFF
--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -231,7 +231,7 @@ class I18n
      * @param bool $formatNumber
      * @return mixed
      */
-    public static function translateCount(string $key, int $count, string $locale = null)
+    public static function translateCount(string $key, int $count, string $locale = null, bool $formatNumber = true)
     {
         $locale = $locale ?? static::locale();
 
@@ -255,8 +255,12 @@ class I18n
             }
         }
 
-        $formatter = static::decimalNumberFormatter($locale);
-        $count = $formatter->format($count);
+        if ($formatNumber) {
+            $formatter = static::decimalNumberFormatter($locale);
+            if ($formatter !== null) {
+                $count = $formatter->format($count);
+            }
+        }
 
         return str_replace('{{ count }}', $count, $message);
     }

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -87,6 +87,25 @@ class I18n
     }
 
     /**
+     * Format a number
+     *
+     * @param int|float $number
+     * @param string $locale
+     * @return string
+     */
+    public static function formatNumber($number, string $locale = null): string
+    {
+        $locale = $locale ?? static::locale();
+
+        $formatter = static::decimalNumberFormatter($locale);
+        if ($formatter !== null) {
+            $number = $formatter->format($number);
+        }
+
+        return (string)$number;
+    }
+
+    /**
      * Returns the locale code
      *
      * @return string
@@ -256,10 +275,7 @@ class I18n
         }
 
         if ($formatNumber) {
-            $formatter = static::decimalNumberFormatter($locale);
-            if ($formatter !== null) {
-                $count = $formatter->format($count);
-            }
+            $count = static::formatNumber($count, $locale);
         }
 
         return str_replace('{{ count }}', $count, $message);

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -233,6 +233,8 @@ class I18n
      */
     public static function translateCount(string $key, int $count, string $locale = null)
     {
+        $locale = $locale ?? static::locale();
+
         $translation = static::translate($key, null, $locale);
 
         if ($translation === null) {
@@ -251,10 +253,6 @@ class I18n
             } else {
                 $message = end($translation);
             }
-        }
-
-        if (!$locale) {
-            $locale = static::locale();
         }
 
         $formatter = static::decimalNumberFormatter($locale);

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -45,7 +45,7 @@ class I18n
     public static $fallback = 'en';
 
     /**
-     * Decimal number formatters by locale
+     * Cache of `NumberFormatter` objects by locale
      *
      * @var array
      */

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -26,6 +26,21 @@ class I18nTest extends TestCase
         $this->assertEquals('none', I18n::form(0, true));
     }
 
+    public function testFormatNumber()
+    {
+        $this->assertEquals('2', I18n::formatNumber(2));
+        $this->assertEquals('2', I18n::formatNumber(2, 'en'));
+        $this->assertEquals('2', I18n::formatNumber(2, 'de'));
+
+        $this->assertEquals('1,234,567', I18n::formatNumber(1234567));
+        $this->assertEquals('1,234,567', I18n::formatNumber(1234567, 'en'));
+        $this->assertEquals('1.234.567', I18n::formatNumber(1234567, 'de'));
+
+        $this->assertEquals('1,234,567.89', I18n::formatNumber(1234567.89));
+        $this->assertEquals('1,234,567.89', I18n::formatNumber(1234567.89, 'en'));
+        $this->assertEquals('1.234.567,89', I18n::formatNumber(1234567.89, 'de'));
+    }
+
     public function testTemplate()
     {
         I18n::$translations = [

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -170,11 +170,16 @@ class I18nTest extends TestCase
         I18n::$translations = [
             'en' => [
                 'car' => ['No cars', 'One car', '{{ count }} cars']
+            ],
+            'de' => [
+                'car' => ['Keine Autos', 'Ein Auto', '{{ count }} Autos']
             ]
         ];
 
         $this->assertEquals('2 cars', I18n::translateCount('car', 2));
         $this->assertEquals('3 cars', I18n::translateCount('car', 3));
+        $this->assertEquals('1,234,567 cars', I18n::translateCount('car', 1234567));
+        $this->assertEquals('1.234.567 Autos', I18n::translateCount('car', 1234567, 'de'));
     }
 
     public function testTranslateCountWithMissingTranslation()

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -179,7 +179,12 @@ class I18nTest extends TestCase
         $this->assertEquals('2 cars', I18n::translateCount('car', 2));
         $this->assertEquals('3 cars', I18n::translateCount('car', 3));
         $this->assertEquals('1,234,567 cars', I18n::translateCount('car', 1234567));
+        $this->assertEquals('1,234,567 cars', I18n::translateCount('car', 1234567, null));
+        $this->assertEquals('1,234,567 cars', I18n::translateCount('car', 1234567, null, true));
+        $this->assertEquals('1234567 cars', I18n::translateCount('car', 1234567, null, false));
         $this->assertEquals('1.234.567 Autos', I18n::translateCount('car', 1234567, 'de'));
+        $this->assertEquals('1.234.567 Autos', I18n::translateCount('car', 1234567, 'de', true));
+        $this->assertEquals('1234567 Autos', I18n::translateCount('car', 1234567, 'de', false));
     }
 
     public function testTranslateCountWithMissingTranslation()


### PR DESCRIPTION
## Describe the PR
The current `I18n::translateCount()` function does not format numbers, so something like "1,234,567 cars" is merely formatted as `1234567 cars`. This PR corrects this in a locale-correct way (example: German uses a period instead of a comma as a thousands separator.)

## Related issues

- Fixes https://github.com/getkirby/ideas/issues/474

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
