### PR TITLE
Improvements to EmailChallenge

### DIFF
--- a/config/templates/emails/auth/login.php
+++ b/config/templates/emails/auth/login.php
@@ -5,4 +5,4 @@
  * @var string $code
  * @var int $timeout
  */
-echo I18n::template('login.email.login.body', null, compact('user', 'code', 'timeout'));
+echo I18n::template('login.email.login.body', null, compact('user', 'code', 'timeout'), $user->language());

--- a/config/templates/emails/auth/password-reset.php
+++ b/config/templates/emails/auth/password-reset.php
@@ -5,4 +5,4 @@
  * @var string $code
  * @var int $timeout
  */
-echo I18n::template('login.email.password-reset.body', null, compact('user', 'code', 'timeout'));
+echo I18n::template('login.email.password-reset.body', null, compact('user', 'code', 'timeout'), $user->language());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,10 @@
             <directory>./config</directory>
             <directory>./src</directory>
         </include>
+
+        <exclude>
+            <directory suffix=".php">./config/templates</directory>
+        </exclude>
     </coverage>
 
     <testsuites>

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -11,6 +11,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Http\Request;
 use Kirby\Http\Router;
 use Kirby\Http\Server;
+use Kirby\Http\Uri;
 use Kirby\Http\Visitor;
 use Kirby\Session\AutoSession;
 use Kirby\Toolkit\A;
@@ -1479,11 +1480,26 @@ class App
      * Returns a system url
      *
      * @param string $type
-     * @return string
+     * @param bool $object If set to `true`, the URL is converted to an object
+     * @return string|\Kirby\Http\Uri
      */
-    public function url(string $type = 'index'): string
+    public function url(string $type = 'index', bool $object = false)
     {
-        return $this->urls->__get($type);
+        $url = $this->urls->__get($type);
+
+        if ($object === true) {
+            if (Url::isAbsolute($url)) {
+                return Url::toObject($url);
+            }
+
+            // index URL was configured without host, use the current host
+            return Uri::current([
+                'path'   => $url,
+                'query'  => null
+            ]);
+        }
+
+        return $url;
     }
 
     /**

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -61,7 +61,7 @@ class EmailChallenge extends Challenge
             'to' => $user,
             'subject' => $kirby->option(
                 'auth.challenge.email.subject',
-                I18n::translate('login.email.' . $mode . '.subject')
+                I18n::translate('login.email.' . $mode . '.subject', null, $user->language())
             ),
             'template' => 'auth/' . $mode,
             'data' => [

--- a/src/Cms/Auth/EmailChallenge.php
+++ b/src/Cms/Auth/EmailChallenge.php
@@ -56,7 +56,7 @@ class EmailChallenge extends Challenge
 
         $kirby = $user->kirby();
         $kirby->email([
-            'from' => $kirby->option('auth.challenge.email.from', 'noreply@' . $kirby->system()->indexUrl()),
+            'from' => $kirby->option('auth.challenge.email.from', 'noreply@' . $kirby->url('index', true)->host()),
             'fromName' => $kirby->option('auth.challenge.email.fromName', $kirby->site()->title()),
             'to' => $user,
             'subject' => $kirby->option(

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -7,8 +7,6 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Http\Remote;
-use Kirby\Http\Uri;
-use Kirby\Http\Url;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
@@ -115,19 +113,7 @@ class System
      */
     public function indexUrl(): string
     {
-        $url = $this->app->url('index');
-
-        if (Url::isAbsolute($url)) {
-            $uri = Url::toObject($url);
-        } else {
-            // index URL was configured without host, use the current host
-            $uri = Uri::current([
-                'path'   => $url,
-                'query'  => null
-            ]);
-        }
-
-        return $uri->setScheme(null)->setSlash(false)->toString();
+        return $this->app->url('index', true)->setScheme(null)->setSlash(false)->toString();
     }
 
     /**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -752,6 +752,41 @@ class AppTest extends TestCase
         $this->assertSame(143, $count);
     }
 
+    public function urlProvider()
+    {
+        return [
+            ['http://getkirby.com', 'http://getkirby.com'],
+            ['https://getkirby.com', 'https://getkirby.com'],
+            ['https://getkirby.com/test', 'https://getkirby.com/test'],
+            ['/', 'http://example.com/'],
+            ['/test', 'http://example.com/test'],
+            ['getkirby.com/test', 'http://example.com/getkirby.com/test'],
+        ];
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testUrl($url, $expected)
+    {
+        $_SERVER['SERVER_ADDR'] = 'example.com';
+
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'url' => $url
+            ]
+        ]);
+
+        $this->assertSame($url, $app->url('index'));
+        $this->assertSame($expected, $app->url('index', true)->toString());
+
+        // reset SERVER_ADDR
+        $_SERVER['SERVER_ADDR'] = null;
+    }
+
     public function testVersionHash()
     {
         $this->assertEquals(md5(App::version()), App::versionHash());


### PR DESCRIPTION
## Describe the PR
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. We may use this for the changelog and/or documentation. -->

### Enhancements

- The email auth challenge now uses the user's language, the configured `panel.language` or site default language for the email text (in that order)

### Bug fixes

- Fixed the default sender domain for the email auth challenge if the site URL contains a path

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3185
- Implements https://kirby.nolt.io/276

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

⚠️ The failing Codecov check is because the email template files can not be covered by PHPUnit as they are no functions or methods. The check should be ignored.

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
