### PR TITLE
`video` kirbytag supports local and remote videos #3104

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -2,6 +2,9 @@
 
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
+use Kirby\Text\KirbyTag;
+use Kirby\Toolkit\F;
+use Kirby\Toolkit\Str;
 
 /**
  * Default KirbyTags definition
@@ -236,23 +239,117 @@ return [
      */
     'video' => [
         'attr' => [
-            'class',
+            'autoplay',
             'caption',
+            'controls',
+            'class',
             'height',
-            'width'
+            'loop',
+            'muted',
+            'poster',
+            'preload',
+            'style',
+            'width',
         ],
         'html' => function ($tag) {
-            $video = Html::video(
-                $tag->value,
-                $tag->kirby()->option('kirbytext.video.options', []),
-                [
-                    'height' => $tag->height ?? $tag->kirby()->option('kirbytext.video.height'),
-                    'width'  => $tag->width  ?? $tag->kirby()->option('kirbytext.video.width'),
-                ]
-            );
+            // all available video tag attributes
+            $availableAttrs = KirbyTag::$types[$tag->type]['attr'];
 
-            return Html::figure([$video], $tag->caption, [
-                'class' => $tag->class  ?? $tag->kirby()->option('kirbytext.video.class', 'video'),
+            // global video tag options
+            $attrs   = $tag->kirby()->option('kirbytext.video', []);
+            $options = $attrs['options'] ?? [];
+
+            // removes options from attributes
+            if (isset($attrs['options']) === true) {
+                unset($attrs['options']);
+            }
+
+            // injects default values from global options
+            // applies only defined attributes to safely update tag props
+            foreach ($attrs as $key => $value) {
+                if (
+                    in_array($key, $availableAttrs) === true &&
+                    (isset($tag->{$key}) === false || $tag->{$key} === null)
+                ) {
+                    $tag->{$key} = $value;
+                }
+            }
+
+            // generates tag attributes helper inline function
+            // for ex: `autoplay` will not work if `false` is a `string` instead of a `boolean`
+            // this is why the type converter is used in function
+            $generateTagAttributes = function ($tag) {
+                // checks local poster file and handle
+                if (
+                    empty($tag->poster) === false &&
+                    Str::startsWith($tag->poster, 'http://') !== true &&
+                    Str::startsWith($tag->poster, 'https://') !== true
+                ) {
+                    if ($poster = $tag->file($tag->poster)) {
+                        $tag->poster = $poster->url();
+                    }
+                }
+
+                return [
+                    'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
+                    'controls' => Str::toType($tag->controls ?? true, 'bool'),
+                    'height'   => $tag->height,
+                    'loop'     => Str::toType($tag->loop, 'bool'),
+                    'muted'    => Str::toType($tag->muted ?? $autoplay, 'bool'),
+                    'poster'   => $tag->poster,
+                    'preload'  => $tag->preload,
+                    'width'    => $tag->width
+                ];
+            };
+
+            // generate handled attributes
+            $attrs = $generateTagAttributes($tag);
+
+            // handles local and remote video file
+            if (
+                Str::startsWith($tag->value, 'http://') !== true &&
+                Str::startsWith($tag->value, 'https://') !== true
+            ) {
+                // handles local video file
+                if ($tag->file = $tag->file($tag->value)) {
+                    $source = Html::tag('source', null, [
+                        'src'  => $tag->file->url(),
+                        'type' => $tag->file->mime()
+                    ]);
+                    $video = Html::tag('video', [$source], $attrs);
+                }
+            } else {
+                // firstly handles supported video providers as youtube, vimeo, etc
+                try {
+                    $video = Html::video(
+                        $tag->value,
+                        $options,
+                        // providers only support width and height attributes
+                        [
+                            'height' => $tag->height,
+                            'width'  => $tag->width
+                        ]
+                    );
+                } catch (Exception $e) {
+                    // if not one of the supported video providers
+                    // it checks if there is a valid remote video file
+                    $extension = F::extension($tag->value);
+                    $type      = F::extensionToType($extension);
+                    $mime      = F::extensionToMime($extension);
+
+                    if ($type === 'video') {
+                        $source = Html::tag('source', null, [
+                            'src'  => $tag->value,
+                            'type' => $mime
+                        ]);
+                        $video = Html::tag('video', [$source], $attrs);
+                    }
+                }
+            }
+
+            return Html::figure([$video ?? ''], $tag->caption, [
+                'class' => $tag->class ?? 'video',
+                'style' => $tag->style
             ]);
         }
     ],

--- a/config/tags.php
+++ b/config/tags.php
@@ -275,35 +275,31 @@ return [
                 }
             }
 
-            // generates tag attributes helper inline function
-            // for ex: `autoplay` will not work if `false` is a `string` instead of a `boolean`
-            // this is why the type converter is used in function
-            $generateTagAttributes = function ($tag) {
-                // checks local poster file and handle
-                if (
-                    empty($tag->poster) === false &&
-                    Str::startsWith($tag->poster, 'http://') !== true &&
-                    Str::startsWith($tag->poster, 'https://') !== true
-                ) {
-                    if ($poster = $tag->file($tag->poster)) {
-                        $tag->poster = $poster->url();
-                    }
+            // checks and gets if poster is local file
+            if (
+                empty($tag->poster) === false &&
+                Str::startsWith($tag->poster, 'http://') !== true &&
+                Str::startsWith($tag->poster, 'https://') !== true
+            ) {
+                if ($poster = $tag->file($tag->poster)) {
+                    $tag->poster = $poster->url();
                 }
+            }
 
-                return [
-                    'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
-                    'controls' => Str::toType($tag->controls ?? true, 'bool'),
-                    'height'   => $tag->height,
-                    'loop'     => Str::toType($tag->loop, 'bool'),
-                    'muted'    => Str::toType($tag->muted ?? $autoplay, 'bool'),
-                    'poster'   => $tag->poster,
-                    'preload'  => $tag->preload,
-                    'width'    => $tag->width
-                ];
-            };
-
-            // generate handled attributes
-            $attrs = $generateTagAttributes($tag);
+            // converts tag attributes to supported formats (listed below) to output correct html
+            // booleans: autoplay, controls, loop, muted
+            // strings : height, poster, preload, width
+            // for ex  : `autoplay` will not work if `false` is a `string` instead of a `boolean`
+            $attrs = [
+                'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
+                'controls' => Str::toType($tag->controls ?? true, 'bool'),
+                'height'   => $tag->height,
+                'loop'     => Str::toType($tag->loop, 'bool'),
+                'muted'    => Str::toType($tag->muted ?? $autoplay, 'bool'),
+                'poster'   => $tag->poster,
+                'preload'  => $tag->preload,
+                'width'    => $tag->width
+            ];
 
             // handles local and remote video file
             if (

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -254,6 +254,8 @@ class File extends ModelWithContent
         } else {
             if ($this->type() === 'image') {
                 return '(image: ' . $url . ')';
+            } elseif ($this->type() === 'video') {
+                return '(video: ' . $url . ')';
             } else {
                 return '(file: ' . $url . ')';
             }

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -63,14 +63,20 @@ class FileTest extends TestCase
         $page = new Page([
             'slug'  => 'test',
             'files' => [
-                [
-                    'filename' => 'test.pdf'
-                ]
+                ['filename' => 'test.jpg'],
+                ['filename' => 'test.mp4'],
+                ['filename' => 'test.pdf'],
             ]
         ]);
 
+        $file = $page->file('test.jpg');
+        $this->assertSame('(image: test.jpg)', $file->dragText());
+
+        $file = $page->file('test.mp4');
+        $this->assertSame('(video: test.mp4)', $file->dragText());
+
         $file = $page->file('test.pdf');
-        $this->assertEquals('(file: test.pdf)', $file->dragText());
+        $this->assertSame('(file: test.pdf)', $file->dragText());
     }
 
     public function testDragTextMarkdown()
@@ -89,17 +95,23 @@ class FileTest extends TestCase
                     [
                         'slug' => 'test',
                         'files' => [
-                            [
-                                'filename' => 'test.pdf'
-                            ]
+                            ['filename' => 'test.jpg'],
+                            ['filename' => 'test.mp4'],
+                            ['filename' => 'test.pdf'],
                         ]
                     ]
                 ]
             ]
         ]);
 
