### PR TITLE
Refactor `Properties`

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -32,7 +32,7 @@ class Api
     /**
      * Authentication callback
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected $authentication;
 
@@ -121,7 +121,16 @@ class Api
      */
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'authentication',
+            'collections',
+            'data',
+            'debug',
+            'models',
+            'requestData',
+            'requestMethod',
+            'routes'
+        ]);
     }
 
     /**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -104,7 +104,7 @@ class App
         $this->bakeUrls($props['urls'] ?? []);
 
         // configurable properties
-        $this->setOptionalProperties($props, [
+        $this->setProperties($props, [
             'languages',
             'request',
             'roles',

--- a/src/Cms/Asset.php
+++ b/src/Cms/Asset.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Toolkit\Properties;
-
 /**
  * Anything in your public path can be converted
  * to an Asset object to use the same handy file
@@ -21,7 +19,6 @@ class Asset
 {
     use FileFoundation;
     use FileModifications;
-    use Properties;
 
     /**
      * @var string

--- a/src/Cms/Auth/Status.php
+++ b/src/Cms/Auth/Status.php
@@ -64,7 +64,13 @@ class Status
      */
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'challenge',
+            'challengeFallback',
+            'email',
+            'kirby',
+            'status'
+        ]);
     }
 
     /**

--- a/src/Cms/ContentTranslation.php
+++ b/src/Cms/ContentTranslation.php
@@ -51,8 +51,12 @@ class ContentTranslation
      */
     public function __construct(array $props)
     {
-        $this->setRequiredProperties($props, ['parent', 'code']);
-        $this->setOptionalProperties($props, ['slug', 'content']);
+        $this->setroperties($props, [
+            'code',
+            'content',
+            'parent',
+            'slug'
+        ]);
     }
 
     /**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -133,7 +133,16 @@ class File extends ModelWithContent
     public function __construct(array $props)
     {
         // properties
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'blueprint',
+            'filename',
+            'kirby',
+            'parent',
+            'root',
+            'site',
+            'template',
+            'url'
+        ]);
     }
 
     /**
@@ -785,7 +794,14 @@ class File extends ModelWithContent
      */
     public function toArray(): array
     {
-        return array_merge($this->asset()->toArray(), parent::toArray());
+        return array_merge($this->asset()->toArray(), parent::toArray(), [
+            'blueprint' => $this->blueprint(),
+            'filename'  => $this->filename(),
+            'parent'    => $this->parent(),
+            'root'      => $this->root(),
+            'template'  => $this->template(),
+            'url'       => $this->url()
+        ]);
     }
 
     /**

--- a/src/Cms/FileVersion.php
+++ b/src/Cms/FileVersion.php
@@ -54,6 +54,19 @@ class FileVersion
     }
 
     /**
+     * FileVersion constructor
+     *
+     * @param array $props
+     */
+    public function __construct(array $props)
+    {
+        $this->setProperties($props, [
+            'modifications',
+            'original'
+        ]);
+    }
+
+    /**
      * Returns the unique ID
      *
      * @return string

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -80,11 +80,8 @@ class Language extends Model
      */
     public function __construct(array $props)
     {
-        $this->setRequiredProperties($props, [
-            'code'
-        ]);
-
-        $this->setOptionalProperties($props, [
+        $this->setProperties($props, [
+            'code',
             'default',
             'direction',
             'locale',

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -104,6 +104,9 @@ abstract class Model
      */
     public function toArray(): array
     {
-        return $this->propertiesToArray();
+        return [
+            'kirby' => $this->kirby(),
+            'site'  => $this->site()
+        ];
     }
 }

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -185,7 +185,19 @@ class Page extends ModelWithContent
         $this->slug = $props['slug'] ?? null;
 
         // add all other properties
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'blueprint',
+            'dirname',
+            'isDraft',
+            'kirby',
+            'num',
+            'parent',
+            'root',
+            'site',
+            'slug',
+            'template',
+            'url'
+        ]);
     }
 
     /**

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -153,6 +153,11 @@ class Plugin extends Model
      */
     public function toArray(): array
     {
-        return $this->propertiesToArray();
+        return array_merge(parent::toArray(), [
+            'extends' => $this->extends(),
+            'info'    => $this->info(),
+            'name'    => $this->name(),
+            'root'    => $this->root()
+        ]);
     }
 }

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -26,7 +26,12 @@ class Role extends Model
 
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'description',
+            'name',
+            'permissions',
+            'title'
+        ]);
     }
 
     /**

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -124,7 +124,15 @@ class Site extends ModelWithContent
      */
     public function __construct(array $props = [])
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'blueprint',
+            'errorPageId',
+            'homePageId',
+            'kirby',
+            'page',
+            'site',
+            'url'
+        ]);
     }
 
     /**

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -25,7 +25,7 @@ class StructureObject extends Model
     /**
      * The content
      *
-     * @var Content
+     * @var \Kirby\Cms\Content
      */
     protected $content;
 
