### PR TITLE
Improve accessibilty of page status icon

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,10 +6,13 @@
 
 root = true
 
-[*.php]
+[*]
 charset = utf-8
+indent_style = space
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
+
+[*.php]
 indent_size = 4
+trim_trailing_whitespace = true

--- a/panel/src/components/Layout/Card.vue
+++ b/panel/src/components/Layout/Card.vue
@@ -18,11 +18,10 @@
     </component>
 
     <nav class="k-card-options">
-      <k-button
+      <k-status
         v-if="flag"
         v-bind="flag"
         class="k-card-options-button"
-        @click="flag.click"
       />
       <slot name="options">
         <k-button
@@ -246,6 +245,11 @@ export default {
 .k-card-options {
   position: absolute;
   bottom: 0;
+  height: 2.25rem;
+  padding: 0 0.5rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 
   [dir="ltr"] & {
     right: 0;
@@ -255,14 +259,16 @@ export default {
     left: 0;
   }
 }
-.k-card-options > .k-button {
+.k-card-options-button {
   position: relative;
-  float: left;
-  height: 2.25rem;
-  padding: 0 0.75rem;
+
+  padding: 0 0.5rem;
   line-height: 1;
 }
 .k-card-options-dropdown {
   top: 2.25rem;
+}
+.k-card-options .k-status {
+  top: -2px;
 }
 </style>

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -17,11 +17,10 @@
     </k-link>
     <nav class="k-list-item-options">
       <slot name="options">
-        <k-button
+        <k-status
           v-if="flag"
           v-bind="flag"
           class="k-list-item-status"
-          @click="flag.click"
         />
         <k-button
           v-if="options"
@@ -171,9 +170,6 @@ $list-item-height: 38px;
   @media screen and (min-width: $breakpoint-small) {
     display: block;
   }
-}
-.k-list-item-status {
-  height: auto !important;
 }
 .k-list-item-options {
   position: relative;

--- a/panel/src/components/Misc/Status.vue
+++ b/panel/src/components/Misc/Status.vue
@@ -1,0 +1,113 @@
+<template>
+  <span>
+    <span class="k-status">
+      <k-button
+        v-bind="button"
+        @click="onClick"
+      >{{ page.label || "" }}</k-button>
+      <k-icon
+        v-if="isDisabled"
+        type="lock"
+        class="k-status-icon-lock"
+      />
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    action: Function,
+    page: Object
+  },
+  computed: {
+    button() {
+      return {
+        class: "k-status-icon k-status-icon-" + this.page.status,
+        icon: this.icon,
+        tooltip: this.tooltip,
+        disabled: this.isDisabled
+      }
+    },
+    icon() {
+      if (this.page.status === "draft") {
+        return "protected";
+      }
+
+      if (this.page.status === "unlisted") {
+        return "circle-outline";
+      }
+
+      return "circle";
+    },
+    isDisabled() {
+      return this.page.permissions.changeStatus === false;
+    },
+    tooltip() {
+      let tooltip = this.$t("page.status") + ": ";
+
+      if (this.page.label) {
+        tooltip += this.page.label;
+      } else {
+        tooltip += this.$t("page.status." + this.page.status);
+      }
+
+      if (this.isDisabled) {
+        tooltip += " " + this.$t("disabled");
+      }
+
+      return tooltip;
+    }
+  },
+  methods: {
+    onClick() {
+      if (this.action) {
+        this.action();
+        return;
+      }
+
+      this.$emit("click");
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.k-status {
+  position: relative;
+}
+
+.k-status-icon svg {
+  width: 14px;
+  height: 14px;
+}
+.k-status-icon-listed .k-icon {
+  color: $color-positive-on-dark;
+}
+.k-status-icon-unlisted .k-icon {
+  color: $color-focus-on-dark;
+}
+.k-status-icon-draft .k-icon {
+  color: $color-negative-on-dark;
+}
+.k-status-icon[disabled] {
+  opacity: 1;
+}
+
+.k-status-icon-lock {
+  position: absolute;
+  left: 1px;
+  bottom: -4px;
+  transform: scale(0.6);
+  transform-origin: right bottom;
+  color: $color-dark-grey;
+}
+.k-card .k-status-icon-lock,
+.k-list-item .k-status-icon-lock {
+  bottom: -1px;
+}
+
+.k-status-icon .k-button-text:empty {
+  display: none;
+}
+</style>

--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -1,6 +1,7 @@
 <template>
   <span
     :id="id"
+    :aria-label="tooltip"
     :data-disabled="true"
     :data-responsive="responsive"
     :data-theme="theme"

--- a/panel/src/components/Navigation/ButtonLink.vue
+++ b/panel/src/components/Navigation/ButtonLink.vue
@@ -1,6 +1,7 @@
 <template>
   <k-link
     :aria-current="current"
+    :aria-label="tooltip"
     :autofocus="autofocus"
     :id="id"
     :data-theme="theme"
@@ -25,7 +26,6 @@
 </template>
 
 <script>
-
 export default {
   inheritAttrs: false,
   props: {
@@ -40,7 +40,7 @@ export default {
     target: String,
     tabindex: String,
     theme: String,
-    tooltip: String,
+    tooltip: String
   }
 };
 </script>

--- a/panel/src/components/Navigation/ButtonNative.vue
+++ b/panel/src/components/Navigation/ButtonNative.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     :aria-current="current"
+    :aria-label="tooltip"
     :autofocus="autofocus"
     :id="id"
     :data-theme="theme"
@@ -12,10 +13,10 @@
     class="k-button"
     v-on="$listeners"
   >
-    <k-icon
-      v-if="icon"
-      :type="icon"
-      :alt="tooltip"
+    <k-icon 
+      v-if="icon" 
+      :type="icon" 
+      :alt="tooltip" 
       class="k-button-icon"
     />
     <span v-if="$slots.default" class="k-button-text"><slot /></span>

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -1,9 +1,9 @@
 <template>
   <section v-if="isLoading === false" class="k-pages-section">
-
     <header class="k-section-header">
       <k-headline :link="options.link">
-        {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
+        {{ headline }}
+        <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
       </k-headline>
 
       <k-button-group v-if="add">
@@ -44,7 +44,7 @@
           icon="page"
           @click="create"
         >
-          {{ options.empty || $t('pages.empty') }}
+          {{ options.empty || $t("pages.empty") }}
         </k-empty>
         <footer class="k-collection-footer">
           <k-text
@@ -64,9 +64,7 @@
       <k-page-template-dialog ref="template" @success="update" />
       <k-page-remove-dialog ref="remove" @success="update" />
     </template>
-
   </section>
-
 </template>
 
 <script>
@@ -97,7 +95,6 @@ export default {
       }
     },
     action(page, action) {
-
       switch (action) {
         case "duplicate": {
           this.$refs.duplicate.open(page.id);
@@ -153,21 +150,9 @@ export default {
           throw new Error("Invalid action");
         }
       }
-
     },
     items(data) {
       return data.map(page => {
-        const isEnabled = page.permissions.changeStatus !== false;
-
-        page.flag = {
-          class: "k-status-flag k-status-flag-" + page.status,
-          tooltip: isEnabled ? this.$t("page.status") : `${this.$t("page.status")} (${this.$t("disabled")})`,
-          icon: isEnabled ? "circle" : "protected",
-          disabled: !isEnabled,
-          click: () => {
-            this.action(page, "status");
-          }
-        };
 
         page.options = ready => {
           this.$api.pages
@@ -176,6 +161,13 @@ export default {
             .catch(error => {
               this.$store.dispatch("notification/error", error);
             });
+        };
+
+        page.flag = {
+          page: page,
+          action: () => {
+            this.action(page, "status");
+          }
         };
 
         page.sortable = page.permissions.sort && this.options.sortable;

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -21,17 +21,12 @@
         >
           {{ $t('open') }}
         </k-button>
-        <k-button
+        <k-status
           v-if="status"
-          :class="['k-status-flag', 'k-status-flag-' + page.status]"
-          :disabled="!permissions.changeStatus || isLocked"
-          :icon="!permissions.changeStatus || isLocked ? 'protected' : 'circle'"
+          :page="status"
           :responsive="true"
-          :tooltip="status.label"
           @click="action('status')"
-        >
-          {{ status.label }}
-        </k-button>
+        />
         <k-dropdown>
           <k-button
             :responsive="true"
@@ -131,9 +126,17 @@ export default {
       }
     },
     status() {
-      return this.page.status !== null
-        ? this.page.blueprint.status[this.page.status]
-        : null;
+      if (this.page.status === null) {
+        return null;
+      }
+
+      return {
+        ...this.page.blueprint.status[this.page.status],
+        status: this.page.status,
+        permissions: {
+          changeStatus: this.permissions.changeStatus && !this.isLocked
+        }
+      };
     },
     tabsKey() {
       return "page-" + this.page.id + "-tabs";
@@ -220,22 +223,3 @@ export default {
   }
 };
 </script>
-
-<style lang="scss">
-.k-status-flag svg {
-  width: 14px;
-  height: 14px;
-}
-.k-status-flag-listed .k-icon {
-  color: $color-positive-on-dark;
-}
-.k-status-flag-unlisted .k-icon {
-  color: $color-focus-on-dark;
-}
-.k-status-flag-draft .k-icon {
-  color: $color-negative-on-dark;
-}
-.k-status-flag[disabled] {
-  opacity: 1;
-}
-</style>

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -232,6 +232,7 @@ import Icon from "@/components/Misc/Icon.vue";
 import Image from "@/components/Misc/Image.vue";
 import Progress from "@/components/Misc/Progress.vue";
 import SortHandle from "@/components/Misc/SortHandle.vue";
+import Status from "@/components/Misc/Status.vue";
 import Text from "@/components/Misc/Text.vue";
 
 Vue.component("k-draggable", Draggable);
@@ -241,6 +242,7 @@ Vue.component("k-icon", Icon);
 Vue.component("k-image", Image);
 Vue.component("k-progress", Progress);
 Vue.component("k-sort-handle", SortHandle);
+Vue.component("k-status", Status);
 Vue.component("k-text", Text);
 
 /* Navigation */


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- Added `aria-label`to buttons
- Distinct shape for each page status
- Added lock icon when status change is disabled

<img width="593" alt="Screen Shot 2020-03-07 at 12 44 23" src="https://user-images.githubusercontent.com/3788865/76142894-3cc05f80-6072-11ea-8444-123511d180ca.png">


## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #1444 
- Solves https://github.com/getkirby/ideas/issues/109