### PR TITLE
Don’t ignore port from database config in default connection

### DIFF
--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -51,7 +51,8 @@ class Db
             'user'     => Config::get('db.user', 'root'),
             'password' => Config::get('db.password', ''),
             'database' => Config::get('db.database', ''),
-            'prefix'   => Config::get('db.prefix', '')
+            'prefix'   => Config::get('db.prefix', ''),
+            'port'     => Config::get('db.port', '')
         ];
         $params = $params ?? $defaults;
 


### PR DESCRIPTION
## Describe the PR
The db.port config is now used to supply port information to the default database connection

## Related issues
- Fixes #3302

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [ ] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
