### PR TITLE
Keeps `cover` option in `ModelWithContent::panelImage()` method

### DIFF
--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -139,21 +139,31 @@ abstract class Model
                 ];
 
                 // for lists
-                $settings['list'] = [
-                    'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
-                    'srcset' => $image->srcset([
-                        '1x' => [
-                            'width' => 38,
-                            'height' => 38,
-                            'crop' => 'center'
-                        ],
-                        '2x' => [
-                            'width' => 76,
-                            'height' => 76,
-                            'crop' => 'center'
-                        ],
-                    ])
-                ];
+                if (($settings['cover'] ?? false) === false) {
+                    $settings['list'] = [
+                        'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                        'srcset' => $image->srcset([
+                            38,
+                            76
+                        ])
+                    ];
+                } else {
+                    $settings['list'] = [
+                        'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                        'srcset' => $image->srcset([
+                            '1x' => [
+                                'width' => 38,
+                                'height' => 38,
+                                'crop' => 'center'
+                            ],
+                            '2x' => [
+                                'width' => 76,
+                                'height' => 76,
+                                'crop' => 'center'
+                            ],
+                        ])
+                    ];
+                }
             }
 
             unset($settings['query']);

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -128,9 +128,12 @@ abstract class Model
             // only create srcsets for actual File objects
             if (is_a($image, 'Kirby\Cms\File') === true) {
 
+                // pixelated transparent image placeholder
+                $placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
+
                 // for cards
                 $settings['cards'] = [
-                    'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                    'url' => $placeholder,
                     'srcset' => $image->srcset([
                         352,
                         864,
@@ -141,7 +144,7 @@ abstract class Model
                 // for lists
                 if (($settings['cover'] ?? false) === false) {
                     $settings['list'] = [
-                        'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                        'url' => $placeholder,
                         'srcset' => $image->srcset([
                             38,
                             76
@@ -149,7 +152,7 @@ abstract class Model
                     ];
                 } else {
                     $settings['list'] = [
-                        'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                        'url' => $placeholder,
                         'srcset' => $image->srcset([
                             '1x' => [
                                 'width' => 38,

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -15,6 +15,22 @@ namespace Kirby\Panel;
 class Site extends Model
 {
     /**
+     * Returns the image file object based on provided query
+     *
+     * @internal
+     * @param string|null $query
+     * @return \Kirby\Cms\File|\Kirby\Filesystem\Asset|null
+     */
+    protected function imageSource(string $query = null)
+    {
+        if ($query === null) {
+            $query = 'site.image';
+        }
+
+        return parent::imageSource($query);
+    }
+
+    /**
      * Returns the full path without leading slash
      *
      * @return string

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -265,6 +265,7 @@ class FileTest extends TestCase
         $panel = new File($file);
 
         $hash = $file->mediaHash();
+        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -273,11 +274,11 @@ class FileTest extends TestCase
             'cover' => false,
             'url' => '/media/site/' . $hash . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => '/media/site/' . $hash . '/test-38x.jpg 38w, /media/site/' . $hash . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -289,11 +290,11 @@ class FileTest extends TestCase
             'cover' => true,
             'url' => '/media/site/' . $hash . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => '/media/site/' . $hash . '/test-38x38.jpg 1x, /media/site/' . $hash . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel;
 use Kirby\Cms\App;
 use Kirby\Cms\File as ModelFile;
 use Kirby\Cms\Page as ModelPage;
+use Kirby\Toolkit\Dir;
 use PHPUnit\Framework\TestCase;
 
 class ModelFileTestForceLocked extends ModelFile
@@ -20,6 +21,11 @@ class ModelFileTestForceLocked extends ModelFile
  */
 class FileTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Dir::remove(__DIR__ . '/tmp');
+    }
+
     /**
      * @covers ::dragText
      * @covers \Kirby\Panel\Model::dragTextType
@@ -234,6 +240,63 @@ class FileTest extends TestCase
         $this->assertSame('3/2', $image['ratio']);
         $this->assertSame('pattern', $image['back']);
         $this->assertTrue(array_key_exists('url', $image));
+    }
+
+    /**
+     * @covers ::imageSource
+     * @covers \Kirby\Panel\Model::image
+     * @covers \Kirby\Panel\Model::imageSource
+     */
+    public function testImageCover()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+                'media' => __DIR__ . '/tmp'
+            ],
+            'site' => [
+                'files' => [
+                    ['filename' => 'test.jpg']
+                ]
+            ]
+        ]);
+
+        $file  = $app->site()->image();
+        $panel = new File($file);
+
+        $hash = $file->mediaHash();
+
+        // cover disabled as default
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => false,
+            'url' => '/media/site/' . $hash . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/site/' . $hash . '/test-38x.jpg 38w, /media/site/' . $hash . '/test-76x.jpg 76w'
+            ]
+        ], $panel->image());
+
+        // cover enabled
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => true,
+            'url' => '/media/site/' . $hash . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/site/' . $hash . '/test-38x38.jpg 1x, /media/site/' . $hash . '/test-76x76.jpg 2x'
+            ]
+        ], $panel->image(['cover' => true]));
     }
 
     /**

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -277,6 +277,55 @@ class PageTest extends TestCase
     }
 
     /**
+     * @covers ::imageSource
+     * @covers \Kirby\Panel\Model::image
+     * @covers \Kirby\Panel\Model::imageSource
+     */
+    public function testImageCover()
+    {
+        $page = new ModelPage([
+            'slug' => 'test',
+            'files' => [
+                ['filename' => 'test.jpg']
+            ]
+        ]);
+
+        $hash = $page->image()->mediaHash();
+
+        // cover disabled as default
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => false,
+            'url' => '/media/pages/test/' . $hash . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/pages/test/' . $hash . '/test-352x.jpg 352w, /media/pages/test/' . $hash . '/test-864x.jpg 864w, /media/pages/test/' . $hash . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/pages/test/' . $hash . '/test-38x.jpg 38w, /media/pages/test/' . $hash . '/test-76x.jpg 76w'
+            ]
+        ], (new Page($page))->image());
+
+        // cover enabled
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => true,
+            'url' => '/media/pages/test/' . $hash . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/pages/test/' . $hash . '/test-352x.jpg 352w, /media/pages/test/' . $hash . '/test-864x.jpg 864w, /media/pages/test/' . $hash . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => '/media/pages/test/' . $hash . '/test-38x38.jpg 1x, /media/pages/test/' . $hash . '/test-76x76.jpg 2x'
+            ]
+        ], (new Page($page))->image(['cover' => true]));
+    }
+
+    /**
      * @covers \Kirby\Panel\Model::options
      */
     public function testOptions()

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -311,6 +311,7 @@ class PageTest extends TestCase
 
         $hash = $page->image()->mediaHash();
         $mediaUrl = $page->mediaUrl() . '/' . $hash;
