### PR TITLE
Date field: fix missing `format` option #3026

### DIFF
--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -106,6 +106,9 @@ return [
                 return Str::upper($this->display);
             }
         },
+        'format' => function () {
+            return $this->props['format'] ?? ($this->time === false ? 'Y-m-d' : 'Y-m-d H:i:s');
+        },
         'time' => function () {
             if ($this->time === false) {
                 return false;
@@ -127,10 +130,6 @@ return [
             return $this->toDatetime($this->value);
         },
     ],
-    'save' => function ($value) {
-        $format = $this->time === false ? 'Y-m-d' : 'Y-m-d H:i:s';
-        return $this->toContent($value, $format);
-    },
     'validations' => [
         'date',
         'minMax' => function ($value) {

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -1,6 +1,14 @@
 <?php
 
 return [
+    'props' => [
+        /**
+         * Defines a custom format that is used when the field is saved
+         */
+        'format' => function (string $format = null) {
+            return $format;
+        }
+    ],
     'methods' => [
         'toDatetime' => function ($value, string $format = 'Y-m-d H:i:s') {
             if ($timestamp = timestamp($value, $this->step)) {
@@ -8,13 +16,13 @@ return [
             }
 
             return null;
-        },
-        'toContent' => function ($value, string $format = 'Y-m-d H:i:s') {
-            if ($value !== null && $timestamp = strtotime($value)) {
-                return date($format, $timestamp);
-            }
-
-            return '';
         }
-    ]
+    ],
+    'save' => function ($value) {
+        if ($value !== null && $timestamp = strtotime($value)) {
+            return date($this->format, $timestamp);
+        }
+
+        return '';
+    },
 ];

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -95,13 +95,13 @@ return [
 
             return $this->notation === 24 ? 'HH:mm' : 'h:mm a';
         },
+        'format' => function () {
+            return $this->props['format'] ?? 'H:i:s';
+        },
         'value' => function () {
             return $this->toDatetime($this->value, 'H:i:s');
         }
     ],
-    'save' => function ($value): string {
-        return $this->toContent($value, 'H:i:s');
-    },
     'validations' => [
         'time',
         'minMax' => function ($value) {


### PR DESCRIPTION
## Describe the PR

During the development the development of the new date fields, I got to a point where the old `format` option conflicted with the new `display` option. Therefore, we removed `format` from 3.5.0 as breaking change. But upon reviewing the final version of the new date field, it has become clear to me that the breaking change is actually not necessary anymore.

This PR re-implements the `format` option.

Thanks to @renestalder for pointing this out.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3026

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
