### PR TITLE
Don’t load languages in SettingsView if multilang is not set to true

### DIFF
--- a/panel/src/components/Views/SettingsView.vue
+++ b/panel/src/components/Views/SettingsView.vue
@@ -100,7 +100,7 @@ export default {
   methods: {
     fetch() {
 
-      if (this.multilang === false) {
+      if (this.multilang !== true) {
         this.languages = [];
         return;
       }


### PR DESCRIPTION
## Describe the PR

The SettingsView did still access the languages API, even if the site is in single-language mode. 