### PR TITLE
Handle content case-insensitively

### DIFF
--- a/src/Cms/Content.php
+++ b/src/Cms/Content.php
@@ -60,9 +60,14 @@ class Content
      *
      * @param array|null $data
      * @param object|null $parent
+     * @param bool $normalize Set to `false` if the input field keys are already lowercase
      */
-    public function __construct(array $data = [], $parent = null)
+    public function __construct(array $data = [], $parent = null, bool $normalize = true)
     {
+        if ($normalize === true) {
+            $data = array_change_key_case($data, CASE_LOWER);
+        }
+
         $this->data   = $data;
         $this->parent = $parent;
     }
@@ -163,9 +168,7 @@ class Content
             return $this->fields[$key];
         }
 
-        // fetch the value no matter the case
-        $data  = $this->data();
-        $value = $data[$key] ?? array_change_key_case($data)[$key] ?? null;
+        $value = $this->data()[$key] ?? null;
 
         return $this->fields[$key] = new Field($this->parent, $key, $value);
     }
@@ -178,10 +181,7 @@ class Content
      */
     public function has(string $key): bool
     {
-        $key  = strtolower($key);
-        $data = array_change_key_case($this->data);
-
-        return isset($data[$key]) === true;
+        return isset($this->data[strtolower($key)]) === true;
     }
 
     /**
@@ -208,7 +208,7 @@ class Content
         $copy->fields = null;
 
         foreach ($keys as $key) {
-            unset($copy->data[$key]);
+            unset($copy->data[strtolower($key)]);
         }
 
         return $copy;
@@ -258,7 +258,8 @@ class Content
      */
     public function update(array $content = null, bool $overwrite = false)
     {
-        $this->data = $overwrite === true ? (array)$content : array_merge($this->data, (array)$content);
+        $content = array_change_key_case((array)$content, CASE_LOWER);
+        $this->data = $overwrite === true ? $content : array_merge($this->data, $content);
 
         // clear cache of Field objects
         $this->fields = [];

--- a/src/Cms/ContentTranslation.php
+++ b/src/Cms/ContentTranslation.php
@@ -177,7 +177,12 @@ class ContentTranslation
      */
     protected function setContent(array $content = null)
     {
-        $this->content = $content;
+        if ($content !== null) {
+            $this->content = array_change_key_case($content);
+        } else {
+            $this->content = null;
+        }
+
         return $this;
     }
 
@@ -220,7 +225,8 @@ class ContentTranslation
      */
     public function update(array $data = null, bool $overwrite = false)
     {
-        $this->content = $overwrite === true ? (array)$data : array_merge($this->content(), (array)$data);
+        $data = array_change_key_case((array)$data);
+        $this->content = $overwrite === true ? $data : array_merge($this->content(), $data);
         return $this;
     }
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -90,7 +90,8 @@ abstract class ModelWithContent extends Model
                 return $this->content;
             }
 
