### PR TITLE
Deprecated: improve docs and warnings

### DIFF
--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -36,7 +36,10 @@ return [
     [
         'pattern' => [
             'pages/(:any)/blueprints',
-            // Deprecated: remove in 3.6.0
+            /**
+             * @deprecated
+             * @todo remove in 3.6.0
+             */
             'pages/(:any)/children/blueprints',
         ],
         'method'  => 'GET',

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -49,7 +49,10 @@ return [
     [
         'pattern' => [
             'site/blueprints',
-            // Deprecated: remove in 3.6.0
+            /**
+             * @deprecated
+             * @todo remove in 3.6.0
+             */
             'site/children/blueprints',
         ],
         'method'  => 'GET',

--- a/config/components.php
+++ b/config/components.php
@@ -330,6 +330,8 @@ return [
      * @param Closure $originalHandler Deprecated: Callback function to the original URL handler with `$path` and `$options` as parameters
      *                                 Use `$kirby->nativeComponent('url')` inside your URL component instead.
      * @return string
+     *
+     * @todo Remove $originalHandler parameter in 3.6.0
      */
     'url' => function (App $kirby, string $path = null, $options = null, Closure $originalHandler = null): string {
         $language = null;

--- a/panel/src/api/index.js
+++ b/panel/src/api/index.js
@@ -47,8 +47,10 @@ export default (extensions = {}) => {
   api.translations = translations(api);
   api.users = users(api);
 
-  // @deprecated aliases
-  // TODO: remove in 3.6.0
+  /**
+   * @deprecated
+   * @todo remove in 3.7.0
+   */
   api.files.rename = api.files.changeName;
   api.pages.slug = api.pages.changeSlug;
   api.pages.status = api.pages.changeStatus;

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -158,7 +158,8 @@ trait AppTranslations
     /**
      * Set locale settings
      *
-     * @deprecated 3.5.0 Use \Kirby\Toolkit\Locale::set() instead
+     * @deprecated 3.5.0 Use `\Kirby\Toolkit\Locale::set()` instead
+     * @todo Remove in 3.6.0
      *
      * @param string|array $locale
      */

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -86,6 +86,10 @@ class Block extends Item
     /**
      * Deprecated method to return the block type
      *
+     * @deprecated 3.5.0 Use `\Kirby\Cms\Block::type()` instead
+     * @todo Add deprecated() helper warning in 3.6.0
+     * @todo Remove in 3.7.0
+     *
      * @return string
      */
     public function _key(): string
@@ -95,6 +99,10 @@ class Block extends Item
 
     /**
      * Deprecated method to return the block id
+     *
+     * @deprecated 3.5.0 Use `\Kirby\Cms\Block::id()` instead
+     * @todo Add deprecated() helper warning in 3.6.0
+     * @todo Remove in 3.7.0
      *
      * @return string
      */

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -788,6 +788,7 @@ trait PageActions
 
     /**
      * @deprecated 3.5.0 Use `Page::changeSort()` instead
+     * @todo Remove in 3.6.0
      *
      * @param null $position
      * @return self

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -92,7 +92,7 @@ abstract class FieldClass
     }
 
     /**
-     * DEPRECATED!
+     * @deprecated
      *
      * Returns the field data
      * in a format to be stored
@@ -379,7 +379,7 @@ abstract class FieldClass
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      *
      * @return bool
      */

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -55,7 +55,9 @@ class I18n
     /**
      * Returns the first fallback locale
      *
-     * @deprecated 3.5.1 Use \Kirby\Toolkit\I18n::fallbacks() instead
+     * @deprecated 3.5.1 Use `\Kirby\Toolkit\I18n::fallbacks()` instead
+     * @todo Add deprecated() helper warning in 3.6.0
+     * @todo Remove in 3.7.0
      *
      * @return string
      */


### PR DESCRIPTION
- `@deprecated` messages need to wrap alternative class/methods in ` for automatic linking on the website
- Add `@todo` messages for when to remove deprecated code
-  Use `@deprecated` more instead of other comments
- Add more warnings via `deprecated()` helper

Fixes https://github.com/getkirby/getkirby.com/issues/1222