### PR TITLE
Fixes video block caption marks #3264

### DIFF
--- a/panel/src/components/Blocks/Types/Video.vue
+++ b/panel/src/components/Blocks/Types/Video.vue
@@ -1,6 +1,7 @@
 <template>
   <k-block-figure
     :caption="content.caption"
+    :caption-marks="captionMarks"
     :empty-text="$t('field.blocks.video.placeholder') + ' …'"
     :is-empty="!video"
     empty-icon="video"
@@ -16,6 +17,9 @@
 <script>
 export default {
   computed: {
+    captionMarks() {
+      return this.field("caption", { marks: true }).marks;
+    },
     video() {
 
       var url = this.content.url;


### PR DESCRIPTION
## Describe the PR

Fixes video block caption marks with adding missing `:caption-marks` prop like `Image` block.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3264 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
