### PR TITLE
Updated return type of $site->find()

### DIFF
--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -126,7 +126,7 @@ trait HasChildren
      * Finds one or multiple children by id
      *
      * @param string ...$arguments
-     * @return \Kirby\Cms\Page|\Kirby\Cms\Pages
+     * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
      */
     public function find(...$arguments)
     {


### PR DESCRIPTION
`$site->find()` returns `null` when page is not found.

## Describe the PR


## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