+        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -319,11 +320,11 @@ class PageTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -335,11 +336,11 @@ class PageTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -310,20 +310,21 @@ class PageTest extends TestCase
         $panel = new Page($page);
 
         $hash = $page->image()->mediaHash();
+        $mediaUrl = $page->mediaUrl() . '/' . $hash;
 
         // cover disabled as default
         $this->assertSame([
             'ratio' => '3/2',
             'back' => 'pattern',
             'cover' => false,
-            'url' => '/media/pages/test/' . $hash . '/test.jpg',
+            'url' => $mediaUrl . '/test.jpg',
             'cards' => [
                 'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
-                'srcset' => '/media/pages/test/' . $hash . '/test-352x.jpg 352w, /media/pages/test/' . $hash . '/test-864x.jpg 864w, /media/pages/test/' . $hash . '/test-1408x.jpg 1408w'
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
                 'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
-                'srcset' => '/media/pages/test/' . $hash . '/test-38x.jpg 38w, /media/pages/test/' . $hash . '/test-76x.jpg 76w'
+                'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
 
@@ -332,14 +333,14 @@ class PageTest extends TestCase
             'ratio' => '3/2',
             'back' => 'pattern',
             'cover' => true,
-            'url' => '/media/pages/test/' . $hash . '/test.jpg',
+            'url' => $mediaUrl . '/test.jpg',
             'cards' => [
                 'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
-                'srcset' => '/media/pages/test/' . $hash . '/test-352x.jpg 352w, /media/pages/test/' . $hash . '/test-864x.jpg 864w, /media/pages/test/' . $hash . '/test-1408x.jpg 1408w'
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
                 'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
-                'srcset' => '/media/pages/test/' . $hash . '/test-38x38.jpg 1x, /media/pages/test/' . $hash . '/test-76x76.jpg 2x'
+                'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));
     }

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Site as ModelSite;
+use Kirby\Toolkit\Dir;
+use Kirby\Toolkit\Str;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -11,6 +13,11 @@ use PHPUnit\Framework\TestCase;
  */
 class SiteTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Dir::remove(__DIR__ . '/tmp');
+    }
+
     /**
      * @covers ::path
      * @covers \Kirby\Panel\Model::path
@@ -37,5 +44,81 @@ class SiteTest extends TestCase
         $panel = new Site($site);
         $this->assertSame('/panel/site', $panel->url());
         $this->assertSame('/site', $panel->url(true));
+    }
+
+    /**
+     * @covers ::imageSource
+     * @covers \Kirby\Panel\Model::image
+     * @covers \Kirby\Panel\Model::imageSource
+     */
+    public function testImage()
+    {
+        $site = new ModelSite([
+            'files' => [
+                ['filename' => 'test.jpg']
+            ]
+        ]);
+
+        // fallback to model itself
+        $image = (new Site($site))->image();
+        $this->assertTrue(Str::endsWith($image['url'], '/test.jpg'));
+    }
+
+    /**
+     * @covers ::imageSource
+     * @covers \Kirby\Panel\Model::image
+     * @covers \Kirby\Panel\Model::imageSource
+     */
+    public function testImageCover()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+                'media' => __DIR__ . '/tmp'
+            ],
+            'site' => [
+                'files' => [
+                    ['filename' => 'test.jpg']
+                ]
+            ]
+        ]);
+
+        $site  = $app->site();
+        $panel = new Site($site);
+
+        $hash = $site->image()->mediaHash();
+        $mediaUrl = $site->mediaUrl() . '/' . $hash;
+
+        // cover disabled as default
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => false,
+            'url' => $mediaUrl . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
+            ]
+        ], $panel->image());
+
+        // cover enabled
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => true,
+            'url' => $mediaUrl . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
+            ]
+        ], $panel->image(['cover' => true]));
     }
 }

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -88,6 +88,7 @@ class SiteTest extends TestCase
 
         $hash = $site->image()->mediaHash();
         $mediaUrl = $site->mediaUrl() . '/' . $hash;
