### PR TITLE
Don't pin Composer installer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "ext-mbstring": "*",
     "claviska/simpleimage": "3.6.3",
     "filp/whoops": "2.12.1",
-    "getkirby/composer-installer": "1.2.1",
+    "getkirby/composer-installer": "^1.2.0",
     "laminas/laminas-escaper": "2.7.0",
     "michelf/php-smartypants": "1.8.1",
     "mustangostang/spyc": "0.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfc3d1f85d0383961a65c7a75810a458",
+    "content-hash": "610357980f470fee7ad051e6e8d35dd0",
     "packages": [
         {
             "name": "claviska/simpleimage",


### PR DESCRIPTION
The Composer installer version is the only one that's not pinned on purpose. This allows us to fix bugs in the installer separately from the CMS version. In the regular CMS usage this doesn't matter because the installer is not actually used by Kirby itself.