### PR TITLE
esc helper: Remove unused $strict param

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -172,13 +172,12 @@ if (function_exists('e') === false) {
  *
  * @param string $string Untrusted data
  * @param string $context Location of output
- * @param bool $strict Whether to escape an extended set of characters (HTML attributes only)
  * @return string Escaped data
  */
-function esc($string, $context = 'html', $strict = false)
+function esc($string, $context = 'html')
 {
     if (method_exists('Kirby\Toolkit\Escape', $context) === true) {
-        return Escape::$context($string, $strict);
+        return Escape::$context($string);
     }
 
     return $string;


### PR DESCRIPTION
None of the methods of the `Toolkit\Escape` class accept a second param, so the `$strict` param already has no effect whatsoever. Therefore this is no breaking-change.