### PR TITLE
FileCache: Clean up empty directories on remove() #3162

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -189,6 +189,7 @@ class FileCache extends Cache
 
     /**
      * Removes empty directories safely by checking each directory
+     * up to the root directory
      *
      * @param string $dir
      * @return void

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -379,5 +379,6 @@ class FileCacheTest extends TestCase
         $this->assertDirectoryDoesNotExist($root . '/foo/bar/baz');
         $this->assertDirectoryDoesNotExist($root . '/foo/bar');
         $this->assertDirectoryDoesNotExist($root . '/foo');
+        $this->assertDirectoryExists($root);
     }
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -357,4 +357,27 @@ class FileCacheTest extends TestCase
         $this->assertFileExists($root . '/test2/b');
         $this->assertFileExists($root . '/test2/c/a');
     }
+
+    /**
+     * @covers ::removeEmptyDirectories
+     */
+    public function testRemoveEmptyDirectories()
+    {
+        $cache = new FileCache([
+            'root'      => $root = __DIR__ . '/fixtures/file',
+            'extension' => 'cache'
+        ]);
+
+        // set & retrieve
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar/baz');
+        $this->assertTrue($cache->set('foo/bar/baz/test', 'Another basic value', 10));
+        $this->assertFileExists($root . '/foo/bar/baz/test.cache');
+        $this->assertSame('Another basic value', $cache->retrieve('foo/bar/baz/test')->value());
+
+        // remove
+        $this->assertTrue($cache->remove('foo/bar/baz/test'));
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar/baz');
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar');
+        $this->assertDirectoryDoesNotExist($root . '/foo');
+    }
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -381,4 +381,31 @@ class FileCacheTest extends TestCase
         $this->assertDirectoryDoesNotExist($root . '/foo');
         $this->assertDirectoryExists($root);
     }
+
+    /**
+     * @covers ::removeEmptyDirectories
+     */
+    public function testRemoveEmptyDirectoriesWithNotEmptyDirs()
+    {
+        $cache = new FileCache([
+            'root'      => $root = __DIR__ . '/fixtures/file',
+            'extension' => 'cache'
+        ]);
+
+        // set & retrieve
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar/baz');
+        $this->assertTrue($cache->set('foo/bar/baz/test', 'Value A', 10));
+        $this->assertTrue($cache->set('foo/test', 'Value B', 10));
+        $this->assertFileExists($root . '/foo/bar/baz/test.cache');
+        $this->assertFileExists($root . '/foo/test.cache');
+        $this->assertSame('Value A', $cache->retrieve('foo/bar/baz/test')->value());
+        $this->assertSame('Value B', $cache->retrieve('foo/test')->value());
+
+        // remove
+        $this->assertTrue($cache->remove('foo/bar/baz/test'));
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar/baz');
+        $this->assertDirectoryDoesNotExist($root . '/foo/bar');
+        $this->assertDirectoryExists($root . '/foo');
+        $this->assertDirectoryExists($root);
+    }
 }


### PR DESCRIPTION
## Describe the PR

When the cache is removed, it moves to the root directory, removing empty directories.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3162 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
