### PR TITLE
pre-commit script for static analysis

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+##########
+## Pre-commit hook script for Git
+## Runs static analysis on all staged files before they are committed
+##
+## ------
+## Usage:
+## Create an executable file `.git/hooks/pre-commit` with the following contents:
+##
+##   #!/bin/sh
+##   exec scripts/pre-commit
+##
+## You may need to modify the `$PATH` variable so Git can find your tools;
+## if the script above triggers an error, use a line like this above `exec`:
+##
+##   export PATH=$HOME/.composer/vendor/bin:$PATH
+##########
+
+# exit on the first error
+set -e
+
+# enable extended globbing
+shopt -s extglob
+
+# loop over all files that are currently staged
+git diff-index --cached --name-only HEAD | while read -r file; do
+    case "$file" in
+        bootstrap.php | router.php | @(config|src|tests|views)/**.php)
+            echo "### PHP-CS-Fixer on $file"
+            php-cs-fixer fix --config .php_cs --dry-run --diff --diff-format=udiff "$file"
+            echo
+
+            if [[ "$file" != tests/** ]]; then
+                echo "### Psalm on $file"
+                psalm "$file"
+                echo
+
+                echo "### PHPMD on $file"
+                phpmd "$file" ansi phpmd.xml.dist
+                echo
+            fi
+        ;;
+
+        *.js | *.vue)
+            echo "### ESLint on $file"
+            npm --prefix panel run lint -- --no-fix "../$file"
+            echo
+        ;;
+
+        composer.json | composer.lock)
+            echo "### composer validate"
+            composer run analyze:composer
+            echo
+        ;;
+    esac
+done


### PR DESCRIPTION
I've been using this script for a few months now and feel it could be useful for the rest of the team. It introduces a delay into the commit process, but makes sure that we don't commit something that will fail in CI.

In any case this script is completely voluntary as it needs to be manually enabled as described in the docblock.

The script is configured to use the dry run feature of all tools, so it does not automatically fix anything. This is by design as otherwise the staged changes wouldn't match anymore. So if the commit fails, check why in Tower's output, run the appropriate tool to fix the error, stage the fix and then commit again.