### PR TITLE
Improved translation fallback handling

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -15,7 +15,7 @@ return [
             return $this->kirby()->auth()->status()->toArray();
         },
         'defaultLanguage' => function () {
-            return $this->kirby()->option('panel.language', 'en');
+            return $this->kirby()->panelLanguage();
         },
         'isOk' => function (System $system) {
             return $system->isOk();
@@ -61,7 +61,7 @@ return [
             if ($user = $this->user()) {
                 $translationCode = $user->language();
             } else {
-                $translationCode = $this->kirby()->option('panel.language', 'en');
+                $translationCode = $this->kirby()->panelLanguage();
             }
 
             if ($translation = $this->kirby()->translation($translationCode)) {

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -41,8 +41,11 @@ class Api extends BaseApi
 
         $allowImpersonation = $this->kirby()->option('api.allowImpersonation', false);
         if ($user = $this->kirby->user(null, $allowImpersonation)) {
-            $this->kirby->setCurrentTranslation($user->language());
+            $translation = $user->language();
+        } else {
+            $translation = $this->kirby->panelLanguage();
         }
+        $this->kirby->setCurrentTranslation($translation);
 
         return parent::call($path, $method, $requestData);
     }

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -57,7 +57,21 @@ trait AppTranslations
 
         I18n::$fallback = function (): array {
             if ($this->multilang() === true) {
-                return [$this->defaultLanguage()->code(), 'en'];
+                // first try to fall back to the configured default language
+                $defaultCode = $this->defaultLanguage()->code();
+                $fallback = [$defaultCode];
+
+                // if the default language is specified with a country code
+                // (e.g. `en-us`), also try with just the language code
+                if (preg_match('/^([a-z]+)-[a-z]+$/i', $defaultCode, $matches) === 1) {
+                    $fallback[] = $matches[1];
+                }
+
+                // fall back to the complete English translation
+                // as a last resort
+                $fallback[] = 'en';
+
+                return $fallback;
             } else {
                 return ['en'];
             }

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -63,7 +63,7 @@ trait AppTranslations
 
                 // if the default language is specified with a country code
                 // (e.g. `en-us`), also try with just the language code
-                if (preg_match('/^([a-z]+)-[a-z]+$/i', $defaultCode, $matches) === 1) {
+                if (preg_match('/^([a-z]{2})-[a-z]+$/i', $defaultCode, $matches) === 1) {
                     $fallback[] = $matches[1];
                 }
 
@@ -103,7 +103,7 @@ trait AppTranslations
 
             // extract the language code from a language that
             // contains the country code (e.g. `en-us`)
-            if (preg_match('/^([a-z]+)-[a-z]+$/i', $defaultCode, $matches) === 1) {
+            if (preg_match('/^([a-z]{2})-[a-z]+$/i', $defaultCode, $matches) === 1) {
                 $defaultCode = $matches[1];
             }
         } else {

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -90,6 +90,30 @@ trait AppTranslations
     }
 
     /**
+     * Returns the language code that will be used
+     * for the Panel if no user is logged in or if
+     * no language is configured for the user
+     *
+     * @return string
+     */
+    public function panelLanguage(): string
+    {
+        if ($this->multilang() === true) {
+            $defaultCode = $this->defaultLanguage()->code();
+
+            // extract the language code from a language that
+            // contains the country code (e.g. `en-us`)
+            if (preg_match('/^([a-z]+)-[a-z]+$/i', $defaultCode, $matches) === 1) {
+                $defaultCode = $matches[1];
+            }
+        } else {
+            $defaultCode = 'en';
+        }
+
+        return $this->option('panel.language', $defaultCode);
+    }
+
+    /**
      * Load and set the current language if it exists
      * Otherwise fall back to the default language
      *

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -400,7 +400,7 @@ class User extends ModelWithContent
      */
     public function language(): string
     {
-        return $this->language ?? $this->language = $this->credentials()['language'] ?? $this->kirby()->option('panel.language', 'en');
+        return $this->language ?? $this->language = $this->credentials()['language'] ?? $this->kirby()->panelLanguage();
     }
 
     /**

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Toolkit\Dir;
+use Kirby\Toolkit\I18n;
 
 class ApiTest extends TestCase
 {
@@ -155,6 +156,118 @@ class ApiTest extends TestCase
         $this->assertSame('de_AT.UTF-8', setlocale(LC_ALL, 0));
 
         $_GET = [];
+    }
+
+    public function testCallTranslation()
+    {
+        // with logged in user with language
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email'    => 'homer@simpsons.com',
+                    'language' => 'fr'
+                ]
+            ]
+        ]);
+        $app->impersonate('homer@simpsons.com');
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('fr', I18n::$locale);
+
+        // with logged in user without language
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com'
+                ]
+            ],
+            'languages' => [
+                [
+                    'code'    => 'it-it',
+                    'default' => true,
+                ]
+            ],
+            'options' => [
+                'panel.language' => 'de'
+            ]
+        ]);
+        $app->impersonate('homer@simpsons.com');
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('de', I18n::$locale);
+
+        // with logged in user without language without Panel language
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com'
+                ]
+            ],
+            'languages' => [
+                [
+                    'code'    => 'it-it',
+                    'default' => true,
+                ]
+            ]
+        ]);
+        $app->impersonate('homer@simpsons.com');
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('it', I18n::$locale);
+
+        // with logged in user without any configuration
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'homer@simpsons.com'
+                ]
+            ]
+        ]);
+        $app->impersonate('homer@simpsons.com');
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('en', I18n::$locale);
+
+        // without logged in user
+        $app = $this->app->clone([
+            'languages' => [
+                [
+                    'code'    => 'it-it',
+                    'default' => true,
+                ]
+            ],
+            'options' => [
+                'panel.language' => 'de'
+            ]
+        ]);
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('de', I18n::$locale);
+
+        // without logged in user without Panel language
+        $app = $this->app->clone([
+            'languages' => [
+                [
+                    'code'    => 'it-it',
+                    'default' => true,
+                ]
+            ]
+        ]);
+
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('it', I18n::$locale);
+
+        // without logged in user without any configuration
+        $app = $this->app->clone();
+        $api = $app->api();
+        $this->assertSame('something', $api->call('foo'));
+        $this->assertSame('en', I18n::$locale);
     }
 
     public function testLanguage()

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -405,4 +405,71 @@ class AppTranslationsTest extends TestCase
         $this->assertSame('de_CH.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
         $this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
     }
+
+    public function testPanelLanguage()
+    {
+        // single-language setup
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+        $this->assertSame('en', $app->panelLanguage());
+
+        // override with the panel.language option
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'panel.language' => 'it'
+            ]
+        ]);
+        $this->assertSame('it', $app->panelLanguage());
+
+        // multi-language setup with a simple default language
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'fr',
+                    'default' => true
+                ]
+            ]
+        ]);
+        $this->assertSame('fr', $app->panelLanguage());
+
+        // multi-language setup with a default language with country code
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'de-ch',
+                    'default' => true
+                ]
+            ]
+        ]);
+        $this->assertSame('de', $app->panelLanguage());
+
+        // override with the panel.language option
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'languages' => [
+                [
+                    'code'    => 'fr',
+                    'default' => true
+                ]
+            ],
+            'options' => [
+                'panel.language' => 'it'
+            ]
+        ]);
+        $this->assertSame('it', $app->panelLanguage());
+    }
 }

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -135,21 +135,40 @@ class AppTranslationsTest extends TestCase
             ],
             'languages' => [
                 [
-                    'code'         => 'en-us',
+                    'code'         => 'de-de',
                     'default'      => true,
                     'translations' => [
-                        'button' => 'Button'
+                        'button1' => 'Knopf1 de-de'
+                    ]
+                ],
+                [
+                    'code'         => 'de-at',
+                    'translations' => [
+                        'button1' => 'Knopf1 de-at'
                     ]
                 ]
             ],
             'translations' => [
                 'de' => [
+                    'button1' => 'Knopf1',
+                    'button2' => 'Knopf2'
                 ]
             ]
         ]);
 
-        I18n::$locale = 'en-us';
-        $this->assertSame('Button', t('button'));
+        I18n::$locale = 'de-de';
+        $this->assertSame('Knopf1 de-de', t('button1'));
+        $this->assertSame('Knopf2', t('button2'));
+        $this->assertSame('Deutsch', t('translation.name'));
+
+        I18n::$locale = 'de-at';
+        $this->assertSame('Knopf1 de-at', t('button1'));
+        $this->assertSame('Knopf2', t('button2'));
+        $this->assertSame('Deutsch', t('translation.name'));
+
+        I18n::$locale = 'en';
+        $this->assertSame('Knopf1 de-de', t('button1'));
+        $this->assertSame('Knopf2', t('button2'));
         $this->assertSame('English', t('translation.name'));
     }
 


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

- The Kirby translation language is now also correctly detected if the configured default site language includes a country code (e.g. `en-us`).
- If `panel.language` is not configured, Kirby now falls back to the default site language before using `en` as a last resort.
- If no user is logged in, the translation in the Panel and API is now consistently determined based on the `panel.language` option or the default site language.

---

Open issue: If a *secondary* language (let's say `de-de`) includes a country code, the chain will now be `de-de`, `en-us`, `en`. Meaning: `de` is not considered by default. I think this would require deeper changes to the code and therefore I left it out for now. Maybe we can rewrite the `I18n` class to use a single `$locale` array instead of a `$locale` string and a `$fallback` array in Kirby 4.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3006
- See the discussion in https://github.com/getkirby/kirby/pull/3021

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
