### PR TITLE
Graceful fallback for Parsley when xml extension is missing

### DIFF
--- a/src/Parsley/Element.php
+++ b/src/Parsley/Element.php
@@ -19,7 +19,11 @@ class Element
 
     public function attr(string $attr, $fallback = null)
     {
-        return $this->node->getAttribute($attr) ?? $fallback;
+        if ($this->node->hasAttribute($attr)) {
+            return $this->node->getAttribute($attr) ?? $fallback;
+        }
+
+        return $fallback;
     }
 
     public function children()

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -8,7 +8,6 @@ use Kirby\Parsley\Schema\Plain;
 
 class Parsley
 {
-
     protected $blocks = [];
     protected $body;
     protected $doc;
@@ -229,5 +228,4 @@ class Parsley
 
         return class_exists('DOMDocument') === true;
     }
-
 }

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -8,6 +8,8 @@ use Kirby\Parsley\Schema\Plain;
 
 class Parsley
 {
+    public static $documentClass = 'DOMDocument';
+
     protected $blocks = [];
 
     protected $body;
@@ -19,6 +21,17 @@ class Parsley
 
     public function __construct(string $html, Schema $schema = null)
     {
+        // fail gracefully if the XML extension is not installed
+        if ($this->hasXmlExtension() === false) {
+            $this->blocks[] = [
+                'type' => 'markdown',
+                'content' => [
+                    'text' => $html,
+                ]
+            ];
+            return;
+        }
+
         libxml_use_internal_errors(true);
 
         $this->doc = new DOMDocument();
@@ -105,6 +118,11 @@ class Parsley
         }
 
         return false;
+    }
+
+    public function hasXmlExtension(): bool
+    {
+        return class_exists(static::$documentClass) === true;
     }
 
     public function isBlock($element): bool

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -8,10 +8,8 @@ use Kirby\Parsley\Schema\Plain;
 
 class Parsley
 {
-    public static $documentClass = 'DOMDocument';
 
     protected $blocks = [];
-
     protected $body;
     protected $doc;
     protected $marks = [];
@@ -19,10 +17,13 @@ class Parsley
     protected $schema;
     protected $skip = [];
 
+    public static $useXmlExtension = true;
+
     public function __construct(string $html, Schema $schema = null)
     {
         // fail gracefully if the XML extension is not installed
-        if ($this->hasXmlExtension() === false) {
+        // or should be skipped
+        if ($this->useXmlExtension() === false) {
             $this->blocks[] = [
                 'type' => 'markdown',
                 'content' => [
@@ -118,11 +119,6 @@ class Parsley
         }
 
         return false;
-    }
-
-    public function hasXmlExtension(): bool
-    {
-        return class_exists(static::$documentClass) === true;
     }
 
     public function isBlock($element): bool
@@ -224,4 +220,14 @@ class Parsley
     {
         return (new DOMXPath($element))->query($query);
     }
+
+    public function useXmlExtension(): bool
+    {
+        if (static::$useXmlExtension !== true) {
+            return false;
+        }
+
+        return class_exists('DOMDocument') === true;
+    }
+
 }

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -16,10 +16,10 @@ class Blocks extends Plain
         }
 
         return [
-            'type' => 'text',
             'content' => [
                 'text' => '<p>' . $html . '</p>',
-            ]
+            ],
+            'type' => 'text',
         ];
     }
 
@@ -34,9 +34,11 @@ class Blocks extends Plain
             $content['id'] = $id;
         }
 
+        ksort($content);
+
         return [
-            'type' => 'heading',
-            'content' => $content
+            'content' => $content,
+            'type'    => 'heading',
         ];
     }
 
@@ -138,11 +140,11 @@ class Blocks extends Plain
                     }
 
                     return [
-                        'type' => 'quote',
                         'content' => [
                             'citation' => $citation,
                             'text'     => $text
-                        ]
+                        ],
+                        'type' => 'quote',
                     ];
                 }
             ],
