### PR TITLE
Add separators to the file dropdown

### DIFF
--- a/panel/src/api/files.js
+++ b/panel/src/api/files.js
@@ -65,6 +65,8 @@ export default (api) => {
           text: Vue.i18n.translate("open"),
           click: "download"
         });
+
+        result.push("-");
       }
 
       result.push({
@@ -81,6 +83,7 @@ export default (api) => {
         disabled: !options.replace
       });
 
+      result.push("-");
       result.push({
         icon: "trash",
         text: Vue.i18n.translate("delete"),


### PR DESCRIPTION
## Describe the PR

To be more consistent with the page dropdown, the file dropdown now also features logical separators. 

## Related issues

- Fixes #2787 