### PR TITLE
feat: add excerpt() to block class

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -85,19 +85,6 @@ class Block extends Item
     }
 
     /**
-     * Converts the block to HTML and then
-     * uses the Str::excerpt method to create
-     * a non-formatted, shortened excerpt from it
-     *
-     * @param mixed ...$args
-     * @return string
-     */
-    public function excerpt(...$args)
-    {
-        return Str::excerpt($this->toHtml(), ...$args);
-    }
-
-    /**
      * Deprecated method to return the block type
      *
      * @return string
@@ -143,6 +130,19 @@ class Block extends Item
             'prev'    => $this->prev(),
             'next'    => $this->next()
         ];
+    }
+
+    /**
+     * Converts the block to HTML and then
+     * uses the Str::excerpt method to create
+     * a non-formatted, shortened excerpt from it
+     *
+     * @param mixed ...$args
+     * @return string
+     */
+    public function excerpt(...$args)
+    {
+        return Str::excerpt($this->toHtml(), ...$args);
     }
 
     /**

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
@@ -81,6 +82,19 @@ class Block extends Item
     public function __toString(): string
     {
         return $this->toHtml();
+    }
+
+    /**
+     * Converts the block to HTML and then
+     * uses the Str::excerpt method to create
+     * a non-formatted, shortened excerpt from it
+     *
+     * @param mixed ...$args
+     * @return string
+     */
+    public function excerpt(...$args)
+    {
+        return Str::excerpt($this->toHtml(), ...$args);
     }
 
     /**

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -193,4 +193,19 @@ class BlockTest extends TestCase
         $this->assertSame($expected, $block->__toString());
         $this->assertSame($expected, (string)$block);
     }
+
+    public function testToExcerpt()
+    {
+        $block = new Block([
+            'content' => [
+                'text' => $expected = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+            ],
+            'type' => 'text',
+        ]);
+
+        $this->assertSame($expected, $block->toHtml());
+        $this->assertSame($expected, $block->excerpt());
+        $this->assertSame("Lorem ipsum dolor …", $block->excerpt(20));
+        $this->assertSame($expected, (string)$block);
+    }
 }

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -198,7 +198,7 @@ class BlockTest extends TestCase
     {
         $block = new Block([
             'content' => [
-                'text' => $expected = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                'text' => $expected = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
             ],
             'type' => 'text',
         ]);

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -194,18 +194,18 @@ class BlockTest extends TestCase
         $this->assertSame($expected, (string)$block);
     }
 
-    public function testToExcerpt()
+    public function testExcerpt()
     {
         $block = new Block([
             'content' => [
-                'text' => $expected = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+                'text' => $expected = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             ],
             'type' => 'text',
         ]);
 
         $this->assertSame($expected, $block->toHtml());
         $this->assertSame($expected, $block->excerpt());
-        $this->assertSame("Lorem ipsum dolor …", $block->excerpt(20));
+        $this->assertSame('Lorem ipsum dolor …', $block->excerpt(20));
         $this->assertSame($expected, (string)$block);
     }
 }

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -205,7 +205,7 @@ class BlocksTest extends TestCase
         $this->assertSame($expected, $blocks->toHtml());
     }
 
-    public function testToExcerpt()
+    public function testExcerpt()
     {
         $blocks = Blocks::factory([
             [
@@ -225,8 +225,8 @@ class BlocksTest extends TestCase
         $expected = "<h2>Hello world</h2>\nLorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
         $this->assertSame($expected, $blocks->toHtml());
-        $this->assertSame("Hello world Lorem ipsum dolor sit amet, consectetur adipiscing elit.", $blocks->excerpt());
-        $this->assertSame("Hello world Lorem ipsum dolor sit amet, …", $blocks->excerpt(50));
+        $this->assertSame('Hello world Lorem ipsum dolor sit amet, consectetur adipiscing elit.', $blocks->excerpt());
+        $this->assertSame('Hello world Lorem ipsum dolor sit amet, …', $blocks->excerpt(50));
         $this->assertSame($expected, (string)$blocks);
     }
 }

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -204,4 +204,29 @@ class BlocksTest extends TestCase
 
         $this->assertSame($expected, $blocks->toHtml());
     }
+
+    public function testToExcerpt()
+    {
+        $blocks = Blocks::factory([
+            [
+                'content' => [
+                    'text' => 'Hello world'
+                ],
+                'type' => 'heading'
+            ],
+            [
+                'content' => [
+                    'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+                ],
+                'type' => 'text'
+            ],
+        ]);
+
+        $expected = "<h2>Hello world</h2>\nLorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+        $this->assertSame($expected, $blocks->toHtml());
+        $this->assertSame("Hello world Lorem ipsum dolor sit amet, consectetur adipiscing elit.", $blocks->excerpt());
+        $this->assertSame("Hello world Lorem ipsum dolor sit amet, …", $blocks->excerpt(50));
+        $this->assertSame($expected, (string)$blocks);
+    }
 }


### PR DESCRIPTION
## Describe the PR
Currently, only `blocks` has an excerpt() function. I don't see why a single `block` shouldn't have it, too. Am I missing something?

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.