### PR TITLE
Passwordless login, password reset via email & 2FA support

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -35,6 +35,21 @@ return [
         'license' => function (System $system) {
             return $system->license();
         },
+        'loginMethods' => function (System $system) {
+            return array_keys($system->loginMethods());
+        },
+        'pendingChallenge' => function () {
+            if ($this->session()->get('kirby.challenge.email') === null) {
+                return null;
+            }
+
+            // fake the email challenge if no challenge was created
+            // to avoid leaking whether the user exists
+            return $this->session()->get('kirby.challenge.type', 'email');
+        },
+        'pendingEmail' => function () {
+            return $this->session()->get('kirby.challenge.email');
+        },
         'requirements' => function (System $system) {
             return $system->toArray();
         },
@@ -86,6 +101,9 @@ return [
             'isOk',
             'isInstallable',
             'isInstalled',
+            'loginMethods',
+            'pendingChallenge',
+            'pendingEmail',
             'title',
             'translation'
         ],

--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -61,13 +61,14 @@ return [
                     throw new InvalidArgumentException('Login with password is not enabled');
                 }
 
-                $user = $this->kirby()->auth()->login($email, $password, $long);
-
-                return [
-                    'code'   => 200,
-                    'status' => 'ok',
-                    'user'   => $this->resolve($user)->view('auth')->toArray()
-                ];
+                if (
+                    isset($methods['password']['2fa']) === true &&
+                    $methods['password']['2fa'] === true
+                ) {
+                    $challenge = $auth->login2fa($email, $password, $long);
+                } else {
+                    $user = $auth->login($email, $password, $long);
+                }
             } else {
                 if (isset($methods['code']) === true) {
                     $mode = 'login';
@@ -78,7 +79,15 @@ return [
                 }
 
                 $challenge = $auth->createChallenge($email, $long, $mode);
+            }
 
+            if (isset($user)) {
+                return [
+                    'code'   => 200,
+                    'status' => 'ok',
+                    'user'   => $this->resolve($user)->view('auth')->toArray()
+                ];
+            } else {
                 return [
                     'code'   => 200,
                     'status' => 'ok',

--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -19,7 +19,7 @@ return [
         }
     ],
     [
-        'pattern' => 'auth/login',
+        'pattern' => 'auth/code',
         'method'  => 'POST',
         'auth'    => false,
         'action'  => function () {
@@ -30,17 +30,63 @@ return [
                 throw new InvalidArgumentException('Invalid CSRF token');
             }
 
-            $email    = $this->requestBody('email');
-            $long     = $this->requestBody('long');
-            $password = $this->requestBody('password');
-
-            $user = $this->kirby()->auth()->login($email, $password, $long);
+            $user = $auth->verifyChallenge($this->requestBody('code'));
 
             return [
                 'code'   => 200,
                 'status' => 'ok',
                 'user'   => $this->resolve($user)->view('auth')->toArray()
             ];
+        }
+    ],
+    [
+        'pattern' => 'auth/login',
+        'method'  => 'POST',
+        'auth'    => false,
+        'action'  => function () {
+            $auth    = $this->kirby()->auth();
+            $methods = $this->kirby()->system()->loginMethods();
+
+            // csrf token check
+            if ($auth->type() === 'session' && $auth->csrf() === false) {
+                throw new InvalidArgumentException('Invalid CSRF token');
+            }
+
+            $email    = $this->requestBody('email');
+            $long     = $this->requestBody('long');
+            $password = $this->requestBody('password');
+
+            if ($password) {
+                if (isset($methods['password']) !== true) {
+                    throw new InvalidArgumentException('Login with password is not enabled');
+                }
+
+                $user = $this->kirby()->auth()->login($email, $password, $long);
+
+                return [
+                    'code'   => 200,
+                    'status' => 'ok',
+                    'user'   => $this->resolve($user)->view('auth')->toArray()
+                ];
+            } else {
+                if (isset($methods['code']) === true) {
+                    $mode = 'login';
+                } elseif (isset($methods['password-reset']) === true) {
+                    $mode = 'password-reset';
+                } else {
+                    throw new InvalidArgumentException('Login without password is not enabled');
+                }
+
+                $challenge = $auth->createChallenge($email, $long, $mode);
+
+                return [
+                    'code'   => 200,
+                    'status' => 'ok',
+
+                    // don't leak users that don't exist at this point
+                    'challenge' => $challenge ?? 'email'
+                ];
+            }
         }
     ],
     [

--- a/config/templates.php
+++ b/config/templates.php
@@ -2,6 +2,7 @@
 
 // @codeCoverageIgnoreStart
 return [
-
+    'emails/auth/login' => __DIR__ . '/templates/emails/auth/login.php',
+    'emails/auth/password-reset' => __DIR__ . '/templates/emails/auth/password-reset.php'
 ];
 // @codeCoverageIgnoreEnd

--- a/config/templates/emails/auth/login.php
+++ b/config/templates/emails/auth/login.php
@@ -1,0 +1,3 @@
+<?php
+
+echo I18n::template('login.email.login.body', null, compact('user', 'code', 'timeout'));

--- a/config/templates/emails/auth/password-reset.php
+++ b/config/templates/emails/auth/password-reset.php
@@ -1,0 +1,3 @@
+<?php
+
+echo I18n::template('login.email.password-reset.body', null, compact('user', 'code', 'timeout'));

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -284,11 +284,20 @@
   "lock.isUnlocked": "Your unsaved changes have been overwritten by another user. You can download your changes to merge them manually.",
 
   "login": "Login",
+  "login.code.label.login": "Login code",
+  "login.code.label.password-reset": "Password reset code",
+  "login.code.placeholder.email": "000 000",
+  "login.code.text.email": "If your email address is registered, the requested code was sent via email.",
   "login.email.login.body": "Hi {user.nameOrEmail},\n\nYou recently requested a login code for the Kirby Panel.\nThe following login code will be valid for {timeout} minutes:\n\n{code}\n\nIf you did not request a login code, please ignore this email or contact your administrator if you have questions.\nFor security, please DO NOT forward this email.",
   "login.email.login.subject": "Your login code",
   "login.email.password-reset.body": "Hi {user.nameOrEmail},\n\nYou recently requested a password reset code for the Kirby Panel.\nThe following password reset code will be valid for {timeout} minutes:\n\n{code}\n\nIf you did not request a password reset code, please ignore this email or contact your administrator if you have questions.\nFor security, please DO NOT forward this email.",
   "login.email.password-reset.subject": "Your password reset code",
   "login.remember": "Keep me logged in",
+  "login.reset": "Reset password",
+  "login.toggleText.code.email": "Login via email",
+  "login.toggleText.code.email-password": "Login with password",
+  "login.toggleText.password-reset.email": "Forgot your password?",
+  "login.toggleText.password-reset.email-password": "← Back to login",
 
   "logout": "Logout",
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -283,6 +283,10 @@
   "lock.isUnlocked": "Your unsaved changes have been overwritten by another user. You can download your changes to merge them manually.",
 
   "login": "Login",
+  "login.email.login.body": "Hi {user.nameOrEmail},\n\nYou recently requested a login code for the Kirby Panel.\nThe following login code will be valid for {timeout} minutes:\n\n{code}\n\nIf you did not request a login code, please ignore this email or contact your administrator if you have questions.\nFor security, please DO NOT forward this email.",
+  "login.email.login.subject": "Your login code",
+  "login.email.password-reset.body": "Hi {user.nameOrEmail},\n\nYou recently requested a password reset code for the Kirby Panel.\nThe following password reset code will be valid for {timeout} minutes:\n\n{code}\n\nIf you did not request a password reset code, please ignore this email or contact your administrator if you have questions.\nFor security, please DO NOT forward this email.",
+  "login.email.password-reset.subject": "Your password reset code",
   "login.remember": "Keep me logged in",
 
   "logout": "Logout",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -41,6 +41,7 @@
   "email": "Email",
   "email.placeholder": "mail@example.com",
 
+  "error.access.code": "Invalid code",
   "error.access.login": "Invalid login",
   "error.access.panel": "You are not allowed to access the panel",
   "error.access.view": "You are not allowed to access this part of the panel",

--- a/panel/src/api/auth.js
+++ b/panel/src/api/auth.js
@@ -7,8 +7,7 @@ export default (api) => {
         password: user.password
       };
 
-      const auth = await api.post("auth/login", data);
-      return auth.user;
+      return await api.post("auth/login", data);
     },
     async logout() {
       return api.post("auth/logout");
@@ -16,5 +15,8 @@ export default (api) => {
     async user(params) {
       return api.get("auth", params);
     },
+    async verifyCode(code) {
+      return await api.post("auth/code", {code});
+    }
   }
 };

--- a/panel/src/components/Forms/Login.vue
+++ b/panel/src/components/Forms/Login.vue
@@ -7,10 +7,29 @@
       <k-icon type="alert" />
     </div>
 
-    <k-fieldset :novalidate="true" :fields="fields" v-model="user" />
+    <div class="k-login-fields">
+      <button
+        v-if="canToggle === true"
+        class="k-login-toggler"
+        type="button"
+        @click="toggleForm"
+      >
+        {{ toggleText }}
+      </button>
+
+      <k-fieldset
+        ref="fieldset"
+        v-model="user"
+        :novalidate="true"
+        :fields="fields"
+      />
+    </div>
 
     <div class="k-login-buttons">
-      <span class="k-login-checkbox">
+      <span
+        v-if="isResetForm === false"
+        class="k-login-checkbox"
+      >
         <k-checkbox-input
           :value="user.remember"
           :label="$t('login.remember')"
@@ -22,7 +41,8 @@
         icon="check"
         type="submit"
       >
-        {{ $t("login") }} <template v-if="isLoading">…</template>
+        {{ $t("login" + (isResetForm ? ".reset" : "")) }}
+        <template v-if="isLoading">…</template>
       </k-button>
     </div>
   </form>
@@ -32,6 +52,7 @@
 export default {
   data() {
     return {
+      currentForm: null,
       isLoading: false,
       issue: "",
       user: {
@@ -42,43 +63,122 @@ export default {
     };
   },
   computed: {
+    canToggle() {
+      let loginMethods = this.$store.state.system.info.loginMethods;
+
+      return (
+        this.codeMode !== null &&
+        loginMethods.includes("password") === true &&
+        (
+          loginMethods.includes("password-reset") === true ||
+          loginMethods.includes("code") === true
+        )
+      );
+    },
+    codeMode() {
+      let loginMethods = this.$store.state.system.info.loginMethods;
+
+      if (loginMethods.includes("password-reset") === true) {
+        return "password-reset";
+      } else if (loginMethods.includes("code") === true) {
+        return "code";
+      } else {
+        return null;
+      }
+    },
     fields() {
-      return {
+      let fields = {
         email: {
           autofocus: true,
           label: this.$t("email"),
           type: "email",
           required: true,
           link: false,
-        },
-        password: {
+        }
+      };
+
+      if (this.form === "email-password") {
+        fields.password = {
           label: this.$t("password"),
           type: "password",
           minLength: 8,
           required: true,
           autocomplete: "current-password",
           counter: false
-        }
-      };
+        };
+      }
+
+      return fields;
+    },
+    form() {
+      if (this.currentForm) {
+        return this.currentForm;
+      } else if (this.$store.state.system.info.loginMethods[0] === "password") {
+        return "email-password";
+      } else {
+        return "email";
+      }
+    },
+    isResetForm() {
+      return (
+        this.codeMode === "password-reset" &&
+        this.form === "email"
+      );
+    },
+    toggleText() {
+      return this.$t(
+        "login.toggleText." +
+        this.codeMode + "." +
+        this.formOpposite(this.form)
+      );
     }
   },
   methods: {
+    formOpposite(input) {
+      if (input === "email-password") {
+        return "email";
+      } else {
+        return "email-password";
+      }
+    },
     async login() {
       this.issue     = null;
       this.isLoading = true;
 
+      // clear field data that is not needed for login
+      let user = Object.assign({}, this.user);
+
+      if (this.currentForm === "email") {
+        user.password = null;
+      }
+
+      if (this.isResetForm === true) {
+        user.remember = false;
+      }
+
       try {
-        await this.$store.dispatch("user/login", this.user);
-        await this.$store.dispatch("system/load", true);
+        const result = await this.$api.auth.login(user);
 
-        this.$store.dispatch("notification/success", this.$t("welcome"));
+        if (result.challenge) {
+          this.$store.dispatch("user/pending", {
+            email: user.email,
+            challenge: result.challenge
+          });
+        } else {
+          this.$store.dispatch("user/login", result.user);
+          await this.$store.dispatch("system/load", true);
 
+          this.$store.dispatch("notification/success", this.$t("welcome"));
+        }
       } catch (error) {
         this.issue = error.message;
-
       } finally {
         this.isLoading = false;
       }
+    },
+    toggleForm() {
+      this.currentForm = this.formOpposite(this.form);
+      this.$refs.fieldset.focus("email");
     }
   }
 };

--- a/panel/src/components/Forms/LoginCode.vue
+++ b/panel/src/components/Forms/LoginCode.vue
@@ -1,0 +1,106 @@
+<template>
+  <form class="k-login-form k-login-code-form" @submit.prevent="login">
+    <h1 class="k-offscreen">{{ $t('login') }}</h1>
+
+    <div v-if="issue" class="k-login-alert" @click="issue = null">
+      <span>{{ issue }}</span>
+      <k-icon type="alert" />
+    </div>
+
+    <k-user-info :user="$store.state.user.pendingEmail" />
+
+    <k-text-field
+      v-model="code"
+      :autofocus="true"
+      :counter="false"
+      :help="$t('login.code.text.' + $store.state.user.pendingChallenge)"
+      :label="$t('login.code.label.' + mode)"
+      :novalidate="true"
+      :placeholder="$t('login.code.placeholder.' + $store.state.user.pendingChallenge)"
+      :required="true"
+      autocomplete="one-time-code"
+      icon="unlock"
+      name="code"
+    />
+
+    <div class="k-login-buttons">
+      <k-button
+        class="k-login-button k-login-back-button"
+        icon="angle-left"
+        @click="back"
+      >
+        {{ $t("back") }} <template v-if="isLoadingBack">…</template>
+      </k-button>
+
+      <k-button
+        class="k-login-button"
+        icon="check"
+        type="submit"
+      >
+        {{ $t("login" + (mode === "password-reset" ? ".reset" : "")) }}
+        <template v-if="isLoadingLogin">…</template>
+      </k-button>
+    </div>
+  </form>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      code: "",
+      isLoadingBack: false,
+      isLoadingLogin: false,
+      issue: ""
+    };
+  },
+  computed: {
+    mode() {
+      if (this.$store.state.system.info.loginMethods.includes("password-reset") === true) {
+        return "password-reset";
+      } else {
+        return "login";
+      }
+    }
+  },
+  methods: {
+    async back() {
+      this.isLoadingBack = true;
+      await this.$store.dispatch("user/logout");
+      this.isLoadingBack = false;
+    },
+    async login() {
+      this.issue          = null;
+      this.isLoadingLogin = true;
+
+      try {
+        const result = await this.$api.auth.verifyCode(this.code);
+
+        if (this.mode === "password-reset") {
+          this.$store.dispatch("user/visit", "/reset-password");
+        }
+
+        this.$store.dispatch("user/login", result.user);
+        await this.$store.dispatch("system/load", true);
+
+        this.$store.dispatch("notification/success", this.$t("welcome"));
+      } catch (error) {
+        this.issue = error.message;
+      } finally {
+        this.isLoadingLogin = false;
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+.k-login-code-form .k-user-info {
+  height: 38px;
+  margin-bottom: 2.25rem;
+  padding: .5rem;
+  background: $color-white;
+  border-radius: $rounded-xs;
+  box-shadow: $shadow;
+}
+</style>

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -2,23 +2,37 @@
   <k-error-view v-if="issue">
     {{ issue.message }}
   </k-error-view>
-  <k-view v-else-if="ready" align="center" class="k-login-view">
+  <k-view v-else-if="ready && form === 'login'" align="center" class="k-login-view">
     <k-login-form />
+  </k-view>
+  <k-view v-else-if="ready && form === 'code'" align="center" class="k-login-code-view">
+    <k-login-code-form />
   </k-view>
 </template>
 
 <script>
 import LoginForm from "../Forms/Login.vue";
+import LoginCodeForm from "../Forms/LoginCode.vue";
 
 export default {
   components: {
-    "k-login-form": window.panel.plugins.login || LoginForm
+    "k-login-form": window.panel.plugins.login || LoginForm,
+    "k-login-code-form": LoginCodeForm
   },
   data() {
     return {
       ready: false,
       issue: null
     };
+  },
+  computed: {
+    form() {
+      if (this.$store.state.user.pendingEmail) {
+        return "code";
+      } else {
+        return "login";
+      }
+    }
   },
   created() {
     this.$store.dispatch("content/current", null);
@@ -33,6 +47,13 @@ export default {
           this.$go("/");
         }
 
+        if (system.pendingChallenge) {
+          this.$store.dispatch("user/pending", {
+            email: system.pendingEmail,
+            challenge: system.pendingChallenge
+          });
+        }
+
         this.ready = true;
         this.$store.dispatch("title", this.$t("login"));
       })
@@ -44,6 +65,20 @@ export default {
 </script>
 
 <style lang="scss">
+.k-login-fields {
+  position: relative;
+}
+
+.k-login-toggler {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+
+  text-decoration: underline;
+  font-size: 0.875rem;
+}
+
 .k-login-form label abbr {
   visibility: hidden;
 }
@@ -77,11 +112,25 @@ export default {
   opacity: 0.25;
 }
 
+.k-login-back-button,
 .k-login-checkbox {
   display: flex;
   align-items: center;
-  padding: 0.5rem 0;
   flex-grow: 1;
+}
+
+.k-login-back-button {
+  [dir="ltr"] & {
+    margin-left: -1rem;
+  }
+
+  [dir="rtl"] & {
+    margin-right: -1rem;
+  }
+}
+
+.k-login-checkbox {
+  padding: 0.5rem 0;
   font-size: $text-sm;
   cursor: pointer;
 }

--- a/panel/src/store/modules/user.js
+++ b/panel/src/store/modules/user.js
@@ -4,11 +4,15 @@ export default {
   namespaced: true,
   state: {
     current: null,
-    path: null
+    path: null,
+    pendingEmail: null,
+    pendingChallenge: null
   },
   mutations: {
     SET_CURRENT(state, user) {
       state.current = user;
+      state.pendingEmail = null;
+      state.pendingChallenge = null;
 
       if (user && user.permissions) {
         Vue.prototype.$user        = user;
@@ -20,6 +24,13 @@ export default {
     },
     SET_PATH(state, path) {
       state.path = path;
+    },
+    SET_PENDING(state, {email, challenge}) {
+      state.pendingEmail = email;
+      state.pendingChallenge = challenge;
+      state.user = null;
+      Vue.prototype.$user = null;
+      Vue.prototype.$permissions = null;
     }
   },
   actions: {
@@ -40,19 +51,17 @@ export default {
       });
     },
     async load(context) {
-      const user = await Vue.$api.auth.user()
+      const user = await Vue.$api.auth.user();
       context.commit("SET_CURRENT", user);
       return user;
     },
-    async login(context, credentials) {
-      const user = await  Vue.$api.auth.login(credentials);
+    login(context, user) {
       context.commit("SET_CURRENT", user);
       context.dispatch("translation/activate", user.language, { root: true });
       Vue.prototype.$go(context.state.path || "/");
       return user;
     },
     async logout(context, force) {
-
       context.commit("SET_CURRENT", null);
 
       if (force) {
@@ -72,6 +81,9 @@ export default {
         ...context.state.current,
         name: name
       });
+    },
+    pending(context, pending) {
+      context.commit("SET_PENDING", pending);
     },
     visit(context, path) {
       context.commit("SET_PATH", path);

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -313,6 +313,25 @@ class Auth
     }
 
     /**
+     * Login a user by email, password and auth challenge
+     *
+     * @param string $email
+     * @param string $password
+     * @param bool $long
+     * @return string|null Name of the challenge that was created;
+     *                     `null` if no challenge was available for the user
+     *
+     * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occured with debug mode off
+     * @throws \Kirby\Exception\NotFoundException If the email was invalid
+     * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+     */
+    public function login2fa(string $email, string $password, bool $long = false)
+    {
+        $this->validatePassword($email, $password);
+        return $this->createChallenge($email, $long, '2fa');
+    }
+
+    /**
      * Sets a user object as the current user in the cache
      * @internal
      *

--- a/src/Cms/Auth/Challenge.php
+++ b/src/Cms/Auth/Challenge.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\User;
+
+/**
+ * Template class for authentication challenges
+ * that create and verify one-time auth codes
+ *
+ * @package   Kirby Cms
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+abstract class Challenge
+{
+    /**
+     * Generates a random one-time auth code and returns that code
+     * for later verification
+     *
+     * @param \Kirby\Cms\User $user User to generate the code for
+     * @param array $options Details of the challenge request:
+     *                       - 'mode': Purpose of the code ('login' or 'reset')
+     *                       - 'timeout': Number of seconds the code will be valid for
+     * @return string|null The generated and sent code or `null` in case
+     *                     there was no code to generate by this algorithm
+     */
+    abstract public static function create(User $user, array $options): ?string;
+
+    /**
+     * Verifies the provided code against the created one;
+     * default implementation that checks the code that was
+     * returned from the `create()` method
+     *
+     * @param \Kirby\Cms\User $user User to check the code for
+     * @param string $code Code to verify
+     * @return bool
+     */
+    public static function verify(User $user, string $code): bool
+    {
+        $hash = $user->kirby()->session()->get('kirby.challenge.code');
+        if (is_string($hash) !== true) {
+            return false;
+        }
+
+        // normalize the formatting in the user-provided code
+        $code = str_replace(' ', '', $code);
+
+        return password_verify($code, $hash);
+    }
+}

--- a/src/Cms/Auth/Challenge.php
+++ b/src/Cms/Auth/Challenge.php
@@ -22,7 +22,7 @@ abstract class Challenge
      *
      * @param \Kirby\Cms\User $user User to generate the code for
      * @param array $options Details of the challenge request:
-     *                       - 'mode': Purpose of the code ('login' or 'reset')
+     *                       - 'mode': Purpose of the code ('login', 'reset' or '2fa')
      *                       - 'timeout': Number of seconds the code will be valid for
      * @return string|null The generated and sent code or `null` in case
      *                     there was no code to generate by this algorithm

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -24,7 +24,7 @@ class EmailChallenge extends Challenge
      *
      * @param \Kirby\Cms\User $user User to generate the code for
      * @param array $options Details of the challenge request:
-     *                       - 'mode': Purpose of the code ('login' or 'reset')
+     *                       - 'mode': Purpose of the code ('login', 'reset' or '2fa')
      *                       - 'timeout': Number of seconds the code will be valid for
      * @return string The generated and sent code
      */
@@ -35,6 +35,12 @@ class EmailChallenge extends Challenge
         // insert a space in the middle for easier readability
         $formatted = substr($code, 0, 3) . ' ' . substr($code, 3, 3);
 
+        // use the login templates for 2FA
+        $mode = $options['mode'];
+        if ($mode === '2fa') {
+            $mode = 'login';
+        }
+
         $kirby = $user->kirby();
         $kirby->email([
             'from' => $kirby->option('panel.login.email.from', 'noreply@' . $kirby->system()->indexUrl()),
@@ -42,9 +48,9 @@ class EmailChallenge extends Challenge
             'to' => $user,
             'subject' => $kirby->option(
                 'panel.login.email.subject',
-                I18n::translate('login.email.' . $options['mode'] . '.subject')
+                I18n::translate('login.email.' . $mode . '.subject')
             ),
-            'template' => 'auth/' . $options['mode'],
+            'template' => 'auth/' . $mode,
             'data' => [
                 'user'    => $user,
                 'code'    => $formatted,

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\User;
+use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
+
+/**
+ * Creates and verifies one-time auth codes
+ * that are sent via email
+ *
+ * @package   Kirby Cms
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class EmailChallenge extends Challenge
+{
+    /**
+     * Generates a random one-time auth code and returns that code
+     * for later verification
+     *
+     * @param \Kirby\Cms\User $user User to generate the code for
+     * @param array $options Details of the challenge request:
+     *                       - 'mode': Purpose of the code ('login' or 'reset')
+     *                       - 'timeout': Number of seconds the code will be valid for
+     * @return string The generated and sent code
+     */
+    public static function create(User $user, array $options): string
+    {
+        $code = Str::random(6, 'num');
+
+        // insert a space in the middle for easier readability
+        $formatted = substr($code, 0, 3) . ' ' . substr($code, 3, 3);
+
+        $kirby = $user->kirby();
+        $kirby->email([
+            'from' => $kirby->option('panel.login.email.from', 'noreply@' . $kirby->system()->indexUrl()),
+            'fromName' => $kirby->option('panel.login.email.fromName', $kirby->site()->title()),
+            'to' => $user,
+            'subject' => $kirby->option(
+                'panel.login.email.subject',
+                I18n::translate('login.email.' . $options['mode'] . '.subject')
+            ),
+            'template' => 'auth/' . $options['mode'],
+            'data' => [
+                'user'    => $user,
+                'code'    => $formatted,
+                'timeout' => round($options['timeout'] / 60)
+            ]
+        ]);
+
+        return $code;
+    }
+}

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -341,6 +341,51 @@ class System
     }
 
     /**
+     * Returns the configured UI modes for the login form
+     * with their respective options
+     *
+     * @return array
+     *
+     * @throws \Kirby\Exception\InvalidArgumentException If the configuration is invalid
+     *                                                   (only in debug mode)
+     */
+    public function loginMethods(): array
+    {
+        $default = ['password' => []];
+        $methods = A::wrap($this->app->option('panel.login.methods', $default));
+
+        // normalize the syntax variants
+        $normalized = [];
+        foreach ($methods as $key => $value) {
+            if (is_int($key) === true) {
+                // ['password']
+                $normalized[$value] = [];
+            } elseif ($value === true) {
+                // ['password' => true]
+                $normalized[$key] = [];
+            } else {
+                // ['password' => [...]]
+                $normalized[$key] = $value;
+            }
+        }
+
+        // only one code-based mode can be active at once
+        if (
+            isset($normalized['code']) === true &&
+            isset($normalized['password-reset']) === true
+        ) {
+            unset($normalized['code']);
+
+            if ($this->app->option('debug') === true) {
+                $message = 'The "code" and "password-reset" login methods cannot be enabled together';
+                throw new InvalidArgumentException($message);
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
      * Check for an existing mbstring extension
      *
      * @return bool

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Email\Email;
+
+require_once __DIR__ . '/../mocks.php';
+
+/**
+ * @coversDefaultClass Kirby\Cms\Auth
+ */
+class AuthChallengeTest extends TestCase
+{
+    public $failedEmail;
+
+    protected $app;
+    protected $auth;
+    protected $fixtures;
+
+    public function setUp(): void
+    {
+        Email::$debug = true;
+        Email::$emails = [];
+        $_SERVER['SERVER_NAME'] = 'kirby.test';
+
+        $self = $this;
+
+        $this->app = new App([
+            'hooks' => [
+                'user.login:failed' => function ($email) use ($self) {
+                    $self->failedEmail = $email;
+                }
+            ],
+            'options' => [
+                'auth.trials' => 2,
+                'debug' => true
+            ],
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/AuthTest'
+            ],
+            'users' => [
+                [
+                    'email' => 'marge@simpsons.com',
+                    'id'    => 'marge'
+                ],
+                [
+                    'email' => 'test@exämple.com'
+                ]
+            ]
+        ]);
+        Dir::make($this->fixtures . '/site/accounts');
+
+        $this->auth = new Auth($this->app);
+    }
+
+    public function tearDown(): void
+    {
+        $this->app->session()->destroy();
+        Dir::remove($this->fixtures);
+
+        Email::$debug = false;
+        Email::$emails = [];
+        unset($_SERVER['SERVER_NAME']);
+        $this->failedEmail = null;
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallenge()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'debug' => false
+            ]
+        ]);
+        $auth    = $this->app->auth();
+        $session = $this->app->session();
+
+        $this->app->visitor()->ip('10.1.123.234');
+
+        // existing user
+        $this->assertSame('email', $auth->createChallenge('marge@simpsons.com'));
+        $this->assertSame(1800, $session->timeout());
+        $this->assertSame('marge@simpsons.com', $session->get('kirby.challenge.email'));
+        $this->assertSame('email', $session->get('kirby.challenge.type'));
+        preg_match('/^[0-9]{3} [0-9]{3}$/m', Email::$emails[0]->body()->text(), $codeMatches);
+        $this->assertTrue(password_verify(str_replace(' ', '', $codeMatches[0]), $session->get('kirby.challenge.code')));
+        $this->assertSame(MockTime::$time + 600, $session->get('kirby.challenge.timeout'));
+        $this->assertNull($this->failedEmail);
+        $session->remove('kirby.challenge.type');
+
+        // non-existing user
+        $this->assertNull($auth->createChallenge('invalid@example.com'));
+        $this->assertSame('invalid@example.com', $session->get('kirby.challenge.email'));
+        $this->assertNull($session->get('kirby.challenge.type'));
+        $this->assertSame('invalid@example.com', $this->failedEmail);
+
+        // verify rate-limiting log
+        $data = [
+            'by-ip' => [
+                '87084f11690867b977a611dd2c943a918c3197f4c02b25ab59' => [
+                    'time'   => MockTime::$time,
+                    'trials' => 2
+                ]
+            ],
+            'by-email' => [
+                'marge@simpsons.com' => [
+                    'time'   => MockTime::$time,
+                    'trials' => 1
+                ]
+            ]
+        ];
+        $this->assertSame($data, $auth->log());
+
+        // cannot create challenge when rate-limited
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Invalid login');
+        $auth->createChallenge('marge@simpsons.com');
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallengeDebugNotFound()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The user "invalid@example.com" cannot be found');
+        
+        $this->auth->createChallenge('invalid@example.com');
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallengeDebugRateLimit()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'debug' => true
+            ]
+        ]);
+        $auth = $this->app->auth();
+
+        $auth->createChallenge('marge@simpsons.com');
+        $auth->createChallenge('marge@simpsons.com');
+
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Rate limit exceeded');
+        $auth->createChallenge('marge@simpsons.com');
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallengeCustomTimeout()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'panel.login.timeout' => 10
+            ]
+        ]);
+        $auth    = $this->app->auth();
+        $session = $this->app->session();
+
+        $this->assertSame('email', $auth->createChallenge('marge@simpsons.com'));
+        $this->assertSame(MockTime::$time + 10, $session->get('kirby.challenge.timeout'));
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallengeLong()
+    {
+        $session = $this->app->session();
+
+        $this->assertSame('email', $this->auth->createChallenge('marge@simpsons.com', true));
+        $this->assertFalse($session->timeout());
+    }
+
+    /**
+     * @covers ::createChallenge
+     */
+    public function testCreateChallengeWithPunycodeEmail()
+    {
+        $session = $this->app->session();
+
+        $this->assertSame('email', $this->auth->createChallenge('test@xn--exmple-cua.com'));
+        $this->assertSame('test@exämple.com', $session->get('kirby.challenge.email'));
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallenge()
+    {
+        $session = $this->app->session();
+
+        $session->set('kirby.challenge.email', 'marge@simpsons.com');
+        $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $session->set('kirby.challenge.type', 'email');
+        $session->set('kirby.challenge.timeout', MockTime::$time + 1);
+
+        $this->assertSame(
+            $this->app->user('marge@simpsons.com'),
+            $this->auth->verifyChallenge('123456')
+        );
+        $this->assertSame(['kirby.userId' => 'marge'], $session->data()->get());
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeNoChallenge1()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('No authentication challenge is active');
+
+        $this->auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeNoChallenge2()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('No authentication challenge is active');
+
+        $this->app->session()->set('kirby.challenge.email', 'marge@simpsons.com');
+        $this->auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeNoChallengeNoDebug()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'debug' => false
+            ]
+        ]);
+        $auth    = $this->app->auth();
+
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Invalid code');
+
+        $auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeInvalidEmail()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The user "invalid@example.com" cannot be found');
+
+        $this->app->session()->set('kirby.challenge.email', 'invalid@example.com');
+        $this->app->session()->set('kirby.challenge.type', 'email');
+        $this->auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeRateLimited()
+    {
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        $session = $this->app->session();
+
+        $this->auth->track('marge@simpsons.com');
+        $this->auth->track('homer@simpsons.com');
+        $session->set('kirby.challenge.email', 'marge@simpsons.com');
+        $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $session->set('kirby.challenge.type', 'email');
+
+        $this->auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeTimeLimited()
+    {
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Authentication challenge timeout');
+
+        $session = $this->app->session();
+
+        $session->set('kirby.challenge.email', 'marge@simpsons.com');
+        $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $session->set('kirby.challenge.type', 'email');
+        $session->set('kirby.challenge.timeout', MockTime::$time - 1);
+        
+        $this->auth->verifyChallenge('123456');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeInvalidCode()
+    {
+        $this->expectException('Kirby\Exception\PermissionException');
+        $this->expectExceptionMessage('Invalid code');
+
+        $session = $this->app->session();
+        
+        $session->set('kirby.challenge.email', 'marge@simpsons.com');
+        $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $session->set('kirby.challenge.type', 'email');
+        $session->set('kirby.challenge.timeout', MockTime::$time + 1);
+        
+        $this->auth->verifyChallenge('654321');
+    }
+
+    /**
+     * @covers ::verifyChallenge
+     */
+    public function testVerifyChallengeInvalidChallenge()
+    {
+        $this->expectException('Kirby\Exception\LogicException');
+        $this->expectExceptionMessage('Invalid authentication challenge: test');
+
+        $session = $this->app->session();
+        
+        $session->set('kirby.challenge.email', 'marge@simpsons.com');
+        $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $session->set('kirby.challenge.type', 'test');
+        $session->set('kirby.challenge.timeout', MockTime::$time + 1);
+
+        $this->auth->verifyChallenge('123456');
+    }
+}

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -152,9 +152,11 @@ class AuthProtectionTest extends TestCase
         $this->app->visitor()->ip('10.3.123.234');
         $this->assertTrue($this->auth->track('homer@simpsons.com'));
         $this->assertTrue($this->auth->track('marge@simpsons.com'));
-        $this->assertTrue($this->auth->track('lisa@simpsons.com'));
+        $this->assertTrue($this->auth->track('lisa@simpsons.com', false));
+        $this->assertSame('marge@simpsons.com', $this->failedEmail);
 
-        $this->assertSame('lisa@simpsons.com', $this->failedEmail);
+        $this->assertTrue($this->auth->track(null));
+        $this->assertNull($this->failedEmail);
 
         $data = [
             'by-ip' => [
@@ -168,7 +170,7 @@ class AuthProtectionTest extends TestCase
                 ],
                 '85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da' => [
                     'time'   => MockTime::$time,
-                    'trials' => 3
+                    'trials' => 4
                 ]
             ],
             'by-email' => [

--- a/tests/Cms/Auth/Challenge/ChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/ChallengeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\TestCase;
+use Kirby\Cms\User;
+use Kirby\Toolkit\Dir;
+
+class MockChallenge extends Challenge
+{
+    public static function create(User $user, array $options): ?string
+    {
+    }
+}
+
+/**
+ * @coversDefaultClass Kirby\Cms\Auth\Challenge
+ */
+class ChallengeTest extends TestCase
+{
+    protected $app;
+    protected $fixtures;
+    protected $session;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => $this->fixtures = dirname(__DIR__) . '/fixtures/AuthChallengeTest'
+            ],
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com'
+                ]
+            ]
+        ]);
+
+        $this->session = $this->app->session();
+    }
+
+    public function tearDown(): void
+    {
+        $this->session->destroy();
+        Dir::remove($this->fixtures);
+    }
+
+    /**
+     * @covers ::verify
+     */
+    public function testVerify()
+    {
+        $user = $this->app->user('homer@simpsons.com');
+
+        $this->assertFalse(MockChallenge::verify($user, '123 456'));
+
+        $this->session->set('kirby.challenge.code', 'test');
+        $this->assertFalse(MockChallenge::verify($user, '123 456'));
+
+        $this->session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
+        $this->assertTrue(MockChallenge::verify($user, '123456'));
+        $this->assertTrue(MockChallenge::verify($user, '12 34 56'));
+        $this->assertFalse(MockChallenge::verify($user, '654321'));
+    }
+}

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\TestCase;
+use Kirby\Email\Email;
+use Kirby\Toolkit\Dir;
+
+/**
+ * @coversDefaultClass Kirby\Cms\Auth\EmailChallenge
+ */
+class EmailChallengeTest extends TestCase
+{
+    protected $app;
+    protected $fixtures;
+
+    public function setUp(): void
+    {
+        Email::$debug = true;
+        Email::$emails = [];
+        $_SERVER['SERVER_NAME'] = 'kirby.test';
+
+        $this->app = new App([
+            'roots' => [
+                'index' => $this->fixtures = dirname(__DIR__) . '/fixtures/AuthTest'
+            ],
+            'site' => [
+                'content' => [
+                    'title' => 'Test Site'
+                ]
+            ],
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com',
+                    'name'  => 'Homer'
+                ],
+                [
+                    'email' => 'marge@simpsons.com'
+                ]
+            ]
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        Dir::remove($this->fixtures);
+
+        Email::$debug = false;
+        Email::$emails = [];
+        unset($_SERVER['SERVER_NAME']);
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateLogin()
+    {
+        $user = $this->app->user('homer@simpsons.com');
+        $options = ['mode' => 'login', 'timeout' => 7.3 * 60];
+
+        $code1 = EmailChallenge::create($user, $options);
+        $this->assertStringMatchesFormat('%d', $code1);
+        $this->assertSame(6, strlen($code1));
+        $this->assertCount(1, Email::$emails);
+        $email = Email::$emails[0];
+        $this->assertSame('noreply@kirby.test', $email->from());
+        $this->assertSame('Test Site', $email->fromName());
+        $this->assertSame(['homer@simpsons.com' => 'Homer'], $email->to());
+        $this->assertSame('Your login code', $email->subject());
+        $this->assertStringContainsString('login code', $email->body()->text());
+        $this->assertStringContainsString('Homer', $email->body()->text());
+        $this->assertStringContainsString('7 minutes', $email->body()->text());
+        $this->assertStringContainsString(
+            substr($code1, 0, 3) . ' ' . substr($code1, 3, 3),
+            $email->body()->text()
+        );
+
+        $code2 = EmailChallenge::create($user, $options);
+        $this->assertNotSame($code1, $code2);
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateReset()
+    {
+        $user = $this->app->user('marge@simpsons.com');
+        $options = ['mode' => 'password-reset', 'timeout' => 7.3 * 60];
+
+        $code1 = EmailChallenge::create($user, $options);
+        $this->assertStringMatchesFormat('%d', $code1);
+        $this->assertSame(6, strlen($code1));
+        $this->assertCount(1, Email::$emails);
+        $email = Email::$emails[0];
+        $this->assertSame('noreply@kirby.test', $email->from());
+        $this->assertSame('Test Site', $email->fromName());
+        $this->assertSame(['marge@simpsons.com' => ''], $email->to());
+        $this->assertSame('Your password reset code', $email->subject());
+        $this->assertStringContainsString('password reset code', $email->body()->text());
+        $this->assertStringContainsString('marge@simpsons.com', $email->body()->text());
+        $this->assertStringContainsString('7 minutes', $email->body()->text());
+        $this->assertStringContainsString(
+            substr($code1, 0, 3) . ' ' . substr($code1, 3, 3),
+            $email->body()->text()
+        );
+
+        $code2 = EmailChallenge::create($user, $options);
+        $this->assertNotSame($code1, $code2);
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateCustom()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'panel.login.email.from' => 'test@example.com',
+                'panel.login.email.fromName' => 'Test',
+                'panel.login.email.subject' => 'Custom subject'
+            ],
+            'templates' => [
+                'emails/auth/login' => dirname(__DIR__) . '/fixtures/auth.email.text.php'
+            ]
+        ]);
+
+        $user = $this->app->user('homer@simpsons.com');
+        $options = ['mode' => 'login', 'timeout' => 7.3 * 60];
+
+        $code = EmailChallenge::create($user, $options);
+        $this->assertStringMatchesFormat('%d', $code);
+        $this->assertSame(6, strlen($code));
+        $this->assertCount(1, Email::$emails);
+        $email = Email::$emails[0];
+        $this->assertSame('test@example.com', $email->from());
+        $this->assertSame('Test', $email->fromName());
+        $this->assertSame(['homer@simpsons.com' => 'Homer'], $email->to());
+        $this->assertSame('Custom subject', $email->subject());
+        $this->assertSame(
+            "homer@simpsons.com\n7\n" . substr($code, 0, 3) . ' ' . substr($code, 3, 3),
+            $email->body()->text()
+        );
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateCustomHtml()
+    {
+        $this->app = $this->app->clone([
+            'templates' => [
+                'emails/auth/login'      => dirname(__DIR__) . '/fixtures/auth.email.text.php',
+                'emails/auth/login.html' => dirname(__DIR__) . '/fixtures/auth.email.html.php'
+            ]
+        ]);
+
+        $user = $this->app->user('homer@simpsons.com');
+        $options = ['mode' => 'login', 'timeout' => 7.3 * 60];
+
+        $code = EmailChallenge::create($user, $options);
+        $this->assertStringMatchesFormat('%d', $code);
+        $this->assertSame(6, strlen($code));
+        $this->assertCount(1, Email::$emails);
+        $email = Email::$emails[0];
+        $this->assertSame('noreply@kirby.test', $email->from());
+        $this->assertSame('Test Site', $email->fromName());
+        $this->assertSame(['homer@simpsons.com' => 'Homer'], $email->to());
+        $this->assertSame('Your login code', $email->subject());
+        $this->assertSame(
+            "homer@simpsons.com\n7\n" . substr($code, 0, 3) . ' ' . substr($code, 3, 3),
+            $email->body()->text()
+        );
+        $this->assertSame(
+            "HTML: homer@simpsons.com\n7\n" . substr($code, 0, 3) . ' ' . substr($code, 3, 3),
+            $email->body()->html()
+        );
+    }
+}

