### PR TITLE
Remove vuelidate

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -20,7 +20,6 @@
         "vue": "^2.6.12",
         "vue-router": "^3.4.9",
         "vuedraggable": "^2.24.3",
-        "vuelidate": "^0.7.6",
         "vuex": "^3.5.1"
       },
       "devDependencies": {
@@ -5866,15 +5865,6 @@
         "sortablejs": "1.10.2"
       }
     },
-    "node_modules/vuelidate": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.6.tgz",
-      "integrity": "sha512-suzIuet1jGcyZ4oUSW8J27R2tNrJ9cIfklAh63EbAkFjE380iv97BAiIeolRYoB9bF9usBXCu4BxftWN1Dkn3g==",
-      "engines": {
-        "node": ">= 4.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
@@ -10848,11 +10838,6 @@
       "requires": {
         "sortablejs": "1.10.2"
       }
-    },
-    "vuelidate": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.6.tgz",
-      "integrity": "sha512-suzIuet1jGcyZ4oUSW8J27R2tNrJ9cIfklAh63EbAkFjE380iv97BAiIeolRYoB9bF9usBXCu4BxftWN1Dkn3g=="
     },
     "vuex": {
       "version": "3.6.2",

--- a/panel/package.json
+++ b/panel/package.json
@@ -25,7 +25,6 @@
     "vue": "^2.6.12",
     "vue-router": "^3.4.9",
     "vuedraggable": "^2.24.3",
-    "vuelidate": "^0.7.6",
     "vuex": "^3.5.1"
   },
   "devDependencies": {

--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -23,7 +23,6 @@
               v-bind="field"
               @input="$emit('input', value, field, fieldName)"
               @focus="$emit('focus', $event, field, fieldName)"
-              @invalid="($invalid, $v) => onInvalid($invalid, $v, field, fieldName)"
               @submit="$emit('submit', $event, field, fieldName)"
             />
             <k-box v-else theme="negative">
@@ -65,11 +64,6 @@ export default {
         return {};
       }
     }
-  },
-  data() {
-    return {
-      errors: {}
-    };
   },
   methods: {
     /**
@@ -126,13 +120,6 @@ export default {
 
       return result;
 
-    },
-    onInvalid($invalid, $v, field, fieldName) {
-      this.errors[fieldName] = $v;
-      this.$emit("invalid", this.errors);
-    },
-    hasErrors() {
-      return Object.keys(this.errors).length;
     }
   }
 };

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :data-disabled="disabled"
-    :data-invalid="!novalidate && isInvalid"
+    :data-invalid="!novalidate && invalid"
     :data-theme="theme"
     :data-type="type"
     class="k-input"
@@ -66,13 +66,8 @@ export default {
   inheritAttrs: false,
   data() {
     return {
-      isInvalid: this.invalid,
       listeners: {
-        ...this.$listeners,
-        invalid: ($invalid, $v) => {
-          this.isInvalid = $invalid;
-          this.$emit("invalid", $invalid, $v);
-        }
+        ...this.$listeners
       }
     };
   },

--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -37,8 +37,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { required as validateRequired } from "vuelidate/lib/validators";
-
 /**
  * 
  * @example <k-input v-model="checkbox" type="checkbox" />
@@ -55,14 +53,7 @@ export default {
   props: {
     value: Boolean,
   },
-  watch: {
-    value() {
-      this.onInvalid();
-    }
-  },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -79,22 +70,8 @@ export default {
        */
       this.$emit("input", checked);
     },
-    onInvalid() {
-      /**
-       * The invalid event is triggered when the input validation fails. This can be used to react on errors immediately.
-       * @event invalid
-       */
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     select() {
       this.focus();
-    }
-  },
-  validations() {
-    return {
-      value: {
-        required: this.required ? validateRequired : true,
-      }
     }
   }
 }

--- a/panel/src/components/Forms/Input/CheckboxesInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxesInput.vue
@@ -19,12 +19,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { 
-  required as validateRequired, 
-  minLegth as validateMinLength, 
-  maxLength as validateMaxLength 
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -60,14 +54,9 @@ export default {
   watch: {
     value(value) {
       this.selected = this.valueToArray(value);
-    },
-    selected() {
-      this.onInvalid();
     }
   },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -87,9 +76,6 @@ export default {
       }
       this.$emit("input", this.selected);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     select() {
       this.focus();
     },
@@ -106,15 +92,6 @@ export default {
         return Object.values(value);
       }
     },
-  },
-  validations() {
-    return {
-      selected: {
-        required: this.required ? validateRequired : true,
-        min: this.min ? validateMinLength(this.min) : true,
-        max: this.max ? validateMaxLength(this.max) : true,
-      }
-    };
   }
 }
 

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -9,7 +9,6 @@
     type="text"
     @blur="onBlur"
     @input="onInput"
