### PR TITLE
Fix some return types

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -139,7 +139,7 @@ class Page extends ModelWithContent
     /**
      * The intended page template
      *
-     * @var string
+     * @var \Kirby\Cms\Template
      */
     protected $template;
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -533,6 +533,8 @@ trait PageActions
                 $lang   = $this->kirby()->defaultLanguage() ?? null;
                 $field  = $this->content($lang)->get('date');
                 $date   = $field->isEmpty() ? 'now' : $field;
+                // TODO: in 3.6.0 throw an error if date() doesn't
+                // return a number, see https://github.com/getkirby/kirby/pull/3061#discussion_r552783943
                 return (int)date($format, strtotime($date));
                 break;
             case 'default':

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -533,7 +533,7 @@ trait PageActions
                 $lang   = $this->kirby()->defaultLanguage() ?? null;
                 $field  = $this->content($lang)->get('date');
                 $date   = $field->isEmpty() ? 'now' : $field;
-                return date($format, strtotime($date));
+                return (int)date($format, strtotime($date));
                 break;
             case 'default':
 

--- a/src/Image/Location.php
+++ b/src/Image/Location.php
@@ -95,7 +95,7 @@ class Location
         $parts = explode('/', $part);
 
         if (count($parts) === 1) {
-            return $parts[0];
+            return (float)$parts[0];
         }
 
         return (float)($parts[0]) / (float)($parts[1]);

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -597,7 +597,7 @@ class A
      */
     public static function isAssociative(array $array): bool
     {
-        return ctype_digit(implode(null, array_keys($array))) === false;
+        return ctype_digit(implode('', array_keys($array))) === false;
     }
 
     /**

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -525,7 +525,7 @@ class F
      * Converts an integer size into a human readable format
      *
      * @param mixed $size The file size or a file path
-     * @return string|int
+     * @return string
      */
     public static function niceSize($size): string
     {

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -129,7 +129,7 @@ class Iterator implements IteratorAggregate
      * Tries to find the index number for the given element
      *
      * @param mixed $needle the element to search for
-     * @return string|false the name of the key or false
+     * @return int|false the index (int) of the element or false
      */
     public function indexOf($needle)
     {

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -196,7 +196,7 @@ class Pagination
             return 0;
         }
 
-        return ceil($this->total() / $this->limit());
+        return (int)ceil($this->total() / $this->limit());
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -410,7 +410,7 @@ class Str
      */
     public static function isURL(string $string = null): bool
     {
-        return filter_var($string, FILTER_VALIDATE_URL);
+        return filter_var($string, FILTER_VALIDATE_URL) !== false;
     }
 
     /**


### PR DESCRIPTION
- `PageActions:: createNum()` should always return `int`, so we need to type cast the result of `date()`
- `Location::num()` should also be type casted to a `float` if only one part exist
- `F:: niceSize()` never returns an `int`, always just `string`
- `Iterator::indexOf()`always returns the `int` index position (or false) but never a string key of an associative array, since we use `array_key()`. This has been the behavior so far, so we're only fixing the description.
- Pagination: `ceil()` still returns a `float`, so we need to cast it to an `int`
- `Str::isUrl()`: `filter_var` will return `false` or the value - so we need to explicitly check that the return is not `false`