### PR TITLE
Support 12-columns layout field for panel ui

### DIFF
--- a/panel/src/components/Layout/Column.vue
+++ b/panel/src/components/Layout/Column.vue
@@ -30,33 +30,53 @@ export default {
   .k-column[data-width="2/2"],
   .k-column[data-width="3/3"],
   .k-column[data-width="4/4"],
-  .k-column[data-width="6/6"] {
+  .k-column[data-width="6/6"],
+  .k-column[data-width="12/12"] {
     grid-column-start: span 12;
+  }
+  .k-column[data-width="11/12"] {
+    grid-column-start: span 11;
+  }
+  .k-column[data-width="5/6"],
+  .k-column[data-width="10/12"] {
+    grid-column-start: span 10;
+  }
+  .k-column[data-width="3/4"],
+  .k-column[data-width="9/12"] {
+    grid-column-start: span 9;
+  }
+  .k-column[data-width="2/3"],
+  .k-column[data-width="4/6"],
+  .k-column[data-width="8/12"] {
+    grid-column-start: span 8;
+  }
+  .k-column[data-width="7/12"] {
+    grid-column-start: span 7;
   }
   .k-column[data-width="1/2"],
   .k-column[data-width="2/4"],
-  .k-column[data-width="3/6"] {
+  .k-column[data-width="3/6"],
+  .k-column[data-width="6/12"] {
     grid-column-start: span 6;
   }
+  .k-column[data-width="5/12"] {
+    grid-column-start: span 5;
+  }
   .k-column[data-width="1/3"],
-  .k-column[data-width="2/6"] {
+  .k-column[data-width="2/6"],
+  .k-column[data-width="4/12"] {
     grid-column-start: span 4;
   }
-  .k-column[data-width="2/3"],
-  .k-column[data-width="4/6"] {
-    grid-column-start: span 8;
-  }
-  .k-column[data-width="1/4"] {
+  .k-column[data-width="1/4"],
+  .k-column[data-width="3/12"] {
     grid-column-start: span 3;
   }
-  .k-column[data-width="1/6"] {
+  .k-column[data-width="1/6"],
+  .k-column[data-width="2/12"] {
     grid-column-start: span 2;
   }
-  .k-column[data-width="5/6"] {
-    grid-column-start: span 10;
-  }
-  .k-column[data-width="3/4"] {
-    grid-column-start: span 9;
+  .k-column[data-width="1/12"] {
+    grid-column-start: span 1;
   }
 }
 


### PR DESCRIPTION
## Describe the PR

Adds missing 12-columns support to layout field for panel ui.

Sample Blueprint

````yaml
fields:
  layout:
    label: Layout
    type: layout
    layouts:
      - "12/12"
      - "1/12, 11/12"
      - "2/12, 10/12"
      - "3/12, 9/12"
      - "4/12, 8/12"
      - "5/12, 7/12"
      - "6/12, 6/12"
      - "1/12, 2/12, 3/12, 6/12"
      - "9/12, 1/12, 1/12, 1/12"
      - "1/4, 3/12, 1/3, 2/12"
````

Screenshot

![screen-capture-595-About us - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/103864773-39ec2c00-50d4-11eb-9175-32b443806e1d.png)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
