### PR TITLE
Deprecate optional `parent` prop in `Cms\File`

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -27,6 +27,7 @@ return [
             if ($template) {
                 $file = new File([
                     'filename' => 'tmp',
+                    'parent'   => $this->model(),
                     'template' => $template
                 ]);
 

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -69,6 +69,7 @@ return [
             if ($this->template) {
                 $file = new File([
                     'filename' => 'tmp',
+                    'parent'   => $this->model(),
                     'template' => $this->template
                 ]);
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -520,7 +520,7 @@ class File extends ModelWithContent
     {
         // @codeCoverageIgnoreStart
         if ($parent === null) {
-            deprecated('You are creating a `Kirby\Cms\File` object without passing a `parent` prop. Whule unsupported, this hasn\'t thrown any direct errors so far. to fix inconsistencies, the `parent` property will be required for creating a `Kirby\Cms\File` object with 3.7.0 and higher. Not passing one will start throwing a breaking error');
+            deprecated('You are creating a `Kirby\Cms\File` object without passing the `parent` property. While unsupported, this hasn\'t caused any direct errors so far. To fix inconsistencies, the `parent` property will be required when creating a `Kirby\Cms\File` object in Kirby 3.7.0 and higher. Not passing this property will start throwing a breaking error.');
         }
         // @codeCoverageIgnoreEnd
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -511,7 +511,9 @@ class File extends ModelWithContent
     }
 
     /**
-     * Sets the parent model object
+     * Sets the parent model object;
+     * this property is required for `File::create()` and
+     * will be generally required starting with Kirby 3.7.0
      *
      * @param \Kirby\Cms\Model|null $parent
      * @return $this

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -514,9 +514,16 @@ class File extends ModelWithContent
      *
      * @param \Kirby\Cms\Model|null $parent
      * @return $this
+     * @todo make property required in 3.7.0
      */
     protected function setParent(Model $parent = null)
     {
+        // @codeCoverageIgnoreStart
+        if ($parent === null) {
+            deprecated('You are creating a `Kirby\Cms\File` object without passing a `parent` prop. Whule unsupported, this hasn\'t thrown any direct errors so far. to fix inconsistencies, the `parent` property will be required for creating a `Kirby\Cms\File` object with 3.7.0 and higher. Not passing one will start throwing a breaking error');
+        }
+        // @codeCoverageIgnoreEnd
+
         $this->parent = $parent;
         return $this;
     }

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -425,6 +425,7 @@ class File extends ModelWithContent
      * Returns the parent id if a parent exists
      *
      * @internal
+     * @todo 3.7.0 When setParent() is changed, the if check is not needed anymore
      * @return string|null
      */
     public function parentId(): ?string

--- a/tests/Cms/Api/collections/FilesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/FilesApiCollectionTest.php
@@ -20,9 +20,13 @@ class FilesApiCollectionTest extends TestCase
 
     public function testCollection()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $collection = $this->api->collection('files', new Files([
-            new File(['filename' => 'a.jpg']),
-            new File(['filename' => 'b.jpg'])
+            new File(['filename' => 'a.jpg', 'parent' => $page]),
+            new File(['filename' => 'b.jpg', 'parent' => $page])
         ]));
 
         $result = $collection->toArray();

--- a/tests/Cms/Api/models/FileBlueprintApiModelTest.php
+++ b/tests/Cms/Api/models/FileBlueprintApiModelTest.php
@@ -26,8 +26,12 @@ class FileBlueprintApiModelTest extends TestCase
             ],
         ]);
 
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $this->api  = $this->app->api();
-        $this->file = new File(['filename' => 'test.jpg']);
+        $this->file = new File(['filename' => 'test.jpg', 'parent' => $page]);
     }
 
     public function testName()

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -6,8 +6,12 @@ class FileBlueprintTest extends TestCase
 {
     public function testOptions()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $blueprint = new FileBlueprint([
-            'model' => new File(['filename' => 'test.jpg'])
+            'model' => new File(['filename' => 'test.jpg', 'parent' => $page])
         ]);
 
         $expected = [
@@ -24,8 +28,13 @@ class FileBlueprintTest extends TestCase
 
     public function testTemplateFromContent()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent' => $page,
             'content' => [
                 'template' => 'gallery'
             ]
@@ -36,8 +45,13 @@ class FileBlueprintTest extends TestCase
 
     public function testCustomTemplate()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent'   => $page,
             'template' => 'gallery'
         ]);
 
@@ -46,8 +60,13 @@ class FileBlueprintTest extends TestCase
 
     public function testDefaultBlueprint()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent'   => $page,
             'template' => 'does-not-exist',
         ]);
 
@@ -67,8 +86,13 @@ class FileBlueprintTest extends TestCase
             ]
         ]);
 
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent'   => $page,
             'template' => 'gallery',
         ]);
 
