### PR TITLE
Use email as lowercase to consistently on `User::changeEmail()` and `System::register()`

### DIFF
--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -448,7 +448,7 @@ class System
         $response = Remote::get('https://licenses.getkirby.com/register', [
             'data' => [
                 'license' => $license,
-                'email'   => $email,
+                'email'   => Str::lower(trim($email)),
                 'domain'  => $this->indexUrl()
             ]
         ]);

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -445,6 +445,7 @@ class System
             ]);
         }
 
+        // @codeCoverageIgnoreStart
         $response = Remote::get('https://licenses.getkirby.com/register', [
             'data' => [
                 'license' => $license,
@@ -474,6 +475,7 @@ class System
                 'key' => 'license.verification'
             ]);
         }
+        // @codeCoverageIgnoreEnd
 
         return true;
     }

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -30,10 +30,7 @@ trait UserActions
      */
     public function changeEmail(string $email)
     {
-        $email = Str::lower(trim($email));
-        $email = Idn::decodeEmail($email);
-
-        return $this->commit('changeEmail', ['user' => $this, 'email' => $email], function ($user, $email) {
+        return $this->commit('changeEmail', ['user' => $this, 'email' => Idn::decodeEmail($email)], function ($user, $email) {
             $user = $user->clone([
                 'email' => $email
             ]);
@@ -330,6 +327,11 @@ trait UserActions
      */
     protected function updateCredentials(array $credentials): bool
     {
+        // normalize the email address
+        if (isset($credentials['email']) === true) {
+            $credentials['email'] = Str::lower(trim($credentials['email']));
+        }
+
         return $this->writeCredentials(array_merge($this->credentials(), $credentials));
     }
 

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -30,7 +30,10 @@ trait UserActions
      */
     public function changeEmail(string $email)
     {
-        return $this->commit('changeEmail', ['user' => $this, 'email' => Idn::decodeEmail($email)], function ($user, $email) {
+        $email = Str::lower(trim($email));
+        $email = Idn::decodeEmail($email);
+
+        return $this->commit('changeEmail', ['user' => $this, 'email' => $email], function ($user, $email) {
             $user = $user->clone([
                 'email' => $email
             ]);

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -66,6 +66,14 @@ class UserActionsTest extends TestCase
         $this->assertSame('test@täst.com', $user->email());
     }
 
+    public function testChangeEmailWithUppercase()
+    {
+        $user = $this->app->user('editor@domain.com');
+        $user = $user->changeEmail('ANOTHER@domain.com');
+
+        $this->assertSame('another@domain.com', $user->email());
+    }
+
     public function testChangeLanguage()
     {
         $user = $this->app->user('editor@domain.com');

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -2,15 +2,26 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Data\Data;
 use Kirby\Toolkit\Dir;
 
 class UserActionsTest extends TestCase
 {
     protected $app;
-    protected $fixtures;
+    protected $fixtures = __DIR__ . '/fixtures/UserActionsTest';
 
     public function setUp(): void
     {
+        Dir::remove($this->fixtures);
+        Data::write($this->fixtures . '/admin/index.php', [
+            'email' => 'admin@domain.com',
+            'role' => 'admin'
+        ]);
+        Data::write($this->fixtures . '/editor/index.php', [
+            'email' => 'editor@domain.com',
+            'role' => 'editor'
+        ]);
+
         $this->app = new App([
             'roles' => [
                 [
@@ -22,22 +33,10 @@ class UserActionsTest extends TestCase
             ],
             'roots' => [
                 'index'    => '/dev/null',
-                'accounts' => $this->fixtures = __DIR__ . '/fixtures/UserActionsTest',
+                'accounts' => $this->fixtures,
             ],
-            'user'  => 'admin@domain.com',
-            'users' => [
-                [
-                    'email' => 'admin@domain.com',
-                    'role'  => 'admin'
-                ],
-                [
-                    'email' => 'editor@domain.com',
-                    'role'  => 'editor'
-                ]
-            ],
+            'user'  => 'admin@domain.com'
         ]);
-
-        Dir::remove($this->fixtures);
     }
 
     public function tearDown(): void
@@ -50,7 +49,10 @@ class UserActionsTest extends TestCase
         $user = $this->app->user('editor@domain.com');
         $user = $user->changeEmail('another@domain.com');
 
-        $this->assertEquals('another@domain.com', $user->email());
+        $this->assertSame('another@domain.com', $user->email());
+
+        // verify the value stored on disk
+        $this->assertSame('another@domain.com', $this->app->clone()->user($user->id())->email());
     }
 
     public function testChangeEmailWithUnicode()
@@ -61,9 +63,15 @@ class UserActionsTest extends TestCase
         $user = $user->changeEmail('test@exämple.com');
         $this->assertSame('test@exämple.com', $user->email());
 
+        // verify the value stored on disk
+        $this->assertSame('test@exämple.com', $this->app->clone()->user($user->id())->email());
+
         // with Punycode email
         $user = $user->changeEmail('test@xn--tst-qla.com');
         $this->assertSame('test@täst.com', $user->email());
+
+        // verify the value stored on disk
+        $this->assertSame('test@täst.com', $this->app->clone()->user($user->id())->email());
     }
 
     public function testChangeEmailWithUppercase()
@@ -72,6 +80,9 @@ class UserActionsTest extends TestCase
         $user = $user->changeEmail('ANOTHER@domain.com');
 
         $this->assertSame('another@domain.com', $user->email());
+
+        // verify the value stored on disk
+        $this->assertSame('another@domain.com', $this->app->clone()->user($user->id())->email());
     }
 
     public function testChangeLanguage()


### PR DESCRIPTION
## Describe the PR

Used email as lowercase to consistently on `User::changeEmail()` and `System::register()`.

### Side Note

I don't think we have a chance to test the change (registering license) in the `System::register()` method. For this reason I had to ignore coverage. Do you have an opinion on this matter?

## Related issues
<!-- PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: -->

- Fixes #3305 

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Added in-code documentation (if needed)
- [x] CI passes (runs automatically when the PR is created or run `composer ci` locally)
  Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.

<!-- We will take care of the following TODO when reviewing the PR. -->

- [x] Checked whether the PR needs documentation, if needed added to the [release docs checklist](https://github.com/getkirby/getkirby.com/pulls)
