### PR TITLE
[Blocks] Fix multi-language groups labels issue on blocks field

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -109,7 +109,7 @@ class Fieldset extends Item
             $tab = Blueprint::extend($tab);
 
             $tab['fields'] = $this->createFields($tab['fields'] ?? []);
-            $tab['label']  = I18n::translate($label = $tab['label'] ?? Str::ucfirst($name), $label);
+            $tab['label']  = $this->createLabel($tab['label'] ?? Str::ucfirst($name));
             $tab['name']   = $name;
 
             $tabs[$name] = $tab;

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
 /**
@@ -46,9 +47,10 @@ class Fieldsets extends Items
             if ($fieldset['type'] === 'group') {
                 $result    = static::createFieldsets($fieldset['fieldsets'] ?? []);
                 $fieldsets = array_merge($fieldsets, $result['fieldsets']);
+                $label     = $fieldset['label'] ?? Str::ucfirst($type);
 
                 $groups[$type] = [
-                    'label'     => $fieldset['label'] ?? Str::ucfirst($type),
+                    'label'     => I18n::translate($label, $label),
                     'name'      => $type,
                     'open'      => $fieldset['open'] ?? true,
                     'sets'      => array_column($result['fieldsets'], 'type'),


### PR DESCRIPTION
## Describe the PR

Now groups labels support multi-language on blocks field.

````yaml
fields:
  text:
    type: blocks
    fieldsets:
      text:
        label: 
          en: Text
          tr: Metin
        type: group
        ...
        ...
        ...
````

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2964 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
