### PR TITLE
Fix/progress bar styling

### DIFF
--- a/panel/src/components/Misc/Progress.vue
+++ b/panel/src/components/Misc/Progress.vue
@@ -31,6 +31,8 @@ export default {
   width: 100%;
   height: 0.5rem;
   border-radius: 5rem;
+  background: $color-border;
+  border: none;
 }
 
 .k-progress::-webkit-progress-bar {
@@ -41,7 +43,13 @@ export default {
 }
 
 .k-progress::-webkit-progress-value {
-  border-radius: 20px;
+  border-radius: inherit;
+  background: $color-focus;
+  transition: width 0.3s;
+}
+
+.k-progress::-moz-progress-bar {
+  border-radius: inherit;
   background: $color-focus;
   transition: width 0.3s;
 }

--- a/panel/src/components/Misc/Progress.vue
+++ b/panel/src/components/Misc/Progress.vue
@@ -32,6 +32,7 @@ export default {
   height: 0.5rem;
   border-radius: 5rem;
   background: $color-border;
+  overflow: hidden;
   border: none;
 }
 


### PR DESCRIPTION
## Describe the PR

This PR fixes styling Issues of the progress bar component. Styles for firefox are added and overflowing the bar is now prevented.

## Related issues

- Fixes #2784 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