@@ -209,19 +211,19 @@ class Blocks extends Plain
                     // correct video URL
                     if ($src) {
                         return [
-                            'type' => 'video',
                             'content' => [
                                 'caption' => $caption,
                                 'url'     => $src
-                            ]
+                            ],
+                            'type' => 'video',
                         ];
                     }
 
                     return [
-                        'type' => 'markdown',
                         'content' => [
                             'text' => $node->outerHTML()
-                        ]
+                        ],
+                        'type' => 'markdown',
                     ];
                 }
             ],
@@ -243,14 +245,14 @@ class Blocks extends Plain
                     }
 
                     return [
-                        'type' => 'image',
                         'content' => [
                             'alt'      => $node->attr('alt'),
                             'caption'  => $caption,
                             'link'     => $link,
                             'location' => 'web',
                             'src'      => $node->attr('src'),
-                        ]
+                        ],
+                        'type' => 'image',
                     ];
                 }
             ],
@@ -258,10 +260,10 @@ class Blocks extends Plain
                 'tag' => 'ol',
                 'parse' => function ($node) {
                     return [
-                        'type'    => 'list',
                         'content' => [
                             'text' => $this->list($node)
-                        ]
+                        ],
+                        'type' => 'list',
                     ];
                 }
             ],
@@ -280,11 +282,11 @@ class Blocks extends Plain
                     }
 
                     return [
-                        'type' => 'code',
                         'content' => [
                             'code'     => $node->innerText(),
                             'language' => $language
-                        ]
+                        ],
+                        'type' => 'code',
                     ];
                 }
             ],
@@ -292,10 +294,10 @@ class Blocks extends Plain
                 'tag' => 'table',
                 'parse' => function ($node) {
                     return [
-                        'type' => 'markdown',
                         'content' => [
                             'text' => $node->outerHTML(),
-                        ]
+                        ],
+                        'type' => 'markdown',
                     ];
                 }
             ],
@@ -303,10 +305,10 @@ class Blocks extends Plain
                 'tag' => 'ul',
                 'parse' => function ($node) {
                     return [
-                        'type'    => 'list',
                         'content' => [
                             'text' => $this->list($node)
-                        ]
+                        ],
+                        'type' => 'list',
                     ];
                 }
             ],

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -83,11 +83,11 @@ class BlocksTest extends TestCase
         $input = '<h1>Test</h1>';
         $expected = [
             [
-                'type' => 'heading',
                 'content' => [
                     'level' => 'h1',
                     'text' => 'Test'
-                ]
+                ],
+                'type' => 'heading',
             ]
         ];
 
@@ -108,10 +108,10 @@ class BlocksTest extends TestCase
     {
         $expected = [
             [
-                'type' => 'text',
                 'content' => [
                     'text' => '<p>This is test string</p>'
-                ]
+                ],
+                'type' => 'text',
             ]
         ];
 
@@ -123,10 +123,10 @@ class BlocksTest extends TestCase
     {
         $expected = [
             [
-                'type' => 'text',
                 'content' => [
                     'text' => '<p>test</p>'
-                ]
+                ],
+                'type' => 'text',
             ]
         ];
 

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -19,7 +19,7 @@ class ParsleyTest extends TestCase
             $parser = new Parsley($input, new Blocks());
             $output = $parser->blocks();
 
-            $this->assertEquals($output, $expected, basename($example));
+            $this->assertSame($expected, $output, basename($example));
         }
     }
 
@@ -38,7 +38,7 @@ class ParsleyTest extends TestCase
             ]
         ];
 
-        $this->assertEquals($output, $expected);
+        $this->assertSame($output, $expected);
 
         // revert the global change
         Parsley::$documentClass = 'DOMDocument';

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -19,7 +19,28 @@ class ParsleyTest extends TestCase
             $parser = new Parsley($input, new Blocks());
             $output = $parser->blocks();
 
-            $this->assertEquals($expected, $output, basename($example));
+            $this->assertEquals($output, $expected, basename($example));
         }
