### PR TITLE
Allow extending the core login form in plugins

### DIFF
--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -3,21 +3,19 @@
     {{ issue.message }}
   </k-error-view>
   <k-view v-else-if="ready && form === 'login'" align="center" class="k-login-view">
-    <k-login-form />
+    <k-login-plugin />
   </k-view>
   <k-view v-else-if="ready && form === 'code'" align="center" class="k-login-code-view">
-    <k-login-code-form />
+    <k-login-code />
   </k-view>
 </template>
 
 <script>
 import LoginForm from "../Forms/Login.vue";
-import LoginCodeForm from "../Forms/LoginCode.vue";
 
 export default {
   components: {
-    "k-login-form": window.panel.plugins.login || LoginForm,
-    "k-login-code-form": LoginCodeForm
+    "k-login-plugin": window.panel.plugins.login || LoginForm
   },
   data() {
     return {

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -74,6 +74,8 @@ import FormIndicator from "@/components/Forms/FormIndicator.vue";
 import Field from "@/components/Forms/Field.vue";
 import Fieldset from "@/components/Forms/Fieldset.vue";
 import Input from "@/components/Forms/Input.vue";
+import Login from "@/components/Forms/Login.vue";
+import LoginCode from "@/components/Forms/LoginCode.vue";
 import Upload from "@/components/Forms/Upload.vue";
 
 /** Form Inputs */
@@ -145,6 +147,8 @@ Vue.component("k-form-indicator", FormIndicator);
 Vue.component("k-field", Field);
 Vue.component("k-fieldset", Fieldset);
 Vue.component("k-input", Input);
+Vue.component("k-login", Login);
+Vue.component("k-login-code", LoginCode);
 Vue.component("k-upload", Upload);
 
 Vue.component("k-checkbox-input", CheckboxInput);


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

If the user only wants to theme the login form (add additional logos or information above or below it) instead of replacing the whole form, it is now possible to use the core `<k-login>` component inside the custom login screen.

**Note:** Merge #2923 first as this PR depends on the commits in that PR. Let's hope that GitHub will automatically refresh this PR afterwards, otherwise I will rebase it.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Implements https://kirby.nolt.io/136