### PR TITLE
Router fixes for custom views

### DIFF
--- a/panel/src/components/Views/CustomView.vue
+++ b/panel/src/components/Views/CustomView.vue
@@ -1,6 +1,9 @@
 <template>
   <k-error-boundary :key="plugin">
-    <component :is="'k-' + plugin + '-plugin-view'" />
+    <component
+      :is="'k-' + plugin + '-plugin-view'"
+      v-bind="$props"
+    />
     <k-error-view slot="error" slot-scope="{ error }">
       {{ error.message || error }}
     </k-error-view>
@@ -10,21 +13,14 @@
 <script>
 export default {
   props: {
-    plugin: String
+    plugin: String,
+    hash: String
   },
   beforeRouteEnter(to, from, next) {
     next(vm => {
       vm.$store.dispatch("breadcrumb", []);
       vm.$store.dispatch("content/current", null);
     })
-  },
-  watch: {
-    plugin: {
-      handler() {
-        this.$store.dispatch("view", this.plugin);
-      },
-      immediate: true
-    }
   }
 };
 </script>

--- a/panel/src/config/router.js
+++ b/panel/src/config/router.js
@@ -23,16 +23,20 @@ router.beforeEach((to, from, next) => {
   if (!to.meta.outside) {
     store.dispatch("user/visit", to.path);
   }
-  
+
   // store the current view
-  store.dispatch("view", to.meta.view);
-  
+  if (to.meta.view === "plugin") {
+    store.dispatch("view", to.params.id);
+  } else {
+    store.dispatch("view", to.meta.view);
+  }
+
   // reset the content locks
   store.dispatch("content/lock", null);
   store.dispatch("content/unlock", null);
-  
+
   // clear all heartbeats
-  store.dispatch("heartbeat/clear");  
+  store.dispatch("heartbeat/clear");
 
   next();
 });

--- a/panel/src/config/routes.js
+++ b/panel/src/config/routes.js
@@ -191,7 +191,8 @@ export default [
       view: "plugin"
     },
     props: route => ({
-      plugin: route.params.id
+      plugin: route.params.id,
+      hash: route.hash.slice(1)
     }),
     beforeEnter: auth,
     component: Vue.component("k-custom-view")

--- a/panel/src/main.js
+++ b/panel/src/main.js
@@ -30,6 +30,14 @@ import store from "./store/store.js";
 Vue.use(Api, store);
 
 Vue.prototype.$go = (path) => {
+
+  // support links with hash
+  path = path.split("#");
+  path = {
+    path: path[0],
+    hash: path[1] || null
+  };
+
   router.push(path).catch(e => {
     if (e && e.name && e.name === "NavigationDuplicated") {
       return true;


### PR DESCRIPTION
## Describe the PR

- Toolbar doesn't disappear anymore when hash is added to custom view route url
- Removes duplicate store dispatch to `view`
- `this.$go` now supports paths with hash as well

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->
- Fixes #2932
- Fixes #2941
