### PR TITLE
Locale option: Support for all locale formats (array/string)

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
 
 /**
@@ -119,18 +120,13 @@ trait AppTranslations
     /**
      * Set locale settings
      *
-     * @internal
+     * @deprecated 3.5.0 Use \Kirby\Toolkit\Locale::set() instead
+     *
      * @param string|array $locale
      */
     public function setLocale($locale): void
     {
-        if (is_array($locale) === true) {
-            foreach ($locale as $key => $value) {
-                setlocale($key, $value);
-            }
-        } else {
-            setlocale(LC_ALL, $locale);
-        }
+        Locale::set($locale);
     }
 
     /**

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -85,7 +85,7 @@ trait AppTranslations
     public function setCurrentLanguage(string $languageCode = null)
     {
         if ($this->multilang() === false) {
-            $this->setLocale($this->option('locale', 'en_US.utf-8'));
+            Locale::set($this->option('locale', 'en_US.utf-8'));
             return $this->language = null;
         }
 
@@ -96,7 +96,7 @@ trait AppTranslations
         }
 
         if ($this->language) {
-            $this->setLocale($this->language->locale());
+            Locale::set($this->language->locale());
         }
 
         // add language slug rules to Str class

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -4,9 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Exception\Exception;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Toolkit\F;
+use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
 use Throwable;
 
@@ -366,45 +366,6 @@ class Language extends Model
     }
 
     /**
-     * Returns the locale array but with the locale
-     * constants replaced with their string representations
-     *
-     * @return array
-     */
-    protected function localeExport(): array
-    {
-        // list of all possible constant names
-        $constantNames = [
-            'LC_ALL', 'LC_COLLATE', 'LC_CTYPE', 'LC_MONETARY',
-            'LC_NUMERIC', 'LC_TIME', 'LC_MESSAGES'
-        ];
-
-        // build an associative array with the locales
-        // that are actually supported on this system
-        $constants = [];
-        foreach ($constantNames as $name) {
-            if (defined($name) === true) {
-                $constants[constant($name)] = $name;
-            }
-        }
-
-        // replace the keys in the locale data array with the locale names
-        $return = [];
-        foreach ($this->locale() as $key => $value) {
-            if (isset($constants[$key]) === true) {
-                // the key is a valid constant,
-                // replace it with its string representation
-                $return[$constants[$key]] = $value;
-            } else {
-                // not found, keep it as-is
-                $return[$key] = $value;
-            }
-        }
-
-        return $return;
-    }
-
-    /**
      * Returns the human-readable name
      * of the language
      *
@@ -498,7 +459,7 @@ class Language extends Model
             'code'         => $this->code(),
             'default'      => $this->isDefault(),
             'direction'    => $this->direction(),
-            'locale'       => $this->localeExport(),
+            'locale'       => Locale::export($this->locale()),
             'name'         => $this->name(),
             'translations' => $this->translations(),
             'url'          => $this->url,
@@ -549,24 +510,10 @@ class Language extends Model
      */
     protected function setLocale($locale = null)
     {
-        if (is_array($locale)) {
-            // replace string constant keys with the constant values
-            $convertedLocale = [];
-            foreach ($locale as $key => $value) {
-                if (is_string($key) === true && Str::startsWith($key, 'LC_') === true) {
-                    $key = constant($key);
-                }
-
-                $convertedLocale[$key] = $value;
-            }
-
-            $this->locale = $convertedLocale;
-        } elseif (is_string($locale)) {
-            $this->locale = [LC_ALL => $locale];
-        } elseif ($locale === null) {
+        if ($locale === null) {
             $this->locale = [LC_ALL => $this->code];
         } else {
-            throw new InvalidArgumentException('Locale must be string or array');
+            $this->locale = Locale::normalize($locale);
         }
 
         return $this;

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Kirby\Exception\InvalidArgumentException;
+
+/**
+ * PHP locale handling
+ *
+ * @package   Kirby Toolkit
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Locale
+{
+    /**
+     * Converts a normalized locale array to an array with the
+     * locale constants replaced with their string representations
+     *
+     * @param array $locale
+     * @return array
+     */
+    public static function export(array $locale): array
+    {
+        // list of all possible constant names
+        $constantNames = [
+            'LC_ALL', 'LC_COLLATE', 'LC_CTYPE', 'LC_MONETARY',
+            'LC_NUMERIC', 'LC_TIME', 'LC_MESSAGES'
+        ];
+
+        // build an associative array with the locales
+        // that are actually supported on this system
+        $constants = [];
+        foreach ($constantNames as $name) {
+            if (defined($name) === true) {
+                $constants[constant($name)] = $name;
+            }
+        }
+
+        // replace the keys in the locale data array with the locale names
+        $return = [];
+        foreach ($locale as $key => $value) {
+            if (isset($constants[$key]) === true) {
+                // the key is a valid constant,
+                // replace it with its string representation
+                $return[$constants[$key]] = $value;
+            } else {
+                // not found, keep it as-is
+                $return[$key] = $value;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * Converts a locale string or an array with constant or
+     * string keys to a normalized constant => value array
+     *
+     * @param array|string $locale
+     * @return array
+     */
+    public static function normalize($locale): array
+    {
+        if (is_array($locale)) {
+            // replace string constant keys with the constant values
+            $convertedLocale = [];
+            foreach ($locale as $key => $value) {
+                if (is_string($key) === true && Str::startsWith($key, 'LC_') === true) {
+                    $key = constant($key);
+                }
+
+                $convertedLocale[$key] = $value;
+            }
+
+            return $convertedLocale;
+        } elseif (is_string($locale)) {
+            return [LC_ALL => $locale];
+        } else {
+            throw new InvalidArgumentException('Locale must be string or array');
+        }
+    }
+
+    /**
+     * Sets the PHP locale with a locale string or
+     * an array with constant or string keys
+     *
+     * @param array|string $locale
+     * @return void
+     */
+    public static function set($locale): void
+    {
+        $locale = static::normalize($locale);
+
+        foreach ($locale as $key => $value) {
+            setlocale($key, $value);
+        }
+    }
+}

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -5,15 +5,39 @@ namespace Kirby\Cms;
 use Kirby\Exception\Exception;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
 
 class AppTranslationsTest extends TestCase
 {
     protected $app;
     protected $fixtures;
+    protected $locale = [];
+    protected $localeSuffix;
 
     public function setUp(): void
     {
+        $constants = [
+            LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY,
+            LC_NUMERIC, LC_TIME, LC_MESSAGES
+        ];
+
+        // make a backup of the current locale
+        foreach ($constants as $constant) {
+            $this->locale[$constant] = setlocale($constant, '0');
+        }
+
+        // test which locale suffix the system supports
+        setlocale(LC_ALL, 'de_DE.' . $this->localeSuffix);
+        if (setlocale(LC_ALL, '0') === 'de_DE.' . $this->localeSuffix) {
+            $this->localeSuffix = 'utf8';
+        } else {
+            $this->localeSuffix = 'UTF-8';
+        }
+
+        // now set a baseline
+        setlocale(LC_ALL, 'C');
+
         $this->app = new App([
             'roots' => [
                 'index' => '/dev/null'
@@ -44,6 +68,9 @@ class AppTranslationsTest extends TestCase
     public function tearDown(): void
     {
         Dir::remove($this->fixtures);
+
+        Locale::set($this->locale);
+        $this->locale = [];
     }
 
     public function app()
@@ -292,5 +319,45 @@ class AppTranslationsTest extends TestCase
         $this->assertSame('kompaniya', Str::slug('Компания'));
         $this->assertSame('кнопка', t('button'));
         $this->assertSame('kompaniya', Str::slug('Компания'));
+    }
+
+    public function testLocaleString()
+    {
+        $this->assertSame('C', setlocale(LC_ALL, '0'));
+
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'locale' => 'de_DE.' . $this->localeSuffix
+            ]
+        ]);
+        $app->setCurrentLanguage();
+
+        $this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
+    }
+
+    public function testLocaleArray()
+    {
+        $this->assertSame('C', setlocale(LC_ALL, '0'));
+
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'locale' => [
+                    'LC_ALL'   => 'de_AT.' . $this->localeSuffix,
+                    'LC_CTYPE' => 'de_DE.' . $this->localeSuffix,
+                    LC_NUMERIC => 'de_CH.' . $this->localeSuffix
+                ]
+            ]
+        ]);
+        $app->setCurrentLanguage();
+
+        $this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
+        $this->assertSame('de_CH.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
+        $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
     }
 }

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Toolkit\Locale
+ */
+class LocaleTest extends TestCase
+{
+    protected $locale = [];
+    protected $localeSuffix;
+
+    public function setUp(): void
+    {
+        $constants = [
+            LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY,
+            LC_NUMERIC, LC_TIME, LC_MESSAGES
+        ];
+
+        // make a backup of the current locale
+        foreach ($constants as $constant) {
+            $this->locale[$constant] = setlocale($constant, '0');
+        }
+
+        // test which locale suffix the system supports
+        setlocale(LC_ALL, 'de_DE.' . $this->localeSuffix);
+        if (setlocale(LC_ALL, '0') === 'de_DE.' . $this->localeSuffix) {
+            $this->localeSuffix = 'utf8';
+        } else {
+            $this->localeSuffix = 'UTF-8';
+        }
+
+        // now set a baseline
+        setlocale(LC_ALL, 'C');
+    }
+
+    public function tearDown(): void
+    {
+        Locale::set($this->locale);
+        $this->locale = [];
+    }
+
+    /**
+     * @covers ::export
+     */
+    public function testExport()
+    {
+        // valid array
+        $this->assertSame([
+            'LC_ALL'     => 'test1',
+            'LC_NUMERIC' => 'test2'
+        ], Locale::export([
+            LC_ALL     => 'test1',
+            LC_NUMERIC => 'test2'
+        ]));
+
+        // with prepared string key
+        $this->assertSame([
+            'LC_TEST' => 'test'
+        ], Locale::export([
+            'LC_TEST' => 'test'
+        ]));
+
+        // unknown key
+        $this->assertSame([
+            1234 => 'test'
+        ], Locale::export([
+            1234 => 'test'
+        ]));
+    }
+
+    /**
+     * @covers ::normalize
+     */
+    public function testNormalize()
+    {
+        // empty array
+        $this->assertSame([], Locale::normalize([]));
+
+        // array with different key types
+        $this->assertSame([
+            LC_ALL     => 'test1',
+            LC_NUMERIC => 'test2',
+            'TEST'     => 'test3'
+        ], Locale::normalize([
+            'LC_ALL'   => 'test1',
+            LC_NUMERIC => 'test2',
+            'TEST'     => 'test3'
+        ]));
+
+        // single string
+        $this->assertSame([
+            LC_ALL => 'test'
+        ], Locale::normalize('test'));
+
+        // invalid argument
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Locale must be string or array');
+        Locale::normalize(123);
+    }
+
+    /**
+     * @covers ::set
+     */
+    public function testSetString()
+    {
+        $this->assertSame('C', setlocale(LC_ALL, '0'));
+
+        Locale::set('de_DE.' . $this->localeSuffix);
+        $this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_ALL, '0'));
+    }
+
+    /**
+     * @covers ::set
+     */
+    public function testSetArray1()
+    {
+        $this->assertSame('C', setlocale(LC_ALL, '0'));
+
+        Locale::set([
+            'LC_ALL'   => 'de_AT.' . $this->localeSuffix,
+            'LC_CTYPE' => 'de_DE.' . $this->localeSuffix,
+            LC_NUMERIC => 'de_CH.' . $this->localeSuffix
+        ]);
+        $this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
+        $this->assertSame('de_CH.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
+        $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
+    }
+
+    /**
+     * @covers ::set
+     */
+    public function testSetArray2()
+    {
+        $this->assertSame('C', setlocale(LC_ALL, '0'));
+
+        Locale::set([
+            'LC_CTYPE' => 'de_DE.' . $this->localeSuffix,
+            LC_NUMERIC => 'de_CH.' . $this->localeSuffix,
+            'LC_ALL'   => 'de_AT.' . $this->localeSuffix
+        ]);
+        $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
+        $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
+        $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
+    }
+}


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The `locale` option now supports setting the locale with named string keys (like `['LC_ALL' => 'en_US']`), which has previously been possible in language files already.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2893 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
