### PR TITLE
Improvements to the Query class

### DIFF
--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -23,8 +23,8 @@ class Query
 
     const NO_PNTH = '\([^\(]+\)(*SKIP)(*FAIL)';
     const NO_SQBR = '\[[^]]+\](*SKIP)(*FAIL)';
-    const NO_DLQU = '\"[^"]+\"(*SKIP)(*FAIL)';
-    const NO_SLQU = '\'[^\']+\'(*SKIP)(*FAIL)';
+    const NO_DLQU = '\"(?:[^"\\\\]|\\\\.)*\"(*SKIP)(*FAIL)';  // allow \" escaping inside string
+    const NO_SLQU = '\'(?:[^\'\\\\]|\\\\.)*\'(*SKIP)(*FAIL)'; // allow \' escaping inside string
     const SKIP    = self::NO_PNTH . '|' . self::NO_SQBR . '|' .
                     self::NO_DLQU . '|' . self::NO_SLQU;
 
@@ -175,13 +175,13 @@ class Query
         $arg = trim($arg);
 
         // string with double quotes
-        if (substr($arg, 0, 1) === '"') {
-            return trim($arg, '"');
+        if (substr($arg, 0, 1) === '"' && substr($arg, -1) === '"') {
+            return str_replace('\"', '"', substr($arg, 1, -1));
         }
 
         // string with single quotes
-        if (substr($arg, 0, 1) === '\'') {
-            return trim($arg, '\'');
+        if (substr($arg, 0, 1) === "'" && substr($arg, -1) === "'") {
+            return str_replace("\'", "'", substr($arg, 1, -1));
         }
 
         // boolean or null

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -110,8 +110,18 @@ class Query
                     static::accessError($data, $method, 'property');
                 }
             } elseif (is_object($data)) {
-                if (method_exists($data, $method) || method_exists($data, '__call')) {
+                if (
+                    method_exists($data, $method) === true ||
+                    method_exists($data, '__call') === true
+                ) {
                     $value = $data->$method(...$args);
+                } elseif (
+                    $args === [] && (
+                        property_exists($data, $method) === true ||
+                        method_exists($data, '__get') === true
+                    )
+                ) {
+                    $value = $data->$method;
                 } else {
                     $label = ($args === []) ? 'method/property' : 'method';
                     static::accessError($data, $method, $label);

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -20,7 +20,7 @@ class Query
 {
     const PARTS      = '!([a-zA-Z_][a-zA-Z0-9_]*(\(.*?\))?)\.|' . self::SKIP . '!';
     const METHOD     = '!\((.*)\)!';
-    const PARAMETERS = '!,|' . self::SKIP . '!';
+    const PARAMETERS = '!,|' . self::SKIP . '!'; // split by comma, but not inside skip groups
 
     const NO_PNTH = '\([^\(]+\)(*SKIP)(*FAIL)';
     const NO_SQBR = '\[[^]]+\](*SKIP)(*FAIL)';
@@ -46,10 +46,10 @@ class Query
     /**
      * Creates a new Query object
      *
-     * @param string $query
+     * @param string|null $query
      * @param array|object $data
      */
-    public function __construct(string $query = null, $data = [])
+    public function __construct(?string $query = null, $data = [])
     {
         $this->query = $query;
         $this->data  = $data;
@@ -57,7 +57,7 @@ class Query
 
     /**
      * Returns the query result if anything
-     * can be found. Otherwise returns null.
+     * can be found, otherwise returns null
      *
      * @return mixed
      */
@@ -72,7 +72,7 @@ class Query
 
     /**
      * Resolves the query if anything
-     * can be found. Otherwise returns null.
+     * can be found, otherwise returns null
      *
      * @param string $query
      * @return mixed
@@ -90,12 +90,10 @@ class Query
         $data  = $this->data;
         $value = null;
 
-        while (count($parts)) {
-            $part   = array_shift($parts);
+        foreach ($parts as $part) {
             $info   = $this->part($part);
             $method = $info['method'];
             $args   = $info['args'];
-            $value  = null;
 
             if (is_array($data)) {
                 if (array_key_exists($method, $data) === true) {
@@ -162,7 +160,7 @@ class Query
 
     /**
      * Analyzes each part of the query string and
-     * extracts methods and method arguments.
+     * extracts methods and method arguments
      *
      * @param string $part
      * @return array
@@ -182,13 +180,13 @@ class Query
     }
 
     /**
-     * Converts a parameter of query to
-     * proper type.
+     * Converts a parameter of a query to
+     * its proper native PHP type
      *
-     * @param mixed $arg
+     * @param string $arg
      * @return mixed
      */
-    protected function parameter($arg)
+    protected function parameter(string $arg)
     {
         $arg = trim($arg);
 

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -113,9 +113,8 @@ class Query
                 static::accessError($data, $method, 'method/property');
             }
 
-            if (is_array($value) || is_object($value)) {
-                $data = $value;
-            }
+            // continue with the current value for the next part
+            $data = $value;
         }
 
         return $value;

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -900,7 +900,11 @@ class Str
 
             // if the placeholder contains a dot, it is a query
             if (strpos($query, '.') !== false) {
-                $result = (new Query($match[1], $data))->result();
+                try {
+                    $result = (new Query($match[1], $data))->result();
+                } catch (Exception $e) {
+                    $result = null;
+                }
             } else {
                 $result = $data[$query] ?? null;
             }

--- a/tests/Toolkit/QueryTest.php
+++ b/tests/Toolkit/QueryTest.php
@@ -2,34 +2,30 @@
 
 namespace Kirby\Toolkit;
 
+use stdClass;
+
+/**
+ * @covers Kirby\Toolkit\Query
+ */
 class QueryTest extends TestCase
 {
-    public function testWithMissingData()
-    {
-        // 1-level
-        $query = new Query('user', []);
-
-        $this->assertEquals(null, $query->result());
-
-        // 2-level
-        $query = new Query('user.username', []);
-
-        $this->assertEquals(null, $query->result());
-    }
-
     public function testWithEmptyQuery()
     {
         $query = new Query('', $data = ['foo' => 'bar']);
-        $this->assertEquals($data, $query->result());
+        $this->assertSame($data, $query->result());
     }
 
-    public function testWithDottedData()
+    public function testWithExactArrayMatch()
     {
+        $query = new Query('user', [
+            'user' => 'homer'
+        ]);
+        $this->assertSame('homer', $query->result());
+
         $query = new Query('user.username', [
             'user.username' => 'homer'
         ]);
-
-        $this->assertEquals('homer', $query->result());
+        $this->assertSame('homer', $query->result());
     }
 
     public function testWithContainsNumericParts()
@@ -42,11 +38,14 @@ class QueryTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('@homer', $query->result());
+        $this->assertSame('@homer', $query->result());
     }
 
     public function testWithStartsNumericParts()
     {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing property user on array');
+
         $query = new Query('0user.1profiles.twitter', [
             '0user' => [
                 '1profiles' => [
@@ -55,19 +54,10 @@ class QueryTest extends TestCase
             ]
         ]);
 
-        $this->assertNull($query->result());
+        $query->result();
     }
 
-    public function test0LevelArrayQuery()
-    {
-        $query = new Query('user', [
-            'user' => 'homer'
-        ]);
-
-        $this->assertEquals('homer', $query->result());
-    }
-
-    public function test1LevelArrayQuery()
+    public function testWithArray1Level()
     {
         $query = new Query('user.username', [
             'user' => [
@@ -75,10 +65,10 @@ class QueryTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('homer', $query->result());
+        $this->assertSame('homer', $query->result());
     }
 
-    public function test2LevelArrayQuery()
+    public function testWithArray2Level()
     {
         $query = new Query('user.profiles.twitter', [
             'user' => [
@@ -88,61 +78,25 @@ class QueryTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('@homer', $query->result());
-    }
-
-    public function test1LevelObjectQuery()
-    {
-        $query = new Query('user.username', [
-            'user' => new QueryTestUser()
-        ]);
-
-        $this->assertEquals('homer', $query->result());
-
-        // 2-level
-        $query = new Query('user.profiles.twitter', [
-            'user' => new QueryTestUser()
-        ]);
-
-        $this->assertEquals('@homer', $query->result());
-    }
-
-    public function test2LevelObjectQuery()
-    {
-        $query = new Query('user.profiles.twitter', [
-            'user' => new QueryTestUser()
-        ]);
-
-        $this->assertEquals('@homer', $query->result());
-    }
-
-    public function scalarProvider()
-    {
-        return [
-            ['test'],
-            [1],
-            [1.1],
-            [true],
-            [false]
-        ];
+        $this->assertSame('@homer', $query->result());
     }
 
     /**
      * @dataProvider scalarProvider
      */
-    public function test1LevelScalarQuery($scalar)
+    public function testWithArrayScalarValue($scalar)
     {
         $query = new Query('value', [
             'value' => $scalar
         ]);
 
-        $this->assertEquals($scalar, $query->result());
+        $this->assertSame($scalar, $query->result());
     }
 
     /**
      * @dataProvider scalarProvider
      */
-    public function test2LevelScalarQuery($scalar)
+    public function testWithArrayScalarValue2Level($scalar)
     {
         $query = new Query('parent.value', [
             'parent' => [
@@ -150,28 +104,146 @@ class QueryTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals($scalar, $query->result());
+        $this->assertSame($scalar, $query->result());
     }
 
-    public function testNullValueQuery()
+    /**
+     * @dataProvider scalarProvider
+     */
+    public function testWithArrayScalarValueError($scalar, $type)
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to method/property method on ' . $type);
+
+        $query = new Query('value.method', [
+            'value' => $scalar
+        ]);
+
+        $query->result();
+    }
+
+    public function scalarProvider()
+    {
+        return [
+            ['test', 'string'],
+            [1, 'integer'],
+            [1.1, 'float'],
+            [true, 'boolean'],
+            [false, 'boolean']
+        ];
+    }
+
+    public function testWithArrayNullValue()
     {
         $query = new Query('value', [
             'value' => null
         ]);
 
-        $this->assertEquals(null, $query->result());
+        $this->assertNull($query->result());
     }
 
-    public function testObjectMethodWithInteger()
+    public function testWithArrayNullValueError()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to method/property method on null');
+
+        $query = new Query('value.method', [
+            'value' => null
+        ]);
+
+        $this->assertNull($query->result());
+    }
+
+    public function testWithArrayCallClosure()
+    {
+        $query = new Query('closure("test")', [
+            'closure' => function ($arg) {
+                return strtoupper($arg);
+            }
+        ]);
+
+        $this->assertSame('TEST', $query->result());
+    }
+
+    public function testWithArrayCallError()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Cannot access array element user with arguments');
+
+        $query = new Query('user("test")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $query->result();
+    }
+
+    public function testWithArrayMissingKey1()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing property user on array');
+
+        $query = new Query('user', []);
+        $query->result();
+    }
+
+    public function testWithArrayMissingKey2()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing property user on array');
+
+        $query = new Query('user.username', []);
+        $query->result();
+    }
+
+    public function testWithObject1Level()
+    {
+        $query = new Query('user.username', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('homer', $query->result());
+    }
+
+    public function testWithObject2Level()
+    {
+        $query = new Query('user.profiles.twitter', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('@homer', $query->result());
+    }
+
+    public function testWithObjectProperty()
+    {
+        $obj = new stdClass();
+        $obj->test = 'testtest';
+        $query = new Query('obj.test', compact('obj'));
+
+        $this->assertSame('testtest', $query->result());
+    }
+
+    public function testWithObjectPropertyCallError()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing method test on object');
+
+        $obj = new stdClass();
+        $obj->test = 'testtest';
+        $query = new Query('obj.test(123)', compact('obj'));
+
+        $query->result();
+    }
+
+    public function testWithObjectMethodWithInteger()
     {
         $query = new Query('user.age(12)', [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals(12, $query->result());
+        $this->assertSame(12, $query->result());
     }
 
-    public function testObjectMethodWithBoolean()
+    public function testWithObjectMethodWithBoolean()
     {
         // true
         $query = new Query('user.isYello(true)', [
@@ -188,7 +260,7 @@ class QueryTest extends TestCase
         $this->assertFalse($query->result());
     }
 
-    public function testObjectMethodWithNull()
+    public function testWithObjectMethodWithNull()
     {
         $query = new Query('user.brainDump(null)', [
             'user' => new QueryTestUser()
@@ -197,52 +269,122 @@ class QueryTest extends TestCase
         $this->assertNull($query->result());
     }
 
-    public function testObjectMethodWithSingleArgument()
+    public function testWithObjectMethodWithString()
     {
+        // double quotes
         $query = new Query('user.says("hello world")', [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals('hello world', $query->result());
+        $this->assertSame('hello world', $query->result());
+
+        // single quotes
+        $query = new Query("user.says('hello world')", [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('hello world', $query->result());
     }
 
-    public function testObjectMethodWithMultipleArguments()
+    public function testWithObjectMethodWithEmptyString()
+    {
+        // double quotes
+        $query = new Query('user.says("")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('', $query->result());
+
+        // single quotes
+        $query = new Query("user.says('')", [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('', $query->result());
+    }
+
+    public function testWithObjectMethodWithStringEscape()
+    {
+        // double quotes
+        $query = new Query('user.says("hello \" world")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('hello " world', $query->result());
+
+        // single quotes
+        $query = new Query("user.says('hello \' world')", [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame("hello ' world", $query->result());
+    }
+
+    public function testWithObjectMethodWithMultipleArguments()
     {
         $query = new Query('user.says("hello", "world")', [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals('hello world', $query->result());
+        $this->assertSame('hello : world', $query->result());
+
+        // with escaping
+        $query = new Query('user.says("hello\"", "world")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('hello" : world', $query->result());
+
+        // with mixed quotes
+        $query = new Query('user.says(\'hello\\\'\', "world\"")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('hello\' : world"', $query->result());
     }
 
-    public function testObjectMethodWithMultipleArgumentsAndComma()
+    public function testWithObjectMethodWithMultipleArgumentsAndComma()
     {
         $query = new Query('user.says("hello,", "world")', [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals('hello, world', $query->result());
+        $this->assertSame('hello, : world', $query->result());
+
+        // with escaping
+        $query = new Query('user.says("hello,\"", "world")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('hello," : world', $query->result());
     }
 
-    public function testObjectMethodWithMultipleArgumentsAndDot()
+    public function testWithObjectMethodWithMultipleArgumentsAndDot()
     {
         $query = new Query('user.says("I like", "love.jpg")', [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals('I like love.jpg', $query->result());
+        $this->assertSame('I like : love.jpg', $query->result());
+
+        // with escaping
+        $query = new Query('user.says("I \" like", "love.\"jpg")', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertSame('I " like : love."jpg', $query->result());
     }
 
-    public function testObjectMethodWithTrickyCharacters()
+    public function testWithObjectMethodWithTrickyCharacters()
     {
         $query = new Query("user.likes(['(', ',', ']', '[']).self.brainDump('hello')", [
             'user' => new QueryTestUser()
         ]);
 
-        $this->assertEquals('hello', $query->result());
+        $this->assertSame('hello', $query->result());
     }
 
-    public function testObjectMethodWithArray()
+    public function testWithObjectMethodWithArray()
     {
         $query = new Query('user.self.check("gin", "tonic", ["gin", "tonic", "cucumber"])', [
             'user' => new QueryTestUser()
@@ -251,7 +393,7 @@ class QueryTest extends TestCase
         $this->assertTrue($query->result());
     }
 
-    public function testObjectMethodWithObjectMethodAsParameter()
+    public function testWithObjectMethodWithObjectMethodAsParameter()
     {
         $query = new Query('user.self.check("gin", "tonic", user.drink)', [
             'user' => new QueryTestUser()
@@ -260,12 +402,30 @@ class QueryTest extends TestCase
         $this->assertTrue($query->result());
     }
 
-    public function testObjectMethodWithObjectMethodAsParameterAndMoreLevels()
+    public function testWithObjectMethodWithObjectMethodAsParameterAndMoreLevels()
     {
         $query = new Query("user.likes([',']).likes(user.brainDump(['(', ',', ']', '['])).self", [
             'user' => $user = new QueryTestUser()
         ]);
 
-        $this->assertEquals($user, $query->result());
+        $this->assertSame($user, $query->result());
+    }
+
+    public function testWithObjectMissingMethod1()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing method/property username on object');
+
+        $query = new Query('user.username', ['user' => new stdClass()]);
+        $query->result();
+    }
+
+    public function testWithObjectMissingMethod2()
+    {
+        $this->expectException('Kirby\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Access to non-existing method username on object');
+
+        $query = new Query('user.username(12)', ['user' => new stdClass()]);
+        $query->result();
     }
 }

--- a/tests/Toolkit/QueryTestUser.php
+++ b/tests/Toolkit/QueryTestUser.php
@@ -18,7 +18,7 @@ class QueryTestUser
 
     public function says(...$message)
     {
-        return implode(' ', $message);
+        return implode(' : ', $message);
     }
 
     public function age(int $years)
@@ -60,5 +60,10 @@ class QueryTestUser
         }
 
         return $this;
+    }
+
+    public function nothing()
+    {
+        return null;
     }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

To make sure that the fix for #2624 doesn't cause issues in other situations, I took the time to refactor the `Query` class, and while I did that, I have also added a few useful features and improvements:

### Features

- Query: Support for escaping quotes with `\"` and `\'`:

```
{{ site.title.or("This is a default value with \"quotes\"") }}
```

- Query: Support for calling closures in arrays:

```php
$query = new Query('closure(123)', [
    'closure' => function ($argument) {
        return $argument;
    }
]);
echo $query->result(); // 123
```

- Query: Support for accessing properties in objects (used if no method with the same name exists and only if no arguments are passed in the query)

### Enhancements

- Errors in queries are now clearly thrown as Exceptions instead of being swallowed

### Fixes

- If a part of a query returns `null` or a scalar value (number, string or boolean), Kirby now correctly blocks further calls on the return value instead of using the return value of the previous part #2624
- The query language now blocks several edge-cases where the query didn't fully match the underlying data structure (for example calling an array element with arguments even though it is not callable)

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2624 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
