### PR TITLE
Support arrays with page/file/user ids in $collection->not()

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -54,7 +54,7 @@ class Collection extends BaseCollection
      * Creates a new Collection with the given objects
      *
      * @param array $objects
-     * @param object $parent
+     * @param object|null $parent
      */
     public function __construct($objects = [], $parent = null)
     {
@@ -71,7 +71,7 @@ class Collection extends BaseCollection
      * the collection prop on each object correctly.
      *
      * @param string $id
-     * @param object $object
+     * @param object|null $object
      */
     public function __set(string $id, $object)
     {
@@ -84,6 +84,7 @@ class Collection extends BaseCollection
      * current collection
      *
      * @param mixed $object
+     * @return \Kirby\Cms\Collection
      */
     public function add($object)
     {
@@ -103,6 +104,7 @@ class Collection extends BaseCollection
      *
      * @param mixed $key Optional collection key, will be determined from the item if not given
      * @param mixed $item
+     * @param mixed ...$args
      * @return \Kirby\Cms\Collection
      */
     public function append(...$args)
@@ -126,6 +128,7 @@ class Collection extends BaseCollection
      * @param string $field
      * @param bool $i Ignore upper/lowercase for group names
      * @return \Kirby\Cms\Collection
+     * @throws \Exception
      */
     public function groupBy($field, bool $i = true)
     {
@@ -202,14 +205,23 @@ class Collection extends BaseCollection
     public function not(...$keys)
     {
         $collection = $this->clone();
+
         foreach ($keys as $key) {
-            if (is_a($key, 'Kirby\Toolkit\Collection') === true) {
-                $collection = $collection->not(...$key->keys());
-            } elseif (is_object($key) === true) {
-                $key = $key->id();
+            if (is_array($key) === true) {
+                foreach ($key as $id) {
+                    unset($collection->{$id});
+                }
+            } else {
+                if (is_a($key, 'Kirby\Toolkit\Collection') === true) {
+                    $collection = $collection->not(...$key->keys());
+                } elseif (is_object($key) === true) {
+                    $key = $key->id();
+                }
+
+                unset($collection->{$key});
             }
-            unset($collection->$key);
         }
+
         return $collection;
     }
 
@@ -242,6 +254,7 @@ class Collection extends BaseCollection
      *
      * @param mixed $key Optional collection key, will be determined from the item if not given
      * @param mixed $item
+     * @param mixed ...$args
      * @return \Kirby\Cms\Collection
      */
     public function prepend(...$args)
@@ -294,6 +307,7 @@ class Collection extends BaseCollection
      * Removes an object
      *
      * @param mixed $key the name of the key
+     * @return \Kirby\Cms\Collection
      */
     public function remove($key)
     {
@@ -307,7 +321,7 @@ class Collection extends BaseCollection
     /**
      * Searches the collection
      *
-     * @param string $query
+     * @param string|null $query
      * @param array $params
      * @return self
      */
@@ -321,7 +335,7 @@ class Collection extends BaseCollection
      * to an array. This can also take a callback
      * function to further modify the array result.
      *
-     * @param Closure $map
+     * @param \Closure|null $map
      * @return array
      */
     public function toArray(Closure $map = null): array

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -205,18 +205,14 @@ class Collection extends BaseCollection
 
         foreach ($keys as $key) {
             if (is_array($key) === true) {
-                foreach ($key as $id) {
-                    unset($collection->{$id});
-                }
-            } else {
-                if (is_a($key, 'Kirby\Toolkit\Collection') === true) {
-                    $collection = $collection->not(...$key->keys());
-                } elseif (is_object($key) === true) {
-                    $key = $key->id();
-                }
-
-                unset($collection->{$key});
+                return $this->not(...$key);
+            } elseif (is_a($key, 'Kirby\Toolkit\Collection') === true) {
+                $collection = $collection->not(...$key->keys());
+            } elseif (is_object($key) === true) {
+                $key = $key->id();
             }
+
+            unset($collection->{$key});
         }
 
         return $collection;

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -54,7 +54,7 @@ class Collection extends BaseCollection
      * Creates a new Collection with the given objects
      *
      * @param array $objects
-     * @param object|null $parent
+     * @param object $parent
      */
     public function __construct($objects = [], $parent = null)
     {
@@ -71,7 +71,7 @@ class Collection extends BaseCollection
      * the collection prop on each object correctly.
      *
      * @param string $id
-     * @param object|null $object
+     * @param object $object
      */
     public function __set(string $id, $object)
     {
@@ -84,7 +84,6 @@ class Collection extends BaseCollection
      * current collection
      *
      * @param mixed $object
-     * @return \Kirby\Cms\Collection
      */
     public function add($object)
     {
@@ -104,7 +103,6 @@ class Collection extends BaseCollection
      *
      * @param mixed $key Optional collection key, will be determined from the item if not given
      * @param mixed $item
-     * @param mixed ...$args
      * @return \Kirby\Cms\Collection
      */
     public function append(...$args)
@@ -128,7 +126,6 @@ class Collection extends BaseCollection
      * @param string $field
      * @param bool $i Ignore upper/lowercase for group names
      * @return \Kirby\Cms\Collection
-     * @throws \Exception
      */
     public function groupBy($field, bool $i = true)
     {
@@ -254,7 +251,6 @@ class Collection extends BaseCollection
      *
      * @param mixed $key Optional collection key, will be determined from the item if not given
      * @param mixed $item
-     * @param mixed ...$args
      * @return \Kirby\Cms\Collection
      */
     public function prepend(...$args)
@@ -321,7 +317,7 @@ class Collection extends BaseCollection
     /**
      * Searches the collection
      *
-     * @param string|null $query
+     * @param string $query
      * @param array $params
      * @return self
      */
@@ -335,7 +331,7 @@ class Collection extends BaseCollection
      * to an array. This can also take a callback
      * function to further modify the array result.
      *
-     * @param \Closure|null $map
+     * @param Closure $map
      * @return array
      */
     public function toArray(Closure $map = null): array

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -303,7 +303,6 @@ class Collection extends BaseCollection
      * Removes an object
      *
      * @param mixed $key the name of the key
-     * @return \Kirby\Cms\Collection
      */
     public function remove($key)
     {

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -222,9 +222,9 @@ class CollectionTest extends TestCase
     public function testNotWithCollection()
     {
         $collection = new Collection([
-            $a = new MockObject(['id' => 'a']),
-            $b = new MockObject(['id' => 'b']),
-            $c = new MockObject(['id' => 'c'])
+            new MockObject(['id' => 'a']),
+            new MockObject(['id' => 'b']),
+            new MockObject(['id' => 'c'])
         ]);
 
         $not = $collection->find('a', 'c');
@@ -234,12 +234,12 @@ class CollectionTest extends TestCase
         $this->assertEquals('b', $result->first()->id());
     }
 
-    public function testNotWithArray()
+    public function testNotWithSimpleArray()
     {
         $collection = new Collection([
-            $a = new MockObject(['id' => 'a']),
-            $b = new MockObject(['id' => 'b']),
-            $c = new MockObject(['id' => 'c'])
+            new MockObject(['id' => 'a']),
+            new MockObject(['id' => 'b']),
+            new MockObject(['id' => 'c'])
         ]);
 
         $not = ['a', 'c', 'non-exists'];
@@ -247,6 +247,48 @@ class CollectionTest extends TestCase
         $result = $collection->not($not);
         $this->assertCount(1, $result);
         $this->assertSame('b', $result->first()->id());
+    }
+
+    public function testNotWithCollectionsArray()
+    {
+        $collection = new Collection([
+            new MockObject(['id' => 'a']),
+            new MockObject(['id' => 'b']),
+            new MockObject(['id' => 'c'])
+        ]);
+
+        $not = [
+            new Collection([
+                new MockObject(['id' => 'a']),
+                new MockObject(['id' => 'non-exists'])
+            ]),
+            new Collection([
+                new MockObject(['id' => 'b'])
+            ])
+        ];
+
+        $result = $collection->not($not);
+        $this->assertCount(1, $result);
+        $this->assertSame('c', $result->first()->id());
+    }
+
+    public function testNotWithObjectsArray()
+    {
+        $collection = new Collection([
+            new MockObject(['id' => 'a']),
+            new MockObject(['id' => 'b']),
+            new MockObject(['id' => 'c'])
+        ]);
+
+        $not = [
+            new MockObject(['id' => 'b']),
+            new MockObject(['id' => 'c']),
+            new MockObject(['id' => 'non-exists']),
+        ];
+
+        $result = $collection->not($not);
+        $this->assertCount(1, $result);
+        $this->assertSame('a', $result->first()->id());
     }
 
     public function testNotWithString()

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -234,6 +234,21 @@ class CollectionTest extends TestCase
         $this->assertEquals('b', $result->first()->id());
     }
 
+    public function testNotWithArray()
+    {
+        $collection = new Collection([
+            $a = new MockObject(['id' => 'a']),
+            $b = new MockObject(['id' => 'b']),
+            $c = new MockObject(['id' => 'c'])
+        ]);
+
+        $not = ['a', 'c', 'non-exists'];
+
+        $result = $collection->not($not);
+        $this->assertCount(1, $result);
+        $this->assertSame('b', $result->first()->id());
+    }
+
     public function testNotWithString()
     {
         $collection = new Collection([


### PR DESCRIPTION
## Describe the PR

Now `\Kirby\Cms\Collection::not()` method supports array (simple, collections, objects) that contains page/file/user ids:

````php
$pages->not(['page-a', 'page-c', 'page-non-exists']);
````

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Closes https://github.com/getkirby/ideas/issues/604

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
