### PR TITLE
Use local time instead UTC getting today #3005

### DIFF
--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -233,7 +233,7 @@ export default {
       return this.datetimes.some(current => date.isSame(current, "day"));
     },
     isToday(day) {
-      return this.toDate(day).isSame(this.$library.dayjs.utc(), "day");
+      return this.toDate(day).local().isSame(this.toToday(), "day");
     },
     next() {
       let next = this.viewDt.clone().add(1, "month");

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -314,7 +314,7 @@ export default {
       return dt.format("YYYY-MM-DD HH:mm:ss");
     },
     toToday() {
-      return this.$library.dayjs.utc();
+      return this.$library.dayjs.utc().local();
     },
   }
 };


### PR DESCRIPTION
## Describe the PR

I'm not sure the solution is correct but since we do not use the timezone plugin in dayjs, we are using UTC. Therefore, when merging the UTC time hour in the following method, it takes UTC time. 

https://github.com/getkirby/kirby/blob/develop/panel/src/components/Forms/Calendar.vue#L246-L250

For ex:
 - Local Time     : 2021-01-08 01:55:00
 - UTC Time       : 2021-01-07 22:55:00
 - Merged Time : 2021-01-08 22:55:00

For this reason, I preferred to use local time instead of UTC when getting today. 

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3005 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
