### PR TITLE
Email: Allow body as fallback for template

### DIFF
--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -126,7 +126,7 @@ class Email
                 // fallback to single email text template
             } elseif ($text->exists()) {
                 $this->props['body'] = $text->render($data);
-            } else {
+            } elseif (isset($this->props['body']) !== true) {
                 throw new NotFoundException('The email template "' . $this->props['template'] . '" cannot be found');
             }
         }

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -106,6 +106,33 @@ class EmailTest extends TestCase
         ], $email->toArray()['body']);
     }
 
+    public function testTemplateBody()
+    {
+        $app = new App([
+            'templates' => [
+                'emails/contact' => __DIR__ . '/fixtures/emails/contact.php'
+            ]
+        ]);
+
+        $email = new Email([
+            'body'     => 'Hi, Alex!',
+            'template' => 'contact',
+            'data' => [
+                'name' => 'Alex'
+            ]
+        ]);
+        $this->assertEquals('Cheers, Alex!', $email->toArray()['body']);
+
+        $email = new Email([
+            'body'     => 'Hi, Alex!',
+            'template' => 'invalid',
+            'data' => [
+                'name' => 'Alex'
+            ]
+        ]);
+        $this->assertEquals('Hi, Alex!', $email->toArray()['body']);
+    }
+
     public function testInvalidTemplate()
     {
         $this->expectException('Kirby\Exception\NotFoundException');


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

It is now possible to set both a `body` and a `template` for `$kirby->email()`. The `body` becomes the fallback in case the snippet that was defined with `template` does not exist.

*Note:* This change is needed for the password reset feature as it will be possible to create completely custom email templates. If the custom email template does not exist, Kirby will use the standard text that comes from a translation variable.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
