### PR TITLE
Allow required field when not meeting conditions

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -24,6 +24,20 @@ use Kirby\Toolkit\V;
 class Field extends Component
 {
     /**
+     * An array of all found errors
+     *
+     * @var array|null
+     */
+    protected $errors;
+
+    /**
+     * Parent collection with all fields of the current form
+     *
+     * @var \Kirby\Form\Fields|null
+     */
+    protected $formFields;
+
+    /**
      * Registry for all component mixins
      *
      * @var array
@@ -37,14 +51,7 @@ class Field extends Component
      */
     public static $types = [];
 
-    /**
-     * An array of all found errors
-     *
-     * @var array
-     */
-    protected $errors = [];
-
-    public function __construct(string $type, array $attrs = [])
+    public function __construct(string $type, array $attrs = [], ?Fields $formFields = null)
     {
         if (isset(static::$types[$type]) === false) {
             throw new InvalidArgumentException('The field type "' . $type . '" does not exist');
@@ -54,13 +61,13 @@ class Field extends Component
             throw new InvalidArgumentException('Field requires a model');
         }
 
+        $this->formFields = $formFields;
+
         // use the type as fallback for the name
         $attrs['name'] = $attrs['name'] ?? $type;
         $attrs['type'] = $type;
 
         parent::__construct($type, $attrs);
-
-        $this->validate();
     }
 
     /**
@@ -225,8 +232,17 @@ class Field extends Component
         ];
     }
 
+    public function formFields(): ?Fields
+    {
+        return $this->formFields;
+    }
+
     public function errors(): array
     {
+        if ($this->errors === null) {
+            $this->validate();
+        }
+
         return $this->errors;
     }
 
@@ -247,7 +263,7 @@ class Field extends Component
 
     public function isInvalid(): bool
     {
-        return empty($this->errors) === false;
+        return empty($this->errors()) === false;
     }
 
     public function isRequired(): bool
@@ -257,7 +273,7 @@ class Field extends Component
 
     public function isValid(): bool
     {
-        return empty($this->errors) === true;
+        return empty($this->errors()) === true;
     }
 
     /**
@@ -271,6 +287,46 @@ class Field extends Component
     public function model()
     {
         return $this->model;
+    }
+
+    /**
+     * Checks if the field needs a value before being saved;
+     * this is the case if all of the following requirements are met:
+     * - The field is saveable
+     * - The field is required
+     * - The field is currently empty
+     * - The field is not currently inactive because of a `when` rule
+     *
+     * @return bool
+     */
+    protected function needsValue(): bool
+    {
+        // check simple conditions first
+        if ($this->save() === false || $this->isRequired() === false || $this->isEmpty() === false) {
+            return false;
+        }
+
+        // check the data of the relevant fields if there is a `when` option
+        if (empty($this->when) === false && is_array($this->when) === true) {
+            $formFields = $this->formFields();
+
+            if ($formFields !== null) {
+                foreach ($this->when as $field => $value) {
+                    $field      = $formFields->get($field);
+                    $inputValue = $field !== null ? $field->value() : '';
+
+                    // if the input data doesn't match the requested `when` value,
+                    // that means that this field is not required and can be saved
+                    // (*all* `when` conditions must be met for this field to be required)
+                    if ($inputValue !== $value) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // either there was no `when` condition or all conditions matched
+        return true;
     }
 
     public function save(): bool
@@ -302,7 +358,7 @@ class Field extends Component
         $this->errors = [];
 
         // validate required values
-        if ($this->isRequired() === true && $this->save() === true && $this->isEmpty() === true) {
+        if ($this->needsValue() === true) {
             $this->errors['required'] = I18n::translate('error.validation.required');
         }
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -59,7 +59,7 @@ class Form
             }
 
             try {
-                $field = new Field($props['type'], $props);
+                $field = new Field($props['type'], $props, $this->fields);
             } catch (Throwable $e) {
                 $field = static::exceptionField($e, $props);
             }

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -804,4 +804,107 @@ class FieldTest extends TestCase
 
         $this->assertEquals($expected, $field->errors());
     }
+
+    public function testWhenRequired()
+    {
+        $page = new Page(['slug' => 'test']);
+
+        Field::$types = [
+            'foo' => [],
+            'bar' => [],
+            'baz' => [],
+        ];
+
+        $fields = new Fields([
+            'foo' => [
+                'type'  => 'foo',
+                'model' => $page,
+                'value' => 'a'
+            ],
+            'bar' => [
+                'type'  => 'bar',
+                'model' => $page,
+                'value' => 'b'
+            ],
+            'baz' => [
+                'type'  => 'baz',
+                'model' => $page,
+                'value' => 'c'
+            ]
+        ]);
+
+        // default
+        $field = new Field('foo', [
+            'model' => $page,
+        ]);
+
+        $this->assertSame([], $field->errors());
+
+        // passed (simple)
+        // 'bar' is required if 'foo' value is 'x'
+        $field = new Field('bar', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'x'
+            ]
+        ], $fields);
+
+        $this->assertSame([], $field->errors());
+
+        // passed (multiple conditions without any match)
+        // 'baz' is required if 'foo' value is 'x' and 'bar' value is 'y'
+        $field = new Field('baz', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'x',
+                'bar' => 'y'
+            ]
+        ], $fields);
+
+        $this->assertSame([], $field->errors());
+
+        // passed (multiple conditions with single match)
+        // 'baz' is required if 'foo' value is 'a' and 'bar' value is 'y'
+        $field = new Field('baz', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'a',
+                'bar' => 'y'
+            ]
+        ], $fields);
+
+        $this->assertSame([], $field->errors());
+
+        // failed (simple)
+        // 'bar' is required if 'foo' value is 'a'
+        $field = new Field('bar', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'a'
+            ]
+        ], $fields);
+
+        $expected = [
+            'required' => 'Please enter something',
+        ];
+
+        $this->assertSame($expected, $field->errors());
+
+        // failed (multiple conditions)
+        // 'baz' is required if 'foo' value is 'a' and 'bar' value is 'b'
+        $field = new Field('baz', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'a',
+                'bar' => 'b'
+            ]
+        ], $fields);
+
+        $this->assertSame($expected, $field->errors());
+    }
 }


### PR DESCRIPTION
## Describe the PR

I have implemented the feature with simplest way:

- The syntax of use has not changed
- When the fields used are shown only `when` options match in the panel, I did not make any changes on the panel/vue side.
- When validating while saving, we needed other fields data to check `when` fields.

````yaml
fields:
  foo:
    ...
  bar:
    ...
  headline:
    type: text
    required: true
    when:
        foo: design
        bar: architecture
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/234

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
