### PR TITLE
Remove commas from sortBy argument

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -95,6 +95,7 @@ class Collection extends Iterator implements Countable
      *
      * @param string $key string or array
      * @param mixed $value
+     * @return Collection
      */
     public function __set(string $key, $value)
     {
@@ -132,6 +133,7 @@ class Collection extends Iterator implements Countable
      *
      * @param mixed $key
      * @param mixed $item
+     * @param mixed ...$args
      * @return \Kirby\Toolkit\Collection
      */
     public function append(...$args)
@@ -159,7 +161,7 @@ class Collection extends Iterator implements Countable
         // chunk size keep keys of the elements
         $chunks = array_chunk($this->data, $size, true);
 
-        // convert each chunk to a subcollection
+        // convert each chunk to a sub collection
         $collection = [];
 
         foreach ($chunks as $items) {
@@ -191,7 +193,7 @@ class Collection extends Iterator implements Countable
     /**
      * Getter and setter for the data
      *
-     * @param array $data
+     * @param array|null $data
      * @return array|Collection
      */
     public function data(array $data = null)
@@ -240,6 +242,7 @@ class Collection extends Iterator implements Countable
      *
      * @param Closure $filter
      * @return self
+     * @throws Exception
      */
     public function filter($filter)
     {
@@ -498,7 +501,8 @@ class Collection extends Iterator implements Countable
      * Groups the elements by a given callback
      *
      * @param Closure $callback
-     * @return self A new collection with an element for each group and a subcollection in each group
+     * @return self A new collection with an element for each group and a sub collection in each group
+     * @throws Exception
      */
     public function group(Closure $callback)
     {
@@ -542,7 +546,8 @@ class Collection extends Iterator implements Countable
      *
      * @param string $field
      * @param bool $i
-     * @return \Kirby\Toolkit\Collection A new collection with an element for each group and a subcollection in each group
+     * @return \Kirby\Toolkit\Collection A new collection with an element for each group and a sub collection in each group
+     * @throws Exception
      */
     public function groupBy($field, bool $i = true)
     {
@@ -704,6 +709,7 @@ class Collection extends Iterator implements Countable
      *
      * @param array ...$arguments
      * @return \Kirby\Toolkit\Collection a sliced set of data
+     * @throws \Kirby\Exception\Exception
      */
     public function paginate(...$arguments)
     {
@@ -728,7 +734,7 @@ class Collection extends Iterator implements Countable
      * a new array
      *
      * @param string $field
-     * @param string $split
+     * @param string|null $split
      * @param bool $unique
      * @return array
      */
@@ -758,6 +764,7 @@ class Collection extends Iterator implements Countable
      *
      * @param mixed $key
      * @param mixed $item
+     * @param mixed ...$args
      * @return self
      */
     public function prepend(...$args)
@@ -781,6 +788,7 @@ class Collection extends Iterator implements Countable
      *
      * @param array $arguments
      * @return self
+     * @throws \Kirby\Exception\Exception
      */
     public function query(array $arguments = [])
     {
@@ -810,6 +818,11 @@ class Collection extends Iterator implements Countable
             if (is_array($arguments['sortBy'])) {
                 $sort = explode(' ', implode(' ', $arguments['sortBy']));
             } else {
+                // if there are commas in the sortBy argument, removes it
+                if (Str::contains($arguments['sortBy'], ',') === true) {
+                    $arguments['sortBy'] = Str::replace($arguments['sortBy'], ',', '');
+                }
+
                 $sort = explode(' ', $arguments['sortBy']);
             }
             $result = $result->sortBy(...$sort);
@@ -826,6 +839,7 @@ class Collection extends Iterator implements Countable
      * Removes an element from the array by key
      *
      * @param mixed $key the name of the key
+     * @return Collection
      */
     public function remove($key)
     {
@@ -877,7 +891,7 @@ class Collection extends Iterator implements Countable
      * Returns a slice of the object
      *
      * @param int $offset The optional index to start the slice from
-     * @param int $limit The optional number of elements to return
+     * @param int|null $limit The optional number of elements to return
      * @return \Kirby\Toolkit\Collection
      */
     public function slice(int $offset = 0, int $limit = null)
@@ -899,6 +913,11 @@ class Collection extends Iterator implements Countable
      */
     public static function sortArgs(string $sortBy): array
     {
+        // if there are commas in the sortBy argument, removes it
+        if (Str::contains($sortBy, ',') === true) {
+            $sortBy = Str::replace($sortBy, ',', '');
+        }
+
         $sortArgs = Str::split($sortBy, ' ');
 
         // fill in PHP constants
@@ -1030,7 +1049,7 @@ class Collection extends Iterator implements Countable
     /**
      * Converts the object into an array
      *
-     * @param Closure $map
+     * @param Closure|null $map
      * @return array
      */
     public function toArray(Closure $map = null): array
@@ -1078,12 +1097,12 @@ class Collection extends Iterator implements Countable
      * is true. If the first parameter is false, the Closure will not be executed.
      * You may pass another Closure as the third parameter to the when method.
      * This Closure will execute if the first parameter evaluates as false
-     * @since 3.3.0
      *
      * @param mixed $condition
      * @param Closure $callback
-     * @param Closure $fallback
+     * @param Closure|null $fallback
      * @return mixed
+     * @since 3.3.0
      */
     public function when($condition, Closure $callback, Closure $fallback = null)
     {
@@ -1112,6 +1131,12 @@ class Collection extends Iterator implements Countable
 
 /**
  * Equals Filter
+ *
+ * @param $collection
+ * @param $field
+ * @param $test
+ * @param bool $split
+ * @return mixed
  */
 Collection::$filters['=='] = function ($collection, $field, $test, $split = false) {
     foreach ($collection->data as $key => $item) {
@@ -1131,6 +1156,12 @@ Collection::$filters['=='] = function ($collection, $field, $test, $split = fals
 
 /**
  * Not Equals Filter
+ *
+ * @param $collection
+ * @param $field
+ * @param $test
+ * @param bool $split
+ * @return mixed
  */
 Collection::$filters['!='] = function ($collection, $field, $test, $split = false) {
     foreach ($collection->data as $key => $item) {

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -36,7 +36,7 @@ class Collection extends Iterator implements Countable
 
     /**
      * Pagination object
-     * @var Pagination
+     * @var \Kirby\Toolkit\Pagination
      */
     protected $pagination;
 
@@ -95,7 +95,7 @@ class Collection extends Iterator implements Countable
      *
      * @param string $key string or array
      * @param mixed $value
-     * @return Collection
+     * @return \Kirby\Toolkit\Collection
      */
     public function __set(string $key, $value)
     {
@@ -183,7 +183,7 @@ class Collection extends Iterator implements Countable
     /**
      * Returns a cloned instance of the collection
      *
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      */
     public function clone()
     {
@@ -194,7 +194,7 @@ class Collection extends Iterator implements Countable
      * Getter and setter for the data
      *
      * @param array|null $data
-     * @return array|Collection
+     * @return array|\Kirby\Toolkit\Collection
      */
     public function data(array $data = null)
     {
@@ -228,7 +228,7 @@ class Collection extends Iterator implements Countable
      * Adds all elements to the collection
      *
      * @param mixed $items
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      */
     public function extend($items)
     {
@@ -240,9 +240,9 @@ class Collection extends Iterator implements Countable
      * Filters elements by a custom
      * filter function or an array of filters
      *
-     * @param Closure $filter
+     * @param array|\Closure $filter
      * @return self
-     * @throws Exception
+     * @throws \Exception
      */
     public function filter($filter)
     {
@@ -270,7 +270,7 @@ class Collection extends Iterator implements Countable
      *
      * @param string $field
      * @param array ...$args
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      */
     public function filterBy(string $field, ...$args)
     {
@@ -320,6 +320,12 @@ class Collection extends Iterator implements Countable
         return $filter(clone $this, $field, $test, $split);
     }
 
+    /**
+     * @param $validator
+     * @param $values
+     * @param $test
+     * @return bool
+     */
     protected function filterMatchesAny($validator, $values, $test): bool
     {
         foreach ($values as $value) {
@@ -331,6 +337,12 @@ class Collection extends Iterator implements Countable
         return false;
     }
 
+    /**
+     * @param $validator
+     * @param $values
+     * @param $test
+     * @return bool
+     */
     protected function filterMatchesAll($validator, $values, $test): bool
     {
         foreach ($values as $value) {
@@ -342,6 +354,12 @@ class Collection extends Iterator implements Countable
         return true;
     }
 
+    /**
+     * @param $validator
+     * @param $values
+     * @param $test
+     * @return bool
+     */
     protected function filterMatchesNone($validator, $values, $test): bool
     {
         $matches = 0;
@@ -500,9 +518,9 @@ class Collection extends Iterator implements Countable
     /**
      * Groups the elements by a given callback
      *
-     * @param Closure $callback
-     * @return self A new collection with an element for each group and a sub collection in each group
-     * @throws Exception
+     * @param \Closure $callback
+     * @return \Kirby\Toolkit\Collection A new collection with an element for each group and a sub collection in each group
+     * @throws \Exception
      */
     public function group(Closure $callback)
     {
@@ -547,7 +565,7 @@ class Collection extends Iterator implements Countable
      * @param string $field
      * @param bool $i
      * @return \Kirby\Toolkit\Collection A new collection with an element for each group and a sub collection in each group
-     * @throws Exception
+     * @throws \Exception
      */
     public function groupBy($field, bool $i = true)
     {
@@ -765,7 +783,7 @@ class Collection extends Iterator implements Countable
      * @param mixed $key
      * @param mixed $item
      * @param mixed ...$args
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      */
     public function prepend(...$args)
     {
@@ -787,7 +805,7 @@ class Collection extends Iterator implements Countable
      * Any part of the query is optional.
      *
      * @param array $arguments
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      * @throws \Kirby\Exception\Exception
      */
     public function query(array $arguments = [])
@@ -839,7 +857,7 @@ class Collection extends Iterator implements Countable
      * Removes an element from the array by key
      *
      * @param mixed $key the name of the key
-     * @return Collection
+     * @return \Kirby\Toolkit\Collection
      */
     public function remove($key)
     {
@@ -852,7 +870,7 @@ class Collection extends Iterator implements Countable
      *
      * @param mixed $key string or array
      * @param mixed $value
-     * @return self
+     * @return \Kirby\Toolkit\Collection
      */
     public function set($key, $value = null)
     {
@@ -936,7 +954,7 @@ class Collection extends Iterator implements Countable
      * @param string|callable $field Field name or value callback to sort by
      * @param string $direction asc or desc
      * @param int $method The sort flag, SORT_REGULAR, SORT_NUMERIC etc.
-     * @return Collection
+     * @return \Kirby\Toolkit\Collection
      */
     public function sortBy()
     {
@@ -1049,7 +1067,7 @@ class Collection extends Iterator implements Countable
     /**
      * Converts the object into an array
      *
-     * @param Closure|null $map
+     * @param \Closure|null $map
      * @return array
      */
     public function toArray(Closure $map = null): array
@@ -1072,7 +1090,7 @@ class Collection extends Iterator implements Countable
     }
 
     /**
-     * Convertes the object to a string
+     * Converts the object to a string
      *
      * @return string
      */
@@ -1099,8 +1117,8 @@ class Collection extends Iterator implements Countable
      * This Closure will execute if the first parameter evaluates as false
      *
      * @param mixed $condition
-     * @param Closure $callback
-     * @param Closure|null $fallback
+     * @param \Closure $callback
+     * @param \Closure|null $fallback
      * @return mixed
      * @since 3.3.0
      */

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -242,7 +242,7 @@ class Collection extends Iterator implements Countable
      *
      * @param array|\Closure $filter
      * @return self
-     * @throws \Exception
+     * @throws \Exception if $filter is neither a closure nor an array 
      */
     public function filter($filter)
     {
@@ -321,9 +321,9 @@ class Collection extends Iterator implements Countable
     }
 
     /**
-     * @param $validator
-     * @param $values
-     * @param $test
+     * @param string $validator
+     * @param mixed $values
+     * @param mixed $test
      * @return bool
      */
     protected function filterMatchesAny($validator, $values, $test): bool
@@ -338,9 +338,9 @@ class Collection extends Iterator implements Countable
     }
 
     /**
-     * @param $validator
-     * @param $values
-     * @param $test
+     * @param string $validator
+     * @param array $values
+     * @param mixed $test
      * @return bool
      */
     protected function filterMatchesAll($validator, $values, $test): bool
@@ -355,9 +355,9 @@ class Collection extends Iterator implements Countable
     }
 
     /**
-     * @param $validator
-     * @param $values
-     * @param $test
+     * @param string $validator
+     * @param array $values
+     * @param mixed $test
      * @return bool
      */
     protected function filterMatchesNone($validator, $values, $test): bool
@@ -508,7 +508,7 @@ class Collection extends Iterator implements Countable
     /**
      * @param object $object
      * @param string $attribute
-     * @return void
+     * @return mixed
      */
     protected function getAttributeFromObject($object, string $attribute)
     {
@@ -727,7 +727,6 @@ class Collection extends Iterator implements Countable
      *
      * @param array ...$arguments
      * @return \Kirby\Toolkit\Collection a sliced set of data
-     * @throws \Kirby\Exception\Exception
      */
     public function paginate(...$arguments)
     {
@@ -806,7 +805,6 @@ class Collection extends Iterator implements Countable
      *
      * @param array $arguments
      * @return \Kirby\Toolkit\Collection
-     * @throws \Kirby\Exception\Exception
      */
     public function query(array $arguments = [])
     {
@@ -1116,11 +1114,11 @@ class Collection extends Iterator implements Countable
      * You may pass another Closure as the third parameter to the when method.
      * This Closure will execute if the first parameter evaluates as false
      *
+     * @since 3.3.0
      * @param mixed $condition
      * @param \Closure $callback
      * @param \Closure|null $fallback
      * @return mixed
-     * @since 3.3.0
      */
     public function when($condition, Closure $callback, Closure $fallback = null)
     {
@@ -1150,9 +1148,9 @@ class Collection extends Iterator implements Countable
 /**
  * Equals Filter
  *
- * @param $collection
- * @param $field
- * @param $test
+ * @param \Kirby\Toolkit\Collection $collection
+ * @param mixed $field
+ * @param mixed $test
  * @param bool $split
  * @return mixed
  */
@@ -1175,9 +1173,9 @@ Collection::$filters['=='] = function ($collection, $field, $test, $split = fals
 /**
  * Not Equals Filter
  *
- * @param $collection
- * @param $field
- * @param $test
+ * @param \Kirby\Toolkit\Collection $collection
+ * @param mixed $field
+ * @param mixed $test
  * @param bool $split
  * @return mixed
  */

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -220,6 +220,43 @@ class PagesSectionTest extends TestCase
         setlocale(LC_ALL, $locale);
     }
 
+    public function testSortByMultiple()
+    {
+        $page = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-3', 'content' => ['title' => 'B']],
+                ['slug' => 'subpage-4', 'content' => ['title' => 'A']],
+                ['slug' => 'subpage-1', 'content' => ['title' => 'A']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'B']]
+            ]
+        ]);
+
+        // simple multiple fields
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title asc slug desc'
+        ]);
+
+        $this->assertSame('test/subpage-4', $section->data()[0]['id']);
+        $this->assertSame('test/subpage-1', $section->data()[1]['id']);
+        $this->assertSame('test/subpage-3', $section->data()[2]['id']);
+        $this->assertSame('test/subpage-2', $section->data()[3]['id']);
+
+        // multiple fields with comma
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $page,
+            'sortBy' => 'title desc, slug asc'
+        ]);
+
+        $this->assertSame('test/subpage-2', $section->data()[0]['id']);
+        $this->assertSame('test/subpage-3', $section->data()[1]['id']);
+        $this->assertSame('test/subpage-1', $section->data()[2]['id']);
+        $this->assertSame('test/subpage-4', $section->data()[3]['id']);
+    }
+
     public function testSortable()
     {
         $section = new Section('pages', [

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -630,6 +630,25 @@ class CollectionTest extends TestCase
         ])->first()['name']);
     }
 
+    public function testQuerySortByComma()
+    {
+        $collection = new Collection([
+            'one'   => ['key' => 'erei', 'value' => 'arsz'],
+            'two'   => ['key' => 'zwei', 'value' => 'fors'],
+            'three' => ['key' => 'erei', 'value' => 'beck'],
+            'four'  => ['key' => 'vier', 'value' => 'tars']
+        ]);
+
+        $results = $collection->query(['sortBy' => 'key asc, value desc'])->toArray();
+
+        $this->assertSame([
+            'three',
+            'one',
+            'four',
+            'two',
+        ], array_keys($results));
+    }
+
     public function testRemoveMultiple()
     {
         $collection = new Collection();


### PR DESCRIPTION
## Describe the PR

Try to implement https://github.com/getkirby/ideas/issues/195 idea. If there are commas in the `sortBy` argument, removes it.

````yaml
sortBy: date desc title desc
# new feature 
sortBy: date desc, title desc
````

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Closes https://github.com/getkirby/ideas/issues/195

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
