### PR TITLE
Avoid calling global functions in filter()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Kirby
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Install memcached
         uses: niden/actions-memcached@v7

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -252,7 +252,7 @@ class Collection extends Iterator implements Countable
         $split    = $args[1] ?? false;
 
         // filter by custom filter function
-        if (is_callable($field) === true) {
+        if (is_string($field) === false && is_callable($field) === true) {
             $collection = clone $this;
             $collection->data = array_filter($this->data, $field);
 


### PR DESCRIPTION
## Describe the PR
The `$collection->filter()` method can erroneously call global functions instead of filtering by fields.

## Related issues
- Fixes #3117

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [ ] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
