### PR TITLE
RTL supports for text, textarea, tags and structure fields

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -80,6 +80,7 @@
           :data-disabled="disabled"
           :options="dragOptions"
           :handle="true"
+          :dir="direction"
           element="tbody"
           @end="onInput"
         >
@@ -160,6 +161,7 @@
 
 <script>
 import Field from "../Field.vue";
+import direction from "@/helpers/direction.js";
 
 export default {
   inheritAttrs: false,
@@ -201,6 +203,9 @@ export default {
     };
   },
   computed: {
+    direction() {
+      return direction(this);
+    },
     dragOptions() {
       return {
         disabled: !this.isSortable,

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -4,6 +4,7 @@
     :list="tags"
     :data-layout="layout"
     :options="dragOptions"
+    :dir="direction"
     class="k-tags-input"
     @end="onInput"
   >
@@ -55,6 +56,7 @@
 
 <script>
 import { required, minLength, maxLength } from "vuelidate/lib/validators";
+import direction from "@/helpers/direction.js";
 
 export default {
   inheritAttrs: false,
@@ -106,6 +108,9 @@ export default {
     };
   },
   computed: {
+    direction() {
+      return direction(this);
+    },
     dragOptions() {
       return {
         delay: 1,

--- a/panel/src/components/Forms/Input/TextInput.vue
+++ b/panel/src/components/Forms/Input/TextInput.vue
@@ -16,6 +16,7 @@
       value
     }"
     class="k-text-input"
+    :dir="direction"
     v-on="listeners"
   >
 </template>
@@ -28,6 +29,7 @@ import {
   email,
   url
 } from "vuelidate/lib/validators";
+import direction from "@/helpers/direction.js";
 
 export default {
   inheritAttrs: false,
@@ -56,6 +58,11 @@ export default {
       default: "text"
     },
     value: String
+  },
+  computed: {
+    direction() {
+      return direction(this);
+    }
   },
   data() {
     return {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -29,6 +29,7 @@
         }"
         :data-font="font"
         :data-size="size"
+        :dir="direction"
         class="k-textarea-input-native"
         @click="onClick"
         @focus="onFocus"
@@ -54,6 +55,7 @@
 <script>
 import config from "@/config/config.js";
 import { required, minLength, maxLength } from "vuelidate/lib/validators";
+import direction from "@/helpers/direction.js";
 
 export default {
   inheritAttrs: false,
@@ -81,6 +83,11 @@ export default {
     theme: String,
     uploads: [Boolean, Object, Array],
     value: String
+  },
+  computed: {
+    direction() {
+      return direction(this);
+    }
   },
   data() {
     return {

--- a/panel/src/helpers/direction.js
+++ b/panel/src/helpers/direction.js
@@ -1,0 +1,29 @@
+
+export default function ($this) {
+  const defaultLanguage = $this.$store.state.languages.default || null;
+  const language = $this.$store.state.languages.current || null;
+  const multilang = $this.$store.state.system.info.multilang || false;
+  const userLanguage = $this.$store.state.system.info.user ? $this.$store.state.system.info.user.language : null;
+  const direction = language ? language.direction : null;
+
+  /**
+   * Return LTR/RTL direction only when;
+   * - Multilang enabled
+   * - Current editing language exists
+   * - Input is not disabled
+   * - Editing language direction not equal with default language direction or
+   *   user language not equal with editing language
+   *
+   */
+  if (
+      multilang &&
+      language &&
+      $this.disabled === false &&
+      (
+          language.direction !== defaultLanguage.direction ||
+          userLanguage !== language.code
+      )
+  ) {
+    return direction;
+  }
+}


### PR DESCRIPTION
## Describe the PR

RTL supports for text (input), textarea (input), tags (input) and structure fields (+ preview). 
**Actually this enhancement supports bidirectional direction, not just RTL. Supports RTL for LTR, LTR for RTL.**

Default direction is user language for whole page with `<html dir>` and input/field direction available only when;
 - Multilang enabled
 - Current editing language exists
 - Input is not disabled
 - Editing language direction not equal with default language direction or user language not equal with editing language

My javascript codes may not be very good, excuse me 🙈 

**EN/LTR Language Screenshot (Current View)**

![image (7)](https://user-images.githubusercontent.com/3393422/92412821-07e2b180-f156-11ea-94dd-ea228d19b537.png)

**AR/RTL Language Screenshot (Enhanced View)**

![image (6)](https://user-images.githubusercontent.com/3393422/92392713-5af14000-f127-11ea-9b9f-640eca7be2f2.png)


## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #1510 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
