### PR TITLE
Fix typo in translations/de.json

### DIFF
--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -93,7 +93,7 @@
   "error.language.duplicate": "Die Sprache besteht bereits",
   "error.language.name": "Bitte gib einen gültigen Namen für die Sprache an",
 
-  "error.layout.validation.block": "Fehler in Block {blockindex} in Layout {layoutIndex}",
+  "error.layout.validation.block": "Fehler in Block {blockIndex} in Layout {layoutIndex}",
   "error.layout.validation.settings": "Fehler in den Einstellungen von Layout {index}",
 
   "error.license.format": "Bitte gib einen gültigen Lizenzschlüssel ein",


### PR DESCRIPTION
## Describe the PR
Fixes tiny typo in German "error.layout.validation.block" translation

## ~~Related issues~~


## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [ ] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
