### PR TITLE
Add 'cache.pages.flush:before' and 'cache.pages.flush:after' hooks

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -115,7 +115,9 @@ trait FileActions
         $kirby->trigger('file.' . $action . ':before', ...$arguments);
         $result = $callback(...$arguments);
         $kirby->trigger('file.' . $action . ':after', $result, $old);
+        $kirby->trigger('cache.pages.flush:before');
         $kirby->cache('pages')->flush();
+        $kirby->trigger('cache.pages.flush:after');
         return $result;
     }
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -317,7 +317,9 @@ trait PageActions
         $this->kirby()->trigger('page.' . $action . ':before', ...$arguments);
         $result = $callback(...$arguments);
         $this->kirby()->trigger('page.' . $action . ':after', $result, $old);
+        $this->kirby()->trigger('cache.pages.flush:before');
         $this->kirby()->cache('pages')->flush();
+        $this->kirby()->trigger('cache.pages.flush:after');
         return $result;
     }
 

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -38,7 +38,9 @@ trait SiteActions
         $kirby->trigger('site.' . $action . ':before', ...$arguments);
         $result = $callback(...$arguments);
         $kirby->trigger('site.' . $action . ':after', $result, $old);
+        $kirby->trigger('cache.pages.flush:before');
         $kirby->cache('pages')->flush();
+        $kirby->trigger('cache.pages.flush:after');
         return $result;
     }
 

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -150,7 +150,9 @@ trait UserActions
         $this->kirby()->trigger('user.' . $action . ':before', ...$arguments);
         $result = $callback(...$arguments);
         $this->kirby()->trigger('user.' . $action . ':after', $result, $old);
+        $kirby->trigger('cache.pages.flush:before');
         $this->kirby()->cache('pages')->flush();
+        $kirby->trigger('cache.pages.flush:after');
         return $result;
     }
 


### PR DESCRIPTION
## Describe the PR

This PR adds a `cache.pages.flush:before` and `cache.page.flush:before` hook.
I'm actually not sure it's useful to have both `:before` and `:after` in this case but I added them for consistency with other hooks.

It's currently quite tedious to mimick the pages flush behaviour for custom global caches. One has to register all events one by one. This would allow us to register:

```php
'hooks' => [
    'cache.pages.flush:after' => function() {
        kirby()->cache('sylvainjule.my-cache')->flush();
    }
]
```

## Related issues

Haven't opened one.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
