### PR TITLE
Fixes converting paragraph editor to blocks

### DIFF
--- a/src/Cms/BlockConverter.php
+++ b/src/Cms/BlockConverter.php
@@ -219,7 +219,7 @@ class BlockConverter
     {
         return [
             'content' => [
-                'text' => $params['content']
+                'text' => '<p>' . $params['content'] . '</p>'
             ],
             'type' => 'text'
         ];

--- a/tests/Cms/Blocks/EditorImportTest.php
+++ b/tests/Cms/Blocks/EditorImportTest.php
@@ -156,7 +156,7 @@ class EditorImportTest extends TestCase
         $block = new Block($params);
 
         $this->assertSame('text', $block->type());
-        $this->assertEquals($params['content'], $block->text());
+        $this->assertSame('<p>' . $params['content'] . '</p>', $block->text()->value());
     }
 
     public function importUl($params)


### PR DESCRIPTION
## Describe the PR
Adding the `<p>` tag when converting editor to blocks, which is the suggestion of @mrflix, is applied.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3204 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
