### PR TITLE
Injects language translations to `kirby()->translations()` #3064

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -188,6 +188,11 @@ trait AppTranslations
         // get injected translation data from plugins etc.
         $inject = $this->extensions['translations'][$locale] ?? [];
 
+        // inject current language translations
+        if ($language = $this->language($locale)) {
+            $inject = array_merge($inject, $language->translations());
+        }
+
         // load from disk instead
         return Translation::load($locale, $this->root('i18n:translations') . '/' . $locale . '.json', $inject);
     }
@@ -203,6 +208,18 @@ trait AppTranslations
             return $this->translations;
         }
 
-        return Translations::load($this->root('i18n:translations'), $this->extensions['translations'] ?? []);
+        $translations = $this->extensions['translations'] ?? [];
+
+        // inject current language translations
+        if ($language = $this->language()) {
+            $translations = array_replace_recursive(
+                $translations,
+                [$language->code() => $language->translations()]
+            );
+        }
+
+        $this->translations = Translations::load($this->root('i18n:translations'), $translations);
+
+        return $this->translations;
     }
 }

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -210,12 +210,17 @@ trait AppTranslations
 
         $translations = $this->extensions['translations'] ?? [];
 
-        // inject current language translations
-        if ($language = $this->language()) {
-            $translations = array_replace_recursive(
-                $translations,
-                [$language->code() => $language->translations()]
-            );
+        // injects languages translations
+        if ($languages = $this->languages()) {
+            foreach ($languages as $language) {
+                // merges language translations with extension translations
+                if ($language->translations()) {
+                    $translations[$language->code()] = array_merge(
+                        $translations[$language->code()],
+                        $language->translations()
+                    );
+                }
+            }
         }
 
         $this->translations = Translations::load($this->root('i18n:translations'), $translations);

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -118,13 +118,36 @@ class AppTranslationsTest extends TestCase
             ],
             'translations' => [
                 'de' => [
+                    'hello' => 'Hallo'
                 ]
             ]
         ]);
 
         I18n::$locale = 'de';
 
-        $this->assertEquals('Knopf', t('button'));
+        // translation
+        $translation = $app->translation('de');
+
+        $this->assertInstanceOf('Kirby\Cms\Translation', $translation);
+        $this->assertIsArray($translation->data());
+        $this->assertArrayHasKey('button', $translation->data());
+        $this->assertArrayHasKey('hello', $translation->data());
+        $this->assertSame('Knopf', $translation->data()['button']);
+        $this->assertSame('Hallo', $translation->data()['hello']);
+        $this->assertSame('Knopf', t('button'));
+        $this->assertSame('Hallo', t('hello'));
+
+        // translations
+        $translation = $app->translations()->find('de');
+
+        $this->assertInstanceOf('Kirby\Cms\Translation', $translation);
+        $this->assertIsArray($translation->data());
+        $this->assertArrayHasKey('button', $translation->data());
+        $this->assertArrayHasKey('hello', $translation->data());
+        $this->assertSame('Knopf', $translation->data()['button']);
+        $this->assertSame('Hallo', $translation->data()['hello']);
+        $this->assertSame('Knopf', t('button'));
+        $this->assertSame('Hallo', t('hello'));
     }
 
     public function testTranslationFallback()


### PR DESCRIPTION
## Describe the PR

Current language translations injected to global translations.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3064 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
