### PR TITLE
Builder: move blocks between fields

### DIFF
--- a/config/fields/builder.php
+++ b/config/fields/builder.php
@@ -27,6 +27,16 @@ return [
         },
 
         /**
+         * Groups fields to move blocks between fields in the same group
+         *
+         * @param string|null $group
+         * @return string|null
+         */
+        'group' => function (string $group = null) {
+            return $group;
+        },
+
+        /**
          * Only allow the given maximum number of blocks
          *
          * @param int|null $max

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -172,7 +172,7 @@ export default {
   computed: {
     draggableOptions() {
       return {
-        id: Math.random(),
+        id: this._uid,
         handle: true,
         list: this.blocks,
         move: this.move,

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -19,88 +19,92 @@
       </k-dropdown-content>
     </k-dropdown>
 
-    <template v-if="blocks.length === 0">
-      <k-empty icon="box" @click="select(blocks.length)">
-        {{ $t("field.builder.empty") }}
-      </k-empty>
-    </template>
-
-    <template v-else>
-      <k-draggable :handle="true" :list="blocks" element="k-grid" @end="sort">
-        <k-column
-          v-for="(block, index) in blocks"
-          :key="block.id"
-          :set="blockOptions = fieldset(block)"
-          :data-disabled="blockOptions.disabled"
-          :data-translate="blockOptions.translate"
-          class="k-builder-column"
-          @mouseenter.native="isHovered = block.id"
-          @mouseleave.native="isHovered = false"
+    <k-draggable
+      v-bind="draggableOptions"
+      element="k-grid"
+      @sort="sort"
+    >
+      <k-column
+        v-for="(block, index) in blocks"
+        :key="block.id"
+        :set="blockOptions = fieldset(block)"
+        :data-disabled="blockOptions.disabled"
+        :data-translate="blockOptions.translate"
+        class="k-builder-column"
+        @mouseenter.native="isHovered = block.id"
+        @mouseleave.native="isHovered = false"
+      >
+        <details
+          :class="'k-builder-block k-builder-fieldset-' + block.type"
+          :data-hidden="block.attrs.hide == true"
+          :open="isOpen(block)"
         >
-          <details
-            :class="'k-builder-block k-builder-fieldset-' + block.type"
-            :data-hidden="block.attrs.hide == true"
-            :open="isOpen(block)"
-          >
-            <summary class="k-builder-block-header" @click.prevent="toggle(block)">
-              <k-sort-handle :icon="isHovered === block.id ? 'sort' : blockOptions.icon || 'sort'" class="k-builder-block-handle" />
-              <span class="k-builder-block-label">
-                {{ $helper.string.template(blockOptions.label, block.content) }} <k-icon v-if="block.attrs.hide" type="hidden" />
-              </span>
+          <summary class="k-builder-block-header" @click.prevent="toggle(block)">
+            <k-sort-handle :icon="isHovered === block.id ? 'sort' : blockOptions.icon || 'sort'" class="k-builder-block-handle" />
+            <span class="k-builder-block-label">
+              {{ $helper.string.template(blockOptions.label, block.content) }} <k-icon v-if="block.attrs.hide" type="hidden" />
+            </span>
 
-              <nav class="k-builder-block-tabs" v-if="Object.keys(blockOptions.tabs).length > 1">
-                <k-button
-                  v-for="(tab, tabId) in blockOptions.tabs"
-                  :key="tabId"
-                  :current="tabs[block.id] === tabId"
-                  :icon="tab.icon"
-                  class="k-builder-block-tab"
-                  @click.stop="open(block, tabId)"
-                >
-                  {{ tab.label }}
-                </k-button>
-              </nav>
+            <nav class="k-builder-block-tabs" v-if="Object.keys(blockOptions.tabs).length > 1">
+              <k-button
+                v-for="(tab, tabId) in blockOptions.tabs"
+                :key="tabId"
+                :current="tabs[block.id] === tabId"
+                :icon="tab.icon"
+                class="k-builder-block-tab"
+                @click.stop="open(block, tabId)"
+              >
+                {{ tab.label }}
+              </k-button>
+            </nav>
 
-              <k-dropdown>
-                <k-button
-                  class="k-builder-block-options-toggle"
-                  icon="dots"
-                  @click="$refs['options-' + block.id][0].toggle()"
-                />
-                <k-dropdown-content :ref="'options-' + block.id" align="right">
-                  <k-dropdown-item :disabled="isFull" icon="angle-up" @click="select(index)">
-                    {{ $t("insert.before") }}
-                  </k-dropdown-item>
-                  <k-dropdown-item :disabled="isFull" icon="angle-down" @click="select(index + 1)">
-                    {{ $t("insert.after") }}
-                  </k-dropdown-item>
-                  <hr>
-                  <k-dropdown-item :icon="block.attrs.hide ? 'preview' : 'hidden'" @click="toggleVisibility(block)">
-                    {{ block.attrs.hide === true ? 'Show' : 'Hide' }}
-                  </k-dropdown-item>
-                  <k-dropdown-item :disabled="isFull" icon="copy" @click="duplicate(block)">
-                    {{ $t("duplicate") }}
-                  </k-dropdown-item>
-                  <hr>
-                  <k-dropdown-item icon="trash" @click="onRemove(block)">
-                    {{ $t("delete") }}
-                  </k-dropdown-item>
-                </k-dropdown-content>
-              </k-dropdown>
-            </summary>
-            <div class="k-builder-block-body" v-if="isOpen(block)">
-              <k-fieldset
-                :ref="'fieldset-' + block.id"
-                :fields="fields(block)"
-                :value="block.content"
-                class="k-builder-block-form"
-                @input="updateContent(block, $event)"
+            <k-dropdown>
+              <k-button
+                class="k-builder-block-options-toggle"
+                icon="dots"
+                @click="$refs['options-' + block.id][0].toggle()"
               />
-            </div>
-          </details>
+              <k-dropdown-content :ref="'options-' + block.id" align="right">
+                <k-dropdown-item :disabled="isFull" icon="angle-up" @click="select(index)">
+                  {{ $t("insert.before") }}
+                </k-dropdown-item>
+                <k-dropdown-item :disabled="isFull" icon="angle-down" @click="select(index + 1)">
+                  {{ $t("insert.after") }}
+                </k-dropdown-item>
+                <hr>
+                <k-dropdown-item :icon="block.attrs.hide ? 'preview' : 'hidden'" @click="toggleVisibility(block)">
+                  {{ block.attrs.hide === true ? 'Show' : 'Hide' }}
+                </k-dropdown-item>
+                <k-dropdown-item :disabled="isFull" icon="copy" @click="duplicate(block)">
+                  {{ $t("duplicate") }}
+                </k-dropdown-item>
+                <hr>
+                <k-dropdown-item icon="trash" @click="onRemove(block)">
+                  {{ $t("delete") }}
+                </k-dropdown-item>
+              </k-dropdown-content>
+            </k-dropdown>
+          </summary>
+          <div class="k-builder-block-body" v-if="isOpen(block)">
+            <k-fieldset
+              :ref="'fieldset-' + block.id"
+              :fields="fields(block)"
+              :value="block.content"
+              class="k-builder-block-form"
+              @input="updateContent(block, $event)"
+            />
+          </div>
+        </details>
+      </k-column>
+
+      <template #footer>
+        <k-column width="1/1" class="k-builder-field-empty">
+          <k-empty icon="box" @click="select(blocks.length)">
+            {{ $t("field.builder.empty") }}
+          </k-empty>
         </k-column>
-      </k-draggable>
-    </template>
+      </template>
+    </k-draggable>
 
     <k-dialog
       ref="fieldsets"
@@ -165,6 +169,21 @@ export default {
     };
   },
   computed: {
+    draggableOptions() {
+      return {
+        id: Math.random(),
+        handle: true,
+        list: this.blocks,
+        move: this.move,
+        data: {
+          fieldsets: this.fieldsets,
+          isFull: this.isFull
+        },
+        options: {
+          group: "k-builder-field"
+        }
+      };
+    },
     isEmpty() {
       return this.blocks.length === 0;
     },
@@ -243,6 +262,29 @@ export default {
     },
     isOpen(block) {
       return this.opened.includes(block.id);
+    },
+    move(event) {
+      // moving block between fields
+      if (event.from !== event.to) {
+        const block = event.draggedContext.element;
+        const to    = event.relatedContext.component.componentData;
+
+        // fieldset is not supported in target field
+        const fieldsets   = Object.values(to.fieldsets || {});
+        const fieldset    = JSON.stringify(this.fieldset(block));
+        const hasFieldset = fieldsets.some(x => JSON.stringify(x) === fieldset);
+
+        if (hasFieldset === false) {
+          return false;
+        }
+
+        // target field has already reached max number of blocks
+        if (to.isFull === true) {
+          return false;
+        }
+      }
+
+      return true;
     },
     onInput() {
       this.$emit("input", this.blocks);
@@ -340,6 +382,9 @@ export default {
 }
 .k-builder-field > .k-grid {
   grid-gap: 2px;
+}
+.k-builder-field > .k-grid > .k-builder-field-empty:not(:only-child) {
+  display: none;
 }
 .k-builder-column {
   position: relative;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -383,9 +383,6 @@ export default {
 .k-builder-field > .k-grid {
   grid-gap: 2px;
 }
-.k-builder-field > .k-grid > .k-builder-field-empty:not(:only-child) {
-  display: none;
-}
 .k-builder-column {
   position: relative;
 }
@@ -399,6 +396,13 @@ export default {
   cursor: grabbing;
   cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
+}
+.k-builder-field > .k-grid > .k-builder-field-empty .k-empty[data-layout="list"] {
+  height: 36px;
+  min-height: 36px;
+}
+.k-builder-field > .k-grid > .k-builder-field-empty:not(:only-child) {
+  display: none;
 }
 .k-builder-block-header {
   height: 36px;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -446,7 +446,7 @@ export default {
 .k-builder-block-tab {
   position: relative;
   padding: .5rem .75rem;
-  height: 36px;
+  height: 38px;
 }
 .k-builder-block-tab > * {
   position: relative;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -22,7 +22,7 @@
     <k-draggable
       v-bind="draggableOptions"
       element="k-grid"
-      @sort="sort"
+      @sort="onInput"
     >
       <k-column
         v-for="(block, index) in blocks"
@@ -211,6 +211,7 @@ export default {
         this.open(this.blocks[this.nextIndex]);
         this.$refs.fieldsets.close();
         this.onInput();
+
       } catch (e) {
         this.$refs.fieldsets.error(e.message);
       }
@@ -267,7 +268,7 @@ export default {
       // moving block between fields
       if (event.from !== event.to) {
         const block = event.draggedContext.element;
-        const to    = event.relatedContext.component.componentData;
+        const to    = event.relatedContext.component.componentData || event.relatedContext.component.$parent.componentData;
 
         // fieldset is not supported in target field
         const fieldsets   = Object.values(to.fieldsets || {});
@@ -330,9 +331,6 @@ export default {
       this.trash = null;
       this.onInput();
       this.$refs.removeAll.close();
-    },
-    sort() {
-      this.onInput();
     },
     select(index) {
       this.nextIndex = index;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -146,6 +146,7 @@ export default {
   props: {
     ...Field.props,
     fieldsets: Object,
+    group: String,
     max: {
       type: Number,
       default: null,
@@ -180,7 +181,7 @@ export default {
           isFull: this.isFull
         },
         options: {
-          group: "k-builder-field"
+          group: this.group
         }
       };
     },
@@ -271,11 +272,7 @@ export default {
         const to    = event.relatedContext.component.componentData || event.relatedContext.component.$parent.componentData;
 
         // fieldset is not supported in target field
-        const fieldsets   = Object.values(to.fieldsets || {});
-        const fieldset    = JSON.stringify(this.fieldset(block));
-        const hasFieldset = fieldsets.some(x => JSON.stringify(x) === fieldset);
-
-        if (hasFieldset === false) {
+        if (Object.keys(to.fieldsets).includes(block.type) === false) {
           return false;
         }
 

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -392,15 +392,12 @@ export default {
   cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
 }
-.k-builder-field > .k-grid > .k-builder-field-empty .k-empty[data-layout="list"] {
-  height: 36px;
-  min-height: 36px;
-}
+
 .k-builder-field > .k-grid > .k-builder-field-empty:not(:only-child) {
   display: none;
 }
 .k-builder-block-header {
-  height: 36px;
+  height: 38px;
   display: flex;
   align-items: center;
   cursor: pointer;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -98,11 +98,13 @@
       </k-column>
 
       <template #footer>
-        <k-column width="1/1" class="k-builder-field-empty">
-          <k-empty icon="box" @click="select(blocks.length)">
-            {{ $t("field.builder.empty") }}
-          </k-empty>
-        </k-column>
+        <k-empty
+          icon="box"
+          class="k-builder-field-empty"
+          @click="select(blocks.length)"
+        >
+          {{ $t("field.builder.empty") }}
+        </k-empty>
       </template>
     </k-draggable>
 
@@ -393,9 +395,15 @@ export default {
   cursor: -webkit-grabbing;
 }
 
-.k-builder-field > .k-grid > .k-builder-field-empty:not(:only-child) {
-  display: none;
+.k-builder-field-empty {
+  grid-column-start: span 12;
+  cursor: pointer;
+
+  .k-builder-field > .k-grid > &:not(:only-child) {
+    display: none;
+  }
 }
+
 .k-builder-block-header {
   height: 38px;
   display: flex;

--- a/panel/src/components/Misc/Draggable.vue
+++ b/panel/src/components/Misc/Draggable.vue
@@ -1,5 +1,6 @@
 <template>
   <draggable
+    :component-data="data"
     :tag="element"
     :list="list"
     :move="move"
@@ -20,6 +21,7 @@ export default {
     draggable: Draggable
   },
   props: {
+    data: Object,
     element: String,
     handle: [String, Boolean],
     list: [Array, Object],


### PR DESCRIPTION
Each builder field has to define the same `group` option to allow blocks to be moved between those fields. 
Moving a block is only allowed if
- the target field has a fieldset with the same name as the block's type
- the target field is not full (`max` option)