### PR TITLE
New page status icons

### DIFF
--- a/panel/src/components/Layout/Card.vue
+++ b/panel/src/components/Layout/Card.vue
@@ -18,11 +18,10 @@
     </component>
 
     <nav class="k-card-options">
-      <k-button
+      <k-status-icon
         v-if="flag"
         v-bind="flag"
         class="k-card-options-button"
-        @click="flag.click"
       />
       <slot name="options">
         <k-button

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -17,11 +17,10 @@
     </k-link>
     <nav class="k-list-item-options">
       <slot name="options">
-        <k-button
+        <k-status-icon
           v-if="flag"
           v-bind="flag"
           class="k-list-item-status"
-          @click="flag.click"
         />
         <k-button
           v-if="options"

--- a/panel/src/components/Misc/StatusIcon.vue
+++ b/panel/src/components/Misc/StatusIcon.vue
@@ -1,0 +1,80 @@
+<template>
+  <k-button
+    :disabled="disabled"
+    :icon="icon"
+    :responsive="responsive"
+    :tooltip="title"
+    :class="'k-status-icon k-status-icon-' + status"
+    @click="onClick"
+  >
+    {{ text }}
+  </k-button>
+</template>
+
+<script>
+export default {
+  props: {
+    click: {
+      type: Function,
+      default: () => {}
+    },
+    disabled: Boolean,
+    responsive: Boolean,
+    status: String,
+    text: String,
+    tooltip: String
+  },
+  computed: {
+    icon() {
+      if (this.status === "draft") {
+        return "circle-outline";
+      }
+
+      if (this.status === "unlisted") {
+        return "circle-half";
+      }
+
+      return "circle"
+    },
+    title() {
+      let title = this.tooltip || this.text;
+
+      if (this.disabled) {
+        title += ` (${this.$t("disabled")})`;
+      }
+
+      return title;
+    }
+  },
+  methods: {
+    onClick() {
+      this.click();
+      this.$emit("click");
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.k-status-icon svg {
+  width: 14px;
+  height: 14px;
+}
+.k-status-icon-listed .k-icon {
+  color: $color-positive-on-dark;
+}
+.k-status-icon-unlisted .k-icon {
+  color: $color-focus-on-dark;
+}
+.k-status-icon-draft  .k-icon {
+  color: $color-negative-on-dark;
+}
+.k-status-icon[data-disabled] {
+  opacity: 1 !important;
+
+  .k-icon {
+    color: $color-gray-400;
+    opacity: .5;
+  }
+}
+</style>

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -167,9 +167,8 @@ export default {
         const isEnabled = page.permissions.changeStatus !== false;
 
         page.flag = {
-          class: "k-status-flag k-status-flag-" + page.status,
-          tooltip: isEnabled ? this.$t("page.status") : `${this.$t("page.status")} (${this.$t("disabled")})`,
-          icon: isEnabled ? "circle" : "protected",
+          status: page.status,
+          tooltip: this.$t("page.status"),
           disabled: !isEnabled,
           click: () => {
             this.action(page, "status");

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -21,17 +21,14 @@
         >
           {{ $t('open') }}
         </k-button>
-        <k-button
+        <k-status-icon
           v-if="status"
-          :class="['k-status-flag', 'k-status-flag-' + page.status]"
+          :status="page.status"
           :disabled="!permissions.changeStatus || isLocked"
-          :icon="!permissions.changeStatus || isLocked ? 'protected' : 'circle'"
           :responsive="true"
-          :tooltip="status.label"
+          :text="status.label"
           @click="action('status')"
-        >
-          {{ status.label }}
-        </k-button>
+        />
         <k-dropdown>
           <k-button
             :responsive="true"
@@ -210,22 +207,3 @@ export default {
   }
 };
 </script>
-
-<style lang="scss">
-.k-status-flag svg {
-  width: 14px;
-  height: 14px;
-}
-.k-status-flag-listed .k-icon {
-  color: $color-positive-on-dark;
-}
-.k-status-flag-unlisted .k-icon {
-  color: $color-focus-on-dark;
-}
-.k-status-flag-draft .k-icon {
-  color: $color-negative-on-dark;
-}
-.k-status-flag[disabled] {
-  opacity: 1;
-}
-</style>

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -247,6 +247,7 @@ import Image from "@/components/Misc/Image.vue";
 import Loader from "@/components/Misc/Loader.vue";
 import Progress from "@/components/Misc/Progress.vue";
 import SortHandle from "@/components/Misc/SortHandle.vue";
+import StatusIcon from "@/components/Misc/StatusIcon.vue";
 import Text from "@/components/Misc/Text.vue";
 
 Vue.component("k-draggable", Draggable);
@@ -256,6 +257,7 @@ Vue.component("k-icon", Icon);
 Vue.component("k-image", Image);
 Vue.component("k-loader", Loader);
 Vue.component("k-progress", Progress);
+Vue.component("k-status-icon", StatusIcon);
 Vue.component("k-sort-handle", SortHandle);
 Vue.component("k-text", Text);
 


### PR DESCRIPTION
Another bit from `storybook`:

<img width="499" alt="Screen Shot 2020-10-09 at 15 01 50" src="https://user-images.githubusercontent.com/3788865/95586869-94c4a780-0a41-11eb-838d-ed32392e030d.png">
