### PR TITLE
Fix missing button in Dialogs #2670

### DIFF
--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -54,7 +54,10 @@
         type: String,
         default: "default"
       },
-      submitButton: [String, Boolean],
+      submitButton: {
+        type: [String, Boolean],
+        default: true
+      },
       theme: String,
       visible: Boolean
     },


### PR DESCRIPTION
## Describe the PR

This fixes a regression that hides the submit button in dialogs. 

## Related issues

- Fixes #2670 