### PR TITLE
Date & time fields

### DIFF
--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -35,13 +35,13 @@ return [
         },
 
         /**
-         * Youngest date, which can be selected/saved (Y-m-d)
+         * Latest date, which can be selected/saved (Y-m-d)
          */
         'max' => function (string $max = null) {
             return $this->toDatetime($max);
         },
         /**
-         * Oldest date, which can be selected/saved (Y-m-d)
+         * Earliest date, which can be selected/saved (Y-m-d)
          */
         'min' => function (string $min = null) {
             return $this->toDatetime($min);

--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -1,21 +1,30 @@
 <?php
 
 use Kirby\Exception\Exception;
+use Kirby\Toolkit\Str;
 
 return [
+    'mixins' => ['datetime'],
     'props' => [
+        /**
+         * Unset inherited props
+         */
+        'placeholder' => null,
+
+
         /**
          * Default date when a new page/file/user gets created
          */
-        'default' => function ($default = null) {
+        'default' => function (string $default = null) {
             return $default;
         },
 
         /**
-         * Defines a custom format that is used when the field is saved
+         * Custom format (dayjs tokens) that is used to display
+         * the field in the Panel
          */
-        'format' => function (string $format = null) {
-            return $format;
+        'display' => function (string $display = 'YYYY-MM-DD') {
+            return $display;
         },
 
         /**
@@ -24,22 +33,52 @@ return [
         'icon' => function (string $icon = 'calendar') {
             return $icon;
         },
+
         /**
-         * Youngest date, which can be selected/saved
+         * Youngest date, which can be selected/saved (Y-m-d)
          */
         'max' => function (string $max = null) {
-            return $this->toDate($max);
+            return $this->toDatetime($max);
         },
         /**
-         * Oldest date, which can be selected/saved
+         * Oldest date, which can be selected/saved (Y-m-d)
          */
         'min' => function (string $min = null) {
-            return $this->toDate($min);
+            return $this->toDatetime($min);
         },
+
         /**
-         * The placeholder is not available
+         * Round to the nearest: sub-options for `unit` (day) and `size` (1)
          */
-        'placeholder' => null,
+        'step' => function ($step = null) {
+            if ($step === null) {
+                return [
+                    'size' => 1,
+                    'unit' => 'day'
+                ];
+            }
+
+            if (is_array($step) === true) {
+                return $step;
+            }
+
+            if (is_int($step) === true) {
+                return [
+                    'size' => $step,
+                    'unit' => 'day'
+                ];
+            }
+
+            if (is_string($step) === true) {
+                return [
+                    'size' => 1,
+                    'unit' => $step
+                ];
+            }
+
+            throw new Exception('step option has to be defined as array');
+        },
+
         /**
          * Pass `true` or an array of time field options to show the time selector.
          */
@@ -55,27 +94,26 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->toDate($this->default);
+            return $this->toDatetime($this->default);
         },
-        'format' => function () {
-            return $this->props['format'] ?? ($this->time() === false ? 'Y-m-d' : 'Y-m-d H:i');
+        'display' => function () {
+            return Str::upper($this->display);
         },
-        'value' => function () {
-            return $this->toDate($this->value);
-        },
-    ],
-    'methods' => [
-        'toDate' => function ($value) {
-            if ($timestamp = timestamp($value, $this->time['step'] ?? 5)) {
-                return date('Y-m-d H:i:s', $timestamp);
+        'step' => function () {
+            if ($this->time !== false) {
+                $timeField = require __DIR__ . '/time.php';
+                return $timeField['props']['step']($this->time['step'] ?? null);
             }
 
-            return null;
-        }
+            return $this->step;
+        },
+        'value' => function () {
+            return $this->toDatetime($this->value);
+        },
     ],
     'save' => function ($value) {
-        if ($value !== null && $date = strtotime($value)) {
-            return date($this->format(), $date);
+        if ($value !== null && $timestamp = timestamp($value)) {
+            return $this->toISO($timestamp);
         }
 
         return '';

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'methods' => [
+        'toDatetime' => function ($value) {
+            if ($timestamp = timestamp($value, $this->step)) {
+                return $this->toISO($timestamp);
+            }
+
+            return null;
+        },
+        'toISO' => function (int $time) {
+            return date('Y-m-d H:i:s', $time);
+        }
+    ]
+];

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -31,6 +31,19 @@ return [
             return $icon;
         },
         /**
+         * Latest time, which can be selected/saved (H:i or H:i:s)
+         */
+        'max' => function (string $max = null) {
+            return $max ? $this->toDatetime(date('Y-m-d ') . $max) : null;
+        },
+        /**
+         * Earliest time, which can be selected/saved (H:i or H:i:s)
+         */
+        'min' => function (string $min = null) {
+            return $min ? $this->toDatetime(date('Y-m-d ') . $min) : null;
+        },
+
+        /**
          * `12` or `24` hour notation. If `12`, an AM/PM selector will be shown.
          */
         'notation' => function (int $value = 24) {
@@ -95,5 +108,48 @@ return [
     },
     'validations' => [
         'time',
+        'minMax' => function ($value) {
+            $min    = $this->min ? strtotime($this->min) : null;
+            $max    = $this->max ? strtotime($this->max) : null;
+            $value  = strtotime($this->value());
+            $format = 'H:i:s';
+            $errors = [];
+
+            if ($value && $min && $value < $min) {
+                $errors['min'] = $min;
+            }
+
+            if ($value && $max && $value > $max) {
+                $errors['max'] = $max;
+            }
+
+            if (empty($errors) === false) {
+                if ($min && $max) {
+                    throw new Exception([
+                        'key' => 'validation.time.between',
+                        'data' => [
+                            'min' => date($format, $min),
+                            'max' => date($format, $max)
+                        ]
+                    ]);
+                } elseif ($min) {
+                    throw new Exception([
+                        'key' => 'validation.time.after',
+                        'data' => [
+                            'time' => date($format, $min),
+                        ]
+                    ]);
+                } else {
+                    throw new Exception([
+                        'key' => 'validation.time.before',
+                        'data' => [
+                            'time' => date($format, $max),
+                        ]
+                    ]);
+                }
+            }
+
+            return true;
+        },
     ]
 ];

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -1,11 +1,13 @@
 <?php
 
 return [
+    'mixins' => ['datetime'],
     'props' => [
         /**
          * Unset inherited props
          */
         'placeholder' => null,
+
 
         /**
          * Sets the default time when a new page/file/user is created
@@ -13,6 +15,15 @@ return [
         'default' => function ($default = null) {
             return $default;
         },
+
+        /**
+         * Custom format (dayjs tokens) that is used to display
+         * the field in the Panel
+         */
+        'display' => function (string $display = null) {
+            return $display;
+        },
+
         /**
          * Changes the clock icon
          */
@@ -26,10 +37,35 @@ return [
             return $value === 24 ? 24 : 12;
         },
         /**
-         * The interval between minutes in the minutes select dropdown.
+         * Round to the nearest: sub-options for `unit` (minute) and `size` (5)
          */
-        'step' => function (int $step = 5) {
-            return $step;
+        'step' => function ($step = null) {
+            if ($step === null) {
+                return [
+                    'size' => 5,
+                    'unit' => 'minute'
+                ];
+            }
+
+            if (is_array($step) === true) {
+                return $step;
+            }
+
+            if (is_int($step) === true) {
+                return [
+                    'size' => $step,
+                    'unit' => 'minute'
+                ];
+            }
+
+            if (is_string($step) === true) {
+                return [
+                    'size' => 1,
+                    'unit' => $step
+                ];
+            }
+
+            throw new Exception('step option has to be defined as array');
         },
         'value' => function ($value = null) {
             return $value;
@@ -37,27 +73,22 @@ return [
     ],
     'computed' => [
         'default' => function () {
-            return $this->toTime($this->default);
+            return $this->toDatetime($this->default);
         },
-        'format' => function () {
-            return $this->notation === 24 ? 'H:i' : 'h:i a';
-        },
-        'value' => function () {
-            return $this->toTime($this->value);
-        }
-    ],
-    'methods' => [
-        'toTime' => function ($value) {
-            if ($timestamp = timestamp($value, $this->step)) {
-                return date('H:i', $timestamp);
+        'display' => function () {
+            if ($this->display) {
+                return $this->display;
             }
 
-            return null;
+            return $this->notation === 24 ? 'HH:mm' : 'hh:mm a';
+        },
+        'value' => function () {
+            return $this->toDatetime($this->value);
         }
     ],
     'save' => function ($value): string {
-        if ($timestamp = strtotime($value)) {
-            return date($this->format, $timestamp);
+        if ($value != null && $timestamp = strtotime($value)) {
+            return date('H:i:s', $timestamp);
         }
 
         return '';

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Exception\Exception;
+
 return [
     'mixins' => ['datetime'],
     'props' => [

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -747,10 +747,10 @@ function tc($key, int $count)
  * by the defined step
  *
  * @param string $date
- * @param int $step
+ * @param int $step array of `unit` and `size` to round to nearest
  * @return string|null
  */
-function timestamp(string $date = null, int $step = null): ?string
+function timestamp(string $date = null, $step = null): ?string
 {
     if (V::date($date) === false) {
         return null;
@@ -762,13 +762,46 @@ function timestamp(string $date = null, int $step = null): ?string
         return $date;
     }
 
-    $hours   = date('H', $date);
-    $minutes = date('i', $date);
-    $minutes = floor($minutes / $step) * $step;
-    $minutes = str_pad($minutes, 2, 0, STR_PAD_LEFT);
-    $date    = date('Y-m-d', $date) . ' ' . $hours . ':' . $minutes;
+    if (is_int($step) === true) {
+        $step = [
+            'unit' => 'minute',
+            'size' => 1
+        ];
+    }
 
-    return strtotime($date);
+    if (is_array($step) === false) {
+        return $date;
+    }
+
+    $parts = [
+        'second' => date('s', $date),
+        'minute' => date('i', $date),
+        'hour'   => date('H', $date),
+        'day'    => date('d', $date),
+        'month'  => date('m', $date),
+        'year'   => date('Y', $date),
+    ];
+
+    $current = $parts[$step['unit']];
+    $nearest = round($current / $step['size']) * $step['size'];
+    $parts[$step['unit']] = $nearest;
+
+    foreach ($parts as $part => $value) {
+        if ($part === $step['unit']) {
+            break;
+        }
+
+        $parts[$part] = 0;
+    }
+
+    return strtotime(
+        $parts['year'] . '-' .
+        str_pad($parts['month'], 2, 0, STR_PAD_LEFT) . '-' .
+        str_pad($parts['day'], 2, 0, STR_PAD_LEFT) . ' ' .
+        str_pad($parts['hour'], 2, 0, STR_PAD_LEFT) . ':' .
+        str_pad($parts['minute'], 2, 0, STR_PAD_LEFT) . ':' .
+        str_pad($parts['second'], 2, 0, STR_PAD_LEFT)
+    );
 }
 
 /**

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -196,6 +196,9 @@
   "error.validation.size": "The size of the value must be \"{size}\"",
   "error.validation.startswith": "The value must start with \"{start}\"",
   "error.validation.time": "Please enter a valid time",
+  "error.validation.time.after": "Please enter a time after {time}",
+  "error.validation.time.before": "Please enter a time before {time}",
+  "error.validation.time.between": "Please enter a time between {min} and {max}",
   "error.validation.url": "Please enter a valid URL",
 
   "field.required": "The field is required",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -5803,9 +5803,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.22",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.22.tgz",
-      "integrity": "sha512-N8IXfxBD62Y9cKTuuuSoOlCXRnnzaTj1vu91r855iq6FbY5cZqOZnW/95nUn6kJiR+W9PHHrLykEoQOe6fUKxQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.1.tgz",
+      "integrity": "sha512-01NCTBg8cuMJG1OQc6PR7T66+AFYiPwgDvdJmvJBn29NGzIG+DIFxPLNjHzwz3cpFIvG+NcwIjP9hSaPVoOaDg=="
     },
     "de-indent": {
       "version": "1.0.2",

--- a/panel/package.json
+++ b/panel/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@linusborg/vue-simple-portal": "^0.1.4",
     "autosize": "^4.0.2",
-    "dayjs": "^1.8.22",
+    "dayjs": "^1.9.1",
     "npm": "^6.14.7",
     "vue": "^2.6.11",
     "vue-router": "^3.1.6",

--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -4,12 +4,12 @@
       ref="input"
       :id="_uid"
       :type="inputType"
-      :value="date"
+      :value="value"
       v-bind="$props"
       theme="field"
       v-on="listeners"
     >
-      <template slot="icon">
+      <template #icon>
         <k-dropdown>
           <k-button
             :icon="icon"
@@ -20,8 +20,10 @@
           />
           <k-dropdown-content ref="dropdown" align="right">
             <k-calendar
-              :value="date"
-              @input="onInput($event); $refs.dropdown.close()"
+              :value="datetime"
+              :min="min"
+              :max="max"
+              @input="onSelect"
             />
           </k-dropdown-content>
         </k-dropdown>
@@ -49,30 +51,44 @@ export default {
   },
   data() {
     return {
-      date: this.value,
-      listeners: {
-        ...this.$listeners,
-        input: this.onInput
-      }
+      datetime: this.value
     };
   },
   computed: {
     inputType() {
       return this.time === false ? "date" : "datetime";
+    },
+    listeners() {
+      return {
+        ...this.$listeners,
+        blur: this.onBlur,
+        enter: this.onSelect,
+        focus: this.onFocus,
+        input: this.onInput
+      };
     }
   },
   watch: {
     value(value) {
-      this.date = value;
+      this.datetime = value;
     }
   },
   methods: {
     focus() {
       this.$refs.input.focus();
     },
-    onInput(date) {
-      this.date = date;
-      this.$emit("input", date);
+    onBlur(value) {
+      this.$emit("input", value);
+    },
+    onFocus() {
+      this.$refs.dropdown.open();
+    },
+    onInput(value) {
+      this.datetime = value;
+    },
+    onSelect(value) {
+      this.onBlur(value);
+      this.$refs.dropdown.close();
     }
   }
 }

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -6,7 +6,7 @@
       v-bind="$props"
       theme="field"
       type="time"
-      v-on="$listeners"
+      v-on="listeners"
     />
   </k-field>
 </template>
@@ -25,6 +25,15 @@ export default {
     icon: {
       type: String,
       default: "clock"
+    }
+  },
+  computed: {
+    listeners() {
+      return {
+        ...this.$listeners,
+        blur: input => this.$emit("input", input),
+        input: () => {}
+      };
     }
   },
   methods: {

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -229,13 +229,15 @@ export default {
           this,
           value,
           this.min,
-          "isAfter"
+          "isAfter",
+          this.step.unit
         ) : true,
         max: this.max ? value => this.$helper.validate.datetime(
           this,
           value,
           this.max,
-          "isBefore"
+          "isBefore",
+          this.step.unit
         ) : true,
       }
     }

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -225,16 +225,18 @@ export default {
   validations() {
     return {
       value: {
-        min: this.min ? (value) => {
-          const date = this.$library.dayjs.utc(value);
-          const min  = this.$library.dayjs.utc(this.min);
-          return date.isSame(min, "day") || date.isAfter(min, "day");
-        } : true,
-        max: this.max ? (value) => {
-          const date = this.$library.dayjs.utc(value);
-          const max  = this.$library.dayjs.utc(this.max);
-          return date.isSame(max, "day") || date.isBefore(max, "day");
-        } : true,
+        min: this.min ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.min,
+          "isAfter"
+        ) : true,
+        max: this.max ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.max,
+          "isBefore"
+        ) : true,
       }
     }
   }

--- a/panel/src/components/Forms/Input/DateTimeInput.vue
+++ b/panel/src/components/Forms/Input/DateTimeInput.vue
@@ -141,13 +141,15 @@ export default {
           this,
           value,
           this.min,
-          "isAfter"
+          "isAfter",
+          this.step.unit
         ) : true,
         max: this.max ? value => this.$helper.validate.datetime(
           this,
           value,
           this.max,
-          "isBefore"
+          "isBefore",
+          this.step.unit
         ) : true,
         required: this.required ? required : true,
       }

--- a/panel/src/components/Forms/Input/DateTimeInput.vue
+++ b/panel/src/components/Forms/Input/DateTimeInput.vue
@@ -137,16 +137,18 @@ export default {
   validations() {
     return {
       value: {
-        min: this.min ? (value) => {
-          const date = this.$library.dayjs.utc(value);
-          const min  = this.$library.dayjs.utc(this.min);
-          return date.isSame(min) || date.isAfter(min);
-        } : true,
-        max: this.max ? (value) => {
-          const date = this.$library.dayjs.utc(value);
-          const max  = this.$library.dayjs.utc(this.max);
-          return date.isSame(max) || date.isBefore(max);
-        } : true,
+        min: this.min ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.min,
+          "isAfter"
+        ) : true,
+        max: this.max ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.max,
+          "isBefore"
+        ) : true,
         required: this.required ? required : true,
       }
     };

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -1,199 +1,64 @@
-<template>
-  <div class="k-time-input">
-    <k-select-input
-      ref="hour"
-      :id="id"
-      :aria-label="$t('hour')"
-      :autofocus="autofocus"
-      :options="hours"
-      :required="required"
-      :disabled="disabled"
-      v-model="hour"
-      placeholder="––"
-      @input="setHour"
-      @invalid="onInvalid"
-    />
-    <span class="k-time-input-separator">:</span>
-    <k-select-input
-      ref="minute"
-      :aria-label="$t('minutes')"
-      :options="minutes"
-      :required="required"
-      :disabled="disabled"
-      v-model="minute"
-      placeholder="––"
-      @input="setMinute"
-      @invalid="onInvalid"
-    />
-    <k-select-input
-      v-if="notation === 12"
-      ref="meridiem"
-      :aria-label="$t('meridiem')"
-      :empty="false"
-      :options="[
-        { value: 'AM', text: 'AM' },
-        { value: 'PM', text: 'PM' },
-      ]"
-      :required="required"
-      :disabled="disabled"
-      v-model="meridiem"
-      class="k-time-input-meridiem"
-      @input="onInput"
-    />
-  </div>
-</template>
-
 <script>
+import DateInput from "./DateInput.vue";
+
 export default {
-  inheritAttrs: false,
+  extends: DateInput,
   props: {
-    autofocus: Boolean,
-    disabled: Boolean,
-    id: [String, Number],
+    display: {
+      type: String,
+      default: "HH:mm"
+    },
     notation: {
       type: Number,
       default: 24
     },
-    required: Boolean,
     step: {
-      type: Number,
-      default: 5
-    },
-    value: {
-      type: String,
-    },
-  },
-  data() {
-    const date = this.toObject(this.value);
-
-    return {
-      time: this.value,
-      hour: date.hour,
-      minute: date.minute,
-      meridiem: date.meridiem
-    };
-  },
-  computed: {
-    hours() {
-      return this.options(
-        this.notation === 24 ? 0 : 1,
-        this.notation === 24 ? 23 : 12
-      );
-    },
-    minutes() {
-      return this.options(0, 59, this.step);
-    }
-  },
-  watch: {
-    value(value) {
-      this.time = value;
-    },
-    time(time) {
-      const date = this.toObject(time);
-
-      this.hour     = date.hour;
-      this.minute   = date.minute;
-      this.meridiem = date.meridiem;
-    },
-  },
-  methods: {
-    focus() {
-      this.$refs.hour.focus();
-    },
-    setHour(hour) {
-      if (hour && !this.minute) {
-        this.minute = 0;
-      }
-
-      if (!hour) {
-        this.minute = null;
-      }
-
-      this.onInput();
-    },
-    setMinute(minute) {
-      if (minute && !this.hour) {
-        this.hour = 0;
-      }
-
-      if (!minute) {
-        this.hour = null;
-      }
-
-      this.onInput();
-    },
-    onInput() {
-      if (this.hour === null || this.minute === null) {
-        this.$emit("input", "");
-        return;
-      }
-
-      const h = this.$helper.pad(this.hour || 0);
-      const m = this.$helper.pad(this.minute || 0);
-      const a = String(this.meridiem || "AM").toUpperCase();
-
-      const time   = this.notation === 24 ? `${h}:${m}:00` : `${h}:${m}:00 ${a}`;
-      const format = this.notation === 24 ? `HH:mm:ss` : `hh:mm:ss A`
-      const date = this.$library.dayjs("2000-01-01 " + time, "YYYY-MM-DD " + format);
-
-      this.$emit("input", date.format("HH:mm"));
-    },
-    onInvalid($invalid, $v) {
-      this.$emit("invalid", $invalid, $v);
-    },
-    options(start, end, step = 1) {
-      let options = [];
-
-      for (var x = start; x <= end; x += step) {
-        options.push({
-          value: x,
-          text: this.$helper.pad(x)
-        });
-      }
-
-      return options;
-    },
-    reset() {
-      this.hour = null;
-      this.minute = null;
-      this.meridiem = null;
-    },
-    round(minute) {
-      return Math.floor(minute / this.step) * this.step;
-    },
-    toObject(time) {
-
-      const date = this.$library.dayjs("2001-01-01 " + time + ":00", "YYYY-MM-DD HH:mm:ss");
-
-      if (!time || date.isValid() === false) {
+      type: Object,
+      default() {
         return {
-          hour: null,
-          minute: null,
-          meridiem: null
+          size: 5,
+          unit: "minute"
         };
       }
-
-      return {
-        hour: date.format(this.notation === 24 ? 'H' : 'h'),
-        minute: this.round(date.format('m')),
-        meridiem: date.format('A')
+    },
+    type: {
+      type: String,
+      default: "time"
+    }
+  },
+  computed: {
+    /**
+     * Match format chunks to dayjs tokens
+     */
+    tokens() {
+      return{
+        H: ["HH"],
+        h: ["hh"],
+        m: ["mm"],
+        s: ["ss"]
       };
+    },
+    /**
+     *  Generate all possible dayjs parsing patterns
+     *  for all chunks of the provided format
+     */
+    patterns() {
+      // get computed patterns prop from original DateInput component
+      let patterns = DateInput.computed.patterns.apply(this);
+
+      // add patterns for am/pm token
+      if (this.notation === 12) {
+        patterns = patterns.map(pattern => pattern  + "a").concat(patterns);
+      }
+
+      return patterns;
+    },
+    /**
+     * Separator for date format
+     */
+    separator() {
+      return ":";
     }
   }
-}
+};
 </script>
-
-<style lang="scss">
-.k-time-input {
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-  line-height: 1;
-}
-.k-time-input-separator {
-  padding: 0 $field-input-padding / 4;
-}
-.k-time-input-meridiem {
-  padding-left: $field-input-padding;
-}
-</style>

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -8,6 +8,8 @@ export default {
       type: String,
       default: "HH:mm"
     },
+    max: String,
+    min: String,
     notation: {
       type: Number,
       default: 24
@@ -58,6 +60,26 @@ export default {
      */
     separator() {
       return ":";
+    }
+  },
+  validations() {
+    return {
+      value: {
+        min: this.min ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.min,
+          "isAfter",
+          this.step.unit
+        ) : true,
+        max: this.max ? value => this.$helper.validate.datetime(
+          this,
+          value,
+          this.max,
+          "isBefore",
+          this.step.unit
+        ) : true,
+      }
     }
   }
 };

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -61,26 +61,6 @@ export default {
     separator() {
       return ":";
     }
-  },
-  validations() {
-    return {
-      value: {
-        min: this.min ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.min,
-          "isAfter",
-          this.step.unit
-        ) : true,
-        max: this.max ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.max,
-          "isBefore",
-          this.step.unit
-        ) : true,
-      }
-    }
   }
 };
 </script>

--- a/panel/src/config/libraries.js
+++ b/panel/src/config/libraries.js
@@ -4,7 +4,9 @@ import autosize from "autosize";
 
 import dayjs from "dayjs";
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import utc from 'dayjs/plugin/utc';
 dayjs.extend(customParseFormat);
+dayjs.extend(utc);
 
 Vue.prototype.$library = {
   autosize: autosize,

--- a/panel/src/helpers/index.js
+++ b/panel/src/helpers/index.js
@@ -8,6 +8,7 @@ import slug from "./slug.js";
 import sort from "./sort.js";
 import string from "./string.js";
 import upload from "./upload.js";
+import validate from "./validate.js";
 
 import "./regex.js";
 
@@ -46,7 +47,8 @@ export default {
       slug: slug,
       sort: sort,
       string: string,
-      upload: upload
+      upload: upload,
+      validate: validate
     };
 
   }

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -51,5 +51,9 @@ export default {
   ucfirst(string) {
     const str = String(string);
     return str.charAt(0).toUpperCase() + str.substr(1);
+  },
+  ucwords(string) {
+    const str = String(string);
+    return str.split(/ /g).map(word => `${word.substring(0,1).toUpperCase()}${word.substring(1)}`).join(" ");
   }
 };

--- a/panel/src/helpers/validate.js
+++ b/panel/src/helpers/validate.js
@@ -1,0 +1,17 @@
+
+export default {
+  datetime(app, value, limit, condition, base = "day") {
+    value = app.$library.dayjs.utc(value);
+
+    if (!limit) {
+      return value && value.isValid();
+    }
+
+    if (!value || !value.isValid()) {
+      return true;
+    }
+
+    limit = app.$library.dayjs.utc(limit);
+    return value.isSame(limit, base) || value[condition](limit, base);
+  }
+}

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -618,6 +618,7 @@ trait AppPlugins
         // load static extensions only once
         if (static::$systemExtensions === null) {
             // Form Field Mixins
+            FormField::$mixins['datetime'] = include $root . '/config/fields/mixins/datetime.php';
             FormField::$mixins['filepicker'] = include $root . '/config/fields/mixins/filepicker.php';
             FormField::$mixins['min']        = include $root . '/config/fields/mixins/min.php';
             FormField::$mixins['options']    = include $root . '/config/fields/mixins/options.php';

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -44,15 +44,7 @@ class DateFieldTest extends TestCase
             'value' => '12.12.2012',
         ]);
 
-        $this->assertEquals('2012-12-12', $field->data());
-
-        // with custom format
-        $field = $this->field('date', [
-            'format' => 'd.m.Y',
-            'value'  => '12.12.2012',
-        ]);
-
-        $this->assertEquals('12.12.2012', $field->data());
+        $this->assertEquals('2012-12-12 00:00:00', $field->data());
 
         // empty value
         $field = $this->field('date', [

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -27,6 +27,60 @@ class DateFieldTest extends TestCase
         $this->assertEquals('', $field->toString());
     }
 
+    public function testMinMax()
+    {
+        // no limits
+        $field = $this->field('date', [
+            'value' => '2020-10-10'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // valid
+        $field = $this->field('date', [
+            'min'   => '2020-10-01',
+            'value' => '2020-10-10',
+            'max'   => '2020-10-31'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // same day valid
+        $field = $this->field('date', [
+            'min'   => '2020-10-10',
+            'value' => '2020-10-10',
+            'max'   => '2020-10-10'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // min failed
+        $field = $this->field('date', [
+            'min'   => '2020-10-01',
+            'value' => '2020-09-10'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+
+        // max failed
+        $field = $this->field('date', [
+            'value' => '2020-11-10',
+            'max'   => '2020-10-31'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+    }
+
     public function valueProvider()
     {
         return [

--- a/tests/Form/Fields/TimeFieldTest.php
+++ b/tests/Form/Fields/TimeFieldTest.php
@@ -18,6 +18,93 @@ class TimeFieldTest extends TestCase
         $this->assertTrue($field->save());
     }
 
+    public function testMinMax()
+    {
+        // no limits
+        $field = $this->field('time', [
+            'value' => '10:00:00'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // valid
+        $field = $this->field('time', [
+            'min'   => '09:00',
+            'value' => '10:00:00',
+            'max'   => '11:00'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // same time valid
+        $field = $this->field('time', [
+            'min'   => '10:00',
+            'value' => '10:00:00',
+            'max'   => '10:00'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // min failed
+        $field = $this->field('time', [
+            'min'   => '11:00',
+            'value' => '10:00:00'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+
+        // max failed
+        $field = $this->field('time', [
+            'value' => '10:00:00',
+            'max'   => '09:00'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+
+        // valid with seconds
+        $field = $this->field('time', [
+            'min'   => '09:00:00',
+            'value' => '10:00:00',
+            'max'   => '11:00:00',
+            'step'  => 'second'
+        ]);
+
+        $field->validate();
+        $this->assertTrue($field->isValid());
+        $this->assertFalse($field->isInvalid());
+
+        // invalid with seconds
+        $field = $this->field('time', [
+            'min'   => '10:00:05',
+            'value' => '10:00:00',
+            'step'  => 'second'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+
+        $field = $this->field('time', [
+            'value' => '10:00:05',
+            'max'   => '10:00:00',
+            'step'  => 'second'
+        ]);
+
+        $field->validate();
+        $this->assertFalse($field->isValid());
+        $this->assertTrue($field->isInvalid());
+    }
+
     public function valueProvider()
     {
         return [
@@ -28,8 +115,8 @@ class TimeFieldTest extends TestCase
             ['22:33:00', date('Y-m-d ') . '22:35:00', 5],
             ['22:36:00', date('Y-m-d ') . '22:35:00', 5],
             ['22:39:00', date('Y-m-d ') . '22:45:00', 15],
-            ['22:35:15', date('Y-m-d ') . '22:35:30', ['size'=>30, 'unit'=>'second']],
-            ['22:35:15', date('Y-m-d ') . '22:00:00', ['size'=>1, 'unit'=>'hour']],
+            ['22:35:15', date('Y-m-d ') . '22:35:30', ['size' => 30, 'unit' => 'second']],
+            ['22:35:15', date('Y-m-d ') . '22:00:00', ['size' => 1, 'unit' => 'hour']],
             ['2012-12-12 22:33:00', '2012-12-12 22:33:00']
         ];
     }

--- a/tests/Form/Fields/TimeFieldTest.php
+++ b/tests/Form/Fields/TimeFieldTest.php
@@ -14,7 +14,7 @@ class TimeFieldTest extends TestCase
         $this->assertEquals(null, $field->default());
         $this->assertEquals('clock', $field->icon());
         $this->assertEquals(24, $field->notation());
-        $this->assertEquals(5, $field->step());
+        $this->assertEquals(['size' => 5, 'unit' => 'minute'], $field->step());
         $this->assertTrue($field->save());
     }
 
@@ -23,10 +23,14 @@ class TimeFieldTest extends TestCase
         return [
             [null, null],
             ['invalid time', null],
-            ['22:33:00', '22:33'],
-            ['22:33:00', '22:30', 5],
-            ['22:36:00', '22:35', 5],
-            ['2012-12-12 22:33:00', '22:33']
+            ['22:33:00', date('Y-m-d ') . '22:33:00'],
+            ['22:32:00', date('Y-m-d ') . '22:30:00', 5],
+            ['22:33:00', date('Y-m-d ') . '22:35:00', 5],
+            ['22:36:00', date('Y-m-d ') . '22:35:00', 5],
+            ['22:39:00', date('Y-m-d ') . '22:45:00', 15],
+            ['22:35:15', date('Y-m-d ') . '22:35:30', ['size'=>30, 'unit'=>'second']],
+            ['22:35:15', date('Y-m-d ') . '22:00:00', ['size'=>1, 'unit'=>'hour']],
+            ['2012-12-12 22:33:00', '2012-12-12 22:33:00']
         ];
     }
 


### PR DESCRIPTION
- Select inputs have been removed, instead a text input will be parsed by tokenized patterns based on `display` option
- `display` option to define format displayed in Panel, based on dayjs tokens - but we should only promise support on `YYYY`, `YY`, `M` `MM`, `DD`, `d`, `HH`, `hh`, `mm`, `ss`, `a`
- Calendar truly supports `min` and `max` dates
- `step` option and `timestamp` helper support rounding not just to minute, but also year, month, day, hour and second.

**Breaking changes**
- So far the `format` option defined the format how the date is stored in the content file. Now we always store the date as `Y-m-d H:i:s` - which should be no problem for everyone using `->toDate()`. The `format` option has been removed.

## To do's
- [ ] Date field with time: inputs are aligned with so much space between
- [x] Inline validations missing for `min` and `max` (or leave them out for the meantime?)
- [x] ~Date field with time. correct value gets emitted from date field (with time), ends up in content file without time~



## Implements
- https://kirby.nolt.io/96
- https://kirby.nolt.io/72
- https://kirby.nolt.io/71