### PR TITLE
More detailed `accept` options for file blueprints; limit file types by default

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -30,7 +30,7 @@ return [
                     'template' => $template
                 ]);
 
-                $uploads['accept'] = $file->blueprint()->accept()['mime'] ?? '*';
+                $uploads['accept'] = $file->blueprint()->acceptMime();
             } else {
                 $uploads['accept'] = '*';
             }

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -72,7 +72,7 @@ return [
                     'template' => $this->template
                 ]);
 
-                return $file->blueprint()->accept()['mime'] ?? '*';
+                return $file->blueprint()->acceptMime();
             }
 
             return null;

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -67,6 +67,7 @@
   "error.file.changeName.permission": "You are not allowed to change the name of \"{filename}\"",
   "error.file.duplicate": "A file with the name \"{filename}\" already exists",
   "error.file.extension.forbidden": "The extension \"{extension}\" is not allowed",
+  "error.file.extension.invalid": "Invalid extension: {extension}",
   "error.file.extension.missing": "The extensions for \"{filename}\" is missing",
   "error.file.maxheight": "The height of the image must not exceed {height} pixels",
   "error.file.maxsize": "The file is too large",
@@ -82,6 +83,7 @@
   "error.file.notFound": "The file \"{filename}\" cannot be found",
   "error.file.orientation": "The orientation of the image must be \"{orientation}\"",
   "error.file.type.forbidden": "You are not allowed to upload {type} files",
