### PR TITLE
Adds some missing `@since` tags

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -82,7 +82,7 @@ class Auth
     /**
      * Creates an authentication challenge
      * (one-time auth code)
-     * @since 3.5.1
+     * @since 3.5.0
      *
      * @param string $email
      * @param bool $long If `true`, a long session will be created
@@ -285,6 +285,7 @@ class Auth
     /**
      * Returns the list of enabled challenges in the
      * configured order
+     * @since 3.5.1
      *
      * @return array
      */
@@ -407,6 +408,7 @@ class Auth
 
     /**
      * Login a user by email, password and auth challenge
+     * @since 3.5.0
      *
      * @param string $email
      * @param string $password
@@ -443,6 +445,7 @@ class Auth
 
     /**
      * Returns the authentication status object
+     * @since 3.5.1
      *
      * @param \Kirby\Session\Session|array|null $session
      * @param bool $allowImpersonation If set to false, only the actually
@@ -761,6 +764,7 @@ class Auth
      * Verifies an authentication code that was
      * requested with the `createChallenge()` method;
      * if successful, the user is automatically logged in
+     * @since 3.5.0
      *
      * @param string $code User-provided auth code to verify
      * @return \Kirby\Cms\User User object of the logged-in user

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -82,6 +82,7 @@ class Auth
     /**
      * Creates an authentication challenge
      * (one-time auth code)
+     * @since 3.5.1
      *
      * @param string $email
      * @param bool $long If `true`, a long session will be created
@@ -822,7 +823,7 @@ class Auth
                     throw new PermissionException(['key' => 'access.code']);
                 }
             }
-            
+
             throw new LogicException('Invalid authentication challenge: ' . $challenge);
         } catch (Throwable $e) {
             if ($e->getMessage() !== 'Rate limit exceeded') {

--- a/src/Cms/Auth/Status.php
+++ b/src/Cms/Auth/Status.php
@@ -9,6 +9,7 @@ use Kirby\Toolkit\Properties;
 /**
  * Information container for the
  * authentication status
+ * @since 3.5.1
  *
  * @package   Kirby Cms
  * @author    Lukas Bestle <lukas@getkirby.com>

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -10,6 +10,7 @@ use Throwable;
  * Represents a single block
  * which can be inspected further or
  * converted to HTML
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/BlockConverter.php
+++ b/src/Cms/BlockConverter.php
@@ -2,6 +2,17 @@
 
 namespace Kirby\Cms;
 
+/**
+ * Converts the data from the old builder and editor fields
+ * to the format supported by the new block field.
+ * @since 3.5.0
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
 class BlockConverter
 {
     public static function builderBlock(array $params): array

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -13,6 +13,7 @@ use Throwable;
 
 /**
  * A collection of blocks
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Event.php
+++ b/src/Cms/Event.php
@@ -10,6 +10,7 @@ use Kirby\Toolkit\Controller;
  * The Event object is created whenever the `$kirby->trigger()`
  * or `$kirby->apply()` methods are called. It collects all
  * event information and handles calling the individual hooks.
+ * @since 3.4.0
  *
  * @package   Kirby Cms
  * @author    Lukas Bestle <lukas@getkirby.com>,

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -9,6 +9,7 @@ use Kirby\Toolkit\Str;
 
 /**
  * Represents a single Fieldset
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -8,6 +8,7 @@ use Kirby\Toolkit\Str;
 
 /**
  * A collection of fieldsets
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -10,6 +10,7 @@ namespace Kirby\Cms;
  * - a Block in a collection of Blocks
  * - a Layout in a collection of Layouts
  * - a Column in a collection of Columns
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -7,6 +7,7 @@ use Exception;
 
 /**
  * A collection of items
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -77,6 +77,7 @@ class Layout extends Item
 
     /**
      * Checks if the layout is empty
+     * @since 3.5.2
      *
      * @return bool
      */
@@ -92,6 +93,7 @@ class Layout extends Item
 
     /**
      * Checks if the layout is not empty
+     * @since 3.5.2
      *
      * @return bool
      */

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 /**
  * Represents a single Layout with
  * multiple columns
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -56,6 +56,7 @@ class LayoutColumn extends Item
 
     /**
      * Checks if the column is empty
+     * @since 3.5.2
      *
      * @return bool
      */
