### PR TITLE
use shared laminas escaper instance

### DIFF
--- a/src/Toolkit/Escape.php
+++ b/src/Toolkit/Escape.php
@@ -28,7 +28,7 @@ class Escape
      *
      * @var \Laminas\Escaper\Escaper
      */
-    private static $escaper;
+    protected static $escaper;
 
     /**
      * Escape common HTML attributes data
@@ -50,7 +50,7 @@ class Escape
      */
     public static function attr($string)
     {
-        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeHtmlAttr($string);
+        return static::escaper()->escapeHtmlAttr($string);
     }
 
     /**
@@ -71,7 +71,17 @@ class Escape
      */
     public static function css($string)
     {
-        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeCss($string);
+        return static::escaper()->escapeCss($string);
+    }
+
+    /**
+     * Get the escaper instance (and create if needed)
+     *
+     * @return \Laminas\Escaper\Escaper
+     */
+    protected static function escaper()
+    {
+        return static::$escaper = static::$escaper ?? new Escaper('utf-8');
     }
 
     /**
@@ -91,7 +101,7 @@ class Escape
      */
     public static function html($string)
     {
-        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeHtml($string);
+        return static::escaper()->escapeHtml($string);
     }
 
     /**
@@ -109,7 +119,7 @@ class Escape
      */
     public static function js($string)
     {
-        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeJs($string);
+        return static::escaper()->escapeJs($string);
     }
 
     /**

--- a/src/Toolkit/Escape.php
+++ b/src/Toolkit/Escape.php
@@ -24,6 +24,13 @@ use Laminas\Escaper\Escaper;
 class Escape
 {
     /**
+     * The internal singleton escaper instance
+     *
+     * @var \Laminas\Escaper\Escaper
+     */
+    private static $escaper;
+
+    /**
      * Escape common HTML attributes data
      *
      * This can be used to put untrusted data into typical attribute values
@@ -43,7 +50,7 @@ class Escape
      */
     public static function attr($string)
     {
-        return (new Escaper('utf-8'))->escapeHtmlAttr($string);
+        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeHtmlAttr($string);
     }
 
     /**
@@ -64,7 +71,7 @@ class Escape
      */
     public static function css($string)
     {
-        return (new Escaper('utf-8'))->escapeCss($string);
+        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeCss($string);
     }
 
     /**
@@ -84,7 +91,7 @@ class Escape
      */
     public static function html($string)
     {
-        return (new Escaper('utf-8'))->escapeHtml($string);
+        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeHtml($string);
     }
 
     /**
@@ -102,7 +109,7 @@ class Escape
      */
     public static function js($string)
     {
-        return (new Escaper('utf-8'))->escapeJs($string);
+        return (self::$escaper ?? self::$escaper = new Escaper('utf-8'))->escapeJs($string);
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

Use a single laminas escaper instance instead of a different instance per method call. This is possible as all instances are created with the same `utf-8` $encoding and the fact that the escaper internal encoding cannot be changed after creation.

- Fixes: nothing
