### PR TITLE
Fix fatal dialog

### DIFF
--- a/panel/src/App.vue
+++ b/panel/src/App.vue
@@ -122,11 +122,13 @@ export default {
     fatal(html) {
       if (html !== null) {
         this.$nextTick(() => {
-          if (this.$refs.fatal && this.$refs.contentWindow) {
+          try {
             let doc = this.$refs.fatal.contentWindow.document;
             doc.open();
             doc.write(html);
             doc.close();
+          } catch (e) {
+            console.error(e);
           }
         })
       }

--- a/panel/src/App.vue
+++ b/panel/src/App.vue
@@ -122,10 +122,12 @@ export default {
     fatal(html) {
       if (html !== null) {
         this.$nextTick(() => {
-          let doc = this.$refs.fatal.contentWindow.document;
-          doc.open();
-          doc.write(html);
-          doc.close();
+          if (this.$refs.fatal && this.$refs.contentWindow) {
+            let doc = this.$refs.fatal.contentWindow.document;
+            doc.open();
+            doc.write(html);
+            doc.close();
+          }
         })
       }
     }


### PR DESCRIPTION
## Describe the PR

The fatal iframe for API errors could cause issues itself when it's not accessible. This additional error handling fix will at least catch that and send the error to the console instead. 