### PR TITLE
Alpha and alphanum validation supports unicode optional

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -35,6 +35,7 @@ class V
      * @param array $rules
      * @param array $messages
      * @return array
+     * @throws Exception
      */
     public static function errors($input, array $rules, $messages = []): array
     {
@@ -51,6 +52,7 @@ class V
      * @param string $validatorName
      * @param mixed ...$params
      * @return string|null
+     * @throws \ReflectionException
      */
     public static function message(string $validatorName, ...$params): ?string
     {
@@ -108,6 +110,8 @@ class V
      * @param array $messages
      * @param bool $fail
      * @return bool|array
+     * @throws \ReflectionException
+     * @throws Exception
      */
     public static function value($value, array $rules, array $messages = [], bool $fail = true)
     {
@@ -146,6 +150,7 @@ class V
      * @param array $input
      * @param array $rules
      * @return bool
+     * @throws Exception
      */
     public static function input(array $input, array $rules): bool
     {
@@ -183,6 +188,7 @@ class V
      * @param string $method
      * @param array $arguments
      * @return bool
+     * @throws Exception
      */
     public static function __callStatic(string $method, array $arguments): bool
     {
@@ -213,15 +219,15 @@ V::$validators = [
     /**
      * Valid: `a-z | A-Z`
      */
-    'alpha' => function ($value): bool {
-        return V::match($value, '/^([a-z])+$/i') === true;
+    'alpha' => function ($value, bool $unicode = false): bool {
+        return V::match($value, ($unicode === true ? '/^([\pL])+$/u' : '/^([a-z])+$/i')) === true;
     },
 
     /**
      * Valid: `a-z | A-Z | 0-9`
      */
-    'alphanum' => function ($value): bool {
-        return V::match($value, '/^[a-z0-9]+$/i') === true;
+    'alphanum' => function ($value, bool $unicode = false): bool {
+        return V::match($value, ($unicode === true ? '/^[\pL\pN]+$/u' : '/^([a-z0-9])+$/i')) === true;
     },
 
     /**

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -35,7 +35,6 @@ class V
      * @param array $rules
      * @param array $messages
      * @return array
-     * @throws Exception
      */
     public static function errors($input, array $rules, $messages = []): array
     {
@@ -52,7 +51,6 @@ class V
      * @param string $validatorName
      * @param mixed ...$params
      * @return string|null
-     * @throws \ReflectionException
      */
     public static function message(string $validatorName, ...$params): ?string
     {
@@ -110,8 +108,6 @@ class V
      * @param array $messages
      * @param bool $fail
      * @return bool|array
-     * @throws \ReflectionException
-     * @throws Exception
      */
     public static function value($value, array $rules, array $messages = [], bool $fail = true)
     {
@@ -150,7 +146,6 @@ class V
      * @param array $input
      * @param array $rules
      * @return bool
-     * @throws Exception
      */
     public static function input(array $input, array $rules): bool
     {
@@ -188,7 +183,6 @@ class V
      * @param string $method
      * @param array $arguments
      * @return bool
-     * @throws Exception
      */
     public static function __callStatic(string $method, array $arguments): bool
     {

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -102,6 +102,11 @@ class VTest extends TestCase
         $this->assertFalse(V::alpha('äöüß'));
         $this->assertFalse(V::alpha('abc1234'));
         $this->assertFalse(V::alpha('abc"§$%&/()=?'));
+
+        $this->assertTrue(V::alpha('uñicode', true));
+        $this->assertTrue(V::alpha('nonunicode', true));
+        $this->assertFalse(V::alpha('uñicode', false));
+        $this->assertFalse(V::alpha('uñi-code', true));
     }
 
     public function testAlphanum()
@@ -116,6 +121,11 @@ class VTest extends TestCase
 
         $this->assertFalse(V::alphanum('äöüß'));
         $this->assertFalse(V::alphanum('abc"§$%&/()=?'));
+
+        $this->assertTrue(V::alphanum('uñicode1234', true));
+        $this->assertTrue(V::alphanum('nonunicode1234', true));
+        $this->assertFalse(V::alphanum('uñicode1234', false));
+        $this->assertFalse(V::alphanum('uñicode-1234', true));
     }
 
     public function testBetween()


### PR DESCRIPTION
## Describe the PR

`V::alpha()` and `V::alphanum()`validations now supports unicode as optional with second bool parameter.

````php
V::alpha('uñicode', true);
V::alphanum('uñicode1234', true);
````

Forum discussion: https://forum.getkirby.com/t/v-alpha-validator-and-non-english-abecedaries/19001

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
