### PR TITLE
Fix regression in go() helper without args #3160

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -220,7 +220,7 @@ function gist(string $url, string $file = null): string
  * @param int $code
  * @return void
  */
-function go(string $url = null, int $code = 302)
+function go(string $url = '/', int $code = 302)
 {
     die(Response::redirect($url, $code));
 }


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

Such a stupid simple error. Unfortunately our tests didn't catch it as `die()` is untestable. :(
Psalm would likely warn about this in higher levels though, so we are getting there.

I have tested it manually now and think that this solution should be the most solid for the way forward.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3160

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
