### PR TITLE
Disable cache on active sessions

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1226,6 +1226,10 @@ class App
      */
     public function session(array $options = [])
     {
+        // never cache responses that depend on the session
+        $this->response()->cache(false);
+        $this->response()->header('Cache-Control', 'no-store', true);
+
         return $this->sessionHandler()->get($options);
     }
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1175,7 +1175,7 @@ class Page extends ModelWithContent
             $response = $kirby->response()->toArray();
 
             // cache the result
-            if ($cache !== null) {
+            if ($cache !== null && $kirby->response()->cache() === true) {
                 $cache->set($cacheId, [
                     'html'     => $html,
                     'response' => $response

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -162,9 +162,10 @@ class Responder
      *
      * @param string $key
      * @param string|false|null $value
+     * @param bool $lazy If `true`, an existing header value is not overridden
      * @return string|$this
      */
-    public function header(string $key, $value = null)
+    public function header(string $key, $value = null, bool $lazy = false)
     {
         if ($value === null) {
             return $this->headers[$key] ?? null;
@@ -172,6 +173,10 @@ class Responder
 
         if ($value === false) {
             unset($this->headers[$key]);
+            return $this;
+        }
+
+        if ($lazy === true && isset($this->headers[$key]) === true) {
             return $this;
         }
 

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -67,7 +67,7 @@ class Responder
      * Setter and getter for the response body
      *
      * @param string|null $body
-     * @return string|self
+     * @return string|$this
      */
     public function body(string $body = null)
     {
@@ -85,7 +85,7 @@ class Responder
      *
      * @param int|string|null $expires Timestamp, number of minutes or time string to parse
      * @param bool $override If `true`, the already defined timestamp will be overridden
-     * @return int|null|self
+     * @return int|null|$this
      */
     public function expires($expires = null, bool $override = false)
     {
@@ -162,7 +162,7 @@ class Responder
      *
      * @param string $key
      * @param string|false|null $value
-     * @return string|self
+     * @return string|$this
      */
     public function header(string $key, $value = null)
     {
@@ -183,7 +183,7 @@ class Responder
      * Setter and getter for all headers
      *
      * @param array|null $headers
-     * @return array|self
+     * @return array|$this
      */
     public function headers(array $headers = null)
     {
@@ -199,7 +199,7 @@ class Responder
      * Shortcut to configure a json response
      *
      * @param array|null $json
-     * @return string|self
+     * @return string|$this
      */
     public function json(array $json = null)
     {
@@ -262,7 +262,7 @@ class Responder
      * Setter and getter for the content type
      *
      * @param string|null $type
-     * @return string|self
+     * @return string|$this
      */
     public function type(string $type = null)
     {

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -40,6 +40,14 @@ class Responder
     protected $body = null;
 
     /**
+     * Flag that defines whether the current
+     * response can be cached by Kirby's cache
+     *
+     * @var string
+     */
+    protected $cache = true;
+
+    /**
      * HTTP headers
      *
      * @var array
@@ -76,6 +84,24 @@ class Responder
         }
 
         $this->body = $body;
+        return $this;
+    }
+
+    /**
+     * Setter and getter for the flag that defines
+     * whether the current response can be cached
+     * by Kirby's cache
+     *
+     * @param bool|null $cache
+     * @return bool|$this
+     */
+    public function cache(?bool $cache = null)
+    {
+        if ($cache === null) {
+            return $this->cache;
+        }
+
+        $this->cache = $cache;
         return $this;
     }
 

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Http\Route;
 use Kirby\Http\Server;
+use Kirby\Session\Session;
 use Kirby\Toolkit\Str;
 use ReflectionMethod;
 
@@ -447,6 +448,30 @@ class AppTest extends TestCase
 
         $this->assertInstanceOf(Page::class, $response);
         $this->assertInstanceOf(Route::class, $route);
+    }
+
+    public function testSession()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+                'sessions' => $fixtures = __DIR__ . '/fixtures/AppTest/sessions',
+            ]
+        ]);
+
+        $this->assertTrue($app->response()->cache());
+        $this->assertSame([], $app->response()->headers());
+
+        $this->assertInstanceOf(Session::class, $app->session());
+
+        $this->assertFalse($app->response()->cache());
+        $this->assertSame(['Cache-Control' => 'no-store'], $app->response()->headers());
+
+        // test lazy header setter
+        $app->response()->header('Cache-Control', 'custom');
+        $this->assertInstanceOf(Session::class, $app->session());
+        $this->assertFalse($app->response()->cache());
+        $this->assertSame(['Cache-Control' => 'custom'], $app->response()->headers());
     }
 
     public function testInstance()

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -19,6 +19,21 @@ class ResponderTest extends TestCase
     }
 
     /**
+     * @covers ::cache
+     */
+    public function testCache()
+    {
+        $responder = new Responder();
+        $this->assertTrue($responder->cache());
+
+        $this->assertSame($responder, $responder->cache(true));
+        $this->assertTrue($responder->cache());
+
+        $this->assertSame($responder, $responder->cache(false));
+        $this->assertFalse($responder->cache());
+    }
+
+    /**
      * @covers ::expires
      */
     public function testExpires()

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -98,4 +98,33 @@ class ResponderTest extends TestCase
         $this->assertSame(['Location' => 'https://example.com'], $responder->headers());
         $this->assertSame('text/plain', $responder->type());
     }
+
+    /**
+     * @covers ::header
+     */
+    public function testHeader()
+    {
+        $responder = new Responder();
+
+        // getter for non-existing header
+        $this->assertNull($responder->header('Cache-Control'));
+
+        // simple setter and getter
+        $this->assertSame($responder, $responder->header('Cache-Control', 'private'));
+        $this->assertSame('private', $responder->header('Cache-Control'));
+
+        // unset existing header
+        $this->assertSame($responder, $responder->header('Cache-Control', false));
+        $this->assertNull($responder->header('Cache-Control'));
+
+        // unset non-existing header
+        $this->assertSame($responder, $responder->header('Location', false));
+        $this->assertNull($responder->header('Location'));
+
+        // lazy setter
+        $this->assertSame($responder, $responder->header('Cache-Control', 'private', true));
+        $this->assertSame('private', $responder->header('Cache-Control'));
+        $this->assertSame($responder, $responder->header('Cache-Control', 'no-cache', true));
+        $this->assertSame('private', $responder->header('Cache-Control'));
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

### Features

- New `$kirby->response()->cache(false)` method that can be used to completely disable Kirby's page cache from controllers or templates
- The `$kirby->response()->header()` method now accepts a new third `$lazy` param. If set to `true`, an already set header is not overridden.

### Enhancements

- All pages that rely on Kirby's session are now automatically excluded from Kirby's page cache and from the browser and intermediary caches

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3242 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
