### PR TITLE
FliesSection.vue: remove if from attribute

### DIFF
--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -44,7 +44,7 @@
             :layout="options.layout"
             :data-invalid="isInvalid"
             icon="image"
-            @click="if (add) upload()"
+            @clik="upload"
           >
             {{ options.empty || $t('files.empty') }}
           </k-empty>

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -44,7 +44,7 @@
             :layout="options.layout"
             :data-invalid="isInvalid"
             icon="image"
-            @clik="upload"
+            @click="upload"
           >
             {{ options.empty || $t('files.empty') }}
           </k-empty>


### PR DESCRIPTION
Sooner or later vite will complain about this if statement inline in the attribute.
It's not needed since the `upload` method checks this itself already.