### PR TITLE
Improved handling of key capitalization differences when updating content

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -544,6 +544,7 @@ abstract class ModelWithContent extends Model
         }
 
         // get the content to store
+        $data         = array_change_key_case($data);
         $content      = $translation->update($data, $overwrite)->content();
         $kirby        = $this->kirby();
         $languageCode = $kirby->languageCode($languageCode);
@@ -552,7 +553,7 @@ abstract class ModelWithContent extends Model
         if ($languageCode !== $kirby->defaultLanguage()->code()) {
             foreach ($this->blueprint()->fields() as $field) {
                 if (($field['translate'] ?? true) === false) {
-                    $content[$field['name']] = null;
+                    $content[strtolower($field['name'])] = null;
                 }
             }
 

--- a/tests/Cms/Pages/PageTranslationsTest.php
+++ b/tests/Cms/Pages/PageTranslationsTest.php
@@ -233,6 +233,13 @@ class PageTranslationsTest extends TestCase
                     'b' => [
                         'type' => 'text',
                         'translate' => false
+                    ],
+                    'CAPITALIZED' => [
+                        'type' => 'text',
+                        'translate' => false
+                    ],
+                    'dDdDdD' => [
+                        'type' => 'text',
                     ]
                 ]
             ]
@@ -240,21 +247,34 @@ class PageTranslationsTest extends TestCase
 
         $app->impersonate('kirby');
 
-        $en = $page->update($input = [
+        $en = $page->update([
             'a' => 'A',
-            'b' => 'B'
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dDdDdD' => 'D'
         ]);
 
-        $this->assertSame($input, $en->content('en')->data());
+        $expected = [
+            'a' => 'A',
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dddddd' => 'D'
+        ];
+
+        $this->assertSame($expected, $en->content('en')->data());
 
         $de = $page->update([
             'a' => 'A',
-            'b' => 'B'
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dDdDdD' => 'D'
         ], 'de');
 
         $expected = [
             'a' => 'A',
-            'b' => null
+            'b' => null,
+            'capitalized' => null,
+            'dddddd' => 'D'
         ];
 
         $this->assertSame($expected, $de->content('de')->data());


### PR DESCRIPTION
## Describe the PR
Whereas most of model's content usage is independent of key case, updating content is extremely sensitive to case differences in keys. This forces all content keys to be lowercase when updating.

This is _technically_ a breaking change, if you're code relies on specific keys in a ContentTranslation's `->data()` value. I would assume most do not.

Open to other suggestions on approaching this.

## Related issues

- Fixes #2577, #2789

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)


I didn't change the behavior of the 