### PR TITLE
Removes opacity from disabled fields #2807

### DIFF
--- a/panel/src/components/Blocks/Block.vue
+++ b/panel/src/components/Blocks/Block.vue
@@ -260,4 +260,7 @@ export default {
   vertical-align: middle;
   display: inline-grid;
 }
+[data-disabled] .k-block-container {
+  background: $color-background;
+}
 </style>

--- a/panel/src/components/Blocks/Blocks.vue
+++ b/panel/src/components/Blocks/Blocks.vue
@@ -428,6 +428,9 @@ export default {
   box-shadow: $shadow;
   border-radius: $rounded;
 }
+[data-disabled] .k-blocks {
+  background: $color-background;
+}
 .k-blocks[data-alt] .k-block-container > * {
   pointer-events: none;
 }

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -102,7 +102,6 @@ export default {
 }
 .k-field[data-disabled] {
   cursor: not-allowed;
-  opacity: .4;
 }
 .k-field[data-disabled] * {
   pointer-events: none;

--- a/panel/src/components/Forms/Field/ListField.vue
+++ b/panel/src/components/Forms/Field/ListField.vue
@@ -8,6 +8,7 @@
     <k-input
       :id="_uid"
       ref="input"
+      v-bind="$props"
       :marks="marks"
       :value="value"
       type="list"

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -798,7 +798,23 @@ $structure-item-height: 38px;
     cursor: -webkit-grabbing;
   }
 }
+[data-disabled] .k-structure-table {
+  background: $color-background;
 
+  th,
+  td {
+    background: $color-background;
+    border-bottom: 1px solid $color-border;
+
+    [dir="ltr"] & {
+      border-right: 1px solid $color-border;
+    }
+
+    [dir="rtl"] & {
+      border-left: 1px solid $color-border;
+    }
+  }
+}
 .k-sortable-row-fallback {
   opacity: 0 !important;
 }

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -77,7 +77,7 @@
             >
               {{ column.label }}
             </th>
-            <th />
+            <th v-if="!disabled" />
           </tr>
         </thead>
         <k-draggable
@@ -123,7 +123,7 @@
                 </template>
               </template>
             </td>
-            <td class="k-structure-table-options">
+            <td v-if="!disabled" class="k-structure-table-options">
               <template v-if="duplicate && more && currentIndex === null">
                 <k-button
                   ref="actionsToggle"
