### PR TITLE
Add missing when prop for FieldClass

### DIFF
--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -353,6 +353,7 @@ abstract class FieldClass
             'saveable'    => $this->isSaveable(),
             'translate'   => $this->translate(),
             'type'        => $this->type(),
+            'when'        => $this->when(),
             'width'       => $this->width(),
         ];
     }
@@ -612,6 +613,16 @@ abstract class FieldClass
     protected function valueToYaml(array $value = null): string
     {
         return Data::encode($value, 'yaml');
+    }
+
+    /**
+     * Conditions when the field will be shown
+     *
+     * @return array|null
+     */
+    public function when(): ?array
+    {
+        return $this->when;
     }
 
     /**

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Form\Fields;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
-use Kirby\Form\Field;
 use Kirby\Form\Fields;
 
 class BlocksFieldTest extends TestCase

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -431,8 +431,7 @@ class BlocksFieldTest extends TestCase
 
         $this->assertSame([], $field->errors());
 
-
-        // text
+        // failed
         $field = $this->field('blocks', [
             'model' => $page,
             'required' => true,

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -3,6 +3,9 @@
 namespace Kirby\Form\Fields;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Page;
+use Kirby\Form\Field;
+use Kirby\Form\Fields;
 
 class BlocksFieldTest extends TestCase
 {
@@ -392,5 +395,57 @@ class BlocksFieldTest extends TestCase
         ]);
 
         $this->assertSame($value, $field->empty());
+    }
+
+    public function testWhen()
+    {
+        $page = new Page(['slug' => 'test']);
+
+        $fields = new Fields([
+            'foo' => [
+                'type'  => 'text',
+                'model' => $page,
+                'value' => 'a'
+            ],
+            'bar' => [
+                'type'  => 'blocks',
+                'model' => $page,
+                'value' => []
+            ]
+        ]);
+
+        // default
+        $field = $this->field('blocks', [
+            'model' => $page,
+        ], $fields);
+
+        $this->assertSame([], $field->errors());
+
+        // passed
+        $field = $this->field('blocks', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'x'
+            ]
+        ], $fields);
+
+        $this->assertSame([], $field->errors());
+
+
+        // text
+        $field = $this->field('blocks', [
+            'model' => $page,
+            'required' => true,
+            'when' => [
+                'foo' => 'a'
+            ]
+        ], $fields);
+
+        $expected = [
+            'required' => 'Please enter something',
+        ];
+
+        $this->assertSame($expected, $field->errors());
     }
 }

--- a/tests/Form/Fields/TestCase.php
+++ b/tests/Form/Fields/TestCase.php
@@ -5,6 +5,7 @@ namespace Kirby\Form\Fields;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Form\Field;
+use Kirby\Form\Fields;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -28,9 +29,9 @@ class TestCase extends BaseTestCase
         return $this->app;
     }
 
-    public function field(string $type, array $attr = [])
+    public function field(string $type, array $attr = [], ?Fields $formFields = null)
     {
         $page = new Page(['slug' => 'test']);
-        return Field::factory($type, array_merge(['model' => $page], $attr));
+        return Field::factory($type, array_merge(['model' => $page], $attr), $formFields);
     }
 }


### PR DESCRIPTION
## Describe the PR

Fixes the issue with adding missing `when` prop  for `\Kirby\Form\FieldClass`

Also the parent class (`\Kirby\Form\Field`) of the other fields and the parent class (`\Kirby\Form\FieldClass`) of the blocks field are different. This should be refactored in next versions.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3013 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
