### PR TITLE
Fix types of `page/s()` helper and `$kirby->page()`

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -551,12 +551,17 @@ function option(string $key, $default = null)
  * id or the current page when no id is specified
  *
  * @param string|array ...$id
- * @return \Kirby\Cms\Page|null
+ * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
+ * @todo reduce to one parameter in 3.7.0 (also change return type)
  */
 function page(...$id)
 {
     if (empty($id) === true) {
         return App::instance()->site()->page();
+    }
+
+    if (count($id) > 1) {
+        deprecated('Passing multiple parameters to the `page()` helper has been deprecated. Please use the `pages()` helper instead.');
     }
 
     return App::instance()->site()->find(...$id);
@@ -566,7 +571,7 @@ function page(...$id)
  * Helper to build page collections
  *
  * @param string|array ...$id
- * @return \Kirby\Cms\Pages
+ * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
  */
 function pages(...$id)
 {

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -552,7 +552,7 @@ function option(string $key, $default = null)
  *
  * @param string|array ...$id
  * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
- * @todo reduce to one parameter in 3.7.0 (also change return type)
+ * @todo reduce to one parameter in 3.7.0 (also change return and return type)
  */
 function page(...$id)
 {
@@ -561,7 +561,9 @@ function page(...$id)
     }
 
     if (count($id) > 1) {
+        // @codeCoverageIgnoreStart
         deprecated('Passing multiple parameters to the `page()` helper has been deprecated. Please use the `pages()` helper instead.');
+        // @codeCoverageIgnoreEnd
     }
 
     return App::instance()->site()->find(...$id);
@@ -572,9 +574,16 @@ function page(...$id)
  *
  * @param string|array ...$id
  * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
+ * @todo return only Pages|null in 3.7.0, wrap in Pages for single passed id
  */
 function pages(...$id)
 {
+    if (count($id) === 1) {
+        // @codeCoverageIgnoreStart
+        deprecated('Passing a single id to the `pages()` helper will return a Kirby\Cms\Pages collection with a single element instead of the single Kirby\Cms\Page object itself - starting in 3.7.0.');
+        // @codeCoverageIgnoreEnd
+    }
+
     return App::instance()->site()->find(...$id);
 }
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -996,6 +996,10 @@ class App
         $parent = $parent ?? $this->site();
 
         if ($page = $parent->find($id)) {
+            /**
+             * We passed a single $id, we can be sure that the result is
+             * @var \Kirby\Cms\Page $page
+             */
             return $page;
         }
 


### PR DESCRIPTION
## Status: ready for review 👀

- Fixes types for `page()`/`pages()` helpers
- Prepares to make their functionality much stricter

## Breaking changes 
- `page()` will now throw a deprecation warning if multiple IDs get passed (suggests to use `pages()`)
- `pages()` will now throw a deprecation warning if single ID get passed (suggests to use `page()`)
- Actual removal of functionality planned for 3.7.0

## When merging
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add breaking changes to [release notes draft](https://github.com/getkirby/kirby/releases)