-            return $this->setContent($this->readContent())->content;
+            // don't normalize field keys (already handled by the `Data` class)
+            return $this->content = new Content($this->readContent(), $this, false);
 
         // multi language support
         } else {
@@ -102,7 +103,8 @@ abstract class ModelWithContent extends Model
 
             // get the translation by code
             if ($translation = $this->translation($languageCode)) {
-                $content = new Content($translation->content(), $this);
+                // don't normalize field keys (already handled by the `ContentTranslation` class)
+                $content = new Content($translation->content(), $this, false);
             } else {
                 throw new InvalidArgumentException('Invalid language: ' . $languageCode);
             }
@@ -453,7 +455,7 @@ abstract class ModelWithContent extends Model
         if ($languageCode !== $kirby->defaultLanguage()->code()) {
             foreach ($this->blueprint()->fields() as $field) {
                 if (($field['translate'] ?? true) === false) {
-                    $content[$field['name']] = null;
+                    $content[strtolower($field['name'])] = null;
                 }
             }
 

--- a/tests/Cms/Content/ContentTest.php
+++ b/tests/Cms/Content/ContentTest.php
@@ -2,160 +2,203 @@
 
 namespace Kirby\Cms;
 
+/**
+ * @coversDefaultClass Kirby\Cms\Content
+ */
 class ContentTest extends TestCase
 {
-    protected function mockData(): array
+    protected $content;
+    protected $parent;
+
+    public function setUp(): void
     {
-        return [
-            'title' => 'Test Content',
-            'text'  => 'Lorem ipsum'
-        ];
+        $this->parent  = new Page(['slug' => 'test']);
+        $this->content = new Content([
+            'a' => 'A',
+            'B' => 'B',
+            'MiXeD' => 'mixed',
+            'mIXeD' => 'MIXED'
+        ], $this->parent);
     }
 
-    protected function mockObject()
+    /**
+     * @covers ::__call
+     */
+    public function testCall()
     {
-        return new Content($this->mockData());
+        $this->assertSame('a', $this->content->a()->key());
+        $this->assertSame('A', $this->content->a()->value());
+        $this->assertSame('mixed', $this->content->mixed()->key());
+        $this->assertSame('MIXED', $this->content->mixed()->value());
+        $this->assertSame('mixed', $this->content->mIXEd()->key());
+        $this->assertSame('MIXED', $this->content->mIXEd()->value());
     }
 
+    /**
+     * @covers ::__construct
+     * @covers ::__debugInfo
+     * @covers ::data
+     * @covers ::toArray
+     */
     public function testData()
     {
-        $data   = $this->mockData();
-        $object = $this->mockObject();
+        $expected = [
+            'a' => 'A',
+            'b' => 'B',
+            'mixed' => 'MIXED'
+        ];
 
-        $this->assertEquals($data, $object->data());
+        $this->assertSame($expected, $this->content->__debugInfo());
+        $this->assertSame($expected, $this->content->data());
+        $this->assertSame($expected, $this->content->toArray());
     }
 
-    public function testKeys()
+    /**
+     * @covers ::fields
+     */
+    public function testFields()
     {
-        $content = $this->mockObject();
+        $fields = $this->content->fields();
 
-        $this->assertEquals(['title', 'text'], $content->keys());
+        $this->assertCount(3, $fields);
+        $this->assertInstanceOf(Field::class, $fields['mixed']);
+        $this->assertSame('mixed', $fields['mixed']->key());
+        $this->assertSame('MIXED', $fields['mixed']->value());
     }
 
+    /**
+     * @covers ::get
+     */
+    public function testGet()
+    {
+        $field = $this->content->get('mixed');
+        $this->assertInstanceOf(Field::class, $field);
+        $this->assertSame('mixed', $field->key());
+        $this->assertSame($this->parent, $field->parent());
+        $this->assertSame('MIXED', $field->value());
+
+        // different case
+        $this->assertSame($field, $this->content->get('MiXeD'));
+
+        // non-existing field
+        $field = $this->content->get('invalid');
+        $this->assertInstanceOf(Field::class, $field);
+        $this->assertSame('invalid', $field->key());
+        $this->assertSame($this->parent, $field->parent());
+        $this->assertSame(null, $field->value());
+
+        // all fields
+        $fields = $this->content->get();
+        $this->assertSame(['mixed', 'invalid', 'a', 'b'], array_keys($fields));
+        $this->assertInstanceOf(Field::class, $fields['mixed']);
+        $this->assertSame('mixed', $fields['mixed']->key());
+        $this->assertSame('MIXED', $fields['mixed']->value());
+    }
+
+    /**
+     * @covers ::has
+     */
     public function testHas()
     {
-        $content = new Content([
-            'a' => 'A'
-        ]);
-
-        $this->assertTrue($content->has('a'));
-        $this->assertFalse($content->has('b'));
+        $this->assertTrue($this->content->has('a'));
+        $this->assertTrue($this->content->has('A'));
+        $this->assertTrue($this->content->has('b'));
+        $this->assertTrue($this->content->has('B'));
+        $this->assertTrue($this->content->has('mixed'));
+        $this->assertTrue($this->content->has('MIXED'));
+        $this->assertFalse($this->content->has('c'));
+        $this->assertFalse($this->content->has('C'));
     }
 
-    public function testHasWithDifferentCase()
+    /**
+     * @covers ::keys
+     */
+    public function testKeys()
     {
-        $content = new Content([
-            'testA' => 'A',
-            'TESTb' => 'B'
-        ]);
-
-        $this->assertTrue($content->has('testA'));
-        $this->assertTrue($content->has('testa'));
-        $this->assertTrue($content->has('TESTb'));
-        $this->assertTrue($content->has('testb'));
+        $this->assertSame(['a', 'b', 'mixed'], $this->content->keys());
     }
 
-    public function testGetExistingField()
-    {
-        $content = $this->mockObject();
-        $field   = $content->get('title');
-
-        $this->assertInstanceOf(Field::class, $field);
-        $this->assertEquals('Test Content', $field->value());
-    }
-
-    public function testGetWithDifferentCase()
-    {
-        $content = new Content([
-            'testA' => 'A',
-            'TESTb' => 'B'
-        ]);
-
-        $this->assertEquals('A', $content->get('testA')->value());
-        $this->assertEquals('A', $content->get('testa')->value());
-        $this->assertEquals('B', $content->get('TESTb')->value());
-        $this->assertEquals('B', $content->get('testb')->value());
-    }
-
-    public function testGetNonExistingField()
-    {
-        $content = $this->mockObject();
-        $field   = $content->get('nonExistingField');
-
-        $this->assertInstanceOf(Field::class, $field);
-        $this->assertEquals(null, $field->value());
-    }
-
-    public function testGetAllFields()
-    {
-        $content = $this->mockObject();
-        $fields  = $content->get();
-
-        foreach ($this->mockData() as $key => $value) {
-            $this->assertInstanceOf(Field::class, $fields[$key]);
-            $this->assertEquals($key, $fields[$key]->key());
-            $this->assertEquals($value, $fields[$key]->value());
-        }
-    }
-
+    /**
+     * @covers ::not
+     */
     public function testNot()
     {
-        $content = $this->mockObject();
-        $content = $content->not('title');
+        $content1 = $this->content->not('a');
+        $this->assertNotSame($this->content, $content1);
+        $this->assertSame(null, $content1->get('a')->value());
+        $this->assertSame('B', $content1->get('b')->value());
 
-        $this->assertEquals(null, $content->get('title')->value());
-        $this->assertEquals('Lorem ipsum', $content->get('text')->value());
+        $content2 = $this->content->not('A');
+        $this->assertNotSame($this->content, $content2);
+        $this->assertSame(null, $content2->get('a')->value());
+        $this->assertSame('B', $content2->get('b')->value());
+
+        $content3 = $this->content->not('MIxeD');
+        $this->assertNotSame($this->content, $content3);
+        $this->assertSame(null, $content3->get('mixed')->value());
+        $this->assertSame('B', $content3->get('b')->value());
+
+        // multiple nots
+        $content4 = $this->content->not('a')->not('MIxed');
+        $this->assertNotSame($this->content, $content4);
+        $this->assertSame(null, $content4->get('a')->value());
+        $this->assertSame(null, $content4->get('mixed')->value());
+        $this->assertSame('B', $content4->get('b')->value());
+
+        // multiple nots in one go
+        $content5 = $this->content->not('a', 'MIxed');
+        $this->assertNotSame($this->content, $content5);
+        $this->assertSame(null, $content5->get('a')->value());
+        $this->assertSame(null, $content5->get('mixed')->value());
+        $this->assertSame('B', $content5->get('b')->value());
     }
 
-    public function testMultipleNot()
-    {
-        $content = $this->mockObject();
-        $content = $content->not('title')->not('text');
-
-        $this->assertEquals(null, $content->get('title')->value());
-        $this->assertEquals(null, $content->get('text')->value());
-    }
-
+    /**
+     * @covers ::parent
+     */
     public function testParent()
     {
-        $page    = new Page(['slug' => 'test']);
-        $content = new Content(['title' => 'Test'], $page);
-
-        $this->assertEquals($page, $content->parent());
+        $this->assertSame($this->parent, $this->content->parent());
     }
 
+    /**
+     * @covers ::setParent
+     */
     public function testSetParent()
     {
-        $page    = new Page(['slug' => 'test']);
-        $content = new Content(['title' => 'Test']);
-        $content->setParent($page);
+        $page = new Page(['slug' => 'another-test']);
+        $this->content->setParent($page);
 
-        $this->assertEquals($page, $content->parent());
+        $this->assertSame($page, $this->content->parent());
     }
 
-    public function testToArray()
-    {
-        $this->assertEquals($this->mockData(), $this->mockObject()->toArray());
-    }
-
+    /**
+     * @covers ::update
+     */
     public function testUpdate()
     {
-        $content = $this->mockObject();
-
-        $content = $content->update([
-            'category' => 'test'
+        $this->content->update([
+            'a' => 'aaa'
         ]);
-        $this->assertEquals('test', $content->get('category')->value());
+        $this->assertSame('aaa', $this->content->get('a')->value());
+
+        $this->content->update([
+            'miXED' => 'mixed!'
+        ]);
+        $this->assertSame('mixed!', $this->content->get('mixed')->value());
 
         // Field objects should be cleared on update
-        $content = $content->update([
-            'category' => 'another-test'
+        $this->content->update([
+            'a' => 'aaaaaa'
         ]);
-        $this->assertEquals('another-test', $content->get('category')->value());
-    }
+        $this->assertSame('aaaaaa', $this->content->get('a')->value());
 
-    public function testDebuginfo()
-    {
-        $this->assertEquals($this->mockData(), $this->mockObject()->__debugInfo());
+        $this->content->update($expected = [
+            'TEST' => 'TEST'
+        ], true);
+        $this->assertSame(['test' => 'TEST'], $this->content->data());
+
+        $this->content->update(null, true);
+        $this->assertSame([], $this->content->data());
     }
 }

--- a/tests/Cms/Pages/PageTranslationsTest.php
+++ b/tests/Cms/Pages/PageTranslationsTest.php
@@ -233,6 +233,13 @@ class PageTranslationsTest extends TestCase
                     'b' => [
                         'type' => 'text',
                         'translate' => false
+                    ],
+                    'CAPITALIZED' => [
+                        'type' => 'text',
+                        'translate' => false
+                    ],
+                    'dDdDdD' => [
+                        'type' => 'text',
                     ]
                 ]
             ]
@@ -240,21 +247,34 @@ class PageTranslationsTest extends TestCase
 
         $app->impersonate('kirby');
 
-        $en = $page->update($input = [
+        $en = $page->update([
             'a' => 'A',
-            'b' => 'B'
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dDdDdD' => 'D'
         ]);
 
-        $this->assertSame($input, $en->content('en')->data());
+        $expected = [
+            'a' => 'A',
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dddddd' => 'D'
+        ];
+
+        $this->assertSame($expected, $en->content('en')->data());
 
         $de = $page->update([
             'a' => 'A',
-            'b' => 'B'
+            'b' => 'B',
+            'capitalized' => 'C',
+            'dDdDdD' => 'D'
         ], 'de');
 
         $expected = [
             'a' => 'A',
-            'b' => null
+            'b' => null,
+            'capitalized' => null,
+            'dddddd' => 'D'
         ];
 
         $this->assertSame($expected, $de->content('de')->data());

--- a/tests/Data/TxtTest.php
+++ b/tests/Data/TxtTest.php
@@ -44,6 +44,34 @@ class TxtTest extends TestCase
      * @covers ::encode
      * @covers ::encodeValue
      * @covers ::encodeResult
+     * @covers ::decode
+     */
+    public function testEncodeDecodeMixedCase()
+    {
+        $array = [
+            'title' => 'Title',
+            'text'  => 'Text',
+            'tItLe' => 'Another title',
+            'TEXT'  => 'UPPERTEXT'
+        ];
+
+        $data = Txt::encode($array);
+        $this->assertSame(
+            "Title: Another title\n\n----\n\nText: UPPERTEXT",
+            $data
+        );
+
+        $result = Txt::decode($data);
+        $this->assertSame([
+            'title' => 'Another title',
+            'text'  => 'UPPERTEXT'
+        ], $result);
+    }
+
+    /**
+     * @covers ::encode
+     * @covers ::encodeValue
+     * @covers ::encodeResult
      */
     public function testEncodeMissingValues()
     {


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

### Refactoring

- Content field names are now always handled case-insensitively.

### Fixes
 
- Fixed a bug where field content was copied to secondary languages even though `translate: false` was set #2577 #2789
- Fixed a bug where fields with uppercase field names in virtual pages could not be searched #4142 

### Breaking changes

- Field names of virtual pages' content are now converted to lowercase. If your virtual page has two fields that only differ in capitalization, only the last defined one will be available.

## Additional notes

I've also rewritten the tests for the `Content` class to test more edge-cases. The old/previous tests also pass, so I hope that we haven't broken anything else. The content fields were mostly case-insensitive anyway, now they are reliably handled that way in all methods.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
