### PR TITLE
Use `Wrong password` message on login instead `notSame`

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -163,6 +163,7 @@
   "error.user.password.invalid": "Please enter a valid password. Passwords must be at least 8 characters long.",
   "error.user.password.notSame": "The passwords do not match",
   "error.user.password.undefined": "The user does not have a password",
+  "error.user.password.wrong": "Wrong password",
   "error.user.role.invalid": "Please enter a valid role",
   "error.user.update.permission": "You are not allowed to update the user \"{name}\"",
 

--- a/panel/src/components/Views/LoginView.spec.js
+++ b/panel/src/components/Views/LoginView.spec.js
@@ -13,7 +13,7 @@ describe('LoginView', () => {
     cy.get('input[type="email"]').type("test@getkirby.com");
     cy.get('input[type="password"]').type("abcdefgh");
     cy.get('form').submit();
-    cy.get('.k-login-alert').should('contain', 'The passwords do not match');
+    cy.get('.k-login-alert').should('contain', 'Wrong password');
   });
 
   it('should login and redirect to SiteView', () => {

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -942,7 +942,7 @@ class User extends ModelWithContent
         }
 
         if (password_verify($password, $this->password()) !== true) {
-            throw new InvalidArgumentException(['key' => 'user.password.notSame']);
+            throw new InvalidArgumentException(['key' => 'user.password.wrong']);
         }
 
         return true;

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -140,7 +140,7 @@ class AuthChallengeTest extends TestCase
     {
         $this->expectException('Kirby\Exception\NotFoundException');
         $this->expectExceptionMessage('The user "invalid@example.com" cannot be found');
-        
+
         $this->auth->createChallenge('invalid@example.com');
     }
 
@@ -318,7 +318,7 @@ class AuthChallengeTest extends TestCase
         $session = $this->app->session();
 
         $this->expectException('Kirby\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('The passwords do not match');
+        $this->expectExceptionMessage('Wrong password');
         $this->auth->login2fa('marge@simpsons.com', 'springfield456');
     }
 
@@ -428,7 +428,7 @@ class AuthChallengeTest extends TestCase
         $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
         $session->set('kirby.challenge.type', 'email');
         $session->set('kirby.challenge.timeout', MockTime::$time - 1);
-        
+
         $this->auth->verifyChallenge('123456');
     }
 
@@ -441,12 +441,12 @@ class AuthChallengeTest extends TestCase
         $this->expectExceptionMessage('Invalid code');
 
         $session = $this->app->session();
-        
+
         $session->set('kirby.challenge.email', 'marge@simpsons.com');
         $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
         $session->set('kirby.challenge.type', 'email');
         $session->set('kirby.challenge.timeout', MockTime::$time + 1);
-        
+
         $this->auth->verifyChallenge('654321');
     }
 
@@ -459,7 +459,7 @@ class AuthChallengeTest extends TestCase
         $this->expectExceptionMessage('Invalid authentication challenge: test');
 
         $session = $this->app->session();
-        
+
         $session->set('kirby.challenge.email', 'marge@simpsons.com');
         $session->set('kirby.challenge.code', password_hash('123456', PASSWORD_DEFAULT));
         $session->set('kirby.challenge.type', 'test');

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -316,7 +316,7 @@ class AuthProtectionTest extends TestCase
         try {
             $this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
         } catch (InvalidArgumentException $e) {
-            $this->assertSame('The passwords do not match', $e->getMessage());
+            $this->assertSame('Wrong password', $e->getMessage());
             $thrown = true;
         }
 


### PR DESCRIPTION
## Describe the PR

Use `Wrong password` message on login instead `The passwords do not match`.

![screen-capture-848-Login - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/111074375-a9770100-84f3-11eb-92e0-e98d6c55c042.png)

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3165 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
