### PR TITLE
`isEmpty()` and `isNotEmpty()` methods for layout field

### DIFF
--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -76,6 +76,31 @@ class Layout extends Item
     }
 
     /**
+     * Checks if the layout is empty
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return $this
+            ->columns()
+            ->filter(function ($column) {
+                return $column->isNotEmpty();
+            })
+            ->count() === 0;
+    }
+
+    /**
+     * Checks if the layout is not empty
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return $this->isEmpty() === false;
+    }
+
+    /**
      * The result is being sent to the editor
      * via the API in the panel
      *

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -55,6 +55,29 @@ class LayoutColumn extends Item
     }
 
     /**
+     * Checks if the column is empty
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return $this
+            ->blocks()
+            ->filter('isHidden', false)
+            ->count() === 0;
+    }
+
+    /**
+     * Checks if the column is not empty
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return $this->isEmpty() === false;
+    }
+
+    /**
      * Returns the number of columns this column spans
      *
      * @param int $columns

--- a/tests/Cms/Layouts/LayoutColumnTest.php
+++ b/tests/Cms/Layouts/LayoutColumnTest.php
@@ -45,4 +45,27 @@ class LayoutColumnTest extends TestCase
 
         $this->assertSame('1/2', $column->width());
     }
+
+    public function testIsEmpty()
+    {
+        $column = new LayoutColumn([
+            'blocks' => []
+        ]);
+
+        $this->assertTrue($column->isEmpty());
+        $this->assertFalse($column->isNotEmpty());
+    }
+
+    public function testIsNotEmpty()
+    {
+        $column = new LayoutColumn([
+            'blocks' => [
+                ['type' => 'heading'],
+                ['type' => 'text']
+            ]
+        ]);
+
+        $this->assertFalse($column->isEmpty());
+        $this->assertTrue($column->isNotEmpty());
+    }
 }

--- a/tests/Cms/Layouts/LayoutTest.php
+++ b/tests/Cms/Layouts/LayoutTest.php
@@ -11,4 +11,56 @@ class LayoutTest extends TestCase
         $layout = new Layout();
         $this->assertInstanceOf('Kirby\Cms\LayoutColumns', $layout->columns());
     }
+
+    public function testIsEmpty()
+    {
+        $layout = new Layout([
+            'columns' => []
+        ]);
+
+        $this->assertTrue($layout->isEmpty());
+        $this->assertFalse($layout->isNotEmpty());
+    }
+
+    public function testIsNotEmpty()
+    {
+        $layout = new Layout([
+            'columns' => [
+                [
+                    'blocks' => [
+                        ['type' => 'heading'],
+                        ['type' => 'text'],
+                    ]
+                ],
+                [
+                    'blocks' => [
+                        ['type' => 'heading'],
+                        ['type' => 'text'],
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertFalse($layout->isEmpty());
+        $this->assertTrue($layout->isNotEmpty());
+    }
+
+    public function testIsEmptyWithHidden()
+    {
+        $layout = new Layout([
+            'columns' => [
+                [
+                    'blocks' => [
+                        [
+                            'type' => 'heading',
+                            'isHidden' => true
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($layout->isEmpty());
+        $this->assertFalse($layout->isNotEmpty());
+    }
 }


### PR DESCRIPTION
## Describe the PR

Methods that check whether the layout or columns are empty have been added. 

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Closes https://kirby.nolt.io/200

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
