### PR TITLE
Avoid invalid content types for missing representations

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1101,6 +1101,7 @@ class App
         if ($page) {
             try {
                 $response = $this->response();
+                $output   = $page->render([], $extension);
 
                 // attach a MIME type based on the representation
                 // only if no custom MIME type was set
@@ -1108,7 +1109,7 @@ class App
                     $response->type($extension);
                 }
 
-                return $response->body($page->render([], $extension));
+                return $response->body($output);
             } catch (NotFoundException $e) {
                 return null;
             }

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -259,4 +259,27 @@ class AppResolveTest extends TestCase
         $this->assertEquals('xml', $result->body());
         $this->assertEquals('en', $app->language()->code());
     }
+
+    public function testRepresentationErrorType()
+    {
+        $this->app = new App([
+            'templates' => [
+                'blog' => __DIR__ . '/fixtures/templates/test.php',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'blog',
+                        'template' => 'blog'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertNull($this->app->resolve('blog.php'));
+
+        // there must be no forced php response type if the
+        // representation cannot be found
+        $this->assertNull($this->app->response()->type());
+    }
 }

--- a/tests/Cms/App/fixtures/templates/test.php
+++ b/tests/Cms/App/fixtures/templates/test.php
@@ -1,0 +1,1 @@
+Just an empty template

--- a/tests/Cms/Pages/PageTemplateTest.php
+++ b/tests/Cms/Pages/PageTemplateTest.php
@@ -106,4 +106,27 @@ class PageTemplateTest extends TestCase
         $page = $this->app->page('with-template');
         $page->representation('xml');
     }
+
+    public function testRepresentationErrorType()
+    {
+        $this->app = new App([
+            'templates' => [
+                'blog' => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'blog',
+                        'template' => 'blog'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->app->resolve('blog.php');
+
+        // there must be no forced php response type if the
+        // represenation cannot be found
+        $this->assertNull($this->app->response()->type());
+    }
 }

--- a/tests/Cms/Pages/PageTemplateTest.php
+++ b/tests/Cms/Pages/PageTemplateTest.php
@@ -106,27 +106,4 @@ class PageTemplateTest extends TestCase
         $page = $this->app->page('with-template');
         $page->representation('xml');
     }
-
-    public function testRepresentationErrorType()
-    {
-        $this->app = new App([
-            'templates' => [
-                'blog' => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-            ],
-            'site' => [
-                'children' => [
-                    [
-                        'slug' => 'blog',
-                        'template' => 'blog'
-                    ]
-                ]
-            ]
-        ]);
-
-        $this->app->resolve('blog.php');
-
-        // there must be no forced php response type if the
-        // represenation cannot be found
-        $this->assertNull($this->app->response()->type());
-    }
 }


### PR DESCRIPTION
## Describe the PR

When a content representation cannot be found, the App::resolve method still set the wrong content type according to the given extension. Of course this can lead to unwanted side-effects. (see issue) 

## Related issues

- Fixes #2924

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`