### PR TITLE
Reverts default info texts for pages/files sections

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -123,7 +123,7 @@ return [
                     'id'       => $file->id(),
                     'icon'     => $file->panelIcon($image),
                     'image'    => $image,
-                    'info'     => $file->toString($this->info),
+                    'info'     => $file->toString($this->info ?? false),
                     'link'     => $file->panelUrl(true),
                     'mime'     => $file->mime(),
                     'parent'   => $file->parent()->panelPath(),

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -157,7 +157,7 @@ return [
                     'id'          => $item->id(),
                     'dragText'    => $item->dragText(),
                     'text'        => $item->toString($this->text),
-                    'info'        => $item->toString($this->info),
+                    'info'        => $item->toString($this->info ?? false),
                     'parent'      => $item->parentId(),
                     'icon'        => $item->panelIcon($image),
                     'image'       => $image,


### PR DESCRIPTION
## Describe the PR

With 3.5.2 (https://github.com/getkirby/kirby/pull/3116), default info texts for pages sections (slug) and files sections (file id) started to appear. This PR reverts the changes.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
