### PR TITLE
Adds image url label translation for image block #3087

### DIFF
--- a/config/blocks/image/image.yml
+++ b/config/blocks/image/image.yml
@@ -21,7 +21,7 @@ fields:
     when:
       location: kirby
   src:
-    label: Image URL
+    label: field.blocks.image.url
     type: url
     when:
       location: web

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -232,6 +232,7 @@
   "field.blocks.image.name": "Image",
   "field.blocks.image.placeholder": "Select an image",
   "field.blocks.image.ratio": "Ratio",
+  "field.blocks.image.url": "Image URL",
   "field.blocks.list.name": "List",
   "field.blocks.markdown.name": "Markdown",
   "field.blocks.markdown.label": "Text",


### PR DESCRIPTION
## Describe the PR
Adds missing translation image url for image block.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3087 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
