### PR TITLE
New "loginMethod" plugin extension

### DIFF
--- a/panel/public/js/plugins.js
+++ b/panel/public/js/plugins.js
@@ -4,6 +4,7 @@ window.panel.plugins = {
   components: {},
   created: [],
   icons: {},
+  loginMethods: {},
   routes: [],
   use: [],
   views: {},
@@ -47,6 +48,11 @@ window.panel.plugin = function (plugin, parts) {
   // Views
   resolve(parts, "views", function (name, options) {
     window.panel.plugins["views"][name] = options;
+  });
+
+  // Login methods
+  resolve(parts, "loginMethods", function (name, options) {
+    window.panel.plugins["loginMethods"][name] = options;
   });
 
   // Login

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -159,4 +159,26 @@ export default {
   box-shadow: $shadow-lg;
   cursor: pointer;
 }
+
+.k-login-view-buttons {
+  margin-top: .5rem;
+  text-align: center;
+}
+
+.k-login-view-buttons .k-button {
+  border: 1px solid transparent;
+  color: $color-gray-700;
+  height: 2.5rem;
+  width: 2.5rem;
+
+  &:not(:last-child) {
+    margin-right: .7rem;
+  }
+
+  &[aria-current="true"] {
+    box-shadow: $shadow-inset;
+    border-color: $color-gray-400;
+    color: $color-black;
+  }
+}
 </style>


### PR DESCRIPTION
It is now possible for plugins to register custom login methods for display in the login form:

<img width="732" alt="Bildschirmfoto 2020-11-19 um 21 06 28" src="https://user-images.githubusercontent.com/1595007/99719541-b5563780-2aac-11eb-8d1a-911ee6dce981.png">

**Login method buttons with custom action:**

```js
panel.plugin("yourname/login", {
  loginMethods: {
    twitter: {
      label: "Twitter",
      icon: "twitter",
      action: function() {
        // your login handler
      }
    }
  }
});
```

**Full form to switch between:**

```js
panel.plugin("yourname/login", {
  loginMethods: {
    customForm: {
      label: "Custom form",
      icon: "...",
      component: {
        template: `
          <!-- your login form code -->
        `
      }
    },
  }
});
```

The login methods can be enabled and sorted by the user like this in the `config.php`:

```php
<?php

return [
  'auth.methods' => ['password', 'code', 'twitter']
];
```

@bastianallgeier The styling of the UI is a rough draft, feel free to change it.