### PR TITLE
Removes `<p>` and `</p>` tags from value

### DIFF
--- a/config/fields/list.php
+++ b/config/fields/list.php
@@ -8,5 +8,9 @@ return [
         'marks' => function ($marks = true) {
             return $marks;
         }
-    ]
+    ],
+    'save' => function ($value): string {
+        // removes `<p>` and `</p>` tags from value
+        return str_replace(['<p>', '</p>'], '', $value);
+    }
 ];

--- a/config/fields/list.php
+++ b/config/fields/list.php
@@ -8,9 +8,5 @@ return [
         'marks' => function ($marks = true) {
             return $marks;
         }
-    ],
-    'save' => function ($value): string {
-        // removes `<p>` and `</p>` tags from value
-        return str_replace(['<p>', '</p>'], '', $value);
-    }
+    ]
 ];

--- a/panel/src/components/Blocks/Blocks.spec.js
+++ b/panel/src/components/Blocks/Blocks.spec.js
@@ -1,0 +1,49 @@
+const dialog = () => {
+  return cy.get('.k-dialog');
+};
+
+const createBlock = (type) => {
+
+  cy.get('.k-blocks-field').as('field');
+  cy.get('@field').find('.k-blocks-empty').click();
+
+  dialog().find('button').contains(type).click();
+
+  cy.get('@field').find('.k-block').as('block');
+
+};
+
+describe('Blocks', () => {
+
+  beforeEach(() => {
+    cy.visit('/env/install/blocks');
+    cy.visit('/env/user/test');
+    cy.visit('/env/auth/test');
+  });
+
+  describe('List block', () => {
+
+    beforeEach(() => {
+      cy.visit('/pages/home');
+    });
+
+    it('should be creatable', () => {
+      createBlock('List');
+
+      cy.get('@block').should('have.class', 'k-block-type-list');
+    });
+
+    it.only('should create list items', () => {
+
+      createBlock('List');
+
+      cy.get('@block').find('.ProseMirror').as('editor');
+
+      cy.get('@editor').type('List item 1{enter}List item 2');
+      cy.get('@editor').find('ul').should('have.length', 1);
+      cy.get('@editor').find('li').should('have.length', 2);
+    });
+
+  });
+
+});

--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -1,6 +1,7 @@
 <template>
   <k-writer
     ref="input"
+    v-model="list"
     v-bind="$props"
     :extensions="extensions"
     :nodes="['bulletList', 'orderedList']"
@@ -21,9 +22,16 @@ export default {
     },
     value: String
   },
+  data() {
+    return {
+      list: this.value
+    };
+  },
   computed: {
     extensions() {
-      return [new ListDoc()];
+      return [new ListDoc({
+        inline: true
+      })];
     }
   },
   methods: {
@@ -35,21 +43,22 @@ export default {
       let list = dom.querySelector('ul, ol');
 
       if (!list) {
-        this.$emit("input", "");
+        this.$emit("input", this.list = "");
         return;
       }
 
       let text = list.textContent.trim();
 
       if (text.length === 0) {
-        this.$emit("input", "");
+        this.$emit("input", this.list = "");
         return;
       }
 
-      // emits only when there is a change
-      if (html !== this.value) {
-        this.$emit("input", html);
-      }
+      // updates `list` data with raw html
+      this.list = html;
+
+      // emit value with removes `<p>` and `</p>` tags from html value
+      this.$emit("input", html.replace(/(<p>|<\/p>)/gi, ""));
     }
   }
 };

--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -46,7 +46,10 @@ export default {
         return;
       }
 
-      this.$emit("input", html);
+      // emits only when there is a change
+      if (html !== this.value) {
+        this.$emit("input", html);
+      }
     }
   }
 };

--- a/tests/Form/Fields/ListFieldTest.php
+++ b/tests/Form/Fields/ListFieldTest.php
@@ -15,38 +15,4 @@ class ListFieldTest extends TestCase
         $this->assertSame(null, $field->text());
         $this->assertTrue($field->save());
     }
-
-    public function testSave()
-    {
-        // sample value
-        $field = $this->field('list', [
-            'value' => $value = '<ul><li>List Item A</li><li>List Item B</li><li>List Item C</li></ul>'
-        ]);
-
-        $this->assertSame($value, $field->data());
-
-        // with html value
-        $value    = '<ul><li><p>List Item A</p></li><li><p><u>List Item B</u></p></li><li><p><em>List Item C</em></p></li></ul>';
-        $expected = '<ul><li>List Item A</li><li><u>List Item B</u></li><li><em>List Item C</em></li></ul>';
-
-        $field = $this->field('list', [
-            'value' => $value
-        ]);
-
-        $this->assertSame($expected, $field->data());
-
-        // empty value
-        $field = $this->field('list', [
-            'value' => ''
-        ]);
-
-        $this->assertSame('', $field->data());
-
-        // null value
-        $field = $this->field('list', [
-            'value' => null
-        ]);
-
-        $this->assertSame('', $field->data());
-    }
 }

--- a/tests/Form/Fields/ListFieldTest.php
+++ b/tests/Form/Fields/ListFieldTest.php
@@ -18,7 +18,7 @@ class ListFieldTest extends TestCase
 
     public function testSave()
     {
-        // default value
+        // sample value
         $field = $this->field('list', [
             'value' => $value = '<ul><li>List Item A</li><li>List Item B</li><li>List Item C</li></ul>'
         ]);
@@ -44,7 +44,7 @@ class ListFieldTest extends TestCase
 
         // null value
         $field = $this->field('list', [
-            'value' => ''
+            'value' => null
         ]);
 
         $this->assertSame('', $field->data());

--- a/tests/Form/Fields/ListFieldTest.php
+++ b/tests/Form/Fields/ListFieldTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kirby\Form\Fields;
+
+class ListFieldTest extends TestCase
+{
+    public function testDefaultProps()
+    {
+        $field = $this->field('list');
+
+        $this->assertSame('list', $field->type());
+        $this->assertSame('list', $field->name());
+        $this->assertSame(null, $field->value());
+        $this->assertSame(null, $field->label());
+        $this->assertSame(null, $field->text());
+        $this->assertTrue($field->save());
+    }
+
+    public function testSave()
+    {
+        // default value
+        $field = $this->field('list', [
+            'value' => $value = '<ul><li>List Item A</li><li>List Item B</li><li>List Item C</li></ul>'
+        ]);
+
+        $this->assertSame($value, $field->data());
+
+        // with html value
+        $value    = '<ul><li><p>List Item A</p></li><li><p><u>List Item B</u></p></li><li><p><em>List Item C</em></p></li></ul>';
+        $expected = '<ul><li>List Item A</li><li><u>List Item B</u></li><li><em>List Item C</em></li></ul>';
+
+        $field = $this->field('list', [
+            'value' => $value
+        ]);
+
+        $this->assertSame($expected, $field->data());
+
+        // empty value
+        $field = $this->field('list', [
+            'value' => ''
+        ]);
+
+        $this->assertSame('', $field->data());
+
+        // null value
+        $field = $this->field('list', [
+            'value' => ''
+        ]);
+
+        $this->assertSame('', $field->data());
+    }
+}


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

~~Since the writer field constantly converts the `value` within itself, I solved the `paragraph` cleaning only while saving the data.~~

[See below comment](https://github.com/getkirby/kirby/pull/3172#issuecomment-786699449)

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3086 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
