### PR TITLE
Support numeric parts in query

### DIFF
--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -15,7 +15,7 @@ namespace Kirby\Toolkit;
  */
 class Query
 {
-    const PARTS      = '!([a-zA-Z_]*(\(.*?\))?)\.|' . self::SKIP . '!';
+    const PARTS      = '!([a-zA-Z0-9_]*(\(.*?\))?)\.|' . self::SKIP . '!';
     const METHOD     = '!\((.*)\)!';
     const PARAMETERS = '!,|' . self::SKIP . '!';
 

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -15,7 +15,7 @@ namespace Kirby\Toolkit;
  */
 class Query
 {
-    const PARTS      = '!([a-zA-Z0-9_]*(\(.*?\))?)\.|' . self::SKIP . '!';
+    const PARTS      = '!([a-zA-Z_][a-zA-Z0-9_]*(\(.*?\))?)\.|' . self::SKIP . '!';
     const METHOD     = '!\((.*)\)!';
     const PARAMETERS = '!,|' . self::SKIP . '!';
 

--- a/tests/Toolkit/QueryTest.php
+++ b/tests/Toolkit/QueryTest.php
@@ -32,7 +32,7 @@ class QueryTest extends TestCase
         $this->assertEquals('homer', $query->result());
     }
 
-    public function testWithNumericKeys()
+    public function testWithContainsNumericParts()
     {
         $query = new Query('user0.profiles1.twitter', [
             'user0' => [
@@ -43,6 +43,19 @@ class QueryTest extends TestCase
         ]);
 
         $this->assertEquals('@homer', $query->result());
+    }
+
+    public function testWithStartsNumericParts()
+    {
+        $query = new Query('0user.1profiles.twitter', [
+            '0user' => [
+                '1profiles' => [
+                    'twitter' => '@homer'
+                ]
+            ]
+        ]);
+
+        $this->assertNull($query->result());
     }
 
     public function test0LevelArrayQuery()

--- a/tests/Toolkit/QueryTest.php
+++ b/tests/Toolkit/QueryTest.php
@@ -32,6 +32,19 @@ class QueryTest extends TestCase
         $this->assertEquals('homer', $query->result());
     }
 
+    public function testWithNumericKeys()
+    {
+        $query = new Query('user0.profiles1.twitter', [
+            'user0' => [
+                'profiles1' => [
+                    'twitter' => '@homer'
+                ]
+            ]
+        ]);
+
+        $this->assertEquals('@homer', $query->result());
+    }
+
     public function test0LevelArrayQuery()
     {
         $query = new Query('user', [


### PR DESCRIPTION
## Describe the PR

Now query parts support `numeric` values with added `0-9` to regex.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2462 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
