### PR TITLE
Fixes writer field preview props in blocks field #3145

### DIFF
--- a/panel/src/components/Blocks/Types/Text.vue
+++ b/panel/src/components/Blocks/Types/Text.vue
@@ -1,8 +1,10 @@
 <template>
   <k-writer
     ref="input"
-    :nodes="false"
-    :placeholder="placeholder"
+    :inline="textField.inline"
+    :marks="textField.marks"
+    :nodes="textField.nodes"
+    :placeholder="textField.placeholder"
     :value="content.text"
     class="k-block-type-text-input"
     @input="update({ text: $event })"
@@ -12,8 +14,8 @@
 <script>
 export default {
   computed: {
-    placeholder() {
-      return this.field("text", {}).placeholder;
+    textField() {
+      return this.field("text", {});
     }
   },
   methods: {


### PR DESCRIPTION
## Describe the PR

The missing props were added for blocks field text preview component.

**Side note:**

There are a few missing props in the other block type previews as well but I didn't want to fix it in this PR. 
Should I create new PR for them too or will we fix it later?

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3145 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
