### PR TITLE
Fix duplicate keys in file components

### DIFF
--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -28,7 +28,7 @@
         <k-list>
           <k-list-item
             v-for="file in models"
-            :key="file.filename"
+            :key="file.id"
             :text="file.text"
             :info="file.info"
             :image="file.image"

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -37,7 +37,7 @@
         <component
           v-for="(file, index) in selected"
           :is="elements.item"
-          :key="file.filename"
+          :key="file.id"
           :sortable="!disabled && selected.length > 1"
           :text="file.text"
           :link="link ? file.link : null"


### PR DESCRIPTION
## Describe the PR

When you have a `files` field with a query like this:

```
site.files.add(site.index.files)
```

...It's very likely to have files with the same name, and Vue components for files use `filename` for `key` instead of `id`, which causes the following error:

![error](https://user-images.githubusercontent.com/5570098/76964244-1381b800-692b-11ea-8f0a-db1a2b9dee58.png)

By using `id` for `key`, it works as expected.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
