### PR TITLE
Automatic fallback for email security = true #2896

### DIFF
--- a/src/Email/PHPMailer.php
+++ b/src/Email/PHPMailer.php
@@ -73,6 +73,24 @@ class PHPMailer extends Email
             $mailer->Password   = $this->transport()['password'] ?? null;
             $mailer->SMTPSecure = $this->transport()['security'] ?? 'ssl';
             $mailer->Port       = $this->transport()['port'] ?? null;
+
+            if ($mailer->SMTPSecure === true) {
+                switch ($mailer->Port) {
+                    case null:
+                    case 587:
+                        $mailer->SMTPSecure = 'tls';
+                        $mailer->Port = 587;
+                        break;
+                    case 465:
+                        $mailer->SMTPSecure = 'ssl';
+                        break;
+                    default:
+                        throw new InvalidArgumentException(
+                            'Could not automatically detect the "security" protocol from the ' .
+                            '"port" option, please set it explicitly to "tls" or "ssl".'
+                        );
+                }
+            }
         }
 
         // accessible phpMailer instance

--- a/tests/Email/PHPMailerTest.php
+++ b/tests/Email/PHPMailerTest.php
@@ -47,6 +47,7 @@ class PHPMailerTest extends TestCase
             ],
             'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
                 $phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
+                $phpunit->assertSame('mail', $mailer->Mailer);
                 $phpunit->assertSame('no-reply@supercompany.com', $mailer->From);
                 $phpunit->assertSame('Super Company NoReply', $mailer->FromName);
                 $phpunit->assertSame([['someone@gmail.com', '']], $mailer->getToAddresses());
@@ -85,5 +86,162 @@ class PHPMailerTest extends TestCase
         $email->send(true);
         $this->assertTrue($email->isSent());
         $this->assertTrue($beforeSend);
+    }
+
+    public function testBeforeSendInvalid()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('"beforeSend" option return should be instance of PHPMailer\PHPMailer\PHPMailer class');
+
+        $email = $this->_email([
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request',
+            'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) {
+                return 'yay';
+            }
+        ], PHPMailer::class);
+
+        $this->assertFalse($email->isSent());
+        $email->send(true);
+    }
+
+    public function testSMTPTransportDefaults()
+    {
+        $phpunit = $this;
+        $beforeSend = false;
+
+        $email = $this->_email([
+            'transport' => [
+                'type' => 'smtp'
+            ],
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request',
+            'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
+                $phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
+                $phpunit->assertSame('smtp', $mailer->Mailer);
+                $phpunit->assertSame(null, $mailer->Host);
+                $phpunit->assertSame(false, $mailer->SMTPAuth);
+                $phpunit->assertSame(null, $mailer->Username);
+                $phpunit->assertSame(null, $mailer->Password);
+                $phpunit->assertSame('ssl', $mailer->SMTPSecure);
+                $phpunit->assertSame(null, $mailer->Port);
+
+                $beforeSend = true;
+            }
+        ], PHPMailer::class);
+
+        $this->assertFalse($beforeSend);
+        $this->assertFalse($email->isSent());
+        $email->send(true);
+        $this->assertTrue($email->isSent());
+        $this->assertTrue($beforeSend);
+    }
+
+    public function testSMTPTransportSecurity1()
+    {
+        $phpunit = $this;
+        $beforeSend = false;
+
+        $email = $this->_email([
+            'transport' => [
+                'type'     => 'smtp',
+                'security' => true
+            ],
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request',
+            'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
+                $phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
+                $phpunit->assertSame('smtp', $mailer->Mailer);
+                $phpunit->assertSame('tls', $mailer->SMTPSecure);
+                $phpunit->assertSame(587, $mailer->Port);
+
+                $beforeSend = true;
+            }
+        ], PHPMailer::class);
+
+        $this->assertFalse($beforeSend);
+        $this->assertFalse($email->isSent());
+        $email->send(true);
+        $this->assertTrue($email->isSent());
+        $this->assertTrue($beforeSend);
+    }
+
+    public function testSMTPTransportSecurity2()
+    {
+        $phpunit = $this;
+        $beforeSend = false;
+
+        $email = $this->_email([
+            'transport' => [
+                'type'     => 'smtp',
+                'security' => true,
+                'port'     => 587
+            ],
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request',
+            'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
+                $phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
+                $phpunit->assertSame('smtp', $mailer->Mailer);
+                $phpunit->assertSame('tls', $mailer->SMTPSecure);
+                $phpunit->assertSame(587, $mailer->Port);
+
+                $beforeSend = true;
+            }
+        ], PHPMailer::class);
+
+        $this->assertFalse($beforeSend);
+        $this->assertFalse($email->isSent());
+        $email->send(true);
+        $this->assertTrue($email->isSent());
+        $this->assertTrue($beforeSend);
+    }
+
+    public function testSMTPTransportSecurity3()
+    {
+        $phpunit = $this;
+        $beforeSend = false;
+
+        $email = $this->_email([
+            'transport' => [
+                'type'     => 'smtp',
+                'security' => true,
+                'port'     => 465
+            ],
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request',
+            'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
+                $phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
+                $phpunit->assertSame('smtp', $mailer->Mailer);
+                $phpunit->assertSame('ssl', $mailer->SMTPSecure);
+                $phpunit->assertSame(465, $mailer->Port);
+
+                $beforeSend = true;
+            }
+        ], PHPMailer::class);
+
+        $this->assertFalse($beforeSend);
+        $this->assertFalse($email->isSent());
+        $email->send(true);
+        $this->assertTrue($email->isSent());
+        $this->assertTrue($beforeSend);
+    }
+
+    public function testSMTPTransportSecurityInvalid()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Could not automatically detect the "security" protocol from the "port" option, please set it explicitly to "tls" or "ssl".');
+
+        $email = $this->_email([
+            'transport' => [
+                'type'     => 'smtp',
+                'security' => true,
+                'port'     => 1234
+            ],
+            'to' => 'someone@gmail.com',
+            'subject' => 'Thank you for your contact request'
+        ], PHPMailer::class);
+
+        $this->assertFalse($email->isSent());
+        $email->send(true);
     }
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Fixed a breaking-change in the PHPMailer dependency that was introduced with Kirby 3.4.0: The `email.transport.security = true` option is now automatically converted to `'tls'` or `'ssl'` depending on the configured port. If no port is given and secure transport is enabled, the port is set to 587 (the common port for SMTP over TLS).

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #2896

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
