### PR TITLE
Bring forward delete button of blocks field 

### DIFF
--- a/panel/src/components/Blocks/Block.vue
+++ b/panel/src/components/Blocks/Block.vue
@@ -51,6 +51,11 @@
           @click="$emit('show')"
         />
         <k-button
+          class="k-drawer-option"
+          icon="trash"
+          @click.prevent.stop="confirmToRemove"
+        />
+        <k-button
           :disabled="!prev"
           class="k-drawer-option"
           icon="angle-left"

--- a/panel/src/components/Blocks/Block.vue
+++ b/panel/src/components/Blocks/Block.vue
@@ -51,11 +51,6 @@
           @click="$emit('show')"
         />
         <k-button
-          class="k-drawer-option"
-          icon="trash"
-          @click.prevent.stop="confirmToRemove"
-        />
-        <k-button
           :disabled="!prev"
           class="k-drawer-option"
           icon="angle-left"
@@ -66,6 +61,11 @@
           class="k-drawer-option"
           icon="angle-right"
           @click.prevent.stop="goTo(next)"
+        />
+        <k-button
+          class="k-drawer-option"
+          icon="trash"
+          @click.prevent.stop="confirmToRemove"
         />
       </template>
     </k-form-drawer>

--- a/panel/src/components/Blocks/BlockOptions.vue
+++ b/panel/src/components/Blocks/BlockOptions.vue
@@ -65,6 +65,10 @@
         <k-dropdown-item :disabled="isFull" icon="copy" @click="$emit('duplicate')">
           {{ $t("duplicate") }}
         </k-dropdown-item>
+        <hr>
+        <k-dropdown-item icon="trash" @click="$emit('confirmToRemove')">
+          {{ $t("delete") }}
+        </k-dropdown-item>
       </k-dropdown-content>
     </template>
   </k-dropdown>
@@ -114,14 +118,14 @@ $block-options-button-size: 30px;
   border-top-right-radius: $rounded;
   border-bottom-right-radius: $rounded;
 }
+.k-block-options-button:last-of-type {
+  border-right: 0;
+}
 .k-block-options-button[aria-current] {
   color: $color-focus;
 }
 .k-block-options-button:hover {
   background: $color-gray-100;
-}
-.k-block-handle {
-  border-right: 0;
 }
 .k-block-options .k-dropdown-content {
   margin-top: .5rem;

--- a/panel/src/components/Blocks/BlockOptions.vue
+++ b/panel/src/components/Blocks/BlockOptions.vue
@@ -23,6 +23,12 @@
         @click="$emit('chooseToAppend')"
       />
       <k-button
+        :tooltip="$t('delete')"
+        class="k-block-options-button"
+        icon="trash"
+        @click="$emit('confirmToRemove')"
+      />
+      <k-button
         :tooltip="$t('more')"
         class="k-block-options-button"
         icon="dots"
@@ -58,10 +64,6 @@
         </k-dropdown-item>
         <k-dropdown-item :disabled="isFull" icon="copy" @click="$emit('duplicate')">
           {{ $t("duplicate") }}
-        </k-dropdown-item>
-        <hr>
-        <k-dropdown-item icon="trash" @click="$emit('confirmToRemove')">
-          {{ $t("delete") }}
         </k-dropdown-item>
       </k-dropdown-content>
     </template>


### PR DESCRIPTION
## Describe the PR

The PR includes two simple enhancements and features.
I pushed it in the same PR because it is simple and linked. I can separate if you want.

1. Delete button inside the drawer 

![screen-capture-1025-Exploring the universe - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/116294672-e7c53880-a7a0-11eb-994d-e72f87479a10.png)

2. Delete button on top of block options navigation

![screen-capture-1028-Exploring the universe - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/116294708-f4e22780-a7a0-11eb-9401-b212ff6db4d8.png)


## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3180 
- Fixes https://kirby.nolt.io/272

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
