### PR TITLE
Whoops: Allow Exceptions to send custom HTTP code

### DIFF
--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -144,6 +144,7 @@ trait AppErrors
         });
 
         $this->setWhoopsHandler($handler);
+        $this->whoops()->sendHttpCode(false);
     }
 
     /**


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

Whoops overrides any sent HTTP code with its own `HTTP 500` unless disabled. This meant that any JSON error response would have `HTTP 500` even if the `Exception` has defined a different code.

It's still the same with the HTML output, but here it's more difficult to set a custom code as we don't have dynamic access to the handled `Exception`.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] ~Added unit tests for fixed bug/feature~ Automated Whoops tests are not possible
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
