### PR TITLE
Add similarity search for Str class

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -804,6 +804,81 @@ class Str
     }
 
     /**
+     * Calculate the similarity between two strings with multibyte support
+     *
+     * @author Antal Áron
+     * @copyright Copyright (c) 2017, Antal Áron
+     * @license https://github.com/antalaron/mb-similar-text/blob/master/LICENSE MIT License
+     * @param string $first
+     * @param string $second
+     * @param float|null $percent Optional variable passed by reference for the similarity in percent
+     * @param bool $caseSensitive If true, compare strings with case sensitive
+     * @return int Number of matching chars in both strings
+     */
+    public static function similarity(string $first, string $second, float &$percent = null, bool $caseSensitive = false): int
+    {
+        if ($caseSensitive === false) {
+            $first  = static::lower($first);
+            $second = static::lower($second);
+        }
+
+        if (static::length($first) + static::length($second) === 0) {
+            $percent = 0.0;
+
+            return 0;
+        }
+
+        $pos1 = $pos2 = $max = 0;
+        $len1 = static::length($first);
+        $len2 = static::length($second);
+
+        for ($p = 0; $p < $len1; ++$p) {
+            for ($q = 0; $q < $len2; ++$q) {
+                for (
+                    $l = 0;
+                    ($p + $l < $len1) && ($q + $l < $len2) &&
+                    static::substr($first, $p + $l, 1) === static::substr($second, $q + $l, 1);
+                    ++$l
+                ) {
+                    // nothing to do
+                }
+
+                if ($l > $max) {
+                    $max  = $l;
+                    $pos1 = $p;
+                    $pos2 = $q;
+                }
+            }
+        }
+
+        $similarity = $max;
+
+        if ($similarity) {
+            if ($pos1 && $pos2) {
+                $similarity += static::similarity(
+                    static::substr($first, 0, $pos1),
+                    static::substr($second, 0, $pos2),
+                    $percent,
+                    $caseSensitive
+                );
+            }
+
+            if (($pos1 + $max < $len1) && ($pos2 + $max < $len2)) {
+                $similarity += static::similarity(
+                    static::substr($first, $pos1 + $max, $len1 - $pos1 - $max),
+                    static::substr($second, $pos2 + $max, $len2 - $pos2 - $max),
+                    $percent,
+                    $caseSensitive
+                );
+            }
+        }
+
+        $percent = ($similarity * 200.0) / ($len1 + $len2);
+
+        return $similarity;
+    }
+
+    /**
      * Convert a string to snake case.
      *
      * @param string $value

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -578,6 +578,43 @@ EOT;
         $this->assertTrue(Str::startsWith($string, 'hellö', true));
     }
 
+    public function testSimilarity()
+    {
+        $this->assertSame(0, Str::similarity('foo', 'bar', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(0, Str::similarity('foo', '', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(0, Str::similarity('', '', $percent));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(3, Str::similarity('foo', 'fooBar', $percent));
+        $this->assertSame(66.66666666666667, $percent);
+
+        $this->assertSame(3, Str::similarity('foo', 'foo', $percent));
+        $this->assertSame(100.0, $percent);
+
+        $this->assertSame(4, Str::similarity('tête', 'tête', $percent));
+        $this->assertSame(100.0, $percent);
+
+        $this->assertSame(4, Str::similarity('Tête', 'tête', $percent));
+        $this->assertSame(100.0, $percent);
+
+        $this->assertSame(5, Str::similarity('Kirby', 'KIRBY', $percent));
+        $this->assertSame(100.0, $percent);
+
+        // case sensitives
+        $this->assertSame(3, Str::similarity('Tête', 'tête', $percent, true));
+        $this->assertSame(75.0, $percent);
+
+        $this->assertSame(0, Str::similarity('foo', 'FOO', $percent, true));
+        $this->assertSame(0.0, $percent);
+
+        $this->assertSame(1, Str::similarity('Kirby', 'KIRBY', $percent, true));
+        $this->assertSame(20.0, $percent);
+    }
+
     public function testSubstr()
     {
         $string = 'äöü';


### PR DESCRIPTION
## Describe the PR

Add similarity search feature for Str class and extracted PHP side from #2794

**Simple usage**

    Str::similarity('foo', 'fooBar', $percent);
    echo $percent; // 66.67%
    
    

**Case Sensitive**

    Str::similarity('Kirby', 'KIRBY', $percent, true);
    echo $percent; // 20%

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Closes getkirby/ideas#140

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
