### PR TITLE
Fix error page on multilang

### DIFF
--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\Exception;
 use Kirby\Toolkit\F;
 
 class LanguageRoutes

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\Exception;
 use Kirby\Toolkit\F;
 
 class LanguageRoutes
@@ -95,7 +96,13 @@ class LanguageRoutes
                     }
                 }
 
-                return $kirby->defaultLanguage()->router()->call($path);
+                // try the current language first
+                // use the default language if it fails
+                try {
+                    return $kirby->language()->router()->call($path);
+                } catch (Exception $e) {
+                    return $kirby->defaultLanguage()->router()->call($path);
+                }
             }
         ];
     }

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -96,13 +96,7 @@ class LanguageRoutes
                     }
                 }
 
-                // try the current language first
-                // use the default language if it fails
-                try {
-                    return $kirby->language()->router()->call($path);
-                } catch (Exception $e) {
-                    return $kirby->defaultLanguage()->router()->call($path);
-                }
+                return $kirby->language()->router()->call($path);
             }
         ];
     }

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class LanguageRoutesTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        App::destroy();
+
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true,
+                    'locale'  => 'en_US.UTF-8',
+                    'url'     => '/',
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch',
+                    'locale'  => 'de_AT.UTF-8',
+                    'url'     => '/de',
+                ],
+            ]
+        ]);
+    }
+
+    public function testFallback()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'error',
+                        'template' => 'error'
+                    ]
+                ]
+            ]
+        ]);
+
+        $app->call('notes');
+        $this->assertSame($app->language()->code(), 'en');
+
+        $app->call('de/notes');
+        $this->assertSame($app->language()->code(), 'de');
+    }
+}


### PR DESCRIPTION
## Describe the PR

First of all, it was really hard to debug this issue. 
The source of the issue is if fails when checked for all languages for the requested page, the default language is called. 
Instead of the default language, first fallback with the current language was tried, if it fails, the default language will work.

There might be another point I missed. I opened PR only for suggestion. If the code is not suitable, it can be closed.

I tried to add an unit test, but I couldn't write a unit test that checked it correctly.

I'm waiting for your reviews. @bastianallgeier @lukasbestle @distantnative 

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2609 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
