### PR TITLE
Html::isVoid(): Allow modifying the void list

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -36,6 +36,30 @@ class Html extends Xml
     public static $void = '>';
 
     /**
+     * List of HTML tags that are considered to be self-closing
+     *
+     * @var array
+     */
+    public static $voidList = [
+        'area',
+        'base',
+        'br',
+        'col',
+        'command',
+        'embed',
+        'hr',
+        'img',
+        'input',
+        'keygen',
+        'link',
+        'meta',
+        'param',
+        'source',
+        'track',
+        'wbr'
+    ];
+
+    /**
      * Generic HTML tag generator
      * Can be called like `Html::p('A paragraph', ['class' => 'text'])`
      *
@@ -260,26 +284,7 @@ class Html extends Xml
      */
     public static function isVoid(string $tag): bool
     {
-        $void = [
-            'area',
-            'base',
-            'br',
-            'col',
-            'command',
-            'embed',
-            'hr',
-            'img',
-            'input',
-            'keygen',
-            'link',
-            'meta',
-            'param',
-            'source',
-            'track',
-            'wbr',
-        ];
-
-        return in_array(strtolower($tag), $void);
+        return in_array(strtolower($tag), static::$voidList);
     }
 
     /**

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -324,8 +324,16 @@ class HtmlTest extends TestCase
      */
     public function testIsVoid()
     {
+        $original = Html::$voidList;
+
         $this->assertTrue(Html::isVoid('hr'));
+        $this->assertFalse(Html::isVoid('div'));
         $this->assertFalse(Html::isVoid(''));
+
+        Html::$voidList[] = 'div';
+        $this->assertTrue(Html::isVoid('div'));
+
+        Html::$voidList = $original;
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The list of self-closing tags for the `Html::isVoid()` method can now be modified with `Html::$voidList`.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- See https://github.com/getkirby/kirby/issues/2743#issuecomment-665908758.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