--- a/tests/Cms/Auth/fixtures/auth.email.html.php
+++ b/tests/Cms/Auth/fixtures/auth.email.html.php
@@ -1,0 +1,1 @@
+HTML: <?= $user->email() . "\n" . $timeout . "\n" . $code;

--- a/tests/Cms/Auth/fixtures/auth.email.text.php
+++ b/tests/Cms/Auth/fixtures/auth.email.text.php
@@ -1,0 +1,1 @@
+<?= $user->email() . "\n" . $timeout . "\n" . $code;

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -413,11 +413,23 @@ class SystemTest extends TestCase
             [
                 ['code', 'password-reset'],
                 ['password-reset' => []]
+            ],
+            [
+                ['password' => ['2fa' => true], 'code'],
+                ['password' => ['2fa' => true]]
+            ],
+            [
+                ['password' => ['2fa' => true], 'password-reset'],
+                ['password' => ['2fa' => true]]
+            ],
+            [
+                ['password' => ['2fa' => true], 'code', 'password-reset'],
+                ['password' => ['2fa' => true]]
             ]
         ];
     }
 
-    public function testLoginMethodsDebug()
+    public function testLoginMethodsDebug1()
     {
         $app = $this->app->clone([
             'options' => [
@@ -428,6 +440,40 @@ class SystemTest extends TestCase
 
         $this->expectException('Kirby\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');
+        $app->system()->loginMethods();
+    }
+
+    public function testLoginMethodsDebug2()
+    {
+        $app = $this->app->clone([
+            'options' => [
+                'debug' => true,
+                'panel.login.methods' => [
+                    'password' => ['2fa' => true],
+                    'code'
+                ]
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "code" login method cannot be enabled when 2FA is required');
+        $app->system()->loginMethods();
+    }
+
+    public function testLoginMethodsDebug3()
+    {
+        $app = $this->app->clone([
+            'options' => [
+                'debug' => true,
+                'panel.login.methods' => [
+                    'password' => ['2fa' => true],
+                    'password-reset'
+                ]
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "password-reset" login method cannot be enabled when 2FA is required');
         $app->system()->loginMethods();
     }
 }

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -356,4 +356,78 @@ class SystemTest extends TestCase
         F::write($this->fixtures . '/site/config/.license', json_encode($testLicense));
         $this->assertFalse($system->license());
     }
+
+    public function testLoginMethods()
+    {
+        $this->assertSame(['password' => []], $this->app->system()->loginMethods());
+    }
+
+    /**
+     * @dataProvider loginMethodsProvider
+     */
+    public function testLoginMethodsCustom($option, $expected)
+    {
+        $app = $this->app->clone([
+            'options' => [
+                'panel.login.methods' => $option
+            ]
+        ]);
+        $this->assertSame($expected, $app->system()->loginMethods());
+    }
+
+    public function loginMethodsProvider()
+    {
+        return [
+            [
+                'password',
+                ['password' => []]
+            ],
+            [
+                'password-reset',
+                ['password-reset' => []]
+            ],
+            [
+                ['password-reset'],
+                ['password-reset' => []]
+            ],
+            [
+                ['password-reset' => true],
+                ['password-reset' => []]
+            ],
+            [
+                ['password-reset' => []],
+                ['password-reset' => []]
+            ],
+            [
+                ['password-reset' => ['option' => 'test']],
+                ['password-reset' => ['option' => 'test']]
+            ],
+            [
+                ['password', 'password-reset'],
+                ['password' => [], 'password-reset' => []]
+            ],
+            [
+                ['code', 'password'],
+                ['code' => [], 'password' => []]
+            ],
+            [
+                ['code', 'password-reset'],
+                ['password-reset' => []]
+            ]
+        ];
+    }
+
+    public function testLoginMethodsDebug()
+    {
+        $app = $this->app->clone([
+            'options' => [
+                'debug' => true,
+                'panel.login.methods' => ['code', 'password-reset']
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');
+        $app->system()->loginMethods();
+    }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

This PR adds the logic and UI for creating and verifying login codes to log in to the Panel, which results in the following features:

- Passwordless login to the Panel via email
- Password reset via email
- 2FA (or actually two-step auth) via password and an email code

### Login methods

There are now three ways to get into the Panel that can be configured with the `panel.login.methods` option:

1. **Passwordless login** (`code` method)
  Kind of like Notion: The user enters their email address, gets a code and logs in.
2. **Password reset** (`password-reset` method)
  The user enters the email address, gets a code and logs in with it. After logging in, the user will be redirected to the password reset form. After confirming the new password, the user is redirected to the Panel dashboard.

The third and default method is `password`, which will use the same UI and features as previously (i.e. the passwordless login form is disabled). This is because not everyone needs/wants password reset and also because the email configuration needs to be set up and working.

For the `password` method, `2fa` can be enabled like this:

```php
<?php

return [
  'panel.login.methods' => [
    'password' => ['2fa' => true]
  ]
];
```

It is also possible to combine the methods:

```php
<?php

return [
  'panel.login.methods' => ['password', 'password-reset']
];
```

```php
<?php

return [
  'panel.login.methods' => ['code', 'password']
];
```

The first method in the list will be the default.

Other syntax variants that are supported:

```php
<?php

return [
  // just a string
  'panel.login.methods' => 'password',

  // boolean
  'panel.login.methods' => ['password' => true]
];
```

### Other configuration options

The login codes expire after 10 minutes by default. This can be configured with the `panel.login.timeout` option.

The email that gets sent can be fully customized with `panel.login.email.from`, `panel.login.email.fromName`, `panel.login.email.subject` and email body templates in `site/templates/emails/auth/login[.html].php` and `site/templates/emails/auth/password-reset[.html].php`.

### Usage from site templates & plugins

With the `$kirby->auth()->createChallenge()`, `verifyChallenge()` and `login2fa()` methods, users can use the feature themselves for frontend login forms etc.

### Implementation

The implementation was designed according to OWASP recommendations, except that:

- our implementation uses login codes instead of URLs (for best compatibility and to avoid that the link opens in a different default browser – note that the code needs to be entered in the same browser where it was created) and that
- the user gets automatically logged in after (or actually before) resetting the password (contrary to what OWASP says, that actually made the implementation less complex in this case).

Regarding the UI: I have copied over the user info styles @bastianallgeier has written for the password reset form to the login code form. Is it intended that the styles are now duplicated? If not, please move them over to where they belong.

### Following PR

This PR already prepares plugin extensions for auth challenges (SMS, TOTP, hardware tokens...) that will be implemented in a second PR.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Implements https://kirby.nolt.io/9 (password reset)
- Implements https://kirby.nolt.io/36 (2FA)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
