### PR TITLE
Allow Symfony Server to run Kirby

### DIFF
--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -413,6 +413,7 @@ class System
             'caddy',
             'litespeed',
             'nginx',
+            'symfony',
             'php'
         ];
 


### PR DESCRIPTION
## Describe the PR

When developing locally I like to use [Symfony Server](https://symfony.com/doc/current/setup/symfony_server.html) as a substitute for the built-in PHP server. The two major features I like about it is the local https and the ability to specify a PHP version per project with a simple file.

Out of the box, Kirby doesn't allow the Symfony server. I've circumvented this by going into the core of my Kirby projects and modifying the allowed server list. I've done this for months now with no issues. Maybe it would be a good idea to have this in the official core so other developers can also use this.

## Related issues

None.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
