### PR TITLE
Fix typo

### DIFF
--- a/i18n/translations/es_ES.json
+++ b/i18n/translations/es_ES.json
@@ -315,7 +315,7 @@
   "page.status.unlisted": "Sin publicar",
   "page.status.unlisted.description": "La página solo es accesible vía URL",
 
-  "pages": "Paginas",
+  "pages": "Páginas",
   "pages.empty": "Aún no hay páginas",
   "pages.status.draft": "Borradores",
   "pages.status.listed": "Publicadas",


### PR DESCRIPTION
Word "páginas" must always have accent in Spanish.