### PR TITLE
Send missing `$model` param for options api #3260

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -40,7 +40,7 @@ class Options
      * Brings options through api
      *
      * @param $api
-     * @param $model
+     * @param \Kirby\Cms\Model|null $model
      * @return array
      */
     public static function api($api, $model = null): array
@@ -71,7 +71,7 @@ class Options
     }
 
     /**
-     * @param $model
+     * @param \Kirby\Cms\Model $model
      * @return array
      */
     protected static function data($model): array
@@ -100,14 +100,14 @@ class Options
      *
      * @param $options
      * @param array $props
-     * @param null $model
+     * @param \Kirby\Cms\Model|null $model
      * @return array
      */
     public static function factory($options, array $props = [], $model = null): array
     {
         switch ($options) {
             case 'api':
-                $options = static::api($props['api']);
+                $options = static::api($props['api'], $model);
                 break;
             case 'query':
                 $options = static::query($props['query'], $model);
@@ -160,7 +160,7 @@ class Options
      * Brings options with query
      *
      * @param $query
-     * @param null $model
+     * @param \Kirby\Cms\Model|null $model
      * @return array
      */
     public static function query($query, $model = null): array


### PR DESCRIPTION
## Describe the PR

The missing `$model` parameter is added in `\Kirby\Form\Options::factory` method.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3260 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
