### PR TITLE
Remote: Support setting defaults with App options

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -577,12 +577,17 @@ class App
      * Returns the current App instance
      *
      * @param \Kirby\Cms\App $instance
-     * @return self
+     * @param bool $lazy If `true`, the instance is only returned if already existing
+     * @return self|null
      */
-    public static function instance(self $instance = null)
+    public static function instance(self $instance = null, bool $lazy = false)
     {
         if ($instance === null) {
-            return static::$instance ?? new static();
+            if ($lazy === true) {
+                return static::$instance;
+            } else {
+                return static::$instance ?? new static();
+            }
         }
 
         return static::$instance = $instance;

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -3,6 +3,7 @@
 namespace Kirby\Http;
 
 use Exception;
+use Kirby\Cms\App;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 
@@ -96,8 +97,17 @@ class Remote
      */
     public function __construct(string $url, array $options = [])
     {
+        $defaults = static::$defaults;
+
+        // update the defaults with App config if set;
+        // request the App instance lazily
+        $app = App::instance(null, true);
+        if ($app !== null) {
+            $defaults = array_merge($defaults, $app->option('remote', []));
+        }
+
         // set all options
-        $this->options = array_merge(static::$defaults, $options);
+        $this->options = array_merge($defaults, $options);
 
         // add the url
         $this->options['url'] = $url;

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -408,9 +408,16 @@ class AppTest extends TestCase
 
     public function testInstance()
     {
-        $instance = new App();
+        App::destroy();
+        $this->assertNull(App::instance(null, true));
 
-        $this->assertEquals($instance, App::instance());
+        $instance1 = new App();
+        $this->assertSame($instance1, App::instance());
+
+        $instance2 = new App();
+        $this->assertSame($instance2, App::instance());
+        $this->assertSame($instance1, App::instance($instance1));
+        $this->assertSame($instance1, App::instance());
     }
 
     public function testFindPageFile()

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use PHPUnit\Framework\TestCase;
 
 class RemoteTest extends TestCase
@@ -13,7 +14,8 @@ class RemoteTest extends TestCase
         $this->defaults = Remote::$defaults;
 
         Remote::$defaults = array_merge($this->defaults, [
-            'test' => true
+            'test' => true,
+            'key'  => 'value'
         ]);
     }
 
@@ -42,6 +44,22 @@ class RemoteTest extends TestCase
             'basicAuth' => 'user:pw'
         ]);
         $this->assertSame('user:pw', $request->curlopt[CURLOPT_USERPWD]);
+    }
+
+    public function testOptionsFromApp()
+    {
+        new App([
+            'options' => [
+                'remote.key' => 'different-value',
+                'remote.body' => false
+            ]
+        ]);
+
+        $request = Remote::get('https://getkirby.com');
+
+        $options = $request->options();
+        $this->assertSame('different-value', $options['key']);
+        $this->assertFalse($options['body']);
     }
 
     public function testContent()


### PR DESCRIPTION
## Describe the PR

Defaults for the `Http\Remote` class can now be configured in the `site/config.php`:

```php
<?php

return [
    'remote.agent' => 'My Awesome Site'
];
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
