### PR TITLE
Revamped video URL parsing for PHP and JS #2955

### DIFF
--- a/config/blocks/video/video.php
+++ b/config/blocks/video/video.php
@@ -1,7 +1,7 @@
 <?php /** @var \Kirby\Cms\Block $block */ ?>
-<?php if ($block->url()->isNotEmpty()): ?>
+<?php if ($video = video($block->url())): ?>
 <figure>
-  <?= video($block->url()) ?>
+  <?= $video ?>
   <?php if ($block->caption()->isNotEmpty()): ?>
   <figcaption><?= $block->caption() ?></figcaption>
   <?php endif ?>

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -920,9 +920,9 @@ function uuid(): string
  * @param string $url
  * @param array $options
  * @param array $attr
- * @return string
+ * @return string|null
  */
-function video(string $url, array $options = [], array $attr = []): string
+function video(string $url, array $options = [], array $attr = []): ?string
 {
     return Html::video($url, $options, $attr);
 }
@@ -933,9 +933,9 @@ function video(string $url, array $options = [], array $attr = []): string
  * @param string $url
  * @param array $options
  * @param array $attr
- * @return string
+ * @return string|null
  */
-function vimeo(string $url, array $options = [], array $attr = []): string
+function vimeo(string $url, array $options = [], array $attr = []): ?string
 {
     return Html::vimeo($url, $options, $attr);
 }
@@ -959,9 +959,9 @@ function widont(string $string = null): string
  * @param string $url
  * @param array $options
  * @param array $attr
- * @return string
+ * @return string|null
  */
-function youtube(string $url, array $options = [], array $attr = []): string
+function youtube(string $url, array $options = [], array $attr = []): ?string
 {
     return Html::youtube($url, $options, $attr);
 }

--- a/config/tags.php
+++ b/config/tags.php
@@ -3,7 +3,6 @@
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
 use Kirby\Text\KirbyTag;
