### PR TITLE
[Blocks] Fixes empty text blocks/layout fields

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -30,6 +30,7 @@ class BlocksField extends FieldClass
 
         parent::__construct($params);
 
+        $this->setEmpty($params['empty'] ?? null);
         $this->setGroup($params['group'] ?? 'blocks');
         $this->setMax($params['max'] ?? null);
         $this->setMin($params['min'] ?? null);

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -384,4 +384,13 @@ class BlocksFieldTest extends TestCase
         $this->assertFalse($field->isValid());
         $this->assertSame(['blocks' => 'There\'s an error in block 2'], $field->errors());
     }
+
+    public function testEmpty()
+    {
+        $field = $this->field('blocks', [
+            'empty' => $value = 'Custom empty text'
+        ]);
+
+        $this->assertSame($value, $field->empty());
+    }
 }

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -194,4 +194,13 @@ class LayoutFieldTest extends TestCase
         $this->assertFalse($field->isValid());
         $this->assertSame(['layout' => 'There\'s an error in layout 1 settings'], $field->errors());
     }
+
+    public function testEmpty()
+    {
+        $field = $this->field('layout', [
+            'empty' => $value = 'Custom empty text'
+        ]);
+
+        $this->assertSame($value, $field->empty());
+    }
 }


### PR DESCRIPTION
## Describe the PR

Fixes empty text for blocks and layout field issue that reported by @hyr on Discord.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
