### PR TITLE
Casts to string writer&list field value with always trimming

### DIFF
--- a/config/fields/list.php
+++ b/config/fields/list.php
@@ -8,5 +8,10 @@ return [
         'marks' => function ($marks = true) {
             return $marks;
         }
+    ],
+    'computed' => [
+        'value' => function () {
+            return trim($this->value);
+        }
     ]
 ];

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -16,5 +16,10 @@ return [
         'marks' => function ($marks = true) {
             return $marks;
         }
-    ]
+    ],
+    'computed' => [
+        'value' => function () {
+            return trim($this->value);
+        }
+    ],
 ];


### PR DESCRIPTION
## Describe the PR
It always `trim` the value to string as we did in the `textarea` field. It also corrects the `null` data to allow revert changes. Because if the field did not exist before, its data could never be reverted because it was `null`.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3126 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
