### PR TITLE
Add duplicate button for structure field

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -24,6 +24,14 @@ return [
             // be lowercase as well.
             return array_change_key_case($columns);
         },
+
+        /**
+         * Toggles duplicating rows for the structure
+         */
+        'duplicate' => function (bool $duplicate = true) {
+            return $duplicate;
+        },
+
         /**
          * The placeholder text if no items have been added yet
          */

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -118,7 +118,24 @@
               </template>
             </td>
             <td class="k-structure-table-option">
-              <k-button :tooltip="$t('remove')" icon="remove" @click="confirmRemove(index)" />
+              <template v-if="duplicate && more && currentIndex === null">
+                <k-dropdown class="k-structure-options">
+                  <k-button
+                      :key="index"
+                      ref="actionsToggle"
+                      icon="dots"
+                      class="k-structure-options-button"
+                      @click="$refs[index + '-actions'][0].toggle()"
+                  />
+                  <k-dropdown-content :ref="index + '-actions'" align="right">
+                    <k-dropdown-item icon="copy" @click="duplicateItem(index)">{{ $t('duplicate') }}</k-dropdown-item>
+                    <k-dropdown-item icon="remove" @click="confirmRemove(index)">{{ $t('remove') }}</k-dropdown-item>
+                  </k-dropdown-content>
+                </k-dropdown>
+              </template>
+              <template v-else>
+                <k-button :tooltip="$t('remove')" icon="remove" @click="confirmRemove(index)" />
+              </template>
             </td>
           </tr>
         </k-draggable>
@@ -165,6 +182,10 @@ export default {
   props: {
     ...Field.props,
     columns: Object,
+    duplicate: {
+      type: Boolean,
+      default: true
+    },
     empty: String,
     fields: Object,
     limit: Number,
@@ -358,6 +379,9 @@ export default {
       this.close();
       this.trash = index;
       this.$refs.remove.open();
+    },
+    duplicateItem(index) {
+      this.items.push(this.items[index]);
     },
     createForm(field) {
       this.$events.$on("keydown.esc", this.escape);
@@ -610,6 +634,10 @@ $structure-item-height: 38px;
     }
   }
 
+  td:last-child {
+    overflow: visible;
+  }
+
   th {
     position: sticky;
     top: 0;
@@ -747,6 +775,10 @@ $structure-item-height: 38px;
   .k-structure-table-option .k-button {
     width: $structure-item-height;
     height: $structure-item-height;
+  }
+  .k-structure-table-option .k-structure-options .k-dropdown-content .k-button {
+    width: auto;
+    height: auto;
   }
 
   .k-structure-table-text {

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -117,24 +117,27 @@
                 </template>
               </template>
             </td>
-            <td class="k-structure-table-option">
+            <td class="k-structure-table-options">
               <template v-if="duplicate && more && currentIndex === null">
-                <k-dropdown class="k-structure-options">
-                  <k-button
-                      :key="index"
-                      ref="actionsToggle"
-                      icon="dots"
-                      class="k-structure-options-button"
-                      @click="$refs[index + '-actions'][0].toggle()"
-                  />
-                  <k-dropdown-content :ref="index + '-actions'" align="right">
-                    <k-dropdown-item icon="copy" @click="duplicateItem(index)">{{ $t('duplicate') }}</k-dropdown-item>
-                    <k-dropdown-item icon="remove" @click="confirmRemove(index)">{{ $t('remove') }}</k-dropdown-item>
-                  </k-dropdown-content>
-                </k-dropdown>
+                <k-button
+                    :key="index"
+                    ref="actionsToggle"
+                    icon="dots"
+                    class="k-structure-table-options-button"
+                    @click="$refs[index + '-actions'][0].toggle()"
+                />
+                <k-dropdown-content :ref="index + '-actions'" align="right">
+                  <k-dropdown-item icon="copy" @click="duplicateItem(index)">{{ $t('duplicate') }}</k-dropdown-item>
+                  <k-dropdown-item icon="remove" @click="confirmRemove(index)">{{ $t('remove') }}</k-dropdown-item>
+                </k-dropdown-content>
               </template>
               <template v-else>
-                <k-button :tooltip="$t('remove')" icon="remove" @click="confirmRemove(index)" />
+                <k-button
+                  :tooltip="$t('remove')"
+                  class="k-structure-table-options-button"
+                  icon="remove"
+                  @click="confirmRemove(index)"
+                />
               </template>
             </td>
           </tr>
@@ -768,17 +771,15 @@ $structure-item-height: 38px;
     display: flex !important;
   }
 
-  .k-structure-table-option {
+  .k-structure-table-options {
+    position: relative;
     width: $structure-item-height;
     text-align: center;
-  }
-  .k-structure-table-option .k-button {
-    width: $structure-item-height;
     height: $structure-item-height;
   }
-  .k-structure-table-option .k-structure-options .k-dropdown-content .k-button {
-    width: auto;
-    height: auto;
+  .k-structure-table-options-button {
+    width: $structure-item-height;
+    height: $structure-item-height;
   }
 
   .k-structure-table-text {


### PR DESCRIPTION
## Describe the PR

Duplicating enabled by default. To disable use following syntax:

````yaml
fields:
  addresses:
    type: structure
    duplicate: false
    fields:
        ...
        ...
````

**Screenshot**

![image](https://user-images.githubusercontent.com/3393422/76684351-62260e00-661c-11ea-858a-a4d9e22769b3.png)

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/406

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
