### PR TITLE
Media::publish(): No longer check MIME type

### DIFF
--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -202,15 +202,23 @@ class FileRules
      * Validates the extension, MIME type and filename
      *
      * @param \Kirby\Cms\File $file
-     * @param string|null $mime If not passed, the MIME type is detected from the file
+     * @param string|null|false $mime If not passed, the MIME type is detected from the file,
+     *                                if `false`, the MIME type is not validated for performance reasons
      * @return bool
      * @throws \Kirby\Exception\InvalidArgumentException If the extension, MIME type or filename is missing or forbidden
      */
-    public static function validFile(File $file, ?string $mime = null): bool
+    public static function validFile(File $file, $mime = null): bool
     {
+        if ($mime === false) {
+            // request to skip the MIME check for performance reasons
+            $validMime = true;
+        } else {
+            $validMime = static::validMime($file, $mime ?? $file->mime());
+        }
+
         return
+            $validMime &&
             static::validExtension($file, $file->extension()) &&
-            static::validMime($file, $mime ?? $file->mime()) &&
             static::validFilename($file, $file->filename());
     }
 

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -71,7 +71,7 @@ class Media
     public static function publish(File $file, string $dest): bool
     {
         // never publish risky files (e.g. HTML, PHP or Apache config files)
-        FileRules::validFile($file);
+        FileRules::validFile($file, false);
 
         $src       = $file->root();
         $version   = dirname($dest);

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -245,9 +245,9 @@ class FileRulesTest extends TestCase
             ['.gitignore', 'gitignore', 'application/x-git', false, 'You are not allowed to upload invisible files'],
 
             // rule order
-            ['.test.htm', 'htm', 'application/php', false, 'The extension "htm" is not allowed'],
-            ['.test.htm', 'jpg', 'application/php', false, 'You are not allowed to upload PHP files'],
-            ['.test.htm', 'jpg', 'text/plain', false, 'You are not allowed to upload invisible files'],
+            ['.test.jpg', 'jpg', 'application/php', false, 'You are not allowed to upload PHP files'],
+            ['.test.htm', 'htm', 'text/plain', false, 'The extension "htm" is not allowed'],
+            ['.test.jpg', 'jpg', 'text/plain', false, 'You are not allowed to upload invisible files'],
         ];
     }
 
@@ -273,6 +273,24 @@ class FileRulesTest extends TestCase
         $result = FileRules::validFile($file);
 
         $this->assertTrue($result);
+    }
+
+    public function testValidFileSkipMime()
+    {
+        $file = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['filename', 'extension'])
+            ->addMethods(['mime'])
+            ->getMock();
+        $file->method('filename')->willReturn('test.jpg');
+        $file->method('extension')->willReturn('jpg');
+        $file->method('mime')->willReturn('text/html');
+
+        $this->assertTrue(FileRules::validFile($file, false));
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The media type "text/html" is not allowed');
+        $this->assertTrue(FileRules::validFile($file));
     }
 
     public function filenameProvider()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Kirby no longer checks the MIME type of files when copying them to the `media` folder. This can dramatically increase performance on large sites.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2987

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
