### PR TITLE
More `Kirby\Toolkit\Str` unit tests (+ small bugfixes)

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -157,7 +157,7 @@ class Str
         foreach ($items as $quality => $values) {
             foreach ($values as $value) {
                 $result[] = [
-                    'quality' => $quality,
+                    'quality' => (float)$quality,
                     'value'   => $value
                 ];
             }
@@ -474,14 +474,12 @@ class Str
             foreach ($type as $t) {
                 $pool = array_merge($pool, static::pool($t));
             }
-
-            return $pool;
         } else {
-            switch ($type) {
-                case 'alphaLower':
+            switch (strtolower($type)) {
+                case 'alphalower':
                     $pool = range('a', 'z');
                     break;
-                case 'alphaUpper':
+                case 'alphaupper':
                     $pool = range('A', 'Z');
                     break;
                 case 'alpha':
@@ -490,7 +488,7 @@ class Str
                 case 'num':
                     $pool = range(0, 9);
                     break;
-                case 'alphaNum':
+                case 'alphanum':
                     $pool = static::pool(['alpha', 'num']);
                     break;
             }

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -4,6 +4,9 @@ namespace Kirby\Toolkit;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Toolkit\Str
+ */
 class StrTest extends TestCase
 {
     public static function setUpBeforeClass(): void
@@ -11,6 +14,9 @@ class StrTest extends TestCase
         Str::$language = [];
     }
 
+    /**
+     * @covers ::ascii
+     */
     public function testAscii()
     {
         $this->assertSame('aouss', Str::ascii('äöüß'));
@@ -19,6 +25,9 @@ class StrTest extends TestCase
         $this->assertSame('Nashata istorija', Str::ascii('Нашата история'));
     }
 
+    /**
+     * @covers ::after
+     */
     public function testAfter()
     {
         $string = 'Hellö Wörld';
@@ -37,6 +46,9 @@ class StrTest extends TestCase
         $this->assertSame('', Str::after('string', '.'), 'string with non-existing character should return false');
     }
 
+    /**
+     * @covers ::before
+     */
     public function testBefore()
     {
         $string = 'Hellö Wörld';
@@ -52,6 +64,9 @@ class StrTest extends TestCase
         $this->assertSame('', Str::before($string, 'x'));
     }
 
+    /**
+     * @covers ::between
+     */
     public function testBetween()
     {
         $this->assertSame('trin', Str::between('string', 's', 'g'), 'string between s and g should be trin');
@@ -59,6 +74,9 @@ class StrTest extends TestCase
         $this->assertSame('', Str::between('string', '.', 'g'), 'function with non-existing character should return false');
     }
 
+    /**
+     * @covers ::contains
+     */
     public function testContains()
     {
         $string = 'Hellö Wörld';
@@ -76,11 +94,17 @@ class StrTest extends TestCase
         $this->assertTrue(Str::contains($string, 'wörld', true));
     }
 
+    /**
+     * @covers ::encoding
+     */
     public function testEncoding()
     {
         $this->assertSame('UTF-8', Str::encoding('ÖÄÜ'));
     }
 
+    /**
+     * @covers ::endsWith
+     */
     public function testEndsWith()
     {
         $string = 'Hellö Wörld';
@@ -100,6 +124,9 @@ class StrTest extends TestCase
         $this->assertTrue(Str::endsWith($string, 'WÖRLD', true));
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerpt()
     {
         $string   = 'This is a long text<br>with some html';
@@ -109,6 +136,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithoutChars()
     {
         $string   = 'This is a long text<br>with some html';
@@ -118,6 +148,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithZeroLength()
     {
         $string = 'This is a long text with some html';
@@ -126,6 +159,9 @@ class StrTest extends TestCase
         $this->assertSame($string, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithoutStripping()
     {
         $string   = 'This is a long text<br>with some html';
@@ -135,6 +171,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithDifferentRep()
     {
         $string   = 'This is a long text<br>with some html';
@@ -144,6 +183,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithSpaces()
     {
         $string   = 'This is a long text   <br>with some html';
@@ -153,6 +195,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithLineBreaks()
     {
         $string   = 'This is a long text ' . PHP_EOL . ' with some html';
@@ -162,6 +207,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::excerpt
+     */
     public function testExcerptWithUnicodeChars()
     {
         $string   = 'Hellö Wörld text<br>with söme htmäl';
@@ -171,6 +219,9 @@ class StrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @covers ::float
+     */
     public function testFloat()
     {
         $this->assertSame('0', Str::float(false));
@@ -197,6 +248,9 @@ class StrTest extends TestCase
         $this->assertSame('0.00000001', Str::float(0.00000001));
     }
 
+    /**
+     * @covers ::from
+     */
     public function testFrom()
     {
         $string = 'Hellö Wörld';
@@ -212,6 +266,9 @@ class StrTest extends TestCase
         $this->assertSame('', Str::from($string, 'x'));
     }
 
+    /**
+     * @covers ::kebab
+     */
     public function testKebab()
     {
         $string = 'KingCobra';
@@ -221,6 +278,9 @@ class StrTest extends TestCase
         $this->assertSame('king-cobra', Str::kebab($string));
     }
 
+    /**
+     * @covers ::length
+     */
     public function testLength()
     {
         $this->assertSame(0, Str::length(''));
@@ -229,12 +289,18 @@ class StrTest extends TestCase
         $this->assertSame(6, Str::length('Aœ?_ßö'));
     }
 
+    /**
+     * @covers ::lower
+     */
     public function testLower()
     {
         $this->assertSame('öäü', Str::lower('ÖÄÜ'));
         $this->assertSame('öäü', Str::lower('Öäü'));
     }
 
+    /**
+     * @covers ::ltrim
+     */
     public function testLtrim()
     {
         $this->assertSame('test', Str::ltrim(' test'));
@@ -242,6 +308,9 @@ class StrTest extends TestCase
         $this->assertSame('jpg', Str::ltrim('test.jpg', 'test.'));
     }
 
+    /**
+     * @covers ::position
+     */
     public function testPosition()
     {
         $string = 'Hellö Wörld';
@@ -259,6 +328,9 @@ class StrTest extends TestCase
         $this->assertTrue(Str::position($string, 'Ö', true) === 4);
     }
 
+    /**
+     * @covers ::random
+     */
     public function testRandom()
     {
         // choose a high length for a high probability of occurrence of a character of any type
@@ -279,6 +351,9 @@ class StrTest extends TestCase
         $this->assertFalse(Str::random($length, 'something invalid'));
     }
 
+    /**
+     * @covers ::replace
+     */
     public function testReplace()
     {
         // simple strings with limits
@@ -335,6 +410,9 @@ class StrTest extends TestCase
         $this->assertSame('apearpearle pear', Str::replace('a p', ['a', 'p'], ['apple', 'pear'], [1, 3]));
     }
 
+    /**
+     * @covers ::replace
+     */
     public function testReplaceInvalid1()
     {
         $this->expectException('Exception');
@@ -342,6 +420,9 @@ class StrTest extends TestCase
         Str::replace('some string', 'string', ['array'], 1);
     }
 
+    /**
+     * @covers ::replace
+     */
     public function testReplaceInvalid2()
     {
         $this->expectException('Exception');
@@ -349,6 +430,9 @@ class StrTest extends TestCase
         Str::replace('some string', 'string', 'other string', 'some invalid string as limit');
     }
 
+    /**
+     * @covers ::replace
+     */
     public function testReplaceInvalid3()
     {
         $this->expectException('Exception');
@@ -356,6 +440,9 @@ class StrTest extends TestCase
         Str::replace('some string', ['some', 'string'], 'other string', [1, 'string']);
     }
 
+    /**
+     * @covers ::replacements
+     */
     public function testReplacements()
     {
         // simple example
@@ -397,6 +484,9 @@ class StrTest extends TestCase
         ], Str::replacements(['a', 'b'], ['c', 'd'], [2]));
     }
 
+    /**
+     * @covers ::replacements
+     */
     public function testReplacementsInvalid()
     {
         $this->expectException('Exception');
@@ -404,6 +494,9 @@ class StrTest extends TestCase
         Str::replacements('string', ['array'], 1);
     }
 
+    /**
+     * @covers ::replaceReplacements
+     */
     public function testReplaceReplacements()
     {
         $this->assertSame(
@@ -436,6 +529,9 @@ class StrTest extends TestCase
         // edge cases are tested in the Str::replace() unit test
     }
 
+    /**
+     * @covers ::replaceReplacements
+     */
     public function testReplaceReplacementsInvalid()
     {
         $this->expectException('Exception');
@@ -449,6 +545,9 @@ class StrTest extends TestCase
         ]);
     }
 
+    /**
+     * @covers ::rtrim
+     */
     public function testRtrim()
     {
         $this->assertSame('test', Str::rtrim('test '));
@@ -456,6 +555,9 @@ class StrTest extends TestCase
         $this->assertSame('test', Str::rtrim('test.jpg', '.jpg'));
     }
 
+    /**
+     * @covers ::short
+     */
     public function testShort()
     {
         $string = 'Super Äwesøme String';
@@ -482,6 +584,9 @@ class StrTest extends TestCase
         $this->assertSame('12345…', Str::short(123456, 5));
     }
 
+    /**
+     * @covers ::slug
+     */
     public function testSlug()
     {
         // Double dashes
@@ -530,6 +635,9 @@ class StrTest extends TestCase
         Str::$language = [];
     }
 
+    /**
+     * @covers ::snake
+     */
     public function testSnake()
     {
         $string = 'KingCobra';
@@ -539,17 +647,24 @@ class StrTest extends TestCase
         $this->assertSame('king_cobra', Str::snake($string));
     }
 
+    /**
+     * @covers ::split
+     */
     public function testSplit()
     {
+        // default separator
         $string = 'ä,ö,ü,ß';
         $this->assertSame(['ä', 'ö', 'ü', 'ß'], Str::split($string));
 
+        // custom separator
         $string = 'ä/ö/ü/ß';
         $this->assertSame(['ä', 'ö', 'ü', 'ß'], Str::split($string, '/'));
 
+        // custom separator and limited length
         $string = 'ää/ö/üü/ß';
         $this->assertSame(['ää', 'üü'], Str::split($string, '/', 2));
 
+        // custom separator with line-breaks
         $string = <<<EOT
             ---
             -abc-
@@ -557,8 +672,15 @@ class StrTest extends TestCase
             -def-
 EOT;
         $this->assertSame(['-abc-', '-def-'], Str::split($string, '---'));
+
+        // input is already an array
+        $string = ['ää', 'üü', 'ß'];
+        $this->assertSame($string, Str::split($string));
     }
 
+    /**
+     * @covers ::startsWith
+     */
     public function testStartsWith()
     {
         $string = 'Hellö Wörld';
@@ -578,6 +700,9 @@ EOT;
         $this->assertTrue(Str::startsWith($string, 'hellö', true));
     }
 
+    /**
+     * @covers ::similarity
+     */
     public function testSimilarity()
     {
         $this->assertSame([
@@ -647,6 +772,9 @@ EOT;
         ], Str::similarity('Kirby', 'KIRBY', true));
     }
 
+    /**
+     * @covers ::substr
+     */
     public function testSubstr()
     {
         $string = 'äöü';
@@ -659,6 +787,9 @@ EOT;
         $this->assertSame('ü', Str::substr($string, -1));
     }
 
+    /**
+     * @covers ::template
+     */
     public function testTemplate()
     {
         // query with a string
@@ -709,6 +840,9 @@ EOT;
         $this->assertSame('homer says: {{ user.greeting("hi") }}', $template);
     }
 
+    /**
+     * @covers ::toBytes
+     */
     public function testToBytes()
     {
         $this->assertSame(0, Str::toBytes(0));
@@ -729,6 +863,9 @@ EOT;
         $this->assertSame(2 * 1024 * 1024 * 1024, Str::toBytes('2g'));
     }
 
+    /**
+     * @covers ::toType
+     */
     public function testToType()
     {
         // string to string
@@ -765,6 +902,9 @@ EOT;
         $this->assertSame(1, Str::toType('1', 1));
     }
 
+    /**
+     * @covers ::trim
+     */
     public function testTrim()
     {
         $this->assertSame('test', Str::trim(' test '));
@@ -772,12 +912,18 @@ EOT;
         $this->assertSame('test', Str::trim('.test.', '.'));
     }
 
+    /**
+     * @covers ::ucfirst
+     */
     public function testUcfirst()
     {
         $this->assertSame('Hello world', Str::ucfirst('hello world'));
         $this->assertSame('Hello world', Str::ucfirst('Hello World'));
     }
 
+    /**
+     * @covers ::ucwords
+     */
     public function testUcwords()
     {
         $this->assertSame('Hello World', Str::ucwords('hello world'));
@@ -785,12 +931,18 @@ EOT;
         $this->assertSame('Hello World', Str::ucwords('HELLO WORLD'));
     }
 
+    /**
+     * @covers ::unhtml
+     */
     public function testUnhtml()
     {
         $string = 'some <em>crazy</em> stuff';
         $this->assertSame('some crazy stuff', Str::unhtml($string));
     }
 
+    /**
+     * @covers ::until
+     */
     public function testUntil()
     {
         $string = 'Hellö Wörld';
@@ -806,6 +958,9 @@ EOT;
         $this->assertSame('', Str::until($string, 'x'));
     }
 
+    /**
+     * @covers ::upper
+     */
     public function testUpper()
     {
         $this->assertSame('ÖÄÜ', Str::upper('öäü'));

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -15,6 +15,17 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::accepted
+     */
+    public function testAccepted()
+    {
+        $this->assertSame([
+            ['quality' => 1.0, 'value' => 'image/jpeg'],
+            ['quality' => 0.7, 'value' => 'image/png']
+        ], Str::accepted('image/jpeg,  image/png;q=0.7'));
+    }
+
+    /**
      * @covers ::ascii
      */
     public function testAscii()
@@ -92,6 +103,33 @@ class StrTest extends TestCase
         $this->assertTrue(Str::contains($string, 'Wörld', true));
         $this->assertTrue(Str::contains($string, 'hellö', true));
         $this->assertTrue(Str::contains($string, 'wörld', true));
+    }
+
+    /**
+     * @covers ::convert
+     */
+    public function testConvert()
+    {
+        $source = 'ÖÄÜ';
+
+        // same encoding
+        $result = Str::convert($source, 'UTF-8');
+        $this->assertSame('UTF-8', Str::encoding($source));
+        $this->assertSame('UTF-8', Str::encoding($result));
+
+        // different  encoding
+        $result = Str::convert($source, 'ISO-8859-1');
+        $this->assertSame('UTF-8', Str::encoding($source));
+        $this->assertSame('ISO-8859-1', Str::encoding($result));
+    }
+
+    /**
+     * @covers ::encode
+     */
+    public function testEncode()
+    {
+        $email = 'test@getkirby.com';
+        $this->assertSame($email, Html::decode(Str::encode($email)));
     }
 
     /**
@@ -309,6 +347,46 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::pool
+     */
+    public function testPool()
+    {
+        // alpha
+        $string = Str::pool('alpha', false);
+        $this->assertTrue(V::alpha($string));
+        $this->assertSame(52, strlen($string));
+
+        // alphaLower
+        $string = Str::pool('alphaLower', false);
+        $this->assertTrue(V::alpha($string));
+        $this->assertSame(26, strlen($string));
+
+        // alphaUpper
+        $string = Str::pool('alphaUpper', false);
+        $this->assertTrue(V::alpha($string));
+        $this->assertSame(26, strlen($string));
+
+        // num
+        $string = Str::pool('num', false);
+        $this->assertTrue(V::num($string));
+        $this->assertSame(10, strlen($string));
+
+        // alphaNum
+        $string = Str::pool('alphaNum', false);
+        $this->assertTrue(V::alphanum($string));
+        $this->assertSame(62, strlen($string));
+
+        // [alphaLower, num]
+        $string = Str::pool(['alphaLower', 'num'], false);
+        $this->assertTrue(V::alphanum($string));
+        $this->assertSame(36, strlen($string));
+
+        // string vs. array
+        $this->assertIsString(Str::pool('alpha', false));
+        $this->assertIsArray(Str::pool('alpha'));
+    }
+
+    /**
      * @covers ::position
      */
     public function testPosition()
@@ -326,6 +404,15 @@ class StrTest extends TestCase
         $this->assertTrue(Str::position($string, 'h', true) === 0);
         $this->assertTrue(Str::position($string, 'ö', true) === 4);
         $this->assertTrue(Str::position($string, 'Ö', true) === 4);
+    }
+
+    /**
+     * @covers ::query
+     */
+    public function testQuery()
+    {
+        $result = Str::query('data.1', ['data' => ['foo', 'bar']]);
+        $this->assertSame('bar', $result);
     }
 
     /**
@@ -511,7 +598,7 @@ class StrTest extends TestCase
         );
 
         $this->assertSame(
-            'other interesting string',
+            'other interesting story',
             Str::replaceReplacements('some some string', [
                 [
                     'search'  => 'some',
@@ -522,6 +609,11 @@ class StrTest extends TestCase
                     'search'  => 'other string',
                     'replace' => 'interesting string',
                     'limit'   => 1
+                ],
+                [
+                    'search'  => 'string',
+                    'replace' => 'story',
+                    'limit'   => 5
                 ]
             ])
         );
@@ -965,5 +1057,15 @@ EOT;
     {
         $this->assertSame('ÖÄÜ', Str::upper('öäü'));
         $this->assertSame('ÖÄÜ', Str::upper('Öäü'));
+    }
+
+    /**
+     * @covers ::widont
+     */
+    public function testWidont()
+    {
+        $this->assertSame('Test&nbsp;Headline', Str::widont('Test Headline'));
+        $this->assertSame('Test Headline&nbsp;With&#8209;Dash', Str::widont('Test Headline With-Dash'));
+        $this->assertSame('', Str::widont());
     }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Adds more unit tests for `Kirby\Toolkit\Str`
- Makes unit tests stricter (`@covers`)
- More changes see below

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->


### Fixes
- `Str::accepted` returns always floats as `quality` value (before default `1` as int, all actual quality values as string, e.g. `'0.7'`)
- `Str::pool()`: the passed `$type` parameter is now treated case-insensitively
- The second argument to `Str::pool()` now also works if the first argument is set to a list of character pools


## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
