### PR TITLE
Supports predefined beforeSend option

### DIFF
--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -40,6 +40,7 @@ class Email
      * @param string|array $preset Preset name from the config or a simple props array
      * @param array $props Props array to override the $preset
      * @throws \Kirby\Exception\NotFoundException
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     public function __construct($preset = [], array $props = [])
     {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -39,6 +39,7 @@ class Email
      *
      * @param string|array $preset Preset name from the config or a simple props array
      * @param array $props Props array to override the $preset
+     * @throws \Kirby\Exception\NotFoundException
      */
     public function __construct($preset = [], array $props = [])
     {
@@ -51,6 +52,11 @@ class Email
         // add transport settings
         if (isset($this->props['transport']) === false) {
             $this->props['transport'] = $this->options['transport'] ?? [];
+        }
+
+        // add predefined beforeSend option
+        if (isset($this->props['beforeSend']) === false) {
+            $this->props['beforeSend'] = $this->options['beforeSend'] ?? null;
         }
 
         // transform model objects to values
@@ -71,6 +77,7 @@ class Email
      *
      * @param string|array $preset Preset name or simple prop array
      * @return array
+     * @throws \Kirby\Exception\NotFoundException
      */
     protected function preset($preset): array
     {
@@ -95,6 +102,7 @@ class Email
      * to the result
      *
      * @return void
+     * @throws \Kirby\Exception\NotFoundException
      */
     protected function template(): void
     {
@@ -153,6 +161,7 @@ class Email
      *
      * @param string $prop Prop to transform
      * @return void
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformFile(string $prop): void
     {
@@ -168,6 +177,7 @@ class Email
      * @param string|null $contentKey Optional model method that returns the array key;
      *                                returns a simple value-only array if not given
      * @return array Simple key-value or just value array with the transformed prop data
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformModel(string $prop, string $class, string $contentValue, string $contentKey = null): array
     {
@@ -211,6 +221,7 @@ class Email
      * @param string $addressProp Prop with the email address
      * @param string $nameProp Prop with the name corresponding to the $addressProp
      * @return void
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformUserSingle(string $addressProp, string $nameProp): void
     {
@@ -240,6 +251,7 @@ class Email
      *
      * @param string $prop Prop to transform
      * @return void
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformUserMultiple(string $prop): void
     {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -39,8 +39,6 @@ class Email
      *
      * @param string|array $preset Preset name from the config or a simple props array
      * @param array $props Props array to override the $preset
-     * @throws \Kirby\Exception\NotFoundException
-     * @throws \Kirby\Exception\InvalidArgumentException
      */
     public function __construct($preset = [], array $props = [])
     {
@@ -162,7 +160,6 @@ class Email
      *
      * @param string $prop Prop to transform
      * @return void
-     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformFile(string $prop): void
     {
@@ -222,7 +219,6 @@ class Email
      * @param string $addressProp Prop with the email address
      * @param string $nameProp Prop with the name corresponding to the $addressProp
      * @return void
-     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformUserSingle(string $addressProp, string $nameProp): void
     {
@@ -252,7 +248,6 @@ class Email
      *
      * @param string $prop Prop to transform
      * @return void
-     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformUserMultiple(string $prop): void
     {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -76,7 +76,6 @@ class Email
      *
      * @param string|array $preset Preset name or simple prop array
      * @return array
-     * @throws \Kirby\Exception\NotFoundException
      */
     protected function preset($preset): array
     {
@@ -101,7 +100,6 @@ class Email
      * to the result
      *
      * @return void
-     * @throws \Kirby\Exception\NotFoundException
      */
     protected function template(): void
     {
@@ -175,7 +173,6 @@ class Email
      * @param string|null $contentKey Optional model method that returns the array key;
      *                                returns a simple value-only array if not given
      * @return array Simple key-value or just value array with the transformed prop data
-     * @throws \Kirby\Exception\InvalidArgumentException
      */
     protected function transformModel(string $prop, string $class, string $contentValue, string $contentKey = null): array
     {

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -269,6 +269,6 @@ class EmailTest extends TestCase
         $beforeSend = $email->toArray()['beforeSend'];
 
         $this->assertInstanceOf('Closure', $beforeSend);
-        $this->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $beforeSend(new Mailer));
+        $this->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $beforeSend(new Mailer()));
     }
 }

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -22,7 +22,8 @@ class EmailTest extends TestCase
             'to'          => [],
             'cc'          => [],
             'bcc'         => [],
-            'attachments' => []
+            'attachments' => [],
+            'beforeSend'  => null
         ];
 
         $email = new Email($props);

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use PHPMailer\PHPMailer\PHPMailer as Mailer;
+
 class EmailTest extends TestCase
 {
     public function testToArray()
@@ -239,5 +241,34 @@ class EmailTest extends TestCase
 
         $this->assertEquals(['ceo@company.com' => 'Mario'], $email->toArray()['to']);
         $this->assertEquals('Welcome, Mario!', trim($email->toArray()['body']));
+    }
+
+    public function testBeforeSend()
+    {
+        new App([
+            'options' => [
+                'email' => [
+                    'beforeSend' => function ($mailer) {
+                        $mailer->SMTPOptions = [
+                            'ssl' => [
+                                'verify_peer'       => false,
+                                'verify_peer_name'  => false,
+                                'allow_self_signed' => true
+                            ]
+                        ];
+
+                        return $mailer;
+                    }
+                ]
+            ]
+        ]);
+
+        $email = new Email([
+            'to' => 'ceo@company.com'
+        ]);
+        $beforeSend = $email->toArray()['beforeSend'];
+
+        $this->assertInstanceOf('Closure', $beforeSend);
+        $this->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $beforeSend(new Mailer));
     }
 }


### PR DESCRIPTION
## Describe the PR

With https://github.com/getkirby/kirby/pull/2693 PR, we can access to phpMailer instance.

So i'm not sure if this is a bug but I think the `beforeSend` setting should be able to predefine.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