@@ -749,6 +749,7 @@ $structure-item-height: 38px;
 
   .k-structure-table-index {
     width: $structure-item-height;
+    height: $structure-item-height;
     text-align: center;
   }
   .k-structure-table-index-number {

--- a/panel/src/components/Forms/Field/WriterField.vue
+++ b/panel/src/components/Forms/Field/WriterField.vue
@@ -6,6 +6,7 @@
     class="k-writer-field"
   >
     <k-input
+      v-bind="$props"
       :after="after"
       :before="before"
       :icon="icon"

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -134,6 +134,10 @@ export default {
   pointer-events: none;
 }
 
+[data-disabled] .k-input-icon {
+  color: $color-gray-600;
+}
+
 .k-input[data-theme="field"] {
   line-height: 1;
   border: $field-input-border;

--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -114,6 +114,10 @@ export default {
   border-color: $color-gray-900;
   background: $color-gray-900;
 }
+[data-disabled] .k-checkbox-input-native:checked + .k-checkbox-input-icon {
+  border-color: $color-gray-600;
+  background: $color-gray-600;
+}
 .k-checkbox-input-native:checked + .k-checkbox-input-icon svg {
   display: block;
 }

--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -1,10 +1,9 @@
 <template>
   <k-writer
     ref="input"
+    v-bind="$props"
     :extensions="extensions"
-    :marks="marks"
     :nodes="['bulletList', 'orderedList']"
-    :value="value"
     class="k-list-input"
     @input="onInput"
   />

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -111,6 +111,10 @@ export default {
   border-color: $color-gray-900;
   background: $color-gray-900;
 }
+[data-disabled] .k-radio-input input:checked + label::before {
+  border-color: $color-gray-600;
+  background: $color-gray-600;
+}
 .k-radio-input input:focus + label::before {
   border-color: $color-blue-600;
 }

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -129,12 +129,14 @@ export default {
 
 $range-thumb-size: 16px;
 $range-thumb-border: 4px solid $color-gray-900;
+$range-thumb-border-disabled: 4px solid $color-gray-600;
 $range-thumb-background: $color-background;
 $range-thumb-focus-border: 4px solid $color-focus;
 $range-thumb-focus-background: $color-background;
 $range-track-height: 4px;
 $range-track-background: $color-border;
 $range-track-color: $color-gray-900;
+$range-track-color-disabled: $color-gray-600;
 $range-track-focus-color: $color-focus;
 
 @mixin track($fill: 0) {
@@ -278,5 +280,35 @@ $range-track-focus-color: $color-focus;
 }
 .k-range-input-tooltip > * {
   padding: 4px;
+}
+[data-disabled] {
+  .k-range-input-native {
+    &::-webkit-slider-runnable-track {
+      @include track-background($range-track-color-disabled);
+    }
+    &::-moz-range-progress {
+      @include fill($range-track-color-disabled);
+    }
+    &::-ms-fill-lower {
+      @include fill($range-track-color-disabled);
+    }
+    &::-webkit-slider-thumb {
+      border: $range-thumb-border-disabled;
+    }
+    &::-moz-range-thumb {
+      border: $range-thumb-border-disabled;
+    }
+    &::-ms-thumb {
+      border: $range-thumb-border-disabled;
+    }
+  }
+
+  .k-range-input-tooltip {
+    background: $color-gray-600;
+
+    &::after {
+      border-right: 5px solid $color-gray-600;
+    }
+  }
 }
 </style>

--- a/panel/src/components/Layout/ListItem.vue
+++ b/panel/src/components/Layout/ListItem.vue
@@ -96,6 +96,9 @@ $list-item-height: 38px;
   border-radius: $rounded-xs;
   box-shadow: $shadow;
 }
+[data-disabled] .k-list-item {
+  background: $color-background;
+}
 .k-list-item .k-sort-handle {
   position: absolute;
   left: -1.5rem;

--- a/panel/src/components/Layouter/Layout.vue
+++ b/panel/src/components/Layouter/Layout.vue
@@ -152,6 +152,9 @@ $layout-toolbar-width: 2rem;
   margin-top: auto;
   color: currentColor;
 }
+[data-disabled] .k-layout-toolbar {
+  background: $color-gray-200;
+}
 
 /** Columns **/
 .k-layout-columns.k-grid {

--- a/panel/src/components/Layouter/Layout.vue
+++ b/panel/src/components/Layouter/Layout.vue
@@ -20,7 +20,7 @@
         })"
       />
     </k-grid>
-    <nav class="k-layout-toolbar">
+    <nav v-if="!disabled" class="k-layout-toolbar">
       <k-button
         v-if="settings"
         :tooltip="$t('settings')"
@@ -83,6 +83,7 @@ export default {
   props: {
     attrs: [Array, Object],
     columns: Array,
+    disabled: Boolean,
     endpoints: Object,
     fieldsetGroups: Object,
     fieldsets: Object,
@@ -120,6 +121,9 @@ $layout-toolbar-width: 2rem;
   background: #fff;
   box-shadow: $shadow;
 }
+[data-disabled] .k-layout {
+  padding-right: 0;
+}
 .k-layout:not(:last-of-type) {
   margin-bottom: 1px;
 }
@@ -151,9 +155,6 @@ $layout-toolbar-width: 2rem;
 .k-layout-toolbar .k-sort-handle {
   margin-top: auto;
   color: currentColor;
-}
-[data-disabled] .k-layout-toolbar {
-  background: $color-gray-200;
 }
 
 /** Columns **/

--- a/panel/src/components/Layouter/Layouts.vue
+++ b/panel/src/components/Layouter/Layouts.vue
@@ -9,6 +9,7 @@
         <k-layout
           v-for="(layout, layoutIndex) in rows"
           :key="layout.id"
+          :disabled="disabled"
           :endpoints="endpoints"
           :fieldset-groups="fieldsetGroups"
           :fieldsets="fieldsets"

--- a/panel/src/components/Layouter/Layouts.vue
+++ b/panel/src/components/Layouter/Layouts.vue
@@ -30,6 +30,7 @@
       </k-draggable>
 
       <k-button
+        v-if="!disabled"
         class="k-layout-add-button"
         icon="add"
         @click="selectLayout(rows.length)"
@@ -80,6 +81,7 @@ export default {
     "k-layout": Layout
   },
   props: {
+    disabled: Boolean,
     empty: String,
     endpoints: Object,
     fieldsetGroups: Object,

--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -60,6 +60,15 @@ export default {
   background: lighten($color-gray-900, 10%) url($pattern);
   color: $color-white;
 }
+[data-disabled] .k-icon[data-back="black"] {
+  background-color: $color-gray-600;
+}
+[data-disabled] .k-icon[data-back="pattern"] {
+  background: lighten($color-gray-600, 5%) url($pattern);
+  svg {
+    opacity: 1;
+  }
+}
 .k-icon[data-size="medium"] svg {
   width: 2rem;
   height: 2rem;

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -50,9 +50,6 @@ export default {
   border-color: $color-focus;
   color: #fff;
 }
-[data-disabled] .k-tag{
-  background-color: $color-gray-600;
-}
 .k-tag-text {
   padding: 0 .75rem;
 }
@@ -68,5 +65,11 @@ export default {
 .k-tag-toggle:hover {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
+}
+[data-disabled] .k-tag {
+  background-color: $color-gray-600;
+}
+[data-disabled] .k-tag .k-tag-toggle {
+  display: none;
 }
 </style>

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -50,6 +50,9 @@ export default {
   border-color: $color-focus;
   color: #fff;
 }
+[data-disabled] .k-tag{
+  background-color: $color-gray-600;
+}
 .k-tag-text {
   padding: 0 .75rem;
 }


### PR DESCRIPTION
## Describe the PR

Removes opacity from disabled fields.
If there is a point I missed, please specify.
I think it looks fine without opacity but if you want we can still set `opacity: .7`

### Old Style

![screen-capture-714-Test - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/106301985-6de8e600-6269-11eb-833d-e5cb85bf1ccc.png)

### New Style

![screen-capture-717-Test - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/106302003-73463080-6269-11eb-934a-e03f489401f7.png)

### No Disabled Style

![screen-capture-720-Test - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/106306988-d5099900-626f-11eb-872c-caf1c2c2d993.png)

_Screenshot may be skewed. It is related to the Chrome extension._

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #2807 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
