### PR TITLE
F::relativepath() when an unrelated base is given, prefix with ../ for relative travel path

### DIFF
--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -657,8 +657,8 @@ class F
         if (Str::contains($file, $in) === false) {
             // make the paths relative by stripping what they have
             // in common and adding `../` tokens at the start
-            $fileParts = explode('/', $file);
-            $inParts = explode('/', $in);
+            $fileParts = explode('/', rtrim($file, '/'));
+            $inParts = explode('/',  rtrim($in, '/'));
             while (count($fileParts) && count($inParts) && ($fileParts[0] === $inParts[0])) {
                 array_shift($fileParts);
                 array_shift($inParts);

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -658,7 +658,7 @@ class F
             // make the paths relative by stripping what they have
             // in common and adding `../` tokens at the start
             $fileParts = explode('/', rtrim($file, '/'));
-            $inParts = explode('/',  rtrim($in, '/'));
+            $inParts = explode('/', rtrim($in, '/'));
             while (count($fileParts) && count($inParts) && ($fileParts[0] === $inParts[0])) {
                 array_shift($fileParts);
                 array_shift($inParts);

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -653,7 +653,15 @@ class F
         $in   = str_replace('\\', '/', $in);
 
         if (Str::contains($file, $in) === false) {
-            return $file;
+            $fileParts = explode('/', $file);
+            $inParts = explode('/', $in);
+            while (count($fileParts) && count($inParts) && ($fileParts[0] == $inParts[0])) {
+                array_shift($fileParts);
+                array_shift($inParts);
+            }
+            
+            $parentToken = '../';
+            return str_pad('', count($inParts) * strlen($parentToken), $parentToken) . implode('/', $fileParts);
         }
 
         return Str::after($file, $in);

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -654,11 +654,15 @@ class F
         $file = str_replace('\\', '/', $file);
         $in   = str_replace('\\', '/', $in);
 
-        if (Str::contains($file, $in) === false) {
+        // trim trailing slashes
+        $file = rtrim($file, '/');
+        $in   = rtrim($in, '/');
+
+        if (Str::contains($file, $in . '/') === false) {
             // make the paths relative by stripping what they have
             // in common and adding `../` tokens at the start
-            $fileParts = explode('/', rtrim($file, '/'));
-            $inParts = explode('/', rtrim($in, '/'));
+            $fileParts = explode('/', $file);
+            $inParts = explode('/', $in);
             while (count($fileParts) && count($inParts) && ($fileParts[0] === $inParts[0])) {
                 array_shift($fileParts);
                 array_shift($inParts);
@@ -668,7 +672,7 @@ class F
             return str_pad('', count($inParts) * strlen($parentToken), $parentToken) . implode('/', $fileParts);
         }
 
-        return Str::after($file, $in);
+        return '/' . Str::after($file, $in . '/');
     }
 
     /**

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -655,9 +655,11 @@ class F
         $in   = str_replace('\\', '/', $in);
 
         if (Str::contains($file, $in) === false) {
+            // make the paths relative by stripping what they have
+            // in common and adding `../` tokens at the start
             $fileParts = explode('/', $file);
             $inParts = explode('/', $in);
-            while (count($fileParts) && count($inParts) && ($fileParts[0] == $inParts[0])) {
+            while (count($fileParts) && count($inParts) && ($fileParts[0] === $inParts[0])) {
                 array_shift($fileParts);
                 array_shift($inParts);
             }

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -638,6 +638,8 @@ class F
      * Returns the relative path of the file
      * starting after $in
      *
+     * @SuppressWarnings(PHPMD.CountInLoopExpression)
+     *
      * @param string $file
      * @param string $in
      * @return string

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -667,9 +667,8 @@ class F
                 array_shift($fileParts);
                 array_shift($inParts);
             }
-            
-            $parentToken = '../';
-            return str_repeat($parentToken, count($inParts)) . implode('/', $fileParts);
+
+            return str_repeat('../', count($inParts)) . implode('/', $fileParts);
         }
 
         return '/' . Str::after($file, $in . '/');

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -669,7 +669,7 @@ class F
             }
             
             $parentToken = '../';
-            return str_pad('', count($inParts) * strlen($parentToken), $parentToken) . implode('/', $fileParts);
+            return str_repeat($parentToken, count($inParts)) . implode('/', $fileParts);
         }
 
         return '/' . Str::after($file, $in . '/');

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -653,7 +653,7 @@ class F
         $in   = str_replace('\\', '/', $in);
 
         if (Str::contains($file, $in) === false) {
-            return basename($file);
+            return $file;
         }
 
         return Str::after($file, $in);

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -182,6 +182,9 @@ class FTest extends TestCase
         
         $path = F::relativepath(__DIR__ . '/fruits/apples/honeycrisp.txt', __DIR__ . '/vegetables/squash');
         $this->assertEquals('../../fruits/apples/honeycrisp.txt', $path);
+        
+        $path = F::relativepath(__DIR__ . '/test.txt', __DIR__ . '/foo/bar/baz');
+        $this->assertEquals('../../../test.txt', $path);
     }
 
     public function testRelativePathOnWindows()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -174,8 +174,14 @@ class FTest extends TestCase
 
     public function testRelativePathWithUnrelatedBase()
     {
-        $path = F::relativepath(__FILE__, '/something/something');
-        $this->assertEquals(__FILE__, $path);
+        $path = F::relativepath(__DIR__ . '/fruits/apples/fuji.txt', __DIR__ . '/fruits/pineapples');
+        $this->assertEquals('../apples/fuji.txt', $path);
+        
+        $path = F::relativepath(__DIR__ . '/fruits/apples/gala.txt', __DIR__ . '/vegetables');
+        $this->assertEquals('../fruits/apples/gala.txt', $path);
+        
+        $path = F::relativepath(__DIR__ . '/fruits/apples/honeycrisp.txt', __DIR__ . '/vegetables/squash');
+        $this->assertEquals('../../fruits/apples/honeycrisp.txt', $path);
     }
 
     public function testRelativePathOnWindows()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -161,6 +161,9 @@ class FTest extends TestCase
     {
         $path = F::relativepath(__FILE__, __DIR__);
         $this->assertEquals('/' . basename(__FILE__), $path);
+        
+        $path = F::relativepath(__FILE__, __DIR__ . '/');
+        $this->assertEquals('/' . basename(__FILE__), $path);
     }
 
     public function testRelativePathWithEmptyBase()
@@ -194,6 +197,9 @@ class FTest extends TestCase
         
         $path = F::relativepath(__DIR__ . '/test.txt', __DIR__ . '/foo/bar/baz');
         $this->assertEquals('../../../test.txt', $path);
+        
+        $path = F::relativepath('foo/path-extra/file.txt', 'foo/path');
+        $this->assertEquals('../path-extra/file.txt', $path);
     }
 
     public function testRelativePathOnWindows()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -180,6 +180,15 @@ class FTest extends TestCase
         $path = F::relativepath(__DIR__ . '/fruits/apples/gala.txt', __DIR__ . '/vegetables');
         $this->assertEquals('../fruits/apples/gala.txt', $path);
         
+        $path = F::relativepath(__DIR__ . '/fruits/apples/granny-smith.txt', __DIR__ . '/vegetables/');
+        $this->assertEquals('../fruits/apples/granny-smith.txt', $path);
+        
+        $path = F::relativepath(__DIR__ . '/fruits/apples/', __DIR__ . '/vegetables/');
+        $this->assertEquals('../fruits/apples', $path);
+        
+        $path = F::relativepath(__DIR__ . '/fruits/oranges/', __DIR__ . '/vegetables');
+        $this->assertEquals('../fruits/oranges', $path);
+        
         $path = F::relativepath(__DIR__ . '/fruits/apples/honeycrisp.txt', __DIR__ . '/vegetables/squash');
         $this->assertEquals('../../fruits/apples/honeycrisp.txt', $path);
         

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -175,7 +175,7 @@ class FTest extends TestCase
     public function testRelativePathWithUnrelatedBase()
     {
         $path = F::relativepath(__FILE__, '/something/something');
-        $this->assertEquals(basename(__FILE__), $path);
+        $this->assertEquals(__FILE__, $path);
     }
 
     public function testRelativePathOnWindows()


### PR DESCRIPTION
## Describe the PR
When an unrelated base path is given to `F::relativepath()`, it would simply return the filename. This changes causes it to return the full path.

A more sophisticated solution could prepend relative tokens like `../../`, but the change as initially drafted still seems more helpful than existing behavior.

## Related issues
- Fixes #3267

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
