### PR TITLE
Closes calendar when click outside of it #3037

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -76,12 +76,28 @@ export default {
       this.datetime = value;
     }
   },
+  created() {
+    // binds click event that clicking out of the calendar closes it
+    this.outsideClick = (event) => {
+      const calendarInput = this.$el.querySelector(".k-calendar-input");
+      if (calendarInput && this.$el.contains(event.target) === false) {
+        this.close();
+      }
+    };
+
+    document.addEventListener("click", this.outsideClick, true);
+  },
+  destroyed() {
+    document.removeEventListener("click", this.outsideClick);
+  },
   methods: {
+    close() {
+      if (this.$refs.calendar) {
+        this.$refs.calendar.close();
+      }
+    },
     focus() {
       this.$refs.input.focus();
-    },
-    onUpdate(value) {
-      this.$emit("input", value);
     },
     onFocus() {
       if (this.$refs.calendar) {
@@ -93,10 +109,10 @@ export default {
     },
     onSelect(value) {
       this.onUpdate(value);
-
-      if (this.$refs.calendar) {
-        this.$refs.calendar.close();
-      }
+      this.close();
+    },
+    onUpdate(value) {
+      this.$emit("input", value);
     }
   }
 }


### PR DESCRIPTION
## Describe the PR

I tried to do it by triggering `focusout` and `blur` events but it didn't work. Because when blur, the `update` event is triggered. So I did it a little hard way but still wish it was an easier technique.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3037 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
