### PR TITLE
Clean up Html::video() changes #3074

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -423,18 +423,17 @@ class Html extends Xml
      */
     public static function video(string $url, array $options = [], array $attr = []): ?string
     {
-
         // YouTube video
-        if (preg_match('!youtu!i', $url) === 1) {
+        if (Str::contains($url, 'youtu', true) === true) {
             return static::youtube($url, $options['youtube'] ?? [], $attr);
         }
 
         // Vimeo video
-        if (preg_match('!vimeo!i', $url) === 1) {
+        if (Str::contains($url, 'vimeo', true) === true) {
             return static::vimeo($url, $options['vimeo'] ?? [], $attr);
         }
 
-        // Self-hosted video file
+        // self-hosted video file
         $extension = F::extension($url);
         $type      = F::extensionToType($extension);
         $mime      = F::extensionToMime($extension);

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -497,6 +497,9 @@ class HtmlTest extends TestCase
         $this->assertSame($expected, $html);
     }
 
+    /**
+     * @covers ::video
+     */
     public function testVideoFile()
     {
         $html = Html::video('https://getkirby.com/myvideo.mp4');
@@ -665,12 +668,18 @@ class HtmlTest extends TestCase
         ];
     }
 
-    public function testInvalidVimeoUrl()
+    /**
+     * @covers ::vimeo
+     */
+    public function testVimeoInvalidUrl()
     {
         $this->assertNull(Html::vimeo('https://getkirby.com'));
     }
 
-    public function testInvalidYoutubeUrl()
+    /**
+     * @covers ::youtube
+     */
+    public function testYoutubeInvalidUrl()
     {
         $this->assertNull(Html::youtube('https://getkirby.com'));
     }


### PR DESCRIPTION
## Describe the PR
<!-- 
A clear and concise description of the bug the PR fixes or the feature the PR introduces. 
We may use this for the changelog and/or documentation. 
-->

The new video implementation is really awesome! Especially how simple it has become and that it's the same in the backend and frontend. 😍

I mainly made two fixes to the tests that I find really important in general @bastianallgeier:

- All new tests should have `@covers` marks and especially existing marks shouldn't be removed. The more tests we clean up this way, the easier it will become to find really untested code in the end.
- I think we should stay with the pattern that all test methods are named like `test<Method><Suffix>` (so the method name should always be first and written exactly like in the tested class). The reason for this is that this will allow us to sort the methods by name using PHP-CS-Fixer once all test classes are cleaned up that way. Many test classes do not use this pattern at the moment, but I think we should at least start using it in the test classes that are already refactored (like `Html`). These classes can be detected by their general use of `@covers`.

## Breaking changes
<!-- 
If PR creates known breaking changes, please list them: 
-->

None

## Ready?
<!-- 
If you feel like you can help to check off the following tasks, 
that'd be great. If not, don't worry - we will take care of it. 
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!-- 
CI runs automatically when the PR is created or run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR -->

**Not** needed in the changelog (refactoring before the release)