### PR TITLE
 Deactivate the replace action if files cannot be replaced #3031

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -520,7 +520,7 @@ class File extends ModelWithContent
      */
     public function panelOptions(array $unlock = []): array
     {
-        $options = parent::panelOptions();
+        $options = parent::panelOptions($unlock);
 
         try {
             /**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -520,11 +520,8 @@ class File extends ModelWithContent
         $options = parent::panelOptions($unlock);
 
         try {
-            /**
-             * check if the file type is allowed
-             * at all. Otherwise it cannot be
-             * replaced.
-             */
+            // check if the file type is allowed at all,
+            // otherwise it cannot be replaced
             $this->match($this->blueprint()->accept());
         } catch (Throwable $e) {
             $options['replace'] = false;

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Image\Image;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\F;
+use Throwable;
 
 /**
  * The `$file` object provides a set
@@ -502,6 +503,37 @@ class File extends ModelWithContent
         }
 
         return parent::panelImageSource($query);
+    }
+
+    /**
+     * Returns an array of all actions
+     * that can be performed in the Panel
+     *
+     * This also checks for the lock status
+     * @since 3.3.0
+     *
+     * and matching accept settings
+     * @since 3.5.1
+     *
+     * @param array $unlock An array of options that will be force-unlocked
+     * @return array
+     */
+    public function panelOptions(array $unlock = []): array
+    {
+        $options = parent::panelOptions();
+
+        try {
+            /**
+             * check if the file type is allowed
+             * at all. Otherwise it cannot be
+             * replaced.
+             */
+            $this->match($this->blueprint()->accept());
+        } catch (Throwable $e) {
+            $options['replace'] = false;
+        }
+
+        return $options;
     }
 
     /**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -509,11 +509,8 @@ class File extends ModelWithContent
      * Returns an array of all actions
      * that can be performed in the Panel
      *
-     * This also checks for the lock status
-     * @since 3.3.0
-     *
-     * and matching accept settings
-     * @since 3.5.1
+     * @since 3.3.0 This also checks for the lock status
+     * @since 3.5.1 This also checks for matching accept settings
      *
      * @param array $unlock An array of options that will be force-unlocked
      * @return array

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -161,7 +161,7 @@ class FileTest extends TestCase
                             if ($file->extension() === 'heic') {
                                 return sprintf('![](%s)', $url);
                             }
-                    
+
                             return null;
                         },
                     ]
@@ -208,7 +208,7 @@ class FileTest extends TestCase
                             if ($file->extension() === 'heic') {
                                 return sprintf('(image: %s)', $url);
                             }
-                    
+
                             return null;
                         },
                     ]
@@ -544,6 +544,87 @@ class FileTest extends TestCase
         ];
 
         $this->assertEquals($expected, $file->panelOptions(['delete']));
+    }
+
+    public function testPanelOptionsDefaultReplaceOption()
+    {
+        $file = new File([
+            'filename' => 'test.js',
+        ]);
+        $file->kirby()->impersonate('kirby');
+
+        $expected = [
+            'changeName' => true,
+            'create'     => true,
+            'delete'     => true,
+            'read'       => true,
+            'replace'    => false,
+            'update'     => true,
+        ];
+
+        $this->assertSame($expected, $file->panelOptions());
+    }
+
+    public function testPanelOptionsAllowedReplaceOption()
+    {
+        new App([
+            'blueprints' => [
+                'files/test' => [
+                    'name'   => 'test',
+                    'accept' => true
+                ]
+            ]
+        ]);
+
+        $file = new File([
+            'filename' => 'test.js',
+            'template' => 'test',
+        ]);
+
+        $file->kirby()->impersonate('kirby');
+
+        $expected = [
+            'changeName' => true,
+            'create'     => true,
+            'delete'     => true,
+            'read'       => true,
+            'replace'    => true,
+            'update'     => true,
+        ];
+
+        $this->assertSame($expected, $file->panelOptions());
+    }
+
+    public function testPanelOptionsDisabledReplaceOption()
+    {
+        new App([
+            'blueprints' => [
+                'files/test' => [
+                    'name'   => 'test',
+                    'accept' => [
+                        'type' => 'image'
+                    ]
+                ]
+            ]
+        ]);
+
+        $file = new File([
+            'filename' => 'test.js',
+            'template' => 'test',
+        ]);
+
+        $file->kirby()->impersonate('kirby');
+
+        $expected = [
+            'changeName' => true,
+            'create'     => true,
+            'delete'     => true,
+            'read'       => true,
+            'replace'    => false,
+            'update'     => true,
+        ];
+
+        $this->assertSame($expected, $file->panelOptions());
     }
 
     public function testPanelUrl()


### PR DESCRIPTION
## Describe the PR

The accept option in the file blueprint is now checked for the file option menu and the replace button is disabled if a file cannot be re-uploaded/replaced

## Related issues

- Fixes #3031

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
