### PR TITLE
$auth->status() object

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -11,6 +11,9 @@ return [
         'ascii' => function () {
             return Str::$ascii;
         },
+        'authStatus' => function () {
+            return $this->kirby()->auth()->status()->toArray();
+        },
         'defaultLanguage' => function () {
             return $this->kirby()->option('panel.language', 'en');
         },
@@ -37,18 +40,6 @@ return [
         },
         'loginMethods' => function (System $system) {
             return array_keys($system->loginMethods());
-        },
-        'pendingChallenge' => function () {
-            if ($this->session()->get('kirby.challenge.email') === null) {
-                return null;
-            }
-
-            // fake the email challenge if no challenge was created
-            // to avoid leaking whether the user exists
-            return $this->session()->get('kirby.challenge.type', 'email');
-        },
-        'pendingEmail' => function () {
-            return $this->session()->get('kirby.challenge.email');
         },
         'requirements' => function (System $system) {
             return $system->toArray();
@@ -98,12 +89,11 @@ return [
     'type'   => 'Kirby\Cms\System',
     'views'  => [
         'login' => [
+            'authStatus',
             'isOk',
             'isInstallable',
             'isInstalled',
             'loginMethods',
-            'pendingChallenge',
-            'pendingEmail',
             'title',
             'translation'
         ],

--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -65,7 +65,7 @@ return [
                     isset($methods['password']['2fa']) === true &&
                     $methods['password']['2fa'] === true
                 ) {
-                    $challenge = $auth->login2fa($email, $password, $long);
+                    $status = $auth->login2fa($email, $password, $long);
                 } else {
                     $user = $auth->login($email, $password, $long);
                 }
@@ -78,7 +78,7 @@ return [
                     throw new InvalidArgumentException('Login without password is not enabled');
                 }
 
-                $challenge = $auth->createChallenge($email, $long, $mode);
+                $status = $auth->createChallenge($email, $long, $mode);
             }
 
             if (isset($user)) {
@@ -89,11 +89,9 @@ return [
                 ];
             } else {
                 return [
-                    'code'   => 200,
-                    'status' => 'ok',
-
-                    // don't leak users that don't exist at this point
-                    'challenge' => $challenge ?? 'email'
+                    'code'      => 200,
+                    'status'    => 'ok',
+                    'challenge' => $status->challenge()
                 ];
             }
         }

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -47,11 +47,8 @@ export default {
           this.$go("/");
         }
 
-        if (system.pendingChallenge) {
-          this.$store.dispatch("user/pending", {
-            email: system.pendingEmail,
-            challenge: system.pendingChallenge
-          });
+        if (system.authStatus.status === "pending") {
+          this.$store.dispatch("user/pending", system.authStatus);
         }
 
         this.ready = true;

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Cms\Auth\Status;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
@@ -47,6 +48,13 @@ class Auth
     protected $kirby;
 
     /**
+     * Cache of the auth status object
+     *
+     * @var \Kirby\Cms\Auth\Status
+     */
+    protected $status;
+
+    /**
      * Instance of the currently logged in user or
      * `false` if the user was not yet determined
      *
@@ -78,15 +86,13 @@ class Auth
      * @param string $email
      * @param bool $long If `true`, a long session will be created
      * @param string $mode Either 'login' or 'password-reset'
-     * @return string|null Name of the challenge that was created;
-     *                     `null` if the user does not exist or no
-     *                     challenge was available for the user
+     * @return \Kirby\Cms\Auth\Status
      *
      * @throws \Kirby\Exception\LogicException If there is no suitable authentication challenge (only in debug mode)
      * @throws \Kirby\Exception\NotFoundException If the user does not exist (only in debug mode)
      * @throws \Kirby\Exception\PermissionException If the rate limit is exceeded
      */
-    public function createChallenge(string $email, bool $long = false, string $mode = 'login'): ?string
+    public function createChallenge(string $email, bool $long = false, string $mode = 'login')
     {
         // ensure that email addresses with IDN domains are in Unicode format
         $email = Idn::decodeEmail($email);
@@ -116,8 +122,7 @@ class Auth
         if ($user = $this->kirby->users()->find($email)) {
             $timeout = $this->kirby->option('auth.challenge.timeout', 10 * 60);
 
-            $challenges = $this->kirby->option('auth.challenges', ['email']);
-            foreach (A::wrap($challenges) as $name) {
+            foreach ($this->enabledChallenges() as $name) {
                 $class = static::$challenges[$name] ?? null;
                 if (
                     $class &&
@@ -140,7 +145,7 @@ class Auth
             }
 
             // if no suitable challenge was found, `$challenge === null` at this point;
-            // only leak this in debug mode, otherwise `null` is returned below
+            // only leak this in debug mode
             if ($challenge === null && $this->kirby->option('debug') === true) {
                 throw new LogicException('Could not find a suitable authentication challenge');
             }
@@ -167,7 +172,10 @@ class Auth
         // avoid leaking whether the user exists
         usleep(random_int(1000, 300000));
 
-        return $challenge;
+        // clear the status cache
+        $this->status = null;
+
+        return $this->status($session, false);
     }
 
     /**
@@ -255,15 +263,7 @@ class Auth
      */
     public function currentUserFromSession($session = null)
     {
-        // use passed session options or session object if set
-        if (is_array($session) === true) {
-            $session = $this->kirby->session($session);
-        }
-
-        // try session in header or cookie
-        if (is_a($session, 'Kirby\Session\Session') === false) {
-            $session = $this->kirby->session(['detect' => true]);
-        }
+        $session = $this->session($session);
 
         $id = $session->data()->get('kirby.userId');
 
@@ -282,6 +282,17 @@ class Auth
     }
 
     /**
+     * Returns the list of enabled challenges in the
+     * configured order
+     *
+     * @return array
+     */
+    public function enabledChallenges(): array
+    {
+        return A::wrap($this->kirby->option('auth.challenges', ['email']));
+    }
+
+    /**
      * Become any existing user or disable the current user
      *
      * @param string|null $who User ID or email address,
@@ -293,6 +304,9 @@ class Auth
      */
     public function impersonate(?string $who = null)
     {
+        // clear the status cache
+        $this->status = null;
+
         switch ($who) {
             case null:
                 return $this->impersonate = null;
@@ -384,6 +398,9 @@ class Auth
         $user = $this->validatePassword($email, $password);
         $user->loginPasswordless($options);
 
+        // clear the status cache
+        $this->status = null;
+
         return $user;
     }
 
@@ -393,8 +410,7 @@ class Auth
      * @param string $email
      * @param string $password
      * @param bool $long
-     * @return string|null Name of the challenge that was created;
-     *                     `null` if no challenge was available for the user
+     * @return \Kirby\Cms\Auth\Status
      *
      * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occured with debug mode off
      * @throws \Kirby\Exception\NotFoundException If the email was invalid
@@ -419,6 +435,57 @@ class Auth
         $this->impersonate = null;
 
         $this->user = $user;
+
+        // clear the status cache
+        $this->status = null;
+    }
+
+    /**
+     * Returns the authentication status object
+     *
+     * @param \Kirby\Session\Session|array|null $session
+     * @param bool $allowImpersonation If set to false, only the actually
+     *                                 logged in user will be returned
+     * @return \Kirby\Cms\Auth\Status
+     */
+    public function status($session = null, bool $allowImpersonation = true)
+    {
+        // try to return from cache
+        if ($this->status && $session === null && $allowImpersonation === true) {
+            return $this->status;
+        }
+
+        $sessionObj = $this->session($session);
+
+        $props = ['kirby' => $this->kirby];
+        if ($user = $this->user($sessionObj, $allowImpersonation)) {
+            // a user is currently logged in
+            if ($allowImpersonation === true && $this->impersonate !== null) {
+                $props['status'] = 'impersonated';
+            } else {
+                $props['status'] = 'active';
+            }
+
+            $props['email'] = $user->email();
+        } elseif ($email = $sessionObj->get('kirby.challenge.email')) {
+            // a challenge is currently pending
+            $props['status']            = 'pending';
+            $props['email']             = $email;
+            $props['challenge']         = $sessionObj->get('kirby.challenge.type');
+            $props['challengeFallback'] = A::last($this->enabledChallenges());
+        } else {
+            // no active authentication
+            $props['status'] = 'inactive';
+        }
+
+        $status = new Status($props);
+
+        // only cache the default object
+        if ($session === null && $allowImpersonation === true) {
+            $this->status = $status;
+        }
+
+        return $status;
     }
 
     /**
@@ -559,6 +626,9 @@ class Auth
         $session->remove('kirby.challenge.email');
         $session->remove('kirby.challenge.timeout');
         $session->remove('kirby.challenge.type');
+
+        // clear the status cache
+        $this->status = null;
     }
 
     /**
@@ -570,6 +640,7 @@ class Auth
     public function flush(): void
     {
         $this->impersonate = null;
+        $this->status = null;
         $this->user = null;
     }
 
@@ -743,6 +814,9 @@ class Auth
                     $this->logout();
                     $user->loginPasswordless();
 
+                    // clear the status cache
+                    $this->status = null;
+
                     return $user;
                 } else {
                     throw new PermissionException(['key' => 'access.code']);
@@ -768,5 +842,26 @@ class Auth
                 throw new PermissionException(['key' => 'access.code']);
             }
         }
+    }
+
+    /**
+     * Creates a session object from the passed options
+     *
+     * @param \Kirby\Session\Session|array|null $session
+     * @return \Kirby\Session\Session
+     */
+    protected function session($session = null)
+    {
+        // use passed session options or session object if set
+        if (is_array($session) === true) {
+            return $this->kirby->session($session);
+        }
+
+        // try session in header or cookie
+        if (is_a($session, 'Kirby\Session\Session') === false) {
+            return $this->kirby->session(['detect' => true]);
+        }
+
+        return $session;
     }
 }

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -32,9 +32,34 @@ class Auth
      */
     public static $challenges = [];
 
+    /**
+     * Currently impersonated user
+     *
+     * @var \Kirby\App\User|null
+     */
     protected $impersonate;
+
+    /**
+     * Kirby instance
+     *
+     * @var \Kirby\Cms\App
+     */
     protected $kirby;
+
+    /**
+     * Instance of the currently logged in user or
+     * `false` if the user was not yet determined
+     *
+     * @var \Kirby\Cms\User|null|false
+     */
     protected $user = false;
+
+    /**
+     * Exception that was thrown while
+     * determining the current user
+     *
+     * @var \Throwable
+     */
     protected $userException;
 
     /**

--- a/src/Cms/Auth/Status.php
+++ b/src/Cms/Auth/Status.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\Properties;
+
+/**
+ * Information container for the
+ * authentication status
+ *
+ * @package   Kirby Cms
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class Status
+{
+    use Properties;
+
+    /**
+     * Type of the active challenge
+     *
+     * @var string|null
+     */
+    protected $challenge = null;
+
+    /**
+     * Challenge type to use as a fallback
+     * when $challenge is `null`
+     *
+     * @var string|null
+     */
+    protected $challengeFallback = null;
+
+    /**
+     * Email address of the current/pending user
+     *
+     * @var string|null
+     */
+    protected $email = null;
+
+    /**
+     * Kirby instance for user lookup
+     *
+     * @var \Kirby\Cms\App
+     */
+    protected $kirby;
+
+    /**
+     * Authentication status:
+     * `active|impersonated|pending|inactive`
+     *
+     * @var string
+     */
+    protected $status;
+
+    /**
+     * Class constructor
+     *
+     * @param array $props
+     */
+    public function __construct(array $props)
+    {
+        $this->setProperties($props);
+    }
+
+    /**
+     * Returns the authentication status
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->status();
+    }
+
+    /**
+     * Returns the type of the active challenge
+     *
+     * @param bool $automaticFallback If set to `false`, no faked challenge is returned;
+     *                                WARNING: never send the resulting `null` value to the
+     *                                user to avoid leaking whether the pending user exists
+     * @return string|null
+     */
+    public function challenge(bool $automaticFallback = true): ?string
+    {
+        // never return a challenge type if the status doesn't match
+        if ($this->status() !== 'pending') {
+            return null;
+        }
+
+        if ($automaticFallback === false) {
+            return $this->challenge;
+        } else {
+            return $this->challenge ?? $this->challengeFallback;
+        }
+    }
+
+    /**
+     * Returns the email address of the current/pending user
+     *
+     * @return string|null
+     */
+    public function email(): ?string
+    {
+        return $this->email;
+    }
+
+    /**
+     * Returns the authentication status
+     *
+     * @return string `active|impersonated|pending|inactive`
+     */
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Returns an array with all public status data
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'challenge' => $this->challenge(),
+            'email'     => $this->email(),
+            'status'    => $this->status()
+        ];
+    }
+
+    /**
+     * Returns the currently logged in user
+     *
+     * @return \Kirby\Cms\User
+     */
+    public function user()
+    {
+        // for security, only return the user if they are
+        // already logged in
+        if (in_array($this->status(), ['active', 'impersonated']) !== true) {
+            return null;
+        }
+
+        return $this->kirby->user($this->email());
+    }
+
+    /**
+     * Sets the type of the active challenge
+     *
+     * @param string|null $challenge
+     * @return self
+     */
+    protected function setChallenge(?string $challenge = null)
+    {
+        $this->challenge = $challenge;
+        return $this;
+    }
+
+    /**
+     * Sets the challenge type to use as
+     * a fallback when $challenge is `null`
+     *
+     * @param string|null $challengeFallback
+     * @return self
+     */
+    protected function setChallengeFallback(?string $challengeFallback = null)
+    {
+        $this->challengeFallback = $challengeFallback;
+        return $this;
+    }
+
+    /**
+     * Sets the email address of the current/pending user
+     *
+     * @param string|null $email
+     * @return self
+     */
+    protected function setEmail(?string $email = null)
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * Sets the Kirby instance for user lookup
+     *
+     * @param \Kirby\Cms\App $kirby
+     * @return self
+     */
+    protected function setKirby(App $kirby)
+    {
+        $this->kirby = $kirby;
+        return $this;
+    }
+
+    /**
+     * Sets the authentication status
+     *
+     * @param string $status `active|impersonated|pending|inactive`
+     * @return self
+     */
+    protected function setStatus(string $status)
+    {
+        if (in_array($status, ['active', 'impersonated', 'pending', 'inactive']) !== true) {
+            throw new InvalidArgumentException([
+                'data' => ['argument' => '$props[\'status\']', 'method' => 'Status::__construct']
+            ]);
+        }
+
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -258,7 +258,13 @@ class AppPluginsTest extends TestCase
         $auth    = $kirby->auth();
         $session = $kirby->session();
 
-        $this->assertSame('dummy', $auth->createChallenge('homer@simpsons.com'));
+        $status = $auth->createChallenge('homer@simpsons.com');
+        $this->assertSame([
+            'challenge' => 'dummy',
+            'email'     => 'homer@simpsons.com',
+            'status'    => 'pending'
+        ], $status->toArray());
+        $this->assertSame('dummy', $status->challenge(false));
         $this->assertSame('homer@simpsons.com', $session->get('kirby.challenge.email'));
         $this->assertSame('dummy', $session->get('kirby.challenge.type'));
         $this->assertTrue(password_verify('test', $session->get('kirby.challenge.code')));

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -54,6 +54,7 @@ class AuthTest extends TestCase
     /**
      * @covers ::currentUserFromImpersonation
      * @covers ::impersonate
+     * @covers ::status
      * @covers ::user
      */
     public function testImpersonate()
@@ -61,6 +62,11 @@ class AuthTest extends TestCase
         $this->assertSame(null, $this->auth->user());
 
         $user = $this->auth->impersonate('kirby');
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'kirby@getkirby.com',
+            'status'    => 'impersonated'
+        ], $this->auth->status()->toArray());
         $this->assertSame($user, $this->auth->user());
         $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertSame('kirby', $user->id());
@@ -69,19 +75,39 @@ class AuthTest extends TestCase
         $this->assertNull($this->auth->user(null, false));
 
         $user = $this->auth->impersonate('homer@simpsons.com');
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'homer@simpsons.com',
+            'status'    => 'impersonated'
+        ], $this->auth->status()->toArray());
         $this->assertSame('homer@simpsons.com', $user->email());
         $this->assertSame($user, $this->auth->user());
         $this->assertSame($user, $this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $this->assertNull($this->auth->impersonate(null));
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => null,
+            'status'    => 'inactive'
+        ], $this->auth->status()->toArray());
         $this->assertNull($this->auth->user());
         $this->assertNull($this->auth->currentUserFromImpersonation());
         $this->assertNull($this->auth->user(null, false));
 
         $this->auth->setUser($actual = $this->app->user('marge@simpsons.com'));
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'marge@simpsons.com',
+            'status'    => 'active'
+        ], $this->auth->status()->toArray());
         $this->assertSame('marge@simpsons.com', $this->auth->user()->email());
         $impersonated = $this->auth->impersonate('nobody');
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'nobody@getkirby.com',
+            'status'    => 'impersonated'
+        ], $this->auth->status()->toArray());
         $this->assertSame($impersonated, $this->auth->user());
         $this->assertSame($impersonated, $this->auth->currentUserFromImpersonation());
         $this->assertSame('nobody', $impersonated->id());
