### PR TITLE
Fixes link title in writer field #3255

### DIFF
--- a/panel/src/components/Writer/Marks/Link.js
+++ b/panel/src/components/Writer/Marks/Link.js
@@ -89,6 +89,7 @@ export default class Link extends Mark {
           getAttrs: dom => ({
             href: dom.getAttribute("href"),
             target: dom.getAttribute("target"),
+            title: dom.getAttribute("title")
           }),
         },
       ],


### PR DESCRIPTION
## Describe the PR
Added missing `title` prop/dom of link title for writer field.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3255 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
