### PR TITLE
Improvements to login flow feature

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -154,6 +154,19 @@ class Auth
             throw new PermissionException('Basic authentication is not activated');
         }
 
+        // if logging in with password is disabled, basic auth cannot be possible either
+        $loginMethods = $this->kirby->system()->loginMethods();
+        if (isset($loginMethods['password']) !== true) {
+            throw new PermissionException('Login with password is not enabled');
+        }
+
+        // if any login method requires 2FA, basic auth without 2FA would be a weakness
+        foreach ($loginMethods as $method) {
+            if (isset($method['2fa']) === true && $method['2fa'] === true) {
+                throw new PermissionException('Basic authentication cannot be used with 2FA');
+            }
+        }
+
         $request = $this->kirby->request();
         $auth    = $auth ?? $request->auth();
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -80,7 +80,7 @@ class Auth
 
         $challenge = null;
         if ($user = $this->kirby->users()->find($email)) {
-            $timeout = $this->kirby->option('panel.login.timeout', 10 * 60);
+            $timeout = $this->kirby->option('auth.challenge.timeout', 10 * 60);
 
             $challenge = 'email';
             $code = EmailChallenge::create($user, compact('mode', 'timeout'));

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -43,11 +43,11 @@ class EmailChallenge extends Challenge
 
         $kirby = $user->kirby();
         $kirby->email([
-            'from' => $kirby->option('panel.login.email.from', 'noreply@' . $kirby->system()->indexUrl()),
-            'fromName' => $kirby->option('panel.login.email.fromName', $kirby->site()->title()),
+            'from' => $kirby->option('auth.challenge.email.from', 'noreply@' . $kirby->system()->indexUrl()),
+            'fromName' => $kirby->option('auth.challenge.email.fromName', $kirby->site()->title()),
             'to' => $user,
             'subject' => $kirby->option(
-                'panel.login.email.subject',
+                'auth.challenge.email.subject',
                 I18n::translate('login.email.' . $mode . '.subject')
             ),
             'template' => 'auth/' . $mode,

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -352,7 +352,7 @@ class System
     public function loginMethods(): array
     {
         $default = ['password' => []];
-        $methods = A::wrap($this->app->option('panel.login.methods', $default));
+        $methods = A::wrap($this->app->option('auth.methods', $default));
 
         // normalize the syntax variants
         $normalized = [];

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -134,10 +134,7 @@ class AppUsersTest extends TestCase
 
     public function basicAuthApp()
     {
-        return new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        return $this->app->clone([
             'options' => [
                 'api' => [
                     'basicAuth' => true

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -158,7 +158,7 @@ class AuthChallengeTest extends TestCase
     {
         $this->app = $this->app->clone([
             'options' => [
-                'panel.login.timeout' => 10
+                'auth.challenge.timeout' => 10
             ]
         ]);
         $auth    = $this->app->auth();

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -145,9 +145,9 @@ class EmailChallengeTest extends TestCase
     {
         $this->app = $this->app->clone([
             'options' => [
-                'panel.login.email.from' => 'test@example.com',
-                'panel.login.email.fromName' => 'Test',
-                'panel.login.email.subject' => 'Custom subject'
+                'auth.challenge.email.from' => 'test@example.com',
+                'auth.challenge.email.fromName' => 'Test',
+                'auth.challenge.email.subject' => 'Custom subject'
             ],
             'templates' => [
                 'emails/auth/login' => dirname(__DIR__) . '/fixtures/auth.email.text.php'

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -369,7 +369,7 @@ class SystemTest extends TestCase
     {
         $app = $this->app->clone([
             'options' => [
-                'panel.login.methods' => $option
+                'auth.methods' => $option
             ]
         ]);
         $this->assertSame($expected, $app->system()->loginMethods());
@@ -434,7 +434,7 @@ class SystemTest extends TestCase
         $app = $this->app->clone([
             'options' => [
                 'debug' => true,
-                'panel.login.methods' => ['code', 'password-reset']
+                'auth.methods' => ['code', 'password-reset']
             ]
         ]);
 
@@ -448,7 +448,7 @@ class SystemTest extends TestCase
         $app = $this->app->clone([
             'options' => [
                 'debug' => true,
-                'panel.login.methods' => [
+                'auth.methods' => [
                     'password' => ['2fa' => true],
                     'code'
                 ]
@@ -465,7 +465,7 @@ class SystemTest extends TestCase
         $app = $this->app->clone([
             'options' => [
                 'debug' => true,
-                'panel.login.methods' => [
+                'auth.methods' => [
                     'password' => ['2fa' => true],
                     'password-reset'
                 ]


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- Renamed the options:

```
panel.login.methods -> auth.methods
panel.login.timeout -> auth.challenge.timeout
panel.login.email.* -> auth.challenge.email.*
```

- Prevent basic auth from being used if the configured login methods don't allow logging in with just a password (= if 2FA is enabled or logging in with password is completely disabled)