### PR TITLE
Prevent accidental writes from collection methods

### DIFF
--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -35,9 +35,12 @@ trait AppUsers
     }
 
     /**
-     * Become any existing user
+     * Become any existing user or disable the current user
      *
-     * @param string|null $who User ID or email address
+     * @param string|null $who User ID or email address,
+     *                         `null` to use the actual user again,
+     *                         `'kirby'` for a virtual admin user or
+     *                         `'nobody'` to disable the actual user
      * @param Closure|null $callback Optional action function that will be run with
      *                               the permissions of the impersonated user; the
      *                               impersonation will be reset afterwards

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -229,9 +229,12 @@ class Auth
     }
 
     /**
-     * Become any existing user
+     * Become any existing user or disable the current user
      *
-     * @param string|null $who User ID or email address
+     * @param string|null $who User ID or email address,
+     *                         `null` to use the actual user again,
+     *                         `'kirby'` for a virtual admin user or
+     *                         `'nobody'` to disable the actual user
      * @return \Kirby\Cms\User|null
      * @throws \Kirby\Exception\NotFoundException if the given user cannot be found
      */
@@ -245,6 +248,12 @@ class Auth
                     'email' => 'kirby@getkirby.com',
                     'id'    => 'kirby',
                     'role'  => 'admin',
