### PR TITLE
Content representations: Allow custom MIME

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1079,10 +1079,15 @@ class App
         // when the page has been found
         if ($page) {
             try {
-                return $this
-                    ->response()
-                    ->body($page->render([], $extension))
-                    ->type($extension);
+                $response = $this->response();
+
+                // attach a MIME type based on the representation
+                // only if no custom MIME type was set
+                if ($response->type() === null) {
+                    $response->type($extension);
+                }
+
+                return $response->body($page->render([], $extension));
             } catch (NotFoundException $e) {
                 return null;
             }

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -88,6 +88,10 @@ class AppResolveTest extends TestCase
     {
         F::write($template = $this->fixtures . '/test.php', 'html');
         F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+        F::write(
+            $template = $this->fixtures . '/test.png.php',
+            '<?php $kirby->response()->type("image/jpeg"); ?>png'
+        );
 
         $app = new App([
             'roots' => [
@@ -108,11 +112,17 @@ class AppResolveTest extends TestCase
         $result = $app->resolve('test.json');
         $this->assertNull($result);
 
-        // xml presentation
-        $result = $app->resolve('test.xml');
-
+        // xml representation
+        $result = $app->clone()->resolve('test.xml');
         $this->assertInstanceOf(Responder::class, $result);
-        $this->assertEquals('xml', $result->body());
+        $this->assertSame('text/xml', $result->type());
+        $this->assertSame('xml', $result->body());
+
+        // representation with custom MIME type
+        $result = $app->clone()->resolve('test.png');
+        $this->assertInstanceOf(Responder::class, $result);
+        $this->assertSame('image/jpeg', $result->type());
+        $this->assertSame('png', $result->body());
     }
 
     public function testResolveSiteFile()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

It is now possible to set a custom MIME `Content-Type` for a content representation using `$kirby->response()->type()`. If no custom type is set, the type is automatically detected from the extension like before.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes #2803. 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