+        $file = $app->page('test')->file('test.jpg');
+        $this->assertSame('![](test.jpg)', $file->dragText());
+
+        $file = $app->page('test')->file('test.mp4');
+        $this->assertSame('[test.mp4](test.mp4)', $file->dragText());
+
         $file = $app->page('test')->file('test.pdf');
-        $this->assertEquals('[test.pdf](test.pdf)', $file->dragText());
+        $this->assertSame('[test.pdf](test.pdf)', $file->dragText());
     }
 
     public function testDragTextForImages()

--- a/tests/Cms/KirbyText/KirbyTagsTest.php
+++ b/tests/Cms/KirbyText/KirbyTagsTest.php
@@ -306,4 +306,182 @@ class KirbyTagsTest extends TestCase
 
         $this->assertEquals('after', $app->kirbytags('test'));
     }
+
+    public function testVideoLocal()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'text' => '(video: sample.mp4)'
+                        ],
+                        'files' => [
+                            ['filename' => 'sample.mp4']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page  = $kirby->page('test');
+        $image = $page->file('sample.mp4');
+
+        $expected = '<figure class="video"><video controls><source src="' . $image->url() . '" type="video/mp4"></video></figure>';
+
+        $this->assertSame($expected, $page->text()->kt()->value());
+    }
+
+    public function testVideoInlineAttrs()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'text' => '(video: sample.mp4
+                                autoplay: true
+                                caption: Lorem ipsum
+                                controls: false
+                                class: video-class
+                                height: 350
+                                loop: true
+                                muted: true
+                                poster: sample.jpg
+                                preload: auto
+                                style: border: none
+                                width: 500)'
+                        ],
+                        'files' => [
+                            ['filename' => 'sample.mp4'],
+                            ['filename' => 'sample.jpg']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page  = $kirby->page('test');
+
+        $image = $page->file('sample.jpg');
+        $video = $page->file('sample.mp4');
+
+        $expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
+        $this->assertSame($expected, $page->text()->kt()->value());
+    }
+
+    public function testVideoPredefinedAttrs()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'options' => [
+                'kirbytext' => [
+                    'video' => [
+                        'autoplay' => true,
+                        'caption'  => 'Lorem ipsum',
+                        'controls' => false,
+                        'class'    => 'video-class',
+                        'height'   => 350,
+                        'loop'     => true,
+                        'muted'    => true,
+                        'poster'   => 'sample.jpg',
+                        'preload'  => 'auto',
+                        'style'    => 'border: none',
+                        'width'    => 500
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'text' => '(video: sample.mp4)'
+                        ],
+                        'files' => [
+                            ['filename' => 'sample.mp4'],
+                            ['filename' => 'sample.jpg']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page  = $kirby->page('test');
+
+        $image = $page->file('sample.jpg');
+        $video = $page->file('sample.mp4');
+
+        $expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
+        $this->assertSame($expected, $page->text()->kt()->value());
+    }
+
+    public function testVideoOptions()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'options' => [
+                'kirbytext' => [
+                    'video' => [
+                        'options'  => [
+                            'youtube' => [
+                                'controls' => 0
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'text' => '(video: https://www.youtube.com/watch?v=VhP7ZzZysQg)'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page  = $kirby->page('test');
+
+        $expected = '<figure class="video"><iframe allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
+        $this->assertSame($expected, $page->text()->kt()->value());
+    }
+
+    public function testVideoRemote()
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'text' => '(video: https://getkirby.com/sample.mp4)'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page  = $kirby->page('test');
+
+        $expected = '<figure class="video"><video controls><source src="https://getkirby.com/sample.mp4" type="video/mp4"></video></figure>';
+        $this->assertSame($expected, $page->text()->kt()->value());
+    }
 }

--- a/tests/Cms/KirbyText/fixtures/kirbytext/video-youtube/expected.html
+++ b/tests/Cms/KirbyText/fixtures/kirbytext/video-youtube/expected.html
@@ -1,0 +1,1 @@
+<figure class="video"><iframe allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Cms/KirbyText/fixtures/kirbytext/video-youtube/test.txt
+++ b/tests/Cms/KirbyText/fixtures/kirbytext/video-youtube/test.txt
@@ -1,0 +1,1 @@
+(video: https://www.youtube.com/watch?v=VhP7ZzZysQg)


### PR DESCRIPTION
## Describe the PR

This PR implements the https://github.com/getkirby/getkirby.com/pull/1188 PR with some improvements, bug fixes and unit tests.

## 🎉 Features

Supported local and remote video files by extending video tag that supporting only youtube and vimeo videos. Youtube and vimeo features have not been changed.

### New Attributes:
- autoplay
- controls (default: true)
- loop
- muted *
- poster
- preload (auto, metadata, none)

_* muted will enabled if autoplay enabled and muted is not defined_

Usages:

````markdown
# local
(video: local-video.mp4)

# remote
(video: https://www.getkirby.com/sample-video.mp4)

# example 1
(video: local-video.mp4  autoplay: true)

# example 2
(video: local-video.mp4 controls: false autoplay: true loop: true)

# example 3
(video: local-video.mp4 poster: cover.jpg)

# example 4
(video: local-video.mp4 preload: auto)

# example 5
(video: https://www.getkirby.com/sample-video.mp4 muted: true controls: false autoplay: true)

# example 6
(video: local-video.mp4 poster: https://www.getkirby.com/sample-cover.jpg)

````

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3104 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
