### PR TITLE
Support blocks in field queries #2977

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -29,6 +29,7 @@ class Options
         return [
             'Kirby\Cms\File'            => 'file',
             'Kirby\Toolkit\Obj'         => 'arrayItem',
+            'Kirby\Cms\Block'           => 'block',
             'Kirby\Cms\Page'            => 'page',
             'Kirby\Cms\StructureObject' => 'structureItem',
             'Kirby\Cms\User'            => 'user',
@@ -169,6 +170,7 @@ class Options
         // default text setup
         $text = [
             'arrayItem'     => '{{ arrayItem.value }}',
+            'block'         => '{{ block.type }}: {{ block.id }}',
             'file'          => '{{ file.filename }}',
             'page'          => '{{ page.title }}',
             'structureItem' => '{{ structureItem.title }}',
@@ -178,6 +180,7 @@ class Options
         // default value setup
         $value = [
             'arrayItem'     => '{{ arrayItem.value }}',
+            'block'         => '{{ block.id }}',
             'file'          => '{{ file.id }}',
             'page'          => '{{ page.id }}',
             'structureItem' => '{{ structureItem.id }}',

--- a/tests/Form/OptionsTest.php
+++ b/tests/Form/OptionsTest.php
@@ -102,6 +102,71 @@ class OptionsTest extends TestCase
         $this->assertEquals($expected, $options);
     }
 
+    public function testBlocks()
+    {
+        $app = new App([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'a',
+                        'content' => [
+                            'text' => json_encode([
+                                [
+                                    'id' => 'a',
+                                    'content' => [
+                                        'text' => 'Test Heading',
+                                    ],
+                                    'type' => 'heading',
+                                ],
+                                [
+                                    'id' => 'b',
+                                    'content' => [
+                                        'text' => 'Test Text',
+                                    ],
+                                    'type' => 'text',
+                                ]
+                            ])
+                        ]
+                    ],
+                ]
+            ]
+        ]);
+
+        // with query
+        $result = Options::query('site.find("a").text.toBlocks');
+
+        $expected = [
+            [
+                'text'  => 'heading: a',
+                'value' => 'a'
+            ],
+            [
+                'text'  => 'text: b',
+                'value' => 'b'
+            ]
+        ];
+
+        $this->assertSame($expected, $result);
+
+        // with array query
+        $result = Options::query([
+            'fetch' => 'site.find("a").text.toBlocks',
+            'text'  => '{{ block.text }}',
+            'value' => '{{ block.id }}',
+        ]);
+
+        $this->assertSame([
+            [
+                'text'  => 'Test Heading',
+                'value' => 'a'
+            ],
+            [
+                'text'  => 'Test Text',
+                'value' => 'b'
+            ]
+        ], $result);
+    }
+
     public function testPages()
     {
         $app = new App([


### PR DESCRIPTION
## Describe the PR

Blocks are now support in field queries. I.e. 

```
fetch: page.text.toBlocks
text: "{{ block.type }}" 
value: "{{ block.id }}"
```

## Related issues

- Fixes #2977

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`