### PR TITLE
Update npm dev dependencies

### DIFF
--- a/panel/package.json
+++ b/panel/package.json
@@ -16,7 +16,7 @@
     "autosize": "^4.0.2",
     "dayjs": "1.9.1",
     "npm": "6.14.7",
-    "vue": "2.6.11",
+    "vue": "^2.6.12",
     "vue-router": "3.1.6",
     "vuedraggable": "2.23.2",
     "vuelidate": "0.6.2",
@@ -24,18 +24,22 @@
     "vuex-i18n": "1.13.1"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.4.6",
-    "@vue/cli-plugin-eslint": "^3.12.1",
-    "@vue/cli-service": "^3.12.1",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-plugin-wildcard": "^4.0.0",
-    "cypress": "^4.11.0",
-    "node-sass": "^4.14.1",
-    "prettier": "^1.19.1",
-    "pretty-quick": "^1.11.1",
-    "sass-loader": "^7.3.1",
-    "vue-template-compiler": "^2.6.11",
-    "wait-on": "^5.1.0"
+    "@babel/core": "^7.12.3",
+    "@vue/cli-plugin-babel": "^4.5.8",
+    "@vue/cli-plugin-eslint": "^4.5.8",
+    "@vue/cli-service": "^4.5.8",
+    "babel-eslint": "^10.1.0",
+    "babel-plugin-wildcard": "^6.0.0",
+    "cypress": "^4.12.1",
+    "eslint": "^6.7.2",
+    "eslint-plugin-vue": "^6.2.2",
+    "eslint-plugin-cypress": "^2.11.2",
+    "prettier": "^2.1.2",
+    "pretty-quick": "^3.1.0",
+    "sass": "^1.29.0",
+    "sass-loader": "^10.1.0",
+    "vue-template-compiler": "^2.6.12",
+    "wait-on": "^5.2.0"
   },
   "babel": {
     "presets": [
@@ -48,11 +52,13 @@
   "eslintConfig": {
     "root": true,
     "extends": [
-      "plugin:vue/recommended",
-      "eslint:recommended"
+      "eslint:recommended",
+      "plugin:cypress/recommended",
+      "plugin:vue/recommended"
     ],
     "parserOptions": {
-      "ecmaVersion": 2017
+      "ecmaVersion": 2017,
+      "parser": "babel-eslint"
     },
     "rules": {
       "vue/require-default-prop": "off",
@@ -75,6 +81,9 @@
           "multiline": "always"
         }
       ]
+    },
+    "env": {
+      "node": true
     }
   },
   "postcss": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -14,14 +14,14 @@
   "dependencies": {
     "@linusborg/vue-simple-portal": "^0.1.4",
     "autosize": "^4.0.2",
-    "dayjs": "^1.9.1",
-    "npm": "^6.14.7",
-    "vue": "^2.6.11",
-    "vue-router": "^3.1.6",
-    "vuedraggable": "^2.23.2",
-    "vuelidate": "^0.6.2",
-    "vuex": "^3.1.3",
-    "vuex-i18n": "^1.13.1"
+    "dayjs": "1.9.1",
+    "npm": "6.14.7",
+    "vue": "2.6.11",
+    "vue-router": "3.1.6",
+    "vuedraggable": "2.23.2",
+    "vuelidate": "0.6.2",
+    "vuex": "3.1.3",
+    "vuex-i18n": "1.13.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.4.6",

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -122,6 +122,8 @@ export default {
       if (this.hasChanges === true) {
         return "changes";
       }
+
+      return null;
     }
   },
   watch: {

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -134,6 +134,8 @@ export default {
           }
         }
       }
