### PR TITLE
New $user->nameOrEmail() method

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -540,6 +540,18 @@ class User extends ModelWithContent
     }
 
     /**
+     * Returns the user's name or,
+     * if empty, the email address
+     *
+     * @return \Kirby\Cms\Field
+     */
+    public function nameOrEmail()
+    {
+        $name = $this->name();
+        return $name->isNotEmpty() ? $name : new Field($this, 'email', $this->email());
+    }
+
+    /**
      * Create a dummy nobody
      *
      * @internal

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -90,6 +90,25 @@ class UserTest extends TestCase
         $this->assertEquals('Homer Simpson', $user->name());
     }
 
+    public function testNameOrEmail()
+    {
+        $user = new User([
+            'email' => $email = 'homer@simpsons.com',
+            'name'  => $name = 'Homer Simpson',
+        ]);
+
+        $this->assertSame($name, $user->nameOrEmail()->value());
+        $this->assertSame('name', $user->nameOrEmail()->key());
+
+        $user = new User([
+            'email' => $email = 'homer@simpsons.com',
+            'name'  => ''
+        ]);
+
+        $this->assertSame($email, $user->nameOrEmail()->value());
+        $this->assertSame('email', $user->nameOrEmail()->key());
+    }
+
     public function testToString()
     {
         $user = new User([


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

New `$user->nameOrEmail()` method that returns the field for the user's name or, if empty, their email address. The method can be used when the user's identity needs to be printed, but the optional name field may not be filled.

*Note:* Requirement for the password reset feature.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
