### PR TITLE
Fix overflowing text in breadcrumb

### DIFF
--- a/panel/src/components/Navigation/Topbar.vue
+++ b/panel/src/components/Navigation/Topbar.vue
@@ -283,6 +283,7 @@ export default {
 .k-topbar-crumbs {
   flex-grow: 1;
   display: flex;
+  overflow-y: hidden;
 }
 .k-topbar-crumbs a {
   position: relative;


### PR DESCRIPTION
## Describe the PR

This fix truncates overflowing text in the breadcrumb properly. 

## Related issues

- Fixes #2755