### PR TITLE
Use apiUrl for patching sort

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -219,6 +219,7 @@ return [
             'errors'  => $this->errors,
             'options' => [
                 'accept'   => $this->accept,
+                'apiUrl'   => $this->parent->apiUrl(true),
                 'empty'    => $this->empty,
                 'headline' => $this->headline,
                 'help'     => $this->help,

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -42,7 +42,7 @@
           :pagination="pagination"
           :sortable="options.sortable"
           :size="options.size"
-          :data-invalid="isInvalid" 
+          :data-invalid="isInvalid"
           @sort="sort"
           @paginate="paginate"
           @action="action"
@@ -50,7 +50,7 @@
         <template v-else>
           <k-empty
             :layout="options.layout"
-            :data-invalid="isInvalid" 
+            :data-invalid="isInvalid"
             icon="image"
             @click="if (add) upload()"
           >
@@ -187,7 +187,7 @@ export default {
       });
 
       this.$api
-        .patch(this.parent + "/files/sort", {
+        .patch(this.options.apiUrl + "/files/sort", {
           files: items,
           index: this.pagination.offset
         })


### PR DESCRIPTION
Describe the PR

Used `apiUrl` instead of direct `parent` on files sort because conflicting parent of section.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2617 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
