### PR TITLE
Fix error in model views without blueprint #3398

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -498,7 +498,7 @@
   "url.placeholder": "https://example.com",
 
   "user": "User",
-  "user.blueprint": "You can define additional sections and form fields for this user role in <strong>/site/blueprints/users/{role}.yml</strong>",
+  "user.blueprint": "You can define additional sections and form fields for this user role in <strong>/site/blueprints/{blueprint}.yml</strong>",
   "user.changeEmail": "Change email",
   "user.changeLanguage": "Change language",
   "user.changeName": "Rename this user",

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -11,7 +11,7 @@
 <script>
 /**
  * The box component is a multi-purpose box with text. You can use it as a foundation for empty state displays or anything else that needs to be displayed in a box. It comes with several pre-defined styles …
- * 
+ *
  * @example <k-box text="This is a nice box" theme="positive" />
  */
 export default {
@@ -84,7 +84,7 @@ export default {
   padding: .5rem 1.5rem;
 }
 .k-box[data-theme="info"] {
-  background: var(--color-focus-300);
+  background: var(--color-blue-200);
   border: 0;
   border-left: 2px solid var(--color-focus-light);
   padding: .5rem 1.5rem;

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -22,7 +22,9 @@ export default {
     tab: {
       type: Object,
       default() {
-        return {}
+        return {
+          columns: []
+        };
       }
     },
     tabs: {

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -99,7 +99,7 @@
 
         <k-sections
           :blueprint="blueprint"
-          :empty="$t('user.blueprint', { role: model.role.name })"
+          :empty="$t('user.blueprint', { blueprint: blueprint })"
           :lock="lock"
           :parent="'users/' + model.id"
           :tab="tab"

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -329,7 +329,11 @@ abstract class Model
         $tabs      = $blueprint->tabs();
 
         if (!$tab = $blueprint->tab(get('tab'))) {
-            $tab = $tabs[0] ?? [];
+            $tab = $tabs[0] ?? [
+                // A missing blueprint should still
+                // be returned as a valid object
+                'columns' => []
+            ];
         }
 
         return [

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -327,22 +327,23 @@ abstract class Model
     {
         $blueprint = $this->model->blueprint();
         $tabs      = $blueprint->tabs();
+        $tab       = $blueprint->tab(get('tab')) ?? $tabs[0] ?? null;
 
-        if (!$tab = $blueprint->tab(get('tab'))) {
-            $tab = $tabs[0] ?? [
-                // A missing blueprint should still
-                // be returned as a valid object
-                'columns' => []
-            ];
-        }
-
-        return [
+        $props = [
             'blueprint'   => $blueprint->name(),
             'lock'        => $this->lock(),
             'permissions' => $this->model->permissions()->toArray(),
-            'tab'         => $tab,
             'tabs'        => $tabs,
         ];
+
+        // only send the tab if it exists
+        // this will let the vue component define
+        // a proper default value
+        if ($tab) {
+            $props['tab'] = $tab;
+        }
+
+        return $props;
     }
 
     /**

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -39,7 +39,7 @@ class SiteTest extends AreaTestCase
         $this->assertSame('Page', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
-        $this->assertSame([], $props['tab']);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertSame([], $props['tabs']);
 
         // model
@@ -92,7 +92,7 @@ class SiteTest extends AreaTestCase
         $this->assertSame('File', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
-        $this->assertSame([], $props['tab']);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertSame([], $props['tabs']);
 
         // model
@@ -155,7 +155,7 @@ class SiteTest extends AreaTestCase
         $this->assertSame('File', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
-        $this->assertSame([], $props['tab']);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertSame([], $props['tabs']);
 
         // model

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -720,7 +720,7 @@ class FileTest extends TestCase
         $this->assertArrayHasKey('blueprint', $props);
         $this->assertArrayHasKey('lock', $props);
         $this->assertArrayHasKey('permissions', $props);
-        $this->assertArrayHasKey('tab', $props);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertArrayHasKey('tabs', $props);
     }
 

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -494,7 +494,7 @@ class PageTest extends TestCase
         $this->assertArrayHasKey('blueprint', $props);
         $this->assertArrayHasKey('lock', $props);
         $this->assertArrayHasKey('permissions', $props);
-        $this->assertArrayHasKey('tab', $props);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertArrayHasKey('tabs', $props);
 
         $this->assertNull($props['next']());

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -303,7 +303,7 @@ class UserTest extends TestCase
         $this->assertArrayHasKey('blueprint', $props);
         $this->assertArrayHasKey('lock', $props);
         $this->assertArrayHasKey('permissions', $props);
-        $this->assertArrayHasKey('tab', $props);
+        $this->assertArrayNotHasKey('tab', $props);
         $this->assertArrayHasKey('tabs', $props);
 
         $this->assertNull($props['next']());


### PR DESCRIPTION
## Describe the PR

When a model has no blueprint (i.e. a user or file) the model view would break because it expects certain parts from the tab object. This is now fixed by not sending the tab object in those cases at all. The ModelView can then define a proper default to work with. 

## Related issues/ideas
- Fixes #3398 

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
