### PR TITLE
Fields: use mixins instead of destructing props

### DIFF
--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -41,20 +41,34 @@
 </template>
 
 <script>
-export default {
-  inheritAttrs: false,
+import {
+  disabled,
+  help,
+  label,
+  name,
+  required
+} from "@/mixins/props.js";
+
+export const props = {
+  mixins: [
+    disabled,
+    help,
+    label,
+    name,
+    required,
+  ],
   props: {
     counter: [Boolean, Object],
-    disabled: Boolean,
     endpoints: Object,
-    help: String,
     input: [String, Number],
-    label: String,
-    name: [String, Number],
-    required: Boolean,
     translate: Boolean,
     type: String
-  },
+  }
+}
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   computed: {
     labelText() {
       return this.label || " ";

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -33,12 +33,12 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
+import { props as Field } from "../Field.vue";
 
 export default {
+  mixins: [Field],
   inheritAttrs: false,
   props: {
-    ...Field.props,
     empty: String,
     fieldsets: Object,
     fieldsetGroups: Object,

--- a/panel/src/components/Forms/Field/CheckboxesField.vue
+++ b/panel/src/components/Forms/Field/CheckboxesField.vue
@@ -16,36 +16,22 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import CheckboxesInput from "../Input/CheckboxesInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as CheckboxesInput } from "../Input/CheckboxesInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-checkboxes-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    CheckboxesInput,
+    counter
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...CheckboxesInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    }
-  },
-  computed: {
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-      return {
-        count: this.value && Array.isArray(this.value) ? this.value.length : 0,
-        min: this.min,
-        max: this.max
-      };
-    }
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -33,20 +33,22 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import DateTimeInput from "../Input/DateTimeInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as DateTimeInput } from "../Input/DateTimeInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-datetime-input>` for additional information.
  * @example <k-date-field v-model="date" name="date" label="Date" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    DateTimeInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...DateTimeInput.props,
     /**
      * Deactivate the dropdown calendar or not
      */

--- a/panel/src/components/Forms/Field/EmailField.vue
+++ b/panel/src/components/Forms/Field/EmailField.vue
@@ -23,20 +23,22 @@
 </template>
 
 <script>
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as EmailInput } from "../Input/EmailInput.vue";
+
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-email-input>` for additional information.
  * @example <k-email-field v-model="email" name="email" label="Email" />
  */
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import EmailInput from "../Input/EmailInput.vue";
-
 export default {
+  mixins: [
+    Field,
+    Input,
+    EmailInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...EmailInput.props,
     link: {
       type: Boolean,
       default: true

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -77,7 +77,7 @@
 
 <script>
 import config from "@/config/config.js";
-import picker from "@/mixins/picker/field.js";
+import picker from "@/mixins/forms/picker.js";
 
 /**
  * @example <k-files-field v-model="files" name="files" label="Files" />

--- a/panel/src/components/Forms/Field/HeadlineField.vue
+++ b/panel/src/components/Forms/Field/HeadlineField.vue
@@ -17,22 +17,20 @@
 </template>
 
 <script>
+import {
+  help,
+  label
+} from "@/mixins/props.js";
+
 /**
  * @example <k-headline-field label="This is a headline" />
  */
 export default {
+  mixins: [
+    help,
+    label
+  ],
   props: {
-    /**
-     * Help text for below the field
-     */
-    help: String,
-    /**
-     * Label of the field
-     */
-    label: String,
-    /**
-     * Enables or hides the index numbers left next to the headline
-     */
     numbered: Boolean
   }
 };

--- a/panel/src/components/Forms/Field/InfoField.vue
+++ b/panel/src/components/Forms/Field/InfoField.vue
@@ -19,13 +19,20 @@
 </template>
 
 <script>
+import {
+  help,
+  label
+} from "@/mixins/props.js";
+
 /**
  * @example <k-info-field label="Info" text="This is a nice info text" />
  */
 export default {
+  mixins: [
+    help,
+    label
+  ],
   props: {
-    help: String,
-    label: String,
     /**
      * Sets the info text. You can use HTML here to format the info.
      */

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -11,16 +11,16 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
+import { props as Field } from "../Field.vue";
 import Layouts from "@/components/Layouter/Layouts.vue";
 
 export default {
   components: {
     "k-block-layouts": Layouts,
   },
+  mixins: [Field],
   inheritAttrs: false,
   props: {
-    ...Field.props,
     empty: String,
     fieldsetGroups: Object,
     fieldsets: Object,

--- a/panel/src/components/Forms/Field/ListField.vue
+++ b/panel/src/components/Forms/Field/ListField.vue
@@ -19,17 +19,19 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
 
 /**
  * Have a look at `<k-field>` and `<k-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
     marks: [Array, Boolean],
     value: String,
   },

--- a/panel/src/components/Forms/Field/MultiselectField.vue
+++ b/panel/src/components/Forms/Field/MultiselectField.vue
@@ -19,40 +19,26 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import MultiselectInput from "../Input/MultiselectInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as MultiselectInput } from "../Input/MultiselectInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-multiselect-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    MultiselectInput,
+    counter
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...MultiselectInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    },
     icon: {
       type: String,
       default: "angle-down"
-    }
-  },
-  computed: {
-    // REFACTOR: DRY the following - same in TagsField
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-
-      return {
-        count: this.value && Array.isArray(this.value) ? this.value.length : 0,
-        min: this.min,
-        max: this.max
-      };
     }
   },
   mounted() {

--- a/panel/src/components/Forms/Field/NumberField.vue
+++ b/panel/src/components/Forms/Field/NumberField.vue
@@ -12,21 +12,21 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import NumberInput from "../Input/NumberInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as NumberInput } from "../Input/NumberInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-number-input>` for additional information.
  * @example <k-number-field v-model="number" name="number" label="Number" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    NumberInput
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...NumberInput.props
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-import picker from "@/mixins/picker/field.js";
+import picker from "@/mixins/forms/picker.js";
 
 export default {
   mixins: [picker],

--- a/panel/src/components/Forms/Field/PasswordField.vue
+++ b/panel/src/components/Forms/Field/PasswordField.vue
@@ -18,23 +18,23 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import PasswordInput from "../Input/PasswordInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as PasswordInput } from "../Input/PasswordInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-password-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    PasswordInput,
+    counter
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...PasswordInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    },
     minlength: {
       type: Number,
       default: 8
@@ -42,18 +42,6 @@ export default {
     icon: {
       type: String,
       default: "key"
-    }
-  },
-  computed: {
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-      return {
-        count: this.value ? String(this.value).length : 0,
-        min: this.minlength,
-        max: this.maxlength
-      };
     }
   },
   methods: {

--- a/panel/src/components/Forms/Field/RadioField.vue
+++ b/panel/src/components/Forms/Field/RadioField.vue
@@ -12,20 +12,20 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import RadioInput from "../Input/RadioInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as RadioInput } from "../Input/RadioInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-radio-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    RadioInput
+  ],  
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...RadioInput.props
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/RangeField.vue
+++ b/panel/src/components/Forms/Field/RangeField.vue
@@ -12,21 +12,21 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import RangeInput from "../Input/RangeInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as RangeInput } from "../Input/RangeInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-range-input>` for additional information.
  * @example <k-range-field v-model="range" name="range" label="Slider" />
  */
 export default {
+  mixins: [
+    Input,
+    Field,
+    RangeInput
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...RangeInput.props
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/SelectField.vue
+++ b/panel/src/components/Forms/Field/SelectField.vue
@@ -12,19 +12,21 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import SelectInput from "../Input/SelectInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as SelectInput } from "../Input/SelectInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-select-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    SelectInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...SelectInput.props,
     icon: {
       type: String,
       default: "angle-down"

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -168,13 +168,13 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
 import direction from "@/helpers/direction.js";
+import { props as Field } from "../Field.vue";
 
 export default {
+  mixins: [Field],
   inheritAttrs: false,
   props: {
-    ...Field.props,
     columns: Object,
     duplicate: {
       type: Boolean,

--- a/panel/src/components/Forms/Field/TagsField.vue
+++ b/panel/src/components/Forms/Field/TagsField.vue
@@ -17,37 +17,22 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import TagsInput from "../Input/TagsInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as TagsInput } from "../Input/TagsInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-tags-input>` for additional information.
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    TagsInput,
+    counter
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...TagsInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    }
-  },
-  computed: {
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-
-      return {
-        count: this.value && Array.isArray(this.value) ? this.value.length : 0,
-        min: this.min,
-        max: this.max,
-      };
-    }
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/TelField.vue
+++ b/panel/src/components/Forms/Field/TelField.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import TelInput from "../Input/TelInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as TelInput } from "../Input/TelInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-tel-input>` 
@@ -22,11 +22,13 @@ import TelInput from "../Input/TelInput.vue";
  * @example <k-tel-field v-model="tel" name="tel" label="Phone number" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    TelInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...TelInput.props,
     icon: {
       type: String,
       default: "phone"

--- a/panel/src/components/Forms/Field/TextField.vue
+++ b/panel/src/components/Forms/Field/TextField.vue
@@ -17,9 +17,10 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import TextInput from "../Input/TextInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as TextInput } from "../Input/TextInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-text-input>` 
@@ -27,28 +28,13 @@ import TextInput from "../Input/TextInput.vue";
  * @example <k-text-field v-model="text" name="text" label="Boring text" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    TextInput,
+    counter
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...TextInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    }
-  },
-  computed: {
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-      return {
-        count: this.value ? String(this.value).length : 0,
-        min: this.minlength,
-        max: this.maxlength
-      };
-    }
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/TextareaField.vue
+++ b/panel/src/components/Forms/Field/TextareaField.vue
@@ -17,9 +17,10 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import TextareaInput from "../Input/TextareaInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as TextareaInput } from "../Input/TextareaInput.vue";
+import counter from "@/mixins/forms/counter.js";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-textarea-input>` 
@@ -27,28 +28,13 @@ import TextareaInput from "../Input/TextareaInput.vue";
  * @example <k-textarea-field v-model="text" name="text" label="Text" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    TextareaInput,
+    counter
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...TextareaInput.props,
-    counter: {
-      type: Boolean,
-      default: true
-    }
-  },
-  computed: {
-    counterOptions() {
-      if (this.value === null || this.disabled || this.counter === false) {
-        return false;
-      }
-      return {
-        count: this.value ? this.value.length : 0,
-        min: this.minlength,
-        max: this.maxlength
-      };
-    }
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import TimeInput from "../Input/TimeInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as TimeInput } from "../Input/TimeInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-time-input>` 
@@ -22,11 +22,13 @@ import TimeInput from "../Input/TimeInput.vue";
  * @example <k-time-field v-model="time" name="time" label="Time" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    TimeInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...TimeInput.props,
     icon: {
       type: String,
       default: "clock"

--- a/panel/src/components/Forms/Field/ToggleField.vue
+++ b/panel/src/components/Forms/Field/ToggleField.vue
@@ -12,9 +12,9 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import ToggleInput from "../Input/ToggleInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as ToggleInput } from "../Input/ToggleInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-toggle-input>` 
@@ -22,12 +22,12 @@ import ToggleInput from "../Input/ToggleInput.vue";
  * @example <k-toggle-field v-model="toggle" label="Toggle" name="toggle" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    ToggleInput
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...ToggleInput.props
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Field/UrlField.vue
+++ b/panel/src/components/Forms/Field/UrlField.vue
@@ -23,9 +23,9 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import UrlInput from "../Input/UrlInput.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as UrlInput } from "../Input/UrlInput.vue";
 
 /**
  * Have a look at `<k-field>`, `<k-input>` and `<k-url-input>` 
@@ -33,11 +33,13 @@ import UrlInput from "../Input/UrlInput.vue";
  * @example <k-url-field v-model="url" name="url" label="Url" />
  */
 export default {
+  mixins: [
+    Field,
+    Input,
+    UrlInput
+  ],
   inheritAttrs: false,
   props: {
-    ...Field.props,
-    ...Input.props,
-    ...UrlInput.props,
     link: {
       type: Boolean,
       default: true

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-import picker from "@/mixins/picker/field.js";
+import picker from "@/mixins/forms/picker.js";
 
 export default {
   mixins: [picker],

--- a/panel/src/components/Forms/Field/WriterField.vue
+++ b/panel/src/components/Forms/Field/WriterField.vue
@@ -24,17 +24,17 @@
 </template>
 
 <script>
-import Field from "../Field.vue";
-import Input from "../Input.vue";
-import Writer from "@/components/Writer/Writer.vue";
+import { props as Field } from "../Field.vue";
+import { props as Input } from "../Input.vue";
+import { props as Writer } from "@/components/Writer/Writer.vue";
 
 export default {
+  mixins: [
+    Field,
+    Input,
+    Writer
+  ],
   inheritAttrs: false,
-  props: {
-    ...Field.props,
-    ...Input.props,
-    ...Writer.props,
-  },
   methods: {
     focus() {
       this.$refs.input.focus();

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -32,15 +32,23 @@
 </template>
 
 <script>
-export default {
-  inheritAttrs: false,
+import {
+  after,
+  before,
+  disabled,
+  invalid
+} from "@/mixins/props.js";
+
+export const props = {
+  mixins: [
+    after,
+    before,
+    disabled,
+    invalid
+  ],
   props: {
-    after: String,
-    before: String,
-    disabled: Boolean,
     type: String,
     icon: [String, Boolean],
-    invalid: Boolean,
     theme: String,
     novalidate: {
       type: Boolean,
@@ -50,7 +58,12 @@ export default {
       type: [String, Boolean, Number, Object, Array],
       default: null
     }
-  },
+  }
+};
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       isInvalid: this.invalid,

--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -29,38 +29,30 @@
 </template>
 
 <script>
-import { required } from "vuelidate/lib/validators";
+import {
+  autofocus,
+  disabled,
+  id,
+  label,
+  required
+} from "@/mixins/props.js";
+
+import { required as validateRequired } from "vuelidate/lib/validators";
 
 /**
  * 
  * @example <k-input v-model="checkbox" type="checkbox" />
  */
 export default {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    label,
+    required
+  ],
   inheritAttrs: false,
   props: {
-    /**
-     * If true, the input will be instantly focused when the form is created
-     */
-    autofocus: {
-      type: Boolean,
-      default: false
-    },
-    /**
-     * If true, the input is disabled and cannot be filled in or edited
-     */
-    disabled: {
-      type: Boolean,
-      default: false
-    },
-    id: [Number, String],
-    label: String,
-    /**
-     * If true, the input must not be empty
-     */
-    required: {
-      type: Boolean,
-      default: false
-    },
     value: Boolean,
   },
   watch: {
@@ -101,7 +93,7 @@ export default {
   validations() {
     return {
       value: {
-        required: this.required ? required : true,
+        required: this.required ? validateRequired : true,
       }
     }
   }

--- a/panel/src/components/Forms/Input/CheckboxesInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxesInput.vue
@@ -12,24 +12,31 @@
 </template>
 
 <script>
-import { required, minLength, maxLength } from "vuelidate/lib/validators";
+import {
+  autofocus,
+  disabled,
+  id,
+  required
+} from "@/mixins/props.js";
 
-export default {
-  inheritAttrs: false,
+import { 
+  required as validateRequired, 
+  minLegth as validateMinLength, 
+  maxLength as validateMaxLength 
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    required
+  ],
   props: {
-    autofocus: Boolean,
     columns: Number,
-    disabled: Boolean,
-    id: {
-      type: [Number, String],
-      default() {
-        return this._uid;
-      }
-    },
     max: Number,
     min: Number,
     options: Array,
-    required: Boolean,
     /**
      * The value for the input should be provided as array. Each value in the array corresponds with the value in the options. If you provide a string, the string will be split by comma.
      */
@@ -39,7 +46,12 @@ export default {
         return [];
       }
     }
-  },
+  }
+};
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       selected: this.valueToArray(this.value)
@@ -98,9 +110,9 @@ export default {
   validations() {
     return {
       selected: {
-        required: this.required ? required : true,
-        min: this.min ? minLength(this.min) : true,
-        max: this.max ? maxLength(this.max) : true,
+        required: this.required ? validateRequired : true,
+        min: this.min ? validateMinLength(this.min) : true,
+        max: this.max ? validateMaxLength(this.max) : true,
       }
     };
   }

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -19,21 +19,27 @@
 </template>
 
 <script>
-import { required } from "vuelidate/lib/validators";
+import {
+  autofocus,
+  disabled,
+  id,
+  required
+} from "@/mixins/props.js";
 
-/**
- * @example <k-input v-model="date" type="date" name="date" />
- */
-export default {
-  inheritAttrs: false,
+import { required as validateRequired } from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    required
+  ],
   props: {
-    autofocus: Boolean,
-    disabled: Boolean,
     display: {
       type: String,
       default: "DD.MM.YYYY"
     },
-    id: [String, Number],
     /**
      * The last allowed date
      */
@@ -42,7 +48,6 @@ export default {
      * The first allowed date
      */
     min: String,
-    required: Boolean,
     step: {
       type: Object,
       default() {
@@ -61,7 +66,15 @@ export default {
      * @example `2012-12-12 22:33:00`
      */
     value: String
-  },
+  }
+};
+
+/**
+ * @example <k-input v-model="date" type="date" name="date" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       input: this.toFormat(this.value),
@@ -409,7 +422,7 @@ export default {
           "isBefore",
           this.step.unit
         ) : true,
-        required: this.required ? required : true,
+        required: this.required ? validateRequired : true,
       }
     }
   }

--- a/panel/src/components/Forms/Input/DateTimeInput.vue
+++ b/panel/src/components/Forms/Input/DateTimeInput.vue
@@ -22,13 +22,12 @@
 </template>
 
 <script>
-import DateInput from "./DateInput.vue";
-import { required } from "vuelidate/lib/validators";
+import { props as DateInput } from "./DateInput.vue";
+import { required as validateRequired } from "vuelidate/lib/validators";
 
-export default {
-  inheritAttrs: false,
+export const props = {
+  mixins: [DateInput],
   props: {
-    ...DateInput.props,
     time: {
       type: [Boolean, Object],
       default() {
@@ -36,7 +35,12 @@ export default {
       }
     },
     value: String
-  },
+  }
+}
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       input: this.toDatetime(this.value)
@@ -155,7 +159,7 @@ export default {
           "isBefore",
           this.step.unit
         ) : true,
-        required: this.required ? required : true,
+        required: this.required ? validateRequired : true,
       }
     };
   }

--- a/panel/src/components/Forms/Input/EmailInput.vue
+++ b/panel/src/components/Forms/Input/EmailInput.vue
@@ -1,13 +1,10 @@
 <script>
 import TextInput from "./TextInput.vue";
+import { props as TextInputProps } from "./TextInput.vue";
 
-/**
- * @example <k-input v-model="email" type="email" name="email" />
- */
-export default {
-  extends: TextInput,
+export const props = {
+  mixins: [TextInputProps],
   props: {
-    ...TextInput.props,
     autocomplete: {
       type: String,
       default: "email"
@@ -23,5 +20,13 @@ export default {
       default: "email"
     }
   }
+}
+
+/**
+ * @example <k-input v-model="email" type="email" name="email" />
+ */
+export default {
+  extends: TextInput,
+  mixins: [props]
 }
 </script>

--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import ListDoc from "@/components/Writer/Nodes/ListDoc";
+import ListDoc from "@/components/Writer/Nodes/ListDoc.js";
 
 export default {
   inheritAttrs: false,

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -83,13 +83,25 @@
 </template>
 
 <script>
-import { required, minLength, maxLength } from "vuelidate/lib/validators";
+import {
+  disabled,
+  id,
+  required
+} from "@/mixins/props.js";
 
-export default {
-  inheritAttrs: false,
+import { 
+  required as validateRequired, 
+  minLength as validateMinLength, 
+  maxLength as validateMaxLength 
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    disabled,
+    id,
+    required
+  ],
   props: {
-    id: [Number, String],
-    disabled: Boolean,
     max: Number,
     min: Number,
     layout: String,
@@ -99,7 +111,6 @@ export default {
         return [];
       }
     },
-    required: Boolean,
     search: [Object, Boolean],
     separator: {
       type: String,
@@ -113,7 +124,12 @@ export default {
         return [];
       }
     }
-  },
+  }
+};
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       state: this.value,
@@ -306,9 +322,9 @@ export default {
   validations() {
     return {
       state: {
-        required: this.required ? required : true,
-        minLength: this.min ? minLength(this.min) : true,
-        maxLength: this.max ? maxLength(this.max) : true
+        required: this.required ? validateRequired : true,
+        minLength: this.min ? validateMinLength(this.min) : true,
+        maxLength: this.max ? validateMaxLength(this.max) : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/NumberInput.vue
+++ b/panel/src/components/Forms/Input/NumberInput.vue
@@ -23,29 +23,31 @@
 
 <script>
 import {
-  required,
-  minValue,
-  maxValue
+  autofocus,
+  disabled,
+  id,
+  required
+} from "@/mixins/props.js";
+
+import {
+  required as validateRequired,
+  minValue as validateMinValue,
+  maxValue as validateMaxValue
 } from "vuelidate/lib/validators";
 
-/**
- * @example <k-input v-model="number" name="number" type="number" />
- */
-export default {
-  inheritAttrs: false,
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    required
+  ],
   props: {
-    autofocus: Boolean,
-    disabled: Boolean,
-    id: [Number, String],
-    /**
-     * The highest accepted number
-     */
     max: Number,
     min: Number,
     name: [Number, String],
     placeholder: String,
     preselect: Boolean,
-    required: Boolean,
     /**
      * The amount to increment with each input step. This can be a decimal.
      */
@@ -55,6 +57,14 @@ export default {
       default: null
     }
   },
+}
+
+/**
+ * @example <k-input v-model="number" name="number" type="number" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       number: this.format(this.value),
@@ -153,9 +163,9 @@ export default {
   validations() {
     return {
       value: {
-        required: this.required ? required : true,
-        min: this.min ? minValue(this.min) : true,
-        max: this.max ? maxValue(this.max) : true
+        required: this.required ? validateRequired : true,
+        min: this.min ? validateMinValue(this.min) : true,
+        max: this.max ? validateMaxValue(this.max) : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/PasswordInput.vue
+++ b/panel/src/components/Forms/Input/PasswordInput.vue
@@ -1,13 +1,10 @@
 <script>
 import TextInput from "./TextInput.vue";
+import { props as TextInputProps } from "./TextInput.vue";
 
-/**
- * @example <k-input v-model="password" name="password" type="password" />
- */
-export default {
-  extends: TextInput,
+export const props = {
+  mixins: [TextInputProps],
   props: {
-    ...TextInput.props,
     autocomplete: {
       type: String,
       default: "new-password"
@@ -17,5 +14,13 @@ export default {
       default: "password"
     }
   }
+}
+
+/**
+ * @example <k-input v-model="password" name="password" type="password" />
+ */
+export default {
+  extends: TextInput,
+  mixins: [props]
 }
 </script>

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -25,24 +25,32 @@
 </template>
 
 <script>
-import { required } from "vuelidate/lib/validators";
+import {
+  autofocus,
+  disabled,
+  id,
+  required
+} from "@/mixins/props.js";
 
-export default {
-  inheritAttrs: false,
+import { required as validateRequired } from "vuelidate/lib/validators";
+
+export const props = {
+    mixins: [
+    autofocus,
+    disabled,
+    id,
+    required
+  ],
   props: {
-    autofocus: Boolean,
     columns: Number,
-    disabled: Boolean,
-    id: {
-      type: [Number, String],
-      default() {
-        return this._uid;
-      }
-    },
     options: Array,
-    required: Boolean,
     value: [String, Number, Boolean]
   },
+};
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   watch: {
     value() {
       this.onInvalid();
@@ -72,7 +80,7 @@ export default {
   validations() {
     return {
       value: {
-        required: this.required ? required : true
+        required: this.required ? validateRequired : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -27,17 +27,29 @@
 </template>
 
 <script>
-import { required, minValue, maxValue } from "vuelidate/lib/validators";
+import { 
+  autofocus,
+  disabled,
+  id,
+  name,
+  required
+} from "@/mixins/props.js";
 
-/**
- * @example <k-input v-model="range" name="range" type="range" />
- */
-export default {
-  inheritAttrs: false,
+import { 
+  required as validateRequired,
+  minValue as validateMinValue,
+  maxValue as validateMaxValue
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    name,
+    required
+  ],
   props: {
-    autofocus: Boolean,
-    disabled: Boolean,
-    id: [String, Number],
     default: [Number, String],
     /**
      * The highest accepted number
@@ -53,8 +65,6 @@ export default {
       type: Number,
       default: 0
     },
-    name: [String, Number],
-    required: Boolean,
     /**
      * The amount to increment when dragging the slider. This can be a decimal.
      */
@@ -75,7 +85,15 @@ export default {
       }
     },
     value: [Number, String]
-  },
+  }
+}
+
+/**
+ * @example <k-input v-model="range" name="range" type="range" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       listeners: {
@@ -131,9 +149,9 @@ export default {
   validations() {
     return {
       position: {
-        required: this.required ? required : true,
-        min: this.min ? minValue(this.min) : true,
-        max: this.max ? maxValue(this.max) : true
+        required: this.required ? validateRequired : true,
+        min: this.min ? validateMinValue(this.min) : true,
+        max: this.max ? validateMaxValue(this.max) : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -33,15 +33,27 @@
 </template>
 
 <script>
-import { required } from "vuelidate/lib/validators";
+import {
+  autofocus,
+  disabled,
+  id,
+  name,
+  required
+} from "@/mixins/props.js"
 
-export default {
-  inheritAttrs: false,
+import { required as validateRequired } from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    name,
+    required
+  ],
   props: {
-    autofocus: Boolean,
     ariaLabel: String,
     default: String,
-    disabled: Boolean,
     /**
      * The text, that is shown as the first empty option, when the field is not required.
      */
@@ -49,8 +61,6 @@ export default {
       type: [Boolean, String],
       default: true
     },
-    id: [Number, String],
-    name: [Number, String],
     /**
      * The text, that is shown when no option is selected yet.
      */
@@ -61,12 +71,16 @@ export default {
         return [];
       }
     },
-    required: Boolean,
     value: {
       type: [String, Number, Boolean],
       default: ""
     }
-  },
+  }
+}
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       selected: this.value,
@@ -143,7 +157,7 @@ export default {
   validations() {
     return {
       selected: {
-        required: this.required ? required : true,
+        required: this.required ? validateRequired : true,
       }
     };
   }

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -55,23 +55,39 @@
 </template>
 
 <script>
-import { required, minLength, maxLength } from "vuelidate/lib/validators";
 import direction from "@/helpers/direction.js";
 
-export default {
-  inheritAttrs: false,
+import {
+  autofocus,
+  disabled,
+  id,
+  name,
+  required
+} from "@/mixins/props.js";
+
+import { 
+  required as validateRequired, 
+  minLength as validateMinLength, 
+  maxLength as validateMaxLength 
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    name,
+    required
+  ],
   props: {
-    autofocus: Boolean,
     accept: {
       type: String,
       default: "all"
     },
-    disabled: Boolean,
     icon: {
       type: [String, Boolean],
       default: "tag"
     },
-    id: [Number, String],
     /**
      * You can set the layout to `list` to extend the width of each tag 
      * to 100% and show them in a list. This is handy in narrow columns 
@@ -87,7 +103,6 @@ export default {
      * The minimum number of required tags
      */
     min: Number,
-    name: [Number, String],
     /**
      * Options will be shown in the autocomplete dropdown 
      * as soon as you start typing.
@@ -98,7 +113,6 @@ export default {
         return [];
       }
     },
-    required: Boolean,
     separator: {
       type: String,
       default: ","
@@ -109,7 +123,12 @@ export default {
         return [];
       }
     }
-  },
+  }
+}
+
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       tags: this.prepareTags(this.value),
@@ -382,9 +401,9 @@ export default {
   validations() {
     return {
       tags: {
-        required: this.required ? required : true,
-        minLength: this.min ? minLength(this.min) : true,
-        maxLength: this.max ? maxLength(this.max) : true
+        required: this.required ? validateRequired : true,
+        minLength: this.min ? validateMinLength(this.min) : true,
+        maxLength: this.max ? validateMaxLength(this.max) : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/TelInput.vue
+++ b/panel/src/components/Forms/Input/TelInput.vue
@@ -1,13 +1,10 @@
 <script>
 import TextInput from "./TextInput.vue";
+import { props as TextInputProps } from "./TextInput.vue";
 
-/**
- * @example <k-input v-model="tel" name="tel" type="tel" />
- */
-export default {
-  extends: TextInput,
+export const props = {
+  mixins: [TextInputProps],
   props: {
-    ...TextInput.props,
     autocomplete: {
       type: String,
       default: "tel"
@@ -17,5 +14,13 @@ export default {
       default: "tel"
     }
   }
+}
+
+/**
+ * @example <k-input v-model="tel" name="tel" type="tel" />
+ */
+export default {
+  extends: TextInput,
+  mixins: [props]
 }
 </script>

--- a/panel/src/components/Forms/Input/TextInput.vue
+++ b/panel/src/components/Forms/Input/TextInput.vue
@@ -22,36 +22,42 @@
 </template>
 
 <script>
-import {
-  required,
-  minLength,
-  maxLength,
-  email,
-  url
-} from "vuelidate/lib/validators";
 import direction from "@/helpers/direction.js";
 
-/**
- * @example <k-input v-model="text" name="text" type="text" />
- */
-export default {
-  inheritAttrs: false,
-  class: "k-text-input",
+import {
+  autofocus,
+  disabled,
+  id,
+  name,
+  required
+} from "@/mixins/props.js"
+
+import {
+  required as validateRequired,
+  minLength as validateMinLength,
+  maxLength as validateMaxLength,
+  email as validateEmail,
+  url as validateUrl
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    name,
+    required
+  ],
   props: {
     autocomplete: {
       type: [Boolean, String],
       default: "off"
     },
-    autofocus: Boolean,
-    disabled: Boolean,
-    id: [Number, String],
     maxlength: Number,
     minlength: Number,
-    name: [Number, String],
     pattern: String,
     placeholder: String,
     preselect: Boolean,
-    required: Boolean,
     spellcheck: {
       type: [Boolean, String],
       default: "off"
@@ -61,7 +67,15 @@ export default {
       default: "text"
     },
     value: String
-  },
+  }
+}
+
+/**
+ * @example <k-input v-model="text" name="text" type="text" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       listeners: {
@@ -106,18 +120,18 @@ export default {
     }
   },
   validations() {
-    const match = (value) => {
+    const validateMatch = (value) => {
       return (!this.required && !value) || !this.$refs.input.validity.patternMismatch;
     };
 
     return {
       value: {
-        required: this.required ? required : true,
-        minLength: this.minlength ? minLength(this.minlength) : true,
-        maxLength: this.maxlength ? maxLength(this.maxlength) : true,
-        email: this.type === "email" ? email : true,
-        url: this.type === "url" ? url : true,
-        pattern: this.pattern ? match : true,
+        required: this.required ? validateRequired : true,
+        minLength: this.minlength ? validateMinLength(this.minlength) : true,
+        maxLength: this.maxlength ? validateMaxLength(this.maxlength) : true,
+        email: this.type === "email" ? validateEmail : true,
+        url: this.type === "url" ? validateUrl : true,
+        pattern: this.pattern ? validateMatch : true,
       }
     };
   }

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -53,33 +53,41 @@
 
 <script>
 import config from "@/config/config.js";
-import { required, minLength, maxLength } from "vuelidate/lib/validators";
 import direction from "@/helpers/direction.js";
 
-/**
- * @example <k-input v-model="text" name="text" type="textarea" />
- */
-export default {
-  inheritAttrs: false,
+import {
+  autofocus,
+  disabled,
+  id,
+  name,
+  required
+} from "@/mixins/props.js"
+
+import { 
+  required as validateRequired, 
+  minLength as validateMinLength, 
+  maxLength as validateMaxLength 
+} from "vuelidate/lib/validators";
+
+export const props = {
+  mixins: [
+    autofocus,
+    disabled,
+    id,
+    name,
+    required
+  ],
   props: {
-    autofocus: Boolean,
-    /**
-     * Enables or disables all or specific buttons in the toolbar.
-     */
     buttons: {
       type: [Boolean, Array],
       default: true
     },
-    disabled: Boolean,
     endpoints: Object,
     font: String,
-    id: [Number, String],
-    name: [Number, String],
     maxlength: Number,
     minlength: Number,
     placeholder: String,
     preselect: Boolean,
-    required: Boolean,
     /**
      * Pre-selects the size before auto-sizing kicks in. 
      * This can be useful to fill gaps in field layouts.
@@ -94,6 +102,14 @@ export default {
     uploads: [Boolean, Object, Array],
     value: String
   },
+}
+
+/**
+ * @example <k-input v-model="text" name="text" type="textarea" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   data() {
     return {
       over: false
@@ -285,9 +301,9 @@ export default {
   validations() {
     return {
       value: {
-        required: this.required ? required : true,
-        minLength: this.minlength ? minLength(this.minlength) : true,
-        maxLength: this.maxlength ? maxLength(this.maxlength) : true
+        required: this.required ? validateRequired : true,
+        minLength: this.minlength ? validateMinLength(this.minlength) : true,
+        maxLength: this.maxlength ? validateMaxLength(this.maxlength) : true
       }
     };
   }

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -1,11 +1,7 @@
 <script>
 import DateInput from "./DateInput.vue";
 
-/**
- * @example <k-input v-model="time" name="time" type="time" />
- */
-export default {
-  extends: DateInput,
+export const props = {
   props: {
     display: {
       type: String,
@@ -26,7 +22,15 @@ export default {
       type: String,
       default: "time"
     }
-  },
+  }
+}
+
+/**
+ * @example <k-input v-model="time" name="time" type="time" />
+ */
+export default {
+  extends: DateInput,
+  mixins: [props],
   computed: {
     is12HourFormat() {
       return this.display.toLowerCase().includes("a")

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -14,13 +14,9 @@
 </template>
 
 <script>
-import { required } from "vuelidate/lib/validators";
+import { required as validateRequired } from "vuelidate/lib/validators";
 
-/**
- * @example <k-input v-model="toggle" name="toggle" type="toggle" />
- */
-export default {
-  inheritAttrs: false,
+export const props = {
   props: {
     autofocus: Boolean,
     disabled: Boolean,
@@ -42,7 +38,15 @@ export default {
     },
     required: Boolean,
     value: Boolean,
-  },
+  }
+}
+
+/**
+ * @example <k-input v-model="toggle" name="toggle" type="toggle" />
+ */
+export default {
+  mixins: [props],
+  inheritAttrs: false,
   computed: {
     label() {
       if (Array.isArray(this.text)) {
@@ -86,7 +90,7 @@ export default {
   validations() {
     return {
       value: {
-        required: this.required ? required : true,
+        required: this.required ? validateRequired : true,
       }
     }
   }

--- a/panel/src/components/Forms/Input/UrlInput.vue
+++ b/panel/src/components/Forms/Input/UrlInput.vue
@@ -1,13 +1,10 @@
 <script>
 import TextInput from "./TextInput.vue";
+import { props as TextInputProps } from "./TextInput.vue";
 
-/**
- * @example <k-input v-model="url" name="url" type="url" />
- */
-export default {
-  extends: TextInput,
+export const props = {
+  mixins: [TextInputProps],
   props: {
-    ...TextInput.props,
     autocomplete: {
       type: String,
       default: "url"
@@ -17,5 +14,13 @@ export default {
       default: "url"
     }
   }
+}
+
+/**
+ * @example <k-input v-model="url" name="url" type="url" />
+ */
+export default {
+  extends: TextInput,
+  mixins: [props]
 }
 </script>

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -57,11 +57,7 @@ import Toolbar from "./Extensions/Toolbar.js";
 // Toolbar
 import ToolbarComponent from "./Toolbar.vue";
 
-export default {
-  components: {
-    "k-writer-link-dialog": LinkDialog,
-    "k-writer-toolbar": ToolbarComponent,
-  },
+export const props = {
   props: {
     breaks: Boolean,
     code: Boolean,
@@ -101,7 +97,15 @@ export default {
       type: String,
       default: ""
     },
+  }
+}
+
+export default {
+  components: {
+    "k-writer-link-dialog": LinkDialog,
+    "k-writer-toolbar": ToolbarComponent,
   },
+  mixins: [props],
   data() {
     return {
       editor: null,

--- a/panel/src/mixins/forms/counter.js
+++ b/panel/src/mixins/forms/counter.js
@@ -12,8 +12,17 @@ export default {
         return false;
       }
 
+      let count = 0;
+
+      if (this.value) {
+        if (Array.isArray(this.value)) {
+          count = this.value.length;
+        } else {
+          count = String(this.value).length;
+        }
+      }
       return {
-        count: this.value && Array.isArray(this.value) ? this.value.length : 0,
+        count: count,
         min: this.min,
         max: this.max,
       };

--- a/panel/src/mixins/forms/counter.js
+++ b/panel/src/mixins/forms/counter.js
@@ -1,0 +1,22 @@
+
+export default {
+  props: {
+    counter: {
+      type: Boolean,
+      default: true
+    }
+  },
+  computed: {
+    counterOptions() {
+      if (this.value === null || this.disabled || this.counter === false) {
+        return false;
+      }
+
+      return {
+        count: this.value && Array.isArray(this.value) ? this.value.length : 0,
+        min: this.min,
+        max: this.max,
+      };
+    }
+  },
+}

--- a/panel/src/mixins/forms/field.js
+++ b/panel/src/mixins/forms/field.js
@@ -1,0 +1,3 @@
+
+import { props as field } from "@/components/Forms/Field.vue";
+export default field;

--- a/panel/src/mixins/forms/input.js
+++ b/panel/src/mixins/forms/input.js
@@ -1,0 +1,3 @@
+
+import { props as input } from "@/components/Forms/Input.vue";
+export default input;

--- a/panel/src/mixins/forms/picker.js
+++ b/panel/src/mixins/forms/picker.js
@@ -1,9 +1,10 @@
-import Field from "@/components/Forms/Field.vue";
+
+import { props as Field } from "@/components/Forms/Field.vue";
 
 export default {
+  mixins: [Field],
   inheritAttrs: false,
   props: {
-    ...Field.props,
     empty: String,
     info: String,
     link: Boolean,

--- a/panel/src/mixins/props.js
+++ b/panel/src/mixins/props.js
@@ -1,0 +1,24 @@
+
+import after from "./props/after.js";
+import autofocus from "./props/autofocus.js";
+import before from "./props/before.js";
+import disabled from "./props/disabled.js";
+import help from "./props/help.js";
+import id from "./props/id.js";
+import invalid from "./props/invalid.js";
+import label from "./props/label.js";
+import name from "./props/name.js";
+import required from "./props/required.js";
+
+export {
+  after,
+  autofocus,
+  before,
+  disabled,
+  help,
+  id,
+  invalid,
+  label,
+  name,
+  required
+};

--- a/panel/src/mixins/props/after.js
+++ b/panel/src/mixins/props/after.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    after: String
+  }
+}

--- a/panel/src/mixins/props/autofocus.js
+++ b/panel/src/mixins/props/autofocus.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    autofocus: Boolean,
+  }
+}

--- a/panel/src/mixins/props/before.js
+++ b/panel/src/mixins/props/before.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    before: String
+  }
+}

--- a/panel/src/mixins/props/disabled.js
+++ b/panel/src/mixins/props/disabled.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    disabled: Boolean
+  }
+}

--- a/panel/src/mixins/props/help.js
+++ b/panel/src/mixins/props/help.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    help: String
+  }
+}

--- a/panel/src/mixins/props/id.js
+++ b/panel/src/mixins/props/id.js
@@ -1,0 +1,11 @@
+
+export default {
+  props: {
+    id: {
+      type: [Number, String],
+      default() {
+        return this._uid;
+      }
+    }
+  }
+}

--- a/panel/src/mixins/props/invalid.js
+++ b/panel/src/mixins/props/invalid.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    invalid: Boolean
+  }
+}

--- a/panel/src/mixins/props/label.js
+++ b/panel/src/mixins/props/label.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    label: String
+  }
+}

--- a/panel/src/mixins/props/name.js
+++ b/panel/src/mixins/props/name.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    name: [Number, String]
+  }
+}

--- a/panel/src/mixins/props/required.js
+++ b/panel/src/mixins/props/required.js
@@ -1,0 +1,6 @@
+
+export default {
+  props: {
+    required: Boolean
+  }
+}


### PR DESCRIPTION
## Status: ready for review 👀
- Creates `mixins/props` for common props to DRY code (especially with in-line docs)
- Some core elements are already importing such props definition mixins
- Components that have been previously imported by other components to destruct their `props` are now exporting a mixin including the `props` object
- Instead of destructing, the other components now import such `props` object and use it as mixin
- `vuelidate` imports have been renamed to not clash with prop names

## Why?
- Object destructors are not parseable for automated docs, mixins are
- Will provide a first step to make these mixins available to plugin developers as well ("eat your own dog food")

## Future plans
- Import common exported props (from input/fields) into mixins (e.g. `mixins/forms/TextInput,js`) that can easily be exposed to plugins

## Related issues
- Closes https://github.com/getkirby/kirby/issues/3177
- 
## Ready?
<!-- 
If you feel like you can help to check off the following tasks, 
that'd be great. If not, don't worry - we will take care of it. 
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!-- 
CI runs automatically when the PR is created or run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] ~~Add changes to release notes draft in Notion~~