### PR TITLE
Empty: use button if has click listener

### DIFF
--- a/panel/src/components/Layout/Empty.vue
+++ b/panel/src/components/Layout/Empty.vue
@@ -1,8 +1,17 @@
 <template>
-  <div :data-layout="layout" class="k-empty" v-on="$listeners">
-    <k-icon v-if="icon" :type="icon" />
+  <component
+    :is="element"
+    :data-layout="layout"
+    :type="element === 'button' ? 'button' : false"
+    class="k-empty"
+    v-on="$listeners"
+  >
+    <k-icon
+      v-if="icon"
+      :type="icon"
+    />
     <p><slot /></p>
-  </div>
+  </component>
 </template>
 
 <script>
@@ -10,9 +19,17 @@ export default {
   props: {
     text: String,
     icon: String,
+    /**
+     * Available options: `list`|`cards`
+     */
     layout: {
       type: String,
       default: "list"
+    }
+  },
+  computed: {
+    element() {
+      return this.$listeners["click"] !== undefined ? "button" : "div";
     }
   }
 };
@@ -24,8 +41,15 @@ export default {
   display: flex;
   align-items: stretch;
   border-radius: $border-radius;
+
   color: $color-dark-grey;
   border: 1px dashed $color-border;
+}
+button.k-empty {
+  width: 100%;
+}
+button.k-empty:focus {
+  outline: none;
 }
 .k-empty p {
   font-size: $font-size-small;
@@ -59,7 +83,7 @@ export default {
   & > .k-icon {
     width: 36px;
     min-height: 36px;
-    border-right: 1px solid rgba(#000, 0.05);
+    border-right: 1px solid rgba($color-black, 0.05);
   }
 
   & > p {


### PR DESCRIPTION
## Describe the PR

Small enhancement from `storybook`:
If `k-empty` has a `@click` listener, it becomes a `<button>` tag