-use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 
 /**
@@ -315,32 +314,11 @@ return [
                     $video = Html::tag('video', [$source], $attrs);
                 }
             } else {
-                // firstly handles supported video providers as youtube, vimeo, etc
-                try {
-                    $video = Html::video(
-                        $tag->value,
-                        $options,
-                        // providers only support width and height attributes
-                        [
-                            'height' => $tag->height,
-                            'width'  => $tag->width
-                        ]
-                    );
-                } catch (Exception $e) {
-                    // if not one of the supported video providers
-                    // it checks if there is a valid remote video file
-                    $extension = F::extension($tag->value);
-                    $type      = F::extensionToType($extension);
-                    $mime      = F::extensionToMime($extension);
-
-                    if ($type === 'video') {
-                        $source = Html::tag('source', null, [
-                            'src'  => $tag->value,
-                            'type' => $mime
-                        ]);
-                        $video = Html::tag('video', [$source], $attrs);
-                    }
-                }
+                $video = Html::video(
+                    $tag->value,
+                    $options,
+                    $attrs
+                );
             }
 
             return Html::figure([$video ?? ''], $tag->caption, [

--- a/panel/src/components/Blocks/Types/Video.vue
+++ b/panel/src/components/Blocks/Types/Video.vue
@@ -25,29 +25,7 @@ export default {
       return this.field("caption", { marks: true }).marks;
     },
     video() {
-
-      var url = this.content.url;
-
-      if (!url) {
-        return false;
-      }
-
-      var youtubePattern = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-      var youtubeMatch = url.match(youtubePattern);
-
-      if (youtubeMatch) {
-        return "https://www.youtube.com/embed/" + youtubeMatch[2];
-      }
-
-      var vimeoPattern = /vimeo\.com\/([0-9]+)/;
-      var vimeoMatch = url.match(vimeoPattern);
-
-      if (vimeoMatch) {
-        return "https://player.vimeo.com/video/" + vimeoMatch[1];
-      }
-
-      return false;
-
+      return this.$helper.embed.video(this.content.url);
     }
   }
 };

--- a/panel/src/helpers/embed.js
+++ b/panel/src/helpers/embed.js
@@ -119,7 +119,7 @@ export default {
         break;
     }
 
-    if (!id.match(/^[0-9]*$/)) {
+    if (!id || !id.match(/^[0-9]*$/)) {
       return false;
     }
 

--- a/panel/src/helpers/embed.js
+++ b/panel/src/helpers/embed.js
@@ -1,0 +1,131 @@
+export default {
+  youtube(url) {
+
+    if (!url.match("youtu")) {
+      return false;
+    }
+
+    let uri = null;
+
+    try {
+      uri = new URL(url);
+    } catch (e) {
+      return false;
+    }
+
+    const path = uri.pathname.split("/").filter(item => item !== "");
+    const first = path[0];
+    const second = path[1];
+    const host = "https://" + uri.host + "/embed";
+
+    const isYoutubeId = (id) => {
+      return id.match(/^[a-zA-Z0-9_-]+$/) !== null;
+    };
+
+    let query = uri.searchParams;
+    let src = null;
+
+    switch (path.join("/")) {
+      case "embed/videos":
+      case "playlist":
+        if (isYoutubeId(query.get("list"))) {
+          src = host + "/videoseries";
+        }
+        break;
+      case "watch":
+        if (isYoutubeId(query.get("v"))) {
+          src = host + "/" + query.get("v");
+
+          if (query.has("t")) {
+            query.set("start", query.get("t"));
+          }
+
+          query.delete("v");
+          query.delete("t");
+        }
+
+        break;
+      default:
+        // short URLs
+        if (uri.host.includes("youtu.be")) {
+          src = 'https://www.youtube.com/embed/' + first;
+
+          if (query.has("t")) {
+            query.set("start", query.get("t"));
+          }
+
+          query.delete("t");
+        } else if (first === "embed" && isYoutubeId(second)) {
+          src = host + "/" + second;
+        }
+    }
+
+    if (!src) {
+      return false;
+    }
+
+    const queryString = query.toString();
+
+    if (queryString.length) {
+      src += "?" + queryString.replace("&", "&amp;");
+    }
+
+    return src;
+
+  },
+  video(url) {
+
+    // YouTube video
+    if (url.includes("youtu")) {
+      return this.youtube(url);
+    }
+
+    // Vimeo video
+    if (url.includes("vimeo")) {
+      return this.vimeo(url);
+    }
+
+    return false;
+
+  },
+  vimeo(url) {
+
+    let uri = null;
+
+    try {
+      uri = new URL(url);
+    } catch (e) {
+      return false;
+    }
+
+    const path = uri.pathname.split("/").filter(item => item !== "");
+
+    let query = uri.searchParams;
+    let id = null;
+
+    switch (uri.host) {
+      case "vimeo.com":
+      case "www.vimeo.com":
+        id = path[0];
+        break;
+      case "player.vimeo.com":
+        id = path[1];
+        break;
+    }
+
+    if (!id.match(/^[0-9]*$/)) {
+      return false;
+    }
+
+    let src = "https://player.vimeo.com/video/" + id;
+
+    const queryString = query.toString();
+
+    if (queryString.length) {
+      src += "?" + queryString.replace("&", "&amp;");
+    }
+
+    return src;
+
+  }
+};

--- a/panel/src/helpers/embed.js
+++ b/panel/src/helpers/embed.js
@@ -19,6 +19,10 @@ export default {
     const host = "https://" + uri.host + "/embed";
 
     const isYoutubeId = (id) => {
+      if (!id) {
+        return false;
+      }
+
       return id.match(/^[a-zA-Z0-9_-]+$/) !== null;
     };
 
@@ -28,7 +32,7 @@ export default {
     // the query params are appended below
     let src = null;
     switch (path.join("/")) {
-      case "embed/videos":
+      case "embed/videoseries":
       case "playlist":
         if (isYoutubeId(query.get("list"))) {
           src = host + "/videoseries";
@@ -49,7 +53,7 @@ export default {
         break;
       default:
         // short URLs
-        if (uri.host.includes("youtu.be")) {
+        if (uri.host.includes("youtu.be") && isYoutubeId(first)) {
           src = 'https://www.youtube.com/embed/' + first;
 
           if (query.has("t")) {

--- a/panel/src/helpers/embed.js
+++ b/panel/src/helpers/embed.js
@@ -69,7 +69,7 @@ export default {
     const queryString = query.toString();
 
     if (queryString.length) {
-      src += "?" + queryString.replace("&", "&amp;");
+      src += "?" + queryString;
     }
 
     return src;
@@ -124,7 +124,7 @@ export default {
     const queryString = query.toString();
 
     if (queryString.length) {
-      src += "?" + queryString.replace("&", "&amp;");
+      src += "?" + queryString;
     }
 
     return src;

--- a/panel/src/helpers/embed.js
+++ b/panel/src/helpers/embed.js
@@ -23,8 +23,10 @@ export default {
     };
 
     let query = uri.searchParams;
-    let src = null;
 
+    // build the correct base URL for the embed,
+    // the query params are appended below
+    let src = null;
     switch (path.join("/")) {
       case "embed/videos":
       case "playlist":

--- a/panel/src/helpers/embed.spec.js
+++ b/panel/src/helpers/embed.spec.js
@@ -12,7 +12,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'https://www.youtube.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
-        'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+        'https://www.youtube.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
       ],
       [
         'http://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
@@ -20,7 +20,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'http://www.youtube-nocookie.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
-        'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+        'https://www.youtube-nocookie.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
       ],
       [
         'http://www.youtube.com/embed/d9NF2edxy-M',
@@ -32,7 +32,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'http://www.youtube.com/embed/d9NF2edxy-M?start=10&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
-        'https://www.youtube.com/embed/d9NF2edxy-M?start=10&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
       ],
       [
         'https://www.youtube-nocookie.com/embed/d9NF2edxy-M',
@@ -52,7 +52,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'https://www.youtube-nocookie.com/watch?test=value&v=d9NF2edxy-M&t=10',
-        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?test=value&start=10'
       ],
       [
         'https://www.youtube-nocookie.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
@@ -60,7 +60,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'https://www.youtube-nocookie.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
-        'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+        'https://www.youtube-nocookie.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
       ],
       [
         'http://www.youtube.com/watch?v=d9NF2edxy-M',
@@ -80,7 +80,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'https://www.youtube.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
-        'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+        'https://www.youtube.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
       ],
       [
         'https://www.youtu.be/d9NF2edxy-M',
@@ -96,7 +96,7 @@ describe("$helper.embed()", () => {
       ],
       [
         'https://www.youtu.be/d9NF2edxy-M?test=value&t=10',
-        'https://www.youtube.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+        'https://www.youtube.com/embed/d9NF2edxy-M?test=value&start=10'
       ],
 
       // Vimeo

--- a/panel/src/helpers/embed.spec.js
+++ b/panel/src/helpers/embed.spec.js
@@ -139,6 +139,10 @@ describe("$helper.embed()", () => {
         false
       ],
       [
+        'https://vimeo.com',
+        false
+      ],
+      [
         'https://vimeo.com/öööö',
         false
       ]

--- a/panel/src/helpers/embed.spec.js
+++ b/panel/src/helpers/embed.spec.js
@@ -1,0 +1,148 @@
+import embed from "./embed.js";
+
+describe("$helper.embed()", () => {
+
+  it("should create the right embed URLs", () => {
+
+    const tests = [
+      // YouTube
+      [
+        'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'https://www.youtube.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'http://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'http://www.youtube-nocookie.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'http://www.youtube.com/embed/d9NF2edxy-M',
+        'https://www.youtube.com/embed/d9NF2edxy-M'
+      ],
+      [
+        'http://www.youtube.com/embed/d9NF2edxy-M?start=10',
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'http://www.youtube.com/embed/d9NF2edxy-M?start=10&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M',
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'
+      ],
+      [
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10',
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M',
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'
+      ],
+      [
+        'https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M&t=10',
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'https://www.youtube-nocookie.com/watch?test=value&v=d9NF2edxy-M&t=10',
+        'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+      ],
+      [
+        'https://www.youtube-nocookie.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'https://www.youtube-nocookie.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'http://www.youtube.com/watch?v=d9NF2edxy-M',
+        'https://www.youtube.com/embed/d9NF2edxy-M'
+      ],
+      [
+        'http://www.youtube.com/watch?test=value&v=d9NF2edxy-M',
+        'https://www.youtube.com/embed/d9NF2edxy-M?test=value'
+      ],
+      [
+        'http://www.youtube.com/watch?v=d9NF2edxy-M&t=10',
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'https://www.youtube.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'https://www.youtube.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+        'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+      ],
+      [
+        'https://www.youtu.be/d9NF2edxy-M',
+        'https://www.youtube.com/embed/d9NF2edxy-M'
+      ],
+      [
+        'https://www.youtu.be/d9NF2edxy-M?t=10',
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'https://youtu.be/d9NF2edxy-M?t=10',
+        'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+      ],
+      [
+        'https://www.youtu.be/d9NF2edxy-M?test=value&t=10',
+        'https://www.youtube.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+      ],
+
+      // Vimeo
+      [
+        'https://vimeo.com/239882943',
+        'https://player.vimeo.com/video/239882943'
+      ],
+      [
+        'https://vimeo.com/239882943?test=value',
+        'https://player.vimeo.com/video/239882943?test=value'
+      ],
+      [
+        'https://player.vimeo.com/video/239882943',
+        'https://player.vimeo.com/video/239882943'
+      ],
+      [
+        'https://player.vimeo.com/video/239882943?test=value',
+        'https://player.vimeo.com/video/239882943?test=value'
+      ],
+
+      // invalid URLs
+      [
+        'https://getkirby.com',
+        false
+      ],
+      [
+        'https://youtube.com/imprint',
+        false
+      ],
+      [
+        'https://youtube.com/watch?v=öööö',
+        false
+      ],
+      [
+        'https://vimeo.com/öööö',
+        false
+      ]
+    ];
+
+    tests.forEach(test => {
+      const input = test[0];
+      const expected = test[1];
+      const result = embed.video(input);
+
+      expect(result).to.equal(expected);
+    });
+  });
+
+});

--- a/panel/src/helpers/embed.spec.js
+++ b/panel/src/helpers/embed.spec.js
@@ -127,6 +127,14 @@ describe("$helper.embed()", () => {
         false
       ],
       [
+        'https://www.youtu.be',
+        false
+      ],
+      [
+        'https://www.youtube.com/watch?list=zv=21HuwjmuS7A&index=1',
+        false
+      ],
+      [
         'https://youtube.com/watch?v=öööö',
         false
       ],

--- a/panel/src/helpers/index.js
+++ b/panel/src/helpers/index.js
@@ -1,5 +1,6 @@
 import clone from "./clone.js";
 import debounce from "./debounce.js";
+import embed from "./embed.js";
 import isComponent from "./isComponent.js";
 import isUploadEvent from "./isUploadEvent.js";
 import pad from "./pad.js";
@@ -40,6 +41,7 @@ export default {
 
     Vue.prototype.$helper = {
       clone: clone,
+      embed: embed,
       isComponent: isComponent,
       isUploadEvent: isUploadEvent,
       debounce: debounce,

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -471,9 +471,13 @@ class Html extends Xml
             $query->$key = $value;
         }
 
+        // allow fullscreen mode by default
+        $attr = array_merge(['allowfullscreen' => true], $attr);
+
+        // build the full video src URL
         $src = 'https://player.vimeo.com/video/' . $id . $query->toString(true);
 
-        return static::iframe($src, array_merge(['allowfullscreen' => true], $attr));
+        return static::iframe($src, $attr);
     }
 
     /**
@@ -481,10 +485,10 @@ class Html extends Xml
      *
      * @param string $url YouTube video URL
      * @param array $options Query params for the embed URL
-     * @param array $attrs Additional attributes for the `<iframe>` tag
+     * @param array $attr Additional attributes for the `<iframe>` tag
      * @return string The generated HTML
      */
