### PR TITLE
Remove deprecated code

### DIFF
--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -38,12 +38,16 @@ return [
             'pages/(:any)/blueprints',
             /**
              * @deprecated
-             * @todo remove in 3.6.0
+             * @todo remove in 3.7.0
              */
             'pages/(:any)/children/blueprints',
         ],
         'method'  => 'GET',
         'action'  => function (string $id) {
+            if ($this->pattern() === 'pages/(:any)/children/blueprints') {
+                deprecated('`GET pages/(:any)/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET pages/(:any)/blueprints` instead');
+            }
+
             return $this->page($id)->blueprints($this->requestQuery('section'));
         }
     ],

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -45,7 +45,7 @@ return [
         'method'  => 'GET',
         'action'  => function (string $id) {
             // @codeCoverageIgnoreStart
-            if ($this->pattern() === 'pages/(:any)/children/blueprints') {
+            if ($this->route->pattern() === 'pages/(:any)/children/blueprints') {
                 deprecated('`GET pages/(:any)/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET pages/(:any)/blueprints` instead');
             }
             // @codeCoverageIgnoreEnd

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -44,10 +44,11 @@ return [
         ],
         'method'  => 'GET',
         'action'  => function (string $id) {
+            // @codeCoverageIgnoreStart
             if ($this->pattern() === 'pages/(:any)/children/blueprints') {
                 deprecated('`GET pages/(:any)/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET pages/(:any)/blueprints` instead');
             }
-
+            // @codeCoverageIgnoreEnd
             return $this->page($id)->blueprints($this->requestQuery('section'));
         }
     ],

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -58,7 +58,7 @@ return [
         'method'  => 'GET',
         'action'  => function () {
             // @codeCoverageIgnoreStart
-            if ($this->pattern() === 'site/children/blueprints') {
+            if ($this->route->pattern() === 'site/children/blueprints') {
                 deprecated('`GET site/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET site/blueprints` instead.');
             }
             // @codeCoverageIgnoreEnd

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -57,6 +57,10 @@ return [
         ],
         'method'  => 'GET',
         'action'  => function () {
+            if ($this->pattern() === 'site/children/blueprints') {
+                deprecated('`GET site/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET site/blueprints');
+            }
+
             return $this->site()->blueprints($this->requestQuery('section'));
         }
     ],

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -51,16 +51,17 @@ return [
             'site/blueprints',
             /**
              * @deprecated
-             * @todo remove in 3.6.0
+             * @todo remove in 3.7.0
              */
             'site/children/blueprints',
         ],
         'method'  => 'GET',
         'action'  => function () {
+            // @codeCoverageIgnoreStart
             if ($this->pattern() === 'site/children/blueprints') {
-                deprecated('`GET site/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET site/blueprints');
+                deprecated('`GET site/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET site/blueprints` instead.');
             }
-
+            // @codeCoverageIgnoreEnd
             return $this->site()->blueprints($this->requestQuery('section'));
         }
     ],

--- a/panel/src/api/index.js
+++ b/panel/src/api/index.js
@@ -48,7 +48,7 @@ export default (extensions = {}) => {
   api.users = users(api);
 
   /**
-   * @deprecated
+   * @deprecated 3.5.0
    * @todo remove in 3.7.0
    */
   api.files.rename = api.files.changeName;

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -159,12 +159,13 @@ trait AppTranslations
      * Set locale settings
      *
      * @deprecated 3.5.0 Use `\Kirby\Toolkit\Locale::set()` instead
-     * @todo Remove in 3.6.0
+     * @todo Remove in 3.7.0
      *
      * @param string|array $locale
      */
     public function setLocale($locale): void
     {
+        deprecated('`Kirby\Cms\App::setLocale()` has been deprecated and will be removed in 3.7.0. Use `Kirby\Toolkit\Locale::set()` instead');
         Locale::set($locale);
     }
 

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -165,8 +165,10 @@ trait AppTranslations
      */
     public function setLocale($locale): void
     {
+        // @codeCoverageIgnoreStart
         deprecated('`Kirby\Cms\App::setLocale()` has been deprecated and will be removed in 3.7.0. Use `Kirby\Toolkit\Locale::set()` instead');
         Locale::set($locale);
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -89,13 +89,13 @@ class Block extends Item
      * Deprecated method to return the block type
      *
      * @deprecated 3.5.0 Use `\Kirby\Cms\Block::type()` instead
-     * @todo Add deprecated() helper warning in 3.6.0
      * @todo Remove in 3.7.0
      *
      * @return string
      */
     public function _key(): string
     {
+        deprecated('Block::_key() has been deprecated. Use Block::type() instead.');
         return $this->type();
     }
 
@@ -103,13 +103,13 @@ class Block extends Item
      * Deprecated method to return the block id
      *
      * @deprecated 3.5.0 Use `\Kirby\Cms\Block::id()` instead
-     * @todo Add deprecated() helper warning in 3.6.0
      * @todo Remove in 3.7.0
      *
      * @return string
      */
     public function _uid(): string
     {
+        deprecated('Block::_uid() has been deprecated. Use Block::id() instead.');
         return $this->id();
     }
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -531,12 +531,12 @@ trait PageActions
                 return 0;
             case 'date':
             case 'datetime':
+                // the $format needs to produce only digits,
+                // so it can be converted to integer below
                 $format = $mode === 'date' ? 'Ymd' : 'YmdHi';
                 $lang   = $this->kirby()->defaultLanguage() ?? null;
                 $field  = $this->content($lang)->get('date');
                 $date   = $field->isEmpty() ? 'now' : $field;
-                // TODO: in 3.6.0 throw an error if date() doesn't
-                // return a number, see https://github.com/getkirby/kirby/pull/3061#discussion_r552783943
                 return (int)date($format, strtotime($date));
                 break;
             case 'default':
@@ -786,20 +786,6 @@ trait PageActions
         }
 
         return true;
-    }
-
-    /**
-     * @deprecated 3.5.0 Use `Page::changeSort()` instead
-     * @todo Remove in 3.6.0
-     *
-     * @param null $position
-     * @return $this|static
-     */
-    public function sort($position = null)
-    {
-        deprecated('$page->sort() is deprecated, use $page->changeSort() instead. $page->sort() will be removed in Kirby 3.6.0.');
-
-        return $this->changeStatus('listed', $position);
     }
 
     /**

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -92,7 +92,8 @@ abstract class FieldClass
     }
 
     /**
-     * @deprecated
+     * @deprecated 3.5.0
+     * @todo remove when the general field class setup has been refactored
      *
      * Returns the field data
      * in a format to be stored
@@ -379,8 +380,8 @@ abstract class FieldClass
     }
 
     /**
-     * @deprecated
-     *
+     * @deprecated 3.5.0
+     * @todo remove when the general field class setup has been refactored
      * @return bool
      */
     public function save()

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -56,14 +56,16 @@ class I18n
      * Returns the first fallback locale
      *
      * @deprecated 3.5.1 Use `\Kirby\Toolkit\I18n::fallbacks()` instead
-     * @todo Add deprecated() helper warning in 3.6.0
      * @todo Remove in 3.7.0
      *
      * @return string
      */
     public static function fallback(): string
     {
+        // @codeCoverageIgnoreStart
+        deprecated('I18n::fallback() has been deprecated. Use I18n::fallbacks() instead.');
         return static::fallbacks()[0];
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -549,7 +549,7 @@ class PageSortTest extends TestCase
         ]);
 
         $page = $site->find($id);
-        $page = $page->sort($position);
+        $page = $page->changeSort($position);
 
         $this->assertEquals($expected, implode(',', $site->children()->keys()));
     }
@@ -595,7 +595,7 @@ class PageSortTest extends TestCase
         ]);
 
         $page = $site->find('b');
