### PR TITLE
Pass exception to fatal error handler

### DIFF
--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -83,7 +83,7 @@ trait AppErrors
                 $fatal = $this->option('fatal');
 
                 if (is_a($fatal, 'Closure') === true) {
-                    echo $fatal($this);
+                    echo $fatal($this, $exception);
                 } else {
                     include $this->root('kirby') . '/views/fatal.php';
                 }


### PR DESCRIPTION
- Fixes #3154 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
