### PR TITLE
Date field: close calendar on blur #3037

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -64,6 +64,7 @@ export default {
     listeners() {
       return {
         ...this.$listeners,
+        blur: this.onBlur,
         enter: this.onSelect,
         focus: this.onFocus,
         input: this.onInput,
@@ -79,6 +80,16 @@ export default {
   methods: {
     focus() {
       this.$refs.input.focus();
+    },
+    onBlur(event) {
+      // close the calendar dropdown on blur on the input
+      // but make sure the click target wasn't the calendar itself
+      if (
+        this.$refs.calendar &&
+        this.$el.contains(event.relatedTarget) === false
+      ) {
+        this.$refs.calendar.close();
+      }
     },
     onUpdate(value) {
       this.$emit("input", value);

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -215,7 +215,9 @@ export default {
         this.select();
       });
     },
-    onBlur() {
+    onBlur(event) {
+      this.$emit("blur", event);
+
       if (!this.parsed) {
         this.input = null;
       }

--- a/panel/src/components/Forms/Input/DateTimeInput.vue
+++ b/panel/src/components/Forms/Input/DateTimeInput.vue
@@ -7,6 +7,7 @@
       @update="onUpdate($event, 'date')"
       @enter="onEnter($event, 'date')"
       @focus="$emit('focus')"
+      @blur="onBlur"
     />
     <template v-if="time">
       <k-time-input
@@ -16,6 +17,7 @@
         @update="onUpdate($event, 'time')"
         @enter="onEnter($event, 'time')"
         @focus="$emit('focus')"
+        @blur="onBlur"
       />
     </template>
   </div>
@@ -86,6 +88,13 @@ export default {
       const base  = this.toDatetime(this.value);
       input = this.toDatetime(value, input, base);
       this.emit("update", input);
+    },
+    onBlur(event) {
+      // only emit blur if the focus didn't switch between
+      // date and time input
+      if (this.$el.contains(event.relatedTarget) === false) {
+        this.$emit("blur", event);
+      }
     },
     onEnter(value, input) {
       this.onUpdate(input, value);


### PR DESCRIPTION
## Describe the PR

- The input now emit a `blur` event separately from `update` (for date time input it only gets emitted when the focus is outside the input (to avoid emitting it when switching between the two child inputs)
- The field closes the calendar (if existing) on the `blur` event

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3037

