### PR TITLE
Merge default value for structure field

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -1,7 +1,7 @@
 <?php
 
 use Kirby\Cms\Form;
-use Kirby\Data\Data;
+use Kirby\Cms\Structure;
 use Kirby\Toolkit\I18n;
 
 return [
@@ -145,9 +145,9 @@ return [
     ],
     'methods' => [
         'rows' => function ($value) {
-            $rows  = Data::decode($value, 'yaml');
-            $value = [];
+            $rows = Structure::toData($this->name(), $value, $this->model);
 
+            $value = [];
             foreach ($rows as $index => $row) {
                 if (is_array($row) === false) {
                     continue;

--- a/config/methods.php
+++ b/config/methods.php
@@ -250,7 +250,8 @@ return function (App $app) {
          */
         'toStructure' => function (Field $field) {
             try {
-                return new Structure(Data::decode($field->value, 'yaml'), $field->parent());
+                $data = Structure::toData($field->key(), $field->value, $field->parent());
+                return new Structure($data, $field->parent());
             } catch (Exception $e) {
                 if ($field->parent() === null) {
                     $message = 'Invalid structure data for "' . $field->key() . '" field';

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -360,6 +360,71 @@ class FieldMethodsTest extends TestCase
         $this->assertSame('b', $structure->last()->title()->value());
     }
 
+    public function testToStructureTranslate()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                'en' => [
+                    'code' => 'en',
+                    'default' => true
+                ],
+                'de' => [
+                    'code' => 'de'
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => [
+                                    'address' => Yaml::encode([
+                                        [
+                                            'foo' => 'A',
+                                            'bar' => 'C'
+                                        ]
+                                    ])
+                                ]
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => [
+                                    'address' => Yaml::encode([
+                                        [
+                                            'foo' => 'B'
+                                        ]
+                                    ])
+                                ]
+                            ]
+                        ]
+                    ],
+                ]
+            ]
+        ]);
+
+        // default language
+        $app->setCurrentLanguage('en');
+        $page = $app->page('test');
+
+        $structure = $page->address()->toStructure()->first();
+        $this->assertSame('A', $structure->foo()->value());
+        $this->assertSame('C', $structure->bar()->value());
+
+        // secondary language
+        $app = $app->clone();
+        $app->setCurrentLanguage('de');
+        $page = $app->page('test');
+
+        $structure = $page->address()->toStructure()->first();
+        $this->assertSame('B', $structure->foo()->value());
+        $this->assertSame('C', $structure->bar()->value());
+    }
+
     public function testToStructureWithInvalidData()
     {
         $data = [


### PR DESCRIPTION
## Describe the PR

Since the structure field doesn't keep the data of the untranslatable fields, now it merges structure field values with default language field data in multi-language applications like we doing in `ContentTranslation` class.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2790 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
