### PR TITLE
Fix left, right and inner join methods

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -295,6 +295,10 @@ class Query
      */
     public function join(string $table, string $on, string $type = 'JOIN')
     {
+        if (strtolower($type) != 'join') {
+            $type .= ' join';
+        }
+        
         $join = [
             'table' => $table,
             'on'    => $on,


### PR DESCRIPTION
Added the missing 'join' word at the end of the join type in order to avoid the join type validation error on the sql class at https://github.com/rtorresn10/kirby/blob/0330c0ae4214cde349710b099a770fffd0971b4e/src/Database/Sql.php#L453

## Describe the PR

This PR fix the error by adding the join missing word to the variable type.

## Related issues

#2501 

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
