### PR TITLE
Styling: new SCSS variables

### DIFF
--- a/panel/src/App.vue
+++ b/panel/src/App.vue
@@ -158,25 +158,25 @@ export default {
   --color-positive: #{$color-positive};
   --color-positive-light: #{$color-positive-on-dark};
   --color-positive-outline: #{$color-positive-outline};
-  --color-text: #{$color-dark};
-  --color-text-light: #{$color-dark-grey};
+  --color-text: #{$color-gray-900};
+  --color-text-light: #{$color-gray-600};
 
   /** Font families **/
-  --font-family-mono: #{$font-family-mono};
-  --font-family-sans: #{$font-family-sans};
+  --font-family-mono: #{$font-mono};
+  --font-family-sans: #{$font-sans};
 
   /** Font sizes **/
-  --font-size-tiny: #{$font-size-tiny};
-  --font-size-small: #{$font-size-small};
-  --font-size-medium: #{$font-size-medium};
-  --font-size-large: #{$font-size-large};
-  --font-size-huge: #{$font-size-huge};
-  --font-size-monster: #{$font-size-monster};
+  --font-size-tiny: #{$text-xs};
+  --font-size-small: #{$text-sm};
+  --font-size-medium: #{$text-base};
+  --font-size-large: #{$text-xl};
+  --font-size-huge: #{$text-2xl};
+  --font-size-monster: #{$text-3xl};
 
   /** Shadows **/
-  --box-shadow-dropdown: #{$box-shadow};
-  --box-shadow-item: #{$box-shadow-card};
-  --box-shadow-focus: #{$box-shadow-focus-full};
+  --box-shadow-dropdown: #{$shadow-lg};
+  --box-shadow-item: #{$shadow};
+  --box-shadow-focus: #{$shadow-xl};
 }
 
 noscript {
@@ -189,13 +189,13 @@ noscript {
 }
 
 html {
-  font-family: $font-family-sans;
+  font-family: $font-sans;
   background: $color-background;
 }
 
 html,
 body {
-  color: $color-dark;
+  color: $color-gray-900;
   overflow: hidden;
   height: 100%;
 }
@@ -211,7 +211,7 @@ li {
 
 strong,
 b {
-  font-weight: $font-weight-bold;
+  font-weight: $font-bold;
 }
 
 .fade-enter-active,
@@ -280,7 +280,7 @@ b {
   z-index: z-index(loader);
 }
 .k-offline-warning {
-  background: rgba($color-dark, 0.7);
+  background: rgba($color-gray-900, 0.7);
   content: "offline";
   display: flex;
   align-items: center;

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -191,8 +191,8 @@
   position: relative;
   background: $color-light;
   width: 100%;
-  box-shadow: $box-shadow;
-  border-radius: $border-radius;
+  box-shadow: $shadow-lg;
+  border-radius: $rounded-xs;
   line-height: 1;
   max-height: calc(100vh - 3rem);
   margin: 1.5rem;
@@ -226,7 +226,7 @@
 
 .k-dialog-notification {
   padding: 0.75rem 1.5rem;
-  background: $color-dark;
+  background: $color-gray-900;
   width: 100%;
   line-height: 1.25rem;
   color: $color-white;
@@ -269,8 +269,8 @@
 .k-dialog-footer {
   border-top: 1px solid $color-border;
   padding: 0;
-  border-bottom-left-radius: $border-radius;
-  border-bottom-right-radius: $border-radius;
+  border-bottom-left-radius: $rounded-xs;
+  border-bottom-right-radius: $rounded-xs;
   line-height: 1;
   flex-shrink: 0;
 }
@@ -313,6 +313,6 @@
   background: rgba(#000, .075);
   padding: 0 1rem;
   height: 36px;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
 }
 </style>

--- a/panel/src/components/Dialogs/ErrorDialog.vue
+++ b/panel/src/components/Dialogs/ErrorDialog.vue
@@ -70,7 +70,7 @@ export default {
   display: block;
   overflow: auto;
   padding: 1rem;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   line-height: 1.25em;
   margin-top: 0.75rem;
 }

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -223,9 +223,9 @@ $cell-padding: 0.25rem 0.5rem;
 
 .k-calendar-input {
   padding: 0.5rem;
-  background: $color-dark;
+  background: $color-gray-900;
   color: $color-light;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
 }
 .k-calendar-table {
   table-layout: fixed;
@@ -259,8 +259,8 @@ $cell-padding: 0.25rem 0.5rem;
 }
 .k-calendar-selects .k-select-input {
   padding: 0 0.5rem;
-  font-weight: $font-weight-normal;
-  font-size: $font-size-small;
+  font-weight: $font-normal;
+  font-size: $text-sm;
 }
 .k-calendar-selects .k-select-input:focus-within {
   color: $color-focus-on-dark !important;
@@ -268,7 +268,7 @@ $cell-padding: 0.25rem 0.5rem;
 .k-calendar-input th {
   padding: 0.5rem 0;
   color: $color-light-grey;
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
   font-weight: 400;
   text-align: center;
 }
@@ -306,7 +306,7 @@ $cell-padding: 0.25rem 0.5rem;
 }
 .k-calendar-today .k-button {
   color: $color-focus-on-dark;
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
   padding: 1rem;
 }
 .k-calendar-today .k-button-text {

--- a/panel/src/components/Forms/Counter.vue
+++ b/panel/src/components/Forms/Counter.vue
@@ -44,9 +44,9 @@ export default {
 
 <style lang="scss">
 .k-counter {
-  font-size: $font-size-tiny;
-  color: $color-dark;
-  font-weight: $font-weight-bold;
+  font-size: $text-xs;
+  color: $color-gray-900;
+  font-weight: $font-bold;
 }
 .k-counter[data-invalid] {
   box-shadow: none;
@@ -54,8 +54,8 @@ export default {
   color: $color-negative;
 }
 .k-counter-rules {
-  color: $color-dark-grey;
-  font-weight: $font-weight-normal;
+  color: $color-gray-600;
+  font-weight: $font-normal;
 
   [dir="ltr"] & {
     padding-left: .5rem;

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -63,7 +63,7 @@ export default {
 
 <style lang="scss">
 .k-field-label {
-  font-weight: $font-weight-bold;
+  font-weight: $font-bold;
   display: block;
   padding: 0 0 0.75rem;
   flex-grow: 1;

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -603,9 +603,9 @@ $structure-item-height: 38px;
   table-layout: fixed;
   width: 100%;
   background: #fff;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   border-spacing: 0;
-  box-shadow: $box-shadow-card;
+  box-shadow: $shadow;
 
   th,
   td {
@@ -636,7 +636,7 @@ $structure-item-height: 38px;
     background: #fff;
     font-weight: 400;
     z-index: 1;
-    color: $color-dark-grey;
+    color: $color-gray-600;
     padding: 0 0.75rem;
     height: $structure-item-height;
 
@@ -671,7 +671,7 @@ $structure-item-height: 38px;
   }
 
   /* mobile */
-  @media screen and (max-width: $breakpoint-medium) {
+  @media screen and (max-width: $breakpoint-md) {
     td,
     th {
       display: none;
@@ -739,7 +739,7 @@ $structure-item-height: 38px;
     text-align: center;
   }
   .k-structure-table-index-number {
-    font-size: $font-size-tiny;
+    font-size: $text-xs;
     color: $color-light-grey;
     padding-top: 0.15rem;
   }
@@ -777,7 +777,7 @@ $structure-item-height: 38px;
 
   .k-sortable-ghost {
     background: $color-white;
-    box-shadow: rgba($color-dark, 0.25) 0 5px 10px;
+    box-shadow: rgba($color-gray-900, 0.25) 0 5px 10px;
     outline: 2px solid $color-focus;
     margin-bottom: 2px;
     cursor: grabbing;
@@ -802,9 +802,9 @@ $structure-item-height: 38px;
 .k-structure-form {
   position: relative;
   z-index: 3;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   margin-bottom: 1px;
-  box-shadow: rgba($color-dark, 0.05) 0 0 0 3px;
+  box-shadow: rgba($color-gray-900, 0.05) 0 0 0 3px;
   border: 1px solid $color-border;
   background: $color-background;
 }
@@ -821,7 +821,7 @@ $structure-item-height: 38px;
 
 .k-structure-form-buttons .k-pagination {
   display: none;
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     display: flex;
   }
 }

--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -121,7 +121,7 @@ export default {
   grid-row-gap: 2.25rem;
 }
 
-@media screen and (min-width: $breakpoint-small) {
+@media screen and (min-width: $breakpoint-sm) {
   .k-fieldset .k-grid {
     grid-column-gap: 1.5rem;
   }

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -380,7 +380,7 @@ export default {
 
 .k-form-lock-info {
   display: flex;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   align-items: center;
   line-height: 1.5em;
   padding: .625rem 0;

--- a/panel/src/components/Forms/FormIndicator.vue
+++ b/panel/src/components/Forms/FormIndicator.vue
@@ -153,8 +153,8 @@ export default {
 }
 
 .k-form-indicator-info {
-  font-size: $font-size-small;
-  font-weight: $font-weight-bold;
+  font-size: $text-sm;
+  font-weight: $font-bold;
   padding: .75rem 1rem .25rem;
   line-height: 1.25em;
   width: 15rem;

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -208,7 +208,7 @@ export default {
   .k-date-input .k-select-input:focus-within,
   .k-time-input .k-select-input:focus-within {
     color: $color-focus;
-    font-weight: $font-weight-bold;
+    font-weight: $font-bold;
   }
   .k-time-input .k-time-input-meridiem {
     padding-left: $field-input-padding;
@@ -242,7 +242,7 @@ export default {
       margin-bottom: -1px;
       margin-right: -1px;
 
-      @media screen and (min-width: $breakpoint-medium) {
+      @media screen and (min-width: $breakpoint-md) {
         grid-template-columns: repeat(var(--columns), 1fr);
       }
 
@@ -281,7 +281,7 @@ export default {
       margin-bottom: -1px;
       margin-right: -1px;
 
-      @media screen and (min-width: $breakpoint-medium) {
+      @media screen and (min-width: $breakpoint-md) {
         grid-template-columns: repeat(var(--columns), 1fr);
       }
     }
@@ -303,8 +303,8 @@ export default {
     }
     .k-radio-input .k-radio-input-info {
       display: block;
-      font-size: $font-size-small;
-      color: $color-dark-grey;
+      font-size: $text-sm;
+      color: $color-gray-600;
       line-height: $field-input-line-height;
       padding-top: $field-input-line-height / 10;
     }
@@ -352,10 +352,10 @@ export default {
       margin-right: .25rem;
       margin-bottom: .25rem;
       height: 1.75rem;
-      font-size: $font-size-small;
+      font-size: $text-sm;
     }
     .k-tags-input input {
-      font-size: $font-size-small;
+      font-size: $text-sm;
       padding: 0 .25rem;
       height: 1.75rem;
       line-height: 1;
@@ -378,7 +378,7 @@ export default {
       margin-right: .25rem;
       margin-bottom: .25rem;
       height: 1.75rem;
-      font-size: $font-size-small;
+      font-size: $text-sm;
     }
     .k-input-icon {
       position: absolute;

--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -111,14 +111,14 @@ export default {
   stroke: $color-white;
 }
 .k-checkbox-input-native:checked + .k-checkbox-input-icon {
-  border-color: $color-dark;
-  background: $color-dark;
+  border-color: $color-gray-900;
+  background: $color-gray-900;
 }
 .k-checkbox-input-native:checked + .k-checkbox-input-icon svg {
   display: block;
 }
 .k-checkbox-input-native:focus + .k-checkbox-input-icon {
-  border-color: $color-focus-border;
+  border-color: $color-blue-600;
 }
 .k-checkbox-input-native:focus:checked + .k-checkbox-input-icon {
   background: $color-focus;

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -311,7 +311,7 @@ export default {
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   min-height: 2.25rem;
   line-height: 1;
 }
@@ -326,7 +326,7 @@ export default {
 .k-multiselect-search {
   margin-top: 0 !important;
   color: $color-white;
-  background: $color-dark;
+  background: $color-gray-900;
   border-bottom: 1px dashed rgba($color-white, 0.2);
 
   > .k-button-text {

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -108,11 +108,11 @@ export default {
   box-shadow: $color-white 0 0 0 2px inset;
 }
 .k-radio-input input:checked + label::before {
-  border-color: $color-dark;
-  background: $color-dark;
+  border-color: $color-gray-900;
+  background: $color-gray-900;
 }
 .k-radio-input input:focus + label::before {
-  border-color: $color-focus-border;
+  border-color: $color-blue-600;
 }
 .k-radio-input input:focus:checked + label::before {
   background: $color-focus;

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -128,13 +128,13 @@ export default {
 <style lang="scss">
 
 $range-thumb-size: 16px;
-$range-thumb-border: 4px solid $color-dark;
+$range-thumb-border: 4px solid $color-gray-900;
 $range-thumb-background: $color-background;
 $range-thumb-focus-border: 4px solid $color-focus;
 $range-thumb-focus-background: $color-background;
 $range-track-height: 4px;
 $range-track-background: $color-border;
-$range-track-color: $color-dark;
+$range-track-color: $color-gray-900;
 $range-track-focus-color: $color-focus;
 
 @mixin track($fill: 0) {
@@ -186,7 +186,7 @@ $range-track-focus-color: $color-focus;
   width: 100%;
   height: $range-thumb-size;
   background: transparent;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   line-height: 1;
 
   &::-webkit-slider-thumb {
@@ -254,11 +254,11 @@ $range-track-focus-color: $color-focus;
   display: flex;
   align-items: center;
   color: $color-white;
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
   line-height: 1;
   text-align: center;
-  border-radius: $border-radius;
-  background: $color-dark;
+  border-radius: $rounded-xs;
+  background: $color-gray-900;
   margin-left: 1rem;
   padding: 0 .25rem;
   white-space: nowrap;
@@ -271,7 +271,7 @@ $range-track-focus-color: $color-focus;
     height: 0;
     transform: translateY(-50%);
     border-top: 5px solid transparent;
-    border-right: 5px solid $color-dark;
+    border-right: 5px solid $color-gray-900;
     border-bottom: 5px solid transparent;
     content: "";
   }

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -168,6 +168,6 @@ export default {
   cursor: default;
 }
 .k-select-input-native {
-  font-weight: $font-weight-normal;
+  font-weight: $font-normal;
 }
 </style>

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -320,7 +320,7 @@ export default {
   min-height: 45rem;
 }
 .k-textarea-input-native[data-font="monospace"] {
-  font-family: $font-family-mono;
+  font-family: $font-mono;
 }
 
 .k-toolbar {

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -87,7 +87,7 @@ export default {
 <style lang="scss">
 $toggle-background: $color-white;
 $toggle-color: $color-light-grey;
-$toggle-active-color: $color-dark;
+$toggle-active-color: $color-gray-900;
 $toggle-focus-color: $color-focus;
 $toggle-height: 16px;
 
@@ -120,7 +120,7 @@ $toggle-height: 16px;
     box-shadow: inset 0 0 0 2px $color-background, inset $toggle-height*-1 0px 0px 2px $color-background;
     background-color: $color-border;
   }
-  
+
   &[disabled]:checked {
     box-shadow: inset 0 0 0 2px $color-background, inset $toggle-height 0px 0px 2px $color-background;
   }

--- a/panel/src/components/Forms/Previews/PagesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/PagesFieldPreview.vue
@@ -34,7 +34,7 @@ export default {
   display: flex;
   align-items: stretch;
   background: $color-background;
-  box-shadow: $box-shadow-card;
+  box-shadow: $shadow;
 }
 .k-pages-field-preview-image {
   width: 1.525rem;
@@ -47,7 +47,7 @@ export default {
   padding: 0 0.5rem;
   border: 1px solid $color-border;
   border-left: 0;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/panel/src/components/Forms/Previews/UsersFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UsersFieldPreview.vue
@@ -46,7 +46,7 @@ export default {
   display: flex;
   align-items: stretch;
   background: $color-background;
-  box-shadow: $box-shadow-card;
+  box-shadow: $shadow;
 }
 .k-users-field-preview-avatar {
   width: 1.525rem;
@@ -62,7 +62,7 @@ export default {
   padding: 0 .5rem;
   border: 1px solid $color-border;
   border-left: 0;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -177,25 +177,25 @@ export default {
 .k-upload-list,
 .k-upload-error-list {
   line-height: 1.5em;
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-upload-list-filename {
-  color: $color-dark-grey;
+  color: $color-gray-600;
 }
 
 .k-upload-error-list li {
   padding: 0.75rem;
   background: $color-white;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
 }
 .k-upload-error-list li:not(:last-child) {
   margin-bottom: 2px;
 }
 .k-upload-error-filename {
   color: $color-negative;
-  font-weight: $font-weight-bold;
+  font-weight: $font-bold;
 }
 .k-upload-error-message {
-  color: $color-dark-grey;
+  color: $color-gray-600;
 }
 </style>

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -18,22 +18,22 @@ export default {
 <style lang="scss">
 .k-box {
   word-wrap: break-word;
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-box:not([data-theme="none"]) {
   background: lighten($color-light-grey, 25%);
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   padding: 0.375rem 0.75rem;
   line-height: 1.25rem;
   border-left: 2px solid $color-light-grey;
   padding: 0.5rem 1.5rem;
 }
 .k-box[data-theme="code"] {
-  background: $color-dark;
+  background: $color-gray-900;
   border: 1px solid $color-black;
   color: $color-light;
   font-family: "Input", "Menlo", monospace;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   line-height: 1.5;
 }
 .k-box[data-theme="button"] {
@@ -83,8 +83,8 @@ export default {
   align-items: center;
   flex-direction: column;
   background: $color-background;
-  border-radius: $border-radius;
-  color: $color-dark-grey;
+  border-radius: $rounded-xs;
+  color: $color-gray-600;
   border: 1px dashed $color-border;
 }
 .k-box[data-theme="empty"] .k-icon {
@@ -92,6 +92,6 @@ export default {
   color: $color-light-grey;
 }
 .k-box[data-theme="empty"] p {
-  color: $color-dark-grey;
+  color: $color-gray-600;
 }
 </style>

--- a/panel/src/components/Layout/Card.vue
+++ b/panel/src/components/Layout/Card.vue
@@ -91,8 +91,8 @@ export default {
   position: relative;
   min-width: 0;
   background: $color-white;
-  border-radius: $border-radius;
-  box-shadow: $box-shadow-card;
+  border-radius: $rounded-xs;
+  box-shadow: $shadow;
 }
 .k-card a {
   min-width: 0;
@@ -110,10 +110,10 @@ export default {
   top: 0.75rem;
   width: 2rem;
   height: 2rem;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   background: $color-white;
   opacity: 0;
-  color: $color-dark;
+  color: $color-gray-900;
   z-index: 1;
   will-change: opacity;
   transition: opacity 0.3s;
@@ -139,8 +139,8 @@ export default {
 
 .k-card-image,
 .k-card-icon {
-  border-top-left-radius: $border-radius;
-  border-top-right-radius: $border-radius;
+  border-top-left-radius: $rounded-xs;
+  border-top-right-radius: $rounded-xs;
   overflow: hidden;
 }
 .k-card-icon {
@@ -164,8 +164,8 @@ export default {
 
 .k-card-content {
   line-height: 1.25rem;
-  border-bottom-left-radius: $border-radius;
-  border-bottom-right-radius: $border-radius;
+  border-bottom-left-radius: $rounded-xs;
+  border-bottom-right-radius: $rounded-xs;
   min-height: 2.25rem;
   padding: 0.5rem 0.75rem;
   overflow-wrap: break-word;
@@ -174,9 +174,9 @@ export default {
 
 .k-card-text {
   display: block;
-  font-weight: $font-weight-normal;
+  font-weight: $font-normal;
   text-overflow: ellipsis;
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-card-text[data-noinfo]:after {
   content: " ";
@@ -185,9 +185,9 @@ export default {
   display: inline-block;
 }
 .k-card-info {
-  color: $color-dark-grey;
+  color: $color-gray-600;
   display: block;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   text-overflow: ellipsis;
   overflow: hidden;
 

--- a/panel/src/components/Layout/Cards.vue
+++ b/panel/src/components/Layout/Cards.vue
@@ -34,7 +34,7 @@ export default {
   grid-template-columns: repeat(auto-fill, minmax(#{"min(12rem, 100%)"}, 1fr));
 }
 
-@media screen and (min-width: $breakpoint-small) {
+@media screen and (min-width: $breakpoint-sm) {
   .k-cards[data-size="tiny"] {
     grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     /**
@@ -83,7 +83,7 @@ export default {
   }
 }
 
-@media screen and (min-width: $breakpoint-medium) {
+@media screen and (min-width: $breakpoint-md) {
   .k-cards[data-size="large"] {
     grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
     /**

--- a/panel/src/components/Layout/Column.vue
+++ b/panel/src/components/Layout/Column.vue
@@ -25,7 +25,7 @@ export default {
   z-index: 2;
 }
 
-@media screen and (min-width: $breakpoint-medium) {
+@media screen and (min-width: $breakpoint-md) {
   .k-column[data-width="1/1"],
   .k-column[data-width="2/2"],
   .k-column[data-width="3/3"],

--- a/panel/src/components/Layout/Empty.vue
+++ b/panel/src/components/Layout/Empty.vue
@@ -40,9 +40,8 @@ export default {
 .k-empty {
   display: flex;
   align-items: stretch;
-  border-radius: $border-radius;
-
-  color: $color-dark-grey;
+  border-radius: $rounded-xs;
+  color: $color-gray-600;
   border: 1px dashed $color-border;
 }
 button.k-empty {
@@ -52,11 +51,11 @@ button.k-empty:focus {
   outline: none;
 }
 .k-empty p {
-  font-size: $font-size-small;
-  color: $color-dark-grey;
+  font-size: $text-sm;
+  color: $color-gray-600;
 }
 .k-empty > .k-icon {
-  color: $color-light-grey;
+  color: $color-gray-500;
 }
 
 /* layout:cards */

--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -72,19 +72,19 @@ export default {
 </script>
 <style lang="scss">
 .k-file-preview {
-  background: lighten($color-dark, 10%);
+  background: lighten($color-gray-900, 10%);
 }
 .k-file-preview-layout {
   display: grid;
 
-  @media screen and (max-width: $breakpoint-medium) {
+  @media screen and (max-width: $breakpoint-md) {
     padding: 0 !important;
   }
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     grid-template-columns: 50% auto;
   }
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     display: flex;
     align-items: center;
   }
@@ -96,10 +96,10 @@ export default {
   position: relative;
   background: url($pattern);
 
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     width: 33.33%;
   }
-  @media screen and (min-width: $breakpoint-large) {
+  @media screen and (min-width: $breakpoint-lg) {
     width: 25%;
   }
 }
@@ -108,7 +108,7 @@ export default {
   overflow: hidden;
   padding-bottom: 66.66%;
 
-  @media screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-md) {
     position: absolute;
     top: 0;
     left: 0;
@@ -117,7 +117,7 @@ export default {
     padding-bottom: 0 !important;
   }
 
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     padding-bottom: 100%;
   }
 }
@@ -156,7 +156,7 @@ export default {
   padding: 1.5rem;
   flex-grow: 1;
 
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     padding: 3rem;
   }
 }
@@ -167,12 +167,12 @@ export default {
   grid-gap: 1.5rem 3rem;
   grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
 .k-file-preview-details h3 {
-  font-size: $font-size-small;
+  font-size: $text-sm;
   font-weight: 500;
   color: $color-light-grey;
 }
@@ -181,7 +181,7 @@ export default {
   overflow: hidden;
   text-overflow: ellipsis;
   color: rgba($color-white, 0.75);
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-file-preview-details p a {
   display: block;

--- a/panel/src/components/Layout/Grid.vue
+++ b/panel/src/components/Layout/Grid.vue
@@ -21,7 +21,7 @@ export default {
   grid-template-columns: 1fr;
 }
 
-@media screen and (min-width: $breakpoint-small) {
+@media screen and (min-width: $breakpoint-sm) {
 
   .k-grid[data-gutter="small"] {
     grid-column-gap: 1rem;
@@ -37,7 +37,7 @@ export default {
 
 }
 
-@media screen and (min-width: $breakpoint-medium) {
+@media screen and (min-width: $breakpoint-md) {
   .k-grid {
     grid-template-columns: repeat(var(--columns), 1fr);
   }
@@ -49,7 +49,7 @@ export default {
   }
 }
 
-@media screen and (min-width: $breakpoint-large) {
+@media screen and (min-width: $breakpoint-lg) {
   .k-grid[data-gutter="large"] {
     grid-column-gap: 4.5rem;
   }
@@ -59,7 +59,7 @@ export default {
 
 }
 
-@media screen and (min-width: $breakpoint-huge) {
+@media screen and (min-width: $breakpoint-xl) {
   .k-grid[data-gutter="large"] {
     grid-column-gap: 6rem;
   }

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -94,5 +94,4 @@ export default {
 .k-header .k-headline-editable:hover .k-icon {
   opacity: 1;
 }
-
 </style>

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -86,8 +86,8 @@ $list-item-height: 38px;
   display: flex;
   align-items: center;
   background: $color-white;
-  border-radius: $border-radius;
-  box-shadow: $box-shadow-card;
+  border-radius: $rounded-xs;
+  box-shadow: $shadow;
 }
 .k-list-item .k-sort-handle {
   position: absolute;
@@ -106,7 +106,7 @@ $list-item-height: 38px;
   position: relative;
   outline: 2px solid $color-focus;
   z-index: 1;
-  box-shadow: rgba($color-dark, 0.25) 0 5px 10px;
+  box-shadow: rgba($color-gray-900, 0.25) 0 5px 10px;
 }
 .k-list-item.k-sortable-fallback {
   opacity: 0.25 !important;
@@ -156,19 +156,19 @@ $list-item-height: 38px;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: $font-size-small;
-  color: $list-item-text-color;
+  font-size: $text-sm;
+  color: $color-gray-900;
 }
 .k-list-item-text small {
   color: $color-light-grey;
-  font-size: $font-size-tiny;
-  color: $list-item-info-color;
+  font-size: $text-xs;
+  color: $color-gray-600;
   display: none;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     display: block;
   }
 }

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -143,7 +143,7 @@ export default {
   justify-content: center;
   align-items: center;
   padding: .625rem .75rem;
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
   text-transform: uppercase;
   text-align: center;
   font-weight: 500;
@@ -154,12 +154,12 @@ export default {
   flex-direction: column;
   max-width: 15rem;
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     flex-direction: row;
   }
 }
 .k-tab-button.k-button .k-icon {
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     margin-right: .5rem;
   }
 }
@@ -179,8 +179,8 @@ export default {
 
   text-overflow: ellipsis;
 
-  @media screen and (min-width: $breakpoint-small) {
-    font-size: $font-size-tiny;
+  @media screen and (min-width: $breakpoint-sm) {
+    font-size: $text-xs;
     padding-top: 0;
   }
 
@@ -235,6 +235,6 @@ export default {
   }
 }
 .k-tabs[data-theme="notice"] .k-tabs-badge {
-  color: $color-notice;
+  color: $color-orange-600;
 }
 </style>

--- a/panel/src/components/Layout/View.vue
+++ b/panel/src/components/Layout/View.vue
@@ -19,12 +19,12 @@ export default {
   margin: 0 auto;
   max-width: 100rem;
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     padding-left: 3rem;
     padding-right: 3rem;
   }
 
-  @media screen and (min-width: $breakpoint-large) {
+  @media screen and (min-width: $breakpoint-lg) {
     padding-left: 6rem;
     padding-right: 6rem;
   }

--- a/panel/src/components/Misc/Headline.vue
+++ b/panel/src/components/Misc/Headline.vue
@@ -32,27 +32,27 @@ export default {
 
 <style lang="scss">
 .k-headline {
-  font-size: $font-size-medium;
-  font-weight: $font-weight-bold;
+  font-size: $text-base;
+  font-weight: $font-bold;
   line-height: 1.5em;
 }
 .k-headline[data-size="small"] {
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-headline[data-size="large"] {
-  font-size: $font-size-large;
-  font-weight: $font-weight-normal;
+  font-size: $text-xl;
+  font-weight: $font-normal;
 
-  @media screen and (min-width: $breakpoint-medium) {
-    font-size: $font-size-huge;
+  @media screen and (min-width: $breakpoint-md) {
+    font-size: $text-2xl;
   }
 }
 .k-headline[data-size="huge"] {
-  font-size: $font-size-huge;
+  font-size: $text-2xl;
   line-height: 1.15em;
 
-  @media screen and (min-width: $breakpoint-medium) {
-    font-size: $font-size-monster;
+  @media screen and (min-width: $breakpoint-md) {
+    font-size: $text-3xl;
   }
 }
 .k-headline[data-theme="negative"] {

--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -49,15 +49,15 @@ export default {
   fill: currentColor;
 }
 .k-icon[data-back="black"] {
-  background: $color-dark;
+  background: $color-gray-900;
   color: $color-white;
 }
 .k-icon[data-back="white"] {
   background: $color-white;
-  color: $color-dark;
+  color: $color-gray-900;
 }
 .k-icon[data-back="pattern"] {
-  background: lighten($color-dark, 10%) url($pattern);
+  background: lighten($color-gray-900, 10%) url($pattern);
   color: $color-white;
 }
 .k-icon[data-size="medium"] svg {

--- a/panel/src/components/Misc/Image.vue
+++ b/panel/src/components/Misc/Image.vue
@@ -108,17 +108,17 @@ export default {
   object-fit: cover;
 }
 .k-image[data-back="black"] span {
-  background: $color-dark;
+  background: $color-gray-900;
 }
 .k-image[data-back="white"] span {
   background: $color-white;
-  color: $color-dark;
+  color: $color-gray-900;
 }
 .k-image[data-back="white"] .k-image-error {
-  background: $color-dark;
+  background: $color-gray-900;
   color: $color-white;
 }
 .k-image[data-back="pattern"] span {
-  background: lighten($color-dark, 10%) url($pattern);
+  background: lighten($color-gray-900, 10%) url($pattern);
 }
 </style>

--- a/panel/src/components/Misc/SortHandle.vue
+++ b/panel/src/components/Misc/SortHandle.vue
@@ -13,7 +13,7 @@
   cursor: -moz-grab;
   cursor: -webkit-grab;
   line-height: 0;
-  color: $color-dark;
+  color: $color-gray-900;
   justify-content: center;
   align-items: center;
   line-height: 0;

--- a/panel/src/components/Misc/Text.vue
+++ b/panel/src/components/Misc/Text.vue
@@ -41,21 +41,21 @@ export default {
 }
 
 .k-text[data-size="tiny"] {
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
 }
 .k-text[data-size="small"] {
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-text[data-size="medium"] {
-  font-size: $font-size-medium;
+  font-size: $text-base;
 }
 .k-text[data-size="large"] {
-  font-size: $font-size-large;
+  font-size: $text-xl;
 }
 
 .k-text[data-theme="help"] {
-  font-size: $font-size-small;
-  color: $color-dark-grey;
+  font-size: $text-sm;
+  color: $color-gray-600;
   line-height: 1.25rem;
 }
 

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -64,7 +64,7 @@ export default {
 button {
   line-height: inherit;
   border: 0;
-  font-family: $font-family-sans;
+  font-family: $font-sans;
   font-size: 1rem;
   color: currentColor;
   background: none;
@@ -78,7 +78,7 @@ button::-moz-focus-inner {
 .k-button {
   display: inline-block;
   position: relative;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   transition: color 0.3s;
 
   &:focus,
@@ -97,7 +97,7 @@ button::-moz-focus-inner {
 .k-button[data-responsive] .k-button-text {
   display: none;
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     display: inline;
   }
 }

--- a/panel/src/components/Navigation/DropdownContent.vue
+++ b/panel/src/components/Navigation/DropdownContent.vue
@@ -169,11 +169,11 @@ export default {
 .k-dropdown-content {
   position: absolute;
   top: 100%;
-  background: $color-dark;
+  background: $color-gray-900;
   color: $color-white;
   z-index: z-index(dropdown);
-  box-shadow: $box-shadow;
-  border-radius: $border-radius;
+  box-shadow: $shadow-lg;
+  border-radius: $rounded-xs;
   text-align: left;
   margin-bottom: 6rem;
 

--- a/panel/src/components/Navigation/DropdownItem.vue
+++ b/panel/src/components/Navigation/DropdownItem.vue
@@ -51,7 +51,7 @@ export default {
   display: flex;
   width: 100%;
   align-items: center;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   padding: 6px 16px;
 
   &:focus {

--- a/panel/src/components/Navigation/Pagination.vue
+++ b/panel/src/components/Navigation/Pagination.vue
@@ -231,7 +231,7 @@ export default {
   white-space: nowrap;
 }
 .k-pagination > span {
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-pagination[data-align="center"] {
   text-align: center;
@@ -269,7 +269,7 @@ export default {
   border-right: 1px solid rgba(#fff, .35);
   align-items: center;
   padding: .625rem 1rem;
-  font-size: $font-size-tiny;
+  font-size: $text-xs;
 }
 .k-pagination-settings label span {
   margin-right: .5rem;

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -263,7 +263,7 @@ export default {
 .k-search li {
   background: $color-white;
   display: flex;
-  box-shadow: $box-shadow-card;
+  box-shadow: $shadow;
 
   &:not(:last-child) {
     margin-bottom: .25rem;

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -209,9 +209,9 @@ export default {
 .k-search {
   max-width: 30rem;
   margin: 0 auto;
-  box-shadow: $box-shadow;
+  box-shadow: $shadow-lg;
 
-  @media screen and (min-width: $breakpoint-medium) {
+  @media screen and (min-width: $breakpoint-md) {
     margin: 2.5rem auto;
   }
 }
@@ -225,7 +225,7 @@ export default {
 }
 .k-search-types > .k-button {
   padding: 0 0 0 1rem;
-  font-size: $font-size-medium;
+  font-size: $text-base;
   line-height: 1;
   height: 2.5rem;
 
@@ -290,17 +290,17 @@ export default {
 
 .k-search li strong {
   display: block;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   font-weight: 400;
 }
 .k-search li small {
-  font-size: $font-size-tiny;
-  color: $color-dark-grey;
+  font-size: $text-xs;
+  color: $color-gray-600;
 }
 
 .k-search-empty {
   text-align: center;
-  font-size: $font-size-small;
-  color: $color-dark-grey;
+  font-size: $text-xs;
+  color: $color-gray-600;
 }
 </style>

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -33,12 +33,12 @@ export default {
 <style lang="scss">
 .k-tag {
   position: relative;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   line-height: 1;
   cursor: pointer;
-  background-color: $color-dark;
+  background-color: $color-gray-900;
   color: $color-light;
-  border-radius: $border-radius;
+  border-radius: $rounded-xs;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/panel/src/components/Navigation/Topbar.vue
+++ b/panel/src/components/Navigation/Topbar.vue
@@ -203,7 +203,7 @@ export default {
   flex-shrink: 0;
   height: 2.5rem;
   line-height: 1;
-  background: $color-dark;
+  background: $color-gray-900;
 }
 .k-topbar-wrapper {
   position: relative;
@@ -220,7 +220,7 @@ export default {
   height: 2.5rem;
   width: 2.5rem;
   padding: .75rem;
-  background: $color-dark;
+  background: $color-gray-900;
   z-index: 1;
   display: flex;
   align-items: center;
@@ -249,7 +249,7 @@ export default {
 .k-topbar-button {
   padding: 0.75rem;
   line-height: 1;
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-topbar-signals .k-button .k-button-text {
   opacity: 1;
@@ -287,7 +287,7 @@ export default {
 }
 .k-topbar-crumbs a {
   position: relative;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -315,7 +315,7 @@ export default {
 .k-topbar-breadcrumb-menu {
   flex-shrink: 0;
 }
-@media screen and (min-width: $breakpoint-small) {
+@media screen and (min-width: $breakpoint-sm) {
   .k-topbar-crumbs a {
     display: block;
   }
@@ -326,7 +326,7 @@ export default {
 .k-topbar-signals {
   position: absolute;
   top: 0;
-  background: $color-dark;
+  background: $color-gray-900;
   height: 2.5rem;
   display: flex;
   align-items: center;
@@ -350,8 +350,8 @@ export default {
     left: -0.5rem;
     background: -webkit-linear-gradient(
       left,
-      rgba($color-dark, 0),
-      rgba($color-dark, 1)
+      rgba($color-gray-900, 0),
+      rgba($color-gray-900, 1)
     );
   }
 
@@ -359,8 +359,8 @@ export default {
     right: -0.5rem;
     background: -webkit-linear-gradient(
       right,
-      rgba($color-dark, 0),
-      rgba($color-dark, 1)
+      rgba($color-gray-900, 0),
+      rgba($color-gray-900, 1)
     );
   }
 }
@@ -369,7 +369,7 @@ export default {
 }
 
 .k-topbar-notification {
-  font-weight: $font-weight-bold;
+  font-weight: $font-bold;
   line-height: 1;
   display: flex;
 }
@@ -382,7 +382,7 @@ export default {
 .k-topbar .k-button[data-theme="negative"] .k-button-text {
   display: none;
 
-  @media screen and (min-width: $breakpoint-small) {
+  @media screen and (min-width: $breakpoint-sm) {
     display: inline;
   }
 }
@@ -390,7 +390,7 @@ export default {
   opacity: 1;
 }
 .k-topbar .k-dropdown-content {
-  color: $color-dark;
+  color: $color-gray-900;
   background: $color-white;
 }
 .k-topbar .k-dropdown-content hr:after {
@@ -409,12 +409,12 @@ export default {
 }
 .k-registration p {
   color: $color-negative-on-dark;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   margin-right: 1rem;
   font-weight: 600;
   display: none;
 
-  @media screen and (min-width: $breakpoint-large) {
+  @media screen and (min-width: $breakpoint-lg) {
     display: block;
   }
 }

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -181,7 +181,7 @@ export default {
 }
 .k-installation-issues {
   line-height: 1.5em;
-  font-size: $font-size-small;
+  font-size: $text-sm;
 }
 .k-installation-issues li {
   position: relative;

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -81,7 +81,7 @@ export default {
   align-items: center;
   padding: 0.5rem 0;
   flex-grow: 1;
-  font-size: $font-size-small;
+  font-size: $text-sm;
   cursor: pointer;
 }
 
@@ -104,9 +104,9 @@ export default {
   margin-bottom: 2rem;
   background: $color-negative;
   color: #fff;
-  font-size: $font-size-small;
-  border-radius: $border-radius;
-  box-shadow: $box-shadow;
+  font-size: $text-sm;
+  border-radius: $rounded-xs;
+  box-shadow: $shadow-lg;
   cursor: pointer;
 }
 </style>

--- a/panel/src/components/Views/SettingsView.vue
+++ b/panel/src/components/Views/SettingsView.vue
@@ -176,8 +176,8 @@ export default {
   flex-basis: 0;
 }
 .k-system-info-box dt {
-  font-size: $font-size-small;
-  color: $color-dark-grey;
+  font-size: $text-sm;
+  color: $color-gray-600;
   margin-bottom: .25rem;
 }
 .k-system-unregistered {

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -308,7 +308,7 @@ export default {
 .k-user-view-image .k-icon {
   width: 4rem;
   height: 4rem;
-  background: $color-dark;
+  background: $color-gray-900;
   color: $color-light-grey;
 }
 
@@ -317,6 +317,6 @@ export default {
   transition: color 0.3s;
 }
 .k-header[data-editable] .k-user-name-placeholder:hover {
-  color: $color-dark;
+  color: $color-gray-900;
 }
 </style>

--- a/panel/src/main.scss
+++ b/panel/src/main.scss
@@ -6,11 +6,12 @@
  * file is imported. Use only for mixins, variables and functions.
  */
 
-$layers: (
-  loader: 900,
-  notification: 800,
-  dropdown: 700,
-  dialog: 600,
+ $z-index: (
+  loader: 1000,
+  notification: 900,
+  dropdown: 800,
+  dialog: 700,
+  drawer: 600,
   dropzone: 500,
   toolbar: 400,
   navigation: 300,
@@ -19,7 +20,11 @@ $layers: (
 );
 
 @function z-index($key, $add: 0) {
-  @return map-get($layers, $key) + $add;
+  @return map-get($z-index, $key) + $add;
+}
+
+@function spacing($key) {
+  @return map-get($spacing, $key);
 }
 
 /**
@@ -27,111 +32,137 @@ $layers: (
  */
 $color-black: #000;
 $color-white: #fff;
-$color-dark: #16171a;
-$color-dark-grey: #777;
-$color-light: #efefef;
-$color-light-grey: #999;
-$color-background: $color-light;
-$color-positive: #5d800d;
-$color-positive-border: $color-positive;
+
+$color-gray-100: #f7f7f7;
+$color-gray-200: #efefef;
+$color-gray-300: #ddd;
+$color-gray-400: #ccc;
+$color-gray-500: #999;
+$color-gray-600: #777;
+$color-gray-700: #555;
+$color-gray-800: #333;
+$color-gray-900: #111;
+
+$color-red-200: #edc1c1;
+$color-red-300: #e3a0a0;
+$color-red-400: #d16464;
+$color-red-600: #c82829;
+
+$color-orange-200: #f2d4bf;
+$color-orange-300: #ebbe9e;
+$color-orange-400: #de935f;
+$color-orange-600: #f4861f;
+
+$color-yellow-200: #f9e8c7;
+$color-yellow-300: #f7e2b8;
+$color-yellow-400: #f0c674;
+$color-yellow-600: #cca000;
+
+$color-green-200: #dce5c2;
+$color-green-300: #c6d49d;
+$color-green-400: #a7bd68;
+$color-green-600: #5d800d;
+
+$color-aqua-200: #d0e5e2;
+$color-aqua-300: #bbd9d5;
+$color-aqua-400: #8abeb7;
+$color-aqua-600: #398e93;
+
+$color-blue-200: #cbd7e5;
+$color-blue-300: #b1c2d8;
+$color-blue-400: #7e9abf;
+$color-blue-600: #4271ae;
+
+$color-purple-200: #e0d4e4;
+$color-purple-300: #d4c3d9;
+$color-purple-400: #b294bb;
+$color-purple-600: #9c48b9;
+
+
+/**
+ * Color Aliases
+ */
+$color-backdrop: rgba($color-black, 0.6);
+$color-background: $color-gray-200;
+$color-border: $color-gray-400;
+$color-placeholder: $color-gray-500;
+$color-light: $color-gray-200;
+
+/**
+ * Deprecated Colors
+ */
+$color-gray-700: $color-gray-700;
+$color-light-grey: $color-gray-500;
+$color-positive: $color-green-600;
 $color-positive-outline: rgba($color-positive, 0.25);
-$color-positive-on-dark: #a7bd68;
-$color-focus: #4271ae;
-$color-focus-border: $color-focus;
+$color-positive-on-dark: $color-green-400;
+$color-focus: $color-blue-600;
 $color-focus-outline: rgba($color-focus, 0.25);
-$color-focus-on-dark: #81a2be;
-$color-notice: #f5871f;
-$color-notice-on-dark: #de935f;
-$color-negative: #c82829;
-$color-negative-border: $color-negative;
+$color-focus-on-dark: $color-blue-400;
+$color-notice: $color-orange-600;
+$color-notice-on-dark: $color-orange-400;
+$color-negative: $color-red-600;
 $color-negative-outline: rgba($color-negative, 0.25);
-$color-negative-on-dark: #d16464;
-$color-border: #ccc;
-$color-backdrop: rgba($color-dark, 0.6);
-$color-inset: #ebebeb;
+$color-negative-on-dark: $color-red-400;
 
 /**
- * Typography
+ * Text sizes
  */
-$font-size-tiny: 0.75rem;
-$font-size-small: 0.875rem;
-$font-size-medium: 1rem;
-$font-size-large: 1.25rem;
-$font-size-huge: 1.5rem;
-$font-size-monster: 1.75rem;
-
-$font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-$font-family-mono: "SFMono-Regular", Consolas, Liberation Mono, Menlo, Courier, monospace;
-
-$font-weight-normal: 400;
-$font-weight-bold: 600;
+$text-xs: 0.75rem;
+$text-sm: 0.875rem;
+$text-base: 1rem;
+$text-lg: 1.125rem;
+$text-xl: 1.25rem;
+$text-2xl: 1.5rem;
+$text-3xl: 1.875rem;
+$text-4xl: 2.25rem;
+$text-5xl: 3rem;
+$text-6xl: 4rem;
 
 /**
- * Fields
+ * Font families
  */
-$field-input-padding: .5rem;
-$field-input-height: 2.25rem;
-$field-input-line-height: 1.25rem;
-$field-input-font-size: $font-size-medium;
-$field-input-color-before: $color-dark-grey;
-$field-input-color-after: $color-dark-grey;
-$field-input-border: 1px solid $color-border;
-$field-input-focus-border: 1px solid $color-focus-border;
-$field-input-focus-outline: 2px solid $color-focus-outline;
-$field-input-invalid-border: 1px solid $color-negative-outline;
-$field-input-invalid-outline: 0;
-$field-input-invalid-focus-border: 1px solid $color-negative-border;
-$field-input-invalid-focus-outline: 2px solid $color-negative-outline;
-$field-input-background: $color-white;
-$field-input-disabled-color: $color-light-grey;
-$field-input-disabled-background: lighten($color-background, 2.5%);
-$field-input-disabled-border: 1px solid lighten($color-border, 2%);
+$font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-mono: "SFMono-Regular", Consolas, Liberation Mono, Menlo, Courier, monospace;
 
 /**
- * Lists
+ * Font weights
  */
-$list-item-height: calc(2rem + 2px);
-$list-item-text-color: $color-dark;
-$list-item-text-font-size: $font-size-small;
-$list-item-info-color: $color-dark-grey;
-$list-item-info-font-size: $font-size-tiny;
+$font-normal: 400;
+$font-bold: 600;
 
 /**
- * Misc
+ * Border radius
  */
-$border-radius: 1px;
+$rounded-xs: 1px;
+$rounded-sm: 0.125rem;
+$rounded: 0.25rem;
 
 /**
  * Shadows
  */
-$box-shadow: rgba($color-dark, 0.2) 0 2px 10px;
-$box-shadow-card: rgba($color-dark, 0.05) 0 2px 5px;
-$box-shadow-inset: rgba($color-dark, 0.025) 0 5px 5px inset;
-$box-shadow-focus: rgba($color-focus, 0.25) 0 0 0 3px;
-$box-shadow-positive: rgba($color-positive, 0.25) 0 0 0 3px;
-$box-shadow-focus-full: $color-focus 0 0 0 2px,
-  rgba($color-focus, 0.2) 0 0 0 2px;
+$shadow: 0 1px 3px 0 rgba($color-black, 0.1), 0 1px 2px 0 rgba($color-black, 0.06);
+$shadow-md: 0 4px 6px -1px rgba($color-black, 0.1), 0 2px 4px -1px rgba($color-black, 0.06);
+$shadow-lg: 0 10px 15px -3px rgba($color-black, 0.1), 0 4px 6px -2px rgba($color-black, 0.05);
+$shadow-xl: 0 20px 25px -5px rgba($color-black, 0.1), 0 10px 10px -5px rgba($color-black, 0.04);
+$shadow-outline: currentColor 0 0 0 2px;
+$shadow-inset: inset 0 2px 4px 0 rgba($color-black, 0.06);
+$shadow-sticky: rgba($color-black, 0.05) 0 2px 5px;
 
 /**
  * Breakpoints
  */
-$breakpoint-small: 30em;
-$breakpoint-menu: 45em;
-$breakpoint-medium: 65em;
-$breakpoint-large: 90em;
-$breakpoint-huge: 120em;
-
-/**
- * Widths
- */
-$width-menu: 12.5rem;
+$breakpoint-sm: 30em;
+$breakpoint-md: 65em;
+$breakpoint-lg: 90em;
+$breakpoint-xl: 120em;
 
 /**
  * Focus Ring
  */
 @mixin focus-ring {
   outline: none;
-  box-shadow: $box-shadow-focus-full;
+  box-shadow: $shadow-outline;
 }
 
 @mixin highlight-tabbed {
@@ -146,3 +177,45 @@ $width-menu: 12.5rem;
  * Pattern Background
  */
 $pattern: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXR0ZXJuIGlkPSJhIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHBhdHRlcm5Vbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoIGZpbGw9InJnYmEoMCwgMCwgMCwgMC4yKSIgZD0iTTAgMGgxMHYxMEgwem0xMCAxMGgxMHYxMEgxMHoiLz48L3BhdHRlcm4+PHJlY3QgZmlsbD0idXJsKCNhKSIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIvPjwvc3ZnPg==";
+
+/**
+ * Spacing
+ */
+$spacing: (
+  0: 0,
+  px: 1px,
+  2px: 2px,
+  1: .25rem,
+  2: .5rem,
+  3: .75rem,
+  4: 1rem,
+  5: 1.25rem,
+  6: 1.5rem,
+  8: 2rem,
+  10: 2.5rem,
+  12: 3rem,
+  16: 4rem,
+  20: 5rem,
+  24: 6rem
+);
+
+/**
+ * Fields
+ */
+$field-input-padding: .5rem;
+$field-input-height: 2.25rem;
+$field-input-line-height: 1.25rem;
+$field-input-font-size: $text-base;
+$field-input-color-before: $color-gray-700;
+$field-input-color-after: $color-gray-700;
+$field-input-border: 1px solid $color-border;
+$field-input-focus-border: 1px solid $color-focus;
+$field-input-focus-outline: 2px solid $color-focus-outline;
+$field-input-invalid-border: 1px solid $color-negative-outline;
+$field-input-invalid-outline: 0;
+$field-input-invalid-focus-border: 1px solid $color-negative;
+$field-input-invalid-focus-outline: 2px solid $color-negative-outline;
+$field-input-background: $color-white;
+$field-input-disabled-color: $color-gray-500;
+$field-input-disabled-background: lighten($color-background, 2.5%);
+$field-input-disabled-border: 1px solid lighten($color-border, 2%);


### PR DESCRIPTION
As minimal as it can be without breaking things:

- Took the new SCSS variables from `storybook`
- Replaced old SCSS variables in components, trying to match look 1:1
=> this should only introduce minimal visible changes (e.g. `$color-dark` being replaced by `$color-gray-900`)

Actual styling changes should be happening later when refactoring each component