### PR TITLE
Fix Apcu detection

### DIFF
--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -13,7 +13,10 @@ class ApcuCacheTest extends TestCase
 {
     public function setUp(): void
     {
-        if (function_exists('apcu_store') === false) {
+        if (
+            function_exists('apcu_enabled') === false ||
+            apcu_enabled() === false
+        ) {
             $this->markTestSkipped('APCu is not available.');
             return;
         }


### PR DESCRIPTION
In my setup, somehow `apcu_store()` did exist, but APCU still wasn't enabled. Thus, `apcu_enabled()` and others would simply return `false`. This check should be more reliable.