### PR TITLE
Adds info text for users dialog

### DIFF
--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -28,7 +28,8 @@
           <k-list-item
             v-for="user in models"
             :key="user.email"
-            :text="user.username"
+            :text="user.text"
+            :info="user.info !== user.text ? user.info : null"
             :image="user.image"
             :icon="user.icon"
             @click="toggle(user)"


### PR DESCRIPTION
## Describe the PR

Adds `info` text for users dialog and visible only not equal with `text` attribute.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2832 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
