### PR TITLE
Use salted content token for media directories

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -386,6 +386,31 @@ class App
     }
 
     /**
+     * Generates a non-guessable token based on model
+     * data and a configured salt
+     *
+     * @param mixed $model Object to pass to the salt callback if configured
+     * @param string $value Model data to include in the generated token
+     * @return string
+     */
+    public function contentToken($model, string $value): string
+    {
+        if (method_exists($model, 'root') === true) {
+            $default = $model->root();
+        } else {
+            $default = $this->root('content');
+        }
+
+        $salt = $this->option('content.salt', $default);
+
+        if (is_a($salt, 'Closure') === true) {
+            $salt = $salt($model);
+        }
+
+        return hash_hmac('sha1', $value, $salt);
+    }
+
+    /**
      * Calls a page controller by name
      * and with the given arguments
      *

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -344,14 +344,14 @@ class File extends ModelWithContent
     }
 
     /**
-     * Create a unique media hash
+     * Creates a unique media hash
      *
      * @internal
      * @return string
      */
     public function mediaHash(): string
     {
-        return crc32($this->filename()) . '-' . $this->modifiedFile();
+        return $this->mediaToken() . '-' . $this->modifiedFile();
     }
 
     /**
@@ -363,6 +363,18 @@ class File extends ModelWithContent
     public function mediaRoot(): string
     {
         return $this->parent()->mediaRoot() . '/' . $this->mediaHash() . '/' . $this->filename();
+    }
+
+    /**
+     * Creates a non-guessable token string for this file
+     *
+     * @internal
+     * @return string
+     */
+    public function mediaToken(): string
+    {
+        $token = $this->kirby()->contentToken($this, $this->id());
+        return substr($token, 0, 10);
     }
 
     /**

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -254,7 +254,7 @@ trait FileActions
      */
     public function publish()
     {
-        Media::publish($this->root(), $this->mediaRoot());
+        Media::publish($this, $this->mediaRoot());
         return $this;
     }
 
@@ -306,7 +306,7 @@ trait FileActions
      */
     public function unpublish()
     {
-        Media::unpublish($this->parent()->mediaRoot(), $this->filename());
+        Media::unpublish($this->parent()->mediaRoot(), $this);
         return $this;
     }
 }

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -57,18 +57,18 @@ class Media
     /**
      * Copy the file to the final media folder location
      *
-     * @param string $src
+     * @param \Kirby\Cms\File $file
      * @param string $dest
      * @return bool
      */
-    public static function publish(string $src, string $dest): bool
+    public static function publish(File $file, string $dest): bool
     {
-        $filename  = basename($src);
+        $src       = $file->root();
         $version   = dirname($dest);
         $directory = dirname($version);
 
         // unpublish all files except stuff in the version folder
-        Media::unpublish($directory, $filename, $version);
+        Media::unpublish($directory, $file, $version);
 
         // copy/overwrite the file to the dest folder
         return F::copy($src, $dest, true);
@@ -125,21 +125,25 @@ class Media
     }
 
     /**
-     * Deletes all versions of the given filename
+     * Deletes all versions of the given file
      * within the parent directory
      *
      * @param string $directory
-     * @param string $filename
+     * @param \Kirby\Cms\File $file
      * @param string $ignore
      * @return bool
      */
