### PR TITLE
F::niceSize(): Typography and locale improvements

### DIFF
--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -542,7 +542,7 @@ class F
 
         // avoid errors for invalid sizes
         if ($size <= 0) {
-            return '0 KB';
+            return '0 KB';
         }
 
         // the math magic
@@ -553,7 +553,7 @@ class F
             $size = I18n::formatNumber($size, $locale);
         }
 
-        return $size . ' ' . static::$units[$unit];
+        return $size . ' ' . static::$units[$unit];
     }
 
     /**

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -525,9 +525,12 @@ class F
      * Converts an integer size into a human readable format
      *
      * @param mixed $size The file size or a file path
+     * @param string|null|false $locale Locale for number formatting,
+     *                                  `null` for the current locale,
+     *                                  `false` to disable number formatting
      * @return string
      */
-    public static function niceSize($size): string
+    public static function niceSize($size, $locale = null): string
     {
         // file mode
         if (is_string($size) === true && file_exists($size) === true) {
@@ -543,7 +546,14 @@ class F
         }
 
         // the math magic
-        return round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . static::$units[$i];
+        $size = round($size / pow(1024, ($unit = floor(log($size, 1024)))), 2);
+
+        // format the number if requested
+        if ($locale !== false) {
+            $size = I18n::formatNumber($size, $locale);
+        }
+
+        return $size . ' ' . static::$units[$unit];
     }
 
     /**

--- a/tests/Toolkit/DirTest.php
+++ b/tests/Toolkit/DirTest.php
@@ -291,7 +291,7 @@ class DirTest extends TestCase
         F::write($this->tmp . '/testfile-3.txt', Str::random(5));
 
         $this->assertEquals(15, Dir::size($this->tmp));
-        $this->assertEquals('15 B', Dir::niceSize($this->tmp));
+        $this->assertEquals('15 B', Dir::niceSize($this->tmp));
 
         Dir::remove($this->tmp);
     }
@@ -307,7 +307,7 @@ class DirTest extends TestCase
         F::write($this->tmp . '/sub/sub/testfile-3.txt', Str::random(5));
 
         $this->assertEquals(15, Dir::size($this->tmp));
-        $this->assertEquals('15 B', Dir::niceSize($this->tmp));
+        $this->assertEquals('15 B', Dir::niceSize($this->tmp));
 
         Dir::remove($this->tmp);
     }

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -319,9 +319,11 @@ class FTest extends TestCase
 
     public function testNiceSize()
     {
-        F::write($this->tmp, 'test');
+        $locale = I18n::$locale;
 
+        F::write($this->tmp, 'test');
         $this->assertSame('4 B', F::niceSize($this->tmp));
+
         $this->assertSame('4 B', F::niceSize(4));
         $this->assertSame('4 KB', F::niceSize(4096));
         $this->assertSame('4 KB', F::niceSize(4100));
@@ -329,6 +331,20 @@ class FTest extends TestCase
         $this->assertSame('4 MB', F::niceSize(4194304));
         $this->assertSame('4.29 MB', F::niceSize(4500000));
         $this->assertSame('4 GB', F::niceSize(4294967296));
+
+        // default locale
+        I18n::$locale = 'de';
+        $this->assertSame('4,29 MB', F::niceSize(4500000));
+
+        // custom locale
+        $this->assertSame('4.29 MB', F::niceSize(4500000, 'en_US'));
+        $this->assertSame('4,29 MB', F::niceSize(4500000, 'fr_FR'));
+
+        // disable locale formatting
+        $this->assertSame('4.29 MB', F::niceSize(4500000, false));
+
+        // reset locale
+        I18n::$locale = $locale;
     }
 
     public function testRead()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -322,26 +322,26 @@ class FTest extends TestCase
         $locale = I18n::$locale;
 
         F::write($this->tmp, 'test');
-        $this->assertSame('4 B', F::niceSize($this->tmp));
+        $this->assertSame('4 B', F::niceSize($this->tmp));
 
-        $this->assertSame('4 B', F::niceSize(4));
-        $this->assertSame('4 KB', F::niceSize(4096));
-        $this->assertSame('4 KB', F::niceSize(4100));
-        $this->assertSame('4.1 KB', F::niceSize(4200));
-        $this->assertSame('4 MB', F::niceSize(4194304));
-        $this->assertSame('4.29 MB', F::niceSize(4500000));
-        $this->assertSame('4 GB', F::niceSize(4294967296));
+        $this->assertSame('4 B', F::niceSize(4));
+        $this->assertSame('4 KB', F::niceSize(4096));
+        $this->assertSame('4 KB', F::niceSize(4100));
+        $this->assertSame('4.1 KB', F::niceSize(4200));
+        $this->assertSame('4 MB', F::niceSize(4194304));
+        $this->assertSame('4.29 MB', F::niceSize(4500000));
+        $this->assertSame('4 GB', F::niceSize(4294967296));
 
         // default locale
         I18n::$locale = 'de';
-        $this->assertSame('4,29 MB', F::niceSize(4500000));
+        $this->assertSame('4,29 MB', F::niceSize(4500000));
 
         // custom locale
-        $this->assertSame('4.29 MB', F::niceSize(4500000, 'en_US'));
-        $this->assertSame('4,29 MB', F::niceSize(4500000, 'fr_FR'));
+        $this->assertSame('4.29 MB', F::niceSize(4500000, 'en_US'));
+        $this->assertSame('4,29 MB', F::niceSize(4500000, 'fr_FR'));
 
         // disable locale formatting
-        $this->assertSame('4.29 MB', F::niceSize(4500000, false));
+        $this->assertSame('4.29 MB', F::niceSize(4500000, false));
 
         // reset locale
         I18n::$locale = $locale;

--- a/tests/Toolkit/FileTest.php
+++ b/tests/Toolkit/FileTest.php
@@ -114,11 +114,11 @@ class FileTest extends TestCase
     {
         // existing file
         $file = $this->_file('test.js');
-        $this->assertEquals('14 B', $file->niceSize());
+        $this->assertEquals('14 B', $file->niceSize());
 
         // non-existing file
         $file = $this->_file('does/not/exist.js');
-        $this->assertEquals('0 KB', $file->niceSize());
+        $this->assertEquals('0 KB', $file->niceSize());
     }
 
     public function testModified()


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- `F::niceSize()` now respects the locale by default and can also be passed a custom locale or `false` to disable locale-aware formatting.
- `F::niceSize()` now places a no-break space between the number and the unit.

*Missing discussion in the [idea on Nolt](https://kirby.nolt.io/178).*

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Implements https://kirby.nolt.io/178

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
