### PR TITLE
`page.php` API routes: fix check for deprecation

### DIFF
--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -45,7 +45,7 @@ return [
         'method'  => 'GET',
         'action'  => function (string $id) {
             // @codeCoverageIgnoreStart
-            if ($this->route->pattern() === 'pages/(:any)/children/blueprints') {
+            if ($this->route->pattern() === 'pages/([a-zA-Z0-9\.\-_%= \+\@\(\)]+)/children/blueprints') {
                 deprecated('`GET pages/(:any)/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET pages/(:any)/blueprints` instead');
             }
             // @codeCoverageIgnoreEnd


### PR DESCRIPTION
I think it is the easiest to fix this with the regex pattern. Especially since this is only temporary code anyways.