### PR TITLE
Support query templates for fields default values

### DIFF
--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -24,7 +24,7 @@ return [
          * Default value for the field, which will be used when a page/file/user is created
          */
         'default' => function ($default = null) {
-            return Str::split($default, ',');
+            return $default;
         },
         /**
          * Maximum number of checked boxes
@@ -44,7 +44,9 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->sanitizeOptions($this->default);
+            $default = Str::split($this->toString($this->default), ',');
+
+            return $this->sanitizeOptions($default);
         },
         'value' => function () {
             return $this->sanitizeOptions($this->value);

--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -21,12 +21,6 @@ return [
             return $columns;
         },
         /**
-         * Default value for the field, which will be used when a page/file/user is created
-         */
-        'default' => function ($default = null) {
-            return $default;
-        },
-        /**
          * Maximum number of checked boxes
          */
         'max' => function (int $max = null) {

--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -31,10 +31,7 @@ return [
          */
         'min' => function (int $min = null) {
             return $min;
-        },
-        'value' => function ($value = null) {
-            return Str::split($value, ',');
-        },
+        }
     ],
     'computed' => [
         'default' => function () {
@@ -43,7 +40,7 @@ return [
             return $this->sanitizeOptions($default);
         },
         'value' => function () {
-            return $this->sanitizeOptions($this->value);
+            return $this->sanitizeOptions(Str::split($this->value, ','));
         },
     ],
     'save' => function ($value): string {

--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -99,7 +99,7 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->toDatetime($this->default);
+            return $this->toDatetime($this->toString($this->default));
         },
         'display' => function () {
             if ($this->display) {

--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -81,13 +81,7 @@ return [
          */
         'time' => function ($time = false) {
             return $time;
-        },
-        /**
-         * Must be a parseable date string
-         */
-        'value' => function ($value = null) {
-            return $value;
-        },
+        }
     ],
     'computed' => [
         'default' => function () {

--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -20,14 +20,6 @@ return [
             return $calendar;
         },
 
-
-        /**
-         * Default date when a new page/file/user gets created
-         */
-        'default' => function (string $default = null) {
-            return $default;
-        },
-
         /**
          * Custom format (dayjs tokens: `DD`, `MM`, `YYYY`) that is
          * used to display the field in the Panel

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -32,10 +32,6 @@ return [
          */
         'size' => function (string $size = 'auto') {
             return $size;
-        },
-
-        'value' => function ($value = null) {
-            return $value;
         }
     ],
     'computed' => [

--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -21,13 +21,6 @@ return [
         'placeholder' => null,
 
         /**
-         * Sets the file(s), which are selected by default when a new page is created
-         */
-        'default' => function ($default = null) {
-            return $default;
-        },
-
-        /**
          * Changes the layout of the selected files. Available layouts: `list`, `cards`
          */
         'layout' => function (string $layout = 'list') {

--- a/config/fields/info.php
+++ b/config/fields/info.php
@@ -33,10 +33,8 @@ return [
     ],
     'computed' => [
         'text' => function () {
-            if ($text = $this->text) {
-                $text = $this->model()->toString($text);
-                $text = $this->kirby()->kirbytext($text);
-                return $text;
+            if (empty($this->text) === false) {
+                return $this->kirby()->kirbytext($this->toString($this->text));
             }
         }
     ],

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -5,12 +5,6 @@ use Kirby\Toolkit\Str;
 return [
     'props' => [
         /**
-         * Default number that will be saved when a new page/user/file is created
-         */
-        'default' => function ($default = null) {
-            return $this->toNumber($default);
-        },
-        /**
          * The lowest allowed number
          */
         'min' => function (float $min = null) {
@@ -30,6 +24,11 @@ return [
         },
         'value' => function ($value = null) {
             return $this->toNumber($value);
+        }
+    ],
+    'computed' => [
+        'default' => function () {
+            return $this->toNumber($this->default);
         }
     ],
     'methods' => [

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -21,14 +21,14 @@ return [
          */
         'step' => function ($step = null) {
             return $this->toNumber($step);
-        },
-        'value' => function ($value = null) {
-            return $this->toNumber($value);
         }
     ],
     'computed' => [
         'default' => function () {
             return $this->toNumber($this->default);
+        },
+        'value' => function () {
+            return $this->toNumber($this->value);
         }
     ],
     'methods' => [

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -16,13 +16,6 @@ return [
         'placeholder' => null,
 
         /**
-         * Default selected page(s) when a new page/file/user is created
-         */
-        'default' => function ($default = null) {
-            return $this->toPages($default);
-        },
-
-        /**
          * Changes the layout of the selected files. Available layouts: `list`, `cards`
          */
         'layout' => function (string $layout = 'list') {
@@ -55,10 +48,9 @@ return [
         },
     ],
     'computed' => [
-        /**
-         * Unset inherited computed
-         */
-        'default' => null
+        'default' => function () {
+            return $this->toPages($this->default);
+        }
     ],
     'methods' => [
         'pageResponse' => function ($page) {

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -41,15 +41,14 @@ return [
          */
         'subpages' => function (bool $subpages = true) {
             return $subpages;
-        },
-
-        'value' => function ($value = null) {
-            return $this->toPages($value);
-        },
+        }
     ],
     'computed' => [
         'default' => function () {
             return $this->toPages($this->default);
+        },
+        'value' => function () {
+            return $this->toPages($this->value);
         }
     ],
     'methods' => [

--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -20,7 +20,7 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->sanitizeOption($this->default);
+            return $this->sanitizeOption($this->toString($this->default));
         },
         'value' => function () {
             return $this->sanitizeOption($this->value) ?? '';

--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -20,5 +20,10 @@ return [
         'placeholder' => function (string $placeholder = '—') {
             return $placeholder;
         },
-    ]
+    ],
+    'computed' => [
+        'placeholder' => function () {
+            return $this->toString($this->placeholder);
+        }
+    ],
 ];

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -55,7 +55,7 @@ return [
     ],
     'computed' => [
         'default' => function (): array {
-            return $this->toTags($this->default);
+            return $this->toTags($this->toString($this->default));
         },
         'value' => function (): array {
             return $this->toTags($this->value);

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -57,7 +57,7 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->convert($this->default);
+            return $this->convert($this->toString($this->default));
         },
         'value' => function () {
             return (string)$this->convert($this->value);

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -71,15 +71,14 @@ return [
          */
         'spellcheck' => function (bool $spellcheck = true) {
             return $spellcheck;
-        },
-
-        'value' => function (string $value = null) {
-            return trim($value);
         }
     ],
     'computed' => [
         'default' => function () {
             return trim($this->default);
+        },
+        'value' => function () {
+            return trim($this->value);
         }
     ],
     'api' => function () {

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -24,13 +24,6 @@ return [
         },
 
         /**
-         * Sets the default text when a new page/file/user is created
-         */
-        'default' => function (string $default = null) {
-            return trim($default);
-        },
-
-        /**
          * Sets the options for the files picker
          */
         'files' => function ($files = []) {
@@ -82,6 +75,11 @@ return [
 
         'value' => function (string $value = null) {
             return trim($value);
+        }
+    ],
+    'computed' => [
+        'default' => function () {
+            return trim($this->default);
         }
     ],
     'api' => function () {

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -86,7 +86,7 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->toDatetime($this->default, 'H:i:s');
+            return $this->toDatetime($this->toString($this->default), 'H:i:s');
         },
         'display' => function () {
             if ($this->display) {

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -11,14 +11,6 @@ return [
          */
         'placeholder' => null,
 
-
-        /**
-         * Sets the default time when a new page/file/user is created
-         */
-        'default' => function ($default = null) {
-            return $default;
-        },
-
         /**
          * Custom format (dayjs tokens: `HH`, `hh`, `mm`, `ss`, `a`) that is
          * used to display the field in the Panel

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -71,9 +71,6 @@ return [
             if (is_string($step) === true) {
                 return array_merge($default, ['unit' => strtolower($step)]);
             }
-        },
-        'value' => function ($value = null) {
-            return $value;
         }
     ],
     'computed' => [

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -38,7 +38,7 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->toBool($this->default);
+            return $this->toBool($this->toString($this->default));
         },
         'value' => function () {
             if ($this->props['value'] === null) {

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -12,12 +12,6 @@ return [
         'placeholder' => null,
 
         /**
-         * Default value which will be saved when a new page/user/file is created
-         */
-        'default' => function ($default = null) {
-            return $this->default = $default;
-        },
-        /**
          * Sets the text next to the toggle. The text can be a string or an array of two options. The first one is the negative text and the second one the positive. The text will automatically switch when the toggle is triggered.
          */
         'text' => function ($value = null) {

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -15,32 +15,24 @@ return [
         'icon'        => null,
         'placeholder' => null,
 
-        /**
-         * Default selected user(s) when a new page/file/user is created
-         */
-        'default' => function ($default = null) {
-            if ($default === false) {
-                return [];
-            }
-
-            if ($default === null && $user = $this->kirby()->user()) {
-                return [
-                    $this->userResponse($user)
-                ];
-            }
-
-            return $this->toUsers($default);
-        },
-
         'value' => function ($value = null) {
             return $this->toUsers($value);
         },
     ],
     'computed' => [
-        /**
-         * Unset inherited computed
-         */
-        'default' => null
+        'default' => function () {
+            if ($this->default === false) {
+                return [];
+            }
+
+            if ($this->default === null && $user = $this->kirby()->user()) {
+                return [
+                    $this->userResponse($user)
+                ];
+            }
+
+            return $this->toUsers($this->default);
+        }
     ],
     'methods' => [
         'userResponse' => function ($user) {

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -14,10 +14,6 @@ return [
         'before'      => null,
         'icon'        => null,
         'placeholder' => null,
-
-        'value' => function ($value = null) {
-            return $this->toUsers($value);
-        },
     ],
     'computed' => [
         'default' => function () {
@@ -32,6 +28,9 @@ return [
             }
 
             return $this->toUsers($this->default);
+        },
+        'value' => function () {
+            return $this->toUsers($this->value);
         }
     ],
     'methods' => [

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -213,47 +213,43 @@ class Field extends Component
             'computed' => [
                 'after' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->after !== null) {
-                        return $this->model()->toString($this->after);
-                    }
+                    return $this->toString($this->after);
                 },
                 'before' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->before !== null) {
-                        return $this->model()->toString($this->before);
-                    }
+                    return $this->toString($this->before);
                 },
                 'default' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->default === null) {
-                        return;
-                    }
-
-                    if (is_string($this->default) === false) {
-                        return $this->default;
-                    }
-
-                    return $this->model()->toString($this->default);
+                    return $this->toString($this->default);
                 },
                 'help' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->help) {
-                        $help = $this->model()->toString($this->help);
-                        $help = $this->kirby()->kirbytext($help);
-                        return $help;
+                    if ($text = $this->toString($this->help)) {
+                        return $this->kirby()->kirbytext($text);
                     }
                 },
                 'label' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->label !== null) {
-                        return $this->model()->toString($this->label);
-                    }
+                    return $this->toString($this->label);
                 },
                 'placeholder' => function () {
                     /** @var \Kirby\Form\Field $this */
-                    if ($this->placeholder !== null) {
-                        return $this->model()->toString($this->placeholder);
+                    return $this->toString($this->placeholder);
+                }
+            ],
+            'methods' => [
+                'toString' => function ($value = null) {
+                    if ($value === null) {
+                        return;
                     }
+
+                    if (is_string($value) === false) {
+                        return $value;
+                    }
+
+                    /** @var \Kirby\Form\Field $this */
+                    return $this->model()->toString($value);
                 }
             ]
         ];

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -237,20 +237,6 @@ class Field extends Component
                     /** @var \Kirby\Form\Field $this */
                     return $this->toString($this->placeholder);
                 }
-            ],
-            'methods' => [
-                'toString' => function ($value = null) {
-                    if ($value === null) {
-                        return;
-                    }
-
-                    if (is_string($value) === false) {
-                        return $value;
-                    }
-
-                    /** @var \Kirby\Form\Field $this */
-                    return $this->model()->toString($value);
-                }
             ]
         ];
     }
@@ -439,6 +425,29 @@ class Field extends Component
         return array_filter($array, function ($item) {
             return $item !== null && is_object($item) === false;
         });
+    }
+
+    /**
+     * String template builder
+     *
+     * @param mixed $template
+     * @param array $data
+     * @param string $fallback Fallback for tokens in the template that cannot be replaced
+     * @return mixed
+     */
+    protected function toString($template = null, array $data = [], string $fallback = '')
+    {
+        if ($template === null) {
+            // if the input template prop is not defined, the output
+            // of the prop should also be `null` and not an empty string
+            return null;
+        }
+
+        if (is_string($template) === false) {
+            return $template;
+        }
+
+        return $this->model()->toString($template, $data, $fallback);
     }
 
     /**

--- a/tests/Form/Fields/CheckboxesFieldTest.php
+++ b/tests/Form/Fields/CheckboxesFieldTest.php
@@ -47,8 +47,19 @@ class CheckboxesFieldTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(['a', 'b'], $field->default());
-        $this->assertEquals('a, b', $field->data(true));
+        $this->assertSame(['a', 'b'], $field->default());
+        $this->assertSame('a, b', $field->data(true));
+
+        // no default value
+        $field = $this->field('checkboxes', [
+            'options' => [
+                'a',
+                'b',
+                'c'
+            ],
+        ]);
+
+        $this->assertSame([], $field->default());
     }
 
     public function testStringConversion()

--- a/tests/Form/Fields/RadioFieldTest.php
+++ b/tests/Form/Fields/RadioFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Fields;
 
+use Kirby\Cms\Page;
+
 class RadioFieldTest extends TestCase
 {
     public function testDefaultProps()
@@ -41,5 +43,25 @@ class RadioFieldTest extends TestCase
         ]);
 
         $this->assertTrue($expected === $field->value());
+    }
+
+    public function testDefault()
+    {
+        $field = $this->field('radio', [
+            'options' => [
+                'a',
+                'b',
+                'c'
+            ],
+            'default' => '{{ page.slug }}',
+            'model' => new Page([
+                'slug' => 'a',
+                'content' => [
+                    'title' => 'A'
+                ]
+            ])
+        ]);
+
+        $this->assertSame('a', $field->default());
     }
 }

--- a/tests/Form/Fields/TagsFieldTest.php
+++ b/tests/Form/Fields/TagsFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Fields;
 
+use Kirby\Cms\Page;
+
 class TagsFieldTest extends TestCase
 {
     public function testDefaultProps()
@@ -159,5 +161,35 @@ class TagsFieldTest extends TestCase
         ]);
 
         $this->assertTrue($field->isValid());
+    }
+
+    public function testDefault()
+    {
+        $field = $this->field('tags', [
+            'options'  => ['a', 'b', 'c'],
+            'default' => '{{ page.test }}',
+            'model' => new Page([
+                'slug' => 'foo',
+                'content' => [
+                    'title' => 'Foo',
+                    'test' => 'a,b,c'
+                ]
+            ])
+        ]);
+
+        $this->assertSame([
+            [
+                'value' => 'a',
+                'text' => 'a',
+            ],
+            [
+                'value' => 'b',
+                'text' => 'b',
+            ],
+            [
+                'value' => 'c',
+                'text' => 'c',
+            ]
+        ], $field->default());
     }
 }

--- a/tests/Form/Fields/TextFieldTest.php
+++ b/tests/Form/Fields/TextFieldTest.php
@@ -77,4 +77,18 @@ class TextFieldTest extends TestCase
         $this->assertFalse($field->isValid());
         $this->assertArrayHasKey('maxlength', $field->errors());
     }
+
+    public function testDefault()
+    {
+        $field = $this->field('text', [
+            'default' => 'test'
+        ]);
+
+        $this->assertSame('test', $field->default());
+
+        // no default value
+        $field = $this->field('text');
+
+        $this->assertNull($field->default());
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Added `Kirby\Form\Field::toString()` method for fields to support query templates. Fields can do their own operations after using this method first.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements

- Added support for query template to default prop/value of all fields

### Fixes

- Fixed query templates for default values in non-textarea fields

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #2814 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
