### PR TITLE
Feature/inertia content locking

### DIFF
--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -8,33 +8,11 @@ use Kirby\Exception\Exception;
 return [
     [
         'pattern' => '(:all)/lock',
-        'method'  => 'GET',
-        'action'  => function (string $path) {
-            if ($lock = $this->parent($path)->lock()) {
-                return [
-                    'supported' => true,
-                    'locked'    => $lock->get()
-                ];
-            }
-
-            return [
-                'supported' => false,
-                'locked'    => null
-            ];
-        }
-    ],
-    [
-        'pattern' => '(:all)/lock',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->create();
             }
-
-            throw new Exception([
-                'key'      => 'lock.notImplemented',
-                'httpCode' => 501
-            ]);
         }
     ],
     [
@@ -44,28 +22,6 @@ return [
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->remove();
             }
-
-            throw new Exception([
-                'key'      => 'lock.notImplemented',
-                'httpCode' => 501
-            ]);
-        }
-    ],
-    [
-        'pattern' => '(:all)/unlock',
-        'method'  => 'GET',
-        'action'  => function (string $path) {
-            if ($lock = $this->parent($path)->lock()) {
-                return [
-                    'supported' => true,
-                    'unlocked'  => $lock->isUnlocked()
-                ];
-            }
-
-            return [
-                'supported' => false,
-                'unlocked'  => null
-            ];
         }
     ],
     [
@@ -75,11 +31,6 @@ return [
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->unlock();
             }
-
-            throw new Exception([
-                'key'      => 'lock.notImplemented',
-                'httpCode' => 501
-            ]);
         }
     ],
     [
@@ -89,11 +40,6 @@ return [
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->resolve();
             }
-
-            throw new Exception([
-                'key'      => 'lock.notImplemented',
-                'httpCode' => 501
-            ]);
         }
     ],
 ];

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -8,6 +8,29 @@ use Kirby\Exception\Exception;
 return [
     [
         'pattern' => '(:all)/lock',
+        'method'  => 'GET',
+        /**
+         * @deprecated 3.6.0
+         * @todo Remove in 3.7.0
+         */
+        'action'  => function (string $path) {
+            deprecated('The `GET (:all)/lock` API endpoint has been deprecated and will be removed in 3.7.0');
+
+            if ($lock = $this->parent($path)->lock()) {
+                return [
+                    'supported' => true,
+                    'locked'    => $lock->get()
+                ];
+            }
+
+            return [
+                'supported' => false,
+                'locked'    => null
+            ];
+        }
+    ],
+    [
+        'pattern' => '(:all)/lock',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
             if ($lock = $this->parent($path)->lock()) {
@@ -22,6 +45,30 @@ return [
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->remove();
             }
+        }
+    ],
+    [
+        'pattern' => '(:all)/unlock',
+        'method'  => 'GET',
+        /**
+         * @deprecated 3.6.0
+         * @todo Remove in 3.7.0
+         */
+        'action'  => function (string $path) {
+            deprecated('The `GET (:all)/unlock` API endpoint has been deprecated and will be removed in 3.7.0');
+
+
+            if ($lock = $this->parent($path)->lock()) {
+                return [
+                    'supported' => true,
+                    'unlocked'  => $lock->isUnlocked()
+                ];
+            }
+
+            return [
+                'supported' => false,
+                'unlocked'  => null
+            ];
         }
     ],
     [

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -135,18 +135,9 @@ export default {
       immediate: true
     },
     isLocked(locked) {
-      // in the case of a race condition (two users are
-      // making unsaved changes at the same time, both
-      // setting the lock before isLocked status has been 
-      // received) throw away changes of the loser of the race
-      // condition - should be minimal changes
-      if (locked === true) {
-        this.$store.dispatch("content/revert");
-      }
-
-      // model was locked by another user, lock has
-      // been lifted, so refresh data
-      else {
+      // model used to be locked by another user, 
+      // lock has been lifted, so refresh data
+      if (locked === false) {
         this.$events.$emit("model.reload");
       }
     }
@@ -163,16 +154,9 @@ export default {
     this.$events.$off("keydown.cmd.s", this.onSave);
   },
   methods: {
-    /**
-     * Partial reload of lock status
-     */
     check() {
       this.$reload("$props.lock");
     },
-    /**
-     * Write or remove the content lock
-     * @param {boolean} lock 
-     */
     async onLock(lock = true) {
       const api = [this.$view.path + "/lock", null, null, true];
 
@@ -216,17 +200,11 @@ export default {
       link.click();
       document.body.removeChild(link);
     },
-    /**
-     * Resolve unlock warning
-     */
     async onResolve() {
       // remove content unlock and throw away unsaved changes
       await this.onUnlock(false);
       this.$store.dispatch("content/revert");
     },
-    /**
-     * When reverting unsaved changes, first open confirm dialog
-     */
     onRevert() {
       this.$refs.revert.open();
     },

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -26,11 +26,11 @@
       <p class="k-form-lock-info">
         <k-icon type="lock" />
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <span v-html="$t('lock.isLocked', { email: form.lock.email })" />
+        <span v-html="$t('lock.isLocked', { email: lock.data.email })" />
       </p>
 
       <k-icon
-        v-if="!form.lock.unlockable"
+        v-if="!lock.data.unlockable"
         type="loader"
         class="k-form-lock-loader"
       />
@@ -38,7 +38,7 @@
         v-else
         icon="unlock"
         class="k-form-button"
-        @click="setUnlock"
+        @click="onUnlock()"
       >
         {{ $t('lock.unlock') }}
       </k-button>
@@ -49,7 +49,7 @@
         :disabled="isDisabled"
         icon="undo"
         class="k-form-button"
-        @click="$refs.revert.open()"
+        @click="onRevert"
       >
         {{ $t("revert") }}
       </k-button>
@@ -68,7 +68,7 @@
       :submit-button="$t('revert')"
       icon="undo"
       theme="negative"
-      @submit="onRevert"
+      @submit="revert"
     >
       <!-- eslint-disable-next-line vue/no-v-html -->
       <k-text v-html="$t('revert.confirm')" />
@@ -78,46 +78,31 @@
 
 <script>
 export default {
+  props: {
+    lock: [Boolean, Object]
+  },
   data() {
     return {
-      supportsLocking: true
+      isRefreshing: null,
+      isLocking: null
     }
   },
   computed: {
-    api() {
-      return {
-        lock: [this.$view.path + "/lock", null, null, true],
-        unlock: [this.$view.path + "/unlock", null, null, true]
-      }
-    },
     hasChanges() {
       return this.$store.getters["content/hasChanges"]();
     },
-    form() {
-      return {
-        lock: this.$store.state.content.status.lock,
-        unlock: this.$store.state.content.status.unlock
-      };
-    },
-    id() {
-      return this.$store.state.content.current;
-    },
     isDisabled() {
-      return this.$store.state.content.status.enabled === false;
+      return this.$store.state.content.enabled === false;
     },
     isLocked() {
-      return this.form.lock !== null;
+      return this.supportsLocking && this.lock.state === "lock";
     },
     isUnlocked() {
-      return this.form.unlock !== null;
+      return this.supportsLocking && this.lock.state === "unlock";
     },
     mode() {
-      if (this.isUnlocked === true) {
-        return "unlock";
-      }
-
-      if (this.isLocked === true) {
-        return "lock";
+      if (this.supportsLocking && this.lock.state !== null) {
+        return this.lock.state;
       }
 
       if (this.hasChanges === true) {
@@ -125,183 +110,127 @@ export default {
       }
 
       return null;
-    }
+    },
+    supportsLocking() {
+      return this.lock !== false;
+    },
   },
   watch: {
-    hasChanges(current, previous) {
-      // if user started to make changes,
-      // start setting lock on each heartbeat
-      if (previous === false && current === true) {
-        // console.log("watch: hasChanges new -> setLock:30");
-        this.$store.dispatch("heartbeat/remove", this.getLock);
-        this.$store.dispatch("heartbeat/add", [this.setLock, 30]);
-        return;
+    hasChanges: {
+      handler(changes) {
+        if (this.supportsLocking === true) {
+          if (this.isLocked === false && this.isUnlocked === false) {
+            if (changes === true) {
+              // unsaved changes, write lock every 30 seconds
+              this.onLock();
+              this.isLocking = setInterval(this.onLock, 30000);
+            } else {
+              // no more unsaved changes, stop writing lock, remove lock
+              clearInterval(this.isLocking);
+              this.onLock(false);
+            }
+          }
+        }
+      },
+      immediate: true
+    },
+    isLocked(locked) {
+      // in the case of a race condition (two users are
+      // making unsaved changes at the same time, both
+      // setting the lock before isLocked status has been 
+      // received) throw away changes of the loser of the race
+      // condition - should be minimal changes
+      if (locked === true) {
+        this.$store.dispatch("content/revert");
       }
 
-      // if user reversed changes manually,
-      // remove lock and listen to lock from other users again
-      if (this.id && previous === true && current === false) {
-        // console.log("watch: noChanges new -> removeLock");
-        this.removeLock();
-        return;
-      }
-    },
-    id() {
-      // start listening for content lock, when no changes exist
-      if (this.id && this.hasChanges === false) {
-        // console.log("watch: id and noChanges -> getLock:30");
-        this.$store.dispatch("heartbeat/add", [this.getLock, 10]);
+      // model was locked by another user, lock has
+      // been lifted, so refresh data
+      else {
+        this.$events.$emit("model.reload");
       }
     }
   },
   created() {
+    // refresh lock data every 10 seconds
+    this.isRefreshing = setInterval(this.check, 10000);
     this.$events.$on("keydown.cmd.s", this.onSave);
   },
   destroyed() {
+    // make sure to clear all intervals
+    clearInterval(this.isRefreshing);
+    clearInterval(this.isLocking);
     this.$events.$off("keydown.cmd.s", this.onSave);
   },
   methods: {
     /**
-     *  Locking API
+     * Partial reload of lock status
      */
-
-    getLock() {
-      return this.$api
-        .get(...this.api.lock)
-        .then(response => {
-
-          // if content locking is not supported by model,
-          // set flag and stop listening
-          if (response.supported === false) {
-            this.supportsLocking = false;
-            this.$store.dispatch("heartbeat/remove", this.getLock);
-            return;
-          }
-
-          // if content is locked, dispatch info to store
-          if (response.locked !== false) {
-            this.$store.dispatch("content/lock", response.locked);
-            return;
-          }
-
-          // if content is not locked but store still holds a lock
-          // from another user, that lock has been lifted and thus
-          // the content needs to be reloaded to reflect changes
-          if (
-            this.isLocked &&
-            this.form.lock.user !== this.$user.id
-          ) {
-            this.$events.$emit("model.reload");
-          }
-
-          this.$store.dispatch("content/lock", null);
-        })
-        .catch(() => {
-          // fail silently
-        });
+    check() {
+      this.$reload("$props.lock");
     },
-
-    setLock() {
-      if (this.supportsLocking === true) {
-        this.$api.patch(...this.api.lock).catch(error => {
-          // turns out: locking is not supported
-          if (error.key === "error.lock.notImplemented") {
-            this.supportsLocking = false;
-            this.$store.dispatch("heartbeat/remove", this.setLock);
-            return false;
-          }
-
-          // If setting lock failed, a competing lock has been set between
-          // API calls. In that case, discard changes, stop setting lock and
-          // listen to concurrent lock
-          this.$store.dispatch("content/revert", this.id);
-          this.$store.dispatch("heartbeat/remove", this.setLock);
-          this.$store.dispatch("heartbeat/add", [this.getLock, 10]);
-        });
-      }
-    },
-
-    removeLock() {
-      if (this.supportsLocking === true) {
-        this.$store.dispatch("heartbeat/remove", this.setLock);
-
-        this.$api
-          .delete(...this.api.lock)
-          .then(() => {
-            this.$store.dispatch("content/lock", null);
-            this.$store.dispatch("heartbeat/add", [this.getLock, 10]);
-          })
-          .catch(() => {
-            // fail silently
-          });
-      }
-    },
-
-    setUnlock() {
-      if (this.supportsLocking === true) {
-        this.$store.dispatch("heartbeat/remove", this.setLock);
-
-        this.$api
-          .patch(...this.api.unlock)
-          .then(() => {
-            this.$store.dispatch("content/lock", null);
-            this.$store.dispatch("heartbeat/add", [this.getLock, 10]);
-          })
-          .catch(() => {
-            // fail silently
-          });
-      }
-    },
-
-    removeUnlock() {
-      if (this.supportsLocking === true) {
-        this.$store.dispatch("heartbeat/remove", this.setLock);
-
-        this.$api
-          .delete(...this.api.unlock)
-          .then(() => {
-            this.$store.dispatch("content/unlock", null);
-            this.$store.dispatch("heartbeat/add", [this.getLock, 10]);
-          })
-          .catch(() => {
-            // fail silently
-          });
-      }
-    },
-
     /**
-     *  User actions
+     * Write or remove the content lock
+     * @param {boolean} lock 
      */
+    async onLock(lock = true) {
+      const api = [this.$view.path + "/lock", null, null, true];
 
+      // writing lock
+      if (lock === true) {
+        try {
+          await this.$api.patch(...api)
+
+        } catch (error) {
+          // If setting lock failed, a competing lock has been set between
+          // API calls. In that case, discard changes, stop setting lock
+          clearInterval(this.isLocking);
+          this.$store.dispatch("content/revert");
+        }
+      } 
+      
+      // removing lock
+      else {
+        clearInterval(this.isLocking);
+        await this.$api.delete(...api)
+      }
+    },
+    /**
+     * Download unsaved changes after model got unlocked
+     */
     onDownload() {
       let content = "";
+      const changes = this.$store.getters["content/changes"]();
 
-      Object.keys(this.form.unlock).forEach(key => {
-        content += key + ": \n\n" + this.form.unlock[key];
+      Object.keys(changes).forEach(key => {
+        content += key + ": \n\n" + changes[key];
         content += "\n\n----\n\n";
       });
 
       let link = document.createElement('a');
       link.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
-      link.setAttribute('download', this.id + ".txt");
+      link.setAttribute('download', this.$view.path + ".txt");
       link.style.display = 'none';
 
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
     },
-
-    onResolve() {
+    /**
+     * Resolve unlock warning
+     */
+    async onResolve() {
+      // remove content unlock and throw away unsaved changes
+      await this.onUnlock(false);
       this.$store.dispatch("content/revert");
-      this.removeUnlock();
     },
-
+    /**
+     * When reverting unsaved changes, first open confirm dialog
+     */
     onRevert() {
-      this.$store.dispatch("content/revert");
-      this.$refs.revert.close();
+      this.$refs.revert.open();
     },
-
-    onSave(e) {
+    async onSave(e) {
       if (!e) {
         return false;
       }
@@ -314,32 +243,48 @@ export default {
         return true;
       }
 
-      this.$store
-        .dispatch("content/save")
-        .then(() => {
-          this.$events.$emit("model.update");
-          this.$store.dispatch("notification/success", ":)");
-        })
-        .catch(response => {
-          if (response.code === 403) {
-            return;
-          }
+      try {
+        this.$store.dispatch("content/save");
+        this.$events.$emit("model.update");
+        this.$store.dispatch("notification/success", ":)");
 
-          if (response.details && Object.keys(response.details).length > 0) {
-            this.$store.dispatch("notification/error", {
-              message: this.$t("error.form.incomplete"),
-              details: response.details
-            });
-          } else {
-            this.$store.dispatch("notification/error", {
-              message: this.$t("error.form.notSaved"),
-              details: [{
-                label: "Exception: " + response.exception,
-                message: response.message
-              }]
-            });
-          }
-        });
+      } catch (response) {
+        if (response.code === 403) {
+          return;
+        }
+
+        if (response.details && Object.keys(response.details).length > 0) {
+          this.$store.dispatch("notification/error", {
+            message: this.$t("error.form.incomplete"),
+            details: response.details
+          });
+        } else {
+          this.$store.dispatch("notification/error", {
+            message: this.$t("error.form.notSaved"),
+            details: [{
+              label: "Exception: " + response.exception,
+              message: response.message
+            }]
+          });
+        }
+      }
+    },
+    async onUnlock(unlock = true) {
+      const api = [this.$view.path + "/unlock", null, null, true];
+      
+      if (unlock === true) {
+        // unlocking (writing unlock)
+        await this.$api.patch(...api)
+      } else {
+        // resolving unlock (removing unlock)
+        await this.$api.delete(...api)
+      }
+
+      this.$reload();
+    },
+    revert() {
+      this.$store.dispatch("content/revert");
+      this.$refs.revert.close();
     }
   },
 };

--- a/panel/src/components/Forms/FormIndicator.vue
+++ b/panel/src/components/Forms/FormIndicator.vue
@@ -66,8 +66,9 @@ export default {
     },
     load() {
       // create an API request promise for each model with changes
-      const promises = this.models.map(model => {
-        return this.$api.get(model.api, { view: "compact" }, null, true).then(response => {
+      const promises = this.models.map(async model => {
+        try {
+          const response = await this.$api.get(model.api, { view: "compact" }, null, true);
 
           // populate entry depending on model type
           let entry;
@@ -116,10 +117,11 @@ export default {
           }
 
           return entry;
-        }).catch(() => {
+
+        } catch (error) {
           this.$store.dispatch("content/remove", model.id);
           return null;
-        });
+        }
       });
 
       return Promise.all(promises).then(entries => {

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -34,6 +34,9 @@
     <!-- Registration dialog -->
     <k-registration ref="registration" @success="$reload" />
 
+    <!-- Form buttons -->
+    <k-form-buttons />
+
     <!-- Error dialog -->
     <k-error-dialog />
 
@@ -63,6 +66,9 @@ export default {
     "k-registration": Registration
   },
   inheritAttrs: false,
+  props: {
+    lock: [Boolean, Object]
+  },
   data() {
     return {
       offline: false,

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -34,9 +34,6 @@
     <!-- Registration dialog -->
     <k-registration ref="registration" @success="$reload" />
 
-    <!-- Form buttons -->
-    <k-form-buttons />
-
     <!-- Error dialog -->
     <k-error-dialog />
 

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -35,7 +35,7 @@
     <k-registration ref="registration" @success="$reload" />
 
     <!-- Form buttons -->
-    <k-form-buttons />
+    <k-form-buttons :lock="lock" />
 
     <!-- Error dialog -->
     <k-error-dialog />

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -10,7 +10,7 @@
       :fields="fields"
       :validate="true"
       :value="values"
-      :disabled="$store.state.content.status.lock !== null"
+      :disabled="lock !== false && lock.state === 'lock'"
       @input="input"
       @submit="onSubmit"
     />

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -17,10 +17,11 @@
             :is="'k-' + section.type + '-section'"
             v-if="exists(section.type)"
             :key="parent + '-column-' + columnIndex + '-section-' + sectionIndex + '-' + blueprint"
-            :name="section.name"
-            :parent="parent"
             :blueprint="blueprint"
             :column="column.width"
+            :lock="lock"
+            :name="section.name"
+            :parent="parent"
             :class="'k-section k-section-name-' + section.name"
             v-bind="section"
             @submit="$emit('submit', $event)"
@@ -39,6 +40,7 @@ export default {
   props: {
     empty: String,
     blueprint: String,
+    lock: [Boolean, Object],
     parent: String,
     tab: Object
   },

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -1,5 +1,5 @@
 <template>
-  <k-inside>
+  <k-inside :lock="lock">
     <div class="k-file-view">
       <k-file-preview :file="model" />
 
@@ -67,8 +67,6 @@
           :multiple="false"
           @success="onUpload"
         />
-
-        <k-form-buttons :lock="lock" />
       </k-view>
     </div>
   </k-inside>

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -52,6 +52,7 @@
         <k-sections
           :blueprint="blueprint"
           :empty="$t('file.blueprint', { template: blueprint })"
+          :lock="lock"
           :parent="path"
           :tab="tab"
         />
@@ -66,6 +67,8 @@
           :multiple="false"
           @success="onUpload"
         />
+
+        <k-form-buttons :lock="lock" />
       </k-view>
     </div>
   </k-inside>

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -1,7 +1,7 @@
 <template>
   <k-inside>
     <div class="k-file-view">
-      <k-file-preview :file="file" />
+      <k-file-preview :file="model" />
 
       <k-view :data-locked="isLocked" class="k-file-content">
         <k-header
@@ -10,12 +10,12 @@
           :tabs="tabs"
           @edit="action('rename')"
         >
-          {{ file.filename }}
+          {{ model.filename }}
 
           <template #left>
             <k-button-group>
               <k-button
-                :link="file.url"
+                :link="model.url"
                 :responsive="true"
                 icon="open"
                 target="_blank"
@@ -31,7 +31,11 @@
                 >
                   {{ $t('settings') }}
                 </k-button>
-                <k-dropdown-content ref="settings" :options="options" @action="action" />
+                <k-dropdown-content 
+                  ref="settings" 
+                  :options="options" 
+                  @action="action"
+                />
               </k-dropdown>
               <k-languages-dropdown />
             </k-button-group>
@@ -47,17 +51,18 @@
 
         <k-sections
           :blueprint="blueprint"
-          :empty="$t('file.blueprint', { template: blueprint.name })"
+          :empty="$t('file.blueprint', { template: blueprint })"
           :parent="path"
           :tab="tab"
         />
 
         <k-file-rename-dialog ref="rename" @success="onRename" />
         <k-file-remove-dialog ref="remove" @success="onDelete" />
+        
         <k-upload
           ref="upload"
           :url="uploadApi"
-          :accept="file.mime"
+          :accept="model.mime"
           :multiple="false"
           @success="onUpload"
         />
@@ -71,70 +76,53 @@ import ModelView from "./ModelView.vue";
 
 export default {
   extends: ModelView,
-  props: {
-    file: {
-      type: Object,
-      default() {
-        return {}
-      }
-    }
-  },
   computed: {
+    id() {
+      return "files/" + this.model.id;
+    },
     options() {
       return async ready => {
         const options = await this.$api.files.options(
-          this.file.parent,
-          this.file.filename
+          this.model.parent,
+          this.model.filename
         );
         ready(options);
       };
     },
     path() {
-      return this.file.parent + "/files/" + this.file.filename;
+      return this.model.parent + "/files/" + this.model.filename;
     },
     uploadApi() {
       return this.$urls.api + "/" + this.path;
     },
   },
-  watch: {
-    "file.id": {
-      handler() {
-        this.$store.dispatch("content/create", {
-          id: "files/" + this.file.id,
-          api: this.$api.files.link(this.file.parent, this.file.filename),
-          content: this.file.content
-        });
-      },
-      immediate: true
-    }
-  },
   methods: {
     action(action) {
       switch (action) {
         case "rename":
-          this.$refs.rename.open(this.file.parent, this.file.filename);
+          this.$refs.rename.open(this.model.parent, this.model.filename);
           break;
         case "replace":
           this.$refs.upload.open({
-            url: this.$urls.api + "/" + this.$api.files.url(this.file.parent, this.file.filename),
-            accept: "." + this.file.extension + "," + this.file.mime
+            url: this.$urls.api + "/" + this.$api.files.url(this.model.parent, this.model.filename),
+            accept: "." + this.model.extension + "," + this.model.mime
           });
           break;
         case "remove":
-          this.$refs.remove.open(this.file.parent, this.file.filename);
+          this.$refs.remove.open(this.model.parent, this.model.filename);
           break;
       }
     },
     onDelete() {
-      if (this.file.parent) {
-        this.$go('/' + this.file.parent);
+      if (this.model.parent) {
+        this.$go('/' + this.model.parent);
       } else {
         this.$go('/site');
       }
     },
     onRename(file) {
-      if (file.filename !== this.file.filename) {
-        this.$go(this.$api.files.link(this.file.parent, file.filename));
+      if (file.filename !== this.model.filename) {
+        this.$go(this.$api.files.link(this.model.parent, file.filename));
       }
     },
     onUpload() {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -10,6 +10,12 @@ export default {
         return {}
       }
     },
+    model: {
+      type: Object,
+      default() {
+        return {}
+      }
+    },
     tab: {
       type: Object,
       default() {
@@ -24,21 +30,43 @@ export default {
     }
   },
   computed: {
+    id() {
+      return this.model.id;
+    },
     isLocked() {
       return this.$store.state.content.status.lock !== null;
     }
   },
+  watch: {
+    "model.id": {
+      handler() {
+        this.content();
+      },
+      immediate: true
+    }
+  },
   created() {
-    this.$events.$on("model.reload", this.$reload);
+    this.$events.$on("model.reload", this.reload);
     this.$events.$on("keydown.left", this.toPrev);
     this.$events.$on("keydown.right", this.toNext);
   },
   destroyed() {
-    this.$events.$off("model.reload", this.$reload);
+    this.$events.$off("model.reload", this.reload);
     this.$events.$off("keydown.left", this.toPrev);
     this.$events.$off("keydown.right", this.toNext);
   },
   methods: {
+    content() {
+      this.$store.dispatch("content/create", {
+        id: this.id,
+        api: this.$view.path,
+        content: this.model.content
+      });
+    },
+    async reload() {
+      await this.$reload();
+      this.content();
+    },
     toPrev(e) {
       if (this.prev && e.target.localName === "body") {
         this.$go(this.prev.link);

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -10,6 +10,9 @@ export default {
         return {}
       }
     },
+    lock: {
+      type: [Boolean, Object]
+    },
     model: {
       type: Object,
       default() {
@@ -34,7 +37,7 @@ export default {
       return this.model.id;
     },
     isLocked() {
-      return this.$store.state.content.status.lock !== null;
+      return this.lock !== false && this.lock.state === "lock";
     }
   },
   watch: {

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -1,5 +1,5 @@
 <template>
-  <k-inside>
+  <k-inside :lock="lock">
     <k-view :data-locked="isLocked" class="k-page-view">
       <k-header
         :editable="permissions.changeTitle && !isLocked"
@@ -69,8 +69,6 @@
       <k-page-status-dialog ref="status" @success="$reload" />
       <k-page-template-dialog ref="template" @success="$reload" />
       <k-page-remove-dialog ref="remove" @success="onRemove" />
-
-      <k-form-buttons :lock="lock" />
     </k-view>
   </k-inside>
 </template>

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -59,6 +59,7 @@
       <k-sections
         :blueprint="blueprint"
         :empty="$t('page.blueprint', { template: blueprint })"
+        :lock="lock"
         :parent="$api.pages.url(model.id)"
         :tab="tab"
       />
@@ -68,12 +69,13 @@
       <k-page-status-dialog ref="status" @success="$reload" />
       <k-page-template-dialog ref="template" @success="$reload" />
       <k-page-remove-dialog ref="remove" @success="onRemove" />
+
+      <k-form-buttons :lock="lock" />
     </k-view>
   </k-inside>
 </template>
 
 <script>
-// TODO: can we delete mixins/view/prevnext ?
 import ModelView from "./ModelView.vue";
 
 export default {
@@ -88,45 +90,36 @@ export default {
     status: Object
   },
   computed: {
+    id() {
+      return "pages/" + this.model.id;
+    },
     options() {
       return async ready => {
-        const options = await this.$api.pages.options(this.page.id);
+        const options = await this.$api.pages.options(this.model.id);
         ready(options);
       };
-    }
-  },
-  watch: {
-    "page.id": {
-      handler() {
-        this.$store.dispatch("content/create", {
-          id: "pages/" + this.page.id,
-          api: this.$api.pages.link(this.page.id),
-          content: this.page.content
-        });
-      },
-      immediate: true
     }
   },
   methods: {
     action(action) {
       switch (action) {
         case "duplicate":
-          this.$refs.duplicate.open(this.page.id);
+          this.$refs.duplicate.open(this.model.id);
           break;
         case "rename":
-          this.$refs.rename.open(this.page.id, this.permissions, "title");
+          this.$refs.rename.open(this.model.id, this.permissions, "title");
           break;
         case "url":
-          this.$refs.rename.open(this.page.id, this.permissions, "slug");
+          this.$refs.rename.open(this.model.id, this.permissions, "slug");
           break;
         case "status":
-          this.$refs.status.open(this.page.id);
+          this.$refs.status.open(this.model.id);
           break;
         case "template":
-          this.$refs.template.open(this.page.id);
+          this.$refs.template.open(this.model.id);
           break;
         case "remove":
-          this.$refs.remove.open(this.page.id);
+          this.$refs.remove.open(this.model.id);
           break;
         default:
           this.$store.dispatch(
@@ -137,7 +130,7 @@ export default {
       }
     },
     onRemove() {
-      this.$go(this.page.parent);
+      this.$go(this.model.parent);
     }
   }
 };

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -78,6 +78,9 @@ import ModelView from "./ModelView.vue";
 
 export default {
   extends: ModelView,
+  props: {
+    status: Object
+  },
   computed: {
     id() {
       return "pages/" + this.model.id;

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -7,7 +7,7 @@
         :tabs="tabs"
         @edit="action('rename')"
       >
-        {{ page.title }}
+        {{ model.title }}
         <template #left>
           <k-button-group>
             <k-button
@@ -36,9 +36,9 @@
               >
                 {{ $t('settings') }}
               </k-button>
-              <k-dropdown-content 
-                ref="settings" 
-                :options="options" 
+              <k-dropdown-content
+                ref="settings"
+                :options="options"
                 @action="action"
               />
             </k-dropdown>
@@ -78,15 +78,6 @@ import ModelView from "./ModelView.vue";
 
 export default {
   extends: ModelView,
-  props: {
-    page: {
-      type: Object,
-      default() {
-        return {}
-      }
-    },
-    status: Object
-  },
   computed: {
     id() {
       return "pages/" + this.model.id;

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -11,9 +11,9 @@
         <template #left>
           <k-button-group>
             <k-button
-              v-if="permissions.preview && page.previewUrl"
+              v-if="permissions.preview && model.previewUrl"
               :responsive="true"
-              :link="page.previewUrl"
+              :link="model.previewUrl"
               target="_blank"
               icon="open"
             >
@@ -21,7 +21,7 @@
             </k-button>
             <k-status-icon
               v-if="status"
-              :status="page.status"
+              :status="model.status"
               :disabled="!permissions.changeStatus || isLocked"
               :responsive="true"
               :text="status.label"
@@ -36,7 +36,11 @@
               >
                 {{ $t('settings') }}
               </k-button>
-              <k-dropdown-content ref="settings" :options="options" @action="action" />
+              <k-dropdown-content 
+                ref="settings" 
+                :options="options" 
+                @action="action"
+              />
             </k-dropdown>
 
             <k-languages-dropdown />
@@ -45,7 +49,7 @@
 
         <template #right>
           <k-prev-next
-            v-if="page.id"
+            v-if="model.id"
             :prev="prev"
             :next="next"
           />
@@ -55,7 +59,7 @@
       <k-sections
         :blueprint="blueprint"
         :empty="$t('page.blueprint', { template: blueprint })"
-        :parent="$api.pages.url(page.id)"
+        :parent="$api.pages.url(model.id)"
         :tab="tab"
       />
 

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -1,5 +1,5 @@
 <template>
-  <k-inside>
+  <k-inside :lock="lock">
     <k-view
       :data-locked="isLocked"
       class="k-site-view"
@@ -36,8 +36,6 @@
       />
 
       <k-site-rename-dialog ref="rename" @success="$reload" />
-
-      <k-form-buttons :lock="lock" />
     </k-view>
   </k-inside>
 </template>

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -29,12 +29,15 @@
       <k-sections
         :blueprint="blueprint"
         :empty="$t('site.blueprint')"
+        :lock="lock"
         :tab="tab"
         parent="site"
         @submit="$emit('submit', $event)"
       />
 
       <k-site-rename-dialog ref="rename" @success="$reload" />
+
+      <k-form-buttons :lock="lock" />
     </k-view>
   </k-inside>
 </template>

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -10,12 +10,12 @@
         :tab="tab.name"
         @edit="$refs.rename.open()"
       >
-        {{ site.title }}
+        {{ model.title }}
         <template #left>
           <k-button-group>
             <k-button
               :responsive="true"
-              :link="site.previewUrl"
+              :link="model.previewUrl"
               target="_blank"
               icon="open"
             >
@@ -44,12 +44,9 @@ import ModelView from "./ModelView.vue";
 
 export default {
   extends: ModelView,
-  props: {
-    site: {
-      type: Object,
-      default() {
-        return {};
-      }
+  computed: {
+    id() {
+      return "site"
     }
   }
 };

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -100,6 +100,7 @@
         <k-sections
           :blueprint="blueprint"
           :empty="$t('user.blueprint', { role: model.role.name })"
+          :lock="lock"
           :parent="'users/' + model.id"
           :tab="tab"
         />
@@ -118,6 +119,8 @@
           accept="image/*"
           @success="uploadedAvatar"
         />
+
+        <k-form-buttons :lock="lock" />
       </k-view>
     </div>
   </k-inside>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -1,5 +1,5 @@
 <template>
-  <k-inside>
+  <k-inside :lock="lock">
     <div :data-locked="isLocked" class="k-user-view">
       <div class="k-user-profile">
         <k-view>
@@ -119,8 +119,6 @@
           accept="image/*"
           @success="uploadedAvatar"
         />
-
-        <k-form-buttons :lock="lock" />
       </k-view>
     </div>
   </k-inside>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -3,7 +3,7 @@
     <div :data-locked="isLocked" class="k-user-view">
       <div class="k-user-profile">
         <k-view>
-          <template v-if="user.avatar">
+          <template v-if="model.avatar">
             <k-dropdown>
               <k-button
                 :tooltip="$t('avatar')"
@@ -12,9 +12,9 @@
                 @click="$refs.picture.toggle()"
               >
                 <k-image
-                  v-if="user.avatar"
+                  v-if="model.avatar"
                   :cover="true"
-                  :src="user.avatar"
+                  :src="model.avatar"
                   ratio="1/1"
                 />
               </k-button>
@@ -44,21 +44,21 @@
               icon="email"
               @click="action('email')"
             >
-              {{ $t("email") }}: {{ user.email }}
+              {{ $t("email") }}: {{ model.email }}
             </k-button>
             <k-button
               :disabled="!permissions.changeRole || isLocked"
               icon="bolt"
               @click="action('role')"
             >
-              {{ $t("role") }}: {{ user.role }}
+              {{ $t("role") }}: {{ model.role }}
             </k-button>
             <k-button
               :disabled="!permissions.changeLanguage || isLocked"
               icon="globe"
               @click="action('language')"
             >
-              {{ $t("language") }}: {{ user.language }}
+              {{ $t("language") }}: {{ model.language }}
             </k-button>
           </k-button-group>
         </k-view>
@@ -71,9 +71,9 @@
           :tabs="tabs"
           @edit="action('rename')"
         >
-          <span v-if="!user.name || user.name.length === 0" class="k-user-name-placeholder">{{ $t("name") }} …</span>
+          <span v-if="!model.name || model.name.length === 0" class="k-user-name-placeholder">{{ $t("name") }} …</span>
           <template v-else>
-            {{ user.name }}
+            {{ model.name }}
           </template>
 
           <template #left>
@@ -99,8 +99,8 @@
 
         <k-sections
           :blueprint="blueprint"
-          :empty="$t('user.blueprint', { role: user.role.name })"
-          :parent="'users/' + user.id"
+          :empty="$t('user.blueprint', { role: model.role.name })"
+          :parent="'users/' + model.id"
           :tab="tab"
         />
 
@@ -129,43 +129,31 @@ import ModelView from "./ModelView.vue";
 export default {
   extends: ModelView,
   prevnext: true,
-  props: {
-    user: Object
-  },
   computed: {
+    id() {
+      return "users/" + this.model.id;
+    },
     options() {
       return async ready => {
-        const options = await this.$api.users.options(this.user.id);
+        const options = await this.$api.users.options(this.model.id);
         ready(options);
       };
     },
     uploadApi() {
-      return this.$urls.api + "/users/" + this.user.id + "/avatar";
-    }
-  },
-  watch: {
-    "user.id": {
-      handler() {
-        this.$store.dispatch("content/create", {
-          id: "users/" + this.user.id,
-          api: this.$api.users.link(this.user.id),
-          content: this.user.content
-        });
-      },
-      immediate: true
+      return this.$urls.api + "/users/" + this.model.id + "/avatar";
     }
   },
   methods: {
     async action(action) {
       switch (action) {
         case "email":
-          this.$refs.email.open(this.user.id);
+          this.$refs.email.open(this.model.id);
           break;
         case "language":
-          this.$refs.language.open(this.user.id);
+          this.$refs.language.open(this.model.id);
           break;
         case "password":
-          this.$refs.password.open(this.user.id);
+          this.$refs.password.open(this.model.id);
           break;
         case "picture.delete":
           await this.$api.users.deleteAvatar(this.id)
@@ -174,13 +162,13 @@ export default {
           this.$reload();
           break;
         case "remove":
-          this.$refs.remove.open(this.user.id);
+          this.$refs.remove.open(this.model.id);
           break;
         case "rename":
-          this.$refs.rename.open(this.user.id);
+          this.$refs.rename.open(this.model.id);
           break;
         case "role":
-          this.$refs.role.open(this.user.id);
+          this.$refs.role.open(this.model.id);
           break;
         default:
           this.$store.dispatch("notification/error", "Not yet implemented");

--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -66,7 +66,7 @@ export const plugin = {
     }
     Vue.prototype.$reload = function (options) {
       if (typeof options === "string") {
-        options = { only: options};
+        options = { only: [options] };
       }
       return Fiber.reload(options)
     }

--- a/panel/src/fiber/protocol.js
+++ b/panel/src/fiber/protocol.js
@@ -142,6 +142,14 @@ export default {
 
     url = this.toUrl(url, { data: data });
 
+    // create proper URL
+    url = this.toUrl(url, false)
+
+    // make sure only is an array
+    if (Array.isArray(only) === false) {
+      only = [only]
+    }
+
     try {
       // fetch the response (only GET request supported)
       const response = await fetch(url, {

--- a/panel/src/mixins/section/section.js
+++ b/panel/src/mixins/section/section.js
@@ -1,6 +1,7 @@
 export default {
   props: {
     blueprint: String,
+    lock: [Boolean, Object],
     help: String,
     name: String,
     parent: String

--- a/panel/src/store/modules/content.js
+++ b/panel/src/store/modules/content.js
@@ -27,19 +27,8 @@ export default {
      */
     models: {},
 
-    /**
-     * Object of status flags/info
-     */
-    status: {
-      // whether form shall be disabled (e.g. for structure fields)
-      enabled: true,
-
-      // content lock info
-      lock: null,
-
-      // content unlock info
-      unlock: null
-    }
+    // whether form shall be disabled (e.g. for structure fields)
+    enabled: true,
   },
 
 
@@ -152,9 +141,6 @@ export default {
     CURRENT(state, id) {
       state.current = id;
     },
-    LOCK(state, lock) {
-      Vue.set(state.status, "lock", lock);
-    },
     MOVE(state, [from, to]) {
       // move state
       const model = clone(state.models[from]);
@@ -177,15 +163,7 @@ export default {
       }
     },
     STATUS(state, enabled) {
-      Vue.set(state.status, "enabled", enabled);
-    },
-    UNLOCK(state, unlock) {
-      if (unlock) {
-        // reset unsaved changes if content has been unlocked by another user
-        Vue.set(state.models[state.current], "changes", {});
-      }
-
-      Vue.set(state.status, "unlock", unlock);
+      state.enabled = enabled;
     },
     UPDATE(state, [id, field, value]) {
       // avoid updating without a valid model
@@ -281,22 +259,6 @@ export default {
         changes: {}
       };
 
-      // check if content was previously unlocked
-      // TODO: handle this in fiber
-      Vue.$api
-        .get(model.api + "/unlock")
-        .then(response => {
-          if (
-            response.supported === true &&
-            response.unlocked === true
-          ) {
-            context.commit("UNLOCK", context.state.models[model.id].changes);
-          }
-        })
-        .catch(() => {
-          // fail silently
-        });
-
       context.commit("CREATE", [model.id, data]);
       context.dispatch("current", model.id);
     },
@@ -308,9 +270,6 @@ export default {
     },
     enable(context) {
       context.commit("STATUS", true);
-    },
-    lock(context, lock) {
-      context.commit("LOCK", lock);
     },
     move(context, [from, to]) {
       from = context.getters.id(from);
@@ -328,14 +287,14 @@ export default {
       id = id || context.state.current;
       context.commit("REVERT", id);
     },
-    save(context, id) {
+    async save(context, id) {
       id = id || context.state.current;
 
       // don't allow save if model is not current
       // or the form is currently disabled
       if (
         context.getters.isCurrent(id) &&
-        context.state.status.enabled === false
+        context.state.enabled === false
       ) {
         return false;
       }
@@ -347,26 +306,22 @@ export default {
       const data  = {...model.originals, ...model.changes};
 
       // Send updated values to API
-      return Vue.$api
-        .patch(model.api, data)
-        .then(() => {
-          // re-create model with updated values as originals
-          context.commit("CREATE", [id, {
-            ...model,
-            originals: data
-          }]);
+      try {
+        await Vue.$api.patch(model.api, data)
 
-          // revert unsaved changes (which also removes localStorage entry)
-          context.dispatch("revert", id);
-          context.dispatch("enable");
-        })
-        .catch(error => {
-          context.dispatch("enable");
-          throw error;
-        });
-    },
-    unlock(context, unlock) {
-      context.commit("UNLOCK", unlock);
+        // re-create model with updated values as originals
+        context.commit("CREATE", [id, {
+          ...model,
+          originals: data
+        }]);
+
+        // revert unsaved changes (which also removes localStorage entry)
+        context.dispatch("revert", id);
+
+      } finally {
+        context.dispatch("enable");
+      }
+
     },
     update(context, [field, value, id]) {
       id = id || context.state.current;

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -239,7 +239,7 @@ class File extends Model
         );
 
         return array_merge(parent::props(), [
-            'file' => [
+            'model' => [
                 'content'    => $this->content(),
                 'dimensions' => $file->dimensions()->toArray(),
                 'extension'  => $file->extension(),

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -215,6 +215,36 @@ abstract class Model
     }
 
     /**
+     * Returns lock info for the Panel
+     *
+     * @return array|false array with lock info,
+     *                     false if locking is not supported
+     */
+    public function lock()
+    {
+        // return [
+        //     'state' => null
+        // ];
+
+        if ($lock = $this->model->lock()) {
+            if ($lock->isUnlocked() == true) {
+                return ['state' => 'unlock'];
+            }
+
+            if ($lock->isLocked() == true) {
+                return [
+                    'state' => 'lock',
+                    'data'  => $lock->get()
+                ];
+            }
+
+            return ['state' => null];
+        }
+
+        return false;
+    }
+
+    /**
      * Returns an array of all actions
      * that can be performed in the Panel
      * This also checks for the lock status
@@ -301,6 +331,7 @@ abstract class Model
 
         return [
             'blueprint'   => $blueprint->name(),
+            'lock'        => $this->lock(),
             'permissions' => $this->model->permissions()->toArray(),
             'tab'         => $tab,
             'tabs'        => $tabs,

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -141,7 +141,7 @@ class Page extends Model
         $page = $this->model;
 
         return array_merge(parent::props(), [
-            'page' => [
+            'model' => [
                 'content'    => $this->content(),
                 'id'         => $page->id(),
                 'parent'     => $page->parentModel()->panel()->url(true),

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -51,7 +51,8 @@ class Site extends Model
     public function props(): array
     {
         return array_merge(parent::props(), [
-            'site' => [
+            'model' => [
+                'content'    => $this->content(),
                 'previewUrl' => $this->model->previewUrl(),
                 'title'      => $this->model->title()->toString()
             ]

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -96,7 +96,7 @@ class User extends Model
         $avatar = $user->avatar();
 
         return array_merge(parent::props(), [
-            'user' => [
+            'model' => [
                 'avatar'   => $avatar ? $avatar->url() : null,
                 'content'  => $this->content(),
                 'email'    => $user->email(),


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Content locking gets fixed by providing the lock state always via Inertia prop

1. Each model in `Kirby\Panel` now passes a `lock` entry  in their props array:
  - `false` for when content locking isn't supported
  - `['state' => null]` for when no lock/unlock exists
  - `['state' => 'lock', 'data' => [...]]` for when content is locked
  - `['state' => 'unlock']` for when a content lock got unlocked
2. `FormButtons` component is reloading the `lock` prop every 10 seconds via an Inertia partial request
3. When the model has unsaved changes, `FormButtons` also sends an API request every 30 seconds to write the content lock
4. When there are no unsaved changes anymore (saved or reverted), an API request is send to remove the content lock
5. When another user is already doing edits, all field sections will be disabled and a warning bar shown
6. If the other user saves or reverts changes (no more unsaved changes on their side), the lock is lifted and the model fully reloaded incl. content that might have changed (so that user A doesn't overwrite the changes of user B when making their own edits)
7. While user B is editing, user A cannot do anything. When use B stops editing (navigating away from the model),a 60 seconds grace period starts. After that user A can unlock the content lock.
8. Clicking the Unlock button sends an API request that removes the lock and writes an unlock
9. When user B now returns, they find a warning that the content has been unlocked
10. They can download a text file with their old unsaved changes (as backup) and resolve the unlock warning (which sends an API request to remove the unlock and also reverts all unsaved changes from the content store to have a clean slate again)

**Edge cases**
- If the state changes to `lock` for user A (user B edited something), we revert all unsaved changes of user A. This can happen when both start editing pretty much at the same time and user A hasn't gotten the updated state that user B is already editing. Since we update the state every 10 seconds, this should only result in loss of very few changes.


## Performance

**Before PR**
```
dist/css/style.css   94.01kb / brotli: 13.89kb
dist/js/index.js     347.30kb / brotli: 63.53kb
dist/js/vendor.js    407.46kb / brotli: 111.32kb
```

**After PR**
```
dist/css/style.css   94.01kb / brotli: 13.89kb
dist/js/index.js     346.01kb / brotli: 63.36kb
dist/js/vendor.js    407.46kb / brotli: 111.32kb
```

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- GET routes for content locking info have been removed from API
- The other content locking API routes don't throw an exception anymore when content locking isn't supported but just don't do anything
- `this.$store.state.content.status.enabled` is now `this.$store.state.content.enabled` 

## Related PR / issues
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Merges into https://github.com/getkirby/kirby/pull/3327
- Closes https://github.com/getkirby/kirby/issues/3362