### PR TITLE
Prefix core session keys with kirby.

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -66,16 +66,16 @@ function csrf(string $check = null)
     if (func_num_args() === 0) {
         // no arguments, generate/return a token
 
-        $token = $session->get('csrf');
+        $token = $session->get('kirby.csrf');
         if (is_string($token) !== true) {
             $token = bin2hex(random_bytes(32));
-            $session->set('csrf', $token);
+            $session->set('kirby.csrf', $token);
         }
 
         return $token;
-    } elseif (is_string($check) === true && is_string($session->get('csrf')) === true) {
+    } elseif (is_string($check) === true && is_string($session->get('kirby.csrf')) === true) {
         // argument has been passed, check the token
-        return hash_equals($session->get('csrf'), $check) === true;
+        return hash_equals($session->get('kirby.csrf'), $check) === true;
     }
 
     return false;

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -118,7 +118,7 @@ class Auth
             $session = $this->kirby->session(['detect' => true]);
         }
 
-        $id = $session->data()->get('user.id');
+        $id = $session->data()->get('kirby.userId');
 
         if (is_string($id) !== true) {
             return null;

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -422,7 +422,7 @@ class User extends ModelWithContent
         $kirby->trigger('user.login:before', ['user' => $this, 'session' => $session]);
 
         $session->regenerateToken(); // privilege change
-        $session->data()->set('user.id', $this->id());
+        $session->data()->set('kirby.userId', $this->id());
         $this->kirby()->auth()->setUser($this);
 
         $kirby->trigger('user.login:after', ['user' => $this, 'session' => $session]);
@@ -442,7 +442,7 @@ class User extends ModelWithContent
         $kirby->trigger('user.logout:before', ['user' => $this, 'session' => $session]);
 
         // remove the user from the session for future requests
-        $session->data()->remove('user.id');
+        $session->data()->remove('kirby.userId');
 
         // clear the cached user object from the app state of the current request
         $this->kirby()->auth()->flush();

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -34,7 +34,7 @@ class AuthCsrfTest extends TestCase
      */
     public function testCsrfFromSession1()
     {
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = [];
         $this->assertFalse($this->auth->csrf());
@@ -45,7 +45,7 @@ class AuthCsrfTest extends TestCase
      */
     public function testCsrfFromSession2()
     {
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => ''];
         $this->assertFalse($this->auth->csrf());
@@ -56,7 +56,7 @@ class AuthCsrfTest extends TestCase
      */
     public function testCsrfFromSession3()
     {
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => 'session-csrf'];
         $this->assertEquals('session-csrf', $this->auth->csrf());
@@ -67,7 +67,7 @@ class AuthCsrfTest extends TestCase
      */
     public function testCsrfFromSession4()
     {
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => 'invalid-csrf'];
         $this->assertFalse($this->auth->csrf());
@@ -85,7 +85,7 @@ class AuthCsrfTest extends TestCase
         ]);
         $this->auth = new Auth($this->app);
 
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = [];
         $this->assertFalse($this->auth->csrf());
@@ -103,7 +103,7 @@ class AuthCsrfTest extends TestCase
         ]);
         $this->auth = new Auth($this->app);
 
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => 'option-csrf'];
         $this->assertEquals('option-csrf', $this->auth->csrf());
@@ -121,7 +121,7 @@ class AuthCsrfTest extends TestCase
         ]);
         $this->auth = new Auth($this->app);
 
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => 'session-csrf'];
         $this->assertFalse($this->auth->csrf());
@@ -139,7 +139,7 @@ class AuthCsrfTest extends TestCase
         ]);
         $this->auth = new Auth($this->app);
 
-        $this->app->session()->set('csrf', 'session-csrf');
+        $this->app->session()->set('kirby.csrf', 'session-csrf');
 
         $_GET = ['csrf' => 'invalid-csrf'];
         $this->assertFalse($this->auth->csrf());

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -102,7 +102,7 @@ class AuthTest extends TestCase
     public function testUserSession1()
     {
         $session = $this->app->session();
-        $session->set('user.id', 'marge');
+        $session->set('kirby.userId', 'marge');
 
         $user = $this->auth->user();
         $this->assertSame('marge@simpsons.com', $user->email());
@@ -111,7 +111,7 @@ class AuthTest extends TestCase
         $this->assertNull($this->auth->currentUserFromImpersonation());
 
         // value is cached
-        $session->set('user.id', 'homer');
+        $session->set('kirby.userId', 'homer');
         $user = $this->auth->user();
         $this->assertSame('marge@simpsons.com', $user->email());
     }
@@ -122,7 +122,7 @@ class AuthTest extends TestCase
     public function testUserSession2()
     {
         $session = (new AutoSession($this->app->root('sessions')))->createManually();
-        $session->set('user.id', 'homer');
+        $session->set('kirby.userId', 'homer');
 
         $user = $this->auth->user($session);
         $this->assertSame('homer@simpsons.com', $user->email());

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -82,30 +82,30 @@ class HelpersTest extends TestCase
         $session = $this->kirby->session();
 
         // should generate token
-        $session->remove('csrf');
+        $session->remove('kirby.csrf');
         $token = csrf();
         $this->assertIsString($token);
         $this->assertStringMatchesFormat('%x', $token);
         $this->assertEquals(64, strlen($token));
-        $this->assertEquals($session->get('csrf'), $token);
+        $this->assertEquals($session->get('kirby.csrf'), $token);
 
         // should not regenerate when a param is passed
         $this->assertFalse(csrf(null));
         $this->assertFalse(csrf(false));
         $this->assertFalse(csrf(123));
         $this->assertFalse(csrf('some invalid string'));
-        $this->assertEquals($token, $session->get('csrf'));
+        $this->assertEquals($token, $session->get('kirby.csrf'));
 
         // should not regenerate if there is already a token
         $token2 = csrf();
         $this->assertEquals($token, $token2);
 
         // should regenerate if there is an invalid token
-        $session->set('csrf', 123);
+        $session->set('kirby.csrf', 123);
         $token3 = csrf();
         $this->assertNotEquals($token, $token3);
         $this->assertEquals(64, strlen($token3));
-        $this->assertEquals($session->get('csrf'), $token3);
+        $this->assertEquals($session->get('kirby.csrf'), $token3);
 
         // should verify token
         $this->assertTrue(csrf($token3));


### PR DESCRIPTION
For the upcoming password reset/2FA login feature, we need additional session keys in the core. This is a good opportunity to rename the existing session keys with a prefix that will separate them from custom session data.