### PR TITLE
Fixes overwriting block tabs #3101

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -105,6 +105,12 @@ class Fieldset extends Item
 
         // normalize tabs props
         foreach ($tabs as $name => $tab) {
+            // unset/remove tab if its property is false
+            if ($tab === false) {
+                unset($tabs[$name]);
+                continue;
+            }
+
             $tab = Blueprint::extend($tab);
 
             $tab['fields'] = $this->createFields($tab['fields'] ?? []);

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -18,4 +18,21 @@ class FieldsetTest extends TestCase
         $this->assertNull($fieldset->icon());
         $this->assertTrue($fieldset->translate());
     }
+
+    public function testTabsNormalize()
+    {
+        $fieldset = new Fieldset([
+            'type' => 'test',
+            'fields' => [
+                'foo' => ['type' => 'text'],
+                'bar' => ['type' => 'text']
+            ]
+        ]);
+
+        $this->assertIsArray($fieldset->tabs());
+        $this->assertArrayHasKey('content', $fieldset->tabs());
+        $this->assertArrayHasKey('fields', $fieldset->tabs()['content']);
+        $this->assertIsArray($fieldset->tabs()['content']['fields']);
+        $this->assertCount(2, $fieldset->tabs()['content']['fields']);
+    }
 }

--- a/tests/Cms/Fieldsets/FieldsetsTest.php
+++ b/tests/Cms/Fieldsets/FieldsetsTest.php
@@ -37,4 +37,46 @@ class FieldsetsTest extends TestCase
         $this->assertCount(1, $fieldsets->groups());
         $this->assertSame(['heading', 'text'], $fieldsets->groups()['test']['sets']);
     }
+
+    public function testExtendsTabsOverwrite()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'blueprints' => [
+                'blocks/foo' => [
+                    'name' => 'Text',
+                    'tabs' => [
+                        'content' => [
+                            'fields' => [
+                                'text' => ['type' => 'textarea'],
+                            ]
+                        ],
+                        'seo' => [
+                            'fields' => [
+                                'metaTitle' => ['type' => 'text'],
+                                'metaDescription' => ['type' => 'text']
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $fieldsets = Fieldsets::factory([
+            'bar' => [
+                'extends' => 'blocks/foo',
+                'tabs' => [
+                    'seo' => false
+                ]
+            ]
+        ]);
+
+        $fieldset = $fieldsets->first();
+
+        $this->assertIsArray($fieldset->tabs());
+        $this->assertArrayHasKey('content', $fieldset->tabs());
+        $this->assertArrayNotHasKey('seo', $fieldset->tabs());
+    }
 }


### PR DESCRIPTION
## Describe the PR
The issue was fixed by removing the `tab` set to `false`.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3101 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
