### PR TITLE
Update cached auth user data on update

### DIFF
--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -278,6 +278,26 @@ trait UserActions
     }
 
     /**
+     * Updates the user data
+     *
+     * @param array $input
+     * @param string $language
+     * @param bool $validate
+     * @return self
+     */
+    public function update(array $input = null, string $language = null, bool $validate = false)
+    {
+        $user = parent::update($input, $language, $validate);
+
+        // set auth user data only if the current user is this user
+        if ($user->isLoggedIn() === true) {
+            $this->kirby()->auth()->setUser($user);
+        }
+
+        return $user;
+    }
+
+    /**
      * This always merges the existing credentials
      * with the given input.
      *

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -224,4 +224,15 @@ class UserActionsTest extends TestCase
 
         $this->assertEquals($url, $user->website()->value());
     }
+
+    public function testUpdateWithAuthUser()
+    {
+        $user = $this->app->user('editor@domain.com');
+
+        $user->loginPasswordless();
+        $user->update([
+            'website' => $url = 'https://editor.com'
+        ]);
+        $this->assertEquals($url, $this->app->user()->website()->value());
+    }
 }

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -227,12 +227,21 @@ class UserActionsTest extends TestCase
 
     public function testUpdateWithAuthUser()
     {
-        $user = $this->app->user('editor@domain.com');
+        $app = new App([
+            'users' => [
+                [
+                    'email' => 'admin@getkirby.com',
+                    'role'  => 'admin'
+                ]
+            ]
+        ]);
 
+        $user = $app->user('admin@getkirby.com');
         $user->loginPasswordless();
         $user->update([
-            'website' => $url = 'https://editor.com'
+            'website' => $url = 'https://getkirby.com'
         ]);
-        $this->assertEquals($url, $this->app->user()->website()->value());
+        $this->assertEquals($url, $app->user()->website()->value());
+        $user->logout();
     }
 }


### PR DESCRIPTION
## Describe the PR

Update cached auth user data on update only if the current user is this user.

@lukasbestle Could you help me about unit test? 😇 I'm getting error like following:

> Kirby\Cms\UserActionsTest::testUpdateWithAuthUser
> Exception: The directory "/dev/null" cannot be created

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2486 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
