### PR TITLE
Disables `onCodeChanges()` method on language update #3129

### DIFF
--- a/panel/src/components/Dialogs/LanguageUpdateDialog.vue
+++ b/panel/src/components/Dialogs/LanguageUpdateDialog.vue
@@ -30,6 +30,9 @@ export default {
     }
   },
   methods: {
+    onCodeChanges() {
+      return false;
+    },
     onNameChanges() {
       return false;
     },


### PR DESCRIPTION
## Describe the PR
`LanguageUpdateDialog` was using the `LanguageCreateDialog` mixin. I have disabled `onCodeChanges()` method with override.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3129 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
