### PR TITLE
Extendable layout settings

### DIFF
--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Cms\Blueprint;
 use Kirby\Cms\Fieldset;
 use Kirby\Cms\Form;
 use Kirby\Cms\Layout;
@@ -19,7 +20,7 @@ class LayoutField extends BlocksField
     {
         $this->setModel($params['model'] ?? site());
         $this->setLayouts($params['layouts'] ?? ['1/1']);
-        $this->setSettings($params['settings'] ?? []);
+        $this->setSettings($params['settings'] ?? null);
 
         parent::__construct($params);
     }
@@ -120,12 +121,14 @@ class LayoutField extends BlocksField
         }, $layouts);
     }
 
-    protected function setSettings(array $settings = [])
+    protected function setSettings($settings = null)
     {
         if (empty($settings) === true) {
             $this->settings = null;
             return;
         }
+
+        $settings = Blueprint::extend($settings);
 
         $settings['icon']   = 'dashboard';
         $settings['type']   = 'layout';

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -18,6 +18,56 @@ class LayoutFieldTest extends TestCase
         $this->assertTrue($field->save());
     }
 
+    public function testExtends()
+    {
+        $this->app->clone([
+            'blueprints' => [
+                'fields/layout-settings' => [
+                    'fields' => [
+                        'id' => [
+                            'type' => 'text'
+                        ],
+                        'class' => [
+                            'type' => 'text'
+                        ],
+                        'background-color' => [
+                            'type' => 'text'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        // no settings
+        $field = $this->field('layout');
+
+        $this->assertNull($field->settings());
+
+        // extend with simple string
+        $field = $this->field('layout', [
+            'settings' => 'fields/layout-settings'
+        ]);
+
+        $fields = $field->settings()->fields();
+        $this->assertCount(3, $fields);
+        $this->assertArrayHasKey('id', $fields);
+        $this->assertArrayHasKey('class', $fields);
+        $this->assertArrayHasKey('background-color', $fields);
+
+        // extend with array
+        $field = $this->field('layout', [
+            'settings' => [
+                'extends' => 'fields/layout-settings'
+            ]
+        ]);
+
+        $fields = $field->settings()->fields();
+        $this->assertCount(3, $fields);
+        $this->assertArrayHasKey('id', $fields);
+        $this->assertArrayHasKey('class', $fields);
+        $this->assertArrayHasKey('background-color', $fields);
+    }
+
     public function testLayouts()
     {
         $field = $this->field('layout', [


### PR DESCRIPTION
## Describe the PR

Now layout settings are extendable.

````yaml
# simple string:
fields:
  layout:
    type: layout
    settings: fields/settings

# with extends option
fields:
  layout:
    type: layout
    settings: 
      extends: fields/settings
````


## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3011 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