-    public static function youtube(string $url, array $options = [], array $attrs = []): string
+    public static function youtube(string $url, array $options = [], array $attr = []): string
     {
         if (preg_match('!youtu!i', $url) !== 1) {
             throw new Exception('Invalid YouTube source');
@@ -548,9 +552,12 @@ class Html extends Xml
         }
 
         // allow fullscreen mode by default
-        $attrs = array_merge(['allowfullscreen' => true], $attrs);
+        $attr = array_merge(['allowfullscreen' => true], $attr);
+
+        // build the full video src URL
+        $src = $src . $query->toString(true);
 
         // render the iframe
-        return static::iframe($src . $query->toString(true), $attrs);
+        return static::iframe($src, $attr);
     }
 }

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -503,6 +503,10 @@ class Html extends Xml
         $src    = null;
 
         $isYoutubeId = function (string $id): bool {
+            if (empty($id) === true) {
+                return false;
+            }
+
             return preg_match('!^[a-zA-Z0-9_-]+$!', $id);
         };
 
@@ -529,7 +533,7 @@ class Html extends Xml
 
             default:
                 // short URLs
-                if (Str::contains($uri->host(), 'youtu.be') === true) {
+                if (Str::contains($uri->host(), 'youtu.be') === true && $isYoutubeId($first) === true) {
                     $src = 'https://www.youtube.com/embed/' . $first;
 
                     $query->start = $query->t;

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Toolkit;
 
-use Exception;
 use Kirby\Http\Uri;
 use Kirby\Http\Url;
 
@@ -420,9 +419,9 @@ class Html extends Xml
      * @param array $options Additional `vimeo` and `youtube` options
      *                       (will be used as query params in the embed URL)
      * @param array $attr Additional attributes for the `<iframe>` tag
-     * @return string The generated HTML
+     * @return string|null The generated HTML
      */
-    public static function video(string $url, array $options = [], array $attr = []): string
+    public static function video(string $url, array $options = [], array $attr = []): ?string
     {
         // YouTube video
         if (preg_match('!youtu!i', $url) === 1) {
@@ -434,7 +433,7 @@ class Html extends Xml
             return static::vimeo($url, $options['vimeo'] ?? [], $attr);
         }
 
-        throw new Exception('Unexpected video type');
+        return null;
     }
 
     /**
@@ -443,9 +442,9 @@ class Html extends Xml
      * @param string $url Vimeo video URL
      * @param array $options Query params for the embed URL
      * @param array $attr Additional attributes for the `<iframe>` tag
-     * @return string The generated HTML
+     * @return string|null The generated HTML
      */
-    public static function vimeo(string $url, array $options = [], array $attr = []): string
+    public static function vimeo(string $url, array $options = [], array $attr = []): ?string
     {
         $uri   = new Uri($url);
         $path  = $uri->path();
@@ -463,7 +462,7 @@ class Html extends Xml
         }
 
         if (empty($id) === true || preg_match('!^[0-9]*$!', $id) !== 1) {
-            throw new Exception('Invalid Vimeo source');
+            return null;
         }
 
         // append query params
@@ -486,12 +485,12 @@ class Html extends Xml
      * @param string $url YouTube video URL
      * @param array $options Query params for the embed URL
      * @param array $attr Additional attributes for the `<iframe>` tag
-     * @return string The generated HTML
+     * @return string|null The generated HTML
      */
-    public static function youtube(string $url, array $options = [], array $attr = []): string
+    public static function youtube(string $url, array $options = [], array $attr = []): ?string
     {
         if (preg_match('!youtu!i', $url) !== 1) {
-            throw new Exception('Invalid YouTube source');
+            return null;
         }
 
         $uri    = new Uri($url);
@@ -546,7 +545,7 @@ class Html extends Xml
         }
 
         if (empty($src) === true) {
-            throw new Exception('Invalid YouTube source');
+            return null;
         }
 
         // append all query parameters

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -6,7 +6,6 @@ use Exception;
 use Kirby\Http\Uri;
 use Kirby\Http\Url;
 
-
 /**
  * HTML builder for the most common elements
  *

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -462,7 +462,7 @@ class Html extends Xml
                 break;
         }
 
-        if (!preg_match('!^[0-9]*$!', $id)) {
+        if (preg_match('!^[0-9]*$!', $id) !== 1) {
             throw new Exception('Invalid Vimeo source');
         }
 

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -462,7 +462,7 @@ class Html extends Xml
                 break;
         }
 
-        if (preg_match('!^[0-9]*$!', $id) !== 1) {
+        if (empty($id) === true || preg_match('!^[0-9]*$!', $id) !== 1) {
             throw new Exception('Invalid Vimeo source');
         }
 
@@ -502,7 +502,7 @@ class Html extends Xml
         $host   = 'https://' . $uri->host() . '/embed';
         $src    = null;
 
-        $isYoutubeId = function (string $id): bool {
+        $isYoutubeId = function (?string $id = null): bool {
             if (empty($id) === true) {
                 return false;
             }

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -522,7 +522,6 @@ class Html extends Xml
                     $src = $host . '/' . $query->v;
 
                     $query->start = $query->t;
-
                     unset($query->v, $query->t);
                 }
 

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Data\Json;
 use Kirby\Data\Yaml;
 
 class FieldMethodsTest extends TestCase
@@ -670,5 +671,85 @@ class FieldMethodsTest extends TestCase
 
         $yaml = Yaml::encode($data);
         $this->assertSame($data, $this->field($yaml)->yaml());
+    }
+
+    public function testToBlocks()
+    {
+        $data = [
+            [
+                'type' => 'code',
+                'content' => [
+                    'code' => '<?php echo "Hello World!"; ?>',
+                    'language' => 'php',
+                ]
+            ],
+            [
+                'type' => 'gallery',
+                'content' => [
+                    'images' => [
+                        'a.jpg',
+                        'b.jpg'
+                    ],
+                ]
+            ],
+            [
+                'type'    => 'image',
+                'content' => [
+                    'location' => 'web',
+                    'src'      => 'https://getkirby.com/favicon.png',
+                ]
+            ],
+            [
+                'type'    => 'heading',
+                'content' => [
+                    'text' => 'A nice heading',
+                ]
+            ],
+            [
+                'type'    => 'list',
+                'content' => [
+                    'text' => '<ul><li>list item 1<\/li><li>list item 2<\/li><\/ul>',
+                ]
+            ],
+            [
+                'type'    => 'markdown',
+                'content' => [
+                    'text' => '# Heading 1',
+                ]
+            ],
+            [
+                'type'    => 'quote',
+                'content' => [
+                    'text'     => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in ultricies lorem. Fusce vulputate placerat urna sed pellentesque.',
+                    'citation' => 'John Doe',
+                ]
+            ],
+            [
+                'type'    => 'text',
+                'content' => [
+                    'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in ultricies lorem. Fusce vulputate placerat urna sed pellentesque.'
+                ]
+            ],
+            [
+                'type'    => 'video',
+                'content' => [
+                    'url' => 'https://www.youtube.com/watch?v=EDVYjxWMecc',
+                ]
+            ]
+        ];
+
+        $json   = Json::encode($data);
+        $field  = $this->field($json);
+        $blocks = $field->toBlocks();
+
+        $this->assertCount(count($data), $blocks);
+
+        foreach ($data as $index => $row) {
+            $block = $blocks->nth($index);
+
+            $this->assertSame($row['type'], $block->type());
+            $this->assertSame($row['content'], $block->content()->data());
+            $this->assertNotEmpty($block->toHtml());
+        }
     }
 }

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -718,7 +718,7 @@ class HelpersTest extends TestCase
 
     public function testVideo()
     {
-        $video    = video('https://www.youtube.com/watch?v=xB3s_f7PzYk');
+        $video    = video('https://youtube.com/watch?v=xB3s_f7PzYk');
         $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertEquals($expected, $video);
@@ -726,7 +726,7 @@ class HelpersTest extends TestCase
 
     public function testYoutubeVideoWithOptions()
     {
-        $video = video('https://www.youtube.com/watch?v=xB3s_f7PzYk', [
+        $video = video('https://youtube.com/watch?v=xB3s_f7PzYk', [
             'youtube' => [
                 'controls' => 0
             ]
@@ -776,7 +776,7 @@ class HelpersTest extends TestCase
 
     public function testYoutube()
     {
-        $video    = youtube('https://www.youtube.com/watch?v=xB3s_f7PzYk');
+        $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk');
         $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertEquals($expected, $video);
@@ -784,7 +784,7 @@ class HelpersTest extends TestCase
 
     public function testYoutubeWithOptions()
     {
-        $video    = youtube('https://www.youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
+        $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
         $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertEquals($expected, $video);

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -604,7 +604,7 @@ class KirbyTagsTest extends TestCase
 
         $page  = $kirby->page('test');
 
-        $expected = '<figure class="video"><iframe allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
+        $expected = '<figure class="video"><iframe allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
         $this->assertSame($expected, $page->text()->kt()->value());
     }
 

--- a/tests/Text/fixtures/kirbytext/video-youtube/expected.html
+++ b/tests/Text/fixtures/kirbytext/video-youtube/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>
+<figure class="video"><iframe allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/youtube/test.txt
+++ b/tests/Text/fixtures/kirbytext/youtube/test.txt
@@ -1,1 +1,1 @@
-(youtube: https://www.youtube.com/watch?v=VhP7ZzZysQg)
+(youtube: https://youtube.com/watch?v=VhP7ZzZysQg)

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -495,25 +495,116 @@ class HtmlTest extends TestCase
     {
         return [
             // YouTube
-            ['https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys', 'https://youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'],
-            ['http://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys', 'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'],
-            ['http://www.youtube.com/embed/d9NF2edxy-M', 'https://youtube.com/embed/d9NF2edxy-M'],
-            ['http://www.youtube.com/embed/d9NF2edxy-M?start=10', 'https://youtube.com/embed/d9NF2edxy-M?start=10'],
-            ['http://www.youtube.com/embed/d9NF2edxy-M?start=10&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys', 'https://youtube.com/embed/d9NF2edxy-M?start=10&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'],
-            ['https://www.youtube-nocookie.com/embed/d9NF2edxy-M', 'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'],
-            ['https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10', 'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'],
-            ['https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M', 'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'],
-            ['https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M&t=10', 'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'],
-            ['https://www.youtube-nocookie.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys', 'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'],
-            ['http://www.youtube.com/watch?v=d9NF2edxy-M', 'https://youtube.com/embed/d9NF2edxy-M'],
-            ['http://www.youtube.com/watch?v=d9NF2edxy-M&t=10', 'https://youtube.com/embed/d9NF2edxy-M?start=10'],
-            ['https://www.youtube.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys', 'https://youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'],
-            ['https://youtu.be/d9NF2edxy-M', 'https://youtube.com/embed/d9NF2edxy-M'],
-            ['https://youtu.be/d9NF2edxy-M?t=10', 'https://youtube.com/embed/d9NF2edxy-M?start=10'],
+            [
+                'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'https://www.youtube.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'http://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'http://www.youtube-nocookie.com/embed/videoseries?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'http://www.youtube.com/embed/d9NF2edxy-M',
+                'https://www.youtube.com/embed/d9NF2edxy-M'
+            ],
+            [
+                'http://www.youtube.com/embed/d9NF2edxy-M?start=10',
+                'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'http://www.youtube.com/embed/d9NF2edxy-M?start=10&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube.com/embed/d9NF2edxy-M?start=10&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M',
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'
+            ],
+            [
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10',
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M',
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M'
+            ],
+            [
+                'https://www.youtube-nocookie.com/watch?v=d9NF2edxy-M&t=10',
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'https://www.youtube-nocookie.com/watch?test=value&v=d9NF2edxy-M&t=10',
+                'https://www.youtube-nocookie.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+            ],
+            [
+                'https://www.youtube-nocookie.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube-nocookie.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'https://www.youtube-nocookie.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube-nocookie.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'http://www.youtube.com/watch?v=d9NF2edxy-M',
+                'https://www.youtube.com/embed/d9NF2edxy-M'
+            ],
+            [
+                'http://www.youtube.com/watch?test=value&v=d9NF2edxy-M',
+                'https://www.youtube.com/embed/d9NF2edxy-M?test=value'
+            ],
+            [
+                'http://www.youtube.com/watch?v=d9NF2edxy-M&t=10',
+                'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'https://www.youtube.com/playlist?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube.com/embed/videoseries?list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'https://www.youtube.com/playlist?test=value&list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys',
+                'https://www.youtube.com/embed/videoseries?test=value&amp;list=PLj8e95eaxiB9goOAvINIy4Vt3mlWQJxys'
+            ],
+            [
+                'https://www.youtu.be/d9NF2edxy-M',
+                'https://www.youtube.com/embed/d9NF2edxy-M'
+            ],
+            [
+                'https://www.youtu.be/d9NF2edxy-M?t=10',
+                'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'https://youtu.be/d9NF2edxy-M?t=10',
+                'https://www.youtube.com/embed/d9NF2edxy-M?start=10'
+            ],
+            [
+                'https://www.youtu.be/d9NF2edxy-M?test=value&t=10',
+                'https://www.youtube.com/embed/d9NF2edxy-M?test=value&amp;start=10'
+            ],
 
             // Vimeo
-            ['https://vimeo.com/239882943', 'https://player.vimeo.com/video/239882943'],
-            ['https://player.vimeo.com/video/239882943', 'https://player.vimeo.com/video/239882943'],
+            [
+                'https://vimeo.com/239882943',
+                'https://player.vimeo.com/video/239882943'
+            ],
+            [
+                'https://vimeo.com/239882943?test=value',
+                'https://player.vimeo.com/video/239882943?test=value'
+            ],
+            [
+                'https://player.vimeo.com/video/239882943',
+                'https://player.vimeo.com/video/239882943'
+            ],
+            [
+                'https://player.vimeo.com/video/239882943?test=value',
+                'https://player.vimeo.com/video/239882943?test=value'
+            ],
         ];
     }
 

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -643,4 +643,14 @@ class HtmlTest extends TestCase
             ]
         ];
     }
+
+    public function testInvalidVimeoUrl()
+    {
+        $this->assertNull(Html::vimeo('https://getkirby.com'));
+    }
+
+    public function testInvalidYoutubeUrl()
+    {
+        $this->assertNull(Html::youtube('https://getkirby.com'));
+    }
 }

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -461,6 +461,12 @@ class HtmlTest extends TestCase
      */
     public function testVideo($url, $src)
     {
+        // invalid URLs
+        if ($src === false) {
+            $this->assertNull(Html::video($url));
+            return;
+        }
+
         // plain
         $html = Html::video($url);
         $expected = '<iframe allowfullscreen src="' . $src . '"></iframe>';
@@ -605,62 +611,36 @@ class HtmlTest extends TestCase
                 'https://player.vimeo.com/video/239882943?test=value',
                 'https://player.vimeo.com/video/239882943?test=value'
             ],
+
+            // invalid URLs
+            [
+                'https://getkirby.com',
+                false
+            ],
+            [
+                'https://youtube.com/imprint',
+                false
+            ],
+            [
+                'https://www.youtu.be',
+                false
+            ],
+            [
+                'https://www.youtube.com/watch?list=zv=21HuwjmuS7A&index=1',
+                false
+            ],
+            [
+                'https://youtube.com/watch?v=öööö',
+                false
+            ],
+            [
+                'https://vimeo.com',
+                false
+            ],
+            [
+                'https://vimeo.com/öööö',
+                false
+            ]
         ];
-    }
-
-    /**
-     * @covers ::video
-     */
-    public function testVideoWithInvalidUrl()
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Unexpected video type');
-
-        Html::video('https://somevideo.com');
-    }
-
-    public function invalidYoutubeUrlProvider()
-    {
-        return [
-            ['https://youtube.com/imprint'],
-            ['https://www.youtu.be'],
-            ['https://www.youtube.com/watch?list=zv=21HuwjmuS7A&index=1'],
-            ['https://youtube.com/watch?v=öööö']
-        ];
-    }
-
-    /**
-     * @covers ::video
-     * @covers ::youtube
-     * @dataProvider invalidYoutubeUrlProvider
-     */
-    public function testVideoWithInvalidYoutubeUrl($url)
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Invalid YouTube source');
-
-        Html::video($url);
-    }
-
-    public function invalidVimeoUrlProvider()
-    {
-        return [
-            ['https://vimeo.com/asldjhaskjdhakjs'],
-            ['https://vimeo.com'],
-            ['https://vimeo.com/öööö'],
-        ];
-    }
-
-    /**
-     * @covers ::video
-     * @covers ::vimeo
-     * @dataProvider invalidVimeoUrlProvider
-     */
-    public function testVideoWithInvalidVimeoUrl($url)
-    {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Invalid Vimeo source');
-
-        Html::video($url);
     }
 }

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -619,25 +619,48 @@ class HtmlTest extends TestCase
         Html::video('https://somevideo.com');
     }
 