@@ -71,7 +71,14 @@ class StructureObject extends Model
      */
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'content',
+            'id',
+            'kirby',
+            'parent',
+            'site',
+            'structure'
+        ]);
     }
 
     /**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -126,7 +126,17 @@ class User extends ModelWithContent
     public function __construct(array $props)
     {
         $props['id'] = $props['id'] ?? $this->createId();
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'blueprint',
+            'email',
+            'id',
+            'kirby',
+            'language',
+            'name',
+            'password',
+            'role',
+            'site'
+        ]);
     }
 
     /**

--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -36,7 +36,7 @@ class Body
      */
     public function __construct(array $props = [])
     {
-        $this->setProperties($props);
+        $this->setProperties($props, ['html', 'text']);
     }
 
     /**

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -110,7 +110,20 @@ class Email
      */
     public function __construct(array $props = [], bool $debug = false)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'attachments',
+            'body',
+            'bcc',
+            'beforeSend',
+            'cc',
+            'from',
+            'fromName',
+            'replyTo',
+            'replyToName',
+            'subject',
+            'to',
+            'transport'
+        ]);
 
         // @codeCoverageIgnoreStart
         if (static::$debug === false && $debug === false) {
@@ -170,18 +183,6 @@ class Email
     public function cc(): array
     {
         return $this->cc;
-    }
-
-    /**
-     * Returns default transport settings
-     *
-     * @return array
-     */
-    protected function defaultTransport(): array
-    {
-        return [
-            'type' => 'mail'
-        ];
     }
 
     /**
@@ -436,7 +437,7 @@ class Email
      */
     protected function setTransport($transport = null)
     {
-        $this->transport = $transport;
+        $this->transport = $transport ?? ['type' => 'mail'];
         return $this;
     }
 
@@ -467,6 +468,6 @@ class Email
      */
     public function transport(): array
     {
-        return $this->transport ?? $this->defaultTransport();
+        return $this->transport;
     }
 }

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -62,7 +62,14 @@ class OptionsApi
      */
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'data',
+            'fetch',
+            'options',
+            'text',
+            'url',
+            'value'
+        ]);
     }
 
     /**

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -64,7 +64,14 @@ class OptionsQuery
      */
     public function __construct(array $props)
     {
-        $this->setProperties($props);
+        $this->setProperties($props, [
+            'aliases',
+            'data',
+            'options',
+            'query',
+            'text',
+            'value'
+        ]);
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -22,7 +22,7 @@ class Uri
     /**
      * Cache for the current Uri object
      *
-     * @var Uri|null
+     * @var \Kirby\Http\Uri|null
      */
     public static $current;
 
@@ -50,14 +50,14 @@ class Uri
     /**
      * The optional list of params
      *
-     * @var Params
+     * @var \Kirby\Http\Params
      */
     protected $params;
 
     /**
      * The optional path
      *
-     * @var Path
+     * @var \Kirby\Http\Path
      */
     protected $path;
 
@@ -78,7 +78,7 @@ class Uri
     /**
      * The optional query string without leading ?
      *
-     * @var Query
+     * @var \Kirby\Http\Query
      */
     protected $query;
 
@@ -150,7 +150,18 @@ class Uri
             $props['slash']  = $props['slash'] ?? $extract['slash'];
         }
 