+
+      return null;
     },
     /**
      * Separator from `display` format

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -130,6 +130,8 @@ export default {
           tooltip: this.file.prev.filename
         };
       }
+
+      return null;
     },
     language() {
       return this.$store.state.languages.current;
@@ -144,6 +146,8 @@ export default {
           tooltip: this.file.next.filename
         };
       }
+
+      return null;
     }
   },
   watch: {

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -83,7 +83,6 @@ export default {
   },
   computed: {
     state() {
-
       if (this.system.isOk && this.system.isInstallable && !this.system.isInstalled) {
         return 'install';
       }
@@ -92,6 +91,7 @@ export default {
         return 'completed';
       }
 
+      return null;
     },
     translation() {
       return this.$store.state.translation.current;

--- a/panel/src/components/Views/PageView.spec.js
+++ b/panel/src/components/Views/PageView.spec.js
@@ -29,13 +29,12 @@ describe('PageView', () => {
       cy.get('.k-topbar-crumbs a:last-child').should('contain', 'Photography');
 
       // Buttons
-      const openButton = cy.get('.k-header-buttons .k-button-group:first-child .k-button:first-child');
+      cy.get('.k-header-buttons .k-button-group:first-child .k-button:first-child').then((openButton) => {
+        openButton.should('have.attr', 'target', '_blank');
+        openButton.should('have.attr', 'href', 'http://sandbox.test/photography');
+      });
 
-      openButton.should('have.attr', 'target', '_blank');
-      openButton.should('have.attr', 'href', 'http://sandbox.test/photography');
-
-      const statusButton = cy.get('.k-header-buttons .k-button-group:first-child .k-status-flag');
-      statusButton.should('contain', 'Public');
+      cy.get('.k-header-buttons .k-button-group:first-child .k-status-flag').should('contain', 'Public');
 
       // Drafts
       cy.get('@drafts').find('.k-headline').should('contain', 'Drafts');

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -118,6 +118,8 @@ export default {
           tooltip: this.page.next.title
         };
       }
+
+      return null;
     },
     prev() {
       if (this.page.prev) {
@@ -126,6 +128,8 @@ export default {
           tooltip: this.page.prev.title
         };
       }
+
+      return null;
     },
     status() {
       return this.page.status !== null

--- a/panel/src/components/Views/SiteView.spec.js
+++ b/panel/src/components/Views/SiteView.spec.js
@@ -39,8 +39,9 @@ describe('SiteView', () => {
 
   it('should have working preview button', () => {
     cy.visit(host + '/site');
-    const button = cy.get('.k-header-buttons .k-button');
-    button.should('have.attr', 'target', '_blank');
-    button.should('have.attr', 'href', 'http://sandbox.test');
+    cy.get('.k-header-buttons .k-button').then((button) => {
+      button.should('have.attr', 'target', '_blank');
+      button.should('have.attr', 'href', 'http://sandbox.test');
+    });
   });
 });

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -150,6 +150,8 @@ export default {
           tooltip: this.user.next.name
         };
       }
+
+      return null;
     },
     prev() {
       if (this.user.prev) {
@@ -158,6 +160,8 @@ export default {
           tooltip: this.user.prev.name
         };
       }
+
+      return null;
     },
     uploadApi() {
       return config.api + "/users/" + this.user.id + "/avatar";

--- a/panel/src/config/config.js
+++ b/panel/src/config/config.js
@@ -1,5 +1,3 @@
-/* global process */
-
 const panel = window.panel || {};
 const defaults = {
   assets: "@/assets",

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -8,6 +8,7 @@ export default {
     }
 
     // Source: https://thekevinscott.com/emojis-in-javascript/
+    // eslint-disable-next-line no-misleading-character-class
     const result = string.match(/(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c\ude32-\ude3a]|[\ud83c\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/i);
 
     return result !== null && result.length !== null;

--- a/panel/src/mixins/dialog.js
+++ b/panel/src/mixins/dialog.js
@@ -46,7 +46,7 @@ export default {
       }
 
       if (
-        payload.hasOwnProperty("emit") === false ||
+        Object.prototype.hasOwnProperty.call(payload, "emit") === false ||
         payload.emit !== false
       ) {
         this.$emit("success");

--- a/panel/src/store/modules/content.js
+++ b/panel/src/store/modules/content.js
@@ -50,7 +50,7 @@ export default {
      * Checks for an ID if a model exists in the store
      */
     exists: state => id => {
-      return state.models.hasOwnProperty(id);
+      return Object.prototype.hasOwnProperty.call(state.models, id);
     },
     /**
      * Checks for an ID if a model has unsaved changes

--- a/panel/vue.config.js
+++ b/panel/vue.config.js
@@ -16,13 +16,14 @@ module.exports = {
   css: {
     loaderOptions: {
       sass: {
-        data: fs.readFileSync(
+        additionalData: fs.readFileSync(
           "./src/main.scss",
           "utf-8"
         )
       }
     }
   },
+  lintOnSave: 'error',
   productionSourceMap: false,
   configureWebpack: () => {
     let custom = {


### PR DESCRIPTION
- Temporarily pinned the code dependency versions to their current versions so that they can be safely updated one by one, see https://github.com/getkirby/kirby/issues/2930.
- Updated all npm dev dependencies (except Cypress) to their latest versions
  - `node-sass` is deprecated and was replaced with `dart-sass` (the `sass` npm package)
  - `babel-core` was renamed to `@babel/core`
  - The upgrades mean that our setup is now compatible with Node v15
- The Vue CLI ESLint setup changed quite a bit. Might be that our old setup was broken or just that the new setup has new rules, but there were suddenly hundreds of errors and warnings. I have run the auto-fixer and also made manual changes to fix the fatal errors. 35 warnings still remain in `vue-cli-service lint` that we should review one by one.

**TODO:**

- [ ] Rebase against `features` when all other PRs are merged
- [ ] Run `npm update`
- [ ] Run `node_modules/.bin/vue-cli-service lint --fix`