### PR TITLE
Checks whether the field disabled on `prompt()` method in files field

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -94,7 +94,11 @@ export default {
     prompt(e) {
       e.stopPropagation();
 
-      if (this.uploads) {
+      if (this.disabled) {
+        return false;
+      }
+
+      if (this.more && this.uploads) {
         this.$refs.picker.toggle();
       } else {
         this.open();


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

Since the `picker` is only accessible if it is not `max` and not `disabled`, some checks have been added to the `prompt()` method.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3220 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
