### PR TITLE
[Coverage] Ignore deprecated methods and untestable codes from coverage

### DIFF
--- a/config/aliases.php
+++ b/config/aliases.php
@@ -1,5 +1,6 @@
 <?php
 
+// @codeCoverageIgnoreStart
 return [
     // cms classes
     'asset'      => 'Kirby\Cms\Asset',
@@ -58,3 +59,4 @@ return [
     'v'          => 'Kirby\Toolkit\V',
     'xml'        => 'Kirby\Toolkit\Xml'
 ];
+// @codeCoverageIgnoreEnd

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,8 @@
     bootstrap="tests/bootstrap.php"
     colors="true"
     verbose="true"
-    stderr="true">
+    stderr="true"
+    ignoreDeprecatedCodeUnitsFromCodeCoverage="true">
 
     <filter>
         <whitelist>

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -392,6 +392,7 @@ class File extends ModelWithContent
      * @deprecated 3.0.0 Use `File::content()` instead
      *
      * @return \Kirby\Cms\Content
+     * @codeCoverageIgnore
      */
     public function meta()
     {

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -267,6 +267,7 @@ trait FileActions
      * @param string $name
      * @param bool $sanitize
      * @return self
+     * @codeCoverageIgnore
      */
     public function rename(string $name, bool $sanitize = true)
     {

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -177,6 +177,7 @@ trait HasChildren
     /**
      * @deprecated 3.0.0 Use `Page::hasUnlistedChildren()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasInvisibleChildren(): bool
     {
@@ -208,6 +209,7 @@ trait HasChildren
     /**
      * @deprecated 3.0.0 Use `Page::hasListedChildren()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasVisibleChildren(): bool
     {

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -75,6 +75,7 @@ class Languages extends Collection
     /**
      * @deprecated 3.0.0  Use `Languages::default()` instead
      * @return \Kirby\Cms\Language|null
+     * @codeCoverageIgnore
      */
     public function findDefault()
     {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -758,6 +758,7 @@ class Page extends ModelWithContent
     /**
      * @deprecated 3.0.0 Use `Page::isUnlisted()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function isInvisible(): bool
     {
@@ -849,6 +850,7 @@ class Page extends ModelWithContent
     /**
      * @deprecated 3.0.0 Use `Page::isListed()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function isVisible(): bool
     {

--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -141,6 +141,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::hasNextUnlisted()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasNextInvisible(): bool
     {
@@ -152,6 +153,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::hasNextListed()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasNextVisible(): bool
     {
@@ -163,6 +165,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::hasPrevUnlisted()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasPrevInvisible(): bool
     {
@@ -174,6 +177,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::hasPrevListed()` instead
      * @return bool
+     * @codeCoverageIgnore
      */
     public function hasPrevVisible(): bool
     {
@@ -185,6 +189,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::nextUnlisted()` instead
      * @return self|null
+     * @codeCoverageIgnore
      */
     public function nextInvisible()
     {
@@ -197,6 +202,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::nextListed()` instead
      * @return self|null
+     * @codeCoverageIgnore
      */
     public function nextVisible()
     {
@@ -208,6 +214,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::prevUnlisted()` instead
      * @return self|null
+     * @codeCoverageIgnore
      */
     public function prevInvisible()
     {
@@ -219,6 +226,7 @@ trait PageSiblings
     /**
      * @deprecated 3.0.0 Use `Page::prevListed()` instead
      * @return self|null
+     * @codeCoverageIgnore
      */
     public function prevVisible()
     {

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -355,6 +355,7 @@ class Pages extends Collection
      * @deprecated 3.0.0 Use `Pages::unlisted()` instead
      *
      * @return self
+     * @codeCoverageIgnore
      */
     public function invisible()
     {
@@ -515,6 +516,7 @@ class Pages extends Collection
      * @deprecated 3.0.0 Use `Pages::listed()` instead
      *
      * @return \Kirby\Cms\Pages
+     * @codeCoverageIgnore
      */
     public function visible()
     {

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -128,6 +128,7 @@ class Pagination
      *
      * @deprecated 3.3.0 Setter is no longer supported, use $pagination->clone()
      * @return int
+     * @codeCoverageIgnore
      */
     public function page(int $page = null): int
     {
@@ -143,6 +144,7 @@ class Pagination
      *
      * @deprecated 3.3.0 Setter is no longer supported, use $pagination->clone()
      * @return int
+     * @codeCoverageIgnore
      */
     public function total(int $total = null): int
     {
@@ -158,6 +160,7 @@ class Pagination
      *
      * @deprecated 3.3.0 Setter is no longer supported, use $pagination->clone()
      * @return int
+     * @codeCoverageIgnore
      */
     public function limit(int $limit = null): int
     {


### PR DESCRIPTION
## Describe the PR

Deprecated methods and untestable codes ignored from coverage and this PR separated from #2780 (last coverage PR)

Since I cannot fully operate the `ignoreDeprecatedCodeUnitsFromCodeCoverage` setting, I added `@codeCoverageIgnore` to each method separately.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)