### PR TITLE
Add extension registry for plugin permissions

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -63,6 +63,7 @@ trait AppPlugins
         'pageMethods' => [],
         'pagesMethods' => [],
         'pageModels' => [],
+        'permissions' => [],
         'routes' => [],
         'sections' => [],
         'siteMethods' => [],
@@ -333,6 +334,22 @@ trait AppPlugins
     protected function extendPages(array $pages): array
     {
         return $this->extensions['pages'] = array_merge($this->extensions['pages'], $pages);
+    }
+
+    /**
+     * Registers additional permissions
+     *
+     * @param array $permissions
+     * @param \Kirby\Cms\Plugin|null $plugin
+     * @return array
+     */
+    protected function extendPermissions(array $permissions, Plugin $plugin = null): array
+    {
+        if ($plugin !== null) {
+            $permissions = [$plugin->prefix() => $permissions];
+        }
+
+        return $this->extensions['permissions'] = Permissions::$extendedActions = array_merge(Permissions::$extendedActions, $permissions);
     }
 
     /**

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -17,6 +17,8 @@ use Kirby\Exception\InvalidArgumentException;
  */
 class Permissions
 {
+    public static $extendedActions = [];
+
     protected $actions = [
         'access' => [
             'panel'    => true,
@@ -75,6 +77,15 @@ class Permissions
 
     public function __construct($settings = [])
     {
+        // dynamically register the extended actions
+        foreach (static::$extendedActions as $key => $actions) {
+            if (isset($this->actions[$key]) === true) {
+                throw new InvalidArgumentException('The action ' . $key . ' is already a core action');
+            }
+
+            $this->actions[$key] = $actions;
+        }
+
         if (is_array($settings) === true) {
             return $this->setCategories($settings);
         }

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -543,6 +543,53 @@ class AppPluginsTest extends TestCase
         $this->assertInstanceOf('TestPage', $page);
     }
 
+    public function testPermission()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'permissions' => [
+                'test-category' => [
+                    'test-action' => true,
+                    'another'     => false
+                ]
+            ]
+        ]);
+
+        $permissions = new Permissions([]);
+        $this->assertTrue($permissions->for('test-category', 'test-action'));
+        $this->assertFalse($permissions->for('test-category', 'another'));
+
+        // reset actions
+        Permissions::$extendedActions = [];
+    }
+
+    public function testPermissionPlugin()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $plugin = new Plugin('kirby/manual', [
+            'permissions' => [
+                'test-action' => true,
+                'another'     => false
+            ]
+        ]);
+
+        $kirby->extend($plugin->extends(), $plugin);
+
+        $permissions = new Permissions([]);
+        $this->assertTrue($permissions->for('kirby.manual', 'test-action'));
+        $this->assertFalse($permissions->for('kirby.manual', 'another'));
+
+        // reset actions
+        Permissions::$extendedActions = [];
+    }
+
     public function testOption()
     {
         // simple

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -4,7 +4,12 @@ namespace Kirby\Cms;
 
 class PermissionsTest extends TestCase
 {
-    public function actions()
+    public function tearDown(): void
+    {
+        Permissions::$extendedActions = [];
+    }
+
+    public function actionsProvider()
     {
         return [
             ['files', 'changeName'],
@@ -44,9 +49,8 @@ class PermissionsTest extends TestCase
         ];
     }
 
-
     /**
-     * @dataProvider actions
+     * @dataProvider actionsProvider
      */
     public function testActions(string $category, $action)
     {
@@ -84,5 +88,46 @@ class PermissionsTest extends TestCase
         ]);
 
         $this->assertTrue($p->for($category, $action));
+    }
+
+    public function testExtendActions()
+    {
+        Permissions::$extendedActions = [
+            'test-category' => [
+                'test-action' => true,
+                'another'     => false
+            ]
+        ];
+
+        // default values
+        $permissions = new Permissions();
+        $this->assertTrue($permissions->for('test-category', 'test-action'));
+        $this->assertFalse($permissions->for('test-category', 'another'));
+        $this->assertFalse($permissions->for('test-category', 'does-not-exist'));
+
+        // overridden values
+        $permissions = new Permissions([
+            'test-category' => [
+                '*'       => false,
+                'another' => true
+            ]
+        ]);
+        $this->assertFalse($permissions->for('test-category', 'test-action'));
+        $this->assertTrue($permissions->for('test-category', 'another'));
+        $this->assertFalse($permissions->for('test-category', 'does-not-exist'));
+    }
+
+    public function testExtendActionsCoreOverride()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The action pages is already a core action');
+
+        Permissions::$extendedActions = [
+            'pages' => [
+                'test-action' => true
+            ]
+        ];
+
+        new Permissions();
     }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

This makes it possible to register custom permissions from plugins:

```php
Kirby::plugin('my/plugin', [
    'permissions' => [
        'myAction'      => true,
        'anotherAction' => true
    ]
]);
```

**User blueprint:**

```yaml
title: Admin
permissions:
  my.plugin:
    *: false
    myAction: true
```

**Usage in the plugin:**

```php
$kirby->user()->role()->permissions()->for('my.plugin', 'myAction')      // true
$kirby->user()->role()->permissions()->for('my.plugin', 'anotherAction') // false
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
