### PR TITLE
$props param for Response::file()/download()

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -151,9 +151,10 @@ class Response
      *
      * @param string $file
      * @param string $filename
+     * @param array $props Custom overrides for response props (e.g. headers)
      * @return self
      */
-    public static function download(string $file, string $filename = null)
+    public static function download(string $file, string $filename = null, array $props = [])
     {
         if (file_exists($file) === false) {
             throw new Exception('The file could not be found');
@@ -164,7 +165,7 @@ class Response
         $body     = file_get_contents($file);
         $size     = strlen($body);
 
-        return new static([
+        $props = array_replace_recursive([
             'body'    => $body,
             'type'    => 'application/force-download',
             'headers' => [
@@ -176,7 +177,9 @@ class Response
                 'Content-Length'            => $size,
                 'Connection'                => 'close'
             ]
-        ]);
+        ], $props);
+
+        return new static($props);
     }
 
     /**
@@ -184,11 +187,17 @@ class Response
      * sends the file content to the browser
      *
      * @param string $file
+     * @param array $props Custom overrides for response props (e.g. headers)
      * @return self
      */
-    public static function file(string $file)
+    public static function file(string $file, array $props = [])
     {
-        return new static(F::read($file), F::extensionToMime(F::extension($file)));
+        $props = array_merge([
+            'body' => F::read($file),
+            'type' => F::extensionToMime(F::extension($file))
+        ], $props);
+
+        return new static($props);
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -23,11 +23,25 @@ class ResponseTest extends TestCase
 
     public function testDownload()
     {
+        $response = Response::download(__FILE__);
+
+        $this->assertSame($body = file_get_contents(__FILE__), $response->body());
+        $this->assertSame(200, $response->code());
+        $this->assertSame([
+            'Pragma'                    => 'public',
+            'Cache-Control'             => 'no-cache, no-store, must-revalidate',
+            'Last-Modified'             => gmdate('D, d M Y H:i:s', filemtime(__FILE__)) . ' GMT',
+            'Content-Disposition'       => 'attachment; filename="' . basename(__FILE__) . '"',
+            'Content-Transfer-Encoding' => 'binary',
+            'Content-Length'            => strlen($body),
+            'Connection'                => 'close'
+        ], $response->headers());
+
         $response = Response::download(__FILE__, 'test.php');
 
-        $this->assertEquals($body = file_get_contents(__FILE__), $response->body());
-        $this->assertEquals(200, $response->code());
-        $this->assertEquals([
+        $this->assertSame($body, $response->body());
+        $this->assertSame(200, $response->code());
+        $this->assertSame([
             'Pragma'                    => 'public',
             'Cache-Control'             => 'no-cache, no-store, must-revalidate',
             'Last-Modified'             => gmdate('D, d M Y H:i:s', filemtime(__FILE__)) . ' GMT',
@@ -35,6 +49,27 @@ class ResponseTest extends TestCase
             'Content-Transfer-Encoding' => 'binary',
             'Content-Length'            => strlen($body),
             'Connection'                => 'close'
+        ], $response->headers());
+
+        $response = Response::download(__FILE__, 'test.php', [
+            'code'    => '201',
+            'headers' => [
+                'Pragma' => 'no-cache',
+                'X-Test' => 'Test'
+            ]
+        ]);
+
+        $this->assertSame($body, $response->body());
+        $this->assertSame(201, $response->code());
+        $this->assertSame([
+            'Pragma'                    => 'no-cache',
+            'Cache-Control'             => 'no-cache, no-store, must-revalidate',
+            'Last-Modified'             => gmdate('D, d M Y H:i:s', filemtime(__FILE__)) . ' GMT',
+            'Content-Disposition'       => 'attachment; filename="test.php"',
+            'Content-Transfer-Encoding' => 'binary',
+            'Content-Length'            => strlen($body),
+            'Connection'                => 'close',
+            'X-Test'                    => 'Test'
         ], $response->headers());
     }
 
@@ -107,8 +142,23 @@ class ResponseTest extends TestCase
 
         $response = Response::file($file);
 
-        $this->assertEquals('text/plain', $response->type());
-        $this->assertEquals('test', $response->body());
+        $this->assertSame('text/plain', $response->type());
+        $this->assertSame(200, $response->code());
+        $this->assertSame('test', $response->body());
+
+        $response = Response::file($file, [
+            'code'    => '201',
+            'headers' => [
+                'Pragma' => 'no-cache'
+            ]
+        ]);
+
+        $this->assertSame('text/plain', $response->type());
+        $this->assertSame(201, $response->code());
+        $this->assertSame('test', $response->body());
+        $this->assertSame([
+            'Pragma' => 'no-cache'
+        ], $response->headers());
     }
 
     public function testType()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

**Note:** This PR depends on #2644, merge that PR first.

It is now possible to pass custom props (like headers) to `Response::download()` and `Response::file()`:

```php
$response = Response::file($file, [
    'headers' => [
        'Cache-Control' => 'no-cache'
    ]
]);
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
