### PR TITLE
primaryKey for pages, files, users picker fields

### DIFF
--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -54,6 +54,13 @@ return [
         },
 
         /**
+         * Set primary key of collection
+         */
+        'primaryKey' => function ($primaryKey = null) {
+            return $primaryKey;
+        },
+
+        /**
          * Query for the items to be included in the picker
          */
         'query' => function (string $query = null) {


### PR DESCRIPTION
## Describe the PR

### WIP PR

I have implemented dynamic primary key option as `primaryKey` for pickers (pages, files and users field). Please can you share your thoughts? @getkirby/kirby-staff 

### Sample Usage

**Pages field**

````yaml
fields:
  related:
    type: pages
    primaryKey: autoId
````

**Users field**

````yaml
fields:
  author:
    type: users
    primaryKey: username
````

**Files field**

````yaml
fields:
  cover:
    type: files
    primaryKey: hashNumber
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/193

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
