### PR TITLE
Picker fields: “change” not “add” for non-multi

### DIFF
--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -26,6 +26,13 @@ return [
         },
 
         /**
+         * Whether each item should be clickable
+         */
+        'link' => function (bool $link = true) {
+            return $link;
+        },
+
+        /**
          * The minimum number of required selected
          */
         'min' => function (int $min = null) {

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -7,11 +7,11 @@
           <k-dropdown>
             <k-button
               ref="pickerToggle"
-              icon="add"
+              :icon="btnIcon"
               class="k-field-options-button"
               @click="$refs.picker.toggle()"
             >
-              {{ $t('add') }}
+              {{ btnLabel }}
             </k-button>
             <k-dropdown-content ref="picker" align="right">
               <k-dropdown-item icon="check" @click="open">{{ $t('select') }}</k-dropdown-item>
@@ -40,7 +40,7 @@
           :key="file.filename"
           :sortable="!disabled && selected.length > 1"
           :text="file.text"
-          :link="file.link"
+          :link="link ? file.link : null"
           :info="file.info"
           :image="file.image"
           :icon="file.icon"
@@ -62,7 +62,7 @@
       icon="image"
       @click="open"
     >
-      {{ empty || $t('field.files.empty') }}
+      {{ empty || $t("field.files.empty") }}
     </k-empty>
 
     <k-files-dialog ref="selector" @submit="select" />
@@ -78,7 +78,7 @@ import picker from "@/mixins/picker/field.js";
 export default {
   mixins: [picker],
   props: {
-    uploads: [Boolean, Object, Array],
+    uploads: [Boolean, Object, Array]
   },
   created() {
     this.$events.$on("file.delete", this.removeById);

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -3,11 +3,11 @@
     <k-button-group slot="options" class="k-field-options">
       <k-button
         v-if="more && !disabled"
-        icon="add"
+        :icon="btnIcon"
         class="k-field-options-button"
         @click="open"
       >
-        {{ $t('select') }}
+        {{ btnLabel }}
       </k-button>
     </k-button-group>
     <template v-if="selected.length">
@@ -26,7 +26,7 @@
           :sortable="!disabled && selected.length > 1"
           :text="page.text"
           :info="page.info"
-          :link="page.link"
+          :link="link ? page.link : null"
           :icon="page.icon"
           :image="page.image"
         >
@@ -46,7 +46,7 @@
       icon="page"
       @click="open"
     >
-      {{ empty || $t('field.pages.empty') }}
+      {{ empty || $t("field.pages.empty") }}
     </k-empty>
     <k-pages-dialog ref="selector" @submit="select" />
   </k-field>
@@ -68,7 +68,7 @@ export default {
         max: this.max,
         multiple: this.multiple,
         search: this.search,
-        selected: this.selected.map(page => page.id),
+        selected: this.selected.map(page => page.id)
       });
     }
   }

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -4,11 +4,11 @@
     <k-button-group slot="options" class="k-field-options">
       <k-button
         v-if="more && !disabled"
-        icon="add"
+        :icon="btnIcon"
         class="k-field-options-button"
         @click="open"
       >
-        {{ $t('select') }}
+        {{ btnLabel }}
       </k-button>
     </k-button-group>
 
@@ -27,7 +27,7 @@
           :sortable="!disabled && selected.length > 1"
           :text="user.text"
           :info="user.info"
-          :link="$api.users.link(user.id)"
+          :link="link ? $api.users.link(user.id) : null"
           :image="user.image"
           :icon="user.icon"
         >
@@ -40,13 +40,8 @@
         </component>
       </k-draggable>
     </template>
-    <k-empty
-      v-else
-      :data-invalid="isInvalid"
-      icon="users"
-      @click="open"
-    >
-      {{ empty || $t('field.users.empty') }}
+    <k-empty v-else :data-invalid="isInvalid" icon="users" @click="open">
+      {{ empty || $t("field.users.empty") }}
     </k-empty>
     <k-users-dialog ref="selector" @submit="select" />
   </k-field>

--- a/panel/src/mixins/picker/field.js
+++ b/panel/src/mixins/picker/field.js
@@ -6,6 +6,7 @@ export default {
     ...Field.props,
     empty: String,
     info: String,
+    link: Boolean,
     layout: String,
     max: Number,
     multiple: Boolean,
@@ -26,6 +27,20 @@ export default {
     };
   },
   computed: {
+    btnIcon() {
+      if (!this.multiple && this.selected.length > 0) {
+        return "refresh";
+      }
+
+      return "add";
+    },
+    btnLabel() {
+      if (!this.multiple && this.selected.length > 0) {
+        return this.$t("change");
+      }
+
+      return this.$t("add");
+    },
     elements() {
       const layouts = {
         cards: {
@@ -73,8 +88,7 @@ export default {
     }
   },
   methods: {
-    focus() {
-    },
+    focus() {},
     onInput() {
       this.$emit("input", this.selected);
     },


### PR DESCRIPTION
## Describe the PR

1. If `multiple: false` and one item is already selected, don't show "Add" but "Change" (so it is in lien with the files' field dropdown showing "Select" and "Upload" as options) with corresponding icons.

2. Add `link: false` option to picker fields, so that list items are not clickable.