### PR TITLE
Improve page redirection on languages detect

### DIFF
--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -78,6 +78,17 @@ class LanguageRoutes
                     ]);
 
                     if ($url->toString() !== $page->url()) {
+                        // redirect to translated page directly
+                        // if translation is exists and languages detect is enabled
+                        if (
+                            $kirby->option('languages.detect') === true &&
+                            $page->translation($kirby->detectedLanguage()->code())->exists() === true
+                        ) {
+                            return $kirby
+                                ->response()
+                                ->redirect($page->url($kirby->detectedLanguage()->code()));
+                        }
+
                         return $kirby
                             ->response()
                             ->redirect($page->url());


### PR DESCRIPTION
## Describe the PR

When you access to a page with detected language and without language code:
**example.com/contact**

**Redirecting Before PR:**
example.com/en/contact

**Redirecting After PR:**
example.com/tr/iletisim

**Use Case**
You want to link to a page on your site from outside and be language independent. 
Because the user entering the page expecting for the page to be opened in his own language.

You can link without language code, user will be redirecting to own language

**Example Usage**
````html
<a href="http://example.com/an-article-about-kirby">You must read this article</a>
````
Will be redirecting safely to: _example.com/tr/kirby-hakkinda-bir-makale_

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/500

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
