### PR TITLE
Checks the language for extensions translations #3149

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -213,11 +213,14 @@ trait AppTranslations
         // injects languages translations
         if ($languages = $this->languages()) {
             foreach ($languages as $language) {
-                // merges language translations with extension translations
-                if ($language->translations()) {
-                    $translations[$language->code()] = array_merge(
-                        $translations[$language->code()],
-                        $language->translations()
+                $languageCode         = $language->code();
+                $languageTranslations = $language->translations();
+
+                // merges language translations with extensions translations
+                if (empty($languageTranslations) === false) {
+                    $translations[$languageCode] = array_merge(
+                        $translations[$languageCode] ?? [],
+                        $languageTranslations
                     );
                 }
             }

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -114,6 +114,12 @@ class AppTranslationsTest extends TestCase
                     'translations' => [
                         'button' => 'Knopf'
                     ]
+                ],
+                [
+                    'code'         => 'en',
+                    'translations' => [
+                        'hello' => 'Hello'
+                    ]
                 ]
             ],
             'translations' => [


### PR DESCRIPTION
## Describe the PR

Fixes the issue with checks the language for extensions translations.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3149 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
