### PR TITLE
Use PHP_EOL for CS-Fixer setup

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -55,4 +55,5 @@ return PhpCsFixer\Config::create()
         'whitespace_after_comma_in_array' => true
     ])
     ->setRiskyAllowed(true)
-    ->setFinder($finder);
+    ->setFinder($finder)
+    ->setLineEnding(PHP_EOL);


### PR DESCRIPTION
## Describe the PR
When I run the `composer fix` command in Windows, it is trying to fix all the files because it converts end of lines automatically. I used `PHP_EOL` to make it work correctly on all servers/devices.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
