### PR TITLE
Builder: fix nested field api request

### DIFF
--- a/config/fields/builder.php
+++ b/config/fields/builder.php
@@ -2,7 +2,7 @@
 
 use Kirby\Cms\Block;
 use Kirby\Cms\Builder;
-use Kirby\Exception\NotFoundException;
+use Kirby\Cms\Form;
 
 return [
     'props' => [
@@ -88,10 +88,7 @@ return [
                     $builder = $this->field()->builder();
                     $fields  = $builder->fields($fieldsetType);
                     $form    = $builder->form($fields);
-
-                    if (!$field = $form->fields()->$fieldName()) {
-                        throw new NotFoundException('The field could not be found');
-                    }
+                    $field   = Form::fieldFromName($form, $fieldName);
 
                     $fieldApi = $this->clone([
                         'routes' => $field->api(),

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -56,28 +56,8 @@ class Api extends BaseApi
      */
     public function fieldApi($model, string $name, string $path = null)
     {
-        $form       = Form::for($model);
-        $fieldNames = Str::split($name, '+');
-        $index      = 0;
-        $count      = count($fieldNames);
-        $field      = null;
-
-        foreach ($fieldNames as $fieldName) {
-            $index++;
-
-            if ($field = $form->fields()->get($fieldName)) {
-                if ($count !== $index) {
-                    $form = $field->form();
-                }
-            } else {
-                throw new NotFoundException('The field "' . $fieldName . '" could not be found');
-            }
-        }
-
-        // it can get this error only if $name is an empty string as $name = ''
-        if ($field === null) {
-            throw new NotFoundException('No field could be loaded');
-        }
+        $form  = Form::for($model);
+        $field = Form::fieldFromName($form, $name);
 
         $fieldApi = $this->clone([
             'routes' => $field->api(),

--- a/src/Cms/Form.php
+++ b/src/Cms/Form.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\NotFoundException;
 use Kirby\Form\Form as BaseForm;
+use Kirby\Toolkit\Str;
 
 /**
  * Extension of `Kirby\Form\Form` that introduces
@@ -88,5 +90,39 @@ class Form extends BaseForm
         }
 
         return new static($props);
+    }
+
+    /**
+     * Get last field object from name that nested fields
+     *
+     * @param \Kirby\Cms\Form $form
+     * @param string $name
+     * @throws \Kirby\Exception\NotFoundException
+     * @return \Kirby\Form\Field
+     */
+    public static function fieldFromName(self $form, string $name) {
+        $fieldNames = Str::split($name, '+');
+        $index      = 0;
+        $count      = count($fieldNames);
+        $field      = null;
+
+        foreach ($fieldNames as $fieldName) {
+            $index++;
+
+            if ($field = $form->fields()->get($fieldName)) {
+                if ($count !== $index) {
+                    $form = $field->form();
+                }
+            } else {
+                throw new NotFoundException('The field "' . $fieldName . '" could not be found');
+            }
+        }
+
+        // it can get this error only if $name is an empty string as $name = ''
+        if ($field === null) {
+            throw new NotFoundException('No field could be loaded');
+        }
+
+        return $field;
     }
 }

--- a/src/Cms/Form.php
+++ b/src/Cms/Form.php
@@ -100,7 +100,8 @@ class Form extends BaseForm
      * @throws \Kirby\Exception\NotFoundException
      * @return \Kirby\Form\Field
      */
-    public static function fieldFromName(self $form, string $name) {
+    public static function fieldFromName(self $form, string $name)
+    {
         $fieldNames = Str::split($name, '+');
         $index      = 0;
         $count      = count($fieldNames);


### PR DESCRIPTION
## Describe the PR

**Issue:** Image field in structures don’t work 

It could not get the last field in api requests in builder nested fields. 
I made use of a part of the `\Kirby\Cms\Api::fieldApi` method by moving it to a common side that `\Kirby\Cms\Form::fieldFromName`. Of course it could be a better method name.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
