### PR TITLE
New user.login:failed hook

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -265,6 +265,8 @@ class Auth
 
         // check for blocked ips
         if ($this->isBlocked($email) === true) {
+            $this->kirby->trigger('user.login:failed', compact('email'));
+
             if ($this->kirby->option('debug') === true) {
                 $message = 'Rate limit exceeded';
             } else {
@@ -397,6 +399,8 @@ class Auth
      */
     public function track(string $email): bool
     {
+        $this->kirby->trigger('user.login:failed', compact('email'));
+
         $ip   = $this->ipHash();
         $log  = $this->log();
         $time = time();

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -59,7 +59,7 @@ class AuthProtectionTest extends TestCase
      */
     public function testLogfile()
     {
-        $this->assertEquals($this->fixtures . '/site/accounts/.logins', $this->auth->logfile());
+        $this->assertSame($this->fixtures . '/site/accounts/.logins', $this->auth->logfile());
     }
 
     /**
@@ -70,10 +70,10 @@ class AuthProtectionTest extends TestCase
         copy(__DIR__ . '/fixtures/logins.cleanup.json', $this->fixtures . '/site/accounts/.logins');
 
         // should delete expired and old entries and add by-email array
-        $this->assertEquals([
+        $this->assertSame([
             'by-ip' => [
                 '38f0a08519792a17e18a251008f3a116977907f921b0b287c8' => [
-                    'time'   => '9999999999',
+                    'time'   => 9999999999,
                     'trials' => 5
                 ]
             ],
@@ -83,7 +83,7 @@ class AuthProtectionTest extends TestCase
 
         // should handle missing .logins file
         unlink($this->fixtures . '/site/accounts/.logins');
-        $this->assertEquals([
+        $this->assertSame([
             'by-ip'    => [],
             'by-email' => []
         ], $this->auth->log());
@@ -91,7 +91,7 @@ class AuthProtectionTest extends TestCase
 
         // should handle invalid .logins file
         file_put_contents($this->fixtures . '/site/accounts/.logins', 'some gibberish');
-        $this->assertEquals([
+        $this->assertSame([
             'by-ip'    => [],
             'by-email' => []
         ], $this->auth->log());
@@ -105,7 +105,7 @@ class AuthProtectionTest extends TestCase
     {
         $this->app->visitor()->ip('10.1.123.234');
 
-        $this->assertEquals('87084f11690867b977a611dd2c943a918c3197f4c02b25ab59', $this->auth->ipHash());
+        $this->assertSame('87084f11690867b977a611dd2c943a918c3197f4c02b25ab59', $this->auth->ipHash());
     }
 
     /**
@@ -178,8 +178,8 @@ class AuthProtectionTest extends TestCase
                 ]
             ]
         ];
-        $this->assertEquals($data, $this->auth->log());
-        $this->assertEquals(json_encode($data), file_get_contents($this->fixtures . '/site/accounts/.logins'));
+        $this->assertSame($data, $this->auth->log());
+        $this->assertSame(json_encode($data), file_get_contents($this->fixtures . '/site/accounts/.logins'));
     }
 
     /**
@@ -193,7 +193,7 @@ class AuthProtectionTest extends TestCase
         $user = $this->auth->validatePassword('marge@simpsons.com', 'springfield123');
 
         $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals('marge@simpsons.com', $user->email());
+        $this->assertSame('marge@simpsons.com', $user->email());
         $this->assertNull($this->failedEmail);
     }
 
@@ -210,7 +210,7 @@ class AuthProtectionTest extends TestCase
         $this->app->visitor()->ip('10.3.123.234');
         $this->auth->validatePassword('lisa@simpsons.com', 'springfield123');
 
-        $this->assertEquals(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
+        $this->assertSame(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
         $this->assertSame('lisa@simpsons.com', $this->failedEmail);
     }
 
@@ -227,8 +227,8 @@ class AuthProtectionTest extends TestCase
         $this->app->visitor()->ip('10.3.123.234');
         $this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
 
-        $this->assertEquals(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
-        $this->assertEquals(10, $this->auth->log()['by-email']['marge@simpsons.com']['trials']);
+        $this->assertSame(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
+        $this->assertSame(10, $this->auth->log()['by-email']['marge@simpsons.com']['trials']);
         $this->assertSame('marge@simpsons.com', $this->failedEmail);
     }
 
@@ -266,7 +266,7 @@ class AuthProtectionTest extends TestCase
         $this->app->visitor()->ip('10.3.123.234');
         $this->auth->validatePassword('lisa@simpsons.com', 'springfield123');
 
-        $this->assertEquals(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
+        $this->assertSame(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
         $this->assertSame('lisa@simpsons.com', $this->failedEmail);
     }
 
@@ -289,8 +289,8 @@ class AuthProtectionTest extends TestCase
         $this->app->visitor()->ip('10.3.123.234');
         $this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
 
-        $this->assertEquals(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
-        $this->assertEquals(10, $this->auth->log()['by-email']['marge@simpsons.com']['trials']);
+        $this->assertSame(1, $this->auth->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
+        $this->assertSame(10, $this->auth->log()['by-email']['marge@simpsons.com']['trials']);
         $this->assertSame('marge@simpsons.com', $this->failedEmail);
     }
 


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

New `user.login:failed` hook that is triggered whenever Kirby detects an invalid login. The hook can be used for custom security logs and tools like `fail2ban`.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- [Discussion in Slack](https://getkirby.slack.com/archives/C2UTAQAN4/p1601271208035600?thread_ts=1601241805.024500&cid=C2UTAQAN4)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
