### PR TITLE
Fixes global search shortcut #3015

### DIFF
--- a/panel/src/App.vue
+++ b/panel/src/App.vue
@@ -133,13 +133,11 @@ export default {
   created() {
     this.$events.$on("offline", this.isOffline);
     this.$events.$on("online", this.isOnline);
-    this.$events.$on("keydown.cmd.shift.f", this.search);
     this.$events.$on("drop", this.drop);
   },
   destroyed() {
     this.$events.$off("offline", this.isOffline);
     this.$events.$off("online", this.isOnline);
-    this.$events.$off("keydown.cmd.shift.f", this.search);
     this.$events.$off("drop", this.drop);
   },
   methods: {

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -125,6 +125,10 @@ export default {
   },
   created() {
     this.search = debounce(this.search, 250);
+    this.$events.$on("keydown.cmd.shift.f", this.open);
+  },
+  destroyed() {
+    this.$events.$off("keydown.cmd.shift.f", this.open);
   },
   methods: {
     changeType(type) {


### PR DESCRIPTION
## Describe the PR

Since we are using a portal, I solved it by binding the shortcut in its own file `panel/src/components/Navigation/Search.vue` instead of `panel/src/App.vue`.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3015 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
