### PR TITLE
Pages: Only use findBy('slug') on non-default languages

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1376,7 +1376,7 @@ class Page extends ModelWithContent
 
             $defaultLanguageCode = $this->kirby()->defaultLanguage()->code();
 
-            if ($languageCode != $defaultLanguageCode && $translation = $this->translations()->find($languageCode)) {
+            if ($languageCode !== $defaultLanguageCode && $translation = $this->translations()->find($languageCode)) {
                 return $translation->slug() ?? $this->slug;
             }
         }

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1374,7 +1374,9 @@ class Page extends ModelWithContent
                 $languageCode = $this->kirby()->languageCode();
             }
 
-            if ($translation = $this->translations()->find($languageCode)) {
+            $defaultLanguageCode = $this->kirby()->defaultLanguage()->code();
+
+            if ($languageCode != $defaultLanguageCode && $translation = $this->translations()->find($languageCode)) {
                 return $translation->slug() ?? $this->slug;
             }
         }

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -225,7 +225,7 @@ class Pages extends Collection
 
         $multiLang = App::instance()->multilang();
 
-        if ($multiLang === true && $page = $this->findBy('slug', $id)) {
+        if ($multiLang === true && !App::instance()->language()->isDefault() && $page = $this->findBy('slug', $id)) {
             return $page;
         }
 
@@ -254,7 +254,7 @@ class Pages extends Collection
             $query = ltrim($query . '/' . $key, '/');
             $item  = $collection->get($query) ?? null;
 
-            if ($item === null && $multiLang === true) {
+            if ($item === null && $multiLang === true && !App::instance()->language()->isDefault()) {
                 $item = $collection->findBy('slug', $key);
             }
 

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -252,8 +252,7 @@ class Pages extends Collection
                 if (count($path) > 1 || $collection->parent()) {
                     // either the desired path is definitely not a slug, or collection is the children of another collection
                     $item = $collection->findBy('slug', $key);
-                }
-                else {
+                } else {
                     // desired path _could_ be a slug or a "top level" uri
                     $item = $collection->findBy('uri', $key);
                 }

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -249,7 +249,14 @@ class Pages extends Collection
             $item  = $collection->get($query) ?? null;
 
             if ($item === null && $multiLang === true && !App::instance()->language()->isDefault()) {
-                $item = $collection->findBy('slug', $key);
+                if (count($path) > 1 || $collection->parent()) {
+                    // either the desired path is definitely not a slug, or collection is the children of another collection
+                    $item = $collection->findBy('slug', $key);
+                }
+                else {
+                    // desired path _could_ be a slug or a "top level" uri
+                    $item = $collection->findBy('uri', $key);
+                }
             }
 
             if ($item === null) {

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -223,14 +223,8 @@ class Pages extends Collection
             return $page;
         }
 
-        $multiLang = App::instance()->multilang();
-
-        if ($multiLang === true && !App::instance()->language()->isDefault() && $page = $this->findBy('slug', $id)) {
-            return $page;
-        }
-
         $start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
-        $page  = $this->findByIdRecursive($id, $start, $multiLang);
+        $page  = $this->findByIdRecursive($id, $start, App::instance()->multilang());
 
         return $page;
     }

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -483,6 +483,109 @@ class PagesTest extends TestCase
         $this->assertIsPage($pages->findById('kind'), 'grandma/mother/child');
     }
 
