### PR TITLE
Add SVG favicon with dark mode support & PNG fallback

### DIFF
--- a/panel/public/favicon.svg
+++ b/panel/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 42">
+  <style>
+    path { fill: #000000; }
+    @media (prefers-color-scheme: dark) {
+      path { fill: #ffffff; }
+    }
+  </style>
+  <path d="M18 0l18 10.498v21.004L18 42 0 31.502V10.498L18 0zM2 11.693v18.614l16 9.332 16-9.332V11.693L18 2.36 2 11.693z"/><path d="M26 21l-5 2.59V24h5v4H10v-4h5v-.437L10 21v-5l8 4.297L26 16"/>
+</svg>

--- a/panel/public/index.html
+++ b/panel/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="apple-touch-icon" href="<%= webpackConfig.output.publicPath %>apple-touch-icon.png" />
-    <link rel="shortcut icon" href="<%= webpackConfig.output.publicPath %>favicon.png">
+    <link rel="icon" href="<%= webpackConfig.output.publicPath %>favicon.svg" type="image/svg+xml">
+    <link rel="alternate icon" href="<%= webpackConfig.output.publicPath %>favicon.png" type="image/png">
     <link rel="stylesheet" href="<%= process.env.VUE_APP_DEV_SERVER %>/media/plugins/index.css">
 
     <title>Kirby Panel</title>

--- a/views/panel.php
+++ b/views/panel.php
@@ -16,7 +16,8 @@
   <?php endif ?>
 
   <link nonce="<?= $nonce ?>" rel="apple-touch-icon" href="<?= $assetUrl ?>/apple-touch-icon.png" />
-  <link nonce="<?= $nonce ?>" rel="shortcut icon" href="<?= $assetUrl ?>/favicon.png">
+  <link nonce="<?= $nonce ?>" rel="icon" href="<?= $assetUrl ?>/favicon.svg" type="image/svg+xml">
+  <link nonce="<?= $nonce ?>" rel="alternate icon" href="<?= $assetUrl ?>/favicon.png" type="image/png">
 
   <base href="<?= $panelUrl ?>">
 </head>


### PR DESCRIPTION
## Describe the PR

This pull request adds a SVG favicon with dark mode support. Vector favicons are:
- future-proof
- resolution-agnostic – they look crisp regardless of how large the displays is
- quite small

Since CSS media queries are available inside the SVG files, `prefers-color-scheme` helps to provide support for dark mode.

Support is also pretty good: https://caniuse.com/#feat=link-icon-svg. But we define a PNG fallback anyway.

## Related issues

No related issues found.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