-    @invalid="onInvalid"
     @focus="$emit('focus')"
     @keydown.down.stop.prevent="onDown"
     @keydown.up.stop.prevent="onUp"
@@ -25,8 +24,6 @@ import {
   id,
   required
 } from "@/mixins/props.js";
-
-import { required as validateRequired } from "vuelidate/lib/validators";
 
 export const props = {
   mixins: [
@@ -169,11 +166,7 @@ export default {
   watch: {
     value(value) {
       this.input = this.toFormat(value);
-      this.onInvalid();
     }
-  },
-  mounted() {
-    this.onInvalid();
   },
   methods: {
     emit(event) {
@@ -258,9 +251,6 @@ export default {
     },
     onInput() {
       this.emit("input");
-    },
-    onInvalid($invalid, $v) {
-      this.$emit("invalid", $invalid || this.$v.$invalid, $v || this.$v);
     },
     onTab(event) {
       const cursor = this.toCursorIndex();
@@ -403,27 +393,6 @@ export default {
       }
 
       return keys[index];
-    }
-  },
-  validations() {
-    return {
-      value: {
-        min: this.min ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.min,
-          "isAfter",
-          this.step.unit
-        ) : true,
-        max: this.max ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.max,
-          "isBefore",
-          this.step.unit
-        ) : true,
-        required: this.required ? validateRequired : true,
-      }
     }
   }
 };

--- a/panel/src/components/Forms/Input/DateTimeInput.vue
+++ b/panel/src/components/Forms/Input/DateTimeInput.vue
@@ -23,7 +23,6 @@
 
 <script>
 import { props as DateInput } from "./DateInput.vue";
-import { required as validateRequired } from "vuelidate/lib/validators";
 
 export const props = {
   mixins: [DateInput],
@@ -69,11 +68,7 @@ export default {
   watch: {
     value() {
       this.input = this.toDatetime(this.value);
-      this.onInvalid();
     }
-  },
-  mounted() {
-    this.onInvalid();
   },
   methods: {
     emit(event, dt = this.input) {
@@ -98,9 +93,6 @@ export default {
     onInput(value, input) {
       this.input = this.toDatetime(value, input, this.input);
       this.emit("input");
-    },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
     },
     toDatetime(value, input, base) {
       // if only value is passed,
@@ -141,27 +133,6 @@ export default {
                                  .set("second", dt.get("second"));
       }
     }
-  },
-  validations() {
-    return {
-      value: {
-        min: this.min ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.min,
-          "isAfter",
-          this.step.unit
-        ) : true,
-        max: this.max ? value => this.$helper.validate.datetime(
-          this,
-          value,
-          this.max,
-          "isBefore",
-          this.step.unit
-        ) : true,
-        required: this.required ? validateRequired : true,
-      }
-    };
   }
 }
 

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -89,12 +89,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { 
-  required as validateRequired, 
-  minLength as validateMinLength, 
-  maxLength as validateMaxLength 
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     disabled,
@@ -200,11 +194,9 @@ export default {
   watch: {
     value(value) {
       this.state = value;
-      this.onInvalid();
     }
   },
   mounted() {
-    this.onInvalid();
     this.$events.$on("click", this.close);
     this.$events.$on("keydown.cmd.s", this.close);
   },
@@ -285,9 +277,6 @@ export default {
     onInput() {
       this.$emit("input", this.sorted);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     onOpen() {
       this.$nextTick(() => {
         if (this.$refs.search && this.$refs.search.focus) {
@@ -318,15 +307,6 @@ export default {
       string = this.$helper.string.stripHTML(string);
       return string.replace(this.regex, "<b>$1</b>")
     },
-  },
-  validations() {
-    return {
-      state: {
-        required: this.required ? validateRequired : true,
-        minLength: this.min ? validateMinLength(this.min) : true,
-        maxLength: this.max ? validateMaxLength(this.max) : true
-      }
-    };
   }
 };
 </script>

--- a/panel/src/components/Forms/Input/NumberInput.vue
+++ b/panel/src/components/Forms/Input/NumberInput.vue
@@ -29,12 +29,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import {
-  required as validateRequired,
-  minValue as validateMinValue,
-  maxValue as validateMaxValue
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -80,12 +74,6 @@ export default {
   watch: {
     value(value) {
       this.number = value;
-    },
-    number: {
-      immediate: true,
-      handler() {
-        this.onInvalid();
-      }
     }
   },
   mounted() {
@@ -145,9 +133,6 @@ export default {
     focus() {
       this.$refs.input.focus();
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     onInput(value) {
       this.number = value;
       this.emit(value);
@@ -159,15 +144,6 @@ export default {
     select() {
       this.$refs.input.select();
     }
-  },
-  validations() {
-    return {
-      value: {
-        required: this.required ? validateRequired : true,
-        min: this.min ? validateMinValue(this.min) : true,
-        max: this.max ? validateMaxValue(this.max) : true
-      }
-    };
   }
 }
 

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -32,8 +32,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { required as validateRequired } from "vuelidate/lib/validators";
-
 export const props = {
     mixins: [
     autofocus,
@@ -51,14 +49,7 @@ export const props = {
 export default {
   mixins: [props],
   inheritAttrs: false,
-  watch: {
-    value() {
-      this.onInvalid();
-    }
-  },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -70,19 +61,9 @@ export default {
     onInput(value) {
       this.$emit("input", value);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     select() {
       this.focus();
     }
-  },
-  validations() {
-    return {
-      value: {
-        required: this.required ? validateRequired : true
-      }
-    };
   }
 }
 </script>

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -35,12 +35,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { 
-  required as validateRequired,
-  minValue as validateMinValue,
-  maxValue as validateMaxValue
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -115,14 +109,7 @@ export default {
       return (this.value || this.value === 0) ? this.value : this.default || this.baseline;
     }
   },
-  watch: {
-    position() {
-      this.onInvalid();
-    }
-  },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -139,21 +126,9 @@ export default {
         minimumFractionDigits: digits
       }).format(value);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     onInput(value) {
       this.$emit("input", value);
     },
-  },
-  validations() {
-    return {
-      position: {
-        required: this.required ? validateRequired : true,
-        min: this.min ? validateMinValue(this.min) : true,
-        max: this.max ? validateMaxValue(this.max) : true
-      }
-    };
   }
 }
 </script>

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -41,8 +41,6 @@ import {
   required
 } from "@/mixins/props.js"
 
-import { required as validateRequired } from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -116,12 +114,9 @@ export default {
   watch: {
     value(value) {
       this.selected = value;
-      this.onInvalid();
     }
   },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -133,9 +128,6 @@ export default {
     onClick(event) {
       event.stopPropagation();
       this.$emit("click", event);
-    },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
     },
     onInput(value) {
       this.selected = value;
@@ -153,13 +145,6 @@ export default {
       });
       return text;
     }
-  },
-  validations() {
-    return {
-      selected: {
-        required: this.required ? validateRequired : true,
-      }
-    };
   }
 }
 </script>

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -65,12 +65,6 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { 
-  required as validateRequired, 
-  minLength as validateMinLength, 
-  maxLength as validateMaxLength 
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -163,12 +157,9 @@ export default {
   watch: {
     value(value) {
       this.tags = this.prepareTags(value);
-      this.onInvalid();
     }
   },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -322,9 +313,6 @@ export default {
     onInput() {
       this.$emit("input", this.tags);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     leaveInput(e) {
       if (
         e.target.selectionStart === 0 &&
@@ -397,15 +385,6 @@ export default {
       this.newTag = value;
       this.$refs.autocomplete.search(value);
     }
-  },
-  validations() {
-    return {
-      tags: {
-        required: this.required ? validateRequired : true,
-        minLength: this.min ? validateMinLength(this.min) : true,
-        maxLength: this.max ? validateMaxLength(this.max) : true
-      }
-    };
   }
 };
 </script>

--- a/panel/src/components/Forms/Input/TextInput.vue
+++ b/panel/src/components/Forms/Input/TextInput.vue
@@ -32,14 +32,6 @@ import {
   required
 } from "@/mixins/props.js"
 
-import {
-  required as validateRequired,
-  minLength as validateMinLength,
-  maxLength as validateMaxLength,
-  email as validateEmail,
-  url as validateUrl
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -89,14 +81,7 @@ export default {
       return direction(this);
     }
   },
-  watch: {
-    value() {
-      this.onInvalid();
-    }
-  },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -112,28 +97,9 @@ export default {
     onInput(value) {
       this.$emit("input", value);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     select() {
       this.$refs.input.select();
     }
-  },
-  validations() {
-    const validateMatch = (value) => {
-      return (!this.required && !value) || !this.$refs.input.validity.patternMismatch;
-    };
-
-    return {
-      value: {
-        required: this.required ? validateRequired : true,
-        minLength: this.minlength ? validateMinLength(this.minlength) : true,
-        maxLength: this.maxlength ? validateMaxLength(this.maxlength) : true,
-        email: this.type === "email" ? validateEmail : true,
-        url: this.type === "url" ? validateUrl : true,
-        pattern: this.pattern ? validateMatch : true,
-      }
-    };
   }
 };
 </script>

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -63,12 +63,6 @@ import {
   required
 } from "@/mixins/props.js"
 
-import { 
-  required as validateRequired, 
-  minLength as validateMinLength, 
-  maxLength as validateMaxLength 
-} from "vuelidate/lib/validators";
-
 export const props = {
   mixins: [
     autofocus,
@@ -122,7 +116,6 @@ export default {
   },
   watch: {
     value() {
-      this.onInvalid();
       this.$nextTick(() => {
         this.resize();
       });
@@ -132,8 +125,6 @@ export default {
     this.$nextTick(() => {
       this.$library.autosize(this.$refs.input);
     });
-
-    this.onInvalid();
 
     if (this.$props.autofocus) {
       this.focus();
@@ -228,9 +219,6 @@ export default {
     onInput($event) {
       this.$emit("input", $event.target.value);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     onOut() {
       this.$refs.input.blur();
       this.over = false;
@@ -297,15 +285,6 @@ export default {
     wrap(text) {
       this.insert(text + this.selection() + text);
     }
-  },
-  validations() {
-    return {
-      value: {
-        required: this.required ? validateRequired : true,
-        minLength: this.minlength ? validateMinLength(this.minlength) : true,
-        maxLength: this.maxlength ? validateMaxLength(this.maxlength) : true
-      }
-    };
   }
 };
 </script>

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -14,8 +14,6 @@
 </template>
 
 <script>
-import { required as validateRequired } from "vuelidate/lib/validators";
-
 export const props = {
   props: {
     autofocus: Boolean,
@@ -56,14 +54,7 @@ export default {
       return this.text;
     }
   },
-  watch: {
-    value() {
-      this.onInvalid();
-    }
-  },
   mounted() {
-    this.onInvalid();
-
     if (this.$props.autofocus) {
       this.focus();
     }
@@ -80,18 +71,8 @@ export default {
     onInput(checked) {
       this.$emit("input", checked);
     },
-    onInvalid() {
-      this.$emit("invalid", this.$v.$invalid, this.$v);
-    },
     select() {
       this.$refs.input.focus();
-    }
-  },
-  validations() {
-    return {
-      value: {
-        required: this.required ? validateRequired : true,
-      }
     }
   }
 }

--- a/panel/src/index.js
+++ b/panel/src/index.js
@@ -3,7 +3,6 @@ import Api from "./config/api.js";
 import Events from "./config/events.js";
 import I18n from "./config/i18n.js";
 import Vue from "vue";
-import Vuelidate from "vuelidate";
 import Helpers from "./helpers/index.js";
 
 Vue.config.productionTip = false;
@@ -17,7 +16,6 @@ import "./config/libraries.js";
 import "./config/plugins.js";
 
 Vue.use(Events);
-Vue.use(Vuelidate);
 
 import VuePortal from "@linusborg/vue-simple-portal";
 Vue.use(VuePortal);

--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -19,10 +19,6 @@ const proxy = {
 
 export default defineConfig({
   plugins: [createVuePlugin(), pluginRewriteAll()],
-  define: {
-    // Fix vuelidate error
-    'process.env.BUILD': JSON.stringify('production')
-  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Status: on hold ⏸

As a first step to refactor validations via backend calls, a clean removal of `vuelidate` is necessary. And easier to review than bundling all in one huge PR. So this PR tries to do this first step.

We might still only merge this, when the 2nd step (new implementation with backend validations) is ready as well.

- [ ] Remove `validate` helpers