### PR TITLE
Don’t load user data after logout #2713

### DIFF
--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -112,7 +112,7 @@ export default {
   mixins: [PrevNext],
   props: {
     id: {
-      type: String,
+      type: [Boolean, String],
       required: true
     }
   },
@@ -216,6 +216,12 @@ export default {
       }
     },
     fetch() {
+
+      if (!this.id) {
+        // don't load a user if there's no id
+        return;
+      }
+
       this.$api.users
         .get(this.id, { view: "panel" })
         .then(user => {

--- a/panel/src/config/routes.js
+++ b/panel/src/config/routes.js
@@ -160,7 +160,7 @@ export default [
     component: Vue.component("k-user-view"),
     beforeEnter: auth,
     props: () => ({
-      id: store.state.user.current ? store.state.user.current.id : null
+      id: store.state.user.current ? store.state.user.current.id : false
     })
   },
   {


### PR DESCRIPTION
## Describe the PR

The logout route triggers a new user data fetch in the account view. This should stop the view from reloading data. 