### PR TITLE
Checks slug length on page duplicate

### DIFF
--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -292,6 +292,8 @@ class PageRules
             ]);
         }
 
+        self::validateSlugLength($page->slug());
+
         if ($page->exists() === true) {
             throw new DuplicateException([
                 'key'  => 'page.draft.duplicate',
@@ -300,8 +302,6 @@ class PageRules
                 ]
             ]);
         }
-
-        self::validateSlugLength($page->slug());
 
         $siblings = $page->parentModel()->children();
         $drafts   = $page->parentModel()->drafts();

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -254,18 +254,18 @@ class PageRules
      */
     public static function changeTitle(Page $page, string $title): bool
     {
-        if (Str::length($title) === 0) {
-            throw new InvalidArgumentException([
-                'key' => 'page.changeTitle.empty',
-            ]);
-        }
-
         if ($page->permissions()->changeTitle() !== true) {
             throw new PermissionException([
                 'key'  => 'page.changeTitle.permission',
                 'data' => [
                     'slug' => $page->slug()
                 ]
+            ]);
+        }
+
+        if (Str::length($title) === 0) {
+            throw new InvalidArgumentException([
+                'key' => 'page.changeTitle.empty',
             ]);
         }
 
@@ -283,13 +283,14 @@ class PageRules
      */
     public static function create(Page $page): bool
     {
-        if (Str::length($page->slug()) < 1) {
-            throw new InvalidArgumentException([
-                'key' => 'page.slug.invalid',
+        if ($page->permissions()->create() !== true) {
+            throw new PermissionException([
+                'key' => 'page.create.permission',
+                'data' => [
+                    'slug' => $page->slug()
+                ]
             ]);
         }
-
-        self::validateSlugLength($page->slug());
 
         if ($page->exists() === true) {
             throw new DuplicateException([
@@ -300,14 +301,7 @@ class PageRules
             ]);
         }
 
-        if ($page->permissions()->create() !== true) {
-            throw new PermissionException([
-                'key' => 'page.create.permission',
-                'data' => [
-                    'slug' => $page->slug()
-                ]
-            ]);
-        }
+        self::validateSlugLength($page->slug());
 
         $siblings = $page->parentModel()->children();
         $drafts   = $page->parentModel()->drafts();
@@ -377,12 +371,6 @@ class PageRules
             ]);
         }
 
-        if (Str::length($slug) < 1) {
-            throw new InvalidArgumentException([
-                'key' => 'page.slug.invalid',
-            ]);
-        }
-
         self::validateSlugLength($slug);
 
         return true;
@@ -411,19 +399,27 @@ class PageRules
     }
 
     /**
-     * Ensures that the slug doesn't exceed the maximum length to make
-     * sure that the directory name will be accepted by the filesystem
+     * Ensures that the slug is not empty and doesn't exceed the maximum length
+     * to make sure that the directory name will be accepted by the filesystem
      *
      * @param string $slug New slug to check
      * @return void
-     * @throws \Kirby\Exception\InvalidArgumentException If the slug is too long
+     * @throws \Kirby\Exception\InvalidArgumentException If the slug is empty or too long
      */
     protected static function validateSlugLength(string $slug): void
     {
+        $slugLength = Str::length($slug);
+
+        if ($slugLength === 0) {
+            throw new InvalidArgumentException([
+                'key' => 'page.slug.invalid',
+            ]);
+        }
+
         if ($slugsMaxlength = App::instance()->option('slugs.maxlength', 255)) {
             $maxlength = (int)$slugsMaxlength;
 
-            if (Str::length($slug) > $maxlength) {
+            if ($slugLength > $maxlength) {
                 throw new InvalidArgumentException([
                     'key'  => 'page.slug.maxlength',
                     'data' => [

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -377,6 +377,14 @@ class PageRules
             ]);
         }
 
+        if (Str::length($slug) < 1) {
+            throw new InvalidArgumentException([
+                'key' => 'page.slug.invalid',
+            ]);
+        }
+
+        self::validateSlugLength($slug);
+
         return true;
     }
 

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -261,11 +261,13 @@ class PageRulesTest extends TestCase
 
     public function testChangeTitleWithEmptyValue()
     {
-        $page = $this->createMock(Page::class);
-        $page->method('slug')->willReturn('test');
+        $page = new Page([
+            'slug'  => 'test',
+            'kirby' => $this->appWithAdmin(),
+        ]);
 
         $this->expectException('Kirby\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('The title must not be empty');
+        $this->expectExceptionCode('error.page.changeTitle.empty');
 
         PageRules::changeTitle($page, '');
     }

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -482,6 +482,19 @@ class PageRulesTest extends TestCase
         $this->assertTrue(PageRules::duplicate($page, 'test-copy'));
     }
 
+    public function testDuplicateInvalid()
+    {
+        $page = new Page([
+            'slug'  => 'test',
+            'kirby' => $this->appWithAdmin(),
+        ]);
+
+        $this->expectException('\Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionCode('error.page.slug.invalid');
+
+        PageRules::duplicate($page, '');
+    }
+
     public function testDuplicateWithoutPermissions()
     {
         $permissions = $this->createMock(PagePermissions::class);


### PR DESCRIPTION
## Describe the PR

Fixed by checking slug in `PageRules::duplicate()` method.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3214 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
