### PR TITLE
Supports query language in email templates

### DIFF
--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -116,20 +116,21 @@ class Email
 
             // render text template first to use in html or text body
             if ($text->exists() === true) {
-                $textRender = $text->render($data);
-
+                $textRender   = $text->render($data);
                 $textTemplate = Str::template($textRender, $templateData, $textRender);
             }
 
             if ($html->exists() === true) {
-                $htmlRender = $html->render($data);
-
+                $htmlRender   = $html->render($data);
                 $htmlTemplate = Str::template($htmlRender, $templateData, $htmlRender);
 
                 $this->props['body'] = [
-                    'html' => $htmlTemplate,
-                    'text' => $textTemplate ?? null
+                    'html' => $htmlTemplate
                 ];
+
+                if ($text->exists() === true) {
+                    $this->props['body']['text'] = $textTemplate ?? null;
+                }
 
             // fallback to single email text template
             } elseif ($text->exists() === true) {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -132,7 +132,7 @@ class Email
                     $this->props['body']['text'] = $textTemplate ?? null;
                 }
 
-            // fallback to single email text template
+                // fallback to single email text template
             } elseif ($text->exists() === true) {
                 $this->props['body'] = $textTemplate ?? null;
             } else {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -116,28 +116,29 @@ class Email
             // - html template (.html.php extension)
             // - text template (.text.php extension)
             // - default php template (.php extension)
-            if ($kirbyTemplate->exists()) {
-                $html = Str::template($kirbyTemplate->render($data), array_merge($data, [
+            if ($kirbyTemplate->exists() === true) {
+                $render = $kirbyTemplate->render($data);
+                $html = Str::template($render, array_merge($data, [
                     'kirby' => App::instance(),
                     'site'  => App::instance()->site(),
-                ]), '');
+                ]), $render);
 
                 $this->props['body'] = [
                     'html' => $html
                 ];
 
-                if ($textTemplate->exists()) {
+                if ($textTemplate->exists() === true) {
                     $this->props['body']['text'] = $textTemplate->render($data);
                 }
-            } elseif ($htmlTemplate->exists()) {
+            } elseif ($htmlTemplate->exists() === true) {
                 $this->props['body'] = [
                     'html' => $htmlTemplate->render($data)
                 ];
 
-                if ($textTemplate->exists()) {
+                if ($textTemplate->exists() === true) {
                     $this->props['body']['text'] = $textTemplate->render($data);
                 }
-            } elseif ($textTemplate->exists()) {
+            } elseif ($textTemplate->exists() === true) {
                 $this->props['body'] = $textTemplate->render($data);
             } else {
                 throw new NotFoundException('The email template "' . $this->props['template'] . '" cannot be found');

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -109,7 +109,7 @@ class EmailTest extends TestCase
             ]
         ]);
 
-        $expected = "Hey John Doe\r\n\r\nThis is test message!\r\n\r\nCheers\r\nKirby CMS";
+        $expected = "Hey John Doe\n\nThis is test message!\n\nCheers\nKirby CMS";
         $this->assertSame($expected, $email->toArray()['body']);
     }
 

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -134,7 +134,7 @@ class EmailTest extends TestCase
             ]
         ]);
 
-        $expected = "<h2>Hey John Doe</h2>\r\n\r\n<p>This is test message!</p>\r\n\r\n<strong>Cheers</strong>\r\n<h5>Kirby CMS</h5>";
+        $expected = "<h2>Hey John Doe</h2>\n\n<p>This is test message!</p>\n\n<strong>Cheers</strong>\n<h5>Kirby CMS</h5>";
         $this->assertSame([
             'html' => $expected
         ], $email->toArray()['body']);

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -136,8 +136,7 @@ class EmailTest extends TestCase
 
         $expected = "<h2>Hey John Doe</h2>\r\n\r\n<p>This is test message!</p>\r\n\r\n<strong>Cheers</strong>\r\n<h5>Kirby CMS</h5>";
         $this->assertSame([
-            'html' => $expected,
-            'text' => null,
+            'html' => $expected
         ], $email->toArray()['body']);
     }
 

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -88,6 +88,24 @@ class EmailTest extends TestCase
         ], $email->toArray()['body']);
     }
 
