### PR TITLE
`replace` field method: Always use fallback

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -460,7 +460,7 @@ return function (App $app) {
          */
         'replace' => function (Field $field, array $data = [], string $fallback = '') use ($app) {
             if ($parent = $field->parent()) {
-                $field->value = $field->parent()->toString($field->value, $data);
+                $field->value = $field->parent()->toString($field->value, $data, $fallback);
             } else {
                 $field->value = Str::template($field->value, array_replace([
                     'kirby' => $app,


### PR DESCRIPTION
Fixes a small issue in #2672.