### PR TITLE
Add users section for panel

### DIFF
--- a/config/sections/users.php
+++ b/config/sections/users.php
@@ -1,0 +1,198 @@
+<?php
+
+use Kirby\Toolkit\Str;
+use Kirby\Toolkit\I18n;
+
+return [
+    'mixins' => [
+        'empty',
+        'headline',
+        'help',
+        'layout',
+        'min',
+        'max',
+        'pagination'
+    ],
+    'props' => [
+        /**
+         * Enables/disables user creating
+         */
+        'create' => function (bool $create = true) {
+            return $create;
+        },
+        /**
+         * Enables/disables reverse sorting
+         */
+        'flip' => function (bool $flip = false) {
+            return $flip;
+        },
+        /**
+         * Image options to control the source and look of user previews
+         */
+        'image' => function ($image = null) {
+            return $image ?? [];
+        },
+        /**
+         * Optional info text setup. Info text is shown on the right (lists) or below (cards) the user name.
+         */
+        'info' => function (string $info = null) {
+            return $info;
+        },
+        /**
+         * The size option controls the size of cards. By default cards are auto-sized and the cards grid will always fill the full width. With a size you can disable auto-sizing. Available sizes: `tiny`, `small`, `medium`, `large`, `huge`
+         */
+        'size' => function (string $size = 'auto') {
+            return $size;
+        },
+        /**
+         * Overwrites manual sorting and sorts by the given field and sorting direction (i.e. `date desc`)
+         */
+        'sortBy' => function (string $sortBy = null) {
+            return $sortBy;
+        },
+        /**
+         * Filters the list by roles
+         */
+        'roles' => function ($roles = null) {
+            return $roles;
+        },
+        /**
+         * Setup for the main text in the list or cards. By default this will display the user name.
+         */
+        'text' => function (string $text = '{{ user.username }}') {
+            return $text;
+        },
+        /**
+         * Optional query to select a specific set of users
+         */
+        'query' => function (string $query = null) {
+            return $query;
+        },
+    ],
+    'computed' => [
+        'users' => function () {
+            if (empty($this->query) === false) {
+                $users = Str::query($this->query, [
+                    'kirby' => $this->kirby(),
+                    'site'  => $this->site()
+                ]);
+
+                if (is_a($users, 'Kirby\Cms\Users') === false) {
+                    $users = $this->kirby()->users();
+                }
+            } else {
+                $users = $this->kirby()->users();
+            }
+
+            // roles
+            if (empty($this->roles) === false) {
+                $roles = is_array($this->roles) === true ? $this->roles : [$this->roles];
+                $users = $users->filterBy('role', 'in', $roles);
+            }
+
+            // sort
+            if ($this->sortBy) {
+                $users = $users->sortBy(...$users::sortArgs($this->sortBy));
+            }
+
+            // flip
+            if ($this->flip === true) {
+                $users = $users->flip();
+            }
+
+            // pagination
+            $users = $users->paginate([
+                'page'  => $this->page,
+                'limit' => $this->limit
+            ]);
+
+            return $users;
+        },
+        'total' => function () {
+            return $this->users->pagination()->total();
+        },
+        'data' => function () {
+            $data = [];
+
+            foreach ($this->users as $id) {
+                $user        = $this->kirby()->user($id);
+                $image       = $user->panelImage($this->image);
+
+                $data[] = [
+                    'id'     => $user->id(),
+                    'text'   => $user->toString($this->text),
+                    'info'   => $user->toString($this->info ?? false),
+                    'icon'   => $user->panelIcon($image),
+                    'image'  => $image,
+                    'link'   => $user->panelUrl(true),
+                    'status' => $user->status()
+                ];
+            }
+
+            return $data;
+        },
+        'errors' => function () {
+            $errors = [];
+
+            if ($this->validateMax() === false) {
+                $errors['max'] = I18n::template('error.section.users.max.' . I18n::form($this->max), [
+                    'max'     => $this->max,
+                    'section' => $this->headline
+                ]);
+            }
+
+            if ($this->validateMin() === false) {
+                $errors['min'] = I18n::template('error.section.users.min.' . I18n::form($this->min), [
+                    'min'     => $this->min,
+                    'section' => $this->headline
+                ]);
+            }
+
+            if (empty($errors) === true) {
+                return [];
+            }
+
+            return [
+                $this->name => [
+                    'label'   => $this->headline,
+                    'message' => $errors,
+                ]
+            ];
+        },
+        'add' => function () {
+            if ($this->create === false) {
+                return false;
+            }
+
+            if ($this->isFull() === true) {
+                return false;
+            }
+
+            return true;
+        },
+        'link' => function () {
+            return '/users';
+        },
+        'pagination' => function () {
+            return $this->pagination();
+        }
+    ],
+    'toArray' => function () {
+        return [
+            'data'    => $this->data,
+            'errors'  => $this->errors,
+            'options' => [
+                'add'      => $this->add,
+                'empty'    => $this->empty,
+                'headline' => $this->headline,
+                'help'     => $this->help,
+                'layout'   => $this->layout,
+                'link'     => $this->link,
+                'max'      => $this->max,
+                'min'      => $this->min,
+                'size'     => $this->size
+            ],
+            'pagination' => $this->pagination,
+        ];
+    }
+];

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -143,6 +143,15 @@
   "error.section.pages.min.singular":
     "The \"{section}\" section requires at least one page",
 
