### PR TITLE
createMedia and protect options for file blueprints

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -75,7 +75,10 @@ return [
      * @return \Kirby\Cms\File|\Kirby\Cms\FileVersion
      */
     'file::version' => function (App $kirby, $file, array $options = []) {
-        if ($file->isResizable() === false) {
+        if (
+            $file->isResizable() === false ||
+            $file->blueprint()->createMedia() === false
+        ) {
             return $file;
         }
 

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -34,6 +34,20 @@ class FileBlueprint extends Blueprint
 
         // normalize the accept settings
         $this->props['accept'] = $this->normalizeAccept($this->props['accept'] ?? []);
+
+        // default values for security props
+        if (isset($this->props['createMedia']) !== true) {
+            $this->props['createMedia'] = true;
+        }
+
+        if (isset($this->props['protect']) !== true) {
+            $this->props['protect'] = false;
+        }
+
+        // file protection always implies protection against publishing
+        if ($this->props['protect'] === true) {
+            $this->props['createMedia'] = false;
+        }
     }
 
     /**
@@ -42,6 +56,14 @@ class FileBlueprint extends Blueprint
     public function accept(): array
     {
         return $this->props['accept'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function createMedia(): bool
+    {
+        return $this->props['createMedia'];
     }
 
     /**
@@ -75,5 +97,13 @@ class FileBlueprint extends Blueprint
         ];
 
         return array_merge($defaults, $accept);
+    }
+
+    /**
+     * @return bool
+     */
+    public function protect(): bool
+    {
+        return $this->props['protect'];
     }
 }

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -22,6 +22,41 @@ class FileBlueprintTest extends TestCase
         $this->assertEquals($expected, $blueprint->options());
     }
 
+    public function testCreateMediaProtect()
+    {
+        $blueprint = new FileBlueprint([
+            'model' => new File(['filename' => 'test.jpg'])
+        ]);
+
+        $this->assertTrue($blueprint->createMedia());
+        $this->assertFalse($blueprint->protect());
+
+        $blueprint = new FileBlueprint([
+            'model'       => new File(['filename' => 'test.jpg']),
+            'createMedia' => false
+        ]);
+
+        $this->assertFalse($blueprint->createMedia());
+        $this->assertFalse($blueprint->protect());
+
+        $blueprint = new FileBlueprint([
+            'model'       => new File(['filename' => 'test.jpg']),
+            'createMedia' => false,
+            'protect'     => true
+        ]);
+
+        $this->assertFalse($blueprint->createMedia());
+        $this->assertTrue($blueprint->protect());
+
+        $blueprint = new FileBlueprint([
+            'model'   => new File(['filename' => 'test.jpg']),
+            'protect' => true
+        ]);
+
+        $this->assertFalse($blueprint->createMedia());
+        $this->assertTrue($blueprint->protect());
+    }
+
     public function testTemplateFromContent()
     {
         $file = new File([


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

There are two new options for file blueprints:

```yaml
title: Large File
createMedia: false
```

This will prevent Kirby from copying the files to the `media` folder. The file will instead be passed through the router on each request. Please note that this is much less efficient than than letting the web server handle the requests (which only works when the files are copied to the `media` folder). Also it is not possible to create thumbs from images that are not in the `media` folder.

```yaml
title: Confidential File
protect: true
```

Protected files are never copied to the `media` folder (`protect` implies `createMedia: false`), additionally Kirby will check user permissions whenever the file is accessed. The file will only be downloaded if the current user has the `files.read` permission on that file template.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Implements part of https://github.com/getkirby/ideas/issues/554

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
