### PR TITLE
Allow setting the page cache expiry from controllers

### DIFF
--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -25,6 +25,8 @@ class Value
 
     /**
      * the number of minutes until the value expires
+     * @todo Rename this property to $expiry to reflect
+     *       both minutes and absolute timestamps
      * @var int
      */
     protected $minutes;
@@ -40,7 +42,8 @@ class Value
      *
      * @param mixed $value
      * @param int $minutes the number of minutes until the value expires
-     * @param int $created the unix timestamp when the value has been created
+     *                     or an absolute UNIX timestamp
+     * @param int $created the UNIX timestamp when the value has been created
      */
     public function __construct($value, int $minutes = 0, int $created = null)
     {
@@ -70,6 +73,11 @@ class Value
         // 0 = keep forever
         if ($this->minutes === 0) {
             return null;
+        }
+
+        if ($this->minutes > 1000000000) {
+            // absolute timestamp
+            return $this->minutes;
         }
 
         return $this->created + ($this->minutes * 60);

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1179,7 +1179,7 @@ class Page extends ModelWithContent
                 $cache->set($cacheId, [
                     'html'     => $html,
                     'response' => $response
-                ]);
+                ], $kirby->response()->expires() ?? 0);
             }
         }
 

--- a/tests/Cache/ValueTest.php
+++ b/tests/Cache/ValueTest.php
@@ -40,6 +40,12 @@ class ValueTest extends TestCase
 
         $value = new Value('foo', 1000, 10000);
         $this->assertSame(10000 + 1000 * 60, $value->expires());
+
+        $value = new Value('foo', 1234567890, 0);
+        $this->assertSame(1234567890, $value->expires());
+
+        $value = new Value('foo', 1234567890, 10000);
+        $this->assertSame(1234567890, $value->expires());
     }
 
     /**
@@ -56,6 +62,17 @@ class ValueTest extends TestCase
         $value = Value::fromArray($data);
         $this->assertSame(10000, $value->created());
         $this->assertNull($value->expires());
+        $this->assertSame('foo', $value->value());
+        $this->assertSame($data, $value->toArray());
+
+        $data = [
+            'created' => 10000,
+            'minutes' => 1234567890,
+            'value'   => 'foo'
+        ];
+        $value = Value::fromArray($data);
+        $this->assertSame(10000, $value->created());
+        $this->assertSame(1234567890, $value->expires());
         $this->assertSame('foo', $value->value());
         $this->assertSame($data, $value->toArray());
 

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Kirby\Cms;
+
+require_once __DIR__ . '/mocks.php';
+
+/**
+ * @coversDefaultClass \Kirby\Cms\Responder
+ */
+class ResponderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->kirby([
+            'urls' => [
+                'index' => 'https://getkirby.test'
+            ]
+        ]);
+    }
+
+    /**
+     * @covers ::expires
+     */
+    public function testExpires()
+    {
+        $responder = new Responder();
+        $this->assertNull($responder->expires());
+
+        // minutes
+        $this->assertSame($responder, $responder->expires(60 * 24));
+        $this->assertSame(MockTime::$time + 60 * 60 * 24, $responder->expires());
+
+        // explicit timestamp
+        $this->assertSame($responder, $responder->expires(1234567890));
+        $this->assertSame(1234567890, $responder->expires());
+
+        // shorter expiry is always possible
+        $this->assertSame($responder, $responder->expires(1234567889));
+        $this->assertSame(1234567889, $responder->expires());
+
+        // longer expiry only explicitly
+        $this->assertSame($responder, $responder->expires(1234567890));
+        $this->assertSame(1234567889, $responder->expires());
+
+        $this->assertSame($responder, $responder->expires(1234567890, true));
+        $this->assertSame(1234567890, $responder->expires());
+
+        // getter on null input
+        $this->assertSame(1234567890, $responder->expires(null));
+        $this->assertSame(1234567890, $responder->expires());
+
+        // but unset explicitly
+        $this->assertSame($responder, $responder->expires(null, true));
+        $this->assertNull($responder->expires());
+
+        // string value parsing
+        $this->assertSame($responder, $responder->expires('2021-01-01'));
+        $this->assertSame(1609459200, $responder->expires());
+
+        // rules still apply to string values
+        $this->assertSame($responder, $responder->expires('2020-12-31'));
+        $this->assertSame(1609372800, $responder->expires());
+        $this->assertSame($responder, $responder->expires('2021-01-01'));
+        $this->assertSame(1609372800, $responder->expires());
+        $this->assertSame($responder, $responder->expires('2021-01-01', true));
+        $this->assertSame(1609459200, $responder->expires());
+    }
+
+    /**
+     * @covers ::expires
+     */
+    public function testExpiresInvalidString()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid time string "abcde"');
+
+        $responder = new Responder();
+        $responder->expires('abcde');
+    }
+
+    /**
+     * @covers ::fromArray
+     */
+    public function testFromArray()
+    {
+        $responder = new Responder();
+        $responder->fromArray([
+            'body'    => 'Lorem ipsum',
+            'expires' => 1234567890,
+            'code'    => 301,
+            'headers' => ['Location' => 'https://example.com'],
+            'type'    => 'text/plain'
+        ]);
+
+        $this->assertSame('Lorem ipsum', $responder->body());
+        $this->assertSame(1234567890, $responder->expires());
+        $this->assertSame(301, $responder->code());
+        $this->assertSame(['Location' => 'https://example.com'], $responder->headers());
+        $this->assertSame('text/plain', $responder->type());
+    }
+}


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

- It is now possible to set the page cache expiry timestamp from controllers or templates:

```php
$kirby->response()->expires(1234567890); // timestamp
$kirby->response()->expires('2021-12-31');
```

- When setting cache values, you can now define an absolute expiry timestamp instead of the number of minutes. The number of minutes is still supported and auto-detected.

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
