### PR TITLE
Add new content() method to Form class

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -112,7 +112,7 @@ return [
 
                     // Skip hidden and unsaveable fields
                     // They should never be included as column
-                    if ($field['type'] === 'hidden' || $field['save'] === false) {
+                    if ($field['type'] === 'hidden' || $field['saveable'] === false) {
                         continue;
                     }
 
@@ -129,7 +129,7 @@ return [
 
                     $field = $this->fields[$columnName] ?? null;
 
-                    if (empty($field) === true || $field['save'] === false) {
+                    if (empty($field) === true || $field['saveable'] === false) {
                         continue;
                     }
 

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -110,9 +110,9 @@ return [
             if (empty($this->columns)) {
                 foreach ($this->fields as $field) {
 
-                    // Skip hidden fields.
+                    // Skip hidden and unsaveable fields
                     // They should never be included as column
-                    if ($field['type'] === 'hidden') {
+                    if ($field['type'] === 'hidden' || $field['save'] === false) {
                         continue;
                     }
 
@@ -129,7 +129,7 @@ return [
 
                     $field = $this->fields[$columnName] ?? null;
 
-                    if (empty($field) === true) {
+                    if (empty($field) === true || $field['save'] === false) {
                         continue;
                     }
 
@@ -181,7 +181,7 @@ return [
         $data = [];
 
         foreach ($value as $row) {
-            $data[] = $this->form($row)->data();
+            $data[] = $this->form($row)->content();
         }
 
         return $data;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -702,7 +702,7 @@ abstract class ModelWithContent extends Model
             }
         }
 
-        $arguments = [static::CLASS_ALIAS => $this, 'values' => $form->content(), 'strings' => $form->strings(), 'languageCode' => $languageCode];
+        $arguments = [static::CLASS_ALIAS => $this, 'values' => $form->data(), 'strings' => $form->strings(), 'languageCode' => $languageCode];
         return $this->commit('update', $arguments, function ($model, $values, $strings, $languageCode) {
             // save updated values
             $model = $model->save($strings, $languageCode, true);

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -702,7 +702,7 @@ abstract class ModelWithContent extends Model
             }
         }
 
-        $arguments = [static::CLASS_ALIAS => $this, 'values' => $form->data(), 'strings' => $form->strings(), 'languageCode' => $languageCode];
+        $arguments = [static::CLASS_ALIAS => $this, 'values' => $form->content(), 'strings' => $form->strings(), 'languageCode' => $languageCode];
         return $this->commit('update', $arguments, function ($model, $values, $strings, $languageCode) {
             // save updated values
             $model = $model->save($strings, $languageCode, true);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -286,7 +286,7 @@ class Field extends Component
 
         $array['errors']    = $this->errors();
         $array['invalid']   = $this->isInvalid();
-        $array['save']      = $this->save();
+        $array['saveable']  = $this->save();
         $array['signature'] = md5(json_encode($array));
 
         ksort($array);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -284,8 +284,9 @@ class Field extends Component
 
         unset($array['model']);
 
-        $array['invalid']   = $this->isInvalid();
         $array['errors']    = $this->errors();
+        $array['invalid']   = $this->isInvalid();
+        $array['save']      = $this->save();
         $array['signature'] = md5(json_encode($array));
 
         ksort($array);

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -85,13 +85,22 @@ class Form
         }
     }
 
-    public function data($defaults = false): array
+    public function content(): array
+    {
+        return $this->data(false, false);
+    }
+
+    public function data($defaults = false, bool $includeNulls = true): array
     {
         $data = $this->values;
 
         foreach ($this->fields as $field) {
             if ($field->save() === false || $field->unset() === true) {
-                $data[$field->name()] = null;
+                if ($includeNulls === true) {
+                    $data[$field->name()] = null;
+                } else {
+                    unset($data[$field->name()]);
+                }
             } else {
                 $data[$field->name()] = $field->data($defaults);
             }

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -281,4 +281,44 @@ class FormTest extends TestCase
         $this->assertCount(2, $form->toArray()['fields']);
         $this->assertEquals(false, $form->toArray()['invalid']);
     }
+
+    public function testContent()
+    {
+        $form = new Form([
+            'fields' => [],
+            'values' => $values = [
+                'a' => 'A',
+                'b' => 'B'
+            ]
+        ]);
+
+        $this->assertEquals($values, $form->content());
+    }
+
+    public function testContentFromUnsaveableFields()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $page = new Page(['slug' => 'test']);
+        $form = new Form([
+            'fields' => [
+                'info' => [
+                    'type' => 'info',
+                    'model' => $page
+                ]
+            ],
+            'values' => [
+                'info' => 'Yay'
+            ]
+        ]);
+
+        $this->assertCount(0, $form->content());
+        $this->assertArrayNotHasKey('info', $form->content());
+        $this->assertCount(1, $form->data());
+        $this->assertArrayHasKey('info', $form->data());
+    }
 }


### PR DESCRIPTION
## Describe the PR

Added new `$form->content()` method to `Form` class. I preferred to add shortcuts instead of always sending double parameters like `$form->data(false, false)`, of course the final decision is yours.

Also fixes about showing unsaveable fields in panel ui.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2702 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
