### PR TITLE
Add support for custom file drag texts

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -255,7 +255,7 @@ class File extends ModelWithContent
                 // no break
             default:
                 $fileDragTextFn = option('fileDragText');
-                if(!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this, $url))) {
+                if (!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this, $url))) {
                     return $text;
                 }
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -254,6 +254,11 @@ class File extends ModelWithContent
                 }
                 // no break
             default:
+                $fileDragTextFn = option('fileDragText');
+                if(!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this))) {
+                    return $text;
+                }
+                
                 if ($this->type() === 'image') {
                     return '(image: ' . $url . ')';
                 } else {

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -245,13 +245,14 @@ class File extends ModelWithContent
 
         $url = $absolute ? $this->id() : $this->filename();
 
+        $dragTextCallback = option('panel.' . $type . '.fileDragText');
+
+        if (empty($dragTextCallback) === false && is_a($dragTextCallback, 'Closure') === true && ($dragText = $dragTextCallback($this, $url)) !== null) {
+            return $dragText;
+        }
+
         switch ($type) {
             case 'markdown':
-                $dragTextFn = option('panel.markdown.fileDragText');
-                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this, $url))) {
-                    return $text;
-                }
-
                 if ($this->type() === 'image') {
                     return '![' . $this->alt() . '](' . $url . ')';
                 } else {
@@ -259,11 +260,6 @@ class File extends ModelWithContent
                 }
                 // no break
             default:
-                $dragTextFn = option('panel.kirbytext.fileDragText');
-                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this, $url))) {
-                    return $text;
-                }
-
                 if ($this->type() === 'image') {
                     return '(image: ' . $url . ')';
                 } else {

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -247,6 +247,11 @@ class File extends ModelWithContent
 
         switch ($type) {
             case 'markdown':
+                $dragTextFn = option('panel.markdown.fileDragText');
+                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this, $url))) {
+                    return $text;
+                }
+
                 if ($this->type() === 'image') {
                     return '![' . $this->alt() . '](' . $url . ')';
                 } else {
@@ -254,8 +259,8 @@ class File extends ModelWithContent
                 }
                 // no break
             default:
-                $fileDragTextFn = option('fileDragText');
-                if (!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this, $url))) {
+                $dragTextFn = option('panel.kirbytext.fileDragText');
+                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this, $url))) {
                     return $text;
                 }
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -255,10 +255,10 @@ class File extends ModelWithContent
                 // no break
             default:
                 $fileDragTextFn = option('fileDragText');
-                if(!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this))) {
+                if(!empty($fileDragTextFn) && is_callable($fileDragTextFn) && !empty($text = $fileDragTextFn($this, $url))) {
                     return $text;
                 }
-                
+
                 if ($this->type() === 'image') {
                     return '(image: ' . $url . ')';
                 } else {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -443,20 +443,16 @@ class Page extends ModelWithContent
             $type = option('panel.kirbytext', true) ? 'kirbytext' : 'markdown';
         }
 
+        $dragTextCallback = option('panel.' . $type . '.pageDragText');
+
+        if (empty($dragTextCallback) === false && is_a($dragTextCallback, 'Closure') === true && ($dragText = $dragTextCallback($this)) !== null) {
+            return $dragText;
+        }
+
         switch ($type) {
             case 'markdown':
-                $dragTextFn = option('panel.markdown.pageDragText');
-                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this))) {
-                    return $text;
-                }
-
                 return '[' . $this->title() . '](' . $this->url() . ')';
             default:
-                $dragTextFn = option('panel.kirbytext.pageDragText');
-                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this))) {
-                    return $text;
-                }
-
                 return '(link: ' . $this->id() . ' text: ' . $this->title() . ')';
         }
     }

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -445,8 +445,18 @@ class Page extends ModelWithContent
 
         switch ($type) {
             case 'markdown':
+                $dragTextFn = option('panel.markdown.pageDragText');
+                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this))) {
+                    return $text;
+                }
+
                 return '[' . $this->title() . '](' . $this->url() . ')';
             default:
+                $dragTextFn = option('panel.kirbytext.pageDragText');
+                if (!empty($dragTextFn) && is_callable($dragTextFn) && !empty($text = $dragTextFn($this))) {
+                    return $text;
+                }
+
                 return '(link: ' . $this->id() . ' text: ' . $this->title() . ')';
         }
     }

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -146,7 +146,7 @@ class FileTest extends TestCase
         $this->assertEquals('![](test.jpg)', $file->dragText());
     }
 
-    public function testDragTextCustom()
+    public function testDragTextCustomMarkdown()
     {
         $app = new App([
             'roots' => [
@@ -154,14 +154,65 @@ class FileTest extends TestCase
             ],
 
             'options' => [
-                'fileDragText' => function (\Kirby\Cms\File $file, string $url) {
-                    if ($file->extension() === 'heic') {
-                        return sprintf('(image: %s)', $url);
-                    }
-            
-                    return null;
-                },
-            
+                'panel' => [
+                    'kirbytext' => false,
+                    'markdown' => [
+                        'fileDragText' => function (\Kirby\Cms\File $file, string $url) {
+                            if ($file->extension() === 'heic') {
+                                return sprintf('![](%s)', $url);
+                            }
+                    
+                            return null;
+                        },
+                    ]
+                ]
+            ],
+
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            [
+                                'filename' => 'test.heic'
+                            ],
+                            [
+                                'filename' => 'test.jpg'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        // Custom function does not match and returns null, default case
+        $file = $app->page('test')->file('test.jpg');
+        $this->assertEquals('![](test.jpg)', $file->dragText());
+
+        // Custom function should return image tag for heic
+        $file = $app->page('test')->file('test.heic');
+        $this->assertEquals('![](test.heic)', $file->dragText());
+    }
+
+    public function testDragTextCustomKirbytext()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+
+            'options' => [
+                'panel' => [
+                    'kirbytext' => [
+                        'fileDragText' => function (\Kirby\Cms\File $file, string $url) {
+                            if ($file->extension() === 'heic') {
+                                return sprintf('(image: %s)', $url);
+                            }
+                    
+                            return null;
+                        },
+                    ]
+                ]
             ],
 
             'site' => [

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -146,15 +146,16 @@ class FileTest extends TestCase
         $this->assertEquals('![](test.jpg)', $file->dragText());
     }
 
-    public function testDragTextCustom() {
+    public function testDragTextCustom()
+    {
         $app = new App([
             'roots' => [
                 'index' => '/dev/null'
             ],
 
             'options' => [
-                'fileDragText' => function(\Kirby\Cms\File $file, string $url) {
-                    if($file->extension() === 'heic') {
+                'fileDragText' => function (\Kirby\Cms\File $file, string $url) {
+                    if ($file->extension() === 'heic') {
                         return sprintf('(image: %s)', $url);
                     }
             

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -146,6 +146,49 @@ class FileTest extends TestCase
         $this->assertEquals('![](test.jpg)', $file->dragText());
     }
 
+    public function testDragTextCustom() {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+
+            'options' => [
+                'fileDragText' => function(\Kirby\Cms\File $file, string $url) {
+                    if($file->extension() === 'heic') {
+                        return sprintf('(image: %s)', $url);
+                    }
+            
+                    return null;
+                },
+            
+            ],
+
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            [
+                                'filename' => 'test.heic'
+                            ],
+                            [
+                                'filename' => 'test.jpg'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        // Custom function does not match and returns null, default case
+        $file = $app->page('test')->file('test.jpg');
+        $this->assertEquals('(image: test.jpg)', $file->dragText());
+
+        // Custom function should return image tag for heic
+        $file = $app->page('test')->file('test.heic');
+        $this->assertEquals('(image: test.heic)', $file->dragText());
+    }
+
     public function testFilename()
     {
         $this->assertEquals($this->defaults()['filename'], $this->file()->filename());

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -202,6 +202,76 @@ class PageTest extends TestCase
         $this->assertEquals('[Test Title](/test)', $page->dragText());
     }
 
+
+    public function testDragTextCustomMarkdown()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+
+            'options' => [
+                'panel' => [
+                    'kirbytext' => false,
+                    'markdown' => [
+                        'pageDragText' => function (\Kirby\Cms\Page $page) {
+                            return sprintf('Links sind toll: %s', $page->url());
+                        },
+                    ]
+                ]
+            ],
+
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'title' => 'Test Title'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+        $this->assertEquals('Links sind toll: /test', $page->dragText());
+    }
+
+    public function testDragTextCustomKirbytext()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+
+            'options' => [
+                'panel' => [
+                    'kirbytext' => [
+                        'pageDragText' => function (\Kirby\Cms\Page $page) {
+                            return sprintf('Links sind toll: %s', $page->url());
+                        },
+                    ]
+                ]
+            ],
+
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'title' => 'Test Title'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+        $this->assertEquals('Links sind toll: /test', $page->dragText());
+    }
+
+
+
     public function testId()
     {
         $page = new Page([


### PR DESCRIPTION
## Describe the PR

This pull request adds support for defining a custom function that returns the text that should be inserted into a textarea when a file is dragged onto it (or inserted via the toolbar). 

My motivation for this change was to support my custom kirby tags:

- .heic images should be inserted as (image: xxx)
- movies should be inserted as (video: xxx)

The function in the config.php could like like this:

```
  'fileDragText' => function(\Kirby\Cms\File $file, $url) {
        if($file->extension() === 'heic') {
            return sprintf('(image: %s)', $url);
        }

        if($file->type() === 'video') {
            return sprintf('(video: %s loop:true)', $url);
        }

        return null;
    },
```

## Related issues

None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
