### PR TITLE
Fix broken toString method in ModelWithContent after new Str::template behaviour 

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -455,9 +455,10 @@ return function (App $app) {
          *
          * @param \Kirby\Cms\Field $field
          * @param array $data
+         * @param string $fallback Fallback for tokens in the template that cannot be replaced
          * @return \Kirby\Cms\Field
          */
-        'replace' => function (Field $field, array $data = []) use ($app) {
+        'replace' => function (Field $field, array $data = [], string $fallback = '') use ($app) {
             if ($parent = $field->parent()) {
                 $field->value = $field->parent()->toString($field->value, $data);
             } else {
@@ -465,7 +466,7 @@ return function (App $app) {
                     'kirby' => $app,
                     'site'  => $app->site(),
                     'page'  => $app->page()
-                ], $data));
+                ], $data), $fallback);
             }
 
             return $field;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -624,7 +624,7 @@ abstract class ModelWithContent extends Model
             'kirby'             => $this->kirby(),
             'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
             static::CLASS_ALIAS => $this
-        ], $data));
+        ], $data), '');
 
         return $result;
     }

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -612,9 +612,10 @@ abstract class ModelWithContent extends Model
      *
      * @param string|null $template
      * @param array $data
+     * @param string $fallback Fallback for tokens in the template that cannot be replaced
      * @return string
      */
-    public function toString(string $template = null, array $data = []): string
+    public function toString(string $template = null, array $data = [], string $fallback = ''): string
     {
         if ($template === null) {
             return $this->id();
@@ -624,7 +625,7 @@ abstract class ModelWithContent extends Model
             'kirby'             => $this->kirby(),
             'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
             static::CLASS_ALIAS => $this
-        ], $data), '');
+        ], $data), $fallback);
 
         return $result;
     }


### PR DESCRIPTION
## Describe the PR

`ModelWithContent::toString()` doesn't really work well with the new behaviour in Str::template() which leaves the placeholder if the value is empty. This PR fixes this. 

## Related issues

- Fixes #2664 