+  "error.section.users.max.plural":
+  "You must not add more than {max} users to the \"{section}\" section",
+  "error.section.users.max.singular":
+  "You must not add more than one user to the \"{section}\" section",
+  "error.section.users.min.plural":
+  "The \"{section}\" section requires at least {min} users",
+  "error.section.users.min.singular":
+  "The \"{section}\" section requires at least one user",
+
   "error.section.notLoaded": "The section \"{name}\" could not be loaded",
   "error.section.type.invalid": "The section type \"{type}\" is not valid",
 
@@ -467,6 +476,7 @@
     "Do you really want to delete <br><strong>{email}</strong>?",
 
   "users": "Users",
+  "users.empty": "No users yet",
 
   "version": "Version",
 

--- a/panel/src/components/Sections/UsersSection.vue
+++ b/panel/src/components/Sections/UsersSection.vue
@@ -1,0 +1,134 @@
+<template>
+  <section v-if="isLoading === false" class="k-users-section">
+
+    <header class="k-section-header">
+      <k-headline :link="options.link">
+        {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
+      </k-headline>
+
+      <k-button-group v-if="add">
+        <k-button icon="add" @click="create">{{ $t("add") }}</k-button>
+      </k-button-group>
+    </header>
+
+    <template v-if="error">
+      <k-box theme="negative">
+        <k-text size="small">
+          <strong>
+            {{ $t("error.section.notLoaded", { name: name }) }}:
+          </strong>
+          {{ error }}
+        </k-text>
+      </k-box>
+    </template>
+
+    <template v-else>
+      <k-collection
+        v-if="data.length"
+        :layout="options.layout"
+        :help="help"
+        :items="data"
+        :pagination="pagination"
+        :size="options.size"
+        :data-invalid="isInvalid"
+        @paginate="paginate"
+        @action="action"
+      />
+
+      <template v-else>
+        <k-empty
+          :layout="options.layout"
+          :data-invalid="isInvalid"
+          icon="user"
+          @click="create"
+        >
+          {{ options.empty || $t('users.empty') }}
+        </k-empty>
+        <footer class="k-collection-footer">
+          <k-text
+            v-if="help"
+            theme="help"
+            class="k-collection-help"
+            v-html="help"
+          />
+        </footer>
+      </template>
+
+      <k-user-create-dialog ref="create" @success="update" />
+      <k-user-email-dialog ref="email" @success="update" />
+      <k-user-language-dialog ref="language" @success="update" />
+      <k-user-password-dialog ref="password" />
+      <k-user-remove-dialog ref="remove" @success="update" />
+      <k-user-rename-dialog ref="rename" @success="update" />
+      <k-user-role-dialog ref="role" @success="update" />
+    </template>
+
+  </section>
+
+</template>
+
+<script>
+import CollectionSectionMixin from "@/mixins/section/collection.js";
+
+export default {
+  mixins: [CollectionSectionMixin],
+  computed: {
+    add() {
+      return this.options.add && this.$permissions.users.create;
+    }
+  },
+  created() {
+    this.load();
+  },
+  methods: {
+    action(user, action) {
+      switch (action) {
+        case "edit":
+          this.$router.push("/users/" + user.id);
+          break;
+        case "email":
+          this.$refs.email.open(user.id);
+          break;
+        case "role":
+          this.$refs.role.open(user.id);
+          break;
+        case "rename":
+          this.$refs.rename.open(user.id);
+          break;
+        case "password":
+          this.$refs.password.open(user.id);
+          break;
+        case "language":
+          this.$refs.language.open(user.id);
+          break;
+        case "remove":
+          this.$refs.remove.open(user.id);
+          break;
+      }
+    },
+    create() {
+      if (this.add) {
+        this.$refs.create.open();
+      }
+    },
+    items(data) {
+      return data.map(user => {
+        user.options = ready => {
+          this.$api.users
+            .options(user.id, "list")
+            .then(options => ready(options))
+            .catch(error => {
+              this.$store.dispatch("notification/error", error);
+            });
+        };
+
+        return user;
+      });
+    },
+    update() {
+      this.reload();
+      this.$events.$emit("model.update");
+    }
+  }
+};
+</script>

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -282,12 +282,14 @@ import InfoSection from "@/components/Sections/InfoSection.vue";
 import PagesSection from "@/components/Sections/PagesSection.vue";
 import FilesSection from "@/components/Sections/FilesSection.vue";
 import FieldsSection from "@/components/Sections/FieldsSection.vue";
+import UsersSection from "@/components/Sections/UsersSection.vue";
 
 Vue.component("k-sections", Sections);
 Vue.component("k-info-section", InfoSection);
 Vue.component("k-pages-section", PagesSection);
 Vue.component("k-files-section", FilesSection);
 Vue.component("k-fields-section", FieldsSection);
+Vue.component("k-users-section", UsersSection);
 
 /* Views */
 import BrowserView from "@/components/Views/BrowserView.vue";

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -631,6 +631,7 @@ trait AppPlugins
             Section::$types['pages']           = include static::$root . '/config/sections/pages.php';
             Section::$types['files']           = include static::$root . '/config/sections/files.php';
             Section::$types['fields']          = include static::$root . '/config/sections/fields.php';
+            Section::$types['users']           = include static::$root . '/config/sections/users.php';
 
             static::$systemExtensions = [
                 'components'   => include static::$root . '/config/components.php',

--- a/tests/Cms/Sections/UsersSectionTest.php
+++ b/tests/Cms/Sections/UsersSectionTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class UsersSectionTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        App::destroy();
+
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'roles' => [
+                [
+                    'name' => 'admin'
+                ],
+                [
+                    'name' => 'editor'
+                ],
+                [
+                    'name' => 'user'
+                ]
+            ],
+            'users' => [
+                [
+                    'email' => 'admin@domain.com',
+                    'role'  => 'admin'
+                ],
+                [
+                    'email' => 'editor@domain.com',
+                    'role'  => 'editor'
+                ],
+                [
+                    'email' => 'user@domain.com',
+                    'role'  => 'user'
+                ]
+            ],
+        ]);
+    }
+
+    public function testHeadline()
+    {
+
+        // single headline
+        $section = new Section('users', [
+            'name'     => 'test',
+            'headline' => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->headline());
+
+        // translated headline
+        $section = new Section('users', [
+            'name'     => 'test',
+            'headline' => [
+                'en' => 'Users',
+                'de' => 'Benutzer'
+            ]
+        ]);
+
+        $this->assertEquals('Users', $section->headline());
+    }
+
+    public function testAdd()
+    {
+        $section = new Section('users', [
+            'name'  => 'test'
+        ]);
+
+        $this->assertTrue($section->add());
+    }
+
+    public function testEmpty()
+    {
+        $section = new Section('users', [
+            'name'  => 'test',
+            'query' => 'kirby.users.filterBy("name", "john")',
+            'empty' => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->empty());
+    }
+
+    public function testTranslatedEmpty()
+    {
+        $section = new Section('users', [
+            'name'  => 'test',
+            'empty' => ['en' => 'Test', 'de' => 'Töst']
+        ]);
+
+        $this->assertEquals('Test', $section->empty());
+    }
+
+    public function testHelp()
+    {
+        // single help
+        $section = new Section('users', [
+            'name'  => 'test',
+            'help'  => 'Test'
+        ]);
+
+        $this->assertEquals('<p>Test</p>', $section->help());
+
+        // translated help
+        $section = new Section('users', [
+            'name'     => 'test',
+            'help' => [
+                'en' => 'Information',
+                'de' => 'Informationen'
+            ]
+        ]);
+
+        $this->assertEquals('<p>Information</p>', $section->help());
+    }
+
+    public function testSortBy()
+    {
+        $locale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
+
+        // no settings
+        $section = new Section('users', [
+            'name'  => 'test',
+        ]);
+        $this->assertEquals('admin@domain.com', $section->data()[0]['username']);
+        $this->assertEquals('editor@domain.com', $section->data()[1]['username']);
+        $this->assertEquals('user@domain.com', $section->data()[2]['username']);
+
+        // custom sorting direction
+        $section = new Section('users', [
+            'name'   => 'test',
+            'sortBy' => 'username desc'
+        ]);
+        $this->assertEquals('user@domain.com', $section->data()[0]['username']);
+        $this->assertEquals('editor@domain.com', $section->data()[1]['username']);
+        $this->assertEquals('admin@domain.com', $section->data()[2]['username']);
+
+        setlocale(LC_ALL, $locale);
+    }
+
+    public function testFlip()
+    {
+        $section = new Section('users', [
+            'name'  => 'test',
+            'flip'  => true
+        ]);
+
+        $this->assertEquals('user@domain.com', $section->data()[0]['username']);
+        $this->assertEquals('editor@domain.com', $section->data()[1]['username']);
+        $this->assertEquals('admin@domain.com', $section->data()[2]['username']);
+    }
+}


### PR DESCRIPTION
## Describe the PR

### WIP PR

Now we have a section to list users. 
May I have your opinion for the first stage of PR, please? @distantnative 🙏 

I didn't know what the section's `model` data should be for users `section`? 
Could it be a site as `'model' => $this->site()`?

**Sample usage**

````yaml
sections:
  users:
    type: users
    roles: 
      - editor
      - user
    sortBy: birthdate desc
    query: kirby.users.filterBy('birthdate', '<=', date('Y-m-d H:i:s'))
    text: "{{ user.email }}"
    info: "{{ user.birthdate }}"
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/422

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
