### PR TITLE
fix: make argument for Response::redirect() nullable

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -254,7 +254,7 @@ class Response
      * @param int $code
      * @return self
      */
-    public static function redirect(string $location = '/', int $code = 302)
+    public static function redirect(string $location = '/', ?int $code = 302)
     {
         return new static([
             'code' => $code,


### PR DESCRIPTION
Makes the second parameter (HTTP status code) to `redirect()` in the `class Response` nullable. It already has a default parameter set to `302`, which currently will only work if it's being called with `redirect('bla', 0)`, but not with `redirect('bla')` – which is a little odd in my opinion. The default parameter should also work, when no second parameter is given.

Also, in [`kirby/src/Cms/Response.php` (line 26)](https://github.com/getkirby/kirby/blob/551e2f427eaf18e471df1c304552ab3de35e37c6/src/Cms/Response.php#L26) it is already nullable. So calling this child method with `redirect('bla')` will crash, because the parent class does not allow it.