### PR TITLE
Fix Block::parse() method on empty input #2982

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 php:
   - 7.3
   - 7.4
-  - 8.0.0
+  - 8.0
 services:
   - memcached
 before_install:

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Exception;
 use Kirby\Data\Json;
 use Kirby\Data\Yaml;
 use Kirby\Parsley\Parsley;
@@ -101,6 +102,10 @@ class Blocks extends Items
      */
     public static function parse($input): array
     {
+        if (empty($input) === true) {
+            return [];
+        }
+
         if (is_array($input) === false) {
             try {
                 $input = Json::decode((string)$input);
@@ -121,10 +126,6 @@ class Blocks extends Items
                     $input  = $parser->blocks();
                 }
             }
-        }
-
-        if (empty($input) === true) {
-            return [];
         }
 
         return $input;

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -102,11 +102,7 @@ class Blocks extends Items
      */
     public static function parse($input): array
     {
-        if (empty($input) === true) {
-            return [];
-        }
-
-        if (is_array($input) === false) {
+        if (empty($input) === false && is_array($input) === false) {
             try {
                 $input = Json::decode((string)$input);
             } catch (Throwable $e) {
@@ -126,6 +122,10 @@ class Blocks extends Items
                     $input  = $parser->blocks();
                 }
             }
+        }
+
+        if (empty($input) === true) {
+            return [];
         }
 
         return $input;

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -104,6 +104,36 @@ class BlocksTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testParseString()
+    {
+        $expected = [
+            [
+                'type' => 'text',
+                'content' => [
+                    'text' => '<p>This is test string</p>'
+                ]
+            ]
+        ];
+
+        $result = Blocks::parse('This is test string');
+        $this->assertSame($expected, $result);
+    }
+
+    public function testParsePageObject()
+    {
+        $expected = [
+            [
+                'type' => 'text',
+                'content' => [
+                    'text' => '<p>test</p>'
+                ]
+            ]
+        ];
+
+        $result = Blocks::parse($this->page);
+        $this->assertSame($expected, $result);
+    }
+
     public function testToHtml()
     {
         $blocks = Blocks::factory([

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -63,7 +63,7 @@ class BlocksTest extends TestCase
         ];
 
         $result = Blocks::parse(json_encode($input));
-        $this->assertSame($result, $input);
+        $this->assertSame($input, $result);
     }
 
     public function testParseYaml()
@@ -75,7 +75,7 @@ class BlocksTest extends TestCase
         ];
 
         $result = Blocks::parse(Yaml::encode($input));
-        $this->assertSame($result, $input);
+        $this->assertSame($input, $result);
     }
 
     public function testParseHtml()
@@ -92,7 +92,16 @@ class BlocksTest extends TestCase
         ];
 
         $result = Blocks::parse($input);
-        $this->assertSame($result, $expected);
+        $this->assertSame($expected, $result);
+    }
+
+    public function testParseEmpty()
+    {
+        $result = Blocks::parse(null);
+        $this->assertSame([], $result);
+
+        $result = Blocks::parse('');
+        $this->assertSame([], $result);
     }
 
     public function testToHtml()


### PR DESCRIPTION
## Describe the PR

Solved by checking empty input control.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2982 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
