### PR TITLE
Plugin API for auth challenges

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -48,6 +48,7 @@ trait AppPlugins
 
         // other plugin types
         'api' => [],
+        'authChallenges' => [],
         'blueprints' => [],
         'cacheTypes' => [],
         'collections' => [],
@@ -123,6 +124,17 @@ trait AppPlugins
         } else {
             return $this->extensions['api'];
         }
+    }
+
+    /**
+     * Registers additional authentication challenges
+     *
+     * @param array $challenges
+     * @return array
+     */
+    protected function extendAuthChallenges(array $challenges): array
+    {
+        return $this->extensions['authChallenges'] = Auth::$challenges = array_merge(Auth::$challenges, $challenges);
     }
 
     /**
@@ -618,7 +630,7 @@ trait AppPlugins
         // load static extensions only once
         if (static::$systemExtensions === null) {
             // Form Field Mixins
-            FormField::$mixins['datetime'] = include $root . '/config/fields/mixins/datetime.php';
+            FormField::$mixins['datetime']   = include $root . '/config/fields/mixins/datetime.php';
             FormField::$mixins['filepicker'] = include $root . '/config/fields/mixins/filepicker.php';
             FormField::$mixins['min']        = include $root . '/config/fields/mixins/min.php';
             FormField::$mixins['options']    = include $root . '/config/fields/mixins/options.php';
@@ -680,6 +692,11 @@ trait AppPlugins
                 'templates'    => include $root . '/config/templates.php'
             ];
         }
+
+        // default auth challenges
+        $this->extendAuthChallenges([
+            'email' => 'Kirby\Cms\Auth\EmailChallenge'
+        ]);
 
         // default cache types
         $this->extendCacheTypes([

--- a/src/Cms/Auth/Challenge.php
+++ b/src/Cms/Auth/Challenge.php
@@ -17,6 +17,16 @@ use Kirby\Cms\User;
 abstract class Challenge
 {
     /**
+     * Checks whether the challenge is available
+     * for the passed user and purpose
+     *
+     * @param \Kirby\Cms\User $user User the code will be generated for
+     * @param string $mode Purpose of the code ('login', 'reset' or '2fa')
+     * @return bool
+     */
+    abstract public static function isAvailable(User $user, string $mode): bool;
+
+    /**
      * Generates a random one-time auth code and returns that code
      * for later verification
      *

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -19,6 +19,19 @@ use Kirby\Toolkit\Str;
 class EmailChallenge extends Challenge
 {
     /**
+     * Checks whether the challenge is available
+     * for the passed user and purpose
+     *
+     * @param \Kirby\Cms\User $user User the code will be generated for
+     * @param string $mode Purpose of the code ('login', 'reset' or '2fa')
+     * @return bool
+     */
+    public static function isAvailable(User $user, string $mode): bool
+    {
+        return true;
+    }
+
+    /**
      * Generates a random one-time auth code and returns that code
      * for later verification
      *

--- a/tests/Cms/Auth/Challenge/ChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/ChallengeTest.php
@@ -9,6 +9,10 @@ use Kirby\Toolkit\Dir;
 
 class MockChallenge extends Challenge
 {
+    public static function isAvailable(User $user, string $mode): bool
+    {
+    }
+
     public static function create(User $user, array $options): ?string
     {
     }

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -51,6 +51,12 @@ class EmailChallengeTest extends TestCase
         unset($_SERVER['SERVER_NAME']);
     }
 
+    public function testIsAvailable()
+    {
+        $user = $this->app->user('homer@simpsons.com');
+        $this->assertTrue(EmailChallenge::isAvailable($user, 'login'));
+    }
+
     /**
      * @covers ::create
      */


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

This adds a new plugin API for custom authentication challenges, i.e. for generating and verifying login and password reset codes in custom ways besides via email:

### Example plugin

```php
<?php

namespace Superwoman;

use Kirby;
use Kirby\Cms\Auth\Challenge;
use Kirby\Cms\User;

class CustomChallenge extends Challenge
{
    /**
     * Checks whether the challenge is available
     * for the passed user and purpose
     *
     * @param \Kirby\Cms\User $user User the code will be generated for
     * @param string $mode Purpose of the code ('login', 'reset' or '2fa')
     * @return bool
     */
    public static function isAvailable(User $user, string $mode): bool
    {
        // check the plugin configuration and the requirements of your challenge
        return true;
    }

    /**
     * Generates a random one-time auth code and returns that code
     * for later verification
     *
     * @param \Kirby\Cms\User $user User to generate the code for
     * @param array $options Details of the challenge request:
     *                       - 'mode': Purpose of the code ('login', 'reset' or '2fa')
     *                       - 'timeout': Number of seconds the code will be valid for
     * @return string|null The generated and sent code or `null` in case
     *                     there was no code to generate by this algorithm
     */
    public static function create(User $user, array $options): ?string
    {
        // if you generate a code yourself, send it and return it here
        // return 'generated-code';

        // if the code gets generated by the user, you don't need to anything here
        return null;
    }

    /**
     * Verifies the provided code against the created one
     *
     * @param \Kirby\Cms\User $user User to check the code for
     * @param string $code Code to verify
     * @return bool
     */
    public static function verify(User $user, string $code): bool
    {
        // you only need to implement this method if you need to
        // verify a code that was generated by the user;
        // if you returned a code from `create()`, then *don't*
        // define this method to use the automatic internal logic

        return false;
    }
} 

Kirby::plugin('superwoman/custom-challenge', [
    'authChallenges' => [
        'custom' => 'Superwoman\CustomChallenge'
    ],
    'translations' => [
        'en' => [
            // Placeholder for the code field with the general format of the code
            'login.code.placeholder.custom' => '000 000',

            // Help text below the code field
            'login.code.text.custom' => 'If your email address is registered, the requested code was sent via *custom*.'
        ]
    ]
]);
```

### Configuration of the challenge priority

If multiple auth challenges are installed, the user can define the priority of the challenges, i.e. which challenges are tried in which order:

```php
<?php

return [
  'auth.challenges' => ['totp', 'email']
];
```

With the `isAvailable()` method, the challenges can tell Kirby if the challenge can be used to authenticate the current user. If `false` is returned, the next challenge is tried. This is useful for challenges that have additional requirements, e.g. a TOTP challenge needs a prior registration, an SMS challenge needs the mobile number etc.

The `email` challenge is always available as it doesn't need additional configuration (only in some cases the SMTP options). It is also enabled by default if no custom priorities are defined.

If none of the configured challenges is available, Kirby will "fake" an email challenge to avoid leaking security-relevant information (e.g. whether the user exists). In debug mode, there will be a clear error message instead.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
