### PR TITLE
Fixes overwriting blueprint columns #3095

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -375,7 +375,9 @@ class Blueprint
     protected function normalizeColumns(string $tabName, array $columns): array
     {
         foreach ($columns as $columnKey => $columnProps) {
+            // unset/remove column if its property is not array
             if (is_array($columnProps) === false) {
+                unset($columns[$columnKey]);
                 continue;
             }
 

--- a/tests/Cms/Blueprints/BlueprintExtendAndUnsetTest.php
+++ b/tests/Cms/Blueprints/BlueprintExtendAndUnsetTest.php
@@ -29,6 +29,28 @@ class BlueprintExtendAndUnset extends TestCase
                                 ]
                             ]
                         ],
+                        'additional' => [
+                            'columns' => [
+                                'left' => [
+                                    'width'  => '1/2',
+                                    'fields' => [
+                                        'headline' => [
+                                            'label' => 'Headline',
+                                            'type' => 'text'
+                                        ],
+                                    ]
+                                ],
+                                'right' => [
+                                    'width'  => '1/2',
+                                    'fields' => [
+                                        'text' => [
+                                            'label' => 'Text',
+                                            'type' => 'text'
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ],
                         'seo' => [
                             'fields' => [
                                 'seoTitle' => [
@@ -58,10 +80,10 @@ class BlueprintExtendAndUnset extends TestCase
             ]
         ]);
 
-        $this->assertEquals('extended', $blueprint->title());
-        $this->assertEquals(1, sizeof($blueprint->tabs()));
-        $this->assertEquals(false, is_array($blueprint->tab('seo')));
-        $this->assertEquals(true, is_array($blueprint->tab('content')));
+        $this->assertSame('extended', $blueprint->title());
+        $this->assertCount(2, $blueprint->tabs());
+        $this->assertIsArray($blueprint->tab('content'));
+        $this->assertIsNotArray($blueprint->tab('seo'));
     }
 
     public function testExtendAndUnsetSection()
@@ -85,11 +107,11 @@ class BlueprintExtendAndUnset extends TestCase
             $this->assertNull($e->getMessage(), 'Failed to getg sections.');
         }
 
-        $this->assertEquals('extended', $blueprint->title());
-        $this->assertEquals(true, is_array($sections));
-        $this->assertEquals(1, sizeof($sections));
-        $this->assertEquals(true, array_key_exists('pages', $sections));
-        $this->assertEquals(false, array_key_exists('files', $sections));
+        $this->assertSame('extended', $blueprint->title());
+        $this->assertIsArray($sections);
+        $this->assertCount(1, $sections);
+        $this->assertArrayHasKey('pages', $sections);
+        $this->assertArrayNotHasKey('files', $sections);
     }
 
     public function testExtendAndUnsetFields()
@@ -113,10 +135,37 @@ class BlueprintExtendAndUnset extends TestCase
             $this->assertNull($e->getMessage(), 'Failed to get fields.');
         }
 
-        $this->assertEquals('extended', $blueprint->title());
-        $this->assertEquals(true, is_array($fields));
-        $this->assertEquals(1, sizeof($fields));
-        $this->assertEquals(true, array_key_exists('seoTitle', $fields));
-        $this->assertEquals(false, array_key_exists('seoDescription', $fields));
+        $this->assertSame('extended', $blueprint->title());
+        $this->assertIsArray($fields);
+        $this->assertCount(1, $fields);
+        $this->assertArrayHasKey('seoTitle', $fields);
+        $this->assertArrayNotHasKey('seoDescription', $fields);
+    }
+
+    public function testExtendAndUnsetColumns()
+    {
+        $blueprint = new Blueprint([
+            'title'   => 'extended',
+            'model'   => 'page',
+            'extends' => 'pages/base',
+            'tabs'    => [
+                'additional' => [
+                    'columns' => [
+                        'left' => [
+                            'width' => '1/1'
+                        ],
+                        'right' => false
+                    ]
+                ]
+            ]
+        ]);
+
+        $tab = $blueprint->tab('additional');
+
+        $this->assertIsArray($tab);
+        $this->assertCount(1, $tab['columns']);
+        $this->assertArrayHasKey('left', $tab['columns']);
+        $this->assertArrayNotHasKey('right', $tab['columns']);
+        $this->assertSame('1/1', $tab['columns']['left']['width']);
     }
 }


### PR DESCRIPTION
## Describe the PR
The non-array column was just skipped. Now the non-array column is removed from the `$columns` array and bypassed.

_Side note: If you want, we can remove only those that are set to `false`, and we can inform the user by continuing to give errors to those that are set incorrectly._

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3095 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
