### PR TITLE
Move $isResizable to Darkroom class

### DIFF
--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -90,10 +90,6 @@ return [
             return $file->template();
         },
         'thumbs' => function ($file) {
-            if ($file->isResizable() === false) {
-                return null;
-            }
-
             return [
                 'tiny'   => $file->resize(128)->url(),
                 'small'  => $file->resize(256)->url(),

--- a/config/components.php
+++ b/config/components.php
@@ -75,10 +75,6 @@ return [
      * @return \Kirby\Cms\File|\Kirby\Cms\FileVersion
      */
     'file::version' => function (App $kirby, $file, array $options = []) {
-        if ($file->isResizable() === false) {
-            return $file;
-        }
-
         // create url and root
         $mediaRoot = dirname($file->mediaRoot());
         $dst       = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';

--- a/src/Cms/FileFoundation.php
+++ b/src/Cms/FileFoundation.php
@@ -116,24 +116,6 @@ trait FileFoundation
     }
 
     /**
-     * Checks if the file is a resizable image
-     *
-     * @return bool
-     */
-    public function isResizable(): bool
-    {
-        $resizable = [
-            'jpg',
-            'jpeg',
-            'gif',
-            'png',
-            'webp'
-        ];
-
-        return in_array($this->extension(), $resizable) === true;
-    }
-
-    /**
      * Checks if a preview can be displayed for the file
      * in the panel or in the frontend
      *
@@ -217,7 +199,6 @@ trait FileFoundation
     public function toArray(): array
     {
         $array = array_merge($this->asset()->toArray(), [
-            'isResizable' => $this->isResizable(),
             'url'         => $this->url(),
         ]);
 

--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -3,6 +3,7 @@
 namespace Kirby\Image;
 
 use Exception;
+use Kirby\Toolkit\F;
 
 /**
  * A wrapper around resizing and cropping
@@ -19,6 +20,14 @@ class Darkroom
     public static $types = [
         'gd' => 'Kirby\Image\Darkroom\GdLib',
         'im' => 'Kirby\Image\Darkroom\ImageMagick'
+    ];
+
+    public static $resizable = [
+        'jpg',
+        'jpeg',
+        'gif',
+        'png',
+        'webp'
     ];
 
     protected $settings = [];
@@ -137,9 +146,14 @@ class Darkroom
      * @param string $file
      * @param array $options
      * @return array
+     * @throws \Exception
      */
     public function process(string $file, array $options = []): array
     {
+        if (in_array(F::extension($file), static::$resizable) === false) {
+            throw new Exception('Image format not resizable');
+        }
+
         return $this->preprocess($file, $options);
     }
 }


### PR DESCRIPTION
## Describe the PR

Follow-up to #2840 

Maybe I went a little overboard, but maybe this provides the base for future changes, my PHP isn't very strong (lawyer talking). Something like this what you had in mind, @lukasbestle ? Sure, the changes made have to be called / reflected by the Darkroom implementations, since they overwrite the `process()` method - or maybe isResizable should be a method of Darkroom, returning `bool`? I guess that would be better ..

## Related issues

Making `thumb()` more flexible.

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
