### PR TITLE
$kirby->impersonate(): Support for action function

### DIFF
--- a/config/api/authentication.php
+++ b/config/api/authentication.php
@@ -3,15 +3,16 @@
 use Kirby\Exception\PermissionException;
 
 return function () {
-    $auth = $this->kirby()->auth();
+    $auth               = $this->kirby()->auth();
+    $allowImpersonation = $this->kirby()->option('api.allowImpersonation', false);
 
     // csrf token check
-    if ($auth->type() === 'session' && $auth->csrf() === false) {
+    if ($auth->type($allowImpersonation) === 'session' && $auth->csrf() === false) {
         throw new PermissionException('Unauthenticated');
     }
 
     // get user from session or basic auth
-    if ($user = $auth->user()) {
+    if ($user = $auth->user(null, $allowImpersonation)) {
         if ($user->role()->permissions()->for('access', 'panel') === false) {
             throw new PermissionException(['key' => 'access.panel']);
         }

--- a/config/api/authentication.php
+++ b/config/api/authentication.php
@@ -4,7 +4,7 @@ use Kirby\Exception\PermissionException;
 
 return function () {
     $auth               = $this->kirby()->auth();
-    $allowImpersonation = $this->kirby()->option('api.allowImpersonation', false);
+    $allowImpersonation = $this->kirby()->option('api.allowImpersonation') ?? false;
 
     // csrf token check
     if ($auth->type($allowImpersonation) === 'session' && $auth->csrf() === false) {

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -39,7 +39,8 @@ class Api extends BaseApi
 
         $this->kirby->setCurrentLanguage($this->language());
 
-        if ($user = $this->kirby->user()) {
+        $allowImpersonation = $this->kirby()->option('api.allowImpersonation', false);
+        if ($user = $this->kirby->user(null, $allowImpersonation)) {
             $this->kirby->setCurrentTranslation($user->language());
         }
 
@@ -136,7 +137,7 @@ class Api extends BaseApi
                 $model = $kirby->site();
                 break;
             case 'account':
-                $model = $kirby->user();
+                $model = $kirby->user(null, $kirby->option('api.allowImpersonation', false));
                 break;
             case 'page':
                 $id    = str_replace(['+', ' '], '/', basename($path));
@@ -242,7 +243,7 @@ class Api extends BaseApi
     {
         // get the authenticated user
         if ($id === null) {
-            return $this->kirby->auth()->user();
+            return $this->kirby->auth()->user(null, $this->kirby()->option('api.allowImpersonation', false));
         }
 
         // get a specific user by id

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -77,20 +77,23 @@ trait AppUsers
      * Returns a specific user by id
      * or the current user if no id is given
      *
-     * @param string $id
+     * @param string|null $id
+     * @param bool $allowImpersonation If set to false, only the actually
+     *                                 logged in user will be returned
+     *                                 (when `$id` is passed as `null`)
      * @return \Kirby\Cms\User|null
      */
-    public function user(string $id = null)
+    public function user(?string $id = null, bool $allowImpersonation = true)
     {
         if ($id !== null) {
             return $this->users()->find($id);
         }
 
-        if (is_string($this->user) === true) {
+        if ($allowImpersonation === true && is_string($this->user) === true) {
             return $this->auth()->impersonate($this->user);
         } else {
             try {
-                return $this->auth()->user();
+                return $this->auth()->user(null, $allowImpersonation);
             } catch (Throwable $e) {
                 return null;
             }

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -416,16 +416,19 @@ class Auth
     /**
      * Returns the current authentication type
      *
+     * @param bool $allowImpersonation If set to false, 'impersonate' won't
+     *                                 be returned as authentication type
+     *                                 even if an impersonation is active
      * @return string
      */
-    public function type(): string
+    public function type(bool $allowImpersonation = true): string
     {
         $basicAuth = $this->kirby->option('api.basicAuth', false);
         $auth      = $this->kirby->request()->auth();
 
         if ($basicAuth === true && $auth && $auth->type() === 'basic') {
             return 'basic';
-        } elseif ($this->impersonate !== null) {
+        } elseif ($allowImpersonation === true && $this->impersonate !== null) {
             return 'impersonate';
         } else {
             return 'session';
@@ -436,13 +439,15 @@ class Auth
      * Validates the currently logged in user
      *
      * @param \Kirby\Session\Session|array|null $session
+     * @param bool $allowImpersonation If set to false, only the actually
+     *                                 logged in user will be returned
      * @return \Kirby\Cms\User
      *
      * @throws \Throwable If an authentication error occured
      */
-    public function user($session = null)
+    public function user($session = null, bool $allowImpersonation = true)
     {
-        if ($this->impersonate !== null) {
+        if ($allowImpersonation === true && $this->impersonate !== null) {
             return $this->impersonate;
         }
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -86,6 +86,16 @@ class Auth
     }
 
     /**
+     * Returns the currently impersonated user
+     *
+     * @return \Kirby\Cms\User|null
+     */
+    public function currentUserFromImpersonation()
+    {
+        return $this->impersonate;
+    }
+
+    /**
      * Returns the logged in user by checking
      * the current session and finding a valid
      * valid user id in there
@@ -124,10 +134,10 @@ class Auth
     /**
      * Become any existing user
      *
-     * @param string|null $who
+     * @param string|null $who User ID or email address
      * @return \Kirby\Cms\User|null
      */
-    public function impersonate(string $who = null)
+    public function impersonate(?string $who = null)
     {
         switch ($who) {
             case null:

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -45,6 +45,7 @@ class ApiTest extends TestCase
             ],
             'options' => [
                 'api' => [
+                    'allowImpersonation' => true,
                     'authentication' => function () {
                         return true;
                     },

--- a/tests/Cms/Api/routes/AuthRoutesTest.php
+++ b/tests/Cms/Api/routes/AuthRoutesTest.php
@@ -11,6 +11,9 @@ class AuthRoutesTest extends TestCase
     public function setUp(): void
     {
         $this->app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => $fixtures = __DIR__ . '/fixtures/AuthRoutesTest'
             ],

--- a/tests/Cms/Api/routes/LanguagesRoutesTest.php
+++ b/tests/Cms/Api/routes/LanguagesRoutesTest.php
@@ -15,6 +15,7 @@ class LanguagesRoutesTest extends TestCase
                 'index' => $fixtures = __DIR__ . '/fixtures/LanguagesRoutesTest'
             ],
             'options' => [
+                'api.allowImpersonation' => true,
                 'languages' => true
             ],
             'languages' => [

--- a/tests/Cms/Api/routes/PagesRoutesTest.php
+++ b/tests/Cms/Api/routes/PagesRoutesTest.php
@@ -6,12 +6,23 @@ use PHPUnit\Framework\TestCase;
 
 class PagesRoutesTest extends TestCase
 {
-    public function testGet()
+    protected $app;
+
+    public function setUp(): void
     {
-        $app = new App([
+        $this->app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => '/dev/null'
-            ],
+            ]
+        ]);
+    }
+
+    public function testGet()
+    {
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [
@@ -39,10 +50,7 @@ class PagesRoutesTest extends TestCase
 
     public function testChildren()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [
@@ -70,10 +78,7 @@ class PagesRoutesTest extends TestCase
 
     public function testFiles()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [
@@ -106,10 +111,7 @@ class PagesRoutesTest extends TestCase
 
     public function testFilesSorted()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [
@@ -143,10 +145,7 @@ class PagesRoutesTest extends TestCase
 
     public function testFile()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [

--- a/tests/Cms/Api/routes/RolesRoutesTest.php
+++ b/tests/Cms/Api/routes/RolesRoutesTest.php
@@ -11,6 +11,9 @@ class RolesRoutesTest extends TestCase
     public function setUp(): void
     {
         $this->app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => '/dev/null'
             ],

--- a/tests/Cms/Api/routes/SiteRoutesTest.php
+++ b/tests/Cms/Api/routes/SiteRoutesTest.php
@@ -11,6 +11,9 @@ class SiteRoutesTest extends TestCase
     public function setUp(): void
     {
         $this->app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => '/dev/null'
             ],
@@ -85,10 +88,7 @@ class SiteRoutesTest extends TestCase
 
     public function testFilesSorted()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'files' => [
                     [
@@ -136,10 +136,7 @@ class SiteRoutesTest extends TestCase
 
     public function testFind()
     {
-        $app = new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $app = $this->app->clone([
             'site' => [
                 'children' => [
                     [

--- a/tests/Cms/Api/routes/UsersRoutesTest.php
+++ b/tests/Cms/Api/routes/UsersRoutesTest.php
@@ -11,6 +11,9 @@ class UsersRoutesTest extends TestCase
     public function setUp(): void
     {
         $this->app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => '/dev/null'
             ],

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -204,6 +204,9 @@ class AppPluginsTest extends TestCase
         ]);
 
         $app = new App([
+            'options' => [
+                'api.allowImpersonation' => true
+            ],
             'roots' => [
                 'index' => '/dev/null'
             ],

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -28,8 +28,10 @@ class AppUsersTest extends TestCase
     {
         $app = $this->app;
         $app->impersonate('kirby');
-        $this->assertEquals('kirby@getkirby.com', $app->user()->email());
+
+        $this->assertSame('kirby@getkirby.com', $app->user()->email());
         $this->assertTrue($app->user()->isKirby());
+        $this->assertNull($app->user(null, false));
     }
 
     public function testImpersonateAsNull()

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -57,23 +57,27 @@ class AuthTest extends TestCase
      */
     public function testImpersonate()
     {
-        $this->assertEquals(null, $this->auth->user());
+        $this->assertSame(null, $this->auth->user());
 
         $user = $this->auth->impersonate('kirby');
-        $this->assertEquals('kirby', $user->id());
-        $this->assertEquals('kirby@getkirby.com', $user->email());
-        $this->assertEquals('admin', $user->role());
-        $this->assertEquals($user, $this->auth->user());
+        $this->assertSame('kirby', $user->id());
+        $this->assertSame('kirby@getkirby.com', $user->email());
+        $this->assertSame('admin', $user->role()->name());
+        $this->assertSame($user, $this->auth->user());
+        $this->assertNull($this->auth->user(null, false));
 
         $user = $this->auth->impersonate('homer@simpsons.com');
-        $this->assertEquals('homer@simpsons.com', $user->email());
-        $this->assertEquals($user, $this->auth->user());
+        $this->assertSame('homer@simpsons.com', $user->email());
+        $this->assertSame($user, $this->auth->user());
+        $this->assertNull($this->auth->user(null, false));
 
         $this->assertNull($this->auth->impersonate(null));
         $this->assertNull($this->auth->user());
+        $this->assertNull($this->auth->user(null, false));
 
         $this->assertNull($this->auth->impersonate());
         $this->assertNull($this->auth->user());
+        $this->assertNull($this->auth->user(null, false));
     }
 
     /**
@@ -96,12 +100,12 @@ class AuthTest extends TestCase
         $session->set('user.id', 'marge');
 
         $user = $this->auth->user();
-        $this->assertEquals('marge@simpsons.com', $user->email());
+        $this->assertSame('marge@simpsons.com', $user->email());
 
         // value is cached
         $session->set('user.id', 'homer');
         $user = $this->auth->user();
-        $this->assertEquals('marge@simpsons.com', $user->email());
+        $this->assertSame('marge@simpsons.com', $user->email());
     }
 
     /**
@@ -113,7 +117,7 @@ class AuthTest extends TestCase
         $session->set('user.id', 'homer');
 
         $user = $this->auth->user($session);
-        $this->assertEquals('homer@simpsons.com', $user->email());
+        $this->assertSame('homer@simpsons.com', $user->email());
     }
 
     /**
@@ -124,7 +128,7 @@ class AuthTest extends TestCase
         $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:springfield123');
 
         $user = $this->auth->user();
-        $this->assertEquals('homer@simpsons.com', $user->email());
+        $this->assertSame('homer@simpsons.com', $user->email());
     }
 
     /**

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -52,6 +52,7 @@ class AuthTest extends TestCase
     }
 
     /**
+     * @covers ::currentUserFromImpersonation
      * @covers ::impersonate
      * @covers ::user
      */
@@ -64,19 +65,23 @@ class AuthTest extends TestCase
         $this->assertSame('kirby@getkirby.com', $user->email());
         $this->assertSame('admin', $user->role()->name());
         $this->assertSame($user, $this->auth->user());
+        $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $user = $this->auth->impersonate('homer@simpsons.com');
         $this->assertSame('homer@simpsons.com', $user->email());
         $this->assertSame($user, $this->auth->user());
+        $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $this->assertNull($this->auth->impersonate(null));
         $this->assertNull($this->auth->user());
+        $this->assertNull($this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $this->assertNull($this->auth->impersonate());
         $this->assertNull($this->auth->user());
+        $this->assertNull($this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
     }
 
@@ -101,6 +106,9 @@ class AuthTest extends TestCase
 
         $user = $this->auth->user();
         $this->assertSame('marge@simpsons.com', $user->email());
+
+        // impersonation is not set
+        $this->assertNull($this->auth->currentUserFromImpersonation());
 
         // value is cached
         $session->set('user.id', 'homer');


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

It is now possible to pass an action function to `$kirby->impersonate()`, which will run with the permissions of the impersonated user. The impersonated user is reset after the function has returned:

```php
$result = $kirby->impersonate('kirby', function ($user) {
    // $this is the $kirby object
    $email = $user->email(); // 'kirby@getkirby.com'

    return 'this will be returned to $result above';
});
```

**Note:** Merge #2618 first, which will make the duplicated commits disappear here.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- See https://github.com/getkirby/kirby/pull/2618#issuecomment-629064911

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