@@ -90,6 +116,11 @@ class AuthTest extends TestCase
         $this->assertSame($actual, $this->auth->user(null, false));
 
         $this->auth->logout();
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => null,
+            'status'    => 'inactive'
+        ], $this->auth->status()->toArray());
         $this->assertNull($this->auth->impersonate());
         $this->assertNull($this->auth->user());
         $this->assertNull($this->auth->currentUserFromImpersonation());
@@ -108,6 +139,7 @@ class AuthTest extends TestCase
     }
 
     /**
+     * @covers ::status
      * @covers ::user
      */
     public function testUserSession1()
@@ -118,6 +150,12 @@ class AuthTest extends TestCase
         $user = $this->auth->user();
         $this->assertSame('marge@simpsons.com', $user->email());
 
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'marge@simpsons.com',
+            'status'    => 'active'
+        ], $this->auth->status()->toArray());
+
         // impersonation is not set
         $this->assertNull($this->auth->currentUserFromImpersonation());
 
@@ -125,9 +163,15 @@ class AuthTest extends TestCase
         $session->set('kirby.userId', 'homer');
         $user = $this->auth->user();
         $this->assertSame('marge@simpsons.com', $user->email());
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'marge@simpsons.com',
+            'status'    => 'active'
+        ], $this->auth->status()->toArray());
     }
 
     /**
+     * @covers ::status
      * @covers ::user
      */
     public function testUserSession2()