+    }
+
+    public function testMissingXmlExtension()
+    {
+        Parsley::$documentClass = 'DOMDocumentDoesNotExist';
+
+        $parser   = new Parsley('Test', new Blocks());
+        $output   = $parser->blocks();
+        $expected = [
+            [
+                'type' => 'markdown',
+                'content' => [
+                    'text' => 'Test'
+                ]
+            ]
+        ];
+
+        $this->assertEquals($output, $expected);
+
+        // revert the global change
+        Parsley::$documentClass = 'DOMDocument';
     }
 }

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -23,9 +23,9 @@ class ParsleyTest extends TestCase
         }
     }
 
-    public function testMissingXmlExtension()
+    public function testSkipXmlExtension()
     {
-        Parsley::$documentClass = 'DOMDocumentDoesNotExist';
+        Parsley::$useXmlExtension = false;
 
         $parser   = new Parsley('Test', new Blocks());
         $output   = $parser->blocks();
@@ -41,6 +41,6 @@ class ParsleyTest extends TestCase
         $this->assertSame($output, $expected);
 
         // revert the global change
-        Parsley::$documentClass = 'DOMDocument';
+        Parsley::$useXmlExtension = true;
     }
 }

--- a/tests/Parsley/fixtures/blockquote.php
+++ b/tests/Parsley/fixtures/blockquote.php
@@ -3,8 +3,8 @@
 return [
     [
         'content' => [
+            'citation' => null,
             'text' => 'Blockquote',
-            'citation' => null
         ],
         'type' => 'quote',
     ]

--- a/tests/Parsley/fixtures/figure-with-image.php
+++ b/tests/Parsley/fixtures/figure-with-image.php
@@ -3,11 +3,11 @@
 return [
     [
         'content' => [
-            'src'      => 'https://example.com/test.jpg',
             'alt'      => 'Image',
             'caption'  => 'Caption',
             'link'     => null,
-            'location' => 'web'
+            'location' => 'web',
+            'src'      => 'https://example.com/test.jpg',
         ],
         'type' => 'image',
     ],

--- a/tests/Parsley/fixtures/figure-with-linked-image.php
+++ b/tests/Parsley/fixtures/figure-with-linked-image.php
@@ -3,11 +3,11 @@
 return [
     [
         'content' => [
-            'src'     => 'https://example.com/test.jpg',
-            'alt'     => 'Image',
-            'caption' => 'Caption',
-            'link'    => 'https://example.com',
-            'location' => 'web'
+            'alt'      => 'Image',
+            'caption'  => 'Caption',
+            'link'     => 'https://example.com',
+            'location' => 'web',
+            'src'      => 'https://example.com/test.jpg',
         ],
         'type' => 'image',
     ],

--- a/tests/Parsley/fixtures/figure-with-vimeo-video.php
+++ b/tests/Parsley/fixtures/figure-with-vimeo-video.php
@@ -3,8 +3,8 @@
 return [
     [
         'content' => [
+            'caption' => 'Caption',
             'url'     => 'https://vimeo.com/355518557',
-            'caption' => 'Caption'
         ],
         'type' => 'video'
     ],

--- a/tests/Parsley/fixtures/figure-with-youtube-video.php
+++ b/tests/Parsley/fixtures/figure-with-youtube-video.php
@@ -3,8 +3,8 @@
 return [
     [
         'content' => [
+            'caption' => 'Caption',
             'url'     => 'https://youtube.com/watch?v=LccqV6HPZrw',
-            'caption' => 'Caption'
         ],
         'type' => 'video'
     ],

--- a/tests/Parsley/fixtures/image.php
+++ b/tests/Parsley/fixtures/image.php
@@ -5,9 +5,9 @@ return [
         'content' => [
             'alt'      => 'Image',
             'caption'  => null,
-            'src'      => 'https://example.com/test.jpg',
             'link'     => null,
-            'location' => 'web'
+            'location' => 'web',
+            'src'      => 'https://example.com/test.jpg',
         ],
         'type' => 'image',
     ],


### PR DESCRIPTION
## Describe the PR

When the xml extension is not loaded, Parsley will return a single markdown block with the HTML from the original value. 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`