### PR TITLE
Supports HTML for toggle and checkbox field labels

### DIFF
--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -24,7 +24,8 @@
         />
       </svg>
     </span>
-    <span class="k-checkbox-input-label" v-text="label" />
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <span class="k-checkbox-input-label" v-html="label" />
   </label>
 </template>
 

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -9,7 +9,8 @@
       type="checkbox"
       @change="onInput($event.target.checked)"
     >
-    <span class="k-toggle-input-label" v-text="label" />
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <span class="k-toggle-input-label" v-html="label" />
   </label>
 </template>
 

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -86,10 +86,12 @@ class OptionsApi
      * @param array $data
      * @return string
      */
-    protected function field(string $field, array $data)
+    protected function field(string $field, array $data): string
     {
         $value = $this->$field();
-        return Str::template($value, $data);
+        return Str::template($value, $data, null, '{{', '}}', function ($result) {
+            return strip_tags($result);
+        });
     }
 
     /**

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -7,6 +7,7 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Remote;
 use Kirby\Http\Url;
+use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\Properties;
 use Kirby\Toolkit\Query;
 use Kirby\Toolkit\Str;
@@ -89,8 +90,8 @@ class OptionsApi
     protected function field(string $field, array $data): string
     {
         $value = $this->$field();
-        return Str::template($value, $data, null, '{{', '}}', function ($result) {
-            return strip_tags($result);
+        return Str::template($value, $data, function ($result) {
+            return Escape::html($result);
         });
     }
 

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -90,9 +90,11 @@ class OptionsApi
     protected function field(string $field, array $data): string
     {
         $value = $this->$field();
-        return Str::template($value, $data, function ($result) {
-            return Escape::html($result);
-        });
+        return Str::template($value, $data, [
+            'callback' => function ($result) {
+                return Escape::html($result);
+            }
+        ]);
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -968,14 +968,31 @@ class Str
      * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values
-     * @param string|null $fallback A fallback if a token does not have any matches
+     * @param string|array|\Closure|null $fallback A fallback if a token does not have any matches
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
-     * @param \Closure|null $callback A callback to be able to modify each matching result
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], string $fallback = null, string $start = '{{', string $end = '}}', Closure $callback = null): string
+    public static function template(string $string = null, array $data = [], $fallback = null, string $start = '{{', string $end = '}}'): string
     {
+        // handle fallback that can be string, closure, array or null
+        if ($fallback !== null) {
+            if (is_array($fallback) === true) {
+                $callback = $fallback['callback'] ?? null;
+                $fallback = $fallback['fallback'] ?? null;
+            } elseif (is_a($fallback, 'Closure') === true) {
+                $callback = $fallback;
+                $fallback = null;
+            } elseif (is_string($fallback) === true) {
+                $callback = null;
+            } else {
+                $callback = null;
+                $fallback = null;
+            }
+        } else {
+            $callback = null;
+        }
+
         return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback, $callback) {
             $query = trim($match[1]);
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Closure;
 use Exception;
 
 /**
@@ -964,17 +965,18 @@ class Str
      *
      * </code>
      *
-     * @param string $string The string with placeholders
+     * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values
-     * @param string $fallback A fallback if a token does not have any matches
+     * @param string|null $fallback A fallback if a token does not have any matches
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
+     * @param \Closure|null $callback A callback to be able to modify each matching result
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], string $fallback = null, string $start = '{{', string $end = '}}'): string
+    public static function template(string $string = null, array $data = [], string $fallback = null, string $start = '{{', string $end = '}}', Closure $callback = null): string
     {
-        return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback) {
+        return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback, $callback) {
             $query = trim($match[1]);
 
             // if the placeholder contains a dot, it is a query
@@ -991,6 +993,11 @@ class Str
             // if we don't have a result, use the fallback if given
             if ($result === null && $fallback !== null) {
                 $result = $fallback;
+            }
+
+            // callback on result if given
+            if ($callback !== null) {
+                $result = $callback((string)$result, $data);
             }
 
             // if we still don't have a result, keep the original placeholder

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Toolkit;
 
-use Closure;
 use Exception;
 
 /**
@@ -968,30 +967,25 @@ class Str
      * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values
-     * @param string|array|\Closure|null $fallback A fallback if a token does not have any matches
+     * @param string|array|null $options An options that contains:
+     *                                   - fallback: if a token does not have any matches
+     *                                   - callback: to be able to handle each matching result
+     *                                   - start: start placeholder
+     *                                   - end: end placeholder
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
+     *
+     * @todo Remove stringable type for `$options` param in 3.7.0, will only array supports
+     * @todo Remove `$start` and `$end` parameters in 3.8.0
+     *
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], $fallback = null, string $start = '{{', string $end = '}}'): string
+    public static function template(string $string = null, array $data = [], $options = null, string $start = '{{', string $end = '}}'): string
     {
-        // handle fallback that can be string, closure, array or null
-        if ($fallback !== null) {
-            if (is_array($fallback) === true) {
-                $callback = $fallback['callback'] ?? null;
-                $fallback = $fallback['fallback'] ?? null;
-            } elseif (is_a($fallback, 'Closure') === true) {
-                $callback = $fallback;
-                $fallback = null;
-            } elseif (is_string($fallback) === true) {
-                $callback = null;
-            } else {
-                $callback = null;
-                $fallback = null;
-            }
-        } else {
-            $callback = null;
-        }
+        $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
+        $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
+        $start    = (string)($options['start'] ?? $start);
+        $end      = (string)($options['end'] ?? $end);
 
         return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback, $callback) {
             $query = trim($match[1]);


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Escaped values with the `Str::template()` method developed for the reliability of the data coming from the API.
Parts that previously supported HTML have been removed. 
It was brought back again with disabled `eslint` checks.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- `$fallback` param in `Str::template()` renamed to `$options` that accept string or array that can be contains `fallback`, `callback`, `start`, `end`.

### Fixes
- Toggle and checkbox field labels supports HTML again


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3278 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion