### PR TITLE
$page->go()

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -454,6 +454,20 @@ class Page extends ModelWithContent
     }
 
     /**
+     * Redirects to this page,
+     * wrapper for the `go()` helper
+     *
+     * @since 3.4.0
+     *
+     * @param array $options Options for `Kirby\Http\Uri` to create URL parts
+     * @param int $code HTTP status code
+     */
+    public function go(array $options = [], int $code = 302)
+    {
+        go($this->url($options), $code);
+    }
+
+    /**
      * Checks if the intended template
      * for the page exists.
      *

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -245,12 +245,12 @@ class Response
      * @param int $code
      * @return self
      */
-    public static function redirect(?string $location = null, ?int $code = null)
+    public static function redirect(string $location = '/', int $code = 302)
     {
         return new static([
-            'code' => $code ?? 302,
+            'code' => $code,
             'headers' => [
-                'Location' => Url::unIdn($location ?? '/')
+                'Location' => Url::unIdn($location)
             ]
         ]);
     }


### PR DESCRIPTION
## Describe the PR

Implements `$page->go($options, 301)` as shorthand for `go($page->url()`

## Related issues

https://github.com/getkirby/ideas/issues/511

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
