### PR TITLE
F::niceSize(): kB -> KB #2607

### DIFF
--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -103,7 +103,7 @@ class F
         ],
     ];
 
-    public static $units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    public static $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
     /**
      * Appends new content to an existing file
@@ -498,7 +498,7 @@ class F
 
         // avoid errors for invalid sizes
         if ($size <= 0) {
-            return '0 kB';
+            return '0 KB';
         }
 
         // the math magic

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -289,8 +289,14 @@ class FTest extends TestCase
     {
         F::write($this->tmp, 'test');
 
-        $this->assertEquals('4 B', F::niceSize($this->tmp));
-        $this->assertEquals('4 B', F::niceSize(4));
+        $this->assertSame('4 B', F::niceSize($this->tmp));
+        $this->assertSame('4 B', F::niceSize(4));
+        $this->assertSame('4 KB', F::niceSize(4096));
+        $this->assertSame('4 KB', F::niceSize(4100));
+        $this->assertSame('4.1 KB', F::niceSize(4200));
+        $this->assertSame('4 MB', F::niceSize(4194304));
+        $this->assertSame('4.29 MB', F::niceSize(4500000));
+        $this->assertSame('4 GB', F::niceSize(4294967296));
     }
 
     public function testRead()

--- a/tests/Toolkit/FileTest.php
+++ b/tests/Toolkit/FileTest.php
@@ -118,7 +118,7 @@ class FileTest extends TestCase
 
         // non-existing file
         $file = $this->_file('does/not/exist.js');
-        $this->assertEquals('0 kB', $file->niceSize());
+        $this->assertEquals('0 KB', $file->niceSize());
     }
 
     public function testModified()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The correct units would be `KiB`, `MiB` etc., but these are uncommon outside of hard drive sizes and some applications. Both macOS and Windows use `KB`, so I'd suggest to use those here as well to be easy to understand by humans who are used to that.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2607 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
