### PR TITLE
Don't fetch children if there are no more path keys to check

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -238,11 +238,11 @@ class Pages extends Collection
     public function findByIdRecursive(string $id, string $startAt = null, bool $multiLang = false)
     {
         $path       = explode('/', $id);
-        $collection = $this;
         $item       = null;
         $query      = $startAt;
 
         foreach ($path as $key) {
+            $collection = $item ? $item->children() : $this;
             $query = ltrim($query . '/' . $key, '/');
             $item  = $collection->get($query) ?? null;
 
@@ -253,8 +253,6 @@ class Pages extends Collection
             if ($item === null) {
                 return null;
             }
-
-            $collection = $item->children();
         }
 
         return $item;


### PR DESCRIPTION
## Describe the PR

When looking finding a page with an id such as `united-states/california`, the Pages class currently lookups of the children of `united-states` _and_ `california`, even though California's children are irrelevant.

If `california` has a lot of subpages, it's a lot of disk activity and Page Model creations that might ultimately go unused. 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
