### PR TITLE
CI: Use PHP 7.4 for analysis for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,8 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      php: "8.0"
+      # TODO: update to PHP 8.0 when PHP-CS-Fixer fully supports it
+      php: "7.4"
 
     steps:
       - name: Checkout Kirby
@@ -321,8 +322,6 @@ jobs:
 
       - name: Check for PHP coding style violations
         if: always() && steps.finishPrepare.outcome == 'success'
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
         # Use the --dry-run flag in push builds to get a failed CI status
         run: >
           php-cs-fixer fix --diff --diff-format=udiff


### PR DESCRIPTION
The error message from PHP-CS-Fixer shouldn't stop execution as we use the `PHP_CS_FIXER_IGNORE_ENV` option, so that's a bug in PHP-CS-Fixer. I will send a PR to them, but this change is the fastest fix until then.