### PR TITLE
Removes `<p>` tags from list field #3086

### DIFF
--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -47,6 +47,9 @@ export default {
         return;
       }
 
+      // removes <p> tags from value
+      html = html.replace(/(<p>|<\/p>)/gi, "");
+
       this.$emit("input", html);
     }
   }


### PR DESCRIPTION
## Describe the PR

It seems to me a logical and easy solution to resolve `<p>` and `</p>` tags in list items until ProseMirror fixes the issue.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3086 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