+    public function testFindByIdWithSwappedSlugsTranslated()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code' => 'en',
+                ],
+                [
+                    'code' => 'de',
+                ],
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'aaa',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                            ],
+                            [
+                                'code' => 'de',
+                                'slug' => 'zzz',
+                            ],
+                        ],
+                        'children' => [
+                            [
+                                'slug' => 'bbb',
+                                'translations' => [
+                                    [
+                                        'code' => 'en',
+                                    ],
+                                    [
+                                        'code' => 'de',
+                                        'slug' => 'yyy'
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'slug' => 'zzz',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                            ],
+                            [
+                                'code' => 'de',
+                                'slug' => 'aaa',
+                            ],
+                        ],
+                        'children' => [
+                            [
+                                'slug' => 'yyy',
+                                'translations' => [
+                                    [
+                                        'code' => 'en',
+                                    ],
+                                    [
+                                        'code' => 'de',
+                                        'slug' => 'bbb'
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $site = $app->site();
+
+        $this->assertIsPage($site->children()->findById('aaa'), 'aaa');
+        $this->assertIsPage($site->children()->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->findById('zzz'), 'zzz');
+        $this->assertIsPage($site->children()->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'zzz/yyy');
+
+        $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
+        $this->assertIsPage($pages->findById('aaa'), 'aaa');
+        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->findById('zzz'), 'zzz');
+        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+
+//         $app->setCurrentLanguage('de');
+
+//         $this->assertIsPage($site->children()->findById('aaa'), 'zzz');
+//         $this->assertIsPage($site->children()->findById('aaa/bbb'), 'zzz/yyy');
+//         $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'zzz/yyy');
+//         $this->assertIsPage($site->children()->findById('zzz'), 'aaa');
+//         $this->assertIsPage($site->children()->findById('zzz/yyy'), 'aaa/bbb');
+//         $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'aaa/bbb');
+
+//         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
+//         $this->assertIsPage($pages->findById('aaa'), 'zzz');
+//         $this->assertIsPage($pages->findById('aaa/bbb'), 'zzz/yyy');
+//         $this->assertIsPage($pages->findById('zzz'), 'aaa');
+//         $this->assertIsPage($pages->findById('zzz/yyy'), 'aaa/bbb');
+    }
+
     public function testFindMultiple()
     {
         $pages = Pages::factory([

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -301,6 +301,8 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
+//         $this->assertIsPage($site->children()->findById('mother'), 'grandma/mother');
+//         $this->assertIsPage($site->children()->findByUri('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
@@ -308,9 +310,18 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
+
+        $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
+        $this->assertIsPage($pages->findById('grandma'), 'grandma');
+        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
+//         $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
+//         $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
     }
 
-    public function testFindByIdTranslated()
+    public function testFindByIdAndUriTranslated()
     {
         $app = new App([
             'roots' => [
@@ -386,6 +397,8 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('grandma/mother'), 'grandma/mother');
+//         $this->assertIsPage($site->children()->findById('mother'), 'grandma/mother');
+//         $this->assertIsPage($site->children()->findByUri('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
@@ -395,6 +408,15 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
+
+        $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
+        $this->assertIsPage($pages->findById('grandma'), 'grandma');
+        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
 
         $app->setCurrentLanguage('de');
 
@@ -434,6 +456,31 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('kind'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findByUri('kind'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('oma/mother'), 'grandma/mother');
+//         $this->assertIsPage($site->children()->findById('oma/mother/kind'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('oma/mutter/child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('grandmother/mutter/child'), 'grandma/mother/child');
+//         $this->assertIsPage($site->children()->findById('grandmother/mutter/kind'), 'grandma/mother/child');
+
+        $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
+        $this->assertIsPage($pages->findById('grandma'), 'grandma');
+        $this->assertIsPage($pages->findById('oma'), 'grandma');
+        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('grandma/mutter'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('oma/mutter'), 'grandma/mother');
+//         $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('mutter'), 'grandma/mother');
+        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($pages->findById('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($pages->findById('grandma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($pages->findById('oma/mutter/kind'), 'grandma/mother/child');
+//         $this->assertIsPage($pages->findById('oma/mother/kind'), 'grandma/mother/child');
+//         $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
+        $this->assertIsPage($pages->findById('kind'), 'grandma/mother/child');
     }
 
     public function testFindMultiple()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -330,6 +330,7 @@ class PagesTest extends TestCase
             'languages' => [
                 [
                     'code' => 'en',
+                    'default' => true,
                 ],
                 [
                     'code' => 'de',
@@ -414,9 +415,9 @@ class PagesTest extends TestCase
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        // $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
+        // $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
 
         $app->setCurrentLanguage('de');
 
@@ -492,6 +493,7 @@ class PagesTest extends TestCase
             'languages' => [
                 [
                     'code' => 'en',
+                    'default' => true,
                 ],
                 [
                     'code' => 'de',

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -409,6 +409,7 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother')->children()->findById('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findByUri('child'));
@@ -458,7 +459,9 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother')->children()->findById('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mutter')->children()->findById('kind'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mutter')->children()->findByUri('kind'), 'grandma/mother/child');
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findById('kind'));

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -299,11 +299,141 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+    }
+
+    public function testFindByIdTranslated()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code' => 'en',
+                ],
+                [
+                    'code' => 'de',
+                ],
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'grandma',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                            ],
+                            [
+                                'code' => 'de',
+                                'slug' => 'oma',
+                            ],
+                        ],
+                        'children' => [
+                            [
+                                'slug' => 'mother',
+                                'translations' => [
+                                    [
+                                        'code' => 'en',
+                                    ],
+                                    [
+                                        'code' => 'de',
+                                        'slug' => 'mutter'
+                                    ],
+                                ],
+                                'children' => [
+                                    [
+                                        'slug' => 'child',
+                                        'translations' => [
+                                            [
+                                                'code' => 'en',
+                                            ],
+                                            [
+                                                'code' => 'de',
+                                                'slug' => 'kind',
+                                            ],
+                                        ],
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $site = $app->site();
+
+        $this->assertIsPage($site->children()->findById('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->findById('grandma/'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('grandma/'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('grandma.json'), 'grandma');
+        $this->assertIsPage($site->children()->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma/mother/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+
+        $app->setCurrentLanguage('de');
+
+        $this->assertIsPage($site->children()->findById('oma'), 'grandma');
+        $this->assertIsPage($site->children()->findById('oma/'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('oma'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('oma/'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('oma.json'), 'grandma');
+        $this->assertIsPage($site->children()->findById('oma/mutter/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('oma/mutter.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('oma')->children()->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->findById('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma/mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findById('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
     }
 
     public function testFindMultiple()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -301,8 +301,8 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
-//         $this->assertIsPage($site->children()->findById('mother'), 'grandma/mother');
-//         $this->assertIsPage($site->children()->findByUri('mother'), 'grandma/mother');
+        $this->assertNull($site->children()->findById('mother'));
+        $this->assertNull($site->children()->findByUri('mother'));
         $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
@@ -310,15 +310,15 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
+        $this->assertNull($site->children()->findById('child'));
+        $this->assertNull($site->children()->findByUri('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-//         $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        $this->assertNull($pages->findById('mother'));
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-//         $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
+        $this->assertNull($pages->findById('child'));
     }
 
     public function testFindByIdAndUriTranslated()
@@ -398,8 +398,8 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('grandma/mother'), 'grandma/mother');
-//         $this->assertIsPage($site->children()->findById('mother'), 'grandma/mother');
-//         $this->assertIsPage($site->children()->findByUri('mother'), 'grandma/mother');
+        $this->assertNull($site->children()->findById('mother'));
+        $this->assertNull($site->children()->findByUri('mother'));
         $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
@@ -409,15 +409,15 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
+        $this->assertNull($site->children()->findById('child'));
+        $this->assertNull($site->children()->findByUri('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-        // $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
+        $this->assertNull($pages->findById('mother'));
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-        // $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
+        $this->assertNull($pages->findById('child'));
 
         $app->setCurrentLanguage('de');
 
@@ -457,15 +457,15 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('kind'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findByUri('child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findByUri('kind'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('oma/mother'), 'grandma/mother');
-//         $this->assertIsPage($site->children()->findById('oma/mother/kind'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('oma/mutter/child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('grandmother/mutter/child'), 'grandma/mother/child');
-//         $this->assertIsPage($site->children()->findById('grandmother/mutter/kind'), 'grandma/mother/child');
+        $this->assertNull($site->children()->findById('child'));
+        $this->assertNull($site->children()->findById('kind'));
+        $this->assertNull($site->children()->findByUri('child'));
+        $this->assertNull($site->children()->findByUri('kind'));
+        $this->assertNull($site->children()->findById('oma/mother'));
+        $this->assertNull($site->children()->findById('oma/mother/kind'));
+        $this->assertNull($site->children()->findById('oma/mutter/child'));
+        $this->assertNull($site->children()->findById('grandmother/mutter/child'));
+        $this->assertNull($site->children()->findById('grandmother/mutter/kind'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
@@ -473,15 +473,15 @@ class PagesTest extends TestCase
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
         $this->assertIsPage($pages->findById('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($pages->findById('oma/mutter'), 'grandma/mother');
-//         $this->assertIsPage($pages->findById('mother'), 'grandma/mother');
-        $this->assertIsPage($pages->findById('mutter'), 'grandma/mother');
+        $this->assertNull($pages->findById('mother'));
+        $this->assertIsPage($pages->findById('mutter'), 'grandma/mother'); // would expect null
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('grandma/mother/kind'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('grandma/mutter/kind'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('oma/mutter/kind'), 'grandma/mother/child');
-//         $this->assertIsPage($pages->findById('oma/mother/kind'), 'grandma/mother/child');
-//         $this->assertIsPage($pages->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($pages->findById('kind'), 'grandma/mother/child');
+        $this->assertNull($pages->findById('oma/mother/kind'));
+        $this->assertNull($pages->findById('child'));
+        $this->assertIsPage($pages->findById('kind'), 'grandma/mother/child'); // would expect null
     }
 
     public function testFindByIdWithSwappedSlugsTranslated()
@@ -572,20 +572,20 @@ class PagesTest extends TestCase
         $this->assertIsPage($pages->findById('zzz'), 'zzz');
         $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
 
-//         $app->setCurrentLanguage('de');
+        $app->setCurrentLanguage('de');
 
-//         $this->assertIsPage($site->children()->findById('aaa'), 'zzz');
-//         $this->assertIsPage($site->children()->findById('aaa/bbb'), 'zzz/yyy');
-//         $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'zzz/yyy');
-//         $this->assertIsPage($site->children()->findById('zzz'), 'aaa');
-//         $this->assertIsPage($site->children()->findById('zzz/yyy'), 'aaa/bbb');
-//         $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->findById('aaa'), 'aaa');
+        $this->assertIsPage($site->children()->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->findById('zzz'), 'zzz');
+        $this->assertIsPage($site->children()->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'zzz/yyy');
 
-//         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
-//         $this->assertIsPage($pages->findById('aaa'), 'zzz');
-//         $this->assertIsPage($pages->findById('aaa/bbb'), 'zzz/yyy');
-//         $this->assertIsPage($pages->findById('zzz'), 'aaa');
-//         $this->assertIsPage($pages->findById('zzz/yyy'), 'aaa/bbb');
+        $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
+        $this->assertIsPage($pages->findById('aaa'), 'aaa');
+        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->findById('zzz'), 'zzz');
+        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
     }
 
     public function testFindMultiple()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -409,6 +409,7 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findByUri('child'));
 
@@ -457,6 +458,8 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mutter')->children()->findByUri('kind'), 'grandma/mother/child');
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findById('kind'));
         $this->assertNull($site->children()->findByUri('child'));
@@ -474,14 +477,14 @@ class PagesTest extends TestCase
         $this->assertIsPage($pages->findById('grandma/mutter'), 'grandma/mother');
         $this->assertIsPage($pages->findById('oma/mutter'), 'grandma/mother');
         $this->assertNull($pages->findById('mother'));
-        $this->assertIsPage($pages->findById('mutter'), 'grandma/mother'); // would expect null
+        $this->assertNull($pages->findById('mutter'));
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('grandma/mother/kind'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('grandma/mutter/kind'), 'grandma/mother/child');
         $this->assertIsPage($pages->findById('oma/mutter/kind'), 'grandma/mother/child');
         $this->assertNull($pages->findById('oma/mother/kind'));
         $this->assertNull($pages->findById('child'));
-        $this->assertIsPage($pages->findById('kind'), 'grandma/mother/child'); // would expect null
+        $this->assertNull($pages->findById('kind'));
     }
 
     public function testFindByIdWithSwappedSlugsTranslated()


### PR DESCRIPTION
## Describe the PR

In a multi-language setup, finding a Page in a Pages collection by slug is unnecessary for the default language. The existing behavior means that nonexistent ids/slugs incur a full loop iteration that will never actually return a result.

Because the `id` for any page _is_ constructed from default-language slugs, the initial lookup with `->get` should be sufficient.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
