### PR TITLE
#2690 Fix files section sort if not sortable

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -88,7 +88,7 @@ return [
 
             if ($this->sortBy) {
                 $files = $files->sortBy(...$files::sortArgs($this->sortBy));
-            } elseif ($this->sortable === true) {
+            } else {
                 $files = $files->sortBy('sort', 'asc', 'filename', 'asc');
             }
 


### PR DESCRIPTION
I think this has to be just `else`.
The files should be listed in order (and not randomly) even if they aren't sortable - if no `sort` exist, they'll be listed according to filename.