+  "error.file.type.invalid": "Invalid file type: {type}",
   "error.file.undefined": "The file cannot be found",
 
   "error.form.incomplete": "Please fix all form errors…",

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -17,6 +17,14 @@ use Kirby\Toolkit\Str;
  */
 class FileBlueprint extends Blueprint
 {
+    /**
+     * `true` if the default accepted
+     * types are being used
+     *
+     * @var bool
+     */
+    protected $defaultTypes = false;
+
     public function __construct(array $props)
     {
         parent::__construct($props);
@@ -55,6 +63,11 @@ class FileBlueprint extends Blueprint
      */
     public function acceptMime(): string
     {
+        // don't disclose the specific default types
+        if ($this->defaultTypes === true) {
+            return '*';
+        }
+
         $accept       = $this->accept();
         $restrictions = [];
 
@@ -110,10 +123,13 @@ class FileBlueprint extends Blueprint
             $accept = [
                 'mime' => $accept
             ];
-        }
-
-        // accept anything
-        if (empty($accept) === true) {
+        } elseif ($accept === true) {
+            // explicitly no restrictions at all
+            $accept = [
+                'mime' => null
+            ];
+        } elseif (empty($accept) === true) {
+            // no custom restrictions
             $accept = [];
         }
 
@@ -131,6 +147,17 @@ class FileBlueprint extends Blueprint
             'orientation' => null,
             'type'        => null
         ];
+
+        // default type restriction if none are configured;
+        // this ensures that no unexpected files are uploaded
+        if (
+            array_key_exists('mime', $accept) === false &&
+            array_key_exists('extension', $accept) === false &&
+            array_key_exists('type', $accept) === false
+        ) {
+            $defaults['type']   = ['image', 'document', 'archive', 'audio', 'video'];
+            $this->defaultTypes = true;
+        }
 
         $accept = array_merge($defaults, $accept);
 

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -769,6 +769,18 @@ class F
     }
 
     /**
+     * Returns all extensions of a given file type
+     * or `null` if the file type is unknown
+     *
+     * @param string $type
+     * @return array|null
+     */
+    public static function typeToExtensions(string $type): ?array
+    {
+        return static::$types[$type] ?? null;
+    }
+
+    /**
      * Unzips a zip file
      *
      * @param string $file

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -23,14 +23,14 @@ class FileActionsTest extends TestCase
                         'slug'  => 'test',
                         'files' => [
                             [
-                                'filename' => 'page.js'
+                                'filename' => 'page.csv'
                             ]
                         ]
                     ]
                 ],
                 'files' => [
                     [
-                        'filename' => 'site.js'
+                        'filename' => 'site.csv'
                     ]
                 ],
             ],
@@ -108,7 +108,7 @@ class FileActionsTest extends TestCase
         $result = $file->changeName('test');
 
         $this->assertNotEquals($file->root(), $result->root());
-        $this->assertEquals('test.js', $result->filename());
+        $this->assertEquals('test.csv', $result->filename());
         $this->assertFileExists($result->root());
         $this->assertFileExists($result->contentFile());
     }
@@ -146,7 +146,7 @@ class FileActionsTest extends TestCase
         $result = $file->changeName('test');
 
         $this->assertNotEquals($file->root(), $result->root());
-        $this->assertEquals('test.js', $result->filename());
+        $this->assertEquals('test.csv', $result->filename());
         $this->assertFileExists($result->root());
         $this->assertFileExists($result->contentFile('en'));
         $this->assertFileExists($result->contentFile('de'));
@@ -392,14 +392,14 @@ class FileActionsTest extends TestCase
                 'file.changeName:before' => function (File $file, $name) use ($phpunit, &$calls) {
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $file);
                     $phpunit->assertSame('test', $name);
-                    $phpunit->assertSame('site.js', $file->filename());
+                    $phpunit->assertSame('site.csv', $file->filename());
                     $calls++;
                 },
                 'file.changeName:after' => function (File $newFile, File $oldFile) use ($phpunit, &$calls) {
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $newFile);
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $oldFile);
-                    $phpunit->assertSame('test.js', $newFile->filename());
-                    $phpunit->assertSame('site.js', $oldFile->filename());
+                    $phpunit->assertSame('test.csv', $newFile->filename());
+                    $phpunit->assertSame('site.csv', $oldFile->filename());
                     $calls++;
                 },
             ]
@@ -419,13 +419,13 @@ class FileActionsTest extends TestCase
             'site' => [
                 'files' => [
                     [
-                        'filename' => 'site-1.js'
+                        'filename' => 'site-1.csv'
                     ],
                     [
-                        'filename' => 'site-2.js'
+                        'filename' => 'site-2.csv'
                     ],
                     [
-                        'filename' => 'site-3.js'
+                        'filename' => 'site-3.csv'
                     ]
                 ],
             ],
@@ -502,27 +502,27 @@ class FileActionsTest extends TestCase
                 'file.replace:before' => function (File $file, $upload) use ($phpunit, &$calls) {
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $file);
                     $phpunit->assertInstanceOf('Kirby\Image\Image', $upload);
-                    $phpunit->assertSame('site.js', $file->filename());
-                    $phpunit->assertSame('replace.js', $upload->filename());
+                    $phpunit->assertSame('site.csv', $file->filename());
+                    $phpunit->assertSame('replace.csv', $upload->filename());
                     $phpunit->assertFileDoesNotExist($file->root());
                     $calls++;
                 },
                 'file.replace:after' => function (File $newFile, File $oldFile) use ($phpunit, &$calls) {
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $newFile);
                     $phpunit->assertInstanceOf('Kirby\Cms\File', $oldFile);
-                    $phpunit->assertSame('site.js', $newFile->filename());
+                    $phpunit->assertSame('site.csv', $newFile->filename());
                     $phpunit->assertSame('Replace', F::read($newFile->root()));
-                    $phpunit->assertSame('site.js', $oldFile->filename());
+                    $phpunit->assertSame('site.csv', $oldFile->filename());
                     $calls++;
                 },
             ]
         ]);
 
         // create the dummy source
-        F::write($source = $this->fixtures . '/replace.js', 'Replace');
+        F::write($source = $this->fixtures . '/replace.csv', 'Replace');
 
         File::create([
-            'filename' => 'replace.js',
+            'filename' => 'replace.csv',
             'source'   => $source,
             'parent'   => $parent
         ]);

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -117,6 +117,59 @@ class FileBlueprintTest extends TestCase
         ];
 
         $blueprint = new FileBlueprint([
+            'accept' => true,
+            'model'  => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'mime' => null
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'extension' => null
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'type' => null
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'mime' => null,
+                'type' => null
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        // no value = default type restriction
+        $expected = [
+            'extension'   => null,
+            'mime'        => null,
+            'maxheight'   => null,
+            'maxsize'     => null,
+            'maxwidth'    => null,
+            'minheight'   => null,
+            'minsize'     => null,
+            'minwidth'    => null,
+            'orientation' => null,
+            'type'        => ['image', 'document', 'archive', 'audio', 'video']
+        ];
+
+        $blueprint = new FileBlueprint([
             'model' => $file
         ]);
         $this->assertSame($expected, $blueprint->accept());
@@ -185,9 +238,16 @@ class FileBlueprintTest extends TestCase
             'filename' => 'test.jpg'
         ]);
 
+        // default restrictions
+        $blueprint = new FileBlueprint([
+            'model'  => $file
+        ]);
+        $this->assertSame('*', $blueprint->acceptMime());
+
         // no restrictions
         $blueprint = new FileBlueprint([
-            'model' => $file
+            'accept' => true,
+            'model'  => $file
         ]);
         $this->assertSame('*', $blueprint->acceptMime());
 

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -78,6 +78,170 @@ class FileBlueprintTest extends TestCase
         $this->assertEquals('Gallery', $blueprint->title());
     }
 
+    public function testAccept()
+    {
+        $file = new File([
+            'filename' => 'test.jpg'
+        ]);
+
+        // string = MIME types
+        $blueprint = new FileBlueprint([
+            'accept' => 'image/jpeg, text/*',
+            'model'  => $file
+        ]);
+        $this->assertSame([
+            'extension'   => null,
+            'mime'        => ['image/jpeg', 'text/*'],
+            'maxheight'   => null,
+            'maxsize'     => null,
+            'maxwidth'    => null,
+            'minheight'   => null,
+            'minsize'     => null,
+            'minwidth'    => null,
+            'orientation' => null,
+            'type'        => null
+        ], $blueprint->accept());
+
+        // empty value = no restrictions
+        $expected = [
+            'extension'   => null,
+            'mime'        => null,
+            'maxheight'   => null,
+            'maxsize'     => null,
+            'maxwidth'    => null,
+            'minheight'   => null,
+            'minsize'     => null,
+            'minwidth'    => null,
+            'orientation' => null,
+            'type'        => null
+        ];
+
+        $blueprint = new FileBlueprint([
+            'model' => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => null,
+            'model'  => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        $blueprint = new FileBlueprint([
+            'accept' => [],
+            'model'  => $file
+        ]);
+        $this->assertSame($expected, $blueprint->accept());
+
+        // array with mixed case
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'extensION' => ['txt'],
+                'MiMe'      => ['image/jpeg', 'text/*'],
+                'MAXsize'   => 100,
+                'typE'      => ['document']
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame([
+            'extension'   => ['txt'],
+            'mime'        => ['image/jpeg', 'text/*'],
+            'maxheight'   => null,
+            'maxsize'     => 100,
+            'maxwidth'    => null,
+            'minheight'   => null,
+            'minsize'     => null,
+            'minwidth'    => null,
+            'orientation' => null,
+            'type'        => ['document']
+        ], $blueprint->accept());
+
+        // MIME, extension and type normalization
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'mime'      => 'image/jpeg,  image/png;q=0.7',
+                'extension' => 'txt,json  ,  jpg',
+                'type'      => 'document;audio  ,  video'
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame([
+            'extension'   => ['txt', 'json', 'jpg'],
+            'mime'        => ['image/jpeg', 'image/png'],
+            'maxheight'   => null,
+            'maxsize'     => null,
+            'maxwidth'    => null,
+            'minheight'   => null,
+            'minsize'     => null,
+            'minwidth'    => null,
+            'orientation' => null,
+            'type'        => ['document;audio', 'video']
+        ], $blueprint->accept());
+    }
+
+    public function testAcceptMime()
+    {
+        $file = new File([
+            'filename' => 'test.jpg'
+        ]);
+
+        // no restrictions
+        $blueprint = new FileBlueprint([
+            'model' => $file
+        ]);
+        $this->assertSame('*', $blueprint->acceptMime());
+
+        // just MIME restrictions
+        $blueprint = new FileBlueprint([
+            'accept' => 'image/jpeg,  image/png;q=0.7',
+            'model'  => $file
+        ]);
+        $this->assertSame('image/jpeg, image/png', $blueprint->acceptMime());
+
+        // just extension restrictions
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'extension' => 'jpg, mp4'
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame('image/jpeg, video/mp4', $blueprint->acceptMime());
+
+        // just type restrictions
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'type' => 'archive, audio'
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame(
+            'application/x-gzip, application/x-tar, application/x-zip, ' .
+            'audio/x-aiff, audio/mp4, audio/midi, audio/mpeg, audio/x-wav',
+            $blueprint->acceptMime()
+        );
+
+        // combined extension and type restrictions
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'extension' => 'jpg, txt, png',
+                'type'      => 'image, audio'
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame('image/jpeg, image/png', $blueprint->acceptMime());
+
+        // don't override explicit MIME types with other restrictions
+        $blueprint = new FileBlueprint([
+            'accept' => [
+                'mime'      => 'image/jpeg,  application/pdf;q=0.7',
+                'extension' => 'jpg, txt, png',
+                'type'      => 'document, image'
+            ],
+            'model' => $file
+        ]);
+        $this->assertSame('image/jpeg, application/pdf', $blueprint->acceptMime());
+    }
+
     public function testExtendAccept()
     {
         new App([
@@ -106,6 +270,6 @@ class FileBlueprintTest extends TestCase
         ]);
 
         $blueprint = $file->blueprint();
-        $this->assertEquals('image/jpeg', $blueprint->accept()['mime']);
+        $this->assertEquals(['image/jpeg'], $blueprint->accept()['mime']);
     }
 }

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -11,6 +11,12 @@ class ImageTest extends TestCase
         return new Image(static::FIXTURES . '/image/' . $filename, $url);
     }
 
+    public function setUp(): void
+    {
+        // ensure the translations are loaded
+        kirby();
+    }
+
     public function testConstruct()
     {
         $image = $this->_image();
@@ -86,6 +92,56 @@ class ImageTest extends TestCase
 
         // cached object
         $this->assertInstanceOf(Dimensions::class, $image->dimensions());
+    }
+
+    public function testMatch()
+    {
+        $rules = [
+            'miMe'        => ['image/png', 'image/jpeg', 'application/pdf'],
+            'extensION'   => ['jpg', 'pdf'],
+            'tYPe'        => ['image', 'video'],
+            'MINsize'     => 20000,
+            'maxSIze'     => 25000,
+            'minheiGHt'   => 400,
+            'maxHeight'   => 600,
+            'minWIdth'    => 400,
+            'maxwiDth'    => 600,
+            'oriEntation' => 'square'
+        ];
+
+        $this->assertTrue($this->_image()->match($rules));
+    }
+
+    public function testMatchMimeException()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid mime type: image/jpeg');
+
+        $this->_image()->match(['mime' => ['image/png', 'application/pdf']]);
+    }
+
+    public function testMatchExtensionException()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid extension: jpg');
+
+        $this->_image()->match(['extension' => ['png', 'pdf']]);
+    }
+
+    public function testMatchTypeException()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('Invalid file type: image');
+
+        $this->_image()->match(['type' => ['document', 'video']]);
+    }
+
+    public function testMatchOrientationException()
+    {
+        $this->expectException('Kirby\Exception\Exception');
+        $this->expectExceptionMessage('The orientation of the image must be "portrait"');
+
+        $this->_image()->match(['orientation' => 'portrait']);
     }
 
     public function testWidth()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -417,6 +417,13 @@ class FTest extends TestCase
         $this->assertEquals('code', F::type($file));
     }
 
+    public function testTypeToExtensions()
+    {
+        $this->assertSame(F::$types['audio'], F::typeToExtensions('audio'));
+        $this->assertSame(F::$types['document'], F::typeToExtensions('document'));
+        $this->assertNull(F::typeToExtensions('invalid'));
+    }
+
     public function testURI()
     {
         F::write($this->tmp, 'test');


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Previously, file blueprints could be configured to only allow specific MIME types to be uploaded.

- It is now possible to limit the uploaded files based on the file extension and/or the file type.

```yaml
accept:
  extension: jpg, png
```

```yaml
accept:
  type: image, audio, video
```

- These restrictions can be combined with a custom set of MIME types. This makes it possible to define MIME types that are compatible with all browsers while still protecting the uploads based on the extension and/or file type:

```yaml
accept:
  mime: image/*
  type: image
```

In this example, Kirby will generate a file upload input with an `accept="image/*"` attribute and will then validate both the MIME type and the detected file type on the server after the file is uploaded.

- If no restrictions are defined in the file blueprint, Kirby will now limit the accepted uploads to the types image, document, archive, audio and video by default. This protects your sites against unexpected uploads like code files that could be used to attack the server or the visitor's browsers.

- You can disable the automatic types and allow all uploads like this:

```yaml
accept: true

# or:
accept:
  mime: null
  orientation: square
  ...
```

- New `F::typeToExtensions()` method

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
