### PR TITLE
Panel: Prevent adding double-slashes to API request paths #2740

### DIFF
--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -33,7 +33,12 @@ export default (config) => {
       this.running++;
 
       // fetch the resquest's response
-      const response = await fetch(config.endpoint + "/" + path, options);
+      const response = await fetch(
+        [config.endpoint, path].join(
+          (config.endpoint.endsWith("/") || path.startsWith("/")) ? "" : "/"
+        ),
+        options
+      );
       const text     = await response.text();
 
       try {


### PR DESCRIPTION
## Describe the PR

Fixes instances where the Panel would create API requests that have double-slashes in their path (e.g. `https://www.example.com/api//pages/test-page`).

## Related issues

- Fixes #2740 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
