### PR TITLE
Session: Use SameSite cookies

### DIFF
--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -459,7 +459,8 @@ class Session
                 'lifetime' => $this->tokenExpiry,
                 'path'     => Url::index(['host' => null, 'trailingSlash' => true]),
                 'secure'   => Url::scheme() === 'https',
-                'httpOnly' => true
+                'httpOnly' => true,
+                'sameSite' => 'Lax'
             ]);
         } else {
             $this->needsRetransmission = true;


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Session cookies now use `SameSite=Lax` by default, which will ensure that the Panel will still work on non-encrypted HTTP connections with future Firefox versions.

**Note:** Support for SameSite cookies was added in PHP 7.3, so the SameSite attribute won't be set if the site is still using PHP 7.2. I figured it is still a good idea to add support now for the majority of users who already use a recent PHP version. We will drop support for PHP 7.2 at the end of this year anyway.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2601

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
