### PR TITLE
Validate empty locale in language editor

### DIFF
--- a/panel/src/components/Dialogs/LanguageCreateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageCreateDialog.vue
@@ -95,7 +95,7 @@ export default {
     },
     submit() {
       if (this.language.locale) {
-        this.language.locale = this.language.locale.trim();
+        this.language.locale = this.language.locale.trim() || null;
       }
 
       this.$api
@@ -103,7 +103,7 @@ export default {
           name: this.language.name,
           code: this.language.code,
           direction: this.language.direction,
-          locale: this.language.locale || this.language.code
+          locale: this.language.locale
         })
         .then(() => {
           this.$store.dispatch("languages/load");

--- a/panel/src/components/Dialogs/LanguageCreateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageCreateDialog.vue
@@ -94,12 +94,16 @@ export default {
       this.$refs.dialog.open();
     },
     submit() {
+      if (this.language.locale) {
+        this.language.locale = this.language.locale.trim();
+      }
+
       this.$api
         .post("languages", {
           name: this.language.name,
           code: this.language.code,
           direction: this.language.direction,
-          locale: this.language.locale
+          locale: this.language.locale || this.language.code
         })
         .then(() => {
           this.$store.dispatch("languages/load");

--- a/panel/src/components/Dialogs/LanguageUpdateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageUpdateDialog.vue
@@ -64,11 +64,15 @@ export default {
         return;
       }
 
+      if (typeof this.language.locale === "string") {
+        this.language.locale = this.language.locale.trim();
+      }
+
       this.$api
         .patch("languages/" + this.language.code, {
           name: this.language.name,
           direction: this.language.direction,
-          locale: this.language.locale
+          locale: this.language.locale || this.language.code
         })
         .then(() => {
           this.$store.dispatch("languages/load");

--- a/panel/src/components/Dialogs/LanguageUpdateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageUpdateDialog.vue
@@ -65,14 +65,14 @@ export default {
       }
 
       if (typeof this.language.locale === "string") {
-        this.language.locale = this.language.locale.trim();
+        this.language.locale = this.language.locale.trim() || null;
       }
 
       this.$api
         .patch("languages/" + this.language.code, {
           name: this.language.name,
           direction: this.language.direction,
-          locale: this.language.locale || this.language.code
+          locale: this.language.locale
         })
         .then(() => {
           this.$store.dispatch("languages/load");


### PR DESCRIPTION
## Describe the PR

If the `locale` option is string, spaces are deleted with `trim()`, and if empty, the code value is assigned to.

@lukasbestle I fixed it in the language editor for panel, but do we have to do this in the language class? I mean that:

````php
} elseif (is_string($locale)) {
    $locale = trim($locale);
    $locale = empty($locale) === false ? $locale : $this->code;
    $this->locale = [LC_ALL => $locale];
}
````

https://github.com/getkirby/kirby/blob/3.3.3/src/Cms/Language.php#L504-L505


## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2455

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
