### PR TITLE
Fix return type of $field->split()

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -475,7 +475,7 @@ return function (App $app) {
          * Splits the field content into an array
          *
          * @param \Kirby\Cms\Field $field
-         * @return \Kirby\cms\Field
+         * @return array
          */
         'split' => function (Field $field, $separator = ',') {
             return Str::split((string)$field->value, $separator);


### PR DESCRIPTION
## Describe the PR

Only fixed return type of $field->split().

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
