### PR TITLE
`k-breadcrumb` component

### DIFF
--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -1,0 +1,138 @@
+<template>
+  <nav
+    :aria-label="label"
+    class="k-breadcrumb"
+  >
+    <k-dropdown class="k-breadcrumb-dropdown">
+      <k-button
+        icon="road-sign"
+        @click="$refs.dropdown.toggle()"
+      />
+      <k-dropdown-content
+        ref="dropdown"
+        :options="dropdown"
+        theme="light"
+      />
+    </k-dropdown>
+
+    <ol>
+      <li
+        v-for="(crumb, index) in segments"
+        :key="index"
+      >
+        <k-link
+          :title="crumb.text || crumb.label"
+          :to="crumb.link"
+          :aria-current="isLast(index) ? 'page' : false"
+          class="k-breadcrumb-link"
+        >
+          <k-loader
+            v-if="crumb.loading"
+            class="k-breadcrumb-icon"
+          />
+          <k-icon
+            v-else-if="crumb.icon"
+            :type="crumb.icon"
+            class="k-breadcrumb-icon"
+          />
+          <span class="k-breadcrumb-link-text">
+            {{ crumb.text || crumb.label }}
+          </span>
+        </k-link>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script>
+export default {
+  props: {
+    crumbs: {
+      type: Array,
+      default() {
+        return [];
+      }
+    },
+    label: {
+      type: String,
+      default: "Breadcrumb",
+    },
+    view: Object
+  },
+  computed: {
+    dropdown() {
+      return this.segments.map(link => ({
+        ...link,
+        text: link.label,
+        icon: "angle-right"
+      }));
+    },
+    segments() {
+      return [
+        {
+          link:    this.view.link,
+          label:   this.view.breadcrumbLabel,
+          icon:    this.view.icon,
+          loading: this.$store.state.isLoading
+        },
+        ...this.crumbs
+      ];
+    }
+  },
+  methods: {
+    isLast(index) {
+      return (this.crumbs.length - 1) === index;
+    }
+  }
+}
+</script>
+
+<style>
+.k-breadcrumb-dropdown {
+  height: 2.5rem;
+  width: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.k-breadcrumb ol {
+  display: none;
+  align-items: center;
+}
+
+@media screen and (min-width: 30em) {
+  .k-breadcrumb ol {
+    display: flex;
+  }
+  .k-breadcrumb-dropdown {
+    display: none;
+  }
+}
+
+.k-breadcrumb-link {
+  display: flex;
+  align-items: center;
+  font-size: var(--text-sm);
+  min-width: 0;
+  align-self: stretch;
+  padding: .625rem .5rem;
+  line-height: 1.25rem;
+}
+.k-breadcrumb li {
+  display: flex;
+  align-items: center;
+  flex-shrink: 3;
+  min-width: 0;
+}
+.k-breadcrumb li:last-child {
+  flex-shrink: 1;
+}
+.k-breadcrumb li:not(:last-child)::after {
+  content: "/";
+  opacity: .5;
+  flex-shrink: 0;
+}
+.k-breadcrumb-icon {
+  margin-right: .5rem;
+}
+</style>

--- a/panel/src/components/Views/FileView.spec.js
+++ b/panel/src/components/Views/FileView.spec.js
@@ -1,74 +1,90 @@
 const dialog = () => {
-  return cy.get('.k-dialog');
+  return cy.get(".k-dialog");
 };
 
-describe('FileView', () => {
-
+describe("FileView", () => {
   beforeEach(() => {
-    cy.visit('/env/install/starterkit');
-    cy.visit('/env/user/test');
-    cy.visit('/env/auth/test');
+    cy.visit("/env/install/starterkit");
+    cy.visit("/env/user/test");
+    cy.visit("/env/auth/test");
   });
 
-  describe('Page File', () => {
-
+  describe("Page File", () => {
     beforeEach(() => {
-      cy.visit('/panel/pages/photography+trees/files/cheesy-autumn.jpg');
+      cy.visit("/panel/pages/photography+trees/files/cheesy-autumn.jpg");
     });
 
-    it('should display correctly', () => {
+    it("should display correctly", () => {
       // Title
-      cy.get('.k-headline-editable').should('contain', 'cheesy-autumn.jpg');
-      cy.get('.k-topbar-crumbs a:last-child').should('contain', 'cheesy-autumn.jpg');
+      cy.get(".k-headline-editable").should("contain", "cheesy-autumn.jpg");
+      cy.get(".k-topbar-breadcrumb a:last-child").should(
+        "contain",
+        "cheesy-autumn.jpg"
+      );
 
       // Info
-      cy.get('.k-file-preview-details').as('info');
+      cy.get(".k-file-preview-details").as("info");
 
-      cy.get('@info').find('li:nth-child(1)').should('contain', 'Template');
-      cy.get('@info').find('li:nth-child(1)').should('contain', 'image');
+      cy.get("@info").find("li:nth-child(1)").should("contain", "Template");
+      cy.get("@info").find("li:nth-child(1)").should("contain", "image");
 
-      cy.get('@info').find('li:nth-child(2)').should('contain', 'Media Type');
-      cy.get('@info').find('li:nth-child(2)').should('contain', 'image/jpeg');
+      cy.get("@info").find("li:nth-child(2)").should("contain", "Media Type");
+      cy.get("@info").find("li:nth-child(2)").should("contain", "image/jpeg");
 
-      cy.get('@info').find('li:nth-child(3)').should('contain', 'Url');
-      cy.get('@info').find('li:nth-child(3)').should('contain', '/photography/trees/cheesy-autumn.jpg');
+      cy.get("@info").find("li:nth-child(3)").should("contain", "Url");
+      cy.get("@info")
+        .find("li:nth-child(3)")
+        .should("contain", "/photography/trees/cheesy-autumn.jpg");
 
-      cy.get('@info').find('li:nth-child(4)').should('contain', 'Size');
-      cy.get('@info').find('li:nth-child(4)').should('contain', 'KB');
+      cy.get("@info").find("li:nth-child(4)").should("contain", "Size");
+      cy.get("@info").find("li:nth-child(4)").should("contain", "KB");
 
-      cy.get('@info').find('li:nth-child(5)').should('contain', 'Dimensions');
-      cy.get('@info').find('li:nth-child(5)').should('contain', '933×1400 Pixel');
+      cy.get("@info").find("li:nth-child(5)").should("contain", "Dimensions");
+      cy.get("@info")
+        .find("li:nth-child(5)")
+        .should("contain", "933×1400 Pixel");
 
-      cy.get('@info').find('li:nth-child(6)').should('contain', 'Orientation');
-      cy.get('@info').find('li:nth-child(6)').should('contain', 'Portrait');
+      cy.get("@info").find("li:nth-child(6)").should("contain", "Orientation");
+      cy.get("@info").find("li:nth-child(6)").should("contain", "Portrait");
 
       // Preview Button
-      cy.get('.k-header [data-position="left"] > .k-button-group > :nth-child(1)').as('preview');
+      cy.get(
+        '.k-header [data-position="left"] > .k-button-group > :nth-child(1)'
+      ).as("preview");
 
-      cy.get('@preview').should('have.attr', 'target', '_blank');
-      cy.get('@preview').invoke('attr', 'href').should('contain', Cypress.config().baseUrl + '/media/pages/photography/trees');
+      cy.get("@preview").should("have.attr", "target", "_blank");
+      cy.get("@preview")
+        .invoke("attr", "href")
+        .should(
+          "contain",
+          Cypress.config().baseUrl + "/media/pages/photography/trees"
+        );
     });
 
-    it('should be renamed', () => {
+    it("should be renamed", () => {
       // open settings
-      cy.get('.k-headline-editable').click();
+      cy.get(".k-headline-editable").click();
 
-      dialog().find('input[name="name"]').type('trees');
-      dialog().find('form').submit();
+      dialog().find('input[name="name"]').type("trees");
+      dialog().find("form").submit();
 
-      cy.url().should('contain', '/pages/photography+trees/files/trees.jpg');
+      cy.url().should("contain", "/pages/photography+trees/files/trees.jpg");
     });
 
-    it('should be deleted', () => {
-
+    it("should be deleted", () => {
       // open settings
-      cy.get('.k-header [data-position=left] .k-button-group:first-child :nth-child(2) .k-button').click();
-      cy.get('.k-header [data-position=left] .k-dropdown-content .k-button:last-child').click();
+      cy.get(
+        ".k-header [data-position=left] .k-button-group:first-child :nth-child(2) .k-button"
+      ).click();
+      cy.get(
+        ".k-header [data-position=left] .k-dropdown-content .k-button:last-child"
+      ).click();
 
-      dialog().find('.k-dialog-button-submit').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/panel/pages/photography+trees');
+      dialog().find(".k-dialog-button-submit").click();
+      cy.url().should(
+        "eq",
+        Cypress.config().baseUrl + "/panel/pages/photography+trees"
+      );
     });
-
   });
-
 });

--- a/panel/src/components/Views/PageView.spec.js
+++ b/panel/src/components/Views/PageView.spec.js
@@ -1,81 +1,92 @@
 const dialog = () => {
-  return cy.get('.k-dialog');
+  return cy.get(".k-dialog");
 };
 
-describe('PageView', () => {
-
+describe("PageView", () => {
   before(() => {
-    cy.visit('/env/install/starterkit');
-    cy.visit('/env/user/test');
+    cy.visit("/env/install/starterkit");
+    cy.visit("/env/user/test");
   });
 
   beforeEach(() => {
-    cy.visit('/env/auth/test');
+    cy.visit("/env/auth/test");
   });
 
-  describe('Photography', () => {
-
+  describe("Photography", () => {
     beforeEach(() => {
-      cy.visit('/panel/pages/photography');
-      cy.get('.k-section-name-drafts').as('drafts');
-      cy.get('.k-section-name-listed').as('listed');
+      cy.visit("/panel/pages/photography");
+      cy.get(".k-section-name-drafts").as("drafts");
+      cy.get(".k-section-name-listed").as("listed");
     });
 
-    it('should display correctly', () => {
+    it("should display correctly", () => {
       // Title
-      cy.get('.k-headline-editable').should('contain', 'Photography');
-      cy.get('.k-topbar-crumbs a:last-child').should('contain', 'Photography');
+      cy.get(".k-headline-editable").should("contain", "Photography");
+      cy.get(".k-topbar-breadcrumb a:last-child").should(
+        "contain",
+        "Photography"
+      );
 
       // Buttons
-      cy.get('.k-header-buttons .k-button-group:first-child .k-button:first-child').as('button')
-      cy.get('@button').should('have.attr', 'target', '_blank');
-      cy.get('@button').should('have.attr', 'href', Cypress.config().baseUrl + '/photography');
+      cy.get(
+        ".k-header-buttons .k-button-group:first-child .k-button:first-child"
+      ).as("button");
+      cy.get("@button").should("have.attr", "target", "_blank");
+      cy.get("@button").should(
+        "have.attr",
+        "href",
+        Cypress.config().baseUrl + "/photography"
+      );
 
-      cy.get('.k-header-buttons .k-button-group:first-child .k-status-icon').should('contain', 'Public');
+      cy.get(
+        ".k-header-buttons .k-button-group:first-child .k-status-icon"
+      ).should("contain", "Public");
 
       // Drafts
-      cy.get('@drafts').find('.k-headline').should('contain', 'Drafts');
+      cy.get("@drafts").find(".k-headline").should("contain", "Drafts");
 
       // Published Albums
-      cy.get('@listed').find('.k-headline').should('contain', 'Published Albums');
+      cy.get("@listed")
+        .find(".k-headline")
+        .should("contain", "Published Albums");
     });
 
-    it('should create draft', () => {
-      cy.get('@drafts').find('.k-section-header .k-button').click();
+    it("should create draft", () => {
+      cy.get("@drafts").find(".k-section-header .k-button").click();
 
-      dialog().find('input[name=title]').type('Portraits');
-      dialog().find('form').submit();
+      dialog().find("input[name=title]").type("Portraits");
+      dialog().find("form").submit();
 
-      cy.url().should('contain', '/pages/photography+portraits');
-      cy.get('.k-headline-editable').should('contain', 'Portraits');
-      cy.get('.k-status-icon').should('contain', 'Draft');
+      cy.url().should("contain", "/pages/photography+portraits");
+      cy.get(".k-headline-editable").should("contain", "Portraits");
+      cy.get(".k-status-icon").should("contain", "Draft");
     });
 
-    it('should publish draft', () => {
-      cy.get('@drafts').find('.k-card').should('have.length', 2);
-      cy.get('@listed').find('.k-card').should('have.length', 8);
+    it("should publish draft", () => {
+      cy.get("@drafts").find(".k-card").should("have.length", 2);
+      cy.get("@listed").find(".k-card").should("have.length", 8);
 
-      cy.get('@drafts').find('.k-card:first-child .k-status-icon').click();
+      cy.get("@drafts").find(".k-card:first-child .k-status-icon").click();
 
-      dialog().find('.k-radio-input li:last-child label').click();
-      dialog().find('form').submit();
+      dialog().find(".k-radio-input li:last-child label").click();
+      dialog().find("form").submit();
 
-      cy.get('@drafts').find('.k-card').should('have.length', 1);
-      cy.get('@listed').find('.k-card').should('have.length', 9);
+      cy.get("@drafts").find(".k-card").should("have.length", 1);
+      cy.get("@listed").find(".k-card").should("have.length", 9);
     });
 
-    it('should delete draft', () => {
-      cy.get('@drafts').as('draft');
-      cy.get('@drafts').find('.k-card').should('have.length', 1);
+    it("should delete draft", () => {
+      cy.get("@drafts").as("draft");
+      cy.get("@drafts").find(".k-card").should("have.length", 1);
 
-      cy.get('@draft').find('.k-card-options-button:last-child').click();
-      cy.get('@draft').find('.k-card-options-dropdown .k-button:last-child').click();
+      cy.get("@draft").find(".k-card-options-button:last-child").click();
+      cy.get("@draft")
+        .find(".k-card-options-dropdown .k-button:last-child")
+        .click();
 
-      dialog().find('.k-dialog-button-submit').click();
+      dialog().find(".k-dialog-button-submit").click();
 
-      cy.get('@drafts').find('.k-card').should('have.length', 0);
+      cy.get("@drafts").find(".k-card").should("have.length", 0);
     });
-
   });
-
 });

--- a/panel/src/components/Views/SiteView.spec.js
+++ b/panel/src/components/Views/SiteView.spec.js
@@ -1,44 +1,47 @@
-describe('SiteView', () => {
-
+describe("SiteView", () => {
   before(() => {
-    cy.visit('/env/install/minimal');
-    cy.visit('/env/user/test');
+    cy.visit("/env/install/minimal");
+    cy.visit("/env/user/test");
   });
 
   beforeEach(() => {
-    cy.visit('/env/auth/test');
+    cy.visit("/env/auth/test");
   });
 
-  it('should redirect to /site', () => {
-    cy.visit('/panel/');
-    cy.url().should('include', '/site');
+  it("should redirect to /site", () => {
+    cy.visit("/panel/");
+    cy.url().should("include", "/site");
   });
 
-  it('should be active in menu', () => {
-    cy.visit('/panel/site');
-    cy.get('.k-topbar-menu-button').click();
-    cy.get('.k-topbar-menu li:first-child').should('have.attr', 'aria-current', 'true');
+  it("should be active in menu", () => {
+    cy.visit("/panel/site");
+    cy.get(".k-topbar-menu-button").click();
+    cy.get(".k-topbar-menu a:first-child").should(
+      "have.attr",
+      "aria-current",
+      "true"
+    );
   });
 
-  it('should have site title', () => {
-    cy.visit('/panel/site');
-    cy.get('.k-headline-editable').should('contain', 'Test');
-    cy.get('.k-topbar-view-button').should('contain', 'Test');
+  it("should have site title", () => {
+    cy.visit("/panel/site");
+    cy.get(".k-headline-editable").should("contain", "Test");
+    cy.get(".k-topbar-breadcrumb a:first-child").should("contain", "Test");
   });
 
-  it('should update site title', () => {
-    cy.visit('/panel/site');
-    cy.get('.k-headline-editable').click();
-    cy.get('.k-dialog input[name="title"]').type('My Site');
-    cy.get('.k-dialog form').submit();
-    cy.get('.k-headline-editable').should('contain', 'My Site');
-    cy.get('.k-topbar-view-button').should('contain', 'My Site');
+  it("should update site title", () => {
+    cy.visit("/panel/site");
+    cy.get(".k-headline-editable").click();
+    cy.get('.k-dialog input[name="title"]').type("My Site");
+    cy.get(".k-dialog form").submit();
+    cy.get(".k-headline-editable").should("contain", "My Site");
+    cy.get(".k-topbar-breadcrumb a:first-child").should("contain", "My Site");
   });
 
-  it('should have working preview button', () => {
-    cy.visit('/panel/site');
-    cy.get('.k-header-buttons .k-button').as('button')
-    cy.get('@button').should('have.attr', 'target', '_blank');
-    cy.get('@button').should('have.attr', 'href', Cypress.config().baseUrl);
+  it("should have working preview button", () => {
+    cy.visit("/panel/site");
+    cy.get(".k-header-buttons .k-button").as("button");
+    cy.get("@button").should("have.attr", "target", "_blank");
+    cy.get("@button").should("have.attr", "href", Cypress.config().baseUrl);
   });
 });

--- a/panel/src/components/Views/UsersView.spec.js
+++ b/panel/src/components/Views/UsersView.spec.js
@@ -1,63 +1,67 @@
-describe('UsersView', () => {
-
+describe("UsersView", () => {
   before(() => {
-    cy.visit('/env/install/roles');
-    cy.visit('/env/user/test');
+    cy.visit("/env/install/roles");
+    cy.visit("/env/user/test");
   });
 
   beforeEach(() => {
-    cy.visit('/env/auth/test');
-    cy.visit('/panel/users');
-    cy.get('.k-users-view .k-collection').as('users');
+    cy.visit("/env/auth/test");
+    cy.visit("/panel/users");
+    cy.get(".k-users-view .k-collection").as("users");
   });
 
-  it('should display correctly', () => {
-    cy.get('.k-topbar-menu-button').click();
-    cy.get('.k-topbar-menu li:nth-child(3)').should('have.attr', 'aria-current', 'true');
+  it("should display correctly", () => {
+    cy.get(".k-topbar-menu-button").click();
+    cy.get(".k-topbar-menu a:nth-child(3)").should(
+      "have.attr",
+      "aria-current",
+      "true"
+    );
 
-    cy.get('.k-headline').should('contain', 'Users');
-    cy.get('.k-topbar-view-button').should('contain', 'Users');
+    cy.get(".k-headline").should("contain", "Users");
+    cy.get(".k-topbar-breadcrumb a:first-child").should("contain", "Users");
 
-    cy.get('@users').should('have.attr', 'data-layout', 'list');
-    cy.get('@users').find('li').should('have.length', 1);
-    cy.get('@users').find('li:first-child').should('contain', 'test@getkirby.com');
-    cy.get('@users').find('li:first-child').should('contain', 'Admin');
+    cy.get("@users").should("have.attr", "data-layout", "list");
+    cy.get("@users").find("li").should("have.length", 1);
+    cy.get("@users")
+      .find("li:first-child")
+      .should("contain", "test@getkirby.com");
+    cy.get("@users").find("li:first-child").should("contain", "Admin");
   });
 
-  describe('UserCreateDialog', () => {
-
+  describe("UserCreateDialog", () => {
     beforeEach(() => {
-      cy.get('.k-header-buttons .k-button-group:first-child > .k-button:first-child').click();
-      cy.get('.k-dialog').as('dialog');
+      cy.get(
+        ".k-header-buttons .k-button-group:first-child > .k-button:first-child"
+      ).click();
+      cy.get(".k-dialog").as("dialog");
     });
 
-    it('should create admin', () => {
-      cy.get('@dialog').find('input[name="name"]').type('Ada');
-      cy.get('@dialog').find('input[name="email"]').type('ada@getkirby.com');
-      cy.get('@dialog').find('input[name="password"]').type('top-secret-1234');
-      cy.get('@dialog').find('form').submit();
+    it("should create admin", () => {
+      cy.get("@dialog").find('input[name="name"]').type("Ada");
+      cy.get("@dialog").find('input[name="email"]').type("ada@getkirby.com");
+      cy.get("@dialog").find('input[name="password"]').type("top-secret-1234");
+      cy.get("@dialog").find("form").submit();
 
-      cy.get('@users').find('li').should('have.length', 2);
+      cy.get("@users").find("li").should("have.length", 2);
       // @todo the order of the users in the list is non-deterministic;
       // cannot reliably test the order and if the role is in the same line as the name
-      cy.get('@users').find('li.k-list-item').should('contain', 'Ada');
-      cy.get('@users').find('li.k-list-item').should('contain', 'Admin');
+      cy.get("@users").find("li.k-list-item").should("contain", "Ada");
+      cy.get("@users").find("li.k-list-item").should("contain", "Admin");
     });
 
-    it('should create editor', () => {
-      cy.get('@dialog').find('input[name="name"]').type('Grace');
-      cy.get('@dialog').find('input[name="email"]').type('grace@getkirby.com');
-      cy.get('@dialog').find('input[name="password"]').type('top-secret-1234');
-      cy.get('@dialog').find('.k-radio-input li:last-child label').click();
-      cy.get('@dialog').find('form').submit();
+    it("should create editor", () => {
+      cy.get("@dialog").find('input[name="name"]').type("Grace");
+      cy.get("@dialog").find('input[name="email"]').type("grace@getkirby.com");
+      cy.get("@dialog").find('input[name="password"]').type("top-secret-1234");
+      cy.get("@dialog").find(".k-radio-input li:last-child label").click();
+      cy.get("@dialog").find("form").submit();
 
-      cy.get('@users').find('li').should('have.length', 3);
+      cy.get("@users").find("li").should("have.length", 3);
       // @todo the order of the users in the list is non-deterministic;
       // cannot reliably test the order and if the role is in the same line as the name
-      cy.get('@users').find('li.k-list-item').should('contain', 'Grace');
-      cy.get('@users').find('li.k-list-item').should('contain', 'Editor');
+      cy.get("@users").find("li.k-list-item").should("contain", "Grace");
+      cy.get("@users").find("li.k-list-item").should("contain", "Editor");
     });
-
   });
-
 });

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -71,7 +71,6 @@ import FormDrawer from "@/components/Drawers/FormDrawer.vue";
 Vue.component("k-drawer", Drawer);
 Vue.component("k-form-drawer", FormDrawer);
 
-
 /* Form */
 import Autocomplete from "@/components/Forms/Autocomplete.vue";
 import Calendar from "@/components/Forms/Calendar.vue";
@@ -307,6 +306,7 @@ Vue.component("k-text", Text);
 Vue.component("k-user-info", UserInfo);
 
 /* Navigation */
+import Breadcrumb from "@/components/Navigation/Breadcrumb.vue";
 import Button from "@/components/Navigation/Button.vue";
 import ButtonDisabled from "@/components/Navigation/ButtonDisabled.vue";
 import ButtonGroup from "@/components/Navigation/ButtonGroup.vue";
@@ -323,6 +323,7 @@ import Search from "@/components/Navigation/Search.vue";
 import Tag from "@/components/Navigation/Tag.vue";
 import Topbar from "@/components/Navigation/Topbar.vue";
 
+Vue.component("k-breadcrumb", Breadcrumb);
 Vue.component("k-button", Button);
 Vue.component("k-button-disabled", ButtonDisabled);
 Vue.component("k-button-group", ButtonGroup);


### PR DESCRIPTION
## Status: ready for review 👀
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Adds new `k-breadcrumb` component
- Topbar menu gets passed as option array to `k-dropdown-content` instead of recreating the component structure
- Loading indicator moves to first icon of breadcrumb


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

_None_

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_

## Performance

**Before PR**
dist/css/style.css   94.01kb / brotli: 13.89kb
dist/js/index.js     350.54kb / brotli: 64.20kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

**After PR**
dist/css/style.css   93.70kb / brotli: 13.86kb
dist/js/index.js     350.33kb / brotli: 64.14kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
