### PR TITLE
Search feature for pages and files section

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -13,6 +13,7 @@ return [
         'max',
         'pagination',
         'parent',
+        'search'
     ],
     'props' => [
         /**
@@ -86,6 +87,12 @@ return [
             // filter out all protected files
             $files = $files->filterBy('isReadable', true);
 
+            // search
+            if ($this->search === true && empty($this->query) === false) {
+                $files = $files->search($this->query);
+            }
+
+            // sort
             if ($this->sortBy) {
                 $files = $files->sortBy(...$files::sortArgs($this->sortBy));
             } elseif ($this->sortable === true) {
@@ -181,6 +188,10 @@ return [
                 return false;
             }
 
+            if (empty($this->query) === false) {
+                return false;
+            }
+
             if ($this->sortBy !== null) {
                 return false;
             }
@@ -231,8 +242,10 @@ return [
                 'link'     => $this->link,
                 'max'      => $this->max,
                 'min'      => $this->min,
+                'search'   => $this->search,
                 'size'     => $this->size,
                 'sortable' => $this->sortable,
+                'query'    => $this->query,
                 'upload'   => $this->upload
             ],
             'pagination' => $this->pagination

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -2,6 +2,17 @@
 
 return [
     'props' => [
-
+        /**
+         * Enable/disable the search in the sections
+         */
+        'search' => function (bool $search = false) {
+            return $search;
+        },
+        /**
+         * Sets the default query for the sections
+         */
+        'query' => function (string $query = null) {
+            return get('query', $query);
+        }
     ]
 ];

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'props' => [
+
+    ]
+];

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -13,7 +13,8 @@ return [
         'min',
         'max',
         'pagination',
-        'parent'
+        'parent',
+        'search'
     ],
     'props' => [
         /**
@@ -122,6 +123,11 @@ return [
                     unset($pages->data[$id]);
                     continue;
                 }
+            }
+
+            // search
+            if ($this->search === true && empty($this->query) === false) {
+                $pages = $pages->search($this->query);
             }
 
             // sort
@@ -235,6 +241,10 @@ return [
                 return false;
             }
 
+            if (empty($this->query) === false) {
+                return false;
+            }
+
             if ($this->sortBy !== null) {
                 return false;
             }
@@ -289,8 +299,10 @@ return [
                 'link'     => $this->link,
                 'max'      => $this->max,
                 'min'      => $this->min,
+                'search'   => $this->search,
                 'size'     => $this->size,
-                'sortable' => $this->sortable
+                'sortable' => $this->sortable,
+                'query'    => $this->query
             ],
             'pagination' => $this->pagination,
         ];

--- a/panel/src/components/Layout/Collection.vue
+++ b/panel/src/components/Layout/Collection.vue
@@ -164,4 +164,13 @@ export default {
   padding: .5rem .75rem;
   line-height: 1.125rem;
 }
+.k-collection-search {
+  margin-bottom: .75rem;
+}
+.k-collection-search.k-input {
+  background: rgba(#000, .075);
+  padding: 0 1rem;
+  height: 36px;
+  border-radius: $border-radius;
+}
 </style>

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -22,6 +22,16 @@
 
     <template v-else>
       <k-dropzone :disabled="add === false" @drop="drop">
+        <k-input
+            v-if="options.search"
+            :autofocus="true"
+            :placeholder="$t('search') + ' …'"
+            v-model="search"
+            type="text"
+            class="k-collection-search"
+            icon="search"
+        />
+
         <k-collection
           v-if="data.length"
           :help="help"

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -6,8 +6,9 @@
       <k-headline>
         {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
       </k-headline>
-      <k-button-group v-if="add">
-        <k-button icon="upload" @click="upload">{{ $t("add") }}</k-button>
+      <k-button-group v-if="add || options.search">
+        <k-button v-if="options.search" icon="search" @click="toggleSearch"/>
+        <k-button v-if="add" icon="upload" @click="upload">{{ $t("add") }}</k-button>
       </k-button-group>
     </header>
 
@@ -22,15 +23,16 @@
 
     <template v-else>
       <k-dropzone :disabled="add === false" @drop="drop">
-        <k-input
-            v-if="options.search"
-            :autofocus="true"
-            :placeholder="$t('search') + ' …'"
-            v-model="search"
-            type="text"
-            class="k-collection-search"
-            icon="search"
-        />
+        <transition name="fade">
+          <k-input
+              v-if="searchable && options.search"
+              :autofocus="true"
+              :placeholder="$t('search') + ' …'"
+              v-model="search"
+              type="text"
+              class="k-collection-search"
+          />
+        </transition>
 
         <k-collection
           v-if="data.length"
@@ -79,6 +81,11 @@ import CollectionSectionMixin from "@/mixins/section/collection.js";
 
 export default {
   mixins: [CollectionSectionMixin],
+  data() {
+    return {
+      searchable: false,
+    }
+  },
   computed: {
     add() {
       if (this.$permissions.files.create && this.options.upload !== false) {
@@ -187,6 +194,9 @@ export default {
           this.reload();
           this.$store.dispatch("notification/error", response.message);
         });
+    },
+    toggleSearch() {
+      this.searchable = !this.searchable;
     },
     update() {
       this.$events.$emit("model.update");

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -6,8 +6,9 @@
         {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
       </k-headline>
 
-      <k-button-group v-if="add">
-        <k-button icon="add" @click="create">{{ $t("add") }}</k-button>
+      <k-button-group v-if="add || options.search">
+        <k-button v-if="options.search" icon="search" @click="toggleSearch"/>
+        <k-button v-if="add" icon="add" @click="create">{{ $t("add") }}</k-button>
       </k-button-group>
     </header>
 
@@ -23,15 +24,16 @@
     </template>
 
     <template v-else>
-      <k-input
-          v-if="options.search"
-          :autofocus="true"
-          :placeholder="$t('search') + ' …'"
-          v-model="search"
-          type="text"
-          class="k-collection-search"
-          icon="search"
-      />
+      <transition name="fade">
+        <k-input
+            v-if="searchable && options.search"
+            :autofocus="true"
+            :placeholder="$t('search') + ' …'"
+            v-model="search"
+            type="text"
+            class="k-collection-search"
+        />
+      </transition>
 
       <k-collection
         v-if="data.length"
@@ -84,6 +86,11 @@ import CollectionSectionMixin from "@/mixins/section/collection.js";
 
 export default {
   mixins: [CollectionSectionMixin],
+  data() {
+    return {
+      searchable: false,
+    }
+  },
   computed: {
     add() {
       return this.options.add && this.$permissions.pages.create;
@@ -223,6 +230,9 @@ export default {
             this.reload();
           });
       }
+    },
+    toggleSearch() {
+      this.searchable = !this.searchable;
     },
     update() {
       this.reload();

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -23,6 +23,16 @@
     </template>
 
     <template v-else>
+      <k-input
+          v-if="options.search"
+          :autofocus="true"
+          :placeholder="$t('search') + ' …'"
+          v-model="search"
+          type="text"
+          class="k-collection-search"
+          icon="search"
+      />
+
       <k-collection
         v-if="data.length"
         :layout="options.layout"

--- a/panel/src/mixins/section/collection.js
+++ b/panel/src/mixins/section/collection.js
@@ -1,3 +1,5 @@
+import debounce from "@/helpers/debounce";
+
 export default {
   inheritAttrs: false,
   props: {
@@ -20,8 +22,10 @@ export default {
         max: null,
         min: null,
         size: null,
+        search: null,
         sortable: null
       },
+      search: null,
       pagination: {
         page: null
       }
@@ -55,7 +59,11 @@ export default {
   watch: {
     language() {
       this.reload();
-    }
+    },
+    search: debounce(function () {
+      this.pagination.page = 0;
+      this.reload();
+    }, 200),
   },
   methods: {
     items(data) {
@@ -73,7 +81,7 @@ export default {
       try {
         const response = await this.$api.get(
           this.parent + "/sections/" + this.name,
-          { page: this.pagination.page }
+          { page: this.pagination.page, query: this.search }
         );
 
         this.options = response.options;

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -665,6 +665,7 @@ trait AppPlugins
             Section::$mixins['min']            = include $root . '/config/sections/mixins/min.php';
             Section::$mixins['pagination']     = include $root . '/config/sections/mixins/pagination.php';
             Section::$mixins['parent']         = include $root . '/config/sections/mixins/parent.php';
+            Section::$mixins['search']         = include $root . '/config/sections/mixins/search.php';
 
             // section types
             Section::$types['info']            = include $root . '/config/sections/info.php';

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -21,7 +21,6 @@ class FilesSectionTest extends TestCase
 
     public function testHeadline()
     {
-
         // single headline
         $section = new Section('files', [
             'name'     => 'test',
@@ -351,15 +350,9 @@ class FilesSectionTest extends TestCase
         $model = new Page([
             'slug'  => 'test',
             'files' => [
-                [
-                    'filename' => 'c.jpg'
-                ],
-                [
-                    'filename' => 'a.jpg'
-                ],
-                [
-                    'filename' => 'b.jpg'
-                ]
+                ['filename' => 'c.jpg'],
+                ['filename' => 'a.jpg'],
+                ['filename' => 'b.jpg']
             ]
         ]);
 
@@ -372,5 +365,72 @@ class FilesSectionTest extends TestCase
         $this->assertEquals('c.jpg', $section->data()[0]['filename']);
         $this->assertEquals('b.jpg', $section->data()[1]['filename']);
         $this->assertEquals('a.jpg', $section->data()[2]['filename']);
+    }
+
+    public function testSearch()
+    {
+        $model = new Page([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'mount-bike.jpg'],
+                ['filename' => 'mountain.jpg'],
+                ['filename' => 'bike.jpg']
+            ]
+        ]);
+
+        // no search option as default
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => $model
+        ]);
+
+        $this->assertCount(3, $section->data());
+
+        // enabled search with no query
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true
+        ]);
+
+        $this->assertCount(3, $section->data());
+
+        // search with query
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'bike'
+
+        ]);
+
+        $this->assertCount(2, $section->data());
+        $this->assertSame('bike.jpg', $section->data()[0]['filename']);
+        $this->assertSame('mount-bike.jpg', $section->data()[1]['filename']);
+
+        // search with query alternative
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'mount'
+
+        ]);
+
+        $this->assertCount(2, $section->data());
+        $this->assertSame('mount-bike.jpg', $section->data()[0]['filename']);
+        $this->assertSame('mountain.jpg', $section->data()[1]['filename']);
+
+        // search with query alternative
+        $section = new Section('files', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'mountain'
+
+        ]);
+
+        $this->assertCount(1, $section->data());
+        $this->assertSame('mountain.jpg', $section->data()[0]['filename']);
     }
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -404,4 +404,71 @@ class PagesSectionTest extends TestCase
 
         $this->assertEquals('<p>Information</p>', $section->help());
     }
+
+    public function testSearch()
+    {
+        $model = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-1', 'content' => ['title' => 'Mount Bike']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'Mountain']],
+                ['slug' => 'subpage-3', 'content' => ['title' => 'Bike']]
+            ]
+        ]);
+
+        // no search option as default
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $model
+        ]);
+
+        $this->assertCount(3, $section->data());
+
+        // enabled search with no query
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true
+        ]);
+
+        $this->assertCount(3, $section->data());
+
+        // search with query
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'bike'
+
+        ]);
+
+        $this->assertCount(2, $section->data());
+        $this->assertSame('Bike', $section->data()[0]['text']);
+        $this->assertSame('Mount Bike', $section->data()[1]['text']);
+
+        // search with query alternative
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'mount'
+
+        ]);
+
+        $this->assertCount(2, $section->data());
+        $this->assertSame('Mount Bike', $section->data()[0]['text']);
+        $this->assertSame('Mountain', $section->data()[1]['text']);
+
+        // search with query alternative
+        $section = new Section('pages', [
+            'name'   => 'test',
+            'model'  => $model,
+            'search' => true,
+            'query'  => 'mountain'
+
+        ]);
+
+        $this->assertCount(1, $section->data());
+        $this->assertSame('Mountain', $section->data()[0]['text']);
+    }
 }


### PR DESCRIPTION
## Describe the PR

Now pages and files section searchable 🎉 

### Sample usage

````yaml
sections:
  pages:
    type: pages
    create: default
    # enable searching, default is false
    search: true
    # set default query when section loaded, default null
    query: foo
````

### Screenshot

![screen-capture-196-Mægazine-localhost](https://user-images.githubusercontent.com/3393422/90443837-8f07b100-e0e5-11ea-9c98-7633a0ca43a5.png)

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Closes https://github.com/getkirby/ideas/issues/18
- Closes https://kirby.nolt.io/14

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
