### PR TITLE
Topbar: Configurable menu entry for views

### DIFF
--- a/panel/src/components/Navigation/Topbar.vue
+++ b/panel/src/components/Navigation/Topbar.vue
@@ -15,12 +15,12 @@
             <ul>
               <template v-for="(entry, entryName) in views">
                 <li
-                  v-if="entry.menu"
+                  v-if="viewEntryInMenu(entryName, entry) !== false"
                   :key="'menu-item-' + entryName"
                   :aria-current="$store.state.view === entryName"
                 >
                   <k-dropdown-item
-                    :disabled="$permissions.access[entryName] === false"
+                    :disabled="viewEntryInMenu(entryName, entry) === 'disabled'"
                     :icon="entry.icon"
                     :link="entry.link"
                   >
@@ -191,6 +191,24 @@ export default {
       }
 
       return title;
+    },
+    viewEntryInMenu(entryName, entry) {
+      let menu = entry.menu;
+      if (typeof menu === "function") {
+        menu = menu(this);
+      }
+
+      // explicit configuration with one of the possible three values
+      if ([true, false, "disabled"].indexOf(menu) >= 0) {
+        return menu;
+      }
+
+      // default/fallback: disable if no permissions, otherwise enable
+      if (this.$permissions.access[entryName] === false) {
+        return "disabled";
+      }
+
+      return true;
     }
   }
 };


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

Adds two configuration features:
- Views can now provide a `menu(app)` callback to dynamically determine whether a view should be displayed.
- The `menu` option or callback of views can now have the value `"disabled"` to display but disable their menu entry (for example when using a custom [plugin permission](https://getkirby.com/docs/reference/plugins/extensions/permissions)).

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
