### PR TITLE
Redirects user who doesn't have site access to account page

### DIFF
--- a/panel/src/config/auth.js
+++ b/panel/src/config/auth.js
@@ -28,7 +28,7 @@ export default function(to, from, next) {
         message: Vue.i18n.translate("error.access.view")
       });
 
-      return next("/");
+      return next(access.site === false ? "/account" : "/");
     }
 
     next();


### PR DESCRIPTION
## Describe the PR

As a simple solution, redirects user who doesn't have site access to `account` page. Because it is the page that the user always has access to.

A separate error page can be made as an alternative solution 💡 

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2760 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
