### PR TITLE
Spacing specificity

### DIFF
--- a/panel/src/ui/css/utilities/margin.scss
+++ b/panel/src/ui/css/utilities/margin.scss
@@ -1,32 +1,39 @@
 /* Margins */
-.mx-auto,
-.mr-auto {
-  margin-right: auto;
+@each $index, $size in $margin {
+  .m-#{$index} {
+    margin: $size;
+  }
 }
-.mx-auto,
-.ml-auto {
-  margin-left: auto;
+@each $index, $size in $margin {
+  .mx-#{$index} {
+    margin-right: $size;
+    margin-left: $size;
+  }
 }
-
-@each $index, $size in $spacing {
-  .m-#{$index},
-  .my-#{$index},
+@each $index, $size in $margin {
+  .my-#{$index} {
+    margin-top: $size;
+    margin-bottom: $size;
+  }
+}
+@each $index, $size in $margin {
   .mt-#{$index} {
     margin-top: $size;
   }
-  .m-#{$index},
-  .mx-#{$index},
+}
+@each $index, $size in $margin {
   .mr-#{$index} {
     margin-right: $size;
   }
-  .m-#{$index},
-  .my-#{$index},
+}
+@each $index, $size in $margin {
   .mb-#{$index} {
     margin-bottom: $size;
   }
-  .m-#{$index},
-  .mx-#{$index},
+}
+@each $index, $size in $margin {
   .ml-#{$index} {
     margin-left: $size;
   }
 }
+

--- a/panel/src/ui/css/utilities/padding.scss
+++ b/panel/src/ui/css/utilities/padding.scss
@@ -1,22 +1,37 @@
 /* Paddings */
 @each $index, $size in $spacing {
-  .p-#{$index},
-  .py-#{$index},
+  .p-#{$index} {
+    padding: $size;
+  }
+}
+@each $index, $size in $spacing {
+  .px-#{$index} {
+    padding-right: $size;
+    padding-left: $size;
+  }
+}
+@each $index, $size in $spacing {
+  .py-#{$index} {
+    padding-top: $size;
+    padding-bottom: $size;
+  }
+}
+@each $index, $size in $spacing {
   .pt-#{$index} {
     padding-top: $size;
   }
-  .p-#{$index},
-  .px-#{$index},
+}
+@each $index, $size in $spacing {
   .pr-#{$index} {
     padding-right: $size;
   }
-  .p-#{$index},
-  .py-#{$index},
+}
+@each $index, $size in $spacing {
   .pb-#{$index} {
     padding-bottom: $size;
   }
-  .p-#{$index},
-  .px-#{$index},
+}
+@each $index, $size in $spacing {
   .pl-#{$index} {
     padding-left: $size;
   }

--- a/panel/src/ui/css/variables.scss
+++ b/panel/src/ui/css/variables.scss
@@ -200,6 +200,13 @@ $spacing: (
 );
 
 /**
+ * Margin
+ */
+$margin: map-merge((
+  auto: auto
+), $spacing);
+
+/**
  * Fields
  */
 $field-input-padding: .5rem;


### PR DESCRIPTION
## Describe the PR
I just skimmed through some files and I think the way the spacing helpers (margin and padding) are implemented could be improved. Right now something like the following example won't work as expected (at least how I would expect it to work 😬). You will always end up with the spacing of `4` on all sides because higher spacings will always have precedence over the smaller ones in the current implementation. I would expect the  `padding-bottom` to win over the more general `padding`.
```html
<div class="p-4 pb-0"></div>
```
In addition here is a quick [codepen](https://codepen.io/lukaskleinschmidt/pen/yLeGryQ) to illustrate the PR.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