-        $page = $page->sort(3);
+        $page = $page->changeSort(3);
 
         $this->assertEquals(1, $site->find('a')->num());
         $this->assertEquals(2, $site->find('d')->num());
@@ -621,7 +621,7 @@ class PageSortTest extends TestCase
         $this->assertEquals($chars, $this->site()->children()->keys());
 
         foreach ($this->site()->children()->flip()->values() as $index => $page) {
-            $page = $page->sort($index + 1);
+            $page = $page->changeSort($index + 1);
         }
 
         $this->assertEquals(array_reverse($chars), $this->site()->children()->keys());


### PR DESCRIPTION
## Breaking changes

- Deprecated `Kirby\Cms\Page::sort()` has been removed. Use `Kirby\Cms\Page::changeSort()` instead.

## Deprecations

- Deprecated API endpoint `pages/(:any)/children/blueprints` is now throwing deprecation warnings. Will be removed in 3.7.0. Use `pages/(:any)/blueprints` instead.
- Deprecated API endpoint `site/children/blueprints`  is now throwing deprecation warnings. Will be removed in 3.7.0. Use `site/blueprints` instead.
- Deprecated `Kirby\Cms\App::setLocale()`  is now throwing deprecation warnings. Will be removed in 3.7.0. Use `Kirby\Toolkit\Locale::set()` instead.
- Deprecated `Kirby\Cms\Block::_key()` is now throwing deprecation warnings. Will be removed in 3.7.0. Use `Kirby\Cms\Block::type()` instead.
- Deprecated `Kirby\Cms\Block::_uid()` is now throwing deprecation warnings. Will be removed in 3.7.0. Use `Kirby\Cms\Block::id()` instead.
- Deprecated `Kirby\Toolkit\I18n::fallback()` is now throwing deprecation warnings. Will be removed in 3.7.0. Use `Kirby\Toolkit\I18n::fallbacks()[0]` instead.