### PR TITLE
Support plugin views in Inertia

### DIFF
--- a/config/panel.php
+++ b/config/panel.php
@@ -119,6 +119,10 @@ return function ($kirby) {
             'action'  => require __DIR__ . '/views/user.file.php'
         ],
         [
+            'pattern' => 'plugins/(:any)',
+            'action'  => require __DIR__ . '/views/plugin.php'
+        ],
+        [
             'pattern' => '(:all)',
             'action'  => function () use ($kirby) {
                 return 'The view could not be found';

--- a/config/views/plugin.php
+++ b/config/views/plugin.php
@@ -1,0 +1,11 @@
+<?php
+
+return function ($id) use ($kirby) {
+    return [
+        'component' => 'PluginView',
+        'view'      => $id,
+        'props' => [
+            'id' => $id
+        ]
+    ];
+};

--- a/panel/src/components/Views/PluginView.vue
+++ b/panel/src/components/Views/PluginView.vue
@@ -1,0 +1,19 @@
+<template>
+  <k-inside>
+    <component :is="view" />
+  </k-inside>
+</template>
+
+<script>
+
+export default {
+  props: {
+    id: String
+  },
+  computed: {
+    view() {
+      return "k-" + this.id + "-plugin-view";
+    }
+  }
+};
+</script>

--- a/panel/src/config/plugins.js
+++ b/panel/src/config/plugins.js
@@ -65,22 +65,23 @@ Object.entries(window.panel.plugins.views).forEach(([name, options]) => {
     return;
   }
 
-  options.link = "/plugins/" + name;
-
-  // Fallback for icon
+  // Fallbacks
   if (options.icon === undefined) {
     options.icon = "page";
   }
-
-  // Fallback for menu
   if (options.menu === undefined) {
     options.menu = true;
+  }
+  if (options.search === undefined) {
+    options.menu = "pages";
   }
 
   // Update view
   window.panel.plugins.views[name] = {
-    link: options.link,
+    id: name,
+    label: options.label || options.text,
     icon: options.icon,
+    link: "/plugins/" + name,
     menu: options.menu
   };
 

--- a/panel/src/index.js
+++ b/panel/src/index.js
@@ -86,7 +86,10 @@ new Vue({
           Vue.prototype.$urls        = window.panel.$urls        = props.$urls;
           Vue.prototype.$user        = window.panel.$user        = props.$user;
           Vue.prototype.$view        = window.panel.$view        = props.$view;
-          Vue.prototype.$views       = window.panel.$views       = props.$views;
+          Vue.prototype.$views       = window.panel.$views       = {
+            ...props.$views,
+            ...window.panel.plugins.views
+          };
 
           return props.$props;
 


### PR DESCRIPTION
This PR tries to re-implement plugin views with the new Inertia setup.
For the moment, it tries to implement them without breaking changes. We might want to introduce changes (registering more parts on the PHP side, passing more props etc.) in a second step.

**What's broken/missing still**
- [ ] Topbar: highlight as current menu entry
- [ ] Basic breadcrumb