+    public function invalidYoutubeUrlProvider()
+    {
+        return [
+            ['https://youtube.com/imprint'],
+            ['https://www.youtu.be'],
+            ['https://www.youtube.com/watch?list=zv=21HuwjmuS7A&index=1'],
+            ['https://youtube.com/watch?v=öööö']
+        ];
+    }
+
     /**
+     * @covers ::video
      * @covers ::youtube
+     * @dataProvider invalidYoutubeUrlProvider
      */
-    public function testVideoWithInvalidYoutubeUrl()
+    public function testVideoWithInvalidYoutubeUrl($url)
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Invalid YouTube source');
 
-        Html::video('https://youtube.com/asldjhaskjdhakjs');
+        Html::video($url);
+    }
+
+    public function invalidVimeoUrlProvider()
+    {
+        return [
+            ['https://vimeo.com/asldjhaskjdhakjs'],
+            ['https://vimeo.com'],
+            ['https://vimeo.com/öööö'],
+        ];
     }
 
     /**
+     * @covers ::video
      * @covers ::vimeo
+     * @dataProvider invalidVimeoUrlProvider
      */
-    public function testVideoWithInvalidVimeoUrl()
+    public function testVideoWithInvalidVimeoUrl($url)
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Invalid Vimeo source');
 
-        Html::video('https://vimeo.com/asldjhaskjdhakjs');
+        Html::video($url);
     }
 }

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -497,6 +497,27 @@ class HtmlTest extends TestCase
         $this->assertSame($expected, $html);
     }
 
