### PR TITLE
Temporary CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
         with:
           php-version: ${{ env.php }}
           coverage: none
-          tools: php-cs-fixer
+          tools: php-cs-fixer:2.19.0
 
       - name: Cache analysis data
         id: finishPrepare


### PR DESCRIPTION
PHP-CS-Fixer 3.0.0 contains breaking-changes, so I will need to look more closely into that. For now let's use the previous version that works fine.