### PR TITLE
Improvements to `$app->clone()`

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -79,8 +79,9 @@ class App
      * Creates a new App instance
      *
      * @param array $props
+     * @param bool $setInstance If false, the instance won't be set globally
      */
-    public function __construct(array $props = [])
+    public function __construct(array $props = [], bool $setInstance = true)
     {
         // register all roots to be able to load stuff afterwards
         $this->bakeRoots($props['roots'] ?? []);
@@ -110,7 +111,9 @@ class App
         ]);
 
         // set the singleton
-        Model::$kirby = static::$instance = $this;
+        if (static::$instance === null || $setInstance === true) {
+            Model::$kirby = static::$instance = $this;
+        }
 
         // setup the I18n class with the translation loader
         $this->i18n();

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -337,6 +337,24 @@ class App
     }
 
     /**
+     * Creates an instance with the same
+     * initial properties
+     *
+     * @param array $props
+     * @param bool $setInstance If false, the instance won't be set globally
+     * @return self
+     */
+    public function clone(array $props = [], bool $setInstance = true)
+    {
+        $props = array_replace_recursive($this->propertyData, $props);
+
+        $clone = new static($props, $setInstance);
+        $clone->data = $this->data;
+
+        return $clone;
+    }
+
+    /**
      * Returns a specific user-defined collection
      * by name. All relevant dependencies are
      * automatically injected

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -562,7 +562,7 @@ trait PageActions
                 return $num;
             default:
                 // get instance with default language
-                $app = $this->kirby()->clone();
+                $app = $this->kirby()->clone([], false);
                 $app->setCurrentLanguage();
 
                 $template = Str::template($mode, [

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -144,6 +144,32 @@ class AppTest extends TestCase
     }
 
     /**
+     * @covers ::clone
+     */
+    public function testClone()
+    {
+        $app = new App();
+        $app->data['test'] = 'testtest';
+        $this->assertSame($app, App::instance());
+
+        $clone = $app->clone([
+            'options' => ['test' => 123]
+        ]);
+        $this->assertNotSame($app, $clone);
+        $this->assertSame($clone, App::instance());
+        $this->assertSame(123, $clone->option('test'));
+        $this->assertSame('testtest', $clone->data['test']);
+
+        $clone = $app->clone([
+            'options' => ['test' => 123]
+        ], false);
+        $this->assertNotSame($app, $clone);
+        $this->assertNotSame($clone, App::instance());
+        $this->assertSame(123, $clone->option('test'));
+        $this->assertSame('testtest', $clone->data['test']);
+    }
+
+    /**
      * @covers ::contentToken
      */
     public function testContentToken()

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -435,6 +435,10 @@ class AppTest extends TestCase
         $this->assertSame($instance2, App::instance());
         $this->assertSame($instance1, App::instance($instance1));
         $this->assertSame($instance1, App::instance());
+
+        $instance3 = new App([], false);
+        $this->assertSame($instance1, App::instance());
+        $this->assertNotSame($instance3, App::instance());
     }
 
     public function testFindPageFile()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

### Features

- New `$setInstance` argument for `new App()` that allows to create a local Kirby instance without setting it globally

### Bug fixes

- The template data is now copied over to the new `$app` object when cloning the object
- Fixed an "Undefined variable" error in snippets when a string in Kirby's query language was used as the page numbering template

## Missing discussion

My first thought was to set the `$setInstance` argument to `false` by default (meaning: Cloning the `$app` object would by default not set it globally). This would probably be the cleaner solution, but unfortunately hundreds of unit tests failed with this change because a lot of our code currently relies on the `App::instance()` method and therefore on global state.

My current implementation fixes the specific bug in #2555, but doesn't fix the general issue of breaking snippets when the app object is cloned from a controller. I searched the code for other places where the app object is cloned and didn't find any, but of course plugin code could still do this and would cause the same bug.

The question is: Should we merge this as is to fix the specific bug or should we rather rewrite the places in Kirby that rely on the global app object to fix it generally?

My opinion is that we should merge this for now and reconsider the global app object issue (together with the immutable object issue) in Kirby 4.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2555

Thanks a lot to @afbora for the amazing debugging insights that helped a lot tracking down the source of the issue.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
