### PR TITLE
Replace event bus with mitt

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -9,6 +9,7 @@
         "@linusborg/vue-simple-portal": "^0.1.4",
         "autosize": "^4.0.2",
         "dayjs": "^1.9.6",
+        "mitt": "^2.1.0",
         "prosemirror-commands": "^1.1.4",
         "prosemirror-history": "^1.1.3",
         "prosemirror-inputrules": "^1.1.3",
@@ -4339,6 +4340,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "node_modules/mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -9720,6 +9726,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/panel/package.json
+++ b/panel/package.json
@@ -14,6 +14,7 @@
     "@linusborg/vue-simple-portal": "^0.1.4",
     "autosize": "^4.0.2",
     "dayjs": "^1.9.6",
+    "mitt": "^2.1.0",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-history": "^1.1.3",
     "prosemirror-inputrules": "^1.1.3",

--- a/panel/src/config/events.js
+++ b/panel/src/config/events.js
@@ -1,108 +1,98 @@
+import mitt from 'mitt';
 
 export default {
-  install(Vue) {
-    Vue.prototype.$events = new Vue({
-      data() {
-        return {
-          entered: null
-        };
-      },
-      created() {
-        window.addEventListener("online", this.online);
-        window.addEventListener("offline", this.offline);
-        window.addEventListener("dragenter", this.dragenter, false);
-        window.addEventListener("dragover", this.prevent, false);
-        window.addEventListener("dragexit", this.prevent, false);
-        window.addEventListener("dragleave", this.dragleave, false);
-        window.addEventListener("drop", this.drop, false);
-        window.addEventListener("keydown", this.keydown, false);
-        window.addEventListener("keyup", this.keyup, false);
-        document.addEventListener("click", this.click, false);
-      },
-      destroyed() {
-        window.removeEventListener("online", this.online);
-        window.removeEventListener("offline", this.offline);
-        window.removeEventListener("dragenter", this.dragenter, false);
-        window.removeEventListener("dragover", this.prevent, false);
-        window.removeEventListener("dragexit", this.prevent, false);
-        window.removeEventListener("dragleave", this.dragleave, false);
-        window.removeEventListener("drop", this.drop, false);
-        window.removeEventListener("keydown", this.keydown, false);
-        window.removeEventListener("keyup", this.keyup, false);
-        document.removeEventListener("click", this.click, false);
-      },
-      methods: {
-        click(e) {
-          this.$emit("click", e);
-        },
-        drop(e) {
-          this.prevent(e);
-          this.$emit("drop", e);
-        },
-        dragenter(e) {
-          this.entered = e.target;
-          this.prevent(e);
-          this.$emit("dragenter", e);
-        },
-        dragleave(e) {
-          this.prevent(e);
-          if (this.entered === e.target) {
-            this.$emit("dragleave", e);
-          }
-        },
-        keydown(e) {
+  install(app) {
 
-          let parts = ['keydown'];
+    const emitter = mitt();
 
-          // with meta or control key
-          if (e.metaKey || e.ctrlKey) {
-            parts.push('cmd');
-          }
+    const bus = {
+      entered: null,
+      $on: emitter.on,
+      $off: emitter.off,
+      $emit: emitter.emit,
+    };
 
-          if (e.altKey === true) {
-            parts.push("alt");
-          }
+    bus.click = (e) => bus.$emit("click", e);
 
-          if (e.shiftKey === true) {
-            parts.push('shift');
-          }
+    bus.drop = (e) => {
+      bus.prevent(e);
+      bus.$emit("drop", e);
+    };
 
-          let key = this.$helper.string.lcfirst(e.key);
+    bus.dragenter = (e) => {
+      bus.entered = e.target;
+      bus.prevent(e);
+      bus.$emit("dragenter", e);
+    };
 
-          // key replacements
-          const keys = {
-            "escape": "esc",
-            "arrowUp": "up",
-            "arrowDown": "down",
-            "arrowLeft": "left",
-            "arrowRight": "right"
-          };
+    bus.dragleave = (e) => {
+      bus.prevent(e);
 
-          if (keys[key]) {
-            key = keys[key];
-          }
-
-          if (["alt", "control", "shift", "meta"].includes(key) === false) {
-            parts.push(key);
-          }
-
-          this.$emit(parts.join("."), e);
-          this.$emit("keydown", e);
-        },
-        keyup(e) {
-          this.$emit("keyup", e);
-        },
-        online(e) {
-          this.$emit("online", e);
-        },
-        offline(e) {
-          this.$emit("offline", e);
-        },
-        prevent(e) {
-          e.stopPropagation();
-          e.preventDefault();
-        },
+      if (bus.entered === e.target) {
+        bus.$emit("dragleave", e);
       }
-    });
+    };
+
+    bus.keydown = (e) => {
+
+      let parts = ['keydown'];
+
+      // with meta or control key
+      if (e.metaKey || e.ctrlKey) {
+        parts.push('cmd');
+      }
+
+      if (e.altKey === true) {
+        parts.push("alt");
+      }
+
+      if (e.shiftKey === true) {
+        parts.push('shift');
+      }
+
+      let key = app.prototype.$helper.string.lcfirst(e.key);
+
+      // key replacements
+      const keys = {
+        "escape": "esc",
+        "arrowUp": "up",
+        "arrowDown": "down",
+        "arrowLeft": "left",
+        "arrowRight": "right"
+      };
+
+      if (keys[key]) {
+        key = keys[key];
+      }
+
+      if (["alt", "control", "shift", "meta"].includes(key) === false) {
+        parts.push(key);
+      }
+
+      bus.$emit(parts.join("."), e);
+      bus.$emit("keydown", e);
+    };
+
+    bus.keyup = (e) => bus.$emit("keyup", e);
+    bus.online = (e) => bus.$emit("online", e);
+    bus.offline = (e) => bus.$emit("offline", e);
+
+    bus.prevent = (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+    };
+
+    window.addEventListener("online", bus.online);
+    window.addEventListener("offline", bus.offline);
+    window.addEventListener("dragenter", bus.dragenter, false);
+    window.addEventListener("dragover", bus.prevent, false);
+    window.addEventListener("dragexit", bus.prevent, false);
+    window.addEventListener("dragleave", bus.dragleave, false);
+    window.addEventListener("drop", bus.drop, false);
+    window.addEventListener("keydown", bus.keydown, false);
+    window.addEventListener("keyup", bus.keyup, false);
+    document.addEventListener("click", bus.click, false);
+
+    app.prototype.$events = bus;
   }
 };


### PR DESCRIPTION
## Status: ready for review 👀

One small preparation for Vue 3 migration (eventually, down the road)...
https://v3.vuejs.org/guide/migration/events-api.html#_3-x-update

## Breaking changes
_Calling the `this.$events` methods should exactly work as before._

## Related issues
- Contributes to #3189

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.