### PR TITLE
Panel page icons centered correctly for all browsers #2943

### DIFF
--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -73,14 +73,12 @@ export default {
   line-height: 1;
   font-style: normal;
   font-size: 1rem;
-  margin-left: -.3rem;
 }
 
 /* fix emoji alignment on high-res screens */
 @media only screen and (-webkit-min-device-pixel-ratio: 2), not all, not all, not all, only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
   .k-icon-emoji {
     font-size: 1.25rem;
-    margin-left: -.15rem;
   }
 }
 


### PR DESCRIPTION
## Describe the PR

The best solution ever is to remove margins.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2943 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
