### PR TITLE
Update check (backend part)

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\System;
+use Kirby\Exception\PermissionException;
 use Kirby\Toolkit\Str;
 
 /**
@@ -67,6 +68,13 @@ return [
         'kirbytext' => function () {
             return $this->kirby()->option('panel.kirbytext') ?? true;
         },
+        'updateStatus' => function (System $system) {
+            try {
+                return $system->updateStatus();
+            } catch (PermissionException $e) {
+                return false;
+            }
+        },
         'user' => function () {
             return $this->user();
         },
@@ -112,6 +120,7 @@ return [
             'slugs',
             'title',
             'translation',
+            'updateStatus',
             'user' => 'auth',
             'version'
         ]

--- a/config/api/routes/system.php
+++ b/config/api/routes/system.php
@@ -2,6 +2,7 @@
 
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
 
 /**
  * System Routes
@@ -30,6 +31,19 @@ return [
                     'type'   => 'model'
                 ];
             }
+        }
+    ],
+    [
+        'pattern' => 'system/update',
+        'method'  => 'GET',
+        'action'  => function () {
+            $data = $this->kirby()->system()->updateStatus(true);
+
+            if ($data === false) {
+                throw new LogicException('Checking for updates is disabled in the config');
+            }
+
+            return $data;
         }
     ],
     [

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -73,7 +73,8 @@ trait AppCaches
      */
     protected function cacheOptions(string $key): array
     {
-        $options = $this->option($cacheKey = $this->cacheOptionsKey($key), false);
+        $default = $key === 'system' ? true : false;
+        $options = $this->option($cacheKey = $this->cacheOptionsKey($key), $default);
 
         if ($options === false) {
             return [

--- a/tests/Cms/System/RemoteMock.php
+++ b/tests/Cms/System/RemoteMock.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kirby\Cms\System;
+
+use Kirby\Http\Remote;
+
+class RemoteMock extends Remote
+{
+    public static $mockContent = '';
+    public static $mockCode = 200;
+
+    public function fetch()
+    {
+        $this->content = static::$mockContent;
+        $this->info    = ['http_code' => static::$mockCode];
+    }
+}

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -2,9 +2,14 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Cms\System\RemoteMock;
 use Kirby\Toolkit\Dir;
 use ReflectionClass;
+use ReflectionProperty;
 
+/**
+ * @coversDefaultClass Kirby\Cms\System
+ */
 class SystemTest extends TestCase
 {
     protected $_SERVER = null;
@@ -27,6 +32,9 @@ class SystemTest extends TestCase
         $_SERVER = $this->_SERVER;
 
         Dir::remove($this->fixtures);
+
+        RemoteMock::$mockContent = '';
+        RemoteMock::$mockCode = 200;
     }
 
     public function serverProvider()
@@ -253,5 +261,198 @@ class SystemTest extends TestCase
         $this->expectExceptionMessage('Please enter a valid email address');
 
         $system->register('K3-PRO-abc', 'invalid');
+    }
+
+    /**
+     * @covers ::updateStatus
+     */
+    public function testUpdateStatus()
+    {
+        $versionProperty = new ReflectionProperty('Kirby\Cms\App', 'version');
+        $versionProperty->setAccessible(true);
+        $versionProperty->setValue(null, '3.4.5');
+
+        $data = [
+            'latest'    => '3.4.5',
+            'latestUrl' => 'https://kirby.test/release/3.4.5',
+            'incidents' => []
+        ];
+        RemoteMock::$mockContent = json_encode($data);
+
+        $app = $this->app->clone([
+            'options' => [
+                'cache.system' => false
+            ]
+        ]);
+        $app->impersonate('kirby');
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+
+        // latest version
+        $status = $system->updateStatus();
+        $this->assertSame('ok', $status['status']);
+        $this->assertNull($status['severity']);
+        $this->assertSame('3.4.5', $status['current']);
+        $this->assertSame('3.4.5', $status['latest']);
+        $this->assertSame('https://kirby.test/release/3.4.5', $status['latestUrl']);
+        $this->assertSame([], $status['incidents']);
+
+        // outdated version
+        $data['latest'] = '3.4.6';
+        RemoteMock::$mockContent = json_encode($data);
+        $status = $system->updateStatus();
+        $this->assertSame('outdated', $status['status']);
+        $this->assertNull($status['severity']);
+        $this->assertSame('3.4.5', $status['current']);
+        $this->assertSame('3.4.6', $status['latest']);
+        $this->assertSame([], $status['incidents']);
+
+        // incidents
+        $data['incidents'] = [
+            [
+                'affected'    => '>3.0.0 <=3.5.0',
+                'description' => 'Incident 1',
+                'fixed'       => '3.1.2',
+                'severity'    => 'notable'
+            ],
+            [
+                'affected'    => '<=3.1.0',
+                'description' => 'Should be filtered out',
+                'fixed'       => '3.1.2',
+                'severity'    => 'minor'
+            ],
+            [
+                'affected'    => '>3.0.0 invalid-constraint',
+                'description' => 'Incident 2',
+                'fixed'       => '3.1.2',
+                'severity'    => 'minor'
+            ],
+            [
+                'affected'    => '<3.5.0',
+                'description' => 'Incident 3',
+                'fixed'       => '3.5.0',
+                'severity'    => 'invalid'
+            ]
+        ];
+        RemoteMock::$mockContent = json_encode($data);
+        $status = $system->updateStatus();
+        $this->assertSame('at-risk', $status['status']);
+        $this->assertSame('notable', $status['severity']);
+        $this->assertSame('3.4.5', $status['current']);
+        $this->assertSame('3.4.6', $status['latest']);
+        $this->assertSame([
+            [
+                'affected'    => '>3.0.0 <=3.5.0',
+                'description' => 'Incident 1',
+                'fixed'       => '3.1.2',
+                'severity'    => 'notable'
+            ],
+            [
+                'affected'    => '>3.0.0 invalid-constraint',
+                'description' => 'Incident 2',
+                'fixed'       => '3.1.2',
+                'severity'    => 'minor'
+            ],
+            [
+                'affected'    => '<3.5.0',
+                'description' => 'Incident 3',
+                'fixed'       => '3.5.0',
+                'severity'    => 'invalid'
+            ]
+        ], $status['incidents']);
+
+        // disabled update option I
+        $app = $this->app->clone([
+            'options' => [
+                'cache.system' => false,
+                'update'       => 'manual'
+            ]
+        ]);
+        $app->impersonate('kirby');
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+        $this->assertNull($system->updateStatus());
+        $this->assertIsArray($system->updateStatus(true));
+
+        // disabled update option II
+        $app = $this->app->clone([
+            'options' => [
+                'cache.system' => false,
+                'update.kirby' => false
+            ]
+        ]);
+        $app->impersonate('kirby');
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+        $this->assertFalse($system->updateStatus());
+        $this->assertFalse($system->updateStatus(true));
+
+        // disabled update option III
+        $app = $this->app->clone([
+            'options' => [
+                'cache.system' => false,
+                'update.kirby' => 'manual'
+            ]
+        ]);
+        $app->impersonate('kirby');
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+        $this->assertNull($system->updateStatus());
+        $this->assertIsArray($system->updateStatus(true));
+
+        // cache
+        $app = $this->app->clone([
+            'options' => [
+                'cache.system' => [
+                    'type' => 'memory'
+                ]
+            ]
+        ]);
+        $app->impersonate('kirby');
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+        $app->cache('system')->set('updateStatus', $cached = ['current' => '3.4.5', 'latest' => '3.5.0']);
+
+        // use cached data if the version is the same
+        $this->assertSame($cached, $system->updateStatus());
+
+        // always get current data if requested
+        $this->assertSame('3.4.6', $system->updateStatus(true)['latest']);
+
+        // the new data should be cached
+        $status = $system->updateStatus();
+        $this->assertNotSame($cached, $status);
+        $this->assertSame('3.4.5', $status['current']);
+
+        // update data if the version has changed
+        $versionProperty->setValue(null, '3.4.6');
+        $this->assertSame('3.4.6', $system->updateStatus()['current']);
+    }
+
+    /**
+     * @covers ::updateStatus
+     */
+    public function testUpdateStatusNoUser()
+    {
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('You are not allowed to do this');
+
+        $system = new System($this->app, 'Kirby\Cms\System\RemoteMock');
+
+        $system->updateStatus();
+    }
+
+    /**
+     * @covers ::updateStatus
+     */
+    public function testUpdateStatusNoPermission()
+    {
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('You are not allowed to do this');
+
+        $app = $this->app->clone([
+            'user' => 'user@domain.com',
+            'users' => [
+                ['email' => 'user@domain.com', 'role' => 'editor'],
+            ]
+        ]);
+        $system = new System($app, 'Kirby\Cms\System\RemoteMock');
+
+        $system->updateStatus();
     }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

### Already implemented functionality

- Kirby will by default request the security status from the Kirby site and cache the data for three days.
- The check can be disabled with the `update.kirby` option (there could be `update.plugins` later) or with the global `update` option. Both options can either be `notify` (check automatically and notify in the Panel; default), `manual` (display check button on the Settings page in the Panel) or `false` (completely disabled).
- The resulting data is provided to the Panel via the API. The `GET /api/system` route includes a new `updateStatus` key (which will be an array if the option is set to `notify` or `null` if `manual` or disabled). For manual checking, there's a new `GET /api/system/update` route that will always return the information.
- The data structure from the API is the following:

```
{
  "updated": <timestamp of last cache update>,
  "status": "ok | outdated | at-risk",
  "severity": "minor | notable | major", // when status=at-risk
  "current": "x.y.z",
  "latest": "x.y.z",
  "incidents": [...] // only the ones that affect the currently installed version
}
```

### Panel features that can be implemented based on this PR

- When the Panel loads, it should check for the `system.updateStatus.status` value. If `outdated`, the Panel should display an update notification. If `at-risk`, the notification should be displayed more prominently (red, with warning icon?). If `system.updateStatus` is `null`, no notification should be displayed.
- There should be a "Check for updates" button on the Settings page in the Panel if the `update.kirby` or `update` option is not set to `false`. Hitting the button will request `GET /api/system/update`.
- The Settings page in the Panel can use the `updateStatus` data to display the version information and the incidents that affect the currently installed version.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
