### PR TITLE
Fix search words option

### DIFF
--- a/src/Image/Exif.php
+++ b/src/Image/Exif.php
@@ -185,7 +185,7 @@ class Exif
      *
      * @return bool|null
      */
-    public function isBW(): bool
+    public function isBW(): ?bool
     {
         return ($this->isColor !== null) ? $this->isColor === false : null;
     }

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -528,6 +528,48 @@ class PagesTest extends TestCase
         $this->assertCount(2, $result);
     }
 
+    public function testSearchWords()
+    {
+        $pages = Pages::factory([
+            [
+                'slug'    => 'mtb',
+                'content' => [
+                    'title' => 'Mountainbike'
+                ]
+            ],
+            [
+                'slug'    => 'mountain',
+                'content' => [
+                    'title' => 'Mountain'
+                ]
+            ],
+            [
+                'slug'    => 'everest-mountain',
+                'content' => [
+                    'title' => 'Everest Mountain'
+                ]
+            ],
+            [
+                'slug'    => 'mount',
+                'content' => [
+                    'title' => 'Mount'
+                ]
+            ],
+            [
+                'slug'    => 'lakes',
+                'content' => [
+                    'title' => 'Lakes'
+                ]
+            ]
+        ]);
+
+        $result = $pages->search('mountain', ['words' => true]);
+        $this->assertCount(2, $result);
+
+        $result = $pages->search('mount', ['words' => false]);
+        $this->assertCount(4, $result);
+    }
+
     public function testCustomMethods()
     {
         Pages::$methods = [


### PR DESCRIPTION
## Describe the PR

1. checking for exact beginning matches is disabled if `words` options enabled to correct match.
2. checking for exact query matches is improved if `words` options enabled

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2698 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