-    public static function unpublish(string $directory, string $filename, string $ignore = null): bool
+    public static function unpublish(string $directory, File $file, string $ignore = null): bool
     {
         if (is_dir($directory) === false) {
             return true;
         }
 
-        $versions = glob($directory . '/' . crc32($filename) . '*', GLOB_ONLYDIR);
+        // get both old and new versions (pre and post Kirby 3.4.0)
+        $versions = array_merge(
+            glob($directory . '/' . crc32($file->filename()) . '-*', GLOB_ONLYDIR),
+            glob($directory . '/' . $file->mediaToken() . '-*', GLOB_ONLYDIR)
+        );
 
         // delete all versions of the file
         foreach ($versions as $version) {

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
+use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
@@ -41,9 +42,15 @@ class Media
         // this should work for all original files
         if ($file = $model->file($filename)) {
 
-            // the media hash is outdated. redirect to the correct url
+            // check if the request contained an outdated media hash
             if ($file->mediaHash() !== $hash) {
-                return Response::redirect($file->mediaUrl(), 307);
+                // if at least the token was correct, redirect
+                if (Str::startsWith($hash, $file->mediaToken() . '-') === true) {
+                    return Response::redirect($file->mediaUrl(), 307);
+                } else {
+                    // don't leak the correct token
+                    return new Response('Not Found', 'text/plain', 404);
+                }
             }
 
             // send the file to the browser

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1467,13 +1467,7 @@ class Page extends ModelWithContent
      */
     protected function token(): string
     {
-        $salt = $this->kirby()->option('content.salt', $this->root());
-
-        if (is_a($salt, 'Closure') === true) {
-            $salt = $salt($this);
-        }
-
-        return hash_hmac('sha1', $this->id() . $this->template(), $salt);
+        return $this->kirby()->contentToken($this, $this->id() . $this->template());
     }
 
     /**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -143,6 +143,39 @@ class AppTest extends TestCase
         $this->assertSame(143, $app->apply('test.event:after', ['value' => 2], 'value'));
     }
 
+    /**
+     * @covers ::contentToken
+     */
+    public function testContentToken()
+    {
+        // without configured salt
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+        $this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken('model', 'test'));
+        $this->assertSame(hash_hmac('sha1', 'test', '/dev/null'), $app->contentToken($app, 'test'));
+
+        // with custom static salt
+        $app = new App([
+            'options' => [
+                'content.salt' => 'salt and pepper and chili'
+            ]
+        ]);
+        $this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken('model', 'test'));
+
+        // with callback
+        $app = new App([
+            'options' => [
+                'content.salt' => function ($model) {
+                    return 'salt ' . $model;
+                }
+            ]
+        ]);
+        $this->assertSame(hash_hmac('sha1', 'test', 'salt lake city'), $app->contentToken('lake city', 'test'));
+    }
+
     public function testDebugInfo()
     {
         $app = new App();

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -229,6 +229,50 @@ class FileTest extends TestCase
         $this->assertFalse($file->isReadable()); // test caching
     }
 
+    public function testMediaHash()
+    {
+        $app = new App([
+            'roots' => [
+                'index'   => $index = __DIR__ . '/fixtures/FileTest/mediaHash',
+                'content' => $index
+            ],
+            'options' => [
+                'content.salt' => 'test'
+            ]
+        ]);
+
+        F::write($index . '/test.jpg', 'test');
+        touch($index . '/test.jpg', 5432112345);
+        $file = new File([
+            'kirby'    => $app,
+            'filename' => 'test.jpg'
+        ]);
+
+        $this->assertSame('08756f3115-5432112345', $file->mediaHash());
+
+        Dir::remove(dirname($index));
+    }
+
+    public function testMediaToken()
+    {
+        $app = new App([
+            'roots' => [
+                'index'   => $index = __DIR__ . '/fixtures/FileTest/mediaHash',
+                'content' => $index
+            ],
+            'options' => [
+                'content.salt' => 'test'
+            ]
+        ]);
+
+        $file = new File([
+            'kirby'    => $app,
+            'filename' => 'test.jpg'
+        ]);
+
+        $this->assertSame('08756f3115', $file->mediaToken());
+    }
+
     public function testModified()
     {
         $app = new App([

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -55,11 +55,19 @@ class MediaTest extends TestCase
     {
         F::write($this->fixtures . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
+        // with the correct media token
         $file   = $this->app->file('projects/test.svg');
-        $result = Media::link($this->app->page('projects'), 'abc', $file->filename());
+        $result = Media::link($this->app->page('projects'), $file->mediaToken() . '-12345', $file->filename());
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertEquals(307, $result->code());
+
+        // with a completely invalid hash
+        $file   = $this->app->file('projects/test.svg');
+        $result = Media::link($this->app->page('projects'), 'abcde-12345', $file->filename());
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(404, $result->code());
     }
 
     public function testLinkWithoutModel()

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -69,65 +69,102 @@ class MediaTest extends TestCase
 
     public function testPublish()
     {
-        $filename  = 'test.jpg';
-        $hash      = crc32($filename);
-        $directory = $this->fixtures . '/media/pages/projects';
+        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+        $file = new File([
+            'kirby'    => $this->app,
+            'filename' => $filename = 'test.jpg'
+        ]);
 
-        touch($src = $this->fixtures . '/test.jpg');
+        $oldToken  = crc32($filename);
+        $newToken  = $file->mediaToken();
+        $directory = $this->fixtures . '/media/site';
 
-        Dir::make($versionA = $directory . '/' . $hash . '-1234');
-        Dir::make($versionB = $directory . '/' . $hash . '-5678');
+        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
+        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
+        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
+        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
 
-        $this->assertTrue(Media::publish($src, $dest = $versionB . '/test.jpg'));
+        $this->assertTrue(Media::publish($file, $dest = $versionB2 . '/test.jpg'));
 
         // the file should be copied
-        $this->assertTrue(is_dir($versionB));
+        $this->assertTrue(is_dir($versionB2));
         $this->assertTrue(is_file($dest));
 
         // older versions should be removed
-        $this->assertFalse(is_dir($versionA));
+        $this->assertFalse(is_dir($versionA1));
+        $this->assertFalse(is_dir($versionA2));
+        $this->assertFalse(is_dir($versionB1));
     }
 
     public function testUnpublish()
     {
-        $filename  = 'test.jpg';
-        $hash      = crc32($filename);
-        $directory = $this->fixtures . '/media';
+        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+        $file = new File([
+            'kirby'    => $this->app,
+            'filename' => $filename = 'test.jpg'
+        ]);
 
-        Dir::make($versionA = $directory . '/' . $hash . '-1234');
-        Dir::make($versionB = $directory . '/' . $hash . '-5678');
+        $oldToken  = crc32($filename);
+        $newToken  = $file->mediaToken();
+        $directory = $this->fixtures . '/media/site';
 
-        $this->assertTrue(is_dir($versionA));
-        $this->assertTrue(is_dir($versionB));
+        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
+        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
+        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
+        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
 
-        Media::unpublish($directory, $filename);
+        $this->assertTrue(is_dir($versionA1));
+        $this->assertTrue(is_dir($versionA2));
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertTrue(is_dir($versionB2));
 
-        $this->assertFalse(is_dir($versionA));
-        $this->assertFalse(is_dir($versionB));
+        Media::unpublish($directory, $file);
+
+        $this->assertFalse(is_dir($versionA1));
+        $this->assertFalse(is_dir($versionA2));
+        $this->assertFalse(is_dir($versionB1));
+        $this->assertFalse(is_dir($versionB2));
     }
 
     public function testUnpublishAndIgnore()
     {
-        $filename  = 'test.jpg';
-        $hash      = crc32($filename);
-        $directory = $this->fixtures . '/media';
+        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+        $file = new File([
+            'kirby'    => $this->app,
+            'filename' => $filename = 'test.jpg'
+        ]);
 
-        Dir::make($versionA = $directory . '/' . $hash . '-1234');
-        Dir::make($versionB = $directory . '/' . $hash . '-5678');
+        $oldToken  = crc32($filename);
+        $newToken  = $file->mediaToken();
+        $directory = $this->fixtures . '/media/site';
 
-        $this->assertTrue(is_dir($versionA));
-        $this->assertTrue(is_dir($versionB));
+        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
+        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
+        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
+        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
 
-        Media::unpublish($directory, $filename, $versionA);
+        $this->assertTrue(is_dir($versionA1));
+        $this->assertTrue(is_dir($versionA2));
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertTrue(is_dir($versionB2));
 
-        $this->assertTrue(is_dir($versionA));
-        $this->assertFalse(is_dir($versionB));
+        Media::unpublish($directory, $file, $versionB1);
+
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertFalse(is_dir($versionA1));
+        $this->assertFalse(is_dir($versionA2));
+        $this->assertFalse(is_dir($versionB2));
     }
 
     public function testUnpublishNonExistingDirectory()
     {
         $directory = $this->fixtures . '/does-not-exist';
 
-        $this->assertTrue(Media::unpublish($directory, 'something.jpg'));
+        $file = new File([
+            'kirby'    => $this->app,
+            'filename' => 'does-not-exist.jpg'
+        ]);
+
+        $this->assertTrue(Media::unpublish($directory, $file));
     }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The new `content.salt` option (https://github.com/getkirby/kirby/pull/2612) is now also used for the `$file->mediaHash()`. This makes sure that media URLs are never guessable, not even if the modification date and filename are known (which can sometimes both be public, for example in deployment setups where all files get written at once and therefore have the same modification date).

Kirby will automatically delete folders with the old names and create new folders with the new names when each file is first accessed.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Implements part of https://github.com/getkirby/ideas/issues/554

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
