### PR TITLE
Use tabular nums for info section

### DIFF
--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -162,6 +162,7 @@ $list-item-height: 38px;
 .k-list-item-text small {
   color: $color-light-grey;
   font-size: $font-size-tiny;
+  font-variant-numeric: tabular-nums;
   color: $list-item-info-color;
   display: none;
   min-width: 0;


### PR DESCRIPTION
## Describe the PR

This PR just adds `font-variant-numeric: tabular-nums;` to the `<small>` element within every list item. Tabular nums are monospaced and will wor much better, when numbers (e.g. date or filesizes) are displayed within the info section. Maybe, this shoulso be applied to the item title.

Before:
<img width="129" alt="Bildschirmfoto 2020-11-09 um 17 55 21" src="https://user-images.githubusercontent.com/395617/98571775-29c2f680-22b5-11eb-9a82-322ef210c5fa.png">

After:
<img width="128" alt="Bildschirmfoto 2020-11-09 um 17 55 14" src="https://user-images.githubusercontent.com/395617/98571781-2b8cba00-22b5-11eb-82f8-e5871c3de601.png">

