### PR TITLE
Fix return type for `App::translation()`

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -175,7 +175,7 @@ trait AppTranslations
      * Load a specific translation by locale
      *
      * @param string|null $locale Locale name or `null` for the current locale
-     * @return \Kirby\Cms\Translation|null
+     * @return \Kirby\Cms\Translation
      */
     public function translation(?string $locale = null)
     {


### PR DESCRIPTION
If nothing else in that method matches, we at least end up at `Translation::load()` which always just creates a `Translation` object:

https://github.com/getkirby/kirby/blob/master/src/Cms/Translation.php#L152