### PR TITLE
`Form\OptionsApi`: fix props types

### DIFF
--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -26,17 +26,17 @@ class OptionsApi
     use Properties;
 
     /**
-     * @var
+     * @var array
      */
     protected $data;
 
     /**
-     * @var
+     * @var string|null
      */
     protected $fetch;
 
     /**
-     * @var
+     * @var array|string|null
      */
     protected $options;
 
@@ -46,7 +46,7 @@ class OptionsApi
     protected $text = '{{ item.value }}';
 
     /**
-     * @var
+     * @var string
      */
     protected $url;
 
@@ -161,14 +161,14 @@ class OptionsApi
      * @param string|null $fetch
      * @return $this
      */
-    protected function setFetch(string $fetch = null)
+    protected function setFetch(?string $fetch = null)
     {
         $this->fetch = $fetch;
         return $this;
     }
 
     /**
-     * @param $options
+     * @param array|string|null $options
      * @return $this
      */
     protected function setOptions($options = null)
@@ -178,30 +178,30 @@ class OptionsApi
     }
 
     /**
-     * @param $text
+     * @param string $text
      * @return $this
      */
-    protected function setText($text = null)
+    protected function setText(?string $text = null)
     {
         $this->text = $text;
         return $this;
     }
 
     /**
-     * @param $url
+     * @param string $url
      * @return $this
      */
-    protected function setUrl($url)
+    protected function setUrl(string $url)
     {
         $this->url = $url;
         return $this;
     }
 
     /**
-     * @param null $value
+     * @param string|null $value
      * @return $this
      */
-    protected function setValue($value = null)
+    protected function setValue(?string $value = null)
     {
         $this->value = $value;
         return $this;
@@ -210,7 +210,7 @@ class OptionsApi
     /**
      * @return string
      */
-    public function text()
+    public function text(): string
     {
         return $this->text;
     }
@@ -235,7 +235,7 @@ class OptionsApi
     /**
      * @return string
      */
-    public function value()
+    public function value(): string
     {
         return $this->value;
     }


### PR DESCRIPTION
## Status: ready for review 👀

- Fixes types in DocBlocks in `Kirby\Form\OptionsApi` and parameter type hints
- Since some parameter type hint are actually getting stricter (though only in the way they have always been intended), waiting for 3.6.0