### PR TITLE
Builder: fixes and improvements

### DIFF
--- a/config/fields/builder.php
+++ b/config/fields/builder.php
@@ -3,6 +3,7 @@
 use Kirby\Cms\Block;
 use Kirby\Cms\Builder;
 use Kirby\Exception\NotFoundException;
+use Kirby\Toolkit\I18n;
 
 return [
     'props' => [
@@ -15,6 +16,13 @@ return [
         'autofocus'   => null,
         'icon'        => null,
         'placeholder' => null,
+
+        /**
+         * The placeholder text if no blocks have been added yet
+         */
+        'empty' => function ($empty = null) {
+            return I18n::translate($empty, $empty);
+        },
 
         /**
          * Fieldset definitions

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -208,6 +208,7 @@
   "files": "Files",
   "files.empty": "No files yet",
 
+  "hide": "Hide",
   "hour": "Hour",
   "insert": "Insert",
   "insert.after": "Insert after",
@@ -365,6 +366,7 @@
 
   "select": "Select",
   "settings": "Settings",
+  "show": "Show",
   "size": "Size",
   "slug": "URL appendix",
   "sort": "Sort",

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -83,7 +83,7 @@
                   </k-dropdown-item>
                   <hr>
                   <k-dropdown-item :icon="block.attrs.hide ? 'preview' : 'hidden'" @click="toggleVisibility(block)">
-                    {{ block.attrs.hide === true ? 'Show' : 'Hide' }}
+                    {{ block.attrs.hide === true ? $t('show') : $t('hide') }}
                   </k-dropdown-item>
                   <k-dropdown-item :disabled="isFull" icon="copy" @click="duplicate(block)">
                     {{ $t("duplicate") }}

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -113,7 +113,7 @@
       <ul class="k-builder-fieldsets">
         <li v-for="fieldset in fieldsets" :key="fieldset.name">
           <k-button :icon="fieldset.icon || 'box'" @click="add(fieldset.type)">
-            {{ fieldset.name }}
+            {{ fieldset.label }}
           </k-button>
         </li>
       </ul>

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -21,7 +21,7 @@
 
     <template v-if="blocks.length === 0">
       <k-empty icon="box" @click="select(blocks.length)">
-        {{ $t("field.builder.empty") }}
+        {{ empty || $t("field.builder.empty") }}
       </k-empty>
     </template>
 
@@ -148,6 +148,7 @@ export default {
   },
   props: {
     ...Field.props,
+    empty: String,
     fieldsets: Object,
     max: {
       type: Number,

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -45,7 +45,7 @@
             <summary class="k-builder-block-header" @click.prevent="toggle(block)">
               <k-sort-handle :icon="isHovered === block.id ? 'sort' : blockOptions.icon || 'sort'" class="k-builder-block-handle" />
               <span class="k-builder-block-label">
-                {{ $helper.string.template(blockOptions.label, block.content) }} <k-icon v-if="block.attrs.hide" type="hidden" />
+                {{ $helper.string.template(blockOptions.label, block.content) }}
               </span>
 
               <nav class="k-builder-block-tabs" v-if="Object.keys(blockOptions.tabs).length > 1">
@@ -60,6 +60,13 @@
                   {{ tab.label }}
                 </k-button>
               </nav>
+
+              <k-button
+                  v-if="block.attrs.hide"
+                  class="k-builder-block-status"
+                  icon="hidden"
+                  @click.stop="toggleVisibility(block)"
+              />
 
               <k-dropdown>
                 <k-button
@@ -386,6 +393,9 @@ export default {
 }
 .k-builder-block[data-hidden]:not([open]) {
   background: rgba(#fff, .325);
+}
+.k-builder-block[data-hidden] .k-builder-block-status  {
+  opacity: .325;
 }
 .k-builder-block[data-hidden] .k-builder-block-label {
   color: #ccc;

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -52,7 +52,7 @@
                 <k-button
                   v-for="(tab, tabId) in blockOptions.tabs"
                   :key="tabId"
-                  :current="(tabs[block.id] === undefined && (tabs[block.id] = tabId)) || tabs[block.id] === tabId"
+                  :current="isCurrentTab(block, tabId)"
                   :icon="tab.icon"
                   class="k-builder-block-tab"
                   @click.stop="open(block, tabId)"
@@ -248,6 +248,15 @@ export default {
     },
     fieldset(block) {
       return this.fieldsets[block.type];
+    },
+    isCurrentTab(block, tabId) {
+      if (this.tabs[block.id] === undefined) {
+        this.tabs[block.id] = tabId;
+
+        return true;
+      }
+
+      return this.tabs[block.id] === tabId;
     },
     isOpen(block) {
       return this.opened.includes(block.id);

--- a/panel/src/components/Forms/Field/BuilderField.vue
+++ b/panel/src/components/Forms/Field/BuilderField.vue
@@ -52,7 +52,7 @@
                 <k-button
                   v-for="(tab, tabId) in blockOptions.tabs"
                   :key="tabId"
-                  :current="tabs[block.id] === tabId"
+                  :current="(tabs[block.id] === undefined && (tabs[block.id] = tabId)) || tabs[block.id] === tabId"
                   :icon="tab.icon"
                   class="k-builder-block-tab"
                   @click.stop="open(block, tabId)"

--- a/src/Cms/Builder.php
+++ b/src/Cms/Builder.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
+use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
 /**
@@ -197,10 +198,13 @@ class Builder
             ];
         }
 
-        return array_map(function ($tab) {
+        // normalize tabs props
+        array_walk($tabs, function (&$tab, $name) {
             $tab['fields'] = $this->fieldsProps($tab['fields'] ?? []);
-            return $tab;
-        }, $tabs);
+            $tab['label']  = I18n::translate($label = $tab['label'] ?? Str::ucfirst($name), $label);
+        });
+
+        return $tabs;
     }
 
     /**

--- a/src/Cms/Builder.php
+++ b/src/Cms/Builder.php
@@ -80,6 +80,7 @@ class Builder
      *
      * @param string $type
      * @return array
+     * @throws \Kirby\Exception\NotFoundException
      */
     public function fieldset(string $type): array
     {
@@ -95,7 +96,6 @@ class Builder
     /**
      * Expand and return all fieldsets for the builder
      *
-     * @param array $fieldsets
      * @return array
      */
     public function fieldsets(): array
@@ -133,7 +133,7 @@ class Builder
      * form including all the heavy lifting
      * of extensions, groups, nested fields etc.
      *
-     * @param array $fieldsProps
+     * @param array $fields
      * @return array
      */
     public function fieldsProps(array $fields): array
@@ -204,7 +204,7 @@ class Builder
     }
 
     /**
-     * @param array|null $input
+     * @param array|null $blocks
      * @param bool $pretty
      * @return void
      */

--- a/src/Cms/Builder.php
+++ b/src/Cms/Builder.php
@@ -155,7 +155,7 @@ class Builder
         return [
             'disabled'  => $fieldset['disabled'] ?? false,
             'icon'      => $fieldset['icon'] ?? null,
-            'label'     => $fieldset['label'] ?? $fieldset['name'],
+            'label'     => I18n::translate($label = $fieldset['label'] ?? $fieldset['name'], $label),
             'name'      => $fieldset['name'],
             'tabs'      => $this->tabsProps($fieldset),
             'translate' => $fieldset['translate'] ?? null,


### PR DESCRIPTION
## Describe the PR

As they are all simple enhancements, I wanted to create with separated commits in one PR

- Updated doc blocks
- Used tab name if label is empty
- Marked first tab as active on Expand All
- Fieldset labels are translatable now
- Shows fieldsets label in selector
- Added click action for the invisible icon with new position
- Visibility texts area translatable now
- Added empty option
