### PR TITLE
Recursively ignore files in Dir::copy

### DIFF
--- a/src/Toolkit/Dir.php
+++ b/src/Toolkit/Dir.php
@@ -69,7 +69,7 @@ class Dir
 
             if (is_dir($root) === true) {
                 if ($recursive === true) {
-                    static::copy($root, $target . '/' . $name);
+                    static::copy($root, $target . '/' . $name, true, $ignore);
                 }
             } else {
                 F::copy($root, $target . '/' . $name);

--- a/tests/Toolkit/DirTest.php
+++ b/tests/Toolkit/DirTest.php
@@ -34,6 +34,39 @@ class DirTest extends TestCase
         Dir::remove($target);
     }
 
+    public function testCopyNonRecursive()
+    {
+        $src    = static::FIXTURES . '/copy';
+        $target = static::FIXTURES . '/copy-target';
+
+        $result = Dir::copy($src, $target, false);
+
+        $this->assertTrue($result);
+
+        $this->assertTrue(file_exists($target . '/a.txt'));
+        $this->assertFalse(file_exists($target . '/subfolder/b.txt'));
+
+        // clean up
+        Dir::remove($target);
+    }
+
+    public function testCopyIgnore()
+    {
+        $src    = static::FIXTURES . '/copy';
+        $target = static::FIXTURES . '/copy-target';
+
+        $result = Dir::copy($src, $target, true, [$src . '/subfolder/b.txt']);
+
+        $this->assertTrue($result);
+
+        $this->assertTrue(file_exists($target . '/a.txt'));
+        $this->assertTrue(is_dir($target . '/subfolder'));
+        $this->assertFalse(file_exists($target . '/subfolder/b.txt'));
+
+        // clean up
+        Dir::remove($target);
+    }
+
     public function testCopyMissingSource()
     {
         $this->expectException('Exception');


### PR DESCRIPTION
- Fixes #3243

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] ~~Added in-code documentation (if needed)~~
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
