### PR TITLE
Emit empty string when editor is empty #3115

### DIFF
--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -135,7 +135,7 @@ export default {
           this.html    = this.editor.getHTML();
           this.isEmpty = this.editor.isEmpty();
 
-          this.$emit("input", this.html);
+          this.$emit("input", this.isEmpty === false ? this.html : "");
         }
       },
       extensions: [


### PR DESCRIPTION
## Describe the PR
Even if the value is `<p></p>`, the editor's `isEmpty` prop returns correct whether or not there is content.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3115 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