@@ -69,6 +70,7 @@ class LayoutColumn extends Item
 
     /**
      * Checks if the column is not empty
+     * @since 3.5.2
      *
      * @return bool
      */

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -7,6 +7,7 @@ use Kirby\Toolkit\Str;
 /**
  * Represents a single layout column with
  * multiple blocks
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 /**
  * A collection of layout columns
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 /**
  * A collection of layouts
+ * @since 3.5.0
  *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -91,6 +91,7 @@ class Responder
      * Setter and getter for the flag that defines
      * whether the current response can be cached
      * by Kirby's cache
+     * @since 3.5.5
      *
      * @param bool|null $cache
      * @return bool|$this
@@ -108,6 +109,7 @@ class Responder
     /**
      * Setter and getter for the cache expiry
      * timestamp for Kirby's cache
+     * @since 3.5.5
      *
      * @param int|string|null $expires Timestamp, number of minutes or time string to parse
      * @param bool $override If `true`, the already defined timestamp will be overridden

--- a/src/Sane/Handler.php
+++ b/src/Sane/Handler.php
@@ -9,6 +9,7 @@ use Kirby\Toolkit\F;
  * Base handler abstract,
  * which needs to be extended to
  * create valid sane handlers
+ * @since 3.5.4
  *
  * @package   Kirby Sane
  * @author    Lukas Bestle <lukas@getkirby.com>

--- a/src/Sane/Sane.php
+++ b/src/Sane/Sane.php
@@ -10,6 +10,7 @@ use Kirby\Toolkit\F;
  * don't contain potentially harmful contents.
  * The class comes with handlers for `svg`, `svgz` and `xml`
  * files for now, but can be extended and customized.
+ * @since 3.5.4
  *
  * @package   Kirby Sane
  * @author    Lukas Bestle <lukas@getkirby.com>

--- a/src/Sane/Svg.php
+++ b/src/Sane/Svg.php
@@ -11,6 +11,7 @@ use Kirby\Toolkit\Str;
 
 /**
  * Sane handler for SVG files
+ * @since 3.5.4
  *
  * @package   Kirby Sane
  * @author    Bastian Allgeier <bastian@getkirby.com>,

--- a/src/Sane/Svgz.php
+++ b/src/Sane/Svgz.php
@@ -6,6 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 /**
  * Sane handler for gzip-compressed SVGZ files
+ * @since 3.5.4
  *
  * @package   Kirby Sane
  * @author    Lukas Bestle <lukas@getkirby.com>

--- a/src/Sane/Xml.php
+++ b/src/Sane/Xml.php
@@ -12,6 +12,7 @@ use Kirby\Toolkit\Str;
 
 /**
  * Sane handler for XML files
+ * @since 3.5.4
  *
  * @package   Kirby Sane
  * @author    Bastian Allgeier <bastian@getkirby.com>,

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -35,6 +35,7 @@ class A
      * Recursively loops through the array and
      * resolves any item defined as `Closure`,
      * applying the passed parameters
+     * @since 3.6.0
      *
      * @param array $array
      * @param mixed ...$args Parameters to pass to the closures

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 /**
  * PHP locale handling
+ * @since 3.5.0
  *
  * @package   Kirby Toolkit
  * @author    Lukas Bestle <lukas@getkirby.com>
@@ -54,7 +55,6 @@ class Locale
     /**
      * Returns the current locale value for
      * a specified or for all locale categories
-     *
      * @since 3.6.0
      *
      * @param int|string $category Locale category constant or constant name

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -55,6 +55,8 @@ class Locale
      * Returns the current locale value for
      * a specified or for all locale categories
      *
+     * @since 3.6.0
+     *
      * @param int|string $category Locale category constant or constant name
      * @return array|string Associative array if `LC_ALL` was passed (default), otherwise string
      *

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -805,6 +805,7 @@ class Str
 
     /**
      * Calculates the similarity between two strings with multibyte support
+     * @since 3.5.2
      *
      * @author Based on the work of Antal Áron
      * @copyright Original Copyright (c) 2017, Antal Áron


### PR DESCRIPTION
## Describe the PR

Adds missing `@since` tags in doc-blocks for next (3.6.0) and some previous releases.

## Release notes

### Enhancements

- Added some missing `@since` tags in doc-blocks

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
