### PR TITLE
Login view: Don't load login form if logged in

### DIFF
--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -27,9 +27,11 @@ export default {
     form() {
       if (this.$store.state.user.pendingEmail) {
         return "code";
-      } else {
+      } else if (!this.$store.state.user.current) {
         return "login";
       }
+
+      return null;
     }
   },
   created() {


### PR DESCRIPTION
The login view always loaded the login form once `ready` was set to `true` even if the user is already logged in and will immediately be redirected to `/panel/site`. When manually visiting `/panel/login`, this caused an error in the login form because it doesn't get the information it needs from the system API route (the new login form config options are only passed to the frontend when no user is logged in).

The form is now only loaded if no user is logged in.