### PR TITLE
Use PHP 8.0.0 workaround on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 php:
   - 7.3
   - 7.4
-  - 8.0
+  - 8.0.0
 services:
   - memcached
 before_install:
@@ -39,7 +39,7 @@ cache:
 jobs:
   fast_finish: true
   allow_failures:
-    - php: 8.0
+    - php: 8.0.0
   include:
   - name: Backend Coding Standards
     language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ cache:
 
 jobs:
   fast_finish: true
-  allow_failures:
-    - php: 8.0.0
   include:
   - name: Backend Coding Standards
     language: php


### PR DESCRIPTION
## Describe the PR

The Travis CI team suggested that we use `8.0.0` temporarily.

**Discussion details with Travis team**
https://travis-ci.community/t/unable-to-load-dynamic-library-apcu-so-error-on-php-8-nightly/10754

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