@@ -80,8 +104,13 @@ class FileBlueprintTest extends TestCase
 
     public function testAccept()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
-            'filename' => 'test.jpg'
+            'filename' => 'test.jpg',
+            'parent'   => $page
         ]);
 
         // string = MIME types
@@ -234,8 +263,13 @@ class FileBlueprintTest extends TestCase
 
     public function testAcceptMime()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
-            'filename' => 'test.jpg'
+            'filename' => 'test.jpg',
+            'parent'   => $page
         ]);
 
         // default restrictions
@@ -324,8 +358,13 @@ class FileBlueprintTest extends TestCase
             ]
         ]);
 
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent'   => $page,
             'template' => 'image',
         ]);
 

--- a/tests/Cms/Files/FilePermissionsTest.php
+++ b/tests/Cms/Files/FilePermissionsTest.php
@@ -30,7 +30,11 @@ class FilePermissionsTest extends TestCase
 
         $kirby->impersonate('kirby');
 
-        $file  = new File(['filename' => 'test.jpg']);
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        $file  = new File(['filename' => 'test.jpg', 'parent' => $page]);
         $perms = $file->permissions();
 
         $this->assertTrue($perms->can($action));
@@ -47,7 +51,11 @@ class FilePermissionsTest extends TestCase
             ]
         ]);
 
-        $file  = new File(['filename' => 'test.jpg']);
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        $file  = new File(['filename' => 'test.jpg', 'parent' => $page]);
         $perms = $file->permissions();
 
         $this->assertFalse($perms->can($action));

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -22,8 +22,13 @@ class FileVersionTest extends TestCase
 
     public function testConstruct()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $original = new File([
             'filename' => 'test.jpg',
+            'parent' => $page,
             'content' => [
                 'title' => 'Test Title'
             ]
@@ -77,8 +82,13 @@ class FileVersionTest extends TestCase
 
     public function testToArray()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $original = new File([
             'filename' => 'test.jpg',
+            'parent' => $page,
             'content' => [
                 'title' => 'Test Title'
             ]
@@ -95,7 +105,11 @@ class FileVersionTest extends TestCase
 
     public function testToString()
     {
-        $original = new File(['filename' => 'test.jpg']);
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        $original = new File(['filename' => 'test.jpg', 'parent' => $page]);
         $version  = new FileVersion([
             'original' => $original,
             'root'     => __DIR__ . '/fixtures/files/test.txt',

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -13,7 +13,8 @@ class FilesTest extends TestCase
         ], $parent);
 
         $file = new File([
-            'filename' => 'b.jpg'
+            'filename' => 'b.jpg',
+            'parent'   => $parent
         ]);
 
         $result = $files->add($file);

--- a/tests/Cms/Files/HasFilesTest.php
+++ b/tests/Cms/Files/HasFilesTest.php
@@ -72,8 +72,12 @@ class HasFilesTest extends TestCase
      */
     public function testTypes($filename, $type, $expected)
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $parent = new HasFileTraitUser([
-            new File(['filename' => $filename])
+            new File(['filename' => $filename, 'parent' => $page])
         ]);
 
         if ($expected === true) {
@@ -88,8 +92,12 @@ class HasFilesTest extends TestCase
      */
     public function testHas($filename, $type, $expected)
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $parent = new HasFileTraitUser([
-            new File(['filename' => $filename])
+            new File(['filename' => $filename, 'parent' => $page])
         ]);
 
         $this->assertEquals($expected, $parent->{'has' . $type}());
@@ -97,6 +105,10 @@ class HasFilesTest extends TestCase
 
     public function testHasFiles()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         // no files
         $parent = new HasFileTraitUser([
         ]);
@@ -105,7 +117,7 @@ class HasFilesTest extends TestCase
 
         // files
         $parent = new HasFileTraitUser([
-            new File(['filename' => 'test.jpg'])
+            new File(['filename' => 'test.jpg', 'parent' => $page])
         ]);
 
         $this->assertTrue($parent->hasFiles());

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -76,9 +76,12 @@ class MediaTest extends TestCase
 
     public function testPublish()
     {
+        $site = new Site();
+
         F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
         $file = new File([
             'kirby'    => $this->app,
+            'parent'   => $site,
             'filename' => $filename = 'test.jpg'
         ]);
 
@@ -105,9 +108,14 @@ class MediaTest extends TestCase
 
     public function testUnpublish()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
         $file = new File([
             'kirby'    => $this->app,
+            'parent'   => $page,
             'filename' => $filename = 'test.jpg'
         ]);
 
@@ -135,9 +143,14 @@ class MediaTest extends TestCase
 
     public function testUnpublishAndIgnore()
     {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
         $file = new File([
             'kirby'    => $this->app,
+            'parent'   => $page,
             'filename' => $filename = 'test.jpg'
         ]);
 
@@ -167,8 +180,13 @@ class MediaTest extends TestCase
     {
         $directory = $this->fixtures . '/does-not-exist';
 
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'kirby'    => $this->app,
+            'parent'   => $page,
             'filename' => 'does-not-exist.jpg'
         ]);
 

--- a/tests/Cms/Sections/FieldsSectionTest.php
+++ b/tests/Cms/Sections/FieldsSectionTest.php
@@ -23,7 +23,7 @@ class FieldsSectionTest extends TestCase
     {
         return [
             [
-                new Page(['slug' => 'test']),
+                $page = new Page(['slug' => 'test']),
                 true
             ],
             [
@@ -31,7 +31,7 @@ class FieldsSectionTest extends TestCase
                 true
             ],
             [
-                new File(['filename' => 'test.jpg']),
+                new File(['filename' => 'test.jpg', 'parent' => $page]),
                 false
             ],
             [

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -19,6 +19,17 @@ class FilesSectionTest extends TestCase
         ]);
     }
 
+    public function testAccept()
+    {
+        $section = new Section('files', [
+            'name'     => 'test',
+            'model'    => new Page(['slug' => 'test']),
+            'template' => 'note'
+        ]);
+
+        $this->assertSame('*', $section->accept());
+    }
+
     public function testHeadline()
     {
 

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -413,8 +413,13 @@ class FormTest extends TestCase
             ]
         ]);
 
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
         $file = new File([
             'filename' => 'test.jpg',
+            'parent'   => $page,
             'content'  => []
         ]);
 

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -191,8 +191,13 @@ class FileTest extends TestCase
      */
     public function testIconDefault()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
-            'filename' => 'something.jpg'
+            'filename' => 'something.jpg',
+            'parent'   => $page
         ]);
 
         $icon = (new File($file))->icon();
@@ -211,8 +216,13 @@ class FileTest extends TestCase
      */
     public function testIconWithRatio()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
-            'filename' => 'something.jpg'
+            'filename' => 'something.jpg',
+            'parent'   => $page
         ]);
 
         $icon = (new File($file))->icon(['ratio' => '3/2']);
@@ -231,8 +241,13 @@ class FileTest extends TestCase
      */
     public function testImage()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
-            'filename' => 'something.jpg'
+            'filename' => 'something.jpg',
+            'parent'   => $page
         ]);
 
         $image = (new File($file))->image();
