### PR TITLE
New option prevent redirect to new page for pages section

### DIFF
--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -41,6 +41,12 @@ return [
             return $info;
         },
         /**
+         * Enables/disables redirecting after page create
+         */
+        'redirect' => function (bool $redirect = true) {
+            return $redirect;
+        },
+        /**
          * The size option controls the size of cards. By default cards are auto-sized and the cards grid will always fill the full width. With a size you can disable auto-sizing. Available sizes: `tiny`, `small`, `medium`, `large`, `huge`
          */
         'size' => function (string $size = 'auto') {
@@ -287,6 +293,7 @@ return [
                 'link'     => $this->link,
                 'max'      => $this->max,
                 'min'      => $this->min,
+                'redirect' => $this->redirect,
                 'size'     => $this->size,
                 'sortable' => $this->sortable
             ],

--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -3,6 +3,7 @@
     ref="dialog"
     :button="$t('page.draft.create')"
     :notification="notification"
+    :data-redirect="redirect"
     size="medium"
     theme="positive"
     @submit="$refs.form.submit()"
@@ -23,6 +24,14 @@ import DialogMixin from "@/mixins/dialog.js";
 
 export default {
   mixins: [DialogMixin],
+  props: {
+    redirect: {
+      type: Boolean,
+      default() {
+        return true;
+      }
+    }
+  },
   data() {
     return {
       notification: null,
@@ -126,7 +135,7 @@ export default {
         .post(this.parent + "/children", data)
         .then(page => {
           this.success({
-            route: this.$api.pages.link(page.id),
+            route: this.redirect ? this.$api.pages.link(page.id) : null,
             message: ":)",
             event: "page.create"
           });

--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -3,7 +3,6 @@
     ref="dialog"
     :button="$t('page.draft.create')"
     :notification="notification"
-    :data-redirect="redirect"
     size="medium"
     theme="positive"
     @submit="$refs.form.submit()"
@@ -27,9 +26,7 @@ export default {
   props: {
     redirect: {
       type: Boolean,
-      default() {
-        return true;
-      }
+      default: true
     }
   },
   data() {

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -56,7 +56,7 @@
         </footer>
       </template>
 
-      <k-page-create-dialog ref="create" />
+      <k-page-create-dialog ref="create" @success="update" :redirect="options.redirect" />
       <k-page-duplicate-dialog ref="duplicate" />
       <k-page-rename-dialog ref="rename" @success="update" />
       <k-page-url-dialog ref="url" @success="update" />


### PR DESCRIPTION
## Describe the PR

Now we can prevent the redirect to the created page with new `redirect` option.

**Sample Usage**

````yaml
sections:
  drafts:
    headline: Drafts
    type: pages
    status: draft
    templates: article
    redirect: false
````

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Closes https://github.com/getkirby/ideas/issues/185

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