@@ -137,9 +181,15 @@ class AuthTest extends TestCase
 
         $user = $this->auth->user($session);
         $this->assertSame('homer@simpsons.com', $user->email());
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'homer@simpsons.com',
+            'status'    => 'active'
+        ], $this->auth->status()->toArray());
     }
 
     /**
+     * @covers ::status
      * @covers ::user
      */
     public function testUserBasicAuth()
@@ -148,6 +198,12 @@ class AuthTest extends TestCase
 
         $user = $this->auth->user();
         $this->assertSame('homer@simpsons.com', $user->email());
+
+        $this->assertSame([
+            'challenge' => null,
+            'email'     => 'homer@simpsons.com',
+            'status'    => 'active'
+        ], $this->auth->status()->toArray());
     }
 
     /**

--- a/tests/Cms/Auth/StatusTest.php
+++ b/tests/Cms/Auth/StatusTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Kirby\Cms\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\TestCase;
+
+/**
+ * @coversDefaultClass Kirby\Cms\Auth\Status
+ * @covers ::__construct
+ * @covers ::setChallenge
+ * @covers ::setChallengeFallback
+ * @covers ::setEmail
+ * @covers ::setKirby
+ * @covers ::setStatus
+ */
+class StatusTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com',
+                    'name'  => 'Homer Simpson'
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * @covers ::__toString
+     */
+    public function testToString()
+    {
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'active'
+        ]);
+
+        $this->assertSame('active', (string)$status);
+    }
+
+    /**
+     * @covers ::challenge
+     */
+    public function testChallenge()
+    {
+        // no challenge when not in pending status
+        $status = new Status([
+            'kirby'             => $this->app,
+            'challenge'         => 'totp',
+            'challengeFallback' => 'email',
+            'status'            => 'active'
+        ]);
+        $this->assertNull($status->challenge());
+
+        // with pending challenge
+        $status = new Status([
+            'kirby'             => $this->app,
+            'challenge'         => 'totp',
+            'challengeFallback' => 'email',
+            'status'            => 'pending'
+        ]);
+        $this->assertSame('totp', $status->challenge());
+
+        // with faked challenge
+        $status = new Status([
+            'kirby'             => $this->app,
+            'challenge'         => null,
+            'challengeFallback' => 'email',
+            'status'            => 'pending'
+        ]);
+        $this->assertSame('email', $status->challenge());
+
+        // with faked challenge, but without automatic fallback
+        $status = new Status([
+            'kirby'             => $this->app,
+            'challenge'         => null,
+            'challengeFallback' => 'email',
+            'status'            => 'pending'
+        ]);
+        $this->assertNull($status->challenge(false));
+    }
+
+    /**
+     * @covers ::email
+     */
+    public function testEmail()
+    {
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'inactive'
+        ]);
+        $this->assertNull($status->email());
+
+        $status = new Status([
+            'kirby'  => $this->app,
+            'email'  => 'homer@simpsons.com',
+            'status' => 'active'
+        ]);
+        $this->assertSame('homer@simpsons.com', $status->email());
+    }
+
+    /**
+     * @covers ::status
+     * @covers ::setStatus
+     */
+    public function testStatus()
+    {
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'active'
+        ]);
+        $this->assertSame('active', $status->status());
+
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'impersonated'
+        ]);
+        $this->assertSame('impersonated', $status->status());
+
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'pending'
+        ]);
+        $this->assertSame('pending', $status->status());
+
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'inactive'
+        ]);
+        $this->assertSame('inactive', $status->status());
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid argument "$props[\'status\']" in method "Status::__construct"');
+        $status = new Status([
+            'kirby'  => $this->app,
+            'status' => 'invalid'
+        ]);
+    }
+
+    /**
+     * @covers ::toArray
+     */
+    public function testToArray()
+    {
+        $status = new Status([
+            'kirby'             => $this->app,
+            'challenge'         => null,
+            'challengeFallback' => 'email',
+            'email'             => 'homer@simpsons.com',
+            'status'            => 'pending'
+        ]);
+
+        $this->assertSame([
+            'challenge' => 'email',
+            'email'     => 'homer@simpsons.com',
+            'status'    => 'pending'
+        ], $status->toArray());
+    }
+
+    /**
+     * @covers ::user
+     */
+    public function testUser()
+    {
+        // only return active users
+        $status = new Status([
+            'kirby'  => $this->app,
+            'email'  => 'homer@simpsons.com',
+            'status' => 'pending'
+        ]);
+        $this->assertNull($status->user());
+
+        // existing active user
+        $status = new Status([
+            'kirby'  => $this->app,
+            'email'  => 'homer@simpsons.com',
+            'status' => 'active'
+        ]);
+        $this->assertSame('Homer Simpson', $status->user()->name()->value());
+
+        // existing impersonated user
+        $status = new Status([
+            'kirby'  => $this->app,
+            'email'  => 'homer@simpsons.com',
+            'status' => 'impersonated'
+        ]);
+        $this->assertSame('Homer Simpson', $status->user()->name()->value());
+
+        // invalid active user
+        $status = new Status([
+            'kirby'  => $this->app,
+            'email'  => 'invalid@simpsons.com',
+            'status' => 'active'
+        ]);
+        $this->assertNull($status->user());
+    }
+}


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

As already discussed on Monday in Discord, this PR improves the UX for developers of frontend login forms and will allow us to get rid of the [big fat warning in the docs](https://getkirby.com/docs/guide/authentication/frontend-login#creating-an-authentication-challenge).

---

- New `$auth->status()` method that returns an object with all relevant information about the current authentication status:

```php
$status = $kirby->auth()->status();

$status->status();    // active|impersonated|pending|inactive
$status->challenge(); // for example 'email', 'totp', ...
$status->email();     // email address of the active, impersonated or pending authentication
$status->user();      // user object of the currently active or impersonated user
$status->toArray();   // all public information combined in an array
```

- The `$auth->createChallenge()` and `$auth->login2fa()` methods now return the `$auth->status()` object instead of just the challenge type.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
