### PR TITLE
Fixes autofocus fields in structure fields #3083

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -203,6 +203,7 @@ export default {
   },
   data() {
     return {
+      autofocus: null,
       items: this.makeItems(this.value),
       currentIndex: null,
       currentModel: null,
@@ -232,6 +233,10 @@ export default {
           section: this.endpoints.section,
           model: this.endpoints.model
         };
+
+        if (this.autofocus === null && field.autofocus === true) {
+          this.autofocus = name;
+        }
 
         fields[name] = field;
       });
@@ -332,7 +337,6 @@ export default {
         return false;
       }
 
-      let autofocus;
       let data = {};
 
       Object.keys(this.fields).forEach(fieldName => {
@@ -342,16 +346,12 @@ export default {
         } else {
           data[fieldName] = null;
         }
-
-        if (field.autofocus === true) {
-          autofocus = field;
-        }
       });
 
       this.currentIndex = "new";
       this.currentModel = data;
 
-      this.createForm(autofocus);
+      this.createForm();
     },
     addItem(value) {
       if (this.prepend === true) {
@@ -403,7 +403,7 @@ export default {
 
       this.$nextTick(() => {
         if (this.$refs.form) {
-          this.$refs.form.focus(field);
+          this.$refs.form.focus(field || this.autofocus);
         }
       });
     },


### PR DESCRIPTION
## Describe the PR

We have already solved the autofocus issue, but there was also a issue with the pagination part. This issue was also resolved by improving the codes. The autofocus field was cached while loading the fields.

## Related issues

<!-- PR relates to issues in the `kirby` or ideas on `feedback.getkirby.com`: -->

- Fixes #3083 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Fixed code style issues with CS fixer and `composer fix`
- [x] Added in-code documentation (if needed)
