### PR TITLE
Html/Xml::encode() and decode(): null support

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -223,11 +223,11 @@ function go(string $url = null, int $code = 302)
 /**
  * Shortcut for html()
  *
- * @param string $string unencoded text
+ * @param string|null $string unencoded text
  * @param bool $keepTags
  * @return string
  */
-function h(string $string = null, bool $keepTags = false)
+function h(?string $string, bool $keepTags = false)
 {
     return Html::encode($string, $keepTags);
 }
@@ -235,11 +235,11 @@ function h(string $string = null, bool $keepTags = false)
 /**
  * Creates safe html by encoding special characters
  *
- * @param string $string unencoded text
+ * @param string|null $string unencoded text
  * @param bool $keepTags
  * @return string
  */
-function html(string $string = null, bool $keepTags = false)
+function html(?string $string, bool $keepTags = false)
 {
     return Html::encode($string, $keepTags);
 }

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -148,12 +148,16 @@ class Html extends Xml
     /**
      * Converts a string to an HTML-safe string
      *
-     * @param string $string
+     * @param string|null $string
      * @param bool $keepTags If true, existing tags won't be escaped
      * @return string The HTML string
      */
-    public static function encode(string $string, bool $keepTags = false): string
+    public static function encode(?string $string, bool $keepTags = false): string
     {
+        if ($string === null) {
+            return '';
+        }
+
         if ($keepTags === true) {
             $list = static::entities();
             unset($list['"'], $list['<'], $list['>'], $list['&']);

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -194,11 +194,15 @@ class Xml
      * // output: some über crazy stuff
      * ```
      *
-     * @param string $string
+     * @param string|null $string
      * @return string
      */
-    public static function decode(string $string): string
+    public static function decode(?string $string): string
     {
+        if ($string === null) {
+            $string = '';
+        }
+
         $string = strip_tags($string);
         return html_entity_decode($string, ENT_COMPAT, 'utf-8');
     }
@@ -214,12 +218,16 @@ class Xml
      * // output: some &#252;ber crazy stuff
      * ```
      *
-     * @param string $string
+     * @param string|null $string
      * @param bool $html True = Convert to HTML-safe first
      * @return string
      */
-    public static function encode(string $string, bool $html = true): string
+    public static function encode(?string $string, bool $html = true): string
     {
+        if ($string === null) {
+            return '';
+        }
+
         if ($html === true) {
             $string = Html::encode($string, false);
         }

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -245,6 +245,9 @@ class HtmlTest extends TestCase
         $html = Html::encode('ä<span title="Amazing &amp; great">ö</span>', true);
         $expected = '&auml;<span title="Amazing &amp; great">&ouml;</span>';
         $this->assertSame($expected, $html);
+
+        $this->assertSame('', Html::encode(''));
+        $this->assertSame('', Html::encode(null));
     }
 
     /**

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -151,6 +151,11 @@ class XmlTest extends TestCase
         $this->assertSame('Süper Önencœded ßtring', Xml::decode($expected));
 
         $this->assertSame('S&#252;per Täst', Xml::encode('S&uuml;per Täst', false));
+
+        $this->assertSame('', Xml::decode(''));
+        $this->assertSame('', Xml::encode(''));
+        $this->assertSame('', Xml::decode(null));
+        $this->assertSame('', Xml::encode(null));
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The `html()` and `h()` helpers didn't have official support for `null` arguments before (it wasn't documented), so I don't consider the issue behind #2687 a breaking-change. However many people will have used the helpers with arguments that can be `null` nonetheless, so it probably makes sense to add support for it back to the underlying classes.

I don't really like that from a clean-code perspective, but it's one of these places where being strict makes the users' lives harder.

## Related issues

<!-- PR relates to issues in the `kirby` or `idea` repo: -->

- Fixes #2687.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
