### PR TITLE
Fix loading template controllers on representations

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1134,13 +1134,13 @@ class Page extends ModelWithContent
                 $template = $this->representation($contentType);
             }
 
-            $kirby->data = $this->controller($data, $contentType);
-
             if ($template->exists() === false) {
                 throw new NotFoundException([
                     'key' => 'template.default.notFound'
                 ]);
             }
+
+            $kirby->data = $this->controller($data, $contentType);
 
             // render the page
             $html = $template->render($kirby->data);
@@ -1172,7 +1172,7 @@ class Page extends ModelWithContent
         $representation = $kirby->template($template->name(), $type);
 
         if ($representation->exists() === true) {
-            return $this->template = $representation;
+            return $representation;
         }
 
         throw new NotFoundException('The content representation cannot be found');

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1128,13 +1128,13 @@ class Page extends ModelWithContent
 
         // fetch the page regularly
         if ($html === null) {
-            $kirby->data = $this->controller($data, $contentType);
-
             if ($contentType === 'html') {
                 $template = $this->template();
             } else {
                 $template = $this->representation($contentType);
             }
+
+            $kirby->data = $this->controller($data, $contentType);
 
             if ($template->exists() === false) {
                 throw new NotFoundException([
@@ -1172,7 +1172,7 @@ class Page extends ModelWithContent
         $representation = $kirby->template($template->name(), $type);
 
         if ($representation->exists() === true) {
-            return $representation;
+            return $this->template = $representation;
         }
 
         throw new NotFoundException('The content representation cannot be found');

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1168,7 +1168,7 @@ class Page extends ModelWithContent
     public function representation($type)
     {
         $kirby          = $this->kirby();
-        $template       = $this->intendedTemplate();
+        $template       = $this->template();
         $representation = $kirby->template($template->name(), $type);
 
         if ($representation->exists() === true) {

--- a/tests/Cms/Pages/PageTemplateTest.php
+++ b/tests/Cms/Pages/PageTemplateTest.php
@@ -12,7 +12,12 @@ class PageTemplateTest extends TestCase
     {
         $this->app = new App([
             'templates' => [
-                'template' => __DIR__ . '/fixtures/PageTemplateTest/template.php'
+                'default'               => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+                'default.json'          => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+                'default.xml'           => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+                'template'              => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+                'template.json'         => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+                'another-template.json' => __DIR__ . '/fixtures/PageTemplateTest/template.php'
             ],
             'site' => [
                 'children' => [
@@ -23,6 +28,10 @@ class PageTemplateTest extends TestCase
                     [
                         'slug' => 'without-template',
                         'template' => 'does-not-exist'
+                    ],
+                    [
+                        'slug' => 'with-another-template',
+                        'template' => 'another-template'
                     ]
                 ]
             ]
@@ -33,21 +42,68 @@ class PageTemplateTest extends TestCase
     {
         $page = $this->app->page('with-template');
         $this->assertInstanceOf(Template::class, $page->intendedTemplate());
-        $this->assertEquals('template', $page->intendedTemplate()->name());
+        $this->assertSame('template', $page->intendedTemplate()->name());
 
         $page = $this->app->page('without-template');
         $this->assertInstanceOf(Template::class, $page->intendedTemplate());
-        $this->assertEquals('does-not-exist', $page->intendedTemplate()->name());
+        $this->assertSame('does-not-exist', $page->intendedTemplate()->name());
+
+        $page = $this->app->page('with-another-template');
+        $this->assertInstanceOf(Template::class, $page->intendedTemplate());
+        $this->assertSame('another-template', $page->intendedTemplate()->name());
     }
 
     public function testTemplate()
     {
         $page = $this->app->page('with-template');
         $this->assertInstanceOf(Template::class, $page->template());
-        $this->assertEquals('template', $page->template()->name());
+        $this->assertSame('template', $page->template()->name());
+        $this->assertSame('html', $page->template()->type());
 
         $page = $this->app->page('without-template');
         $this->assertInstanceOf(Template::class, $page->template());
-        $this->assertEquals('default', $page->template()->name());
+        $this->assertSame('default', $page->template()->name());
+        $this->assertSame('html', $page->template()->type());
+
+        $page = $this->app->page('with-another-template');
+        $this->assertInstanceOf(Template::class, $page->template());
+        $this->assertSame('default', $page->template()->name());
+        $this->assertSame('html', $page->template()->type());
+    }
+
+    public function testRepresentation()
+    {
+        $page = $this->app->page('with-template');
+        $representation = $page->representation('json');
+        $this->assertInstanceOf(Template::class, $representation);
+        $this->assertSame('template', $representation->name());
+        $this->assertSame('json', $representation->type());
+
+        $page = $this->app->page('without-template');
+        $representation = $page->representation('json');
+        $this->assertInstanceOf(Template::class, $representation);
+        $this->assertSame('default', $representation->name());
+        $this->assertSame('json', $representation->type());
+
+        $page = $this->app->page('without-template');
+        $representation = $page->representation('xml');
+        $this->assertInstanceOf(Template::class, $representation);
+        $this->assertSame('default', $representation->name());
+        $this->assertSame('xml', $representation->type());
+
+        $page = $this->app->page('with-another-template');
+        $representation = $page->representation('xml');
+        $this->assertInstanceOf(Template::class, $representation);
+        $this->assertSame('default', $representation->name());
+        $this->assertSame('xml', $representation->type());
+    }
+
+    public function testRepresentationError()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The content representation cannot be found');
+
+        $page = $this->app->page('with-template');
+        $page->representation('xml');
     }
 }


### PR DESCRIPTION
## Describe the PR

The issue had two sources:

1. Since the `representation()` method doesn't update the `template` variable of class, if there is no template file, it always returns the default template.
2. Since the controller call process is related to the template, the order of setting the template and then calling the controller has been adjusted.

Maybe a better development can be done or you may want to refactor. So I open it as a draft.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2471 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
