### PR TITLE
New servers option to overwrite server check

### DIFF
--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -423,7 +423,7 @@ class System
      */
     public function server(): bool
     {
-        if ($servers = $this->app->option('server')) {
+        if ($servers = $this->app->option('servers')) {
             $servers = A::wrap($servers);
         } else {
             $servers = [

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -9,6 +9,7 @@ use Kirby\Exception\PermissionException;
 use Kirby\Http\Remote;
 use Kirby\Http\Uri;
 use Kirby\Http\Url;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
@@ -422,13 +423,17 @@ class System
      */
     public function server(): bool
     {
-        $servers = [
-            'apache',
-            'caddy',
-            'litespeed',
-            'nginx',
-            'php'
-        ];
+        if ($servers = $this->app->option('server')) {
+            $servers = A::wrap($servers);
+        } else {
+            $servers = [
+                'apache',
+                'caddy',
+                'litespeed',
+                'nginx',
+                'php'
+            ];
+        }
 
         $software = $_SERVER['SERVER_SOFTWARE'] ?? null;
 

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -56,6 +56,22 @@ class SystemTest extends TestCase
         $this->assertEquals($expected, $server);
     }
 
+    public function testCustomServer()
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'symfony';
+
+        $app = $this->app->clone([
+            'options' => [
+                'server' => 'symfony'
+            ]
+        ]);
+
+        $system = new System($app);
+        $server = $system->server();
+
+        $this->assertTrue($server);
+    }
+
     public function serverNameProvider()
     {
         return [

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -56,10 +56,11 @@ class SystemTest extends TestCase
         $this->assertEquals($expected, $server);
     }
 
-    public function testCustomServer()
+    public function testServerOverwrite()
     {
         $_SERVER['SERVER_SOFTWARE'] = 'symfony';
 
+        // single server
         $app = $this->app->clone([
             'options' => [
                 'servers' => 'symfony'
@@ -70,12 +71,8 @@ class SystemTest extends TestCase
         $server = $system->server();
 
         $this->assertTrue($server);
-    }
 
-    public function testCustomServers()
-    {
-        $_SERVER['SERVER_SOFTWARE'] = 'symfony';
-
+        // array of servers
         $app = $this->app->clone([
             'options' => [
                 'servers' => ['symfony', 'apache']

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -62,7 +62,23 @@ class SystemTest extends TestCase
 
         $app = $this->app->clone([
             'options' => [
-                'server' => 'symfony'
+                'servers' => 'symfony'
+            ]
+        ]);
+
+        $system = new System($app);
+        $server = $system->server();
+
+        $this->assertTrue($server);
+    }
+
+    public function testCustomServers()
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'symfony';
+
+        $app = $this->app->clone([
+            'options' => [
+                'servers' => ['symfony', 'apache']
             ]
         ]);
 


### PR DESCRIPTION
## Describe the PR

This PR adds a new "server" option, which can be used to overwrite our internal server check. This way it is now possible to test Kirby with a server setup that is not officially supported. 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
