### PR TITLE
Add `isFile::type()` to fix infinite loop #3353

### DIFF
--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -105,7 +105,7 @@ trait IsFile
             'url'  => $this->url()
         ];
 
-        if (F::type($this->root() ?? $this->url()) === 'image') {
+        if ($this->type() === 'image') {
             return $this->asset = new Image($props);
         }
 
@@ -119,6 +119,9 @@ trait IsFile
      */
     public function exists(): bool
     {
+        // Important to include this in the trait
+        // to avoid infinite loops when trying
+        // to proxy the method from the asset object
         return file_exists($this->root()) === true;
     }
 
@@ -165,6 +168,19 @@ trait IsFile
     {
         $this->url = $url;
         return $this;
+    }
+
+    /**
+     * Returns the file type
+     *
+     * @return string|null
+     */
+    public function type(): ?string
+    {
+        // Important to include this in the trait
+        // to avoid infinite loops when trying
+        // to proxy the method from the asset object
+        return F::type($this->root() ?? $this->url());
     }
 
     /**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -128,12 +128,9 @@ abstract class Model
             // only create srcsets for actual File objects
             if (is_a($image, 'Kirby\Cms\File') === true) {
 
-                // pixelated transparent image placeholder
-                $placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
-
                 // for cards
                 $settings['cards'] = [
-                    'url' => $placeholder,
+                    'url' => static::imagePlaceholder(),
                     'srcset' => $image->srcset([
                         352,
                         864,
@@ -144,7 +141,7 @@ abstract class Model
                 // for lists
                 if (($settings['cover'] ?? false) === false) {
                     $settings['list'] = [
-                        'url' => $placeholder,
+                        'url' => static::imagePlaceholder(),
                         'srcset' => $image->srcset([
                             38,
                             76
@@ -152,7 +149,7 @@ abstract class Model
                     ];
                 } else {
                     $settings['list'] = [
-                        'url' => $placeholder,
+                        'url' => static::imagePlaceholder(),
                         'srcset' => $image->srcset([
                             '1x' => [
                                 'width' => 38,
@@ -173,6 +170,16 @@ abstract class Model
         }
 
         return array_merge($defaults, (array)$settings);
+    }
+
+    /**
+     * Data URI placeholder string for Panel image
+     *
+     * @return string
+     */
+    public static function imagePlaceholder(): string
+    {
+        return 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
     }
 
     /**

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Panel\Model;
 use PHPUnit\Framework\TestCase;
 
 class PagesSectionTest extends TestCase
@@ -359,7 +360,7 @@ class PagesSectionTest extends TestCase
         $data = $section->data();
 
         // existing covers
-        $this->assertStringContainsString('data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw', $data[0]['image']['cards']['url']);
+        $this->assertStringContainsString(Model::imagePlaceholder(), $data[0]['image']['cards']['url']);
 
         // non-existing covers
         $this->assertNull($data[2]['image']['cards']['url'] ?? null);

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -265,7 +265,6 @@ class FileTest extends TestCase
         $panel = new File($file);
 
         $hash = $file->mediaHash();
-        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -274,11 +273,11 @@ class FileTest extends TestCase
             'cover' => false,
             'url' => '/media/site/' . $hash . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => '/media/site/' . $hash . '/test-38x.jpg 38w, /media/site/' . $hash . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -290,11 +289,11 @@ class FileTest extends TestCase
             'cover' => true,
             'url' => '/media/site/' . $hash . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => '/media/site/' . $hash . '/test-352x.jpg 352w, /media/site/' . $hash . '/test-864x.jpg 864w, /media/site/' . $hash . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => '/media/site/' . $hash . '/test-38x38.jpg 1x, /media/site/' . $hash . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -311,7 +311,6 @@ class PageTest extends TestCase
 
         $hash = $page->image()->mediaHash();
         $mediaUrl = $page->mediaUrl() . '/' . $hash;
-        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -320,11 +319,11 @@ class PageTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -336,11 +335,11 @@ class PageTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -88,7 +88,6 @@ class SiteTest extends TestCase
 
         $hash = $site->image()->mediaHash();
         $mediaUrl = $site->mediaUrl() . '/' . $hash;
-        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -97,11 +96,11 @@ class SiteTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -113,11 +112,11 @@ class SiteTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -107,7 +107,6 @@ class UserTest extends TestCase
 
         $hash = $user->image()->mediaHash();
         $mediaUrl = $user->mediaUrl() . '/' . $hash;
-        $imagePlaceholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw';
 
         // cover disabled as default
         $this->assertSame([
@@ -116,11 +115,11 @@ class UserTest extends TestCase
             'cover' => false,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
             ]
         ], $panel->image());
@@ -132,11 +131,11 @@ class UserTest extends TestCase
             'cover' => true,
             'url' => $mediaUrl . '/test.jpg',
             'cards' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-352x.jpg 352w, ' . $mediaUrl . '/test-864x.jpg 864w, ' . $mediaUrl . '/test-1408x.jpg 1408w'
             ],
             'list' => [
-                'url' => $imagePlaceholder,
+                'url' => Model::imagePlaceholder(),
                 'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
             ]
         ], $panel->image(['cover' => true]));


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Adds `isFile::type()` to avoid infinite loops - similarly as adding `isFile::exists()`.
Still needs a good unit test, especially one that would end up in an infinite loop before this PR.

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3353

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
