### PR TITLE
Separates caches for draft mode #3082

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -23,11 +23,18 @@ use Kirby\Exception\InvalidArgumentException;
 class Pages extends Collection
 {
     /**
-     * Cache for the index
+     * Cache for the index only listed and unlisted pages
      *
      * @var \Kirby\Cms\Pages|null
      */
     protected $index = null;
+
+    /**
+     * Cache for the index all statuses also including drafts
+     *
+     * @var \Kirby\Cms\Pages|null
+     */
+    protected $indexWithDrafts = null;
 
     /**
      * All registered pages methods
@@ -331,24 +338,31 @@ class Pages extends Collection
      */
     public function index(bool $drafts = false)
     {
-        if (is_a($this->index, 'Kirby\Cms\Pages') === true) {
-            return $this->index;
+        // get object property by cache mode
+        $index = $drafts === true ? $this->indexWithDrafts : $this->index;
+
+        if (is_a($index, 'Kirby\Cms\Pages') === true) {
+            return $index;
         }
 
-        $this->index = new Pages([], $this->parent);
+        $index = new Pages([], $this->parent);
 
         foreach ($this->data as $pageKey => $page) {
-            $this->index->data[$pageKey] = $page;
-            $index = $page->index($drafts);
+            $index->data[$pageKey] = $page;
+            $pageIndex = $page->index($drafts);
 
-            if ($index) {
-                foreach ($index as $childKey => $child) {
-                    $this->index->data[$childKey] = $child;
+            if ($pageIndex) {
+                foreach ($pageIndex as $childKey => $child) {
+                    $index->data[$childKey] = $child;
                 }
             }
         }
 
-        return $this->index;
+        if ($drafts === true) {
+            return $this->indexWithDrafts = $index;
+        }
+
+        return $this->index = $index;
     }
 
     /**

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -432,6 +432,75 @@ class PagesTest extends TestCase
         $this->assertEquals($expected, $pages->index(true)->keys());
     }
 
+    public function testIndexCacheMode()
+    {
+        $pages = Pages::factory([
+            [
+                'slug' => 'a',
+                'children' => [
+                    [
+                        'slug' => 'aa',
+                        'children' => [
+                            ['slug' => 'aaa'],
+                            ['slug' => 'aab'],
+                        ]
+                    ],
+                    [
+                        'slug' => 'ab'
+                    ]
+                ],
+                'drafts' => [
+                    [
+                        'slug' => 'ac'
+                    ]
+                ]
+            ],
+            [
+                'slug' => 'b',
+                'children' => [
+                    ['slug' => 'ba'],
+                    ['slug' => 'bb']
+                ],
+                'drafts' => [
+                    [
+                        'slug' => 'bc'
+                    ]
+                ]
+            ]
+        ]);
+
+        $expectedIndex = [
+            'a',
+            'a/aa',
+            'a/aa/aaa',
+            'a/aa/aab',
+            'a/ab',
+            'b',
+            'b/ba',
+            'b/bb',
+        ];
+
+        $expectedIndexWithDrafts = [
+            'a',
+            'a/aa',
+            'a/aa/aaa',
+            'a/aa/aab',
+            'a/ab',
+            'a/ac',
+            'b',
+            'b/ba',
+            'b/bb',
+            'b/bc',
+        ];
+
+        // first run index method to cache index and with drafts
+        $pages->index();
+        $pages->index(true);
+
+        $this->assertSame($expectedIndex, $pages->index()->keys());
+        $this->assertSame($expectedIndexWithDrafts, $pages->index(true)->keys());
+    }
+
     public function testNotTemplate()
     {
         $pages = Pages::factory([


### PR DESCRIPTION
## Describe the PR

As @lukasbestle mentioned [in this comment](https://github.com/getkirby/kirby/issues/3082#issuecomment-766176307), the source of the error was caching. Again I applied the solution suggested by @lukasbestle.

_About `indexWithDrafts` variable name, I would appreciate if you have a more descriptive variable name suggestion._

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3082 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
