### PR TITLE
Return $site->url() when converting the site object to a string

### DIFF
--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -141,6 +141,17 @@ class Site extends ModelWithContent
     }
 
     /**
+     * Makes it possible to convert the site model
+     * to a string. Mostly useful for debugging
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->url();
+    }
+
+    /**
      * Returns the url to the api endpoint
      *
      * @internal

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -12,7 +12,8 @@ class SiteTest extends TestCase
             'url' => $url = 'https://getkirby.com'
         ]);
 
-        $this->assertEquals($url, $site->url());
+        $this->assertSame($url, $site->url());
+        $this->assertSame($url, $site->__toString());
     }
 
     public function testToString()


### PR DESCRIPTION
## Describe the PR

Converting the site object to string resulted in an error so far. Now it will return the site url. 

## Related issues

- Fixes #2802 