### PR TITLE
Fixes list field unit test #3182

### DIFF
--- a/tests/Form/Fields/ListFieldTest.php
+++ b/tests/Form/Fields/ListFieldTest.php
@@ -10,7 +10,7 @@ class ListFieldTest extends TestCase
 
         $this->assertSame('list', $field->type());
         $this->assertSame('list', $field->name());
-        $this->assertSame(null, $field->value());
+        $this->assertSame('', $field->value());
         $this->assertSame(null, $field->label());
         $this->assertSame(null, $field->text());
         $this->assertTrue($field->save());


### PR DESCRIPTION
## Describe the PR

When two separate PRs related to the list field were merged, the tests started to fail. 
We now always cast `value` of the writer and list field to the `string`.

**Related PRs about the conflict**

- #3172
- #3182

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3182

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
