### PR TITLE
Str::excerpt - optional space before $rep

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -341,7 +341,7 @@ class Str
      * @param string $rep The element, which should be added if the string is too long. Ellipsis is the default.
      * @return string The shortened string
      */
-    public static function excerpt($string, $chars = 140, $strip = true, $rep = '…')
+    public static function excerpt($string, $chars = 140, $strip = true, $rep = ' …')
     {
         if ($strip === true) {
             $string = strip_tags(str_replace('<', ' <', $string));
@@ -361,7 +361,7 @@ class Str
             return $string;
         }
 
-        return static::substr($string, 0, mb_strrpos(static::substr($string, 0, $chars), ' ')) . ' ' . $rep;
+        return static::substr($string, 0, mb_strrpos(static::substr($string, 0, $chars), ' ')) . $rep;
     }
 
     /**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -134,7 +134,7 @@ class StrTest extends TestCase
     {
         $string   = 'This is a long text<br>with some html';
         $expected = 'This is a long text with ...';
-        $result   = Str::excerpt($string, 27, true, '...');
+        $result   = Str::excerpt($string, 27, true, ' ...');
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
## Describe the PR

Allows to pass a `$rep` that gets added without additional space to the end of the excerpt.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes https://github.com/getkirby/ideas/issues/525

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