@@ -304,8 +319,13 @@ class FileTest extends TestCase
      */
     public function testImageDeactivated()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
-            'filename' => 'something.jpg'
+            'filename' => 'something.jpg',
+            'parent'   => $page
         ]);
 
         $image = (new File($file))->image(false);
@@ -318,8 +338,13 @@ class FileTest extends TestCase
      */
     public function testImageStringIcon()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
-            'filename' => 'something.jpg'
+            'filename' => 'something.jpg',
+            'parent'   => $page
         ]);
 
         $image = (new File($file))->image('icon');
@@ -353,8 +378,13 @@ class FileTest extends TestCase
      */
     public function testOptions()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
             'filename' => 'test.jpg',
+            'parent'   => $page
         ]);
 
         $file->kirby()->impersonate('kirby');
@@ -378,8 +408,13 @@ class FileTest extends TestCase
      */
     public function testOptionsWithLockedFile()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFileTestForceLocked([
             'filename' => 'test.jpg',
+            'parent'   => $page
         ]);
 
         $file->kirby()->impersonate('kirby');
@@ -417,8 +452,13 @@ class FileTest extends TestCase
      */
     public function testOptionsDefaultReplaceOption()
     {
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
             'filename' => 'test.js',
+            'parent'   => $page
         ]);
         $file->kirby()->impersonate('kirby');
 
@@ -450,8 +490,13 @@ class FileTest extends TestCase
             ]
         ]);
 
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
             'filename' => 'test.js',
+            'parent'   => $page,
             'template' => 'test',
         ]);
 
@@ -487,8 +532,13 @@ class FileTest extends TestCase
             ]
         ]);
 
+        $page = new ModelPage([
+            'slug' => 'test'
+        ]);
+
         $file = new ModelFile([
             'filename' => 'test.js',
+            'parent'   => $page,
             'template' => 'restricted',
         ]);
 


### PR DESCRIPTION
## Status: ready for review 👀

## Release notes

### Deprecated
- Creating a `Kirby\Cms\File` without a `parent` property has been deprecated and throws a warning. Starting in 3.7.0 the property will be required and cause a breaking error if not passed.


## Initial post

This https://github.com/getkirby/getkirby.com/issues/1348 issue for the website pointed out that the  `parent` prop should be listed as required, since the `File::create()` method will throw an exception if it is not passed.

However, looking at the code I could not figure out why it should be required. We only seem to pass it to `File::factory()` which creates a new `File` object. There the property setter `File::setParent()` states the property as optional.

@lukasbestle @bastianallgeier 
Do you remember maybe why this Exception was put there to require the `parent` prop?