### PR TITLE
Fix dialog with sticky columns

### DIFF
--- a/panel/src/components/Layout/Column.vue
+++ b/panel/src/components/Layout/Column.vue
@@ -22,6 +22,7 @@ export default {
 .k-column[data-sticky] > div {
   position: sticky;
   top: 4vh;
+  z-index: 2;
 }
 
 @media screen and (min-width: $breakpoint-medium) {


### PR DESCRIPTION
## Describe the PR

Fixed the issue with added `z-index` property as `2` value. The value of `z-index: 1` doesn't fully fix it. Should be min value as `z-index: 2`

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2477 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
