### PR TITLE
Fix cards overflowing in narrow columns #1666

### DIFF
--- a/panel/src/components/Layout/Cards.vue
+++ b/panel/src/components/Layout/Cards.vue
@@ -16,7 +16,7 @@ export default {
   props: {
     cards: Array
   }
-}
+};
 </script>
 
 <style lang="scss">
@@ -24,17 +24,58 @@ export default {
   display: grid;
   grid-gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  /**
+    Making sure card doesn't break layout if
+    in a parent narrower than 12rem
+
+    TODO: refactor once min() is supported by all our browsers
+    since LibSASS has its issues with min() we need to be tricky
+    */
+  grid-template-columns: repeat(auto-fill, minmax(#{"min(12rem, 100%)"}, 1fr));
 }
 
 @media screen and (min-width: $breakpoint-small) {
   .k-cards[data-size="tiny"] {
     grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    /**
+      Making sure card doesn't break layout if
+      in a parent narrower than 12rem
+
+      TODO: refactor once min() is supported by all our browsers
+      since LibSASS has its issues with min() we need to be tricky
+      */
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(#{"min(12rem, 100%)"}, 1fr)
+    );
   }
   .k-cards[data-size="small"] {
     grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+    /**
+      Making sure card doesn't break layout if
+      in a parent narrower than 16rem
+
+      TODO: refactor once min() is supported by all our browsers
+      since LibSASS has its issues with min() we need to be tricky
+      */
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(#{"min(16rem, 100%)"}, 1fr)
+    );
   }
   .k-cards[data-size="medium"] {
     grid-template-columns: repeat(auto-fill, minmax(24rem, 1fr));
+    /**
+      Making sure card doesn't break layout if
+      in a parent narrower than 24rem
+
+      TODO: refactor once min() is supported by all our browsers
+      since LibSASS has its issues with min() we need to be tricky
+      */
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(#{"min(24rem, 100%)"}, 1fr)
+    );
   }
   .k-cards[data-size="large"],
   .k-cards[data-size="huge"] {
@@ -45,7 +86,17 @@ export default {
 @media screen and (min-width: $breakpoint-medium) {
   .k-cards[data-size="large"] {
     grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
+    /**
+      Making sure card doesn't break layout if
+      in a parent narrower than 32rem
+
+      TODO: refactor once min() is supported by all our browsers
+      since LibSASS has its issues with min() we need to be tricky
+     */
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(#{"min(32rem, 100%)"}, 1fr)
+    );
   }
 }
-
 </style>


### PR DESCRIPTION
## Describe the PR

Source of the bug:
Whenever we do for `.k-cards`

```css
grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
```

but the container itself is narrower than `32rem`, the card will actually break out of the container.
To avoid that we can use `min()`:

```css
grid-template-columns: repeat(auto-fill, minmax(min(32rem, 100%), 1fr));
```

With this, `32rem` is only chosen as minimum, if `100%` is more than `32rem`.
Unfortunately, the support for `min()` is not yet everywhere (damn you, Firefox): https://developer.mozilla.org/en-US/docs/Web/CSS/min

However, if we add both lines, older browsers will fallback to the old (buggy) version, but more modern browsers get the fix:

```css
grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
grid-template-columns: repeat(auto-fill, minmax(min(32rem, 100%), 1fr));
```

Then there is one more thing: since SASS once had its own `min()` function and still applies it, we need to use the unquote syntax to make sure the CSS `min()` function is used (otherwise we will also get an error message. So we end up with:

```css
grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
grid-template-columns: repeat(auto-fill, minmax(#{"min(32rem, 100%)"}, 1fr));
```

I added extensive, annoying comments, so we can make sure to remove the old stuff once LibSASS is fixed and/or `min()` is supported by all browsers.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #1666

