### PR TITLE
`overflow: hidden` last column on disabled structure field

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -815,6 +815,11 @@ $structure-item-height: 38px;
       border-left: 1px solid $color-border;
     }
   }
+
+  td:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 .k-sortable-row-fallback {
   opacity: 0 !important;

--- a/panel/src/components/Forms/Previews/UrlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UrlFieldPreview.vue
@@ -31,15 +31,15 @@ export default {
 
 .k-url-field-preview {
   padding: 0 .75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .k-url-field-preview a {
   color: $color-focus;
   text-decoration: underline;
   transition: color .3s;
-  overflow: hidden;
   white-space: nowrap;
   max-width: 100%;
-  text-overflow: ellipsis;
 }
 .k-url-field-preview a:hover {
   color: $color-black;


### PR DESCRIPTION
## Describe the PR
Since there is no last column in the disabled field, `overflow: visible` has been fixed and links are readable with `text-overflow: ellipsis`.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3227 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
