### PR TITLE
New and improved F::load*() methods, prevent access to internal resources by included files

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -546,7 +546,7 @@ trait AppPlugins
             $class = str_replace(['.', '-', '_'], '', $name) . 'Page';
 
             // load the model class
-            include_once $model;
+            F::loadOnce($model);
 
             if (class_exists($class) === true) {
                 $models[$name] = $class;
@@ -777,7 +777,7 @@ trait AppPlugins
                 continue;
             }
 
-            include_once $entry;
+            F::loadOnce($entry);
 
             $loaded[] = $dir;
         }

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Controller;
+use Kirby\Toolkit\F;
 
 /**
  * Manages and loads all collections
@@ -119,8 +120,8 @@ class Collections
         // first check for collection file
         $file = $kirby->root('collections') . '/' . $name . '.php';
 
-        if (file_exists($file)) {
-            $collection = require $file;
+        if (is_file($file) === true) {
+            $collection = F::load($file);
 
             if (is_a($collection, 'Closure')) {
                 return $collection;

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -94,7 +94,7 @@ class Languages extends Collection
         $files     = glob(App::instance()->root('languages') . '/*.php');
 
         foreach ($files as $file) {
-            $props = include $file;
+            $props = F::load($file);
 
             if (is_array($props) === true) {
                 // inject the language code from the filename if it does not exist

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -258,8 +258,10 @@ trait UserActions
      */
     protected function readCredentials(): array
     {
-        if (file_exists($this->root() . '/index.php') === true) {
-            $credentials = require $this->root() . '/index.php';
+        $path = $this->root() . '/index.php';
+
+        if (is_file($path) === true) {
+            $credentials = F::load($path);
 
             return is_array($credentials) === false ? [] : $credentials;
         } else {

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Toolkit\Dir;
+use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 
 /**
@@ -109,8 +110,9 @@ class Users extends Collection
             }
 
             // get role information
-            if (file_exists($root . '/' . $userDirectory . '/index.php') === true) {
-                $credentials = require $root . '/' . $userDirectory . '/index.php';
+            $path = $root . '/' . $userDirectory . '/index.php';
+            if (is_file($path) === true) {
+                $credentials = F::load($path);
             }
 
             // create user model based on role

--- a/src/Data/PHP.php
+++ b/src/Data/PHP.php
@@ -68,7 +68,7 @@ class PHP extends Handler
             throw new Exception('The file "' . $file . '" does not exist');
         }
 
-        return (array)(include $file);
+        return (array)F::load($file, []);
     }
 
     /**

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use ArgumentCountError;
+use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use TypeError;
 
@@ -224,8 +225,12 @@ class Component
         $definition = static::$types[$type];
 
         // load definitions from string
-        if (is_array($definition) === false) {
-            static::$types[$type] = $definition = include $definition;
+        if (is_string($definition) === true) {
+            if (is_file($definition) !== true) {
+                throw new Exception('Component definition ' . $definition . ' does not exist');
+            }
+
+            static::$types[$type] = $definition = F::load($definition);
         }
 
         return $definition;

--- a/src/Toolkit/Controller.php
+++ b/src/Toolkit/Controller.php
@@ -51,11 +51,11 @@ class Controller
 
     public static function load(string $file)
     {
-        if (file_exists($file) === false) {
+        if (is_file($file) === false) {
             return null;
         }
 
-        $function = require $file;
+        $function = F::load($file);
 
         if (is_a($function, 'Closure') === false) {
             return null;

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -379,6 +379,22 @@ class F
     }
 
     /**
+     * Loads a file using `include_once()` and returns whether loading was successful
+     *
+     * @param string $file
+     * @return bool
+     */
+    public static function loadOnce(string $file): bool
+    {
+        if (is_file($file) === false) {
+            return false;
+        }
+
+        include_once $file;
+        return true;
+    }
+
+    /**
      * Returns the mime type of a file
      *
      * @param string $file

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -362,9 +362,10 @@ class F
      *
      * @param string $file
      * @param mixed $fallback
+     * @param array $data Optional array of variables to extract in the variable scope
      * @return mixed
      */
-    public static function load(string $file, $fallback = null)
+    public static function load(string $file, $fallback = null, array $data = [])
     {
         if (is_file($file) === false) {
             return $fallback;
@@ -373,7 +374,7 @@ class F
         // we use the loadIsolated() method here to prevent the included
         // file from overwriting our $fallback in this variable scope; see
         // https://www.php.net/manual/en/function.include.php#example-124
-        $result = static::loadIsolated($file);
+        $result = static::loadIsolated($file, $data);
 
         if ($fallback !== null && gettype($result) !== gettype($fallback)) {
             return $fallback;
@@ -386,11 +387,17 @@ class F
      * Loads a file with as little as possible in the variable scope
      *
      * @param string $file
+     * @param array $data Optional array of variables to extract in the variable scope
      * @return mixed
      */
-    protected static function loadIsolated(string $file)
+    protected static function loadIsolated(string $file, array $data = [])
     {
-        return include $file;
+        // extract the $data variables in this scope to be accessed by the included file;
+        // protect $file against being overwritten by a $data variable
+        $___file___ = $file;
+        extract($data);
+
+        return include $___file___;
     }
 
     /**

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -357,7 +357,8 @@ class F
     }
 
     /**
-     * Loads a file and returns the result
+     * Loads a file and returns the result or `false` if the
+     * file to load does not exist
      *
      * @param string $file
      * @param mixed $fallback
@@ -365,17 +366,31 @@ class F
      */
     public static function load(string $file, $fallback = null)
     {
-        if (file_exists($file) === false) {
+        if (is_file($file) === false) {
             return $fallback;
         }
 
-        $result = include $file;
+        // we use the loadIsolated() method here to prevent the included
+        // file from overwriting our $fallback in this variable scope; see
+        // https://www.php.net/manual/en/function.include.php#example-124
+        $result = static::loadIsolated($file);
 
         if ($fallback !== null && gettype($result) !== gettype($fallback)) {
             return $fallback;
         }
 
         return $result;
+    }
+
+    /**
+     * Loads a file with as little as possible in the variable scope
+     *
+     * @param string $file
+     * @return mixed
+     */
+    protected static function loadIsolated(string $file)
+    {
+        return include $file;
     }
 
     /**

--- a/src/Toolkit/Tpl.php
+++ b/src/Toolkit/Tpl.php
@@ -18,23 +18,21 @@ class Tpl
     /**
      * Renders the template
      *
-     * @param string $__file
-     * @param array $__data
+     * @param string $file
+     * @param array $data
      * @return string
      */
-    public static function load(string $__file = null, array $__data = []): string
+    public static function load(string $file = null, array $data = []): string
     {
-        if (file_exists($__file) === false) {
+        if (is_file($file) === false) {
             return '';
         }
 
-        $exception = null;
-
         ob_start();
-        extract($__data);
 
+        $exception = null;
         try {
-            require $__file;
+            F::load($file, null, $data);
         } catch (Throwable $e) {
             $exception = $e;
         }

--- a/src/Toolkit/View.php
+++ b/src/Toolkit/View.php
@@ -60,7 +60,7 @@ class View
      */
     public function exists(): bool
     {
-        return file_exists($this->file()) === true;
+        return is_file($this->file()) === true;
     }
 
     /**
@@ -94,13 +94,11 @@ class View
             throw new Exception($this->missingViewMessage());
         }
 
-        $exception = null;
-
         ob_start();
-        extract($this->data());
 
+        $exception = null;
         try {
-            require $this->file();
+            F::load($this->file(), null, $this->data());
         } catch (Throwable $e) {
             $exception = $e;
         }

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -222,23 +222,22 @@ class FTest extends TestCase
 
     public function testLoad()
     {
-        F::write($file = $this->fixtures . '/test.php', '<?php return "foo"; ?>');
+        // basic behavior
+        F::write($file = $this->fixtures . '/test.php', '<?php return "foo";');
+        $this->assertSame('foo', F::load($file));
 
-        $this->assertEquals('foo', F::load($file));
-    }
+        // non-existing file
+        $this->assertSame('foo', F::load('does-not-exist.php', 'foo'));
 
-    public function testLoadWithFallback()
-    {
-        $this->assertEquals('foo', F::load('does-not-exist.php', 'foo'));
-    }
-
-    public function testLoadWithTypeMismatch()
-    {
-        F::write($file = $this->fixtures . '/test.php', '<?php return "foo"; ?>');
-
+        // type mismatch
+        F::write($file = $this->fixtures . '/test.php', '<?php return "foo";');
         $expected = ['a' => 'b'];
+        $this->assertSame($expected, F::load($file, $expected));
 
-        $this->assertEquals($expected, F::load($file, $expected));
+        // type mismatch with overwritten $fallback
+        F::write($file = $this->fixtures . '/test.php', '<?php $fallback = "test"; return "foo";');
+        $expected = ['a' => 'b'];
+        $this->assertSame($expected, F::load($file, $expected));
     }
 
     public function testLoadOnce()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -241,6 +241,16 @@ class FTest extends TestCase
         $this->assertEquals($expected, F::load($file, $expected));
     }
 
+    public function testLoadOnce()
+    {
+        // basic behavior
+        F::write($file = $this->fixtures . '/test.php', '<?php return "foo";');
+        $this->assertTrue(F::loadOnce($file));
+
+        // non-existing file
+        $this->assertFalse(F::loadOnce('does-not-exist.php'));
+    }
+
     public function testMove()
     {
         F::write($this->tmp, 'test');

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -238,6 +238,16 @@ class FTest extends TestCase
         F::write($file = $this->fixtures . '/test.php', '<?php $fallback = "test"; return "foo";');
         $expected = ['a' => 'b'];
         $this->assertSame($expected, F::load($file, $expected));
+
+        // with data
+        F::write($file = $this->fixtures . '/test.php', '<?php return $variable;');
+        $this->assertSame('foobar', F::load($file, null, ['variable' => 'foobar']));
+
+        // with overwritten $data
+        $this->assertSame('foobar', F::load($file, null, ['variable' => 'foobar', 'data' => []]));
+
+        // with overwritten $file
+        $this->assertSame('foobar', F::load($file, null, ['variable' => 'foobar', 'file' => null]));
     }
 
     public function testLoadOnce()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- New `F::loadOnce()` method for safely including PHP files using `include_once()`
- `F::load()` now supports passing variables to the included file with a new `$data` argument
- Files included with `F::load()` can no longer overwrite the provided `$fallback` variable
- PHP files included by Kirby (e.g. from plugins, models, controllers etc.) can no longer access `protected` methods of Kirby classes

**Note:** The fourth change is a breaking-change.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2394

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
