### PR TITLE
Fixes broken `flag` prop of k-card and k-list-item

### DIFF
--- a/panel/src/components/Layout/Card.vue
+++ b/panel/src/components/Layout/Card.vue
@@ -19,9 +19,15 @@
     </component>
 
     <nav class="k-card-options">
-      <k-status-icon
+      <k-button
         v-if="flag"
         v-bind="flag"
+        class="k-card-options-button"
+        @click="flag.click"
+      />
+      <k-status-icon
+        v-if="pageFlag"
+        v-bind="pageFlag"
         class="k-card-options-button"
       />
       <slot name="options">
@@ -52,6 +58,7 @@ export default {
   props: {
     column: String,
     flag: Object,
+    pageFlag: Object,
     icon: {
       type: Object,
       default() {

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -17,12 +17,12 @@
       </span>
     </k-link>
     <nav class="k-list-item-options">
+      <k-status-icon
+        v-if="flag"
+        v-bind="flag"
+        class="k-list-item-status"
+      />
       <slot name="options">
-        <k-status-icon
-          v-if="flag"
-          v-bind="flag"
-          class="k-list-item-status"
-        />
         <k-button
           v-if="options"
           :tooltip="$t('options')"

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -17,9 +17,15 @@
       </span>
     </k-link>
     <nav class="k-list-item-options">
-      <k-status-icon
+      <k-button
         v-if="flag"
         v-bind="flag"
+        class="k-list-item-status"
+        @click="flag.click"
+      />
+      <k-status-icon
+        v-if="pageFlag"
+        v-bind="pageFlag"
         class="k-list-item-status"
       />
       <slot name="options">
@@ -68,6 +74,7 @@ export default {
     info: String,
     link: [String, Function],
     flag: Object,
+    pageFlag: Object,
     options: [Array, Function]
   },
   computed: {

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -168,7 +168,7 @@ export default {
       return data.map(page => {
         const isEnabled = page.permissions.changeStatus !== false;
 
-        page.flag = {
+        page.pageFlag = {
           status: page.status,
           tooltip: this.$t("page.status"),
           disabled: !isEnabled,


### PR DESCRIPTION
## Describe the PR

Proposition for fixing #3033 by:
- changing flag prop to `pageFlag` and use it in `k-status-icon`
- re-introducing the flag prop as `k-button` as it was pre 7ded08b89ef6066beafb243cf86bc23e0a129cce

## Related issues

This PR fixes #3033 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
