### PR TITLE
New collectionMethods extension

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -7,7 +7,7 @@ use Kirby\Exception\DuplicateException;
 use Kirby\Form\Field as FormField;
 use Kirby\Text\KirbyTag;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\Collection;
+use Kirby\Toolkit\Collection as ToolkitCollection;
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\V;
@@ -54,6 +54,7 @@ trait AppPlugins
         'components' => [],
         'controllers' => [],
         'collectionFilters' => [],
+        'collectionMethods' => [],
         'fieldMethods' => [],
         'fileMethods' => [],
         'filesMethods' => [],
@@ -154,7 +155,18 @@ trait AppPlugins
      */
     protected function extendCollectionFilters(array $filters): array
     {
-        return $this->extensions['collectionFilters'] = Collection::$filters = array_merge(Collection::$filters, $filters);
+        return $this->extensions['collectionFilters'] = ToolkitCollection::$filters = array_merge(ToolkitCollection::$filters, $filters);
+    }
+
+    /**
+     * Registers additional collection methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendCollectionMethods(array $methods): array
+    {
+        return $this->extensions['collectionMethods'] = Collection::$methods = array_merge(Collection::$methods, $methods);
     }
 
     /**

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -45,7 +45,7 @@ class Collection extends BaseCollection
     public function __call(string $key, $arguments)
     {
         // collection methods
-        if ($this->hasMethod($key)) {
+        if ($this->hasMethod($key) === true) {
             return $this->callMethod($key, $arguments);
         }
     }

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -34,6 +34,33 @@ class MockObject extends Model
 
 class CollectionTest extends TestCase
 {
+    public function testCollectionMethods()
+    {
+        $kirby = $this->kirby([
+            'collectionMethods' => [
+                'test' => function () {
+                    return 'collection test';
+                }
+            ],
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $this->assertSame('collection test', (new Collection())->test());
+        $this->assertSame('collection test', $kirby->site()->children()->test());
+
+        Pages::$methods['test'] = function () {
+            return 'pages test';
+        };
+
+        $this->assertSame('collection test', (new Collection())->test());
+        $this->assertSame('pages test', $kirby->site()->children()->test());
+
+        Collection::$methods = [];
+        Pages::$methods = [];
+    }
+
     public function testWithValidObjects()
     {
         $collection = new Collection([


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

It is now possible to define custom global collection methods that will be used for all collection types (the ones with their own method extensions (`Files`, `Pages` and `Users`) as well as all other CMS collections like `Languages`, `Structure`...):

```php
<?php

Kirby::plugin('superwoman/superplugin', [
    'collectionMethods' => [
        'test' => function () { ... }
    ]
]);
```

Methods on these collection types are matched in the following order:

1. Built-in methods
2. Custom methods defined just for that collection type
3. Custom collection methods

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Implements https://github.com/getkirby/ideas/issues/352

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
