### PR TITLE
Implement fuzzy/similar search

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -114,7 +114,9 @@ return [
                 ->files();
 
             if ($this->requestMethod() === 'GET') {
-                return $files->search($this->requestQuery('q'));
+                return $files->search($this->requestQuery('q'), [
+                    'similar' => filter_var($this->requestQuery('similar'), FILTER_VALIDATE_BOOLEAN)
+                ]);
             } else {
                 return $files->query($this->requestBody());
             }

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -70,7 +70,9 @@ return [
                 ->filterBy('isReadable', true);
 
             if ($this->requestMethod() === 'GET') {
-                return $pages->search($this->requestQuery('q'));
+                return $pages->search($this->requestQuery('q'), [
+                    'similar' => filter_var($this->requestQuery('similar'), FILTER_VALIDATE_BOOLEAN)
+                ]);
             } else {
                 return $pages->query($this->requestBody());
             }

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -26,7 +26,9 @@ return [
         'method'  => 'GET|POST',
         'action'  => function () {
             if ($this->requestMethod() === 'GET') {
-                return $this->users()->search($this->requestQuery('q'));
+                return $this->users()->search($this->requestQuery('q'), [
+                    'similar' => filter_var($this->requestQuery('similar'), FILTER_VALIDATE_BOOLEAN)
+                ]);
             } else {
                 return $this->users()->query($this->requestBody());
             }

--- a/config/components.php
+++ b/config/components.php
@@ -160,6 +160,7 @@ return [
             'fields'    => [],
             'minlength' => 2,
             'score'     => [],
+            'similar'   => false,
             'words'     => false,
         ];
 
@@ -230,6 +231,19 @@ return [
                 if ($matches = preg_match_all($preg, $value, $r)) {
                     $item->searchHits  += $matches;
                     $item->searchScore += $matches * $score;
+                }
+
+                // check for similar matches
+                if ($options['words'] === false && $options['similar'] === true) {
+                    $matches = Str::similarText($lowerQuery, $lowerValue, $similarPercent);
+
+                    if ($matches > 0) {
+                        // calculate score based on percentage
+                        // for example 66.6% result: (66.6 / 10) * $score, final result is (7 * $score)
+                        // the coefficient can be a value between 0 and 10
+                        $item->searchScore += round($similarPercent / 10) * $score;
+                        $item->searchHits  += 1;
+                    }
                 }
             }
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -345,6 +345,7 @@
 
   "save": "Save",
   "search": "Search",
+  "search.similar": "Toggle similar search",
   "search.min": "Enter {min} characters to search",
   "search.all": "Show all",
   "search.results.none": "No results",

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -19,7 +19,7 @@
           ref="input"
           v-model="q"
           :placeholder="$t('search') + ' …'"
-          aria-label="$t('search')"
+          :aria-label="$t('search')"
           type="text"
           @keydown.down.prevent="down"
           @keydown.up.prevent="up"
@@ -27,6 +27,13 @@
           @keydown.enter="enter"
           @keydown.esc="close"
         >
+        <k-button
+            :tooltip="$t('search.similar')"
+            :theme="similar ? 'positive' : 'negative'"
+            class="k-search-similar"
+            icon="wand"
+            @click="toggleSimilar"
+        />
         <k-button
           :tooltip="$t('close')"
           class="k-search-close"
@@ -60,6 +67,7 @@ export default {
     return {
       items: [],
       q: null,
+      similar: false,
       selected: -1,
       currentType: this.$store.state.view === "users" ? "users" : "pages"
     }
@@ -93,6 +101,9 @@ export default {
       this.search(q);
     }, 200),
     currentType() {
+      this.search(this.q);
+    },
+    similar() {
       this.search(this.q);
     }
   },
@@ -157,7 +168,11 @@ export default {
       try {
         const response = await this.$api.get(
           this.type.endpoint,
-          { q: query, limit: config.search.limit }
+          {
+            q: query,
+            limit: config.search.limit,
+            similar: this.similar
+          }
         );
         this.items = response.data.map(this['map_' + this.currentType]);
 
@@ -174,6 +189,9 @@ export default {
       if (item) {
         this.navigate(item);
       }
+    },
+    toggleSimilar() {
+      this.similar = !this.similar;
     },
     up() {
       if (this.selected >= 0) {
@@ -235,6 +253,10 @@ export default {
   height: 2.5rem;
 }
 .k-search-close {
+  width: 2.5rem;
+  line-height: 1;
+}
+.k-search-similar {
   width: 2.5rem;
   line-height: 1;
 }

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -802,6 +802,9 @@ class Str
     /**
      * Calculate the similarity between two strings with multibyte support
      *
+     * @author Antal Áron
+     * @copyright Copyright (c) 2017, Antal Áron
+     * @license https://github.com/antalaron/mb-similar-text/blob/master/LICENSE MIT License
      * @param string $first
      * @param string $second
      * @param float|null $percent

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -800,6 +800,57 @@ class Str
     }
 
     /**
+     * Calculate the similarity between two strings with multibyte support
+     *
+     * @param string $first
+     * @param string $second
+     * @param float|null $percent
+     * @return int
+     */
+    public static function similarText(string $first, string $second, float &$percent = null): int
+    {
+        if (mb_strlen($first) + mb_strlen($second) === 0) {
+            $percent = 0.0;
+
+            return 0;
+        }
+
+        $pos1 = $pos2 = $max = 0;
+        $len1 = mb_strlen($first);
+        $len2 = mb_strlen($second);
+
+        for ($p = 0; $p < $len1; ++$p) {
+            for ($q = 0; $q < $len2; ++$q) {
+                for ($l = 0; ($p + $l < $len1) && ($q + $l < $len2) && mb_substr($first, $p + $l, 1) === mb_substr($second, $q + $l, 1); ++$l) {
+                    // nothing to do
+                }
+                if ($l > $max) {
+                    $max = $l;
+                    $pos1 = $p;
+                    $pos2 = $q;
+                }
+            }
+        }
+
+        $similarity = $max;
+        if ($similarity) {
+            if ($pos1 && $pos2) {
+                $similarity += static::similarText(mb_substr($first, 0, $pos1), mb_substr($second, 0, $pos2));
+            }
+            if (($pos1 + $max < $len1) && ($pos2 + $max < $len2)) {
+                $similarity += static::similarText(
+                    mb_substr($first, $pos1 + $max, $len1 - $pos1 - $max),
+                    mb_substr($second, $pos2 + $max, $len2 - $pos2 - $max)
+                );
+            }
+        }
+
+        $percent = ($similarity * 200.0) / ($len1 + $len2);
+
+        return $similarity;
+    }
+
+    /**
      * Convert a string to snake case.
      *
      * @param string $value

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -605,9 +605,9 @@ class PagesTest extends TestCase
         $result = $pages->search('tete', ['similar' => true]);
         $data = array_values($result->data());
 
-        $this->assertSame("Tête", $data[0]->title()->value());
-        $this->assertSame("Têka", $data[1]->title()->value());
-        $this->assertSame("Bart", $data[2]->title()->value());
+        $this->assertSame('Tête', $data[0]->title()->value());
+        $this->assertSame('Têka', $data[1]->title()->value());
+        $this->assertSame('Bart', $data[2]->title()->value());
     }
 
     public function testCustomMethods()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -570,6 +570,46 @@ class PagesTest extends TestCase
         $this->assertCount(4, $result);
     }
 
+    public function testSearchSimilar()
+    {
+        $pages = Pages::factory([
+            [
+                'slug'    => 'a',
+                'content' => [
+                    'title' => 'Fors'
+                ]
+            ],
+            [
+                'slug'    => 'b',
+                'content' => [
+                    'title' => 'Têka'
+                ]
+            ],
+            [
+                'slug'    => 'c',
+                'content' => [
+                    'title' => 'Bart'
+                ]
+            ],
+            [
+                'slug'    => 'd',
+                'content' => [
+                    'title' => 'Tête'
+                ]
+            ]
+        ]);
+
+        $result = $pages->search('tete', ['similar' => false]);
+        $this->assertCount(0, $result);
+
+        $result = $pages->search('tete', ['similar' => true]);
+        $data = array_values($result->data());
+
+        $this->assertSame("Tête", $data[0]->title()->value());
+        $this->assertSame("Têka", $data[1]->title()->value());
+        $this->assertSame("Bart", $data[2]->title()->value());
+    }
+
     public function testCustomMethods()
     {
         Pages::$methods = [

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -737,4 +737,28 @@ EOT;
         $this->assertEquals('ÖÄÜ', Str::upper('öäü'));
         $this->assertEquals('ÖÄÜ', Str::upper('Öäü'));
     }
+
+    public function testSimilarText()
+    {
+        $this->assertSame(0, Str::similarText('foo', 'bar', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(0, Str::similarText('foo', '', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(0, Str::similarText('', '', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(3, Str::similarText('foo', 'fooBar', $percent));
+        $this->assertSame(66.66666666666667, $percent);
+
+        $this->assertSame(3, Str::similarText('Tête', 'tête', $percent));
+        $this->assertSame(75.0, $percent);
+
+        $this->assertSame(3, Str::similarText('foo', 'foo', $percent));
+        $this->assertSame(100.0, $percent);
+
+        $this->assertSame(4, Str::similarText('tête', 'tête', $percent));
+        $this->assertSame(100.0, $percent);
+    }
 }


### PR DESCRIPTION
## Describe the PR

Similar searches feature added to collections 🎉 

Since the [similar_text()](https://www.php.net/manual/en/function.similar-text.php) method doesn't support multibytes, I used a [different method](https://github.com/antalaron/mb-similar-text). 

Similar search is disabled by default. For the panel UI, I added a button that can be changed instantly and easily.

Feel free to close the PR if a different implementation is being considered 👍 

**Screencast from Panel**

![fuzzy](https://user-images.githubusercontent.com/3393422/91744491-45799480-ebc2-11ea-8350-db70346269bf.gif)

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Closes https://github.com/getkirby/ideas/issues/140

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
