### PR TITLE
Fix infinite loop: FileVersion asset methods #3347

### DIFF
--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -103,6 +103,17 @@ trait IsFile
     }
 
     /**
+     * Checks if the file exists on disk
+     *
+     * @return bool
+     */
+    public function exists(): bool
+    {
+        return file_exists($this->root()) === true;
+    }
+
+
+    /**
      * Returns the app instance
      *
      * @return \Kirby\Cms\App

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -91,7 +91,7 @@ class FileRulesTest extends TestCase
     {
         $file = $this->createMock(File::class);
         $file->method('filename')->willReturn('test.jpg');
-        $file->method('__call')->with('exists')->willReturn(true);
+        $file->method('exists')->willReturn(true);
 
         $this->expectException('Kirby\Exception\DuplicateException');
         $this->expectExceptionMessage('The file exists and cannot be overwritten');

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -15,6 +15,11 @@ class FileVersionTest extends TestCase
         ]);
     }
 
+    public function tearDown(): void
+    {
+        Dir::remove(__DIR__ . '/tmp');
+    }
+
     public function testConstruct()
     {
         $original = new File([
@@ -38,6 +43,36 @@ class FileVersionTest extends TestCase
         $this->assertSame($mods, $version->modifications());
         $this->assertSame($original, $version->original());
         $this->assertSame($original->kirby(), $version->kirby());
+    }
+
+    public function testExists()
+    {
+        $page = new Page([
+            'root' => __DIR__ . '/fixtures/files',
+            'slug' => 'files'
+        ]);
+
+        $original = new File([
+            'filename' => 'test.jpg',
+            'parent'   => $page
+        ]);
+
+        $version = new FileVersion([
+            'original' => $original,
+            'root'     => __DIR__ . '/tmp/test-version.jpg',
+            'modifications' => [
+                'width' => 50,
+            ]
+        ]);
+
+        $this->assertFalse($version->exists());
+
+        // calling an asset method will trigger
+        // `FileVersion::save()` if it doesn't
+        // exist yet
+        $this->assertSame(50, $version->width());
+
+        $this->assertTrue($version->exists());
     }
 
     public function testToArray()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Fixes regression introduced by the `Filesystem` PR. Infinite loop would appear e.g. after uploading an avatar. This line https://github.com/getkirby/kirby/blob/2970a28/src/Cms/FileVersion.php#L40 would cause the invite loop to `FileVersion::__call()`. Adding `IsFile::exists()` will prevent this.


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/kirby/issues/3347

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] ~~Add changes to release notes draft in Notion~~
