### PR TITLE
Use `basename()` method to avoid relative path in cache key

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -4,7 +4,6 @@ namespace Kirby\Cache;
 
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
-use Kirby\Toolkit\Str;
 
 /**
  * File System Cache Driver

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -4,6 +4,7 @@ namespace Kirby\Cache;
 
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
+use Kirby\Toolkit\Str;
 
 /**
  * File System Cache Driver
@@ -68,6 +69,11 @@ class FileCache extends Cache
      */
     protected function file(string $key): string
     {
+        // sanitize the cache key to strip unwanted special characters
+        // and avoid relative paths
+        $key  = Str::replace($key, ['../', './'], '');
+        $key  = Str::slug($key, '-', 'a-z0-9._-');
+
         $file = $this->root . '/' . $key;
 
         if (isset($this->options['extension'])) {

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -69,12 +69,7 @@ class FileCache extends Cache
      */
     protected function file(string $key): string
     {
-        // sanitize the cache key to strip unwanted special characters
-        // and avoid relative paths
-        $key  = Str::replace($key, ['../', './'], '');
-        $key  = Str::slug($key, '-', 'a-z0-9._-');
-
-        $file = $this->root . '/' . $key;
+        $file = $this->root . '/' . basename($key);
 
         if (isset($this->options['extension'])) {
             return $file . '.' . $this->options['extension'];

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -78,6 +78,31 @@ class FileCacheTest extends TestCase
             'extension' => 'cache'
         ]);
         $this->assertSame($root . '/test1/test.cache', $method->invoke($cache, 'test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+        ]);
+        $this->assertSame($root . '/test', $method->invoke($cache, '/test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+        ]);
+        $this->assertSame($root . '/test', $method->invoke($cache, './../test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+        ]);
+        $this->assertSame($root . '/hype-test', $method->invoke($cache, './../hype-test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+        ]);
+        $this->assertSame($root . '/dash.test', $method->invoke($cache, './../dash.test'));
+
+        $cache = new FileCache([
+            'root'   => $root = __DIR__ . '/fixtures/file',
+        ]);
+        $this->assertSame($root . '/sub-test', $method->invoke($cache, '/sub/test/'));
     }
 
     /**

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -80,29 +80,29 @@ class FileCacheTest extends TestCase
         $this->assertSame($root . '/test1/test.cache', $method->invoke($cache, 'test'));
 
         $cache = new FileCache([
-            'root'   => $root = __DIR__ . '/fixtures/file',
+            'root' => $root = __DIR__ . '/fixtures/file',
         ]);
         $this->assertSame($root . '/test', $method->invoke($cache, '/test'));
 
         $cache = new FileCache([
-            'root'   => $root = __DIR__ . '/fixtures/file',
+            'root' => $root = __DIR__ . '/fixtures/file',
         ]);
-        $this->assertSame($root . '/test', $method->invoke($cache, './../test'));
+        $this->assertSame($root . '/test', $method->invoke($cache, '../../test'));
 
         $cache = new FileCache([
-            'root'   => $root = __DIR__ . '/fixtures/file',
+            'root' => $root = __DIR__ . '/fixtures/file',
         ]);
-        $this->assertSame($root . '/hype-test', $method->invoke($cache, './../hype-test'));
+        $this->assertSame($root . '/hype-test', $method->invoke($cache, './hype-test'));
 
         $cache = new FileCache([
-            'root'   => $root = __DIR__ . '/fixtures/file',
+            'root' => $root = __DIR__ . '/fixtures/file',
         ]);
-        $this->assertSame($root . '/dash.test', $method->invoke($cache, './../dash.test'));
+        $this->assertSame($root . '/dash.test', $method->invoke($cache, './dash.test'));
 
         $cache = new FileCache([
-            'root'   => $root = __DIR__ . '/fixtures/file',
+            'root' => $root = __DIR__ . '/fixtures/file',
         ]);
-        $this->assertSame($root . '/sub-test', $method->invoke($cache, '/sub/test/'));
+        $this->assertSame($root . '/test', $method->invoke($cache, '../sub/test/'));
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

Used `basename()` method to avoid relative path in cache key.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
