### PR TITLE
Introduce new $go method to handle routing more safely #2665

### DIFF
--- a/panel/src/components/Dialogs/UserRemoveDialog.vue
+++ b/panel/src/components/Dialogs/UserRemoveDialog.vue
@@ -43,7 +43,7 @@ export default {
           });
 
           if (this.$route.name === "User") {
-            this.$router.push("/users");
+            this.$go("/users");
           }
         })
         .catch(error => {

--- a/panel/src/components/Forms/FormIndicator.vue
+++ b/panel/src/components/Forms/FormIndicator.vue
@@ -61,7 +61,7 @@ export default {
         }
       }
 
-      this.$router.push(target.link);
+      this.$go(target.link);
     },
     load() {
       // create an API request promise for each model with changes

--- a/panel/src/components/Navigation/Link.vue
+++ b/panel/src/components/Navigation/Link.vue
@@ -99,7 +99,7 @@ export default {
 
       if (this.isRoutable(event)) {
         event.preventDefault();
-        this.$router.push(this.to);
+        this.$go(this.to);
       }
 
       this.$emit("click", event);

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -150,9 +150,6 @@ export default {
       };
     },
     navigate(item) {
-
-      console.log(item);
-
       this.$go(item.link);
       this.close();
     },

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -41,7 +41,7 @@
           :data-selected="selected === itemIndex"
           @mouseover="selected = itemIndex"
         >
-          <k-link :to="item.link" @click="click(itemIndex)">
+          <k-link :to="item.link" @click="close">
             <strong>{{ item.title }}</strong>
             <small>{{ item.info }}</small>
           </k-link>
@@ -150,6 +150,9 @@ export default {
       };
     },
     navigate(item) {
+
+      console.log(item);
+
       this.$go(item.link);
       this.close();
     },

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -150,7 +150,7 @@ export default {
       };
     },
     navigate(item) {
-      this.$router.push(item.link);
+      this.$go(item.link);
       this.close();
     },
     search(query) {

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -90,7 +90,7 @@ export default {
 
       switch (action) {
         case "edit":
-          this.$router.push(file.link);
+          this.$go(file.link);
           break;
         case "download":
           window.open(file.url);

--- a/panel/src/components/Views/BrowserView.vue
+++ b/panel/src/components/Views/BrowserView.vue
@@ -36,9 +36,9 @@ export default {
   },
   created() {
     this.$store.dispatch("content/current", null);
-    
+
     if (supports.all()) {
-      this.$router.push("/");
+      this.$go("/");
     }
   }
 };

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -208,13 +208,13 @@ export default {
     },
     deleted() {
       if (this.path) {
-        this.$router.push('/' + this.path);
+        this.$go('/' + this.path);
       } else {
-        this.$router.push('/site');
+        this.$go('/site');
       }
     },
     renamed(file) {
-      this.$router.push(this.$api.files.link(this.path, file.filename));
+      this.$go(this.$api.files.link(this.path, file.filename));
     },
     uploaded() {
       this.fetch();

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -146,7 +146,7 @@ export default {
         .then(user => {
           this.$store.dispatch("user/current", user);
           this.$store.dispatch("notification/success", this.$t("welcome") + "!");
-          this.$router.push("/");
+          this.$go("/");
         })
         .catch(error => {
           this.$store.dispatch("notification/error", error);
@@ -155,7 +155,7 @@ export default {
     check() {
       this.$store.dispatch("system/load", true).then(system => {
         if (system.isInstalled === true && system.isReady) {
-          this.$router.push("/login");
+          this.$go("/login");
           return;
         }
 

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -26,11 +26,11 @@ export default {
       .dispatch("system/load")
       .then(system => {
         if (!system.isReady) {
-          this.$router.push("/installation");
+          this.$go("/installation");
         }
 
         if (system.user && system.user.id) {
-          this.$router.push("/");
+          this.$go("/");
         }
 
         this.ready = true;

--- a/panel/src/components/Views/UsersView.vue
+++ b/panel/src/components/Views/UsersView.vue
@@ -181,7 +181,7 @@ export default {
     action(user, action) {
       switch (action) {
         case "edit":
-          this.$router.push("/users/" + user.id);
+          this.$go("/users/" + user.id);
           break;
         case "email":
           this.$refs.email.open(user.id);
@@ -205,9 +205,9 @@ export default {
     },
     filter(role) {
       if (role === false) {
-        this.$router.push("/users");
+        this.$go("/users");
       } else {
-        this.$router.push("/users/role/" + role.value);
+        this.$go("/users/role/" + role.value);
       }
 
       this.$refs.roles.close();

--- a/panel/src/main.js
+++ b/panel/src/main.js
@@ -22,8 +22,17 @@ Vue.use(Vuelidate);
 import router from "./config/router.js";
 import store from "./store/store.js";
 
+Vue.prototype.$go = (path) => {
+  router.push(path).catch(e => {
+    if (e.name && e.name === "NavigationDuplicated") {
+      return true;
+    }
 
- new Vue({
+    throw e;
+  });
+};
+
+new Vue({
   router,
   store,
   created() {

--- a/panel/src/main.js
+++ b/panel/src/main.js
@@ -24,7 +24,7 @@ import store from "./store/store.js";
 
 Vue.prototype.$go = (path) => {
   router.push(path).catch(e => {
-    if (e.name && e.name === "NavigationDuplicated") {
+    if (e && e.name && e.name === "NavigationDuplicated") {
       return true;
     }
 


### PR DESCRIPTION
## Describe the PR

This PR introduces a new Vue.$go method, which handles routing more safely and catches unnecessary and annoying NavigationDuplicate errors. This new behaviour in the Vue router doesn't seem to be fixable in any other way, which is kind of a shame, but at the same time the $go method feels very Kirbyish and is shorter to write and easier to understand than this.$router.push (push is a weird term in this case anyway)

## Related issues

- Fixes #2665