### PR TITLE
Activate and fix PHPMD LongVariable rule

### DIFF
--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -49,7 +49,6 @@
 
         <!-- Temporarily disabled for step-by-step refactoring/suppression -->
         <exclude name="ShortVariable" />
-        <exclude name="LongVariable" />
         <exclude name="ShortMethodName" />
     </rule>
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -50,7 +50,7 @@ class I18n
      *
      * @var array
      */
-    protected static $decimalNumberFormatters = [];
+    protected static $decimalsFormatters = [];
 
     /**
      * Returns the first fallback locale
@@ -246,15 +246,15 @@ class I18n
      */
     protected static function decimalNumberFormatter(string $locale): ?NumberFormatter
     {
-        if (isset(static::$decimalNumberFormatters[$locale])) {
-            return static::$decimalNumberFormatters[$locale];
+        if (isset(static::$decimalsFormatters[$locale])) {
+            return static::$decimalsFormatters[$locale];
         }
 
         if (extension_loaded('intl') !== true || class_exists('NumberFormatter') !== true) {
             return null; // @codeCoverageIgnore
         }
 
-        return static::$decimalNumberFormatters[$locale] = new NumberFormatter($locale, NumberFormatter::DECIMAL);
+        return static::$decimalsFormatters[$locale] = new NumberFormatter($locale, NumberFormatter::DECIMAL);
     }
 
     /**


### PR DESCRIPTION
Since it's a protected static property, this shouldn't be a breaking change, right?