### PR TITLE
Refactor Whoops usage

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -93,6 +93,9 @@ class App
         $this->optionsFromConfig();
         $this->optionsFromProps($props['options'] ?? []);
 
+        // register the Whoops error handler
+        $this->handleErrors();
+
         // set the path to make it available for the url bakery
         $this->setPath($props['path'] ?? null);
 
@@ -125,9 +128,6 @@ class App
 
         // trigger hook for use in plugins
         $this->trigger('system.loadPlugins:after');
-
-        // handle those damn errors
-        $this->handleErrors();
 
         // execute a ready callback from the config
         $this->optionsFromReadyCallback();

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -10,7 +10,7 @@ use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run as Whoops;
 
 /**
- * AppErrors
+ * PHP error handling using the Whoops library
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -20,14 +20,30 @@ use Whoops\Run as Whoops;
  */
 trait AppErrors
 {
+    /**
+     * Whoops instance cache
+     *
+     * @var \Whoops\Run
+     */
+    protected $whoops;
+
+    /**
+     * Registers the PHP error handler for CLI usage
+     *
+     * @return void
+     */
     protected function handleCliErrors(): void
     {
-        $whoops = new Whoops();
-        $whoops->pushHandler(new PlainTextHandler());
-        $whoops->register();
+        $this->setWhoopsHandler(new PlainTextHandler());
     }
 
-    protected function handleErrors()
+    /**
+     * Registers the PHP error handler
+     * based on the environment
+     *
+     * @return void
+     */
+    protected function handleErrors(): void
     {
         if ($this->request()->cli() === true) {
             $this->handleCliErrors();
@@ -42,9 +58,14 @@ trait AppErrors
         $this->handleHtmlErrors();
     }
 
-    protected function handleHtmlErrors()
+    /**
+     * Registers the PHP error handler for HTML output
+     *
+     * @return void
+     */
+    protected function handleHtmlErrors(): void
     {
-        $whoops = new Whoops();
+        $handler = null;
 
         if ($this->option('debug') === true) {
             if ($this->option('whoops', true) === true) {
@@ -56,9 +77,6 @@ trait AppErrors
                 if ($editor = $this->option('editor')) {
                     $handler->setEditor($editor);
                 }
-
-                $whoops->pushHandler($handler);
-                $whoops->register();
             }
         } else {
             $handler = new CallbackHandler(function ($exception, $inspector, $run) {
@@ -72,15 +90,22 @@ trait AppErrors
 
                 return Handler::QUIT;
             });
+        }
 
-            $whoops->pushHandler($handler);
-            $whoops->register();
+        if ($handler !== null) {
+            $this->setWhoopsHandler($handler);
+        } else {
+            $this->unsetWhoopsHandler();
         }
     }
 
-    protected function handleJsonErrors()
+    /**
+     * Registers the PHP error handler for JSON output
+     *
+     * @return void
+     */
+    protected function handleJsonErrors(): void
     {
-        $whoops  = new Whoops();
         $handler = new CallbackHandler(function ($exception, $inspector, $run) {
             if (is_a($exception, 'Kirby\Exception\Exception') === true) {
                 $httpCode = $exception->getHttpCode();
@@ -114,7 +139,46 @@ trait AppErrors
             return Handler::QUIT;
         });
 
+        $this->setWhoopsHandler($handler);
+    }
+
+    /**
+     * Enables Whoops with the specified handler
+     *
+     * @param Callable|\Whoops\Handler\HandlerInterface $handler
+     * @return void
+     */
+    protected function setWhoopsHandler($handler): void
+    {
+        $whoops = $this->whoops();
+        $whoops->clearHandlers();
         $whoops->pushHandler($handler);
-        $whoops->register();
+        $whoops->register(); // will only do something if not already registered
+    }
+
+    /**
+     * Clears the Whoops handlers and disables Whoops
+     *
+     * @return void
+     */
+    protected function unsetWhoopsHandler(): void
+    {
+        $whoops = $this->whoops();
+        $whoops->clearHandlers();
+        $whoops->unregister(); // will only do something if currently registered
+    }
+
+    /**
+     * Returns the Whoops error handler instance
+     *
+     * @return \Whoops\Run
+     */
+    protected function whoops()
+    {
+        if ($this->whoops !== null) {
+            return $this->whoops;
+        }
+
+        return $this->whoops = new Whoops();
     }
 }

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Http\Server;
+use ReflectionMethod;
+use Whoops\Handler\PlainTextHandler;
+
+/**
+ * @coversDefaultClass \Kirby\Cms\AppErrors
+ */
+class AppErrorsTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        $unsetMethod = new ReflectionMethod(App::class, 'unsetWhoopsHandler');
+        $unsetMethod->setAccessible(true);
+
+        $app = App::instance();
+        $unsetMethod->invoke($app);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @covers ::handleCliErrors
+     */
+    public function testHandleCliErrors()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+        
+        $testMethod = new ReflectionMethod(App::class, 'handleCliErrors');
+        $testMethod->setAccessible(true);
+
+        $app    = App::instance();
+        $whoops = $whoopsMethod->invoke($app);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
+    }
+
+    /**
+     * @covers ::handleErrors
+     */
+    public function testHandleErrors()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+        
+        $testMethod = new ReflectionMethod(App::class, 'handleErrors');
+        $testMethod->setAccessible(true);
+
+        $app    = App::instance();
+        $whoops = $whoopsMethod->invoke($app);
+
+        $oldCli    = Server::$cli;
+        $oldAccept = $_SERVER['HTTP_ACCEPT'] ?? null;
+
+        // CLI
+        Server::$cli = true;
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
+
+        // JSON
+        Server::$cli = false;
+        $_SERVER['HTTP_ACCEPT'] = 'application/json';
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+        
+        // HTML
+        Server::$cli = false;
+        $_SERVER['HTTP_ACCEPT'] = 'text/html';
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'debug' => true
+            ]
+        ]);
+        $whoops = $whoopsMethod->invoke($app);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
+
+        // reset global state
+        Server::$cli            = $oldCli;
+        $_SERVER['HTTP_ACCEPT'] = $oldAccept;
+    }
+
+    /**
+     * @covers ::handleHtmlErrors
+     */
+    public function testHandleHtmlErrors()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+        
+        $optionsMethod = new ReflectionMethod(App::class, 'optionsFromProps');
+        $optionsMethod->setAccessible(true);
+
+        $testMethod = new ReflectionMethod(App::class, 'handleHtmlErrors');
+        $testMethod->setAccessible(true);
+
+        $app    = App::instance();
+        $whoops = $whoopsMethod->invoke($app);
+
+        // without options
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+
+        // disabling Whoops without debugging doesn't matter
+        $optionsMethod->invoke($app, ['debug' => false, 'whoops' => false]);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+
+        // with debugging enabled
+        $optionsMethod->invoke($app, ['debug' => true, 'whoops' => true]);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
+        $this->assertSame('Kirby CMS Debugger', $handlers[0]->getPageTitle());
+        $this->assertSame(dirname(__DIR__, 3) . '/assets', $handlers[0]->getResourcePaths()[0]);
+        $this->assertFalse($handlers[0]->getEditorHref('test', 1));
+
+        // with debugging enabled and editor
+        $optionsMethod->invoke($app, ['debug' => true, 'whoops' => true, 'editor' => 'vscode']);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
+        $this->assertSame('Kirby CMS Debugger', $handlers[0]->getPageTitle());
+        $this->assertSame(dirname(__DIR__, 3) . '/assets', $handlers[0]->getResourcePaths()[0]);
+        $this->assertSame('vscode://file/test:1', $handlers[0]->getEditorHref('test', 1));
+
+        // with debugging enabled, but without Whoops
+        $optionsMethod->invoke($app, ['debug' => true, 'whoops' => false]);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(0, $handlers);
+    }
+
+    /**
+     * @covers ::handleJsonErrors
+     */
+    public function testHandleJsonErrors()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+        
+        $testMethod = new ReflectionMethod(App::class, 'handleJsonErrors');
+        $testMethod->setAccessible(true);
+
+        $app    = App::instance();
+        $whoops = $whoopsMethod->invoke($app);
+
+        $testMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+    }
+
+    /**
+     * @covers ::setWhoopsHandler
+     * @covers ::unsetWhoopsHandler
+     */
+    public function testSetUnsetWhoopsHandler()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+        
+        $setMethod = new ReflectionMethod(App::class, 'setWhoopsHandler');
+        $setMethod->setAccessible(true);
+
+        $unsetMethod = new ReflectionMethod(App::class, 'unsetWhoopsHandler');
+        $unsetMethod->setAccessible(true);
+
+        $app    = App::instance();
+        $whoops = $whoopsMethod->invoke($app);
+
+        $setMethod->invoke($app, new PlainTextHandler());
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\PlaintextHandler', $handlers[0]);
+
+        $setMethod->invoke($app, function () {
+            // empty callback
+        });
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+
+        $unsetMethod->invoke($app);
+        $handlers = $whoops->getHandlers();
+        $this->assertCount(0, $handlers);
+    }
+
+    /**
+     * @covers ::whoops
+     */
+    public function testWhoops()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+
+        $app = App::instance();
+
+        $whoops1 = $whoopsMethod->invoke($app);
+        $this->assertInstanceOf('Whoops\Run', $whoops1);
+
+        $whoops2 = $whoopsMethod->invoke($app);
+        $this->assertInstanceOf('Whoops\Run', $whoops2);
+        $this->assertSame($whoops1, $whoops2);
+    }
+}


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Whoops is now loaded earlier, which allows it to be used when there are PHP errors in plugins, models etc. I have also refactored the `AppErrors` class in preparation for the second PR #2596.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
