### PR TITLE
Translatable sections info and text props #3109

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -30,8 +30,8 @@ return [
         /**
          * Optional info text setup. Info text is shown on the right (lists) or below (cards) the filename.
          */
-        'info' => function (string $info = null) {
-            return $info;
+        'info' => function ($info = null) {
+            return I18n::translate($info, $info);
         },
         /**
          * The size option controls the size of cards. By default cards are auto-sized and the cards grid will always fill the full width. With a size you can disable auto-sizing. Available sizes: `tiny`, `small`, `medium`, `large`, `huge`
@@ -60,8 +60,8 @@ return [
         /**
          * Setup for the main text in the list or cards. By default this will display the filename.
          */
-        'text' => function (string $text = '{{ file.filename }}') {
-            return $text;
+        'text' => function ($text = '{{ file.filename }}') {
+            return I18n::translate($text, $text);
         }
     ],
     'computed' => [
@@ -123,7 +123,7 @@ return [
                     'id'       => $file->id(),
                     'icon'     => $file->panelIcon($image),
                     'image'    => $image,
-                    'info'     => $file->toString($this->info ?? false),
+                    'info'     => $file->toString($this->info),
                     'link'     => $file->panelUrl(true),
                     'mime'     => $file->mime(),
                     'parent'   => $file->parent()->panelPath(),

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -38,8 +38,8 @@ return [
         /**
          * Optional info text setup. Info text is shown on the right (lists) or below (cards) the page title.
          */
-        'info' => function (string $info = null) {
-            return $info;
+        'info' => function ($info = null) {
+            return I18n::translate($info, $info);
         },
         /**
          * The size option controls the size of cards. By default cards are auto-sized and the cards grid will always fill the full width. With a size you can disable auto-sizing. Available sizes: `tiny`, `small`, `medium`, `large`, `huge`
@@ -82,8 +82,8 @@ return [
         /**
          * Setup for the main text in the list or cards. By default this will display the page title.
          */
-        'text' => function (string $text = '{{ page.title }}') {
-            return $text;
+        'text' => function ($text = '{{ page.title }}') {
+            return I18n::translate($text, $text);
         }
     ],
     'computed' => [
@@ -157,7 +157,7 @@ return [
                     'id'          => $item->id(),
                     'dragText'    => $item->dragText(),
                     'text'        => $item->toString($this->text),
-                    'info'        => $item->toString($this->info ?? false),
+                    'info'        => $item->toString($this->info),
                     'parent'      => $item->parentId(),
                     'icon'        => $item->panelIcon($image),
                     'image'       => $image,

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -373,4 +373,52 @@ class FilesSectionTest extends TestCase
         $this->assertEquals('b.jpg', $section->data()[1]['filename']);
         $this->assertEquals('a.jpg', $section->data()[2]['filename']);
     }
+
+    public function testTranslatedInfo()
+    {
+        $model = new Page([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'a.jpg'],
+                ['filename' => 'b.jpg']
+            ]
+        ]);
+
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => $model,
+            'info'  => [
+                'en' => 'en: {{ file.page.title }}',
+                'de' => 'de: {{ file.page.title }}'
+            ]
+        ]);
+
+        $this->assertSame('en: {{ file.page.title }}', $section->info());
+        $this->assertSame('en: test', $section->data()[0]['info']);
+        $this->assertSame('en: test', $section->data()[1]['info']);
+    }
+
+    public function testTranslatedText()
+    {
+        $model = new Page([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'a.jpg'],
+                ['filename' => 'b.jpg']
+            ]
+        ]);
+
+        $section = new Section('files', [
+            'name'  => 'test',
+            'model' => $model,
+            'text'  => [
+                'en' => 'en: {{ file.filename }}',
+                'de' => 'de: {{ file.filename }}'
+            ]
+        ]);
+
+        $this->assertSame('en: {{ file.filename }}', $section->text());
+        $this->assertSame('en: a.jpg', $section->data()[0]['text']);
+        $this->assertSame('en: b.jpg', $section->data()[1]['text']);
+    }
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -441,4 +441,56 @@ class PagesSectionTest extends TestCase
 
         $this->assertEquals('<p>Information</p>', $section->help());
     }
+
+    public function testTranslatedInfo()
+    {
+        $page = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-1', 'content' => ['title' => 'C']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'A']],
+                ['slug' => 'subpage-3', 'content' => ['title' => 'B']]
+            ]
+        ]);
+
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => $page,
+            'info' => [
+                'en' => 'en: {{ page.slug }}',
+                'de' => 'de: {{ page.slug }}'
+            ]
+        ]);
+
+        $this->assertSame('en: {{ page.slug }}', $section->info());
+        $this->assertSame('en: subpage-1', $section->data()[0]['info']);
+        $this->assertSame('en: subpage-2', $section->data()[1]['info']);
+        $this->assertSame('en: subpage-3', $section->data()[2]['info']);
+    }
+
+    public function testTranslatedText()
+    {
+        $page = new Page([
+            'slug'     => 'test',
+            'children' => [
+                ['slug' => 'subpage-1', 'content' => ['title' => 'C']],
+                ['slug' => 'subpage-2', 'content' => ['title' => 'A']],
+                ['slug' => 'subpage-3', 'content' => ['title' => 'B']]
+            ]
+        ]);
+
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => $page,
+            'text' => [
+                'en' => 'en: {{ page.title }}',
+                'de' => 'de: {{ page.title }}'
+            ]
+        ]);
+
+        $this->assertSame('en: {{ page.title }}', $section->text());
+        $this->assertSame('en: C', $section->data()[0]['text']);
+        $this->assertSame('en: A', $section->data()[1]['text']);
+        $this->assertSame('en: B', $section->data()[2]['text']);
+    }
 }


### PR DESCRIPTION
## Describe the PR
Now pages/files section info and text prop translatable.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3109 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
