### PR TITLE
Set fixed types in fields to avoid issues in extended fields #2643

### DIFF
--- a/panel/src/components/Forms/Field/CheckboxesField.vue
+++ b/panel/src/components/Forms/Field/CheckboxesField.vue
@@ -9,6 +9,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="checkboxes"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/EmailField.vue
+++ b/panel/src/components/Forms/Field/EmailField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="email"
       v-on="$listeners"
     >
       <k-button

--- a/panel/src/components/Forms/Field/MultiselectField.vue
+++ b/panel/src/components/Forms/Field/MultiselectField.vue
@@ -12,6 +12,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="multiselect"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/NumberField.vue
+++ b/panel/src/components/Forms/Field/NumberField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="number"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/PasswordField.vue
+++ b/panel/src/components/Forms/Field/PasswordField.vue
@@ -10,6 +10,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="password"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/RadioField.vue
+++ b/panel/src/components/Forms/Field/RadioField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="radio"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/RangeField.vue
+++ b/panel/src/components/Forms/Field/RangeField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="range"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/SelectField.vue
+++ b/panel/src/components/Forms/Field/SelectField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="select"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/TagsField.vue
+++ b/panel/src/components/Forms/Field/TagsField.vue
@@ -10,6 +10,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="tags"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/TelField.vue
+++ b/panel/src/components/Forms/Field/TelField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="tel"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="time"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/ToggleField.vue
+++ b/panel/src/components/Forms/Field/ToggleField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="toggle"
       v-on="$listeners"
     />
   </k-field>

--- a/panel/src/components/Forms/Field/UrlField.vue
+++ b/panel/src/components/Forms/Field/UrlField.vue
@@ -5,6 +5,7 @@
       :id="_uid"
       v-bind="$props"
       theme="field"
+      type="url"
       v-on="$listeners"
     >
       <k-button


### PR DESCRIPTION
## Describe the PR

Not specifically setting the input type in our core fields leads to unwanted issues when you want to extend such a field. This PR fixes this. 

## Related issues

- Fixes #2643

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)