### PR TITLE
Fixes validations for no option for `invalid()` helper

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -308,15 +308,25 @@ function invalid(array $data = [], array $rules = [], array $messages = [])
 
         // See: http://php.net/manual/en/types.comparisons.php
         // only false for: null, undefined variable, '', []
-        $filled  = isset($data[$field]) && $data[$field] !== '' && $data[$field] !== [];
+        $value   = $data[$field] ?? null;
+        $filled  = $value !== null && $value !== '' && $value !== [];
         $message = $messages[$field] ?? $field;
 
         // True if there is an error message for each validation method.
         $messageArray = is_array($message);
 
         foreach ($validations as $method => $options) {
+            // If the index is numeric, there is no option
+            // and `$value` is sent directly as a `$options` parameter
             if (is_numeric($method) === true) {
-                $method = $options;
+                $method  = $options;
+                $options = [$value];
+            } else {
+                if (is_array($options) === false) {
+                    $options = [$options];
+                }
+
+                array_unshift($options, $value);
             }
 
             $validationIndex++;
@@ -327,12 +337,6 @@ function invalid(array $data = [], array $rules = [], array $messages = [])
                     continue;
                 }
             } elseif ($filled) {
-                if (is_array($options) === false) {
-                    $options = [$options];
-                }
-
-                array_unshift($options, $data[$field] ?? null);
-
                 if (V::$method(...$options) === true) {
                     // Field is filled and passes validation method.
                     continue;

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -250,6 +250,7 @@ class HelpersTest extends TestCase
             'email'    => 'homersimpson.com',
             'zip'      => 'abc',
             'website'  => '',
+            'created'  => '9999-99-99',
         ];
 
         $rules = [
@@ -257,26 +258,29 @@ class HelpersTest extends TestCase
             'email'    => ['required', 'email'],
             'zip'      => ['integer'],
             'website'  => ['url'],
+            'created'  => ['date']
         ];
 
         $messages = [
             'username' => 'The username must not contain numbers',
             'email'    => 'Invalid email',
             'zip'      => 'The ZIP must contain only numbers',
+            'created'  => 'Invalid date',
         ];
 
         $result = invalid($data, $rules, $messages);
-        $this->assertEquals($messages, $result);
+        $this->assertSame($messages, $result);
 
         $data = [
             'username' => 'homer',
             'email'    => 'homer@simpson.com',
             'zip'      => 123,
             'website'  => 'http://example.com',
+            'created'  => '2021-01-01',
         ];
 
         $result = invalid($data, $rules, $messages);
-        $this->assertEquals([], $result);
+        $this->assertSame([], $result);
     }
 
     public function testInvalidSimple()


### PR DESCRIPTION
## Describe the PR
If validation rule not have an option (like `email`, `date`, `integer`, etc..) (not like `min => 3`, `max => 10`), the validation name is also sent in the parameter in `invalid()` helper. The PR fixes this.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3208 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
