### PR TITLE
New `logs` root

### DIFF
--- a/config/roots.php
+++ b/config/roots.php
@@ -67,6 +67,9 @@ return [
     'languages' => function (array $roots) {
         return $roots['site'] . '/languages';
     },
+    'logs' => function (array $roots) {
+        return $roots['site'] . '/logs';
+    },
     'models' => function (array $roots) {
         return $roots['site'] . '/models';
     },

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -14,13 +14,14 @@ class RootsTest extends TestCase
             [$index . '/media', 'media'],
             [$index . '/content', 'content'],
             [$site = $index . '/site', 'site'],
+            [$site . '/accounts', 'accounts'],
+            [$site . '/blueprints', 'blueprints'],
             [$site . '/collections', 'collections'],
             [$site . '/controllers', 'controllers'],
-            [$site . '/accounts', 'accounts'],
+            [$site . '/logs', 'logs'],
+            [$site . '/plugins', 'plugins'],
             [$site . '/snippets', 'snippets'],
             [$site . '/templates', 'templates'],
-            [$site . '/plugins', 'plugins'],
-            [$site . '/blueprints', 'blueprints'],
         ];
     }
 
@@ -43,13 +44,14 @@ class RootsTest extends TestCase
             [$index . '/media', 'media'],
             [$index . '/content', 'content'],
             [$site = $index . '/site', 'site'],
+            [$site . '/accounts', 'accounts'],
+            [$site . '/blueprints', 'blueprints'],
             [$site . '/collections', 'collections'],
             [$site . '/controllers', 'controllers'],
-            [$site . '/accounts', 'accounts'],
+            [$site . '/logs', 'logs'],
+            [$site . '/plugins', 'plugins'],
             [$site . '/snippets', 'snippets'],
             [$site . '/templates', 'templates'],
-            [$site . '/plugins', 'plugins'],
-            [$site . '/blueprints', 'blueprints'],
         ];
     }
 


### PR DESCRIPTION
## Describe the PR

Adds `site/logs/` as new root for plugins to store their logs. Helping them to unify where to store these. And if users want to change the root (and plugins use this new roots option), they would only need to change the one root, not plugin options for each plugin.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- https://kirby.nolt.io/122
