### PR TITLE
Remote: Properly check CA constants #2745

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -177,19 +177,25 @@ class Remote
         ];
 
         // determine the TLS CA to use
-        if (is_file($this->options['ca']) === true) {
-            $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
-            $this->curlopt[CURLOPT_CAINFO] = $this->options['ca'];
-        } elseif (is_dir($this->options['ca']) === true) {
-            $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
-            $this->curlopt[CURLOPT_CAPATH] = $this->options['ca'];
-        } elseif ($this->options['ca'] === self::CA_INTERNAL) {
+        if ($this->options['ca'] === self::CA_INTERNAL) {
             $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
             $this->curlopt[CURLOPT_CAINFO] = dirname(__DIR__, 2) . '/cacert.pem';
         } elseif ($this->options['ca'] === self::CA_SYSTEM) {
             $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
         } elseif ($this->options['ca'] === false) {
             $this->curlopt[CURLOPT_SSL_VERIFYPEER] = false;
+        } elseif (
+            is_string($this->options['ca']) === true &&
+            is_file($this->options['ca']) === true
+        ) {
+            $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
+            $this->curlopt[CURLOPT_CAINFO] = $this->options['ca'];
+        } elseif (
+            is_string($this->options['ca']) === true &&
+            is_dir($this->options['ca']) === true
+        ) {
+            $this->curlopt[CURLOPT_SSL_VERIFYPEER] = true;
+            $this->curlopt[CURLOPT_CAPATH] = $this->options['ca'];
         } else {
             throw new InvalidArgumentException('Invalid "ca" option for the Remote class');
         }

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -62,6 +62,19 @@ class RemoteTest extends TestCase
         $this->assertSame(dirname(__DIR__, 2) . '/cacert.pem', $request->curlopt[CURLOPT_CAINFO]);
         $this->assertArrayNotHasKey(CURLOPT_CAPATH, $request->curlopt);
 
+        // explicit internal CA with an existing file named like the constant
+        $originalCwd = getcwd();
+        chdir(__DIR__ . '/fixtures');
+        touch(Remote::CA_INTERNAL);
+        $request = Remote::get('https://getkirby.com', [
+            'ca' => Remote::CA_INTERNAL
+        ]);
+        $this->assertTrue($request->curlopt[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertSame(dirname(__DIR__, 2) . '/cacert.pem', $request->curlopt[CURLOPT_CAINFO]);
+        $this->assertArrayNotHasKey(CURLOPT_CAPATH, $request->curlopt);
+        unlink(Remote::CA_INTERNAL);
+        chdir($originalCwd);
+
         // CA file
         $request = Remote::get('https://getkirby.com', [
             'ca' => __FILE__
@@ -85,6 +98,19 @@ class RemoteTest extends TestCase
         $this->assertTrue($request->curlopt[CURLOPT_SSL_VERIFYPEER]);
         $this->assertArrayNotHasKey(CURLOPT_CAINFO, $request->curlopt);
         $this->assertArrayNotHasKey(CURLOPT_CAPATH, $request->curlopt);
+
+        // system CA with an existing file named like the constant
+        $originalCwd = getcwd();
+        chdir(__DIR__ . '/fixtures');
+        touch(Remote::CA_SYSTEM);
+        $request = Remote::get('https://getkirby.com', [
+            'ca' => Remote::CA_SYSTEM
+        ]);
+        $this->assertTrue($request->curlopt[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertArrayNotHasKey(CURLOPT_CAINFO, $request->curlopt);
+        $this->assertArrayNotHasKey(CURLOPT_CAPATH, $request->curlopt);
+        unlink(Remote::CA_SYSTEM);
+        chdir($originalCwd);
 
         // disabled
         $request = Remote::get('https://getkirby.com', [


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

If a file exists in the root of the site that is named like one of the internal constants of the `Remote` class (`1` or `2`), that file is no longer used as the CA for `Remote` requests.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2745

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
