### PR TITLE
Bring Http\Request\Query in line with Http\Query

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -376,7 +376,7 @@ class Request
     /**
      * Returns the Query object
      *
-     * @return \Kirby\Http\Query
+     * @return \Kirby\Http\Request\Query
      */
     public function query()
     {

--- a/src/Http/Request/Query.php
+++ b/src/Http/Request/Query.php
@@ -56,6 +56,26 @@ class Query
     }
 
     /**
+     * Returns `true` if the request doesn't contain query variables
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->data) === true;
+    }
+
+    /**
+     * Returns `true` if the request contains query variables
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return empty($this->data) === false;
+    }
+
+    /**
      * Converts the query data array
      * back to a query string
      *

--- a/tests/Http/Request/QueryTest.php
+++ b/tests/Http/Request/QueryTest.php
@@ -24,6 +24,19 @@ class QueryTest extends TestCase
         $this->assertEquals($data, $query->data());
     }
 
+    public function testIsEmpty()
+    {
+        // without data
+        $query = new Query();
+        $this->assertTrue($query->isEmpty());
+        $this->assertFalse($query->isNotEmpty());
+
+        // with data
+        $query = new Query(['foo' => 'bar']);
+        $this->assertFalse($query->isEmpty());
+        $this->assertTrue($query->isNotEmpty());
+    }
+
     public function testGet()
     {
         // default


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- Added new `isEmpty()` and `isNotEmpty()` methods to `Http\Request\Query`
- Fixed the return type annotation for the `Http\Request::query()` method

In the long term the two classes should likely be merged, but this would need a full refactoring of the `Http` package.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2692.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
