### PR TITLE
Deprecate `Str::isUrl()` #3386

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -305,7 +305,7 @@ class Html extends Xml
             $text = $attr['href'];
         }
 
-        if (is_string($text) === true && Str::isUrl($text) === true) {
+        if (is_string($text) === true && V::url($text) === true) {
             $text = Url::short($text);
         }
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -414,7 +414,7 @@ class Str
      */
     public static function isURL(?string $string = null): bool
     {
-        return $string !== null ? V::url($string) : false;
+        return filter_var($string, FILTER_VALIDATE_URL) !== false;
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -407,10 +407,13 @@ class Str
      *
      * @param string|null $string
      * @return bool
+     * @deprecated 3.6.0 use `Kirby\Toolkit\V::url()` instead
+     * @todo Throw deprecation warning in 3.7.0
+     * @todo Remove in 3.8.0
      */
-    public static function isURL(string $string = null): bool
+    public static function isURL(?string $string = null): bool
     {
-        return filter_var($string, FILTER_VALIDATE_URL) !== false;
+        return $string !== null ? V::url($string) : false;
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -410,6 +410,7 @@ class Str
      * @deprecated 3.6.0 use `Kirby\Toolkit\V::url()` instead
      * @todo Throw deprecation warning in 3.7.0
      * @todo Remove in 3.8.0
+     * @codeCoverageIgnore
      */
     public static function isURL(?string $string = null): bool
     {


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Deprecations
- `Kirby\Toolkit\Str::isUrl()` has been marked as deprecated and will be removed in 3.8.0


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3386

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