+        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -96,11 +97,11 @@ class SiteTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -112,11 +113,11 @@ class SiteTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Cms\App;
 use Kirby\Cms\User as ModelUser;
+use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -19,6 +21,11 @@ class ModelUserTestForceLocked extends ModelUser
  */
 class UserTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Dir::remove(__DIR__ . '/tmp');
+    }
+
     /**
      * @covers ::icon
      * @covers \Kirby\Panel\Model::icon
@@ -68,6 +75,70 @@ class UserTest extends TestCase
         // fallback to model itself
         $image = (new User($user))->image('foo.bar');
         $this->assertFalse(empty($image));
+    }
+
+    /**
+     * @covers ::imageSource
+     * @covers \Kirby\Panel\Model::image
+     * @covers \Kirby\Panel\Model::imageSource
+     */
+    public function testImageCover()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+                'media' => __DIR__ . '/tmp'
+            ],
+            'users' => [
+                [
+                    'email' => 'test@getkirby.com',
+                    'files' => [
+                        [
+                            'filename' => 'test.jpg',
+                            'template' => 'avatar'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $user  = $app->user('test@getkirby.com');
+        $panel = new User($user);
+
+        $hash = $user->image()->mediaHash();
+        $mediaUrl = $user->mediaUrl() . '/' . $hash;
+
+        // cover disabled as default
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => false,
+            'url' => $mediaUrl . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
+            ]
+        ], $panel->image());
+
+        // cover enabled
+        $this->assertSame([
+            'ratio' => '3/2',
+            'back' => 'pattern',
+            'cover' => true,
+            'url' => $mediaUrl . '/test.jpg',
+            'cards' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
+            ],
+            'list' => [
+                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
+            ]
+        ], $panel->image(['cover' => true]));
     }
 
     /**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -107,6 +107,7 @@ class UserTest extends TestCase
 
         $hash = $user->image()->mediaHash();
         $mediaUrl = $user->mediaUrl() . '/' . $hash;
+        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -115,11 +116,11 @@ class UserTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -131,11 +132,11 @@ class UserTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw',
+                'url' => $imagePlaceholder,
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));


### PR DESCRIPTION
## Describe the PR

The `cover` option in the `list` layout in has been made available again. See issue details [here](https://github.com/getkirby/kirby/issues/3226#issuecomment-830785708)

## ⚠️ Breaking Change

Since 3.2, the `cover` option (should was work) was not working in the list layout and this feature will come back with PR.

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3226 

## Release Note

### Fixes

- `cover` option fixed for all models and list layout in section. It can now be applied.

### Breaking changes

- If the `cover` option is not defined in the sections list layout, it is disabled by default

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
