### PR TITLE
Query: Full support for nested methods #2511

### DIFF
--- a/tests/Toolkit/QueryTest.php
+++ b/tests/Toolkit/QueryTest.php
@@ -41,22 +41,6 @@ class QueryTest extends TestCase
         $this->assertSame('@homer', $query->result());
     }
 
-    public function testWithStartsNumericParts()
-    {
-        $this->expectException('Kirby\Exception\BadMethodCallException');
-        $this->expectExceptionMessage('Access to non-existing property user on array');
-
-        $query = new Query('0user.1profiles.twitter', [
-            '0user' => [
-                '1profiles' => [
-                    'twitter' => '@homer'
-                ]
-            ]
-        ]);
-
-        $query->result();
-    }
-
     public function testWithArray1Level()
     {
         $query = new Query('user.username', [
@@ -66,6 +50,27 @@ class QueryTest extends TestCase
         ]);
 
         $this->assertSame('homer', $query->result());
+    }
+
+    public function testWithArrayNumeric()
+    {
+        $query = new Query('user.0', [
+            'user' => [
+                'homer',
+                'marge'
+            ]
+        ]);
+
+        $this->assertSame('homer', $query->result());
+        
+        $query = new Query('user.1', [
+            'user' => [
+                'homer',
+                'marge'
+            ]
+        ]);
+
+        $this->assertSame('marge', $query->result());
     }
 
     public function testWithArray2Level()
@@ -377,7 +382,7 @@ class QueryTest extends TestCase
 
     public function testWithObjectMethodWithTrickyCharacters()
     {
-        $query = new Query("user.likes(['(', ',', ']', '[']).self.brainDump('hello')", [
+        $query = new Query("user.likes(['(', ',', ']', '[', ')']).self.brainDump('hello')", [
             'user' => new QueryTestUser()
         ]);
 
@@ -402,9 +407,18 @@ class QueryTest extends TestCase
         $this->assertTrue($query->result());
     }
 
+    public function testWithNestedMethodCall()
+    {
+        $query = new Query('user.check("gin", "tonic", user.array("gin", "tonic").args)', [
+            'user' => new QueryTestUser()
+        ]);
+
+        $this->assertTrue($query->result());
+    }
+
     public function testWithObjectMethodWithObjectMethodAsParameterAndMoreLevels()
     {
-        $query = new Query("user.likes([',']).likes(user.brainDump(['(', ',', ']', '['])).self", [
+        $query = new Query("user.likes([',']).likes(user.brainDump(['(', ',', ']', ')', '['])).self", [
             'user' => $user = new QueryTestUser()
         ]);
 

--- a/tests/Toolkit/QueryTestUser.php
+++ b/tests/Toolkit/QueryTestUser.php
@@ -36,6 +36,11 @@ class QueryTestUser
         return $dump;
     }
 
+    public function array(...$args)
+    {
+        return ['args' => $args];
+    }
+
     public function check($needle1, $needle2, $array)
     {
         return in_array($needle1, $array) && in_array($needle2, $array);
@@ -51,10 +56,10 @@ class QueryTestUser
         return $this;
     }
 
-    public function likes($arguments)
+    public function likes(array $arguments)
     {
         foreach ($arguments as $arg) {
-            if (in_array($arg, ['(', ',', ']', '[']) === false) {
+            if (in_array($arg, ['(', ')', ',', ']', '[']) === false) {
                 throw new \Exception();
             }
         }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The RegEx that was used for matching the parts of the query didn't account for nested method calls, so they only sometimes worked by accident.

E.g. this worked before:

```
object.method('test', object.method('test'))
```

But this didn't:

```
object.method('test', object.method('test').anotherMethod, 'test')
```

This is now fixed by always parsing method calls from the outside in and not from left to right. The only edge-case that doesn't work is an opening parenthesis inside a string:

```
object.method(object.method('('))
```

That's hard to fix however because it's hard to express that in a regular expression. However I think that this is not going to affect many queries in practice, so this PR is "a lot better than nothing". Maybe we'll find a solution for that last remaining edge-case in the future.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2511 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
