### PR TITLE
Render the error page on invalid media URLs

### DIFF
--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -48,8 +48,8 @@ class Media
                 if (Str::startsWith($hash, $file->mediaToken() . '-') === true) {
                     return Response::redirect($file->mediaUrl(), 307);
                 } else {
-                    // don't leak the correct token
-                    return new Response('Not Found', 'text/plain', 404);
+                    // don't leak the correct token, render the error page
+                    return false;
                 }
             }
 

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -66,8 +66,7 @@ class MediaTest extends TestCase
         $file   = $this->app->file('projects/test.svg');
         $result = Media::link($this->app->page('projects'), 'abcde-12345', $file->filename());
 
-        $this->assertInstanceOf(Response::class, $result);
-        $this->assertEquals(404, $result->code());
+        $this->assertFalse($result);
     }
 
     public function testLinkWithoutModel()

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -223,7 +223,9 @@ class RouterTest extends TestCase
             ]
         ]);
 
-        $response = $app->call('media/pages/projects/1234-5678/cover.jpg');
+        $mediaHash = $app->file('projects/cover.jpg')->mediaHash();
+
+        $response = $app->call('media/pages/projects/' . $mediaHash . '/cover.jpg');
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -239,7 +241,9 @@ class RouterTest extends TestCase
             ]
         ]);
 
-        $response = $app->call('media/site/1234-5678/background.jpg');
+        $mediaHash = $app->file('background.jpg')->mediaHash();
+
+        $response = $app->call('media/site/' . $mediaHash . '/background.jpg');
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -259,7 +263,9 @@ class RouterTest extends TestCase
             ]
         ]);
 
-        $response = $app->call('media/users/test/1234-5678/test.jpg');
+        $mediaHash = $app->user('test')->file('test.jpg')->mediaHash();
+
+        $response = $app->call('media/users/test/' . $mediaHash . '/test.jpg');
         $this->assertInstanceOf(Response::class, $response);
     }
 


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

More consistent behavior that also allows overriding the error behavior with custom code on the error page.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes https://forum.getkirby.com/t/adjusting-the-media-hash-generation/21456/14?u=lukasbestle.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
