### PR TITLE
Enables `fail_ci_if_error` argument for codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v1
         with:
+          fail_ci_if_error: true
           file: ${{ github.workspace }}/clover.xml
           flags: backend
           env_vars: PHP


### PR DESCRIPTION
## Describe the PR

Enables `fail_ci_if_error` argument for codecov.

**fail_ci_if_error argument description**
> Specify if CI pipeline should fail when Codecov runs into errors during upload. Defaults to false

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
