### PR TITLE
Improves `Cookie::forever()` method for 32-bit servers #2968

### DIFF
--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -98,7 +98,8 @@ class Cookie
      */
     public static function forever(string $key, string $value, array $options = []): bool
     {
-        $options['lifetime'] = 253402214400; // 9999-12-31
+        // 9999-12-31 if supported (lower on 32-bit servers)
+        $options['lifetime'] = min(253402214400, PHP_INT_MAX);
         return static::set($key, $value, $options);
     }
 

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -8,28 +8,28 @@ class CookieTest extends TestCase
 {
     public function testKey()
     {
-        $this->assertEquals('KirbyHttpCookieKey', Cookie::$key);
+        $this->assertSame('KirbyHttpCookieKey', Cookie::$key);
         Cookie::$key = 'KirbyToolkitCookieKey';
-        $this->assertEquals('KirbyToolkitCookieKey', Cookie::$key);
+        $this->assertSame('KirbyToolkitCookieKey', Cookie::$key);
     }
 
     public function testLifetime()
     {
-        $this->assertEquals(12345678901, Cookie::lifetime(12345678901));
-        $this->assertEquals((600 + time()), Cookie::lifetime(10));
-        $this->assertEquals(0, Cookie::lifetime(-10));
+        $this->assertSame(253402214400, Cookie::lifetime(253402214400));
+        $this->assertSame((600 + time()), Cookie::lifetime(10));
+        $this->assertSame(0, Cookie::lifetime(-10));
     }
 
     public function testSet()
     {
         Cookie::set('foo', 'bar');
-        $this->assertEquals('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['foo']);
+        $this->assertSame('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['foo']);
     }
 
     public function testForever()
     {
         Cookie::forever('forever', 'bar');
-        $this->assertEquals('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['forever']);
+        $this->assertSame('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['forever']);
         $this->assertTrue(Cookie::exists('forever'));
     }
 
@@ -48,41 +48,41 @@ class CookieTest extends TestCase
 
     public function testGet()
     {
-        $this->assertEquals('bar', Cookie::get('foo'));
-        $this->assertEquals('some amazing default', Cookie::get('does_not_exist', 'some amazing default'));
-        $this->assertEquals($_COOKIE, Cookie::get());
+        $this->assertSame('bar', Cookie::get('foo'));
+        $this->assertSame('some amazing default', Cookie::get('does_not_exist', 'some amazing default'));
+        $this->assertSame($_COOKIE, Cookie::get());
     }
 
     public function testParse()
     {
         // valid
         $_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
-        $this->assertEquals('bar', Cookie::get('foo'));
+        $this->assertSame('bar', Cookie::get('foo'));
 
         // no value
         $_COOKIE['foo'] = '21fdd6d0d6f5b4ac8109e5f2d0c3f0f7e8e89492+';
-        $this->assertEquals('', Cookie::get('foo'));
+        $this->assertSame('', Cookie::get('foo'));
         $_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
-        $this->assertEquals('bar', Cookie::get('foo'));
+        $this->assertSame('bar', Cookie::get('foo'));
 
         // value with a plus sign
         $_COOKIE['foo'] = '9c8c403efa31d4e4598d75e9c394b48255b65154+bar+baz';
-        $this->assertEquals('bar+baz', Cookie::get('foo'));
+        $this->assertSame('bar+baz', Cookie::get('foo'));
 
         // separator missing
         $_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85';
-        $this->assertEquals(null, Cookie::get('foo'));
+        $this->assertSame(null, Cookie::get('foo'));
         $_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
-        $this->assertEquals('bar', Cookie::get('foo'));
+        $this->assertSame('bar', Cookie::get('foo'));
 
         // no hash
         $_COOKIE['foo'] = '+bar';
-        $this->assertEquals(null, Cookie::get('foo'));
+        $this->assertSame(null, Cookie::get('foo'));
         $_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
-        $this->assertEquals('bar', Cookie::get('foo'));
+        $this->assertSame('bar', Cookie::get('foo'));
 
         // wrong hash
         $_COOKIE['foo'] = '040df854f89c9f9ca3490fb950c91ad9aa304c97+bar';
-        $this->assertEquals(null, Cookie::get('foo'));
+        $this->assertSame(null, Cookie::get('foo'));
     }
 }


### PR DESCRIPTION
## Describe the PR

Since we do not have a test facility on a 32-bit server, I had to do the test without using the `forever()` method.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2968

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
