### PR TITLE
Support for system templates

### DIFF
--- a/config/templates.php
+++ b/config/templates.php
@@ -1,0 +1,7 @@
+<?php
+
+// @codeCoverageIgnoreStart
+return [
+
+];
+// @codeCoverageIgnoreEnd

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -676,7 +676,8 @@ trait AppPlugins
                 'blueprints'   => include $root . '/config/blueprints.php',
                 'fields'       => include $root . '/config/fields.php',
                 'fieldMethods' => include $root . '/config/methods.php',
-                'tags'         => include $root . '/config/tags.php'
+                'tags'         => include $root . '/config/tags.php',
+                'templates'    => include $root . '/config/templates.php'
             ];
         }
 
@@ -693,6 +694,7 @@ trait AppPlugins
         $this->extendFields(static::$systemExtensions['fields']);
         $this->extendFieldMethods((static::$systemExtensions['fieldMethods'])($this));
         $this->extendTags(static::$systemExtensions['tags']);
+        $this->extendTemplates(static::$systemExtensions['templates']);
     }
 
     /**


### PR DESCRIPTION
This is in preparation for the core email templates for password reset.

I first had an implementation that dynamically built the list using `Dir::index()`, but then decided to have a fixed list instead to increase performance on every request and also reliability as only the files will be registered that we explicitly added to the list.

I will put the email templates into a new `config/templates` folder, the list will then look something like this:

```php
<?php

return [
    'emails/name-of-the-template' => __DIR__ . '/templates/emails/name-of-the-template.php'
];
```

Also see the discussion in https://github.com/getkirby/kirby/pull/2909.