### PR TITLE
Callback support for Collection::filterBy

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -237,18 +237,15 @@ class Collection extends Iterator implements Countable
     }
 
     /**
-     * Filters elements by a custom
-     * filter function or an array of filters
+     * Shorthand/alias for static::filterBy()
      *
-     * @deprecated 3.5.0 Use `Kirby\Toolkit\Collection::filterBy` instead
-     *
-     * @param array|\Closure $filter
-     * @return self
-     * @throws \Exception if $filter is neither a closure nor an array
+     * @param string|array|\Closure $field
+     * @param array ...$args
+     * @return \Kirby\Toolkit\Collection
      */
-    public function filter($filter)
+    public function filter($field, ...$args)
     {
-        return $this->filterBy($filter);
+        return $this->filterBy($field, ...$args);
     }
 
     /**

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -256,7 +256,7 @@ class Collection extends Iterator implements Countable
      * predefined filter methods, by a
      * custom filter function or an array of filters
      *
-     * @param string|Closure $field
+     * @param string|array|\Closure $field
      * @param array ...$args
      * @return \Kirby\Toolkit\Collection
      */

--- a/tests/Toolkit/CollectionFilterTest.php
+++ b/tests/Toolkit/CollectionFilterTest.php
@@ -51,6 +51,10 @@ class CollectionFilterTest extends TestCase
             ['role', '==', 'developer'],
             ['color', '==', 'red']
         ]));
+        $this->assertEquals($result, $collection->filterBy([
+            ['role', '==', 'developer'],
+            ['color', '==', 'red']
+        ]));
     }
 
     public function testFilterClosure()
@@ -76,18 +80,9 @@ class CollectionFilterTest extends TestCase
         $this->assertEquals($result, $collection->filter(function ($item) {
             return $item['role'] === 'founder';
         }));
-    }
-
-    public function testFilterException()
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('The filter method needs either an array of filterBy rules or a closure function to be passed as parameter.');
-
-        $collection = new Collection([
-            'one'   => 'eins'
-        ]);
-
-        $collection->filter('one');
+        $this->assertEquals($result, $collection->filterBy(function ($item) {
+            return $item['role'] === 'founder';
+        }));
     }
 
     public function filterDataProvider()


### PR DESCRIPTION
## Describe the PR

- Support passing Closure or array to `Collection::filterBy` (so far supported in `Collection::filter`)
- Use `Collection::filter` as simple alias for `Collection::filterBy`
- Marked `Collection::filter` as deprecated, no warning yet though - I'd suggest to add the warning in 3.6 or 3.7 and eventually remove it in 3.8 or 3.9