+    public function testTemplateKirby()
+    {
+        $app = new App([
+            'templates' => [
+                'emails/media.kirby' => __DIR__ . '/fixtures/emails/media.kirby.php'
+            ],
+            'site' => [
+                'content' => [
+                    'title' => 'Test Site'
+                ]
+            ]
+        ]);
+        $email = new Email(['template' => 'media']);
+        $this->assertEquals([
+            'html' => '<b>Image:</b> <img src="" alt="Test Site"/>'
+        ], $email->toArray()['body']);
+    }
+
     public function testTemplateHtmlText()
     {
         $app = new App([

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -88,21 +88,56 @@ class EmailTest extends TestCase
         ], $email->toArray()['body']);
     }
 
-    public function testTemplateKirby()
+    public function testTemplateTextWithQueryLanguage()
     {
-        $app = new App([
+        new App([
             'templates' => [
-                'emails/media.kirby' => __DIR__ . '/fixtures/emails/media.kirby.php'
+                'emails/query.text' => __DIR__ . '/fixtures/emails/query.text.php'
             ],
             'site' => [
                 'content' => [
-                    'title' => 'Test Site'
+                    'title' => 'Kirby CMS'
                 ]
             ]
         ]);
-        $email = new Email(['template' => 'media']);
-        $this->assertEquals([
-            'html' => '<b>Image:</b> <img src="" alt="Test Site"/>'
+
+        $email = new Email([
+            'template' => 'query',
+            'data' => [
+                'name' => 'John Doe',
+                'message' => 'This is test message!',
+            ]
+        ]);
+
+        $expected = "Hey John Doe\r\n\r\nThis is test message!\r\n\r\nCheers\r\nKirby CMS";
+        $this->assertSame($expected, $email->toArray()['body']);
+    }
+
+    public function testTemplateHtmlWithQueryLanguage()
+    {
+        new App([
+            'templates' => [
+                'emails/query.html' => __DIR__ . '/fixtures/emails/query.html.php'
+            ],
+            'site' => [
+                'content' => [
+                    'title' => 'Kirby CMS'
+                ]
+            ]
+        ]);
+
+        $email = new Email([
+            'template' => 'query',
+            'data' => [
+                'name' => 'John Doe',
+                'message' => 'This is test message!',
+            ]
+        ]);
+
+        $expected = "<h2>Hey John Doe</h2>\r\n\r\n<p>This is test message!</p>\r\n\r\n<strong>Cheers</strong>\r\n<h5>Kirby CMS</h5>";
+        $this->assertSame([
+            'html' => $expected,
+            'text' => null,
         ], $email->toArray()['body']);
     }
 

--- a/tests/Cms/Emails/fixtures/emails/media.kirby.php
+++ b/tests/Cms/Emails/fixtures/emails/media.kirby.php
@@ -1,1 +1,0 @@
-<b>Image:</b> <img src="" alt="{{ site.title }}"/>

--- a/tests/Cms/Emails/fixtures/emails/media.kirby.php
+++ b/tests/Cms/Emails/fixtures/emails/media.kirby.php
@@ -1,0 +1,1 @@
+<b>Image:</b> <img src="" alt="{{ site.title }}"/>

--- a/tests/Cms/Emails/fixtures/emails/query.html.php
+++ b/tests/Cms/Emails/fixtures/emails/query.html.php
@@ -1,0 +1,6 @@
+<h2>Hey {{ name }}</h2>
+
+<p>{{ message }}</p>
+
+<strong>Cheers</strong>
+<h5>{{ site.title }}</h5>

--- a/tests/Cms/Emails/fixtures/emails/query.text.php
+++ b/tests/Cms/Emails/fixtures/emails/query.text.php
@@ -1,0 +1,6 @@
+Hey {{ name }}
+
+{{ message }}
+
+Cheers
+{{ site.title }}


### PR DESCRIPTION
## Describe the PR

Email templates now support kirby query language to avoid swallowing newlines.

### Sample `template.text.php` template usage

````
Hey {{ name }}

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum scelerisque fringilla convallis.

Cheers
{{ site.title }}
````

## Related idea

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Closes https://github.com/getkirby/ideas/issues/589

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
