### PR TITLE
`Str::contains`: use `strpos` instead

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -250,7 +250,7 @@ class Str
      */
     public static function contains(string $string = null, string $needle, bool $caseInsensitive = false): bool
     {
-        return call_user_func($caseInsensitive === true ? 'stristr' : 'strstr', $string, $needle) !== false;
+        return call_user_func($caseInsensitive === true ? 'stripos' : 'strpos', $string, $needle) !== false;
     }
 
     /**


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.strstr.php

> If you only want to determine if a particular needle occurs within haystack, use the faster and less memory intensive function strpos() instead.