### PR TITLE
New `Locale::get()` method

### DIFF
--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -16,6 +16,14 @@ use Kirby\Exception\InvalidArgumentException;
 class Locale
 {
     /**
+     * List of all locale constants supported by PHP
+     */
+    const LOCALE_CONSTANTS = [
+        LC_COLLATE, LC_CTYPE, LC_MONETARY,
+        LC_NUMERIC, LC_TIME, LC_MESSAGES
+    ];
+
+    /**
      * Converts a normalized locale array to an array with the
      * locale constants replaced with their string representations
      *
@@ -56,6 +64,50 @@ class Locale
     }
 
     /**
+     * Returns the current locale value for
+     * a specified or for all locale categories
+     *
+     * @param int|string $category Locale category constant or constant name
+     * @return array|string Associative array if `LC_ALL` was passed (default), otherwise string
+     */
+    public static function get($category = LC_ALL)
+    {
+        $normalizedCategory = static::normalizeConstant($category);
+
+        if (is_int($normalizedCategory) !== true) {
+            throw new InvalidArgumentException('Invalid locale category "' . $category . '"');
+        }
+
+        if ($normalizedCategory !== LC_ALL) {
+            // `setlocale(..., 0)` actually *gets* the locale
+            $locale = setlocale($normalizedCategory, 0);
+
+            if (is_string($locale) !== true) {
+                throw new InvalidArgumentException('Could not determine locale for category "' . $category . '"');
+            }
+
+            return $locale;
+        }
+
+        // no specific `$category` was passed, make a list of all locales
+        $array = [];
+        foreach (static::LOCALE_CONSTANTS as $constant) {
+            // `setlocale(..., 0)` actually *gets* the locale
+            $array[$constant] = setlocale($constant, '0');
+        }
+
+        // if all values are the same, we can use `LC_ALL`
+        // instead of a long array with all constants
+        if (count(array_unique($array)) === 1) {
+            return [
+                LC_ALL => array_shift($array)
+            ];
+        }
+
+        return $array;
+    }
+
+    /**
      * Converts a locale string or an array with constant or
      * string keys to a normalized constant => value array
      *
@@ -68,11 +120,7 @@ class Locale
             // replace string constant keys with the constant values
             $convertedLocale = [];
             foreach ($locale as $key => $value) {
-                if (is_string($key) === true && Str::startsWith($key, 'LC_') === true) {
-                    $key = constant($key);
-                }
-
-                $convertedLocale[$key] = $value;
+                $convertedLocale[static::normalizeConstant($key)] = $value;
             }
 
             return $convertedLocale;
@@ -97,5 +145,22 @@ class Locale
         foreach ($locale as $key => $value) {
             setlocale($key, $value);
         }
+    }
+
+    /**
+     * Tries to convert an `LC_*` constant name
+     * to its constant value
+     *
+     * @param int|string $constant
+     * @return int|string
+     */
+    protected static function normalizeConstant($constant)
+    {
+        if (is_string($constant) === true && Str::startsWith($constant, 'LC_') === true) {
+            return constant($constant);
+        }
+
+        // already an int or we cannot convert it safely
+        return $constant;
     }
 }

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 
 /**
@@ -56,6 +57,9 @@ class Locale
      *
      * @param int|string $category Locale category constant or constant name
      * @return array|string Associative array if `LC_ALL` was passed (default), otherwise string
+     *
+     * @throws \Kirby\Exception\Exception If the locale cannot be determined
+     * @throws \Kirby\Exception\InvalidArgumentException If the provided locale category is invalid
      */
     public static function get($category = LC_ALL)
     {
@@ -70,7 +74,7 @@ class Locale
             $locale = setlocale($normalizedCategory, 0);
 
             if (is_string($locale) !== true) {
-                throw new InvalidArgumentException('Could not determine locale for category "' . $category . '"');
+                throw new Exception('Could not determine locale for category "' . $category . '"');
             }
 
             return $locale;

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -19,8 +19,8 @@ class Locale
      * List of all locale constants supported by PHP
      */
     const LOCALE_CONSTANTS = [
-        LC_COLLATE, LC_CTYPE, LC_MONETARY,
-        LC_NUMERIC, LC_TIME, LC_MESSAGES
+        'LC_COLLATE', 'LC_CTYPE', 'LC_MONETARY',
+        'LC_NUMERIC', 'LC_TIME', 'LC_MESSAGES'
     ];
 
     /**
@@ -32,20 +32,7 @@ class Locale
      */
     public static function export(array $locale): array
     {
-        // list of all possible constant names
-        $constantNames = [
-            'LC_ALL', 'LC_COLLATE', 'LC_CTYPE', 'LC_MONETARY',
-            'LC_NUMERIC', 'LC_TIME', 'LC_MESSAGES'
-        ];
-
-        // build an associative array with the locales
-        // that are actually supported on this system
-        $constants = [];
-        foreach ($constantNames as $name) {
-            if (defined($name) === true) {
-                $constants[constant($name)] = $name;
-            }
-        }
+        $constants = static::supportedConstants(true);
 
         // replace the keys in the locale data array with the locale names
         $return = [];
@@ -91,7 +78,7 @@ class Locale
 
         // no specific `$category` was passed, make a list of all locales
         $array = [];
-        foreach (static::LOCALE_CONSTANTS as $constant) {
+        foreach (static::supportedConstants() as $constant => $name) {
             // `setlocale(..., 0)` actually *gets* the locale
             $array[$constant] = setlocale($constant, '0');
         }
@@ -162,5 +149,29 @@ class Locale
 
         // already an int or we cannot convert it safely
         return $constant;
+    }
+
+    /**
+     * Builds an associative array with the locales
+     * that are actually supported on this system
+     *
+     * @param bool $withAll If set to `true`, `LC_ALL` is returned as well
+     * @return array
+     */
+    protected static function supportedConstants(bool $withAll = false): array
+    {
+        $names = static::LOCALE_CONSTANTS;
+        if ($withAll === true) {
+            array_unshift($names, 'LC_ALL');
+        }
+
+        $constants = [];
+        foreach ($names as $name) {
+            if (defined($name) === true) {
+                $constants[constant($name)] = $name;
+            }
+        }
+
+        return $constants;
     }
 }

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -72,7 +72,62 @@ class LocaleTest extends TestCase
     }
 
     /**
+     * @covers ::get
+     * @covers ::normalizeConstant
+     */
+    public function testGet()
+    {
+        // default case (all locales are set to the same value)
+        $this->assertSame([LC_ALL => 'C'], Locale::get());
+        $this->assertSame([LC_ALL => 'C'], Locale::get(LC_ALL));
+        $this->assertSame([LC_ALL => 'C'], Locale::get('LC_ALL'));
+        $this->assertSame('C', Locale::get(LC_NUMERIC));
+        $this->assertSame('C', Locale::get('LC_NUMERIC'));
+
+        // different locale values
+        Locale::set([LC_NUMERIC => 'de_DE.' . $this->localeSuffix]);
+        $this->assertSame($expected = [
+            LC_COLLATE  => 'C',
+            LC_CTYPE    => 'C',
+            LC_MONETARY => 'C',
+            LC_NUMERIC  => 'de_DE.' . $this->localeSuffix,
+            LC_TIME     => 'C',
+            LC_MESSAGES => 'C'
+        ], Locale::get());
+        $this->assertSame($expected, Locale::get(LC_ALL));
+        $this->assertSame($expected, Locale::get('LC_ALL'));
+        $this->assertSame('de_DE.' . $this->localeSuffix, Locale::get(LC_NUMERIC));
+        $this->assertSame('C', Locale::get(LC_CTYPE));
+        $this->assertSame('C', Locale::get('LC_CTYPE'));
+    }
+
+    /**
+     * @covers ::get
+     * @covers ::normalizeConstant
+     */
+    public function testGetInvalid1()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid locale category "KIRBY_AWESOME_LOCALE"');
+
+        Locale::get('KIRBY_AWESOME_LOCALE');
+    }
+
+    /**
+     * @covers ::get
+     * @covers ::normalizeConstant
+     */
+    public function testGetInvalid2()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Could not determine locale for category "987654321"');
+
+        Locale::get(987654321);
+    }
+
+    /**
      * @covers ::normalize
+     * @covers ::normalizeConstant
      */
     public function testNormalize()
     {

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -115,7 +115,7 @@ class LocaleTest extends TestCase
      */
     public function testGetInvalid2()
     {
-        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectException('Kirby\Exception\Exception');
         $this->expectExceptionMessage('Could not determine locale for category "987654321"');
 
         Locale::get(987654321);

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -9,20 +9,13 @@ use PHPUnit\Framework\TestCase;
  */
 class LocaleTest extends TestCase
 {
-    protected $locale = [];
+    protected $locales = [];
     protected $localeSuffix;
 
     public function setUp(): void
     {
-        $constants = [
-            LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY,
-            LC_NUMERIC, LC_TIME, LC_MESSAGES
-        ];
-
-        // make a backup of the current locale
-        foreach ($constants as $constant) {
-            $this->locale[$constant] = setlocale($constant, '0');
-        }
+        // make a backup of the current locales
+        $this->locales = Locale::get();
 
         // test which locale suffix the system supports
         setlocale(LC_ALL, 'de_DE.' . $this->localeSuffix);
@@ -38,8 +31,7 @@ class LocaleTest extends TestCase
 
     public function tearDown(): void
     {
-        Locale::set($this->locale);
-        $this->locale = [];
+        Locale::set($this->locales);
     }
 
     /**

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -36,6 +36,7 @@ class LocaleTest extends TestCase
 
     /**
      * @covers ::export
+     * @covers ::supportedConstants
      */
     public function testExport()
     {
@@ -66,6 +67,7 @@ class LocaleTest extends TestCase
     /**
      * @covers ::get
      * @covers ::normalizeConstant
+     * @covers ::supportedConstants
      */
     public function testGet()
     {
@@ -96,6 +98,7 @@ class LocaleTest extends TestCase
     /**
      * @covers ::get
      * @covers ::normalizeConstant
+     * @covers ::supportedConstants
      */
     public function testGetInvalid1()
     {
@@ -108,6 +111,7 @@ class LocaleTest extends TestCase
     /**
      * @covers ::get
      * @covers ::normalizeConstant
+     * @covers ::supportedConstants
      */
     public function testGetInvalid2()
     {


### PR DESCRIPTION
## Describe the PR
<!-- 
A clear and concise description of the bug the PR fixes or the feature the PR introduces. 
We may use this for the changelog and/or documentation. 
-->

New `Locale::get()` method that can be used to get the currently configured PHP locale(s).

## Breaking changes
<!-- 
If PR creates known breaking changes, please list them: 
-->

None

## Related issues/ideas
<!-- 
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`: 
-->

- Fixes failing test in #2815

## Ready?
<!-- 
If you feel like you can help to check off the following tasks, 
that'd be great. If not, don't worry - we will take care of it. 
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!-- 
CI runs automatically when the PR is created or run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR -->

- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] Add changes to release notes draft in Notion
