### PR TITLE
Added missing nodes prop for writer field #3125

### DIFF
--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -12,9 +12,17 @@ return [
         },
         /**
          * Sets the allowed HTML formats. Available formats: `bold`, `italic`, `underline`, `strike`, `code`, `link`. Activate them all by passing `true`. Deactivate them all by passing `false`
+         * @param array|bool $marks
          */
         'marks' => function ($marks = true) {
             return $marks;
+        },
+        /**
+         * Sets the allowed nodes. Available nodes: `bulletList`, `orderedList`, `heading`, `horizontalRule`, `listItem`. Activate/deactivate them all by passing `true`/`false`. Default nodes are `heading`, `bulletList`, `orderedList`.
+         * @param array|bool|null $nodes
+         */
+        'nodes' => function ($nodes = null) {
+            return $nodes;
         }
     ]
 ];


### PR DESCRIPTION
## Describe the PR
`nodes` prop missing from [the writer field document](https://getkirby.com/docs/reference/panel/fields/writer#field-properties) was added.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3125 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
