### PR TITLE
Automatically generates language locale code #2427

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -38,6 +38,14 @@ return [
         'license' => function (System $system) {
             return $system->license();
         },
+        'locales' => function () {
+            $locales = [];
+            $translations = $this->kirby()->translations();
+            foreach ($translations as $translation) {
+                $locales[$translation->code()] = $translation->locale();
+            }
+            return $locales;
+        },
         'loginMethods' => function (System $system) {
             return array_keys($system->loginMethods());
         },
@@ -114,6 +122,7 @@ return [
             'kirbytext',
             'languages',
             'license',
+            'locales',
             'multilang',
             'requirements',
             'site',

--- a/panel/src/components/Dialogs/LanguageCreateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageCreateDialog.vue
@@ -15,6 +15,7 @@ export default {
   mixins: [DialogMixin],
   data() {
     return {
+      languages: [],
       language: {
         name: "",
         code: "",
@@ -53,8 +54,7 @@ export default {
         },
         locale: {
           label: this.$t("language.locale"),
-          type: "text",
-          placeholder: "en_US"
+          type: "text"
         },
       };
     },
@@ -68,9 +68,35 @@ export default {
     },
     "language.code"(code) {
       this.language.code = this.$helper.slug(code, [this.system.ascii]);
+      this.onCodeChanges(this.language.code);
     }
   },
   methods: {
+    onCodeChanges(code) {
+      if (!code) {
+        return this.language.locale = null;
+      }
+
+      if (code.length >= 2) {
+        // if the locale value entered has a hyphen
+        // it divides the text and capitalizes the hyphen after it
+        // code: en-us > locale: en_US
+        if (code.indexOf("-") !== -1) {
+          let segments = code.split("-");
+          let locale = [segments[0], segments[1].toUpperCase()];
+          this.language.locale = locale.join("_");
+        } else {
+          // if the entered language code exists
+          // matches the locale values in the languages defined in the system
+          let locales = this.$store.state.system.info.locales || [];
+          if (locales && locales[code]) {
+            this.language.locale = locales[code];
+          } else {
+            this.language.locale = null;
+          }
+        }
+      }
+    },
     onNameChanges(name) {
       this.language.code = this.$helper.slug(name, [this.language.rules, this.system.ascii]).substr(0, 2);
     },

--- a/panel/src/components/Dialogs/LanguageCreateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageCreateDialog.vue
@@ -15,7 +15,6 @@ export default {
   mixins: [DialogMixin],
   data() {
     return {
-      languages: [],
       language: {
         name: "",
         code: "",


### PR DESCRIPTION
## Describe the PR

Instead of helps text, I tried to find and set the locale value automatically. 
If it is acceptable, we can complete a few missings and merge the PR.

**Setting Locale Process**
 - If it contains hyphens, divide it by two and capitalize after the hyphen.
 - Otherwise, match it with the local values defined in the system with new `locales` system info.

What do yo think? @bastianallgeier @texnixe @distantnative @lukasbestle 

## Screencast

![locale](https://user-images.githubusercontent.com/3393422/103831339-e9051500-508c-11eb-8719-e491dc81cb86.gif)

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2427 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
