### PR TITLE
Don’t let the pagination element shrink #3027

### DIFF
--- a/panel/src/components/Layout/Collection.vue
+++ b/panel/src/components/Layout/Collection.vue
@@ -159,6 +159,7 @@ export default {
 }
 .k-collection-pagination {
   line-height: 1.25rem;
+  flex-shrink: 0;
   min-height: 2.75rem;
 }
 .k-collection-pagination .k-pagination .k-button {


### PR DESCRIPTION
## Describe the PR

A small CSS fix to avoid a shrinking pagination element that wraps the pagination arrows. 

## Related issues

- Fixes #3027 