### PR TITLE
Add email mark to writer field

### DIFF
--- a/panel/src/components/Writer/Dialogs/EmailDialog.vue
+++ b/panel/src/components/Writer/Dialogs/EmailDialog.vue
@@ -24,12 +24,12 @@ export default {
     fields() {
       return {
         href: {
-          label: "Email",
+          label: this.$t("email"),
           type: "email",
           icon: "email"
         },
         title: {
-          label: "Title",
+          label: this.$t("title"),
           type: "text",
           icon: "title"
         },

--- a/panel/src/components/Writer/Dialogs/EmailDialog.vue
+++ b/panel/src/components/Writer/Dialogs/EmailDialog.vue
@@ -1,0 +1,53 @@
+<template>
+  <k-form-dialog
+    ref="dialog"
+    v-model="email"
+    :fields="fields"
+    :submit-button="$t('confirm')"
+    size="medium"
+    @close="$emit('close')"
+    @submit="submit"
+  />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      email: {
+        email: null,
+        title: null,
+      }
+    };
+  },
+  computed: {
+    fields() {
+      return {
+        href: {
+          label: "Email",
+          type: "email",
+          icon: "email"
+        },
+        title: {
+          label: "Title",
+          type: "text",
+          icon: "title"
+        },
+      };
+    }
+  },
+  methods: {
+    open(email) {
+      this.email = {
+        title: null,
+        ...email
+      };
+      this.$refs.dialog.open();
+    },
+    submit() {
+      this.$emit("submit", this.email);
+      this.$refs.dialog.close();
+    }
+  }
+};
+</script>

--- a/panel/src/components/Writer/Marks/Email.js
+++ b/panel/src/components/Writer/Marks/Email.js
@@ -1,36 +1,32 @@
 import Mark from "../Mark";
-import Vue from "vue";
 