-        $this->setProperties($this->props = $props);
+        $this->setProperties($this->props = $props, [
+            'fragment',
+            'host',
+            'params',
+            'password',
+            'path',
+            'port',
+            'query',
+            'scheme',
+            'slash',
+            'username'
+        ]);
     }
 
     /**

--- a/src/Toolkit/Properties.php
+++ b/src/Toolkit/Properties.php
@@ -13,6 +13,12 @@ namespace Kirby\Toolkit;
  */
 trait Properties
 {
+    /**
+     * Original or default values for properties
+     * before sett methods have been called
+     *
+     * @var array
+     */
     protected $propertyData = [];
 
     /**
@@ -37,20 +43,41 @@ trait Properties
     public function hardcopy()
     {
         $clone = $this->clone();
-        $clone->toArray();
+        foreach (array_keys($this->propertyData) as $prop) {
+            $this->{$prop}();
+        }
         return $clone;
     }
 
-    protected function setProperties(array $data, array $names)
+    /**
+     * Sets the data for all named properties
+     * by calling the dedicated prop setter method
+     *
+     * @param array $data
+     * @param array $props
+     * @return $this
+     */
+    protected function setProperties(array $data, array $props)
     {
-        foreach ($names as $name) {
-            $this->propertyData[$name] = $data[$name] ?? $this->$name ?? null;
+        // loop through all the prop names
+        // that have been passed to be se
+        foreach ($props as $prop) {
 
-            if (isset($data[$name]) === true) {
-                $this->{'set' . $name}($this->propertyData[$name]);
+            // store the data value for the property;
+            // if none has been passed, use the property
+            // default and `null` as fallbacks
+            $this->propertyData[$prop] = $data[$prop] ?? $this->$prop ?? null;
+
+            // call the setter method for the prop:
+            // if a data value for the prop has been passed,
+            // pass this value to the setter method
+            if (isset($data[$prop]) === true) {
+                $this->{'set' . $prop}($data[$prop]);
             } else {
-                $this->{'set' . $name}();
+                $this->{'set' . $prop}();
             }
         }
+
+        return $this;
     }
 }

--- a/src/Toolkit/Properties.php
+++ b/src/Toolkit/Properties.php
@@ -2,9 +2,6 @@
 
 namespace Kirby\Toolkit;
 
-use Exception;
-use ReflectionMethod;
-
 /**
  * Properties
  *
@@ -31,121 +28,29 @@ trait Properties
     }
 
     /**
-     * Creates a clone and fetches all
-     * lazy-loaded getters to get a full copy
+     * Creates a clone and fetches
+     * lazy-loaded getters to get a
+     * full copy
      *
      * @return static
      */
     public function hardcopy()
     {
         $clone = $this->clone();
-        $clone->propertiesToArray();
+        $clone->toArray();
         return $clone;
     }
 
-    protected function isRequiredProperty(string $name): bool
+    protected function setProperties(array $data, array $names)
     {
-        $method = new ReflectionMethod($this, 'set' . $name);
-        return $method->getNumberOfRequiredParameters() > 0;
-    }
+        foreach ($names as $name) {
+            $this->propertyData[$name] = $data[$name] ?? $this->$name ?? null;
 
-    protected function propertiesToArray()
-    {
-        $array = [];
-
-        foreach (get_object_vars($this) as $name => $default) {
-            if ($name === 'propertyData') {
-                continue;
-            }
-
-            if (method_exists($this, 'convert' . $name . 'ToArray') === true) {
-                $array[$name] = $this->{'convert' . $name . 'ToArray'}();
-                continue;
-            }
-
-            if (method_exists($this, $name) === true) {
-                $method = new ReflectionMethod($this, $name);
-
-                if ($method->isPublic() === true) {
-                    $value = $this->$name();
-
-                    if (is_object($value) === false) {
-                        $array[$name] = $value;
-                    }
-                }
-            }
-        }
-
-        ksort($array);
-
-        return $array;
-    }
-
-    protected function setOptionalProperties(array $props, array $optional)
-    {
-        $this->propertyData = array_merge($this->propertyData, $props);
-
-        foreach ($optional as $propertyName) {
-            if (isset($props[$propertyName]) === true) {
-                $this->{'set' . $propertyName}($props[$propertyName]);
+            if (isset($data[$name]) === true) {
+                $this->{'set' . $name}($this->propertyData[$name]);
             } else {
-                $this->{'set' . $propertyName}();
+                $this->{'set' . $name}();
             }
-        }
-    }
-
-    protected function setProperties($props, array $keys = null)
-    {
-        foreach (get_object_vars($this) as $name => $default) {
-            if ($name === 'propertyData') {
-                continue;
-            }
-
-            $this->setProperty($name, $props[$name] ?? $default);
-        }
-
-        return $this;
-    }
-
-    protected function setProperty($name, $value, $required = null)
-    {
-        // use a setter if it exists
-        if (method_exists($this, 'set' . $name) === false) {
-            return $this;
-        }
-
-        // fetch the default value from the property
-        $value = $value ?? $this->$name ?? null;
-
-        // store all original properties, to be able to clone them later
-        $this->propertyData[$name] = $value;
-
-        // handle empty values
-        if ($value === null) {
-
-            // replace null with a default value, if a default handler exists
-            if (method_exists($this, 'default' . $name) === true) {
-                $value = $this->{'default' . $name}();
-            }
-
-            // check for required properties
-            if ($value === null && ($required ?? $this->isRequiredProperty($name)) === true) {
-                throw new Exception(sprintf('The property "%s" is required', $name));
-            }
-        }
-
-        // call the setter with the final value
-        return $this->{'set' . $name}($value);
-    }
-
-    protected function setRequiredProperties(array $props, array $required)
-    {
-        foreach ($required as $propertyName) {
-            if (isset($props[$propertyName]) !== true) {
-                throw new Exception(sprintf('The property "%s" is required', $propertyName));
-            }
-
-            $this->{'set' . $propertyName}($props[$propertyName]);
         }
     }
 }

--- a/tests/Cms/Models/ModelTest.php
+++ b/tests/Cms/Models/ModelTest.php
@@ -8,8 +8,11 @@ class MyModel extends Model
 
     public function __construct(array $props = [])
     {
-        $this->setProperties($props);
-        $this->setKirby($props['kirby'] ?? null);
+        $this->setProperties($props, [
+            'id',
+            'kirby',
+            'site'
+        ]);
     }
 
     protected function setId($id = null)

--- a/tests/Data/fixtures/php/tmp.php
+++ b/tests/Data/fixtures/php/tmp.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'string' => 'String',
+    'stringWithDoubleQuotes' => '"String"',
+    'stringWithSingleQuotes' => '\'String\'',
+    'int' => 1,
+    'double' => 1, 1,
+    'true' => true,
+    'false' => false,
+    'indexed' => [
+        'a' => 'A'
+    ],
+    'unindexed' => [
+        'A',
+        'B',
+        'C'
+    ],
+    'nested' => [
+        'parent' => [
+            'child' => true
+        ]
+    ]
+];

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -51,8 +51,8 @@ class EmailTest extends TestCase
 
     public function testRequiredProperty()
     {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('The property "from" is required');
+        $this->expectException('TypeError');
+        $this->expectExceptionMessage('Too few arguments to function Kirby\Email\Email::setFrom(), 0 passed');
 
         $email = $this->_email([
             'from' => null


### PR DESCRIPTION
## Status: in progress 👷‍♂️
<!-- 
A clear and concise description of the bug the PR fixes or the feature the PR introduces. 
We may use this for the changelog and/or documentation. 
-->

Currently still failing unit tests left and right. But would be great to get some first other eyes on this, especially on the `Properties` class itself.

Current assumptions
- Properties-setting has to be manually triggered in the constructor via `->setProperties($props, ['propNameA', 'propNameB'])`
- It doesn't matter whether required or optional, we will let PHP TypeErrors resulting from the set methods parameter definition handle required props that don't get passed a value
- Every prop has also a corresponding `setPropA` method - must be present, we can rely on this
- If prop data gets passed, pass it to the set method. If null is passed as prop data, don't pass it to not run into PHP errors due to the parameter definition (e.g. `string $foo = 'bar'`)

## Breaking changes
<!-- 
If PR creates known breaking changes, please list them: 
-->
For performance reasons we made the following changes to the `Properties` class. These only affect you if you used `Properties` in a custom plugin class:

### Setting properties

- The `Properties::setProperties($data, $names)` method now requires passing an array with all property names as they are no longer autodetected.
- The `Properties::setProperties()` now expects a setter method `set*` for every passed property name.
- `default*()` methods are no longer supported. Integrate these into your custom setter methods instead.
- The error message when a required property is not set is now a PHP `ArgumentCountError`/`TypeError` based on the missing/incorrect arguments passed to the property setter.

### Getting properties

- The `Properties::propertiesToArray()` method was removed. If you relied on that in a `toArray()` method or similar, you now need to manually return the fields you need. Please note that `propertiesToArray()` also respected custom getter methods as well as `convert*ToArray()` methods, so both of these need to be integrated into your `toArray()` process.