### PR TITLE
Mock usleep() function for faster PHPUnit tests

### DIFF
--- a/tests/Cms/mocks.php
+++ b/tests/Cms/mocks.php
@@ -22,3 +22,19 @@ class MockTime
 {
     public static $time = 1337000000;
 }
+
+/**
+ * Mock for the PHP usleep() function to skip over
+ * waiting times while testing
+ *
+ * @param int $microSeconds
+ * @return void
+ */
+function usleep(int $microSeconds): void
+{
+    if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+        throw new Exception('Mock usleep() function was loaded outside of the test environment. This should never happen.');
+    }
+
+    // do nothing
+}


### PR DESCRIPTION
With the new additions to the `Auth` class in #2923, the `usleep()` function gets called a lot in tests.

This PR makes the tests run significantly faster as the sleep times are skipped during tests. This saves around 20 seconds, which is about 40 % of the entire PHPUnit run time.