### PR TITLE
Fix options regression

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -289,6 +289,10 @@ trait AppPlugins
             $options = $prefixed;
         }
 
+        // register each option in the nesting blacklist;
+        // this prevents Kirby from nesting the array keys inside each option
+        static::$nestIgnoreOptions = array_merge(static::$nestIgnoreOptions, array_keys($options));
+
         return $this->extensions['options'] = $this->options = A::merge($options, $this->options, A::MERGE_REPLACE);
     }
 

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -289,7 +289,7 @@ trait AppPlugins
             $options = $prefixed;
         }
 
-        return $this->extensions['options'] = $this->options = A::merge(A::nest($options), $this->options, A::MERGE_REPLACE);
+        return $this->extensions['options'] = $this->options = A::merge($options, $this->options, A::MERGE_REPLACE);
     }
 
     /**

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -536,6 +536,35 @@ class AppPluginsTest extends TestCase
         $this->assertEquals($expected, Page::$models);
     }
 
+    public function testExtensionsFromOptions()
+    {
+        $calledRoute = false;
+        $calledHook  = false;
+
+        $kirby = new App([
+            'options' => [
+                'routes' => [
+                    [
+                        'pattern' => 'test',
+                        'action'  => function () use (&$calledRoute) {
+                            $calledRoute = true;
+                        }
+                    ]
+                ],
+                'hooks' => [
+                    'type.action:state' => function () use (&$calledHook) {
+                        $calledHook = true;
+                    }
+                ]
+            ]
+        ]);
+
+        $kirby->call('test');
+        $kirby->trigger('type.action:state');
+        $this->assertTrue($calledRoute);
+        $this->assertTrue($calledHook);
+    }
+
     public function testPluginOptions()
     {
         App::plugin('test/plugin', [

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -570,7 +570,7 @@ class AppPluginsTest extends TestCase
         App::plugin('test/plugin', [
             'options' => [
                 'foo' => 'bar',
-                'another-foo' => 'bar',
+                'another.foo' => 'bar',
                 'dot' => 'line'
             ]
         ]);
@@ -592,7 +592,9 @@ class AppPluginsTest extends TestCase
             'test' => [
                 'plugin' => [
                     'foo' => 'another-bar',
-                    'another-foo' => 'bar',
+                    'another' => [
+                        'foo' => 'bar'
+                    ],
                     'dot' => 'another-line'
                 ]
             ]
@@ -617,17 +619,19 @@ class AppPluginsTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals(['three'], $kirby->option('test.plugin.foo'));
+        $this->assertSame(['three'], $kirby->option('test.plugin.foo'));
     }
 
     public function testPluginOptionsWithAssociativeArray()
     {
-        // non-associative
+        // associative
         App::plugin('test/plugin', [
             'options' => [
-                'foo' => [
-                    'a' => 'A',
-                    'b' => 'B'
+                'foo.a' => 'A',
+                'foo.b.c' => 'B.C',
+                'another.foo' => [
+                    'e' => 'D',
+                    'f.g' => 'E.F'
                 ]
             ]
         ]);
@@ -637,13 +641,39 @@ class AppPluginsTest extends TestCase
                 'index' => '/dev/null'
             ],
             'options' => [
-                'test.plugin.foo' => [
-                    'a' => 'Custom A'
+                'test.plugin' => [
+                    'foo' => [
+                        'a' => 'Custom A',
+                        'b.d' => 'Custom B.D'
+                    ],
+                    'another' => [
+                        'foo' => [
+                            'e' => 'Custom E',
+                            'f.h' => 'Custom F.H'
+                        ]
+                    ]
                 ]
             ]
         ]);
 
-        $this->assertEquals(['a' => 'Custom A', 'b' => 'B'], $kirby->option('test.plugin.foo'));
+        $this->assertSame([
+            'foo' => [
+                'a' => 'Custom A',
+                'b' => [
+                    'c' => 'B.C',
+                    'd' => 'Custom B.D'
+                ]
+            ],
+
+            // the another.foo option should be protected against nesting
+            'another' => [
+                'foo' => [
+                    'e' => 'Custom E',
+                    'f.g' => 'E.F',
+                    'f.h' => 'Custom F.H'
+                ]
+            ]
+        ], $kirby->option('test.plugin'));
     }
 
     public function testRoutes()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -252,6 +252,32 @@ class ATest extends TestCase
         ];
         $this->assertSame($expected, A::nest($input));
 
+        // ignored key
+        $input = [
+            'a' => 'a value',
+            'b' => 'another value',
+            'b.c' => [
+                'd.e.f' => 'a third value'
+            ]
+        ];
+        $expected = $input;
+        $this->assertSame($expected, A::nest($input, ['b']));
+
+        // nested ignored key
+        $expected = [
+            'a' => 'a value',
+            'b' => [
+                'c' => [
+                    'd.e.f' => 'a third value'
+                ]
+            ]
+        ];
+        $this->assertSame($expected, A::nest($input, ['b.c']));
+
+        // ignored key with partially nested input
+        $input = $expected;
+        $this->assertSame($expected, A::nest($input, ['b.c']));
+
         // recursive array replacement
         $input = [
             // replace strings with arrays within deep structures
@@ -300,6 +326,63 @@ class ATest extends TestCase
             ]
         ];
         $this->assertSame($expected, A::nest($input));
+
+        // merged arrays
+        $input1 = [
+            'a' => 'a-1',
+            'b' => [
+                'c' => 'b.c-1',
+                'd' => 'b.d-1'
+            ],
+            'e.f' => [
+                'g.h' => 'e.f.g.h-1',
+                'g.i' => 'e.f.g.i-1'
+            ],
+            'l' => [
+                'm' => 'l.m-1',
+                'o.p' => 'l.o.p-1'
+            ]
+        ];
+        $input2 = [
+            'a' => 'a-2',
+            'b.c' => 'b.c-2',
+            'e' => [
+                'f.g' => [
+                    'h' => 'e.f.g.h-2',
+                    'j' => 'e.f.g.j-2'
+                ],
+                'k' => 'e.k-2'
+            ],
+            'l' => [
+                'm.n' => 'l.m.n-2',
+                'o' => 'l.o-2'
+            ]
+        ];
+        $expected = [
+            'a' => 'a-2',
+            'b' => [
+                'c' => 'b.c-2',
+                'd' => 'b.d-1'
+            ],
+            'e' => [
+                'f' => [
+                    'g' => [
+                        'h' => 'e.f.g.h-2',
+                        'i' => 'e.f.g.i-1',
+                        'j' => 'e.f.g.j-2'
+                    ]
+                ],
+                'k' => 'e.k-2'
+            ],
+            'l' => [
+                'm' => 'l.m-1',
+                'o.p' => 'l.o.p-1',
+                'm.n' => 'l.m.n-2',
+                'o' => 'l.o-2'
+            ]
+        ];
+        $this->assertSame($expected, A::nest(array_replace_recursive($input1, $input2), ['l.m', 'l.o']));
+        $this->assertSame($expected, A::nest(A::merge($input1, $input2, A::MERGE_REPLACE), ['l.m', 'l.o']));
     }
 
     public function testNestByKeys()


### PR DESCRIPTION
This fixes a regression introduced by #2572 (not yet released on the `develop` branch):

Because all options are now nested as much as possible, hooks registered with the `hooks` option would also get nested because the event names and therefore the array keys inside the `hooks` array contain dots.

The `hooks` option is now blacklisted from nesting. If we find out that more options are affected, we can add those to `AppPlugin::$nestIgnoreOptions` as well.

Plugin options are also protected from nesting by adding them to the blacklist automatically.