### PR TITLE
Consistent `::add()` for model collections

### DIFF
--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\InvalidArgumentException;
+
 /**
  * The `$files` object extends the general
  * `Collection` class and refers to a
@@ -30,12 +32,13 @@ class Files extends Collection
      * an entire second collection to the
      * current collection
      *
-     * @param mixed $object
+     * @param \Kirby\Cms\Files|\Kirby\Cms\File|string $object
      * @return $this
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     public function add($object)
     {
-        // add a page collection
+        // add a files collection
         if (is_a($object, self::class) === true) {
             $this->data = array_merge($this->data, $object->data);
 
@@ -46,6 +49,10 @@ class Files extends Collection
         // add a file object
         } elseif (is_a($object, 'Kirby\Cms\File') === true) {
             $this->__set($object->id(), $object);
+
+        // give a useful error message on invalid input
+        } elseif (in_array($object, [null, false, true], true) !== true) {
+            throw new InvalidArgumentException('You must pass a Files or File object or an ID of an existing file to the Files collection');
         }
 
         return $this;

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -50,7 +50,8 @@ class Files extends Collection
         } elseif (is_a($object, 'Kirby\Cms\File') === true) {
             $this->__set($object->id(), $object);
 
-        // give a useful error message on invalid input
+        // give a useful error message on invalid input;
+        // silently ignore "empty" values for compatibility with existing setups
         } elseif (in_array($object, [null, false, true], true) !== true) {
             throw new InvalidArgumentException('You must pass a Files or File object or an ID of an existing file to the Files collection');
         }

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -66,7 +66,8 @@ class Pages extends Collection
         } elseif (is_a($object, 'Kirby\Cms\Page') === true) {
             $this->__set($object->id(), $object);
 
-        // give a useful error message on invalid input
+        // give a useful error message on invalid input;
+        // silently ignore "empty" values for compatibility with existing setups
         } elseif (in_array($object, [null, false, true], true) !== true) {
             throw new InvalidArgumentException('You must pass a Pages or Page object or an ID of an existing page to the Pages collection');
         }

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -48,13 +48,13 @@ class Pages extends Collection
      * an entire second collection to the
      * current collection
      *
-     * @param mixed $object
+     * @param \Kirby\Cms\Pages|\Kirby\Cms\Page|string $object
      * @return $this
      * @throws \Kirby\Exception\InvalidArgumentException
      */
     public function add($object)
     {
-        // add a page collection
+        // add a pages collection
         if (is_a($object, self::class) === true) {
             $this->data = array_merge($this->data, $object->data);
 
@@ -68,7 +68,7 @@ class Pages extends Collection
 
         // give a useful error message on invalid input
         } elseif (in_array($object, [null, false, true], true) !== true) {
-            throw new InvalidArgumentException('You must pass a Page object to the Pages collection');
+            throw new InvalidArgumentException('You must pass a Pages or Page object or an ID of an existing page to the Pages collection');
         }
 
         return $this;

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
@@ -37,12 +38,13 @@ class Users extends Collection
      * an entire second collection to the
      * current collection
      *
-     * @param mixed $object
+     * @param \Kirby\Cms\Users|\Kirby\Cms\User|string $object
      * @return $this
+     * @throws \Kirby\Exception\InvalidArgumentException
      */
     public function add($object)
     {
-        // add a page collection
+        // add a users collection
         if (is_a($object, self::class) === true) {
             $this->data = array_merge($this->data, $object->data);
 
@@ -53,6 +55,10 @@ class Users extends Collection
         // add a user object
         } elseif (is_a($object, 'Kirby\Cms\User') === true) {
             $this->__set($object->id(), $object);
+
+        // give a useful error message on invalid input
+        } elseif (in_array($object, [null, false, true], true) !== true) {
+            throw new InvalidArgumentException('You must pass a Users or User object or an ID of an existing user to the Users collection');
         }
 
         return $this;

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -56,7 +56,8 @@ class Users extends Collection
         } elseif (is_a($object, 'Kirby\Cms\User') === true) {
             $this->__set($object->id(), $object);
 
-        // give a useful error message on invalid input
+        // give a useful error message on invalid input;
+        // silently ignore "empty" values for compatibility with existing setups
         } elseif (in_array($object, [null, false, true], true) !== true) {
             throw new InvalidArgumentException('You must pass a Users or User object or an ID of an existing user to the Users collection');
         }

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -76,4 +76,34 @@ class FilesTest extends TestCase
         $this->assertEquals('a/b.jpg', $files->nth(1)->id());
         $this->assertEquals('b/a.jpg', $files->nth(2)->id());
     }
+
+    public function testAddNull()
+    {
+        $files = new Files();
+        $this->assertCount(0, $files);
+
+        $files->add(null);
+
+        $this->assertCount(0, $files);
+    }
+
+    public function testAddFalse()
+    {
+        $files = new Files();
+        $this->assertCount(0, $files);
+
+        $files->add(false);
+
+        $this->assertCount(0, $files);
+    }
+
+    public function testAddInvalidObject()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('You must pass a Files or File object or an ID of an existing file to the Files collection');
+
+        $site  = new Site();
+        $files = new Files();
+        $files->add($site);
+    }
 }

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -101,7 +101,7 @@ class PagesTest extends TestCase
     public function testAddInvalidObject()
     {
         $this->expectException('Kirby\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('You must pass a Page object to the Pages collection');
+        $this->expectExceptionMessage('You must pass a Pages or Page object or an ID of an existing page to the Pages collection');
 
         $site  = new Site();
         $pages = new Pages();

--- a/tests/Cms/Users/UsersTest.php
+++ b/tests/Cms/Users/UsersTest.php
@@ -66,6 +66,35 @@ class UsersTest extends TestCase
         $this->assertEquals('c@getkirby.com', $users->nth(2)->email());
     }
 
+    public function testAddNull()
+    {
+        $users = new Users();
+        $this->assertCount(0, $users);
+
+        $users->add(null);
+
+        $this->assertCount(0, $users);
+    }
+
+    public function testAddFalse()
+    {
+        $users = new Users();
+        $this->assertCount(0, $users);
+
+        $users->add(false);
+
+        $this->assertCount(0, $users);
+    }
+
+    public function testAddInvalidObject()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('You must pass a Users or User object or an ID of an existing user to the Users collection');
+
+        $site  = new Site();
+        $users = new Users();
+        $users->add($site);
+    }
 
     public function testFind()
     {


### PR DESCRIPTION
## Status: ready for review 👀

- Adds exception message to `Files::add()` and `Users::add()` to be consistent with `Pages::add()`
- Fixes exception message of `Pages::add()`
- More precise parameter type in DocBlock for all `add()` methods


## Breaking changes

- Before this PR, one could pass something else than `Files` object, `File` object, `null`, `false`, `true` to the `Files::add()` method and it would simply be ignored (and the original collection returned). Now, an error is thrown.
- Same for `Users::add()`

## Ready?
<!-- 
If you feel like you can help to check off the following tasks, 
that'd be great. If not, don't worry - we will take care of it. 
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!-- 
CI runs automatically when the PR is created or run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion