### PR TITLE
Fixes overlay jumps top of the page #3387

### DIFF
--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -52,6 +52,11 @@ export default {
   },
   methods: {
     close() {
+      // it makes it run once
+      if (this.isOpen === false) {
+        return;
+      }
+
       this.isOpen = false;
       this.$emit("close");
       this.restoreScrollPosition();
@@ -97,6 +102,11 @@ export default {
       }
     },
     open() {
+      // it makes it run once
+      if (this.isOpen === true) {
+        return;
+      }
+
       this.storeScrollPosition();
       this.isOpen = true;
       this.$emit("open");


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The `close()` method run 2 times when the click OK and the `mouseout`, and 3 times when the escape keydown. There may be a different issue when emitting `close`, but with this fix, it's easy to make it run once.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
 - Fixed overlay jumps top of the page when keydown escape.


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3387

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
