### PR TITLE
More clear login error message

### DIFF
--- a/panel/src/components/Forms/Login.vue
+++ b/panel/src/components/Forms/Login.vue
@@ -74,7 +74,7 @@ export default {
         this.$store.dispatch("notification/success", this.$t("welcome"));
 
       } catch (error) {
-        this.issue = this.$t("error.access.login");
+        this.issue = error.message;
 
       } finally {
         this.isLoading = false;

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -271,7 +271,7 @@ class Auth
                 $message = 'Rate limit exceeded';
             } else {
                 // avoid leaking security-relevant information
-                $message = 'Invalid email or password';
+                $message = ['key' => 'access.login'];
             }
 
             throw new PermissionException($message);
@@ -304,7 +304,7 @@ class Auth
             if ($this->kirby->option('debug') === true) {
                 throw $e;
             } else {
-                throw new PermissionException('Invalid email or password');
+                throw new PermissionException(['key' => 'access.login']);
             }
         }
     }

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -214,7 +214,7 @@ class AuthProtectionTest extends TestCase
         try {
             $this->auth->validatePassword('lisa@simpsons.com', 'springfield123');
         } catch (PermissionException $e) {
-            $this->assertSame('Invalid email or password', $e->getMessage());
+            $this->assertSame('Invalid login', $e->getMessage());
             $thrown = true;
         }
 
@@ -236,7 +236,7 @@ class AuthProtectionTest extends TestCase
         try {
             $this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
         } catch (PermissionException $e) {
-            $this->assertSame('Invalid email or password', $e->getMessage());
+            $this->assertSame('Invalid login', $e->getMessage());
             $thrown = true;
         }
 
@@ -259,7 +259,7 @@ class AuthProtectionTest extends TestCase
         try {
             $this->auth->validatePassword('homer@simpsons.com', 'springfield123');
         } catch (PermissionException $e) {
-            $this->assertSame('Invalid email or password', $e->getMessage());
+            $this->assertSame('Invalid login', $e->getMessage());
             $thrown = true;
         }
 

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -145,7 +145,7 @@ class AuthTest extends TestCase
     public function testUserBasicAuthInvalid1()
     {
         $this->expectException('Kirby\Exception\PermissionException');
-        $this->expectExceptionMessage('Invalid email or password');
+        $this->expectExceptionMessage('Invalid login');
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:invalid');
 
@@ -158,7 +158,7 @@ class AuthTest extends TestCase
     public function testUserBasicAuthInvalid2()
     {
         $this->expectException('Kirby\Exception\PermissionException');
-        $this->expectExceptionMessage('Invalid email or password');
+        $this->expectExceptionMessage('Invalid login');
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:invalid');
 


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

When debugging is enabled, the actual login error message will now be displayed on the login page. There is no change to the error message when debugging is disabled.

<img width="410" alt="Bildschirmfoto 2020-11-13 um 21 50 24" src="https://user-images.githubusercontent.com/1595007/99119956-5ac76200-25fa-11eb-84b6-f71e8c676ca7.png">
<img width="415" alt="Bildschirmfoto 2020-11-13 um 21 50 06" src="https://user-images.githubusercontent.com/1595007/99119960-5c912580-25fa-11eb-9235-e3e8b1db96e6.png">

As we only display the message that is returned by the API anyway, this doesn't lower security, but helps with debugging.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2505

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