+                ]);
+            case 'nobody':
+                return $this->impersonate = new User([
+                    'email' => 'nobody@getkirby.com',
+                    'id'    => 'nobody',
+                    'role'  => 'nobody',
                 ]);
             default:
                 if ($user = $this->kirby->users()->find($who)) {
@@ -585,7 +594,7 @@ class Auth
      * @param \Kirby\Session\Session|array|null $session
      * @param bool $allowImpersonation If set to false, only the actually
      *                                 logged in user will be returned
-     * @return \Kirby\Cms\User
+     * @return \Kirby\Cms\User|null
      *
      * @throws \Throwable If an authentication error occured
      */

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -383,6 +383,17 @@ class User extends ModelWithContent
     }
 
     /**
+     * Checks if the current user is the virtual
+     * Nobody user
+     *
+     * @return bool
+     */
+    public function isNobody(): bool
+    {
+        return $this->email() === 'nobody@getkirby.com';
+    }
+
+    /**
      * Returns the user language
      *
      * @return string

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -41,20 +41,20 @@ class AppUsersTest extends TestCase
 
         // impersonate as kirby
         $user = $app->impersonate('kirby');
+        $this->assertSame($user, $app->user());
         $this->assertSame('kirby', $user->id());
         $this->assertSame('kirby@getkirby.com', $user->email());
         $this->assertSame('admin', $user->role()->name());
         $this->assertTrue($user->isKirby());
-        $this->assertSame($user, $app->user());
         $this->assertNull($app->user(null, false));
 
         // impersonate as existing user
         $user = $app->impersonate('homer@simpsons.com');
-        $this->assertSame('homer@simpsons.com', $user->email());
         $this->assertSame($user, $app->user());
+        $this->assertSame('homer@simpsons.com', $user->email());
         $user = $app->impersonate('testtest');
-        $this->assertSame('homer@simpsons.com', $user->email());
         $this->assertSame($user, $app->user());
+        $this->assertSame('homer@simpsons.com', $user->email());
         $this->assertNull($app->user(null, false));
 
         // impersonate as nobody
@@ -75,8 +75,8 @@ class AppUsersTest extends TestCase
         // with callback
         $result = $app->impersonate('homer@simpsons.com', function ($user) use ($app, $self) {
             $self->assertSame($app, $this);
-            $self->assertSame('homer@simpsons.com', $user->email());
             $self->assertSame($user, $this->user());
+            $self->assertSame('homer@simpsons.com', $user->email());
             $self->assertNull($app->user(null, false));
 
             return 'test1';
@@ -91,8 +91,8 @@ class AppUsersTest extends TestCase
         try {
             $app->impersonate('homer@simpsons.com', function ($user) use ($app, $self) {
                 $self->assertSame($app, $this);
-                $self->assertSame('homer@simpsons.com', $user->email());
                 $self->assertSame($user, $this->user());
+                $self->assertSame('homer@simpsons.com', $user->email());
                 $self->assertNull($app->user(null, false));
 
                 throw new Exception('Something bad happened');

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -57,6 +57,15 @@ class AppUsersTest extends TestCase
         $this->assertSame($user, $app->user());
         $this->assertNull($app->user(null, false));
 
+        // impersonate as nobody
+        $user = $app->impersonate('nobody');
+        $this->assertSame('nobody', $user->id());
+        $this->assertSame('nobody@getkirby.com', $user->email());
+        $this->assertSame('nobody', $user->role()->name());
+        $this->assertTrue($user->isNobody());
+        $this->assertSame($user, $app->user());
+        $this->assertNull($app->user(null, false));
+
         // unimpersonate
         $user = $app->impersonate();
         $this->assertNull($user);

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -41,7 +41,7 @@ class AuthTest extends TestCase
         ]);
         Dir::make($this->fixtures . '/site/accounts');
 
-        $this->auth = new Auth($this->app);
+        $this->auth = $this->app->auth();
     }
 
     public function tearDown(): void
@@ -79,6 +79,17 @@ class AuthTest extends TestCase
         $this->assertNull($this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
+        $this->auth->setUser($actual = $this->app->user('marge@simpsons.com'));
+        $this->assertSame('marge@simpsons.com', $this->auth->user()->email());
+        $impersonated = $this->auth->impersonate('nobody');
+        $this->assertSame('nobody', $impersonated->id());
+        $this->assertSame('nobody@getkirby.com', $impersonated->email());
+        $this->assertSame('nobody', $impersonated->role()->name());
+        $this->assertSame($impersonated, $this->auth->user());
+        $this->assertSame($impersonated, $this->auth->currentUserFromImpersonation());
+        $this->assertSame($actual, $this->auth->user(null, false));
+
+        $this->auth->logout();
         $this->assertNull($this->auth->impersonate());
         $this->assertNull($this->auth->user());
         $this->assertNull($this->auth->currentUserFromImpersonation());

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -61,11 +61,11 @@ class AuthTest extends TestCase
         $this->assertSame(null, $this->auth->user());
 
         $user = $this->auth->impersonate('kirby');
+        $this->assertSame($user, $this->auth->user());
+        $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertSame('kirby', $user->id());
         $this->assertSame('kirby@getkirby.com', $user->email());
         $this->assertSame('admin', $user->role()->name());
-        $this->assertSame($user, $this->auth->user());
-        $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $user = $this->auth->impersonate('homer@simpsons.com');
@@ -82,11 +82,11 @@ class AuthTest extends TestCase
         $this->auth->setUser($actual = $this->app->user('marge@simpsons.com'));
         $this->assertSame('marge@simpsons.com', $this->auth->user()->email());
         $impersonated = $this->auth->impersonate('nobody');
+        $this->assertSame($impersonated, $this->auth->user());
+        $this->assertSame($impersonated, $this->auth->currentUserFromImpersonation());
         $this->assertSame('nobody', $impersonated->id());
         $this->assertSame('nobody@getkirby.com', $impersonated->email());
         $this->assertSame('nobody', $impersonated->role()->name());
-        $this->assertSame($impersonated, $this->auth->user());
-        $this->assertSame($impersonated, $this->auth->currentUserFromImpersonation());
         $this->assertSame($actual, $this->auth->user(null, false));
 
         $this->auth->logout();


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

By disabling logged-in users while running collection methods like `sortBy()`, `filterBy()` and `groupBy()`, accidental calls to methods that cause write operations (like `$page->sort()`) are prevented.

## Related issues

<!-- PR relates to issues in the `kirby` or `ideas` repo: -->

- Fixes a part of #2475 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
