### PR TITLE
Parsedown Extra: Prevent trimming of new line characters

### DIFF
--- a/dependencies/parsedown-extra/ParsedownExtra.php
+++ b/dependencies/parsedown-extra/ParsedownExtra.php
@@ -572,6 +572,9 @@ class ParsedownExtra extends Parsedown
 
         # http://stackoverflow.com/q/11309194/200145
         $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        
+        # Ensure that saveHTML() is not remove new line characters. New lines will be split by this character.
+        $DOMDocument->formatOutput = true;
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);


### PR DESCRIPTION
## Describe the PR

Parsedown Extra trims new line characters in some PHP environments. Trimming these characters breaks the parsing of Parsdown Extra in some cases.

I don't know how fast the PR in the Parsedown Extra repo will be merged. Therefore an extra PR for Kirby.

### Example
```
<?php
$text = <<<TEXT
<div markdown="1">
## Headline
<ul>
<li>Foo</li>
<li>Bar</li>
</ul>

<ul>
<li>Second Foo</li>
<li>Second Bar</li>
</ul>
</div>
TEXT;

echo kirbytext($text)
?>
```

### Output on the local machine

```html
<div>
<h2>Headline</h2>
<ul>
<li>Foo</li>
<li>Bar</li>
</ul>
<ul>
<li>Second Foo</li>
<li>Second Bar</li>
</ul>
</div>
```

### Output on the production server (Uberspace)

```html
<div>
<h2>Headline</h2>
<ul><li>Foo</li>
<li>Bar</li>
</ul>
</div>
```

### Output on production server with the fix

```html
<div>
<h2>Headline</h2>
<ul><li>Foo</li>
<li>Bar</li>
</ul>
<ul><li>Second Foo</li>
<li>Second Bar</li>
</ul>
</div>
```

## Related issues

Parsedown Extra Issue: https://github.com/erusev/parsedown-extra/issues/153
Parsedown Extra PR: https://github.com/erusev/parsedown-extra/pull/155


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
