### PR TITLE
Overridable e() method in helpers

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -152,16 +152,18 @@ if (function_exists('dump') === false) {
     }
 }
 
-/**
- * Smart version of echo with an if condition as first argument
- *
- * @param mixed $condition
- * @param mixed $value The string to be echoed if the condition is true
- * @param mixed $alternative An alternative string which should be echoed when the condition is false
- */
-function e($condition, $value, $alternative = null)
-{
-    echo r($condition, $value, $alternative);
+if (function_exists('e') === false) {
+    /**
+     * Smart version of echo with an if condition as first argument
+     *
+     * @param mixed $condition
+     * @param mixed $value The string to be echoed if the condition is true
+     * @param mixed $alternative An alternative string which should be echoed when the condition is false
+     */
+    function e($condition, $value, $alternative = null)
+    {
+        echo r($condition, $value, $alternative);
+    }
 }
 
 /**


### PR DESCRIPTION
## Describe the PR

This PR fixes `redeclaring the e() function` issue on Laravel components. Now `e()` method is overridable.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
