### PR TITLE
Html::tag(): Treat null as empty tag #2743

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -334,8 +334,8 @@ class Html extends Xml
      * Builds an HTML tag
      *
      * @param string $name Tag name
-     * @param array|string|null $content Scalar value or array with multiple lines of content or `null` to
-     *                                   generate a self-closing tag; pass an empty string to generate empty content
+     * @param array|string $content Scalar value or array with multiple lines of content; self-closing
+     *                              tags are generated automatically based on the `Html::isVoid()` list
      * @param array $attr An associative array with additional attributes for the tag
      * @param string|null $indent Indentation string, defaults to two spaces or `null` for output on one line
      * @param int $level Indentation level
@@ -343,6 +343,12 @@ class Html extends Xml
      */
     public static function tag(string $name, $content = '', array $attr = null, string $indent = null, int $level = 0): string
     {
+        // treat an explicit `null` value as an empty tag
+        // as void tags are already covered below
+        if ($content === null) {
+            $content = '';
+        }
+        
         // force void elements to be self-closing
         if (static::isVoid($name) === true) {
             $content = null;

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -393,7 +393,7 @@ class HtmlTest extends TestCase
         $this->assertSame($expected, $html);
 
         $html = Html::tag('p', null);
-        $expected = '<p>';
+        $expected = '<p></p>';
         $this->assertSame($expected, $html);
 
         $html = Html::tag('hr', '');


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Fixed a regression in 3.4.0 that made `Html::tag()` incorrectly return a self-closing tag if `null` was passed as the `$content` argument.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2743

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
