### PR TITLE
modified() support specifying language

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -375,12 +375,13 @@ class File extends ModelWithContent
      *
      * @param string $format
      * @param string|null $handler date or strftime
+     * @param string|null $languageCode
      * @return mixed
      */
-    public function modified(string $format = null, string $handler = null)
+    public function modified(string $format = null, string $handler = null, string $languageCode = null)
     {
         $file     = $this->modifiedFile();
-        $content  = $this->modifiedContent();
+        $content  = $this->modifiedContent($languageCode);
         $modified = max($file, $content);
 
         if (is_null($format) === true) {
@@ -396,11 +397,12 @@ class File extends ModelWithContent
      * Timestamp of the last modification
      * of the content file
      *
+     * @param string|null $languageCode
      * @return int
      */
-    protected function modifiedContent(): int
+    protected function modifiedContent(string $languageCode = null): int
     {
-        return F::modified($this->contentFile());
+        return F::modified($this->contentFile($languageCode));
     }
 
     /**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -889,11 +889,16 @@ class Page extends ModelWithContent
      *
      * @param string $format
      * @param string|null $handler
+     * @param string|null $languageCode
      * @return int|string
      */
-    public function modified(string $format = null, string $handler = null)
+    public function modified(string $format = null, string $handler = null, string $languageCode = null)
     {
-        return F::modified($this->contentFile(), $format, $handler ?? $this->kirby()->option('date.handler', 'date'));
+        return F::modified(
+            $this->contentFile($languageCode),
+            $format,
+            $handler ?? $this->kirby()->option('date.handler', 'date')
+        );
     }
 
     /**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -515,11 +515,12 @@ class User extends ModelWithContent
      *
      * @param string $format
      * @param string|null $handler
+     * @param string|null $languageCode
      * @return int|string
      */
-    public function modified(string $format = 'U', string $handler = null)
+    public function modified(string $format = 'U', string $handler = null, string $languageCode = null)
     {
-        $modifiedContent = F::modified($this->contentFile());
+        $modifiedContent = F::modified($this->contentFile($languageCode));
         $modifiedIndex   = F::modified($this->root() . '/index.php');
         $modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
         $handler         = $handler ?? $this->kirby()->option('date.handler', 'date');

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -244,6 +244,45 @@ class FileTest extends TestCase
         Dir::remove(dirname($index));
     }
 
+    public function testModifiedSpecifyingLanguage()
+    {
+        $app = new App([
+            'roots' => [
+                'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
+                'content' => $index
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'default' => true,
+                    'name'    => 'English'
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        // create a file
+        F::write($file = $index . '/test.js', 'test');
+
+        // create the english content
+        F::write($content = $index . '/test.js.en.txt', 'test');
+        touch($file, $modifiedEnContent = \time() + 2);
+
+        // create the german content
+        F::write($content = $index . '/test.js.en.txt', 'test');
+        touch($file, $modifiedDeContent = \time() + 5);
+
+        $file = $app->file('test.js');
+
+        $this->assertEquals($modifiedDeContent, $file->modified(null, null, 'en'));
+        $this->assertEquals($modifiedEnContent, $file->modified(null, null, 'de'));
+
+        Dir::remove(dirname($index));
+    }
+
     public function testPanelIconDefault()
     {
         $file = new File([

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -272,7 +272,7 @@ class FileTest extends TestCase
         touch($file, $modifiedEnContent = \time() + 2);
 
         // create the german content
-        F::write($content = $index . '/test.js.en.txt', 'test');
+        F::write($content = $index . '/test.js.de.txt', 'test');
         touch($file, $modifiedDeContent = \time() + 5);
 
         $file = $app->file('test.js');

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -277,8 +277,8 @@ class FileTest extends TestCase
 
         $file = $app->file('test.js');
 
-        $this->assertEquals($modifiedDeContent, $file->modified(null, null, 'en'));
-        $this->assertEquals($modifiedEnContent, $file->modified(null, null, 'de'));
+        $this->assertEquals($modifiedEnContent, $file->modified(null, null, 'en'));
+        $this->assertEquals($modifiedDeContent, $file->modified(null, null, 'de'));
 
         Dir::remove(dirname($index));
     }

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -265,14 +265,14 @@ class FileTest extends TestCase
         ]);
 
         // create a file
-        F::write($file = $index . '/test.js', 'test');
+        F::write($index . '/test.js', 'test');
 
         // create the english content
-        F::write($content = $index . '/test.js.en.txt', 'test');
+        F::write($file = $index . '/test.js.en.txt', 'test');
         touch($file, $modifiedEnContent = \time() + 2);
 
         // create the german content
-        F::write($content = $index . '/test.js.de.txt', 'test');
+        F::write($file = $index . '/test.js.de.txt', 'test');
         touch($file, $modifiedDeContent = \time() + 5);
 
         $file = $app->file('test.js');

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -803,8 +803,10 @@ class PageTest extends TestCase
         F::write($file = $index . '/test/test.de.txt', 'test');
         touch($file, $modifiedDeContent = \time() + 5);
 
-        $this->assertEquals($modifiedEnContent, $app->page('test')->modified(null, null, 'en'));
-        $this->assertEquals($modifiedDeContent, $app->page('test')->modified(null, null, 'de'));
+        $page = $app->page('test');
+
+        $this->assertEquals($modifiedEnContent, $page->modified(null, null, 'en'));
+        $this->assertEquals($modifiedDeContent, $page->modified(null, null, 'de'));
 
         Dir::remove($index);
     }

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -775,6 +775,40 @@ class PageTest extends TestCase
         Dir::remove($index);
     }
 
+    public function testModifiedSpecifyingLanguage()
+    {
+        $app = new App([
+            'roots' => [
+                'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
+                'content' => $index
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'default' => true,
+                    'name'    => 'English'
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        // create the english page
+        F::write($file = $index . '/test/test.en.txt', 'test');
+        touch($file, $modifiedEnContent = \time() + 2);
+
+        // create the german page
+        F::write($file = $index . '/test/test.de.txt', 'test');
+        touch($file, $modifiedDeContent = \time() + 5);
+
+        $this->assertEquals($modifiedEnContent, $app->page('test')->modified(null, null, 'en'));
+        $this->assertEquals($modifiedDeContent, $app->page('test')->modified(null, null, 'de'));
+
+        Dir::remove($index);
+    }
+
     public function testPanelIconDefault()
     {
         $page = new Page([

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -149,8 +149,10 @@ class UserTest extends TestCase
         F::write($file = $index . '/test/user.de.txt', 'test');
         touch($file, $modifiedDeContent = \time() + 5);
 
-        $this->assertEquals($modifiedEnContent, $app->user('test')->modified('U', null, 'en'));
-        $this->assertEquals($modifiedDeContent, $app->user('test')->modified('U', null, 'de'));
+        $user = $app->user('test');
+
+        $this->assertEquals($modifiedEnContent, $user->modified('U', null, 'en'));
+        $this->assertEquals($modifiedDeContent, $user->modified('U', null, 'de'));
 
         Dir::remove($index);
     }

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -118,6 +118,43 @@ class UserTest extends TestCase
         Dir::remove($index);
     }
 
+    public function testModifiedSpecifyingLanguage()
+    {
+        $app = new App([
+            'roots' => [
+                'index'    => $index = __DIR__ . '/fixtures/UserPropsTest/modified',
+                'accounts' => $index
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'default' => true,
+                    'name'    => 'English'
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        // create a user file
+        F::write($file = $index . '/test/index.php', '<?php return [];');
+
+        // create the english page
+        F::write($file = $index . '/test/user.en.txt', 'test');
+        touch($file, $modifiedEnContent = \time() + 2);
+
+        // create the german page
+        F::write($file = $index . '/test/user.de.txt', 'test');
+        touch($file, $modifiedDeContent = \time() + 5);
+
+        $this->assertEquals($modifiedEnContent, $app->user('test')->modified(null, null, 'en'));
+        $this->assertEquals($modifiedDeContent, $app->user('test')->modified(null, null, 'de'));
+
+        Dir::remove($index);
+    }
+
     public function passwordProvider()
     {
         return [

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -149,8 +149,8 @@ class UserTest extends TestCase
         F::write($file = $index . '/test/user.de.txt', 'test');
         touch($file, $modifiedDeContent = \time() + 5);
 
-        $this->assertEquals($modifiedEnContent, $app->user('test')->modified(null, null, 'en'));
-        $this->assertEquals($modifiedDeContent, $app->user('test')->modified(null, null, 'de'));
+        $this->assertEquals($modifiedEnContent, $app->user('test')->modified('U', null, 'en'));
+        $this->assertEquals($modifiedDeContent, $app->user('test')->modified('U', null, 'de'));
 
         Dir::remove($index);
     }


### PR DESCRIPTION
## Describe the PR

`modified()` method now support specifying language for file, page, user models.

**Sample Usage**

````php
$page->modified('c', 'date', 'de');
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/440

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