-export default class Link extends Mark {
+export default class Email extends Mark {
 
   get button() {
     return {
-      icon: "url",
-      /**
-       * @todo replace with `window.panel.$t()` after merging fiber
-       */
-      label: Vue.$t("toolbar.button.link")
+      icon: "email",
+      label: "Email"
     };
   }
 
   commands() {
     return {
-      "link": () => {
-        this.editor.emit("link");
+      "email": () => {
+        this.editor.emit("email");
       },
-      "insertLink": (attrs = {}) => {
+      "insertEmail": (attrs = {}) => {
         if (attrs.href) {
           return this.update(attrs);
         }
       },
-      "removeLink": () => {
+      "removeEmail": () => {
         return this.remove();
       },
-      "toggleLink": (attrs = {}) => {
+      "toggleEmail": (attrs = {}) => {
         if (attrs.href && attrs.href.length > 0) {
-          this.editor.command("insertLink", attrs);
+          this.editor.command("insertEmail", attrs);
         } else {
-          this.editor.command("removeLink");
+          this.editor.command("removeEmail");
         }
       }
     };
@@ -43,13 +39,13 @@ export default class Link extends Mark {
   }
 
   get name() {
-    return "link";
+    return "email";
   }
 
   pasteRules({ type, utils }) {
     return [
       utils.pasteRule(
-        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_+.~#?&//=,]*)/gi,
+        /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/gi,
         type,
         url => ({ href: url }),
       ),
@@ -61,11 +57,11 @@ export default class Link extends Mark {
       {
         props: {
           handleClick: (view, pos, event) => {
-            const attrs = this.editor.getMarkAttrs("link");
+            const attrs = this.editor.getMarkAttrs("email");
 
             if (attrs.href && event.altKey === true && event.target instanceof HTMLAnchorElement) {
               event.stopPropagation()
-              window.open(attrs.href, attrs.target)
+              window.open(attrs.href)
             }
           },
         },
@@ -79,9 +75,6 @@ export default class Link extends Mark {
         href: {
           default: null,
         },
-        target: {
-          default: null,
-        },
         title: {
           default: null
         }
@@ -89,17 +82,15 @@ export default class Link extends Mark {
       inclusive: false,
       parseDOM: [
         {
-          tag: "a[href]:not([href^='mailto:'])",
+          tag: "a[href^='mailto:']",
           getAttrs: dom => ({
-            href: dom.getAttribute("href"),
-            target: dom.getAttribute("target"),
-            title: dom.getAttribute("title")
+            href: dom.getAttribute("href").replace('mailto:', ''),
           }),
         },
       ],
       toDOM: node => ["a", {
         ...node.attrs,
-        rel: "noopener noreferrer nofollow",
+        href: 'mailto:'+ node.attrs.href,
       }, 0],
     }
   }

--- a/panel/src/components/Writer/Marks/Email.js
+++ b/panel/src/components/Writer/Marks/Email.js
@@ -84,13 +84,13 @@ export default class Email extends Mark {
         {
           tag: "a[href^='mailto:']",
           getAttrs: dom => ({
-            href: dom.getAttribute("href").replace('mailto:', ''),
+            href: dom.getAttribute("href").replace("mailto:", ""),
           }),
         },
       ],
       toDOM: node => ["a", {
         ...node.attrs,
-        href: 'mailto:'+ node.attrs.href,
+        href: "mailto:"+ node.attrs.href,
       }, 0],
     }
   }

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -65,11 +65,6 @@ import Toolbar from "./Extensions/Toolbar.js";
 import ToolbarComponent from "./Toolbar.vue";
 
 export const props = {
-  components: {
-    "k-writer-link-dialog": LinkDialog,
-    "k-writer-email-dialog": EmailDialog,
-    "k-writer-toolbar": ToolbarComponent,
-  },
   props: {
     breaks: Boolean,
     code: Boolean,
@@ -114,6 +109,7 @@ export const props = {
 
 export default {
   components: {
+    "k-writer-email-dialog": EmailDialog,
     "k-writer-link-dialog": LinkDialog,
     "k-writer-toolbar": ToolbarComponent,
   },

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -24,6 +24,11 @@
         @close="editor.focus()"
         @submit="editor.command('toggleLink', $event)"
       />
+      <k-writer-email-dialog
+        ref="emailDialog"
+        @close="editor.focus()"
+        @submit="editor.command('toggleEmail', $event)"
+      />
     </template>
   </div>
 </template>
@@ -33,12 +38,14 @@ import Editor from "./Editor";
 
 // Dialogs
 import LinkDialog from "./Dialogs/LinkDialog.vue";
+import EmailDialog from "./Dialogs/EmailDialog.vue";
 
 // Marks
 import Code from "./Marks/Code";
 import Bold from "./Marks/Bold";
 import Italic from "./Marks/Italic";
 import Link from "./Marks/Link";
+import Email from "./Marks/Email";
 import Strike from "./Marks/Strike";
 import Underline from "./Marks/Underline";
 
@@ -58,6 +65,11 @@ import Toolbar from "./Extensions/Toolbar.js";
 import ToolbarComponent from "./Toolbar.vue";
 
 export const props = {
+  components: {
+    "k-writer-link-dialog": LinkDialog,
+    "k-writer-email-dialog": EmailDialog,
+    "k-writer-toolbar": ToolbarComponent,
+  },
   props: {
     breaks: Boolean,
     code: Boolean,
@@ -132,6 +144,9 @@ export default {
         link: () => {
           this.$refs.linkDialog.open(this.editor.getMarkAttrs("link"));
         },
+        email: () => {
+          this.$refs.emailDialog.open(this.editor.getMarkAttrs("email"));
+        },
         toolbar: (toolbar) => {
           this.toolbar = toolbar;
 
@@ -198,6 +213,7 @@ export default {
         underline: new Underline,
         code: new Code,
         link: new Link,
+        email: new Email,
       }, this.marks);
     },
     createNodes() {


### PR DESCRIPTION
## Describe the PR
This PR adds an `email` mark to the Writer field, that I have found myself to need on almost every websites I have used the writer field on.

It is completely unopinionated as of how to obfuscate the address. I find it more convenient to preg_replace them to obfuscate them how I need afterwards, but I don't know how you'd like to handle it.

## Related issues
[kirby.nolt.io/185](https://kirby.nolt.io/185)

## Ready?
- [ ] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [ ] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
