### PR TITLE
Fixes accessing textContent property on empty list

### DIFF
--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -34,8 +34,10 @@ export default {
     onInput(html) {
       let dom  = new DOMParser().parseFromString(html, "text/html");
       let list = dom.querySelector('ul, ol');
+
       if (!list) {
         this.$emit("input", "");
+        return;
       }
 
       let text = list.textContent.trim();


### PR DESCRIPTION
## Describe the PR

If the `list` is `null`, it doesn't need to trim.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2979 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
