### PR TITLE
Select field: remove undocumented `empty` prop

### DIFF
--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -15,7 +15,7 @@ return [
             return $icon;
         },
         /**
-         * Custom placeholder string for empty option.
+         * Text shown when no option is selected yet
          */
         'placeholder' => function (string $placeholder = '—') {
             return $placeholder;

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -55,14 +55,7 @@ export const props = {
     ariaLabel: String,
     default: String,
     /**
-     * The text, that is shown as the first empty option, when the field is not required.
-     */
-    empty: {
-      type: [Boolean, String],
-      default: true
-    },
-    /**
-     * The text, that is shown when no option is selected yet.
+     * Text shown when no option is selected yet
      */
     placeholder: String,
     options: {
@@ -97,10 +90,6 @@ export default {
       return this.placeholder || "—";
     },
     hasEmptyOption() {
-      if (this.empty === false) {
-        return false;
-      }
-
       return !(this.required && this.default);
     },
     label() {


### PR DESCRIPTION
## Status: wait for https://github.com/getkirby/kirby/pull/2815 ⏸
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Removes the undocumented `empty` prop
- `empty = false` prop would remove the empty option, thus acting the same way as `required` but without actually enforcing it
- doesn't seem to me a functional logic - we should rely on `required` instead

After this PR:

```
mySelect:
  type: select
  options:
    - A
    - B
    - C
```

<img width="475" alt="Screen Shot 2021-05-26 at 21 04 38" src="https://user-images.githubusercontent.com/3788865/119716962-02ed9b80-be66-11eb-9fad-1240e5c0180d.png">
<img width="434" alt="Screen Shot 2021-05-26 at 21 04 33" src="https://user-images.githubusercontent.com/3788865/119716966-041ec880-be66-11eb-8476-b8503c9335d1.png">


```
mySelect:
  type: select
  required: true
  options:
    - A
    - B
    - C
```

<img width="446" alt="Screen Shot 2021-05-26 at 21 05 30" src="https://user-images.githubusercontent.com/3788865/119717095-2ca6c280-be66-11eb-9144-950b107fb6bd.png">
<img width="475" alt="Screen Shot 2021-05-26 at 21 04 38" src="https://user-images.githubusercontent.com/3788865/119717099-2dd7ef80-be66-11eb-9e43-6929348e7a64.png">

```
mySelect:
  type: select
  required: true
  default: A
  options:
    - A
    - B
    - C
```

<img width="444" alt="Screen Shot 2021-05-26 at 21 06 40" src="https://user-images.githubusercontent.com/3788865/119717225-51029f00-be66-11eb-8d66-d75316b879cd.png">


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- Select field: the `empty` option has been removed. Pleas use `required` instead.

_If someone has used `empty: false` so far and upgrades without making changes, the only effect is that now an empty option shows up. Saving and validation is just as before (not enforced)._


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/getkirby.com/issues/1006

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