+    public function testVideoFile()
+    {
+        $html = Html::video('https://getkirby.com/myvideo.mp4');
+        $expected = '<video><source src="https://getkirby.com/myvideo.mp4" type="video/mp4"></video>';
+        $this->assertSame($expected, $html);
+
+        // with attributes
+        $html = Html::video('https://getkirby.com/myvideo.mp4', [], ['controls' => true, 'autoplay' => true]);
+        $expected = '<video autoplay controls><source src="https://getkirby.com/myvideo.mp4" type="video/mp4"></video>';
+        $this->assertSame($expected, $html);
+
+        // relative path
+        $html = Html::video('../myvideo.mp4');
+        $expected = '<video><source src="../myvideo.mp4" type="video/mp4"></video>';
+        $this->assertSame($expected, $html);
+
+        // invalid file type
+        $html = Html::video('https://getkirby.com/myvideo.mp3');
+        $this->assertNull($html);
+    }
+
     public function videoProvider()
     {
         return [


### PR DESCRIPTION
## Describe the PR

The parser for video URLs now uses the URI class in PHP and the URL parser in JS. They are actually pretty close, which is very cool. The code is almost identical that way and we can simply adapt it on both ends if needed. Tests have also been ported to JS to test the same URL patterns on both sides. 

## Related issues

- Fixes #2955

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
