### PR TITLE
Fix list input out of sync #3320

### DIFF
--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -1,10 +1,10 @@
 <template>
   <k-writer
     ref="input"
-    v-model="list"
     v-bind="$props"
     :extensions="extensions"
     :nodes="['bulletList', 'orderedList']"
+    :value="list"
     class="k-list-input"
     @input="onInput"
   />
@@ -24,7 +24,8 @@ export default {
   },
   data() {
     return {
-      list: this.value
+      list: this.value,
+      html: this.value
     };
   },
   computed: {
@@ -32,6 +33,18 @@ export default {
       return [new ListDoc({
         inline: true
       })];
+    }
+  },
+  watch: {
+    value(html) {
+      // if we don't compare the passed html
+      // the writer stops from working properly
+      // the list is updated with trimmed spaces
+      // which leads to unwanted side-effects
+      if (html !== this.html) {
+        this.list = html;
+        this.html = html;
+      }
     }
   },
   methods: {
@@ -56,9 +69,10 @@ export default {
 
       // updates `list` data with raw html
       this.list = html;
+      this.html = html.replace(/(<p>|<\/p>)/gi, "");
 
-      // emit value with removes `<p>` and `</p>` tags from html value
-      this.$emit("input", html.replace(/(<p>|<\/p>)/gi, ""));
+      // emit value with removed `<p>` and `</p>` tags from html value
+      this.$emit("input", this.html);
     }
   }
 };


### PR DESCRIPTION
## Describe the PR

The list input was out of sync because of a missing watch method. It's quite tricky to get this right. There's still a remaining issue with multiple line breaks. But this is not solvable quickly without further changes. The fix for the sync issue is already helping quite a lot though and we should add more fixes in additional PRs. 

## Release notes
- The list block is no longer out of sync with the drawer #3320

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3320

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
