### PR TITLE
Improve validate on empty field

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -325,9 +325,14 @@ class Field extends Component
             }
         }
 
-        if (empty($this->validate) === false) {
-            $rules  = A::wrap($this->validate);
-            $errors = V::errors($this->value(), $rules);
+        if (
+            empty($this->validate) === false &&
+            (
+                $this->isEmpty() === false ||
+                ($this->isEmpty() === true && $this->isRequired() === true)
+            )
+        ) {
+            $errors = V::errors($this->value(), $this->validate);
 
             if (empty($errors) === false) {
                 $this->errors = array_merge($this->errors, $errors);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -332,7 +332,8 @@ class Field extends Component
                 ($this->isEmpty() === true && $this->isRequired() === true)
             )
         ) {
-            $errors = V::errors($this->value(), $this->validate);
+            $rules  = A::wrap($this->validate);
+            $errors = V::errors($this->value(), $rules);
 
             if (empty($errors) === false) {
                 $this->errors = array_merge($this->errors, $errors);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -327,10 +327,7 @@ class Field extends Component
 
         if (
             empty($this->validate) === false &&
-            (
-                $this->isEmpty() === false ||
-                ($this->isEmpty() === true && $this->isRequired() === true)
-            )
+            ($this->isEmpty() === false || $this->isRequired() === true)
         ) {
             $rules  = A::wrap($this->validate);
             $errors = V::errors($this->value(), $rules);

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -754,4 +754,54 @@ class FieldTest extends TestCase
         $this->assertEquals('1/2', $field->width());
         $this->assertEquals('1/2', $field->width);
     }
+
+    public function testValidate()
+    {
+        Field::$types = [
+            'test' => []
+        ];
+
+        $page = new Page(['slug' => 'test']);
+
+        // default
+        $field = new Field('test', [
+            'model'    => $page,
+            'validate' => [
+                'integer'
+            ],
+        ]);
+
+        $this->assertEquals([], $field->errors());
+
+        // required
+        $field = new Field('test', [
+            'model'    => $page,
+            'required' => true,
+            'validate' => [
+                'integer'
+            ],
+        ]);
+
+        $expected = [
+            'required' => 'Please enter something',
+            'integer'  => 'Please enter a valid integer',
+        ];
+
+        $this->assertEquals($expected, $field->errors());
+
+        // invalid
+        $field = new Field('test', [
+            'model'    => $page,
+            'value'    => 'abc',
+            'validate' => [
+                'integer'
+            ],
+        ]);
+
+        $expected = [
+            'integer' => 'Please enter a valid integer',
+        ];
+
+        $this->assertEquals($expected, $field->errors());
+    }
 }


### PR DESCRIPTION
## Describe the PR

Now `validate` run only when the field is is not empty or required.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2592 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
