### PR TITLE
Fix `F::rename` overwriting

### DIFF
--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -588,7 +588,7 @@ class F
             return $newRoot;
         }
 
-        if (F::move($file, $newRoot) !== true) {
+        if (F::move($file, $newRoot, $overwrite) !== true) {
             return false;
         }
 

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -368,6 +368,42 @@ class FTest extends TestCase
         $this->assertFileDoesNotExist($c);
     }
 
+    public function testRename()
+    {
+        F::write($this->tmp, 'test');
+
+        // simply rename file
+        $this->assertFalse(file_exists($this->moved));
+        $this->assertTrue(file_exists($this->tmp));
+
+        $this->assertSame($this->moved, F::rename($this->tmp, 'moved'));
+
+        $this->assertTrue(file_exists($this->moved));
+        $this->assertFalse(file_exists($this->tmp));
+
+        // rename file with same name
+
+        $this->assertTrue(file_exists($this->moved));
+        $this->assertFalse(file_exists($this->tmp));
+
+        $this->assertSame($this->moved, F::rename($this->moved, 'moved'));
+        $this->assertSame($this->moved, F::rename($this->moved, 'moved', true));
+
+        $this->assertTrue(file_exists($this->moved));
+        $this->assertFalse(file_exists($this->tmp));
+
+        // replace file via renaming
+        F::copy($this->moved, $this->tmp);
+
+        $this->assertTrue(file_exists($this->moved));
+        $this->assertTrue(file_exists($this->tmp));
+
+        $this->assertFalse(F::rename($this->moved, 'test'));
+        $this->assertSame($this->tmp, F::rename($this->moved, 'test', true));
+
+        $this->assertFalse(file_exists($this->moved));
+        $this->assertTrue(file_exists($this->tmp));
+    }
 
     public function testSafeName()
     {


### PR DESCRIPTION
`F::rename()` wasn't passing it's `$overwrite` parameter to `F::move()`