### PR TITLE
Prevent jumping while insert link to textarea

### DIFF
--- a/panel/src/components/Forms/Toolbar/LinkDialog.vue
+++ b/panel/src/components/Forms/Toolbar/LinkDialog.vue
@@ -63,7 +63,11 @@ export default {
         return `<${this.value.url}>`;
       }
     },
-    submit() {
+    submit(e) {
+      // prevent jumping
+      if (e.preventDefault) {
+        e.preventDefault();
+      }
 
       // insert the link
       this.$emit("submit", this.kirbytext ? this.createKirbytext() : this.createMarkdown());


### PR DESCRIPTION
## Describe the PR

It was difficult to find the source of issue, but it was easy to solve. It was not working with `@submit.prevent` and I used it like Kirby's different places.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2271 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
