### PR TITLE
Filter by template for files field

### DIFF
--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -48,17 +48,6 @@ return [
             return $template;
         },
 
-        /**
-         * If template options defined for filter, disable uploads
-         */
-        'uploads' => function () {
-            if (empty($this->template) === false) {
-                return false;
-            }
-
-            return $this->uploads;
-        },
-
         'value' => function ($value = null) {
             return $value;
         }
@@ -86,6 +75,16 @@ return [
         },
         'default' => function () {
             return $this->toFiles($this->default);
+        },
+        /**
+         * If template options defined for filter, disable uploads
+         */
+        'uploads' => function () {
+            if (empty($this->template) === false) {
+                return false;
+            }
+
+            return $this->uploads;
         },
         'value' => function () {
             return $this->toFiles($this->value);

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -48,6 +48,17 @@ return [
             return $template;
         },
 
+        /**
+         * If template options defined for filter, disable uploads
+         */
+        'uploads' => function () {
+            if (empty($this->template) === false) {
+                return false;
+            }
+
+            return $this->uploads;
+        },
+
         'value' => function ($value = null) {
             return $value;
         }

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -41,6 +41,13 @@ return [
             return $size;
         },
 
+        /**
+         * Filters all files by template
+         */
+        'template' => function ($template = null) {
+            return $template;
+        },
+
         'value' => function ($value = null) {
             return $value;
         }
@@ -57,6 +64,13 @@ return [
             return $this->parentModel->apiUrl(true);
         },
         'query' => function () {
+            if (empty($this->template) === false) {
+                $templates      = is_array($this->template) === true ? $this->template : [$this->template];
+                $templatesQuery = json_encode($templates);
+
+                return $this->parentModel::CLASS_ALIAS . '.files.filterBy("template", "in", ' . $templatesQuery . ')';
+            }
+
             return $this->query ?? $this->parentModel::CLASS_ALIAS . '.files';
         },
         'default' => function () {

--- a/tests/Cms/Files/FilePickerTest.php
+++ b/tests/Cms/Files/FilePickerTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Form\Field;
 use PHPUnit\Framework\TestCase;
 
 class FilePickerTest extends TestCase
@@ -16,9 +17,22 @@ class FilePickerTest extends TestCase
             ],
             'site' => [
                 'files' => [
-                    ['filename' => 'a.jpg'],
-                    ['filename' => 'b.jpg'],
-                    ['filename' => 'c.jpg']
+                    [
+                        'filename' => 'a.jpg',
+                        'template' => 'image'
+                    ],
+                    [
+                        'filename' => 'b.jpg',
+                        'template' => 'image'
+                    ],
+                    [
+                        'filename' => 'c.jpg',
+                        'template' => 'cover'
+                    ],
+                    [
+                        'filename' => 'd.jpg',
+                        'template' => 'other'
+                    ]
                 ]
             ]
         ]);
@@ -30,7 +44,7 @@ class FilePickerTest extends TestCase
     {
         $picker = new FilePicker();
 
-        $this->assertCount(3, $picker->items());
+        $this->assertCount(4, $picker->items());
     }
 
     public function testQuery()
@@ -39,6 +53,37 @@ class FilePickerTest extends TestCase
             'query' => 'site.files.offset(1)'
         ]);
 
-        $this->assertCount(2, $picker->items());
+        $this->assertCount(3, $picker->items());
+    }
+
+    public function testTemplate()
+    {
+        $field = new Field('files', [
+            'model' => $this->app->site(),
+            'template' => 'cover'
+        ]);
+
+        $picker = new FilePicker([
+            'query' => $field->query()
+        ]);
+
+        $this->assertCount(1, $picker->items());
+    }
+
+    public function testTemplates()
+    {
+        $field = new Field('files', [
+            'model' => $this->app->site(),
+            'template' => [
+                'cover',
+                'image'
+            ]
+        ]);
+
+        $picker = new FilePicker([
+            'query' => $field->query()
+        ]);
+
+        $this->assertCount(3, $picker->items());
     }
 }


### PR DESCRIPTION
## Describe the PR

Now you can filter files by `template` with easily for files field.

**Single template**
````yaml
fields:
  cover:
    type: files
    template: cover
````

**Multiple templates**
````yaml
fields:
  cover:
    type: files
    template: 
      - image
      - cover
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/495

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
