### PR TITLE
Simplified Panel class methods (Panel class refactoring part 2)

### DIFF
--- a/config/areas/site.php
+++ b/config/areas/site.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kirby\Panel\Panel;
+use Kirby\Cms\Find;
 
 return function ($kirby) {
     return [
@@ -13,26 +13,26 @@ return function ($kirby) {
         'routes' => [
             [
                 'pattern' => 'pages/(:any)',
-                'action'  => function (string $path) use ($kirby) {
-                    return Panel::page($path)->panel()->route();
+                'action'  => function (string $path) {
+                    return Find::page($path)->panel()->route();
                 }
             ],
             [
                 'pattern' => 'pages/(:any)/files/(:any)',
-                'action'  => function (string $id, string $filename) use ($kirby) {
-                    return Panel::file('pages/' . $id, $filename)->panel()->route();
+                'action'  => function (string $id, string $filename) {
+                    return Find::file('pages/' . $id, $filename)->panel()->route();
                 }
             ],
             [
                 'pattern' => 'site',
-                'action'  => function () use ($kirby) {
-                    return $kirby->site()->panel()->route();
+                'action'  => function () {
+                    return site()->panel()->route();
                 }
             ],
             [
                 'pattern' => 'site/files/(:any)',
-                'action'  => function (string $filename) use ($kirby) {
-                    return Panel::file('site', $filename)->panel()->route();
+                'action'  => function (string $filename) {
+                    return Find::file('site', $filename)->panel()->route();
                 }
             ],
 

--- a/config/areas/users.php
+++ b/config/areas/users.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kirby\Panel\Panel;
+use Kirby\Cms\Find;
 
 return function ($kirby) {
     return [
@@ -64,21 +64,14 @@ return function ($kirby) {
             ],
             [
                 'pattern' => 'users/(:any)',
-                'action'  => function (string $id) use ($kirby) {
-                    return Panel::user($id)->panel()->route();
+                'action'  => function (string $id) {
+                    return Find::user($id)->panel()->route();
                 }
             ],
             [
                 'pattern' => 'users/(:any)/files/(:any)',
-                'action'  => function (string $id, string $filename) use ($kirby) {
-                    $user     = Panel::user($id);
-                    $filename = urldecode($filename);
-
-                    if (!$file = $user->file($filename)) {
-                        return t('error.file.undefined');
-                    }
-
-                    return $file->panel()->route();
+                'action'  => function (string $id, string $filename) {
+                    return Find::file('users/' . $id, $filename)->panel()->route();
                 }
             ],
         ]

--- a/config/routes.php
+++ b/config/routes.php
@@ -97,8 +97,8 @@ return function ($kirby) {
             'pattern' => $panel . '/(:all?)',
             'method'  => 'ALL',
             'env'     => 'panel',
-            'action'  => function ($path = null) use ($kirby) {
-                return Panel::router($kirby, $path);
+            'action'  => function ($path = null) {
+                return Panel::router($path);
             }
         ],
     ];

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -3,8 +3,8 @@
 namespace Kirby\Cms;
 
 use Kirby\Api\Api as BaseApi;
+use Kirby\Exception\NotFoundException;
 use Kirby\Form\Form;
-use Kirby\Panel\Panel;
 
 /**
  * Api
@@ -79,7 +79,7 @@ class Api extends BaseApi
      */
     public function file(string $path = null, string $filename)
     {
-        return Panel::file($path, $filename);
+        return Find::file($path, $filename);
     }
 
     /**
@@ -92,7 +92,7 @@ class Api extends BaseApi
      */
     public function parent(string $path)
     {
-        return Panel::parent($path);
+        return Find::parent($path);
     }
 
     /**
@@ -124,7 +124,7 @@ class Api extends BaseApi
      */
     public function page(string $id)
     {
-        return Panel::page($id);
+        return Find::page($id);
     }
 
     /**
@@ -220,7 +220,15 @@ class Api extends BaseApi
      */
     public function user(string $id = null)
     {
-        return Panel::user($id);
+        try {
+            return Find::user($id);
+        } catch (NotFoundException $e) {
+            if ($id === null) {
+                return null;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
+use Kirby\Toolkit\Str;
+
+/**
+ * The Find class is used in the API and
+ * the Panel to find models and parents
+ * based on request paths
+ *
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier GmbH
+ * @license   https://getkirby.com/license
+ */
+class Find
+{
+    /**
+     * Returns the file object for the given
+     * parent path and filename
+     *
+     * @param string|null $path Path to file's parent model
+     * @param string $filename Filename
+     * @return \Kirby\Cms\File|null
+     * @throws \Kirby\Exception\NotFoundException if the file cannot be found
+     */
+    public static function file(string $path = null, string $filename)
+    {
+        $filename = urldecode($filename);
+        $file     = static::parent($path)->file($filename);
+
+        if ($file && $file->isReadable() === true) {
+            return $file;
+        }
+
+        throw new NotFoundException([
+            'key'  => 'file.notFound',
+            'data' => [
+                'filename' => $filename
+            ]
+        ]);
+    }
+
+    /**
+     * Returns the page object for the given id
+     *
+     * @param string $id Page's id
+     * @return \Kirby\Cms\Page|null
+     * @throws \Kirby\Exception\NotFoundException if the page cannot be found
+     */
+    public static function page(string $id)
+    {
+        $id   = str_replace('+', '/', $id);
+        $page = App::instance()->page($id);
+
+        if ($page && $page->isReadable() === true) {
+            return $page;
+        }
+
+        throw new NotFoundException([
+            'key'  => 'page.notFound',
+            'data' => [
+                'slug' => $id
+            ]
+        ]);
+    }
+
+    /**
+     * Returns the model's object for the given path
+     *
+     * @param string $path Path to parent model
+     * @return \Kirby\Cms\Model|null
+     * @throws \Kirby\Exception\InvalidArgumentException if the model type is invalid
+     * @throws \Kirby\Exception\NotFoundException if the model cannot be found
+     */
+    public static function parent(string $path)
+    {
+        $modelType  = in_array($path, ['site', 'account']) ? $path : trim(dirname($path), '/');
+        $modelTypes = [
+            'site'    => 'site',
+            'users'   => 'user',
+            'pages'   => 'page',
+            'account' => 'account'
+        ];
+
+        $modelName = $modelTypes[$modelType] ?? null;
+
+        if (Str::endsWith($modelType, '/files') === true) {
+            $modelName = 'file';
+        }
+
+        $kirby = App::instance();
+
+        switch ($modelName) {
+            case 'site':
+                $model = $kirby->site();
+                break;
+            case 'account':
+                $model = static::user();
+                break;
+            case 'page':
+                $model = static::page(basename($path));
+                break;
+            case 'file':
+                $model = static::file(...explode('/files/', $path));
+                break;
+            case 'user':
+                $model = $kirby->user(basename($path));
+                break;
+            default:
+                throw new InvalidArgumentException('Invalid model type: ' . $modelType);
+        }
+
+        if ($model) {
+            return $model;
+        }
+
+        throw new NotFoundException([
+            'key' => $modelName . '.undefined'
+        ]);
+    }
+
+    /**
+     * Returns the user object for the given id or
+     * returns the current authenticated user if no
+     * id is passed
+     *
+     * @param string|null $id User's id
+     * @return \Kirby\Cms\User|null
+     * @throws \Kirby\Exception\NotFoundException if the user for the given id cannot be found
+     */
+    public static function user(string $id = null)
+    {
+        $kirby = App::instance();
+
+        // get the authenticated user
+        if ($id === null) {
+            if ($user = $kirby->user(null, $kirby->option('api.allowImpersonation', false))) {
+                return $user;
+            }
+
+            throw new NotFoundException([
+                'key' => 'user.undefined'
+            ]);
+        }
+
+        // get a specific user by id
+        if ($user = $kirby->user($id)) {
+            return $user;
+        }
+
+        throw new NotFoundException([
+            'key'  => 'user.notFound',
+            'data' => [
+                'name' => $id
+            ]
+        ]);
+    }
+}

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -3,7 +3,6 @@
 namespace Kirby\Panel;
 
 use Exception;
-use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\PermissionException;
 use Kirby\Http\Request;
@@ -32,6 +31,13 @@ use Throwable;
 class Panel
 {
     /**
+     * Kirby singleton
+     *
+     * @var \Kirby\Cms\App
+     */
+    public static $kirby;
+
+    /**
      * Normalize a panel area
      *
      * @param string $id
@@ -55,11 +61,11 @@ class Panel
     /**
      * Collect all registered areas
      *
-     * @param \Kirby\Cms\App $kirby
      * @return array
      */
-    public static function areas(App $kirby): array
+    public static function areas(): array
     {
+        $kirby  = kirby();
         $root   = $kirby->root('kirby') . '/config/areas';
         $system = $kirby->system();
         $user   = $kirby->user();
@@ -100,11 +106,12 @@ class Panel
      * Generates an array with all assets
      * that need to be loaded for the panel (js, css, icons)
      *
-     * @param \Kirby\Cms\App $kirby
      * @return array
      */
-    public static function assets(App $kirby): array
+    public static function assets(): array
     {
+        $kirby = kirby();
+
         // get the assets from the Vite dev server in dev mode;
         // dev mode = explicitly enabled in the config AND Vite is running
         $dev   = $kirby->option('panel.dev', false);
@@ -181,12 +188,11 @@ class Panel
      * Check for a custom css file from the
      * config (panel.css)
      *
-     * @param \Kirby\Cms\App $kirby
      * @return string|null
      */
-    public static function customCss(App $kirby): ?string
+    public static function customCss(): ?string
     {
-        if ($css = $kirby->option('panel.css')) {
+        if ($css = kirby()->option('panel.css')) {
             $asset = asset($css);
 
             if ($asset->exists() === true) {
@@ -201,12 +207,11 @@ class Panel
      * Check for a custom js file from the
      * config (panel.js)
      *
-     * @param \Kirby\Cms\App $kirby
      * @return string|null
      */
-    public static function customJs(App $kirby): ?string
+    public static function customJs(): ?string
     {
-        if ($js = $kirby->option('panel.js')) {
+        if ($js = kirby()->option('panel.js')) {
             $asset = asset($js);
 
             if ($asset->exists() === true) {
@@ -220,12 +225,13 @@ class Panel
     /**
      * Creates data array for Fiber and the component
      *
-     * @param \Kirby\Cms\App $kirby
      * @param array $data
      * @return array
      */
-    public static function data(App $kirby, array $data = []): array
+    public static function data(array $data = []): array
     {
+        $kirby = kirby();
+
         // multilang setup check
         $multilang = $kirby->option('languages', false) !== false;
 
@@ -283,17 +289,16 @@ class Panel
     /**
      * Renders the error view with provided message
      *
-     * @param \Kirby\Cms\App $kirby
      * @param string $message
      * @return \Kirby\Http\Response
      */
-    public static function error(App $kirby, string $message)
+    public static function error(string $message)
     {
         return [
             'component' => 'k-error-view',
             'props'     => [
                 'error'  => $message,
-                'layout' => Panel::hasAccess($kirby->user()) ? 'inside' : 'outside'
+                'layout' => static::hasAccess(kirby()->user()) ? 'inside' : 'outside'
             ],
             'title' => 'Error'
         ];
@@ -302,18 +307,17 @@ class Panel
     /**
      * Creates $fiber response array
      *
-     * @param \Kirby\Cms\App $kirby
      * @param string $component
      * @param array $data
      * @return array
      */
-    public static function fiber(App $kirby, string $component, array $data = []): array
+    public static function fiber(string $component, array $data = []): array
     {
         // get all data for the request
-        $data = static::data($kirby, $data);
+        $data = static::data($data);
 
         // filter data, if it's a partial request
-        $data = static::partial($kirby, $component, $data);
+        $data = static::partial($component, $data);
 
         // resolve lazy data entries
         return A::apply($data);
@@ -368,11 +372,12 @@ class Panel
      * It can be loaded partially later if needed,
      * but is otherwise not included in Fiber calls.
      *
-     * @param \Kirby\Cms\App $kirby
      * @return array
      */
-    public static function globals(App $kirby): array
+    public static function globals(): array
     {
+        $kirby = kirby();
+
         return [
             '$config' => function () use ($kirby) {
                 return [
@@ -434,7 +439,8 @@ class Panel
      */
     public static function go(?string $path = null): void
     {
-        $url = url(option('panel.slug', 'panel') . '/' . trim($path, '/'));
+        $slug = kirby()->option('panel.slug', 'panel');
+        $url  = url($slug . '/' . trim($path, '/'));
         throw new Redirect($url);
     }
 
@@ -461,23 +467,23 @@ class Panel
      * This will be injected in the
      * initial HTML document for the Panel
      *
-     * @param \Kirby\Cms\App $kirby
      * @return string
      */
-    public static function icons(App $kirby): string
+    public static function icons(): string
     {
-        return F::read($kirby->root('kirby') . '/panel/dist/img/icons.svg');
+        return F::read(kirby()->root('kirby') . '/panel/dist/img/icons.svg');
     }
 
     /**
      * Checks for a Fiber request
      * via get parameters or headers
      *
-     * @param \Kirby\Http\Request $request
      * @return bool
      */
-    public static function isFiberRequest(Request $request): bool
+    public static function isFiberRequest(): bool
     {
+        $request = kirby()->request();
+
         if ($request->method() === 'GET') {
             return (bool)($request->get('_json') ?? $request->header('X-Fiber'));
         }
@@ -489,12 +495,12 @@ class Panel
      * Links all dist files in the media folder
      * and returns the link to the requested asset
      *
-     * @param \Kirby\Cms\App $kirby
      * @return bool
      * @throws \Exception If Panel assets could not be moved to the public directory
      */
-    public static function link(App $kirby): bool
+    public static function link(): bool
     {
+        $kirby       = kirby();
         $mediaRoot   = $kirby->root('media') . '/panel';
         $panelRoot   = $kirby->root('panel') . '/dist';
         $versionHash = $kirby->versionHash();
@@ -524,14 +530,14 @@ class Panel
      * entries requested via a Fiber partial
      * request (or the whole array if full request).
      *
-     * @param \Kirby\Cms\App $kirby
      * @param string $component
      * @param array $data
      * @return array
      */
-    public static function partial(App $kirby, string $component, array $data): array
+    public static function partial(string $component, array $data): array
     {
         // is it a partial request?
+        $kirby            = kirby();
         $request          = $kirby->request();
         $requestInclude   = $request->header('X-Fiber-Include')   ?? get('_include');
         $requestComponent = $request->header('X-Fiber-Component') ?? get('_component');
@@ -556,7 +562,7 @@ class Panel
 
         // check if globals are requested and need to be merged
         if (Str::contains($requestInclude, '$')) {
-            $data = array_merge_recursive(static::globals($kirby), $data);
+            $data = array_merge_recursive(static::globals(), $data);
         }
 
         // make sure the data is already resolved to make
@@ -574,18 +580,19 @@ class Panel
     /**
      * Renders the main panel view
      *
-     * @param \Kirby\Cms\App $kirby
      * @param string $component
      * @param array $data
      * @return \Kirby\Http\Response
      */
-    public static function render(App $kirby, string $component, array $data)
+    public static function render(string $component, array $data)
     {
+        $kirby = kirby();
+
         // get $fiber response array
-        $fiber = static::fiber($kirby, $component, $data);
+        $fiber = static::fiber($component, $data);
 
         // if requested, send $fiber data as JSON
-        if (static::isFiberRequest($kirby->request()) === true) {
+        if (static::isFiberRequest() === true) {
             return Response::json($fiber, null, get('_pretty'), [
                 'Vary'    => 'Accept',
                 'X-Fiber' => 'true'
@@ -594,7 +601,7 @@ class Panel
 
         // Full HTML response
         try {
-            if (static::link($kirby) === true) {
+            if (static::link() === true) {
                 usleep(1);
                 go($kirby->url('index') . '/' . $kirby->path());
             }
@@ -606,7 +613,7 @@ class Panel
         $uri = new Uri($url = $kirby->url('panel'));
 
         // inject globals
-        $globals = static::globals($kirby);
+        $globals = static::globals();
         $fiber   = array_merge_recursive(A::apply($globals), $fiber);
 
         // fetch all plugins
@@ -614,8 +621,8 @@ class Panel
 
         return new Response(
             Tpl::load($kirby->root('kirby') . '/views/panel.php', [
-                'assets'   => static::assets($kirby),
-                'icons'    => static::icons($kirby),
+                'assets'   => static::assets(),
+                'icons'    => static::icons(),
                 'nonce'    => $kirby->nonce(),
                 'fiber'    => $fiber,
                 'panelUrl' => $uri->path()->toString(true) . '/',
@@ -626,12 +633,13 @@ class Panel
     /**
      * Router for the Panel views
      *
-     * @param \Kirby\Cms\App $kirby
      * @param string $path
      * @return \Kirby\Http\Response|false
      */
-    public static function router(App $kirby, string $path = null)
+    public static function router(string $path = null)
     {
+        $kirby = kirby();
+
         if ($kirby->option('panel') === false) {
             return null;
         }
@@ -639,13 +647,13 @@ class Panel
         // set the translation for Panel UI before
         // gathering areas and routes, so that the
         // `t()` helper can already be used
-        static::setTranslation($kirby);
+        static::setTranslation();
 
         // set the language in multi-lang installations
-        static::setLanguage($kirby);
+        static::setLanguage();
 
-        $areas  = static::areas($kirby);
-        $routes = static::routes($kirby, $areas);
+        $areas  = static::areas();
+        $routes = static::routes($areas);
 
         // create a micro-router for the Panel
         return router($path, $method = $kirby->request()->method(), $routes, function ($route) use ($areas, $kirby, $method, $path) {
@@ -669,7 +677,7 @@ class Panel
             } catch (Redirect $e) {
                 $result = Response::redirect($e->location());
             } catch (Throwable $e) {
-                $result = static::error($kirby, $e->getMessage());
+                $result = static::error($e->getMessage());
             }
 
             // pass responses directly down to the Kirby router
@@ -681,20 +689,20 @@ class Panel
 
             // interpret strings as errors
             if (is_string($result) === true) {
-                $result = static::error($kirby, $result);
+                $result = static::error($result);
             }
 
             // only expect arrays from here on
             if (is_array($result) === false) {
-                $result = static::error($kirby, 'Invalid Panel response');
+                $result = static::error('Invalid Panel response');
             }
 
             // create the view based on the current area
-            $view = static::view($kirby, $area, $result ?? []);
+            $view = static::view($area, $result ?? []);
 
             $kirby->trigger('panel.route:after', compact('route', 'path', 'method', 'result', 'view'));
 
-            return static::render($kirby, $view['component'], [
+            return static::render($view['component'], [
                 '$view'  => $view,
                 '$areas' => array_map(function ($area) {
                     // routes should not be included in the frontend object
@@ -711,8 +719,10 @@ class Panel
      *
      * @return array
      */
-    public static function routes(App $kirby, array $areas): array
+    public static function routes(array $areas): array
     {
+        $kirby = kirby();
+
         // the browser incompatibility
         // warning is always needed
         $routes = [
@@ -794,11 +804,12 @@ class Panel
      * installations based on the session or the
      * query language query parameter
      *
-     * @param \Kirby\Cms\App $kirby
      * @return string|null
      */
-    public static function setLanguage(App $kirby): ?string
+    public static function setLanguage(): ?string
     {
+        $kirby = kirby();
+
         // language switcher
         if ($kirby->options('languages')) {
             $session  = $kirby->session();
@@ -823,11 +834,12 @@ class Panel
      * Set the currently active Panel translation
      * based on the current user or config
      *
-     * @param \Kirby\Cms\App $kirby
      * @return string
      */
-    public static function setTranslation(App $kirby): string
+    public static function setTranslation(): string
     {
+        $kirby = kirby();
+
         if ($user = $kirby->user()) {
             // use the user language for the default translation
             $translation = $user->language();
@@ -845,13 +857,14 @@ class Panel
     /**
      * Returns data array for view
      *
-     * @param \Kirby\Cms\App $kirby
      * @param array $area
      * @param array $view
      * @return array
      */
-    public static function view(App $kirby, ?array $area = null, array $view = []): array
+    public static function view(?array $area = null, array $view = []): array
     {
+        $kirby = kirby();
+
         // merge view with area defaults
         $view = array_replace_recursive($area ?? [], $view);
 

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -5,8 +5,6 @@ namespace Kirby\Panel;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
-use Kirby\Exception\InvalidArgumentException;
-use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Http\Request;
 use Kirby\Http\Response;
@@ -321,31 +319,6 @@ class Panel
         return A::apply($data);
     }
 
-    /**
-     * Returns the file object for the given
-     * parent path and filename
-     *
-     * @param string|null $path Path to file's parent model
-     * @param string $filename Filename
-     * @return \Kirby\Cms\File|null
-     * @throws \Kirby\Exception\NotFoundException if the file cannot be found
-     */
-    public static function file(string $path = null, string $filename)
-    {
-        $filename = urldecode($filename);
-        $file     = static::parent($path)->file($filename);
-
-        if ($file && $file->isReadable() === true) {
-            return $file;
-        }
-
-        throw new NotFoundException([
-            'key'  => 'file.notFound',
-            'data' => [
-                'filename' => $filename
-            ]
-        ]);
-    }
 
     /**
      * Check for access permissions
@@ -544,85 +517,6 @@ class Panel
         }
 
         return true;
-    }
-
-    /**
-     * Returns the page object for the given id
-     *
-     * @param string $id Page's id
-     * @return \Kirby\Cms\Page|null
-     * @throws \Kirby\Exception\NotFoundException if the page cannot be found
-     */
-    public static function page(string $id)
-    {
-        $id   = str_replace('+', '/', $id);
-        $page = kirby()->page($id);
-
-        if ($page && $page->isReadable() === true) {
-            return $page;
-        }
-
-        throw new NotFoundException([
-            'key'  => 'page.notFound',
-            'data' => [
-                'slug' => $id
-            ]
-        ]);
-    }
-
-    /**
-     * Returns the model's object for the given path
-     *
-     * @param string $path Path to parent model
-     * @return \Kirby\Cms\Model|null
-     * @throws \Kirby\Exception\InvalidArgumentException if the model type is invalid
-     * @throws \Kirby\Exception\NotFoundException if the model cannot be found
-     */
-    public static function parent(string $path)
-    {
-        $modelType  = in_array($path, ['site', 'account']) ? $path : trim(dirname($path), '/');
-        $modelTypes = [
-            'site'    => 'site',
-            'users'   => 'user',
-            'pages'   => 'page',
-            'account' => 'account'
-        ];
-
-        $modelName = $modelTypes[$modelType] ?? null;
-
-        if (Str::endsWith($modelType, '/files') === true) {
-            $modelName = 'file';
-        }
-
-        $kirby = kirby();
-
-        switch ($modelName) {
-            case 'site':
-                $model = $kirby->site();
-                break;
-            case 'account':
-                $model = static::user();
-                break;
-            case 'page':
-                $model = static::page(basename($path));
-                break;
-            case 'file':
-                $model = static::file(...explode('/files/', $path));
-                break;
-            case 'user':
-                $model = $kirby->user(basename($path));
-                break;
-            default:
-                throw new InvalidArgumentException('Invalid model type: ' . $modelType);
-        }
-
-        if ($model) {
-            return $model;
-        }
-
-        throw new NotFoundException([
-            'key' => $modelName . '.undefined'
-        ]);
     }
 
     /**
@@ -947,36 +841,6 @@ class Panel
         return $translation;
     }
 
-    /**
-     * Returns the user object for the given id or
-     * returns the current authenticated user if no
-     * id is passed
-     *
-     * @param string|null $id User's id
-     * @return \Kirby\Cms\User|null
-     * @throws \Kirby\Exception\NotFoundException if the user for the given id cannot be found
-     */
-    public static function user(string $id = null)
-    {
-        $kirby = kirby();
-
-        // get the authenticated user
-        if ($id === null) {
-            return $kirby->user(null, $kirby->option('api.allowImpersonation', false));
-        }
-
-        // get a specific user by id
-        if ($user = $kirby->user($id)) {
-            return $user;
-        }
-
-        throw new NotFoundException([
-            'key'  => 'user.notFound',
-            'data' => [
-                'name' => $id
-            ]
-        ]);
-    }
 
     /**
      * Returns data array for view

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -30,12 +30,6 @@ use Throwable;
  */
 class Panel
 {
-    /**
-     * Kirby singleton
-     *
-     * @var \Kirby\Cms\App
-     */
-    public static $kirby;
 
     /**
      * Normalize a panel area

--- a/tests/Cms/Api/routes/SystemRoutesTest.php
+++ b/tests/Cms/Api/routes/SystemRoutesTest.php
@@ -14,7 +14,7 @@ class SystemRoutesTest extends TestCase
         $this->app = new App([
             'roots' => [
                 'index' => $fixtures = __DIR__ . '/fixtures/SystemRoutesTest'
-            ],
+            ]
         ]);
 
         Dir::remove($fixtures);

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Kirby\Cms;
+
+/**
+ * @coversDefaultClass \Kirby\Cms\Find
+ */
+class FindTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+    }
+
+    /**
+     * @covers ::file
+     */
+    public function testFileForPage(): void
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'a',
+                        'files' => [
+                            ['filename' => 'a.jpg']
+                        ],
+                        'children' => [
+                            [
+                                'slug' => 'aa',
+                                'files' => [
+                                    ['filename' => 'aa.jpg']
+                                ],
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+        $this->assertEquals('a.jpg', Find::file('pages/a', 'a.jpg')->filename());
+        $this->assertEquals('aa.jpg', Find::file('pages/a+aa', 'aa.jpg')->filename());
+    }
+
+    /**
+     * @covers ::file
+     */
+    public function testFileForSite(): void
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'files' => [
+                    ['filename' => 'test.jpg']
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+        $this->assertEquals('test.jpg', Find::file('site', 'test.jpg')->filename());
+    }
+
+    /**
+     * @covers ::file
+     */
+    public function testFileForUser(): void
+    {
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'test@getkirby.com',
+                    'files' => [
+                        ['filename' => 'test.jpg']
+                    ]
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+        $this->assertEquals('test.jpg', Find::file('users/test@getkirby.com', 'test.jpg')->filename());
+    }
+
+    /**
+     * @covers ::file
+     */
+    public function testFileNotFound()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The file "nope.jpg" cannot be found');
+
+        Find::file('site', 'nope.jpg');
+    }
+
+    /**
+     * @covers ::file
+     */
+    public function testFileNotReadable()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'files' => [
+                    [
+                        'filename' => 'protected.jpg',
+                        'template' => 'protected'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The file "protected.jpg" cannot be found');
+
+        Find::file('site', 'protected.jpg');
+    }
+
+    /**
+     * @covers ::page
+     */
+    public function testPage()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'a',
+                        'children' => [
+                            [
+                                'slug' => 'aa'
+                            ],
+                        ],
+                    ]
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+
+        $a  = $app->page('a');
+        $aa = $app->page('a/aa');
+
+        $this->assertEquals($a, Find::page('a'));
+        $this->assertEquals($aa, Find::page('a+aa'));
+    }
+
+    /**
+     * @covers ::page
+     */
+    public function testPageNotReadable()
+    {
+        $app = $this->app->clone([
+            'blueprints' => [
+                'pages/protected' => [
+                    'options' => [
+                        'read' => false
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'a',
+                        'template' => 'protected'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The page "a" cannot be found');
+
+        Find::page('a');
+    }
+
+    /**
+     * @covers ::page
+     */
+    public function testPageNotFound()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The page "does-not-exist" cannot be found');
+
+        Find::page('does-not-exist');
+    }
+
+    /**
+     * @covers ::parent
+     */
+    public function testParent()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'a',
+                        'children' => [
+                            [
+                                'slug' => 'aa'
+                            ],
+                        ],
+                        'files' => [
+                            ['filename' => 'a-regular-file.jpg']
+                        ]
+                    ]
+                ],
+                'files' => [
+                    ['filename' => 'sitefile.jpg']
+                ]
+            ],
+            'users' => [
+                [
+                    'email' => 'current@getkirby.com',
+                ],
+                [
+                    'email' => 'test@getkirby.com',
+                    'files' => [
+                        ['filename' => 'userfile.jpg']
+                    ]
+                ]
+            ],
+            'options' => [
+                'api' => [
+                    'allowImpersonation' => true,
+                ]
+            ]
+        ]);
+
+        $app->impersonate('current@getkirby.com');
+
+        $this->assertInstanceOf(User::class, Find::parent('account'));
+        $this->assertInstanceOf(User::class, Find::parent('users/test@getkirby.com'));
+        $this->assertInstanceOf(Site::class, Find::parent('site'));
+        $this->assertInstanceOf(Page::class, Find::parent('pages/a+aa'));
+        $this->assertInstanceOf(File::class, Find::parent('site/files/sitefile.jpg'));
+        $this->assertInstanceOf(File::class, Find::parent('pages/a/files/a-regular-file.jpg'));
+        $this->assertInstanceOf(File::class, Find::parent('users/test@getkirby.com/files/userfile.jpg'));
+    }
+
+    /**
+     * @covers ::parent
+     */
+    public function testParentWithInvalidModelType()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid model type: something');
+        $this->assertNull(Find::parent('something/something'));
+    }
+
+    /**
+     * @covers ::parent
+     */
+    public function testParentNotFound()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The page "does-not-exist" cannot be found');
+        $this->assertNull(Find::parent('pages/does-not-exist'));
+    }
+
+    /**
+     * @covers ::parent
+     */
+    public function testParentUndefined()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The user cannot be found');
+        $this->assertNull(Find::parent('users/does-not-exist'));
+    }
+
+    /**
+     * @covers ::user
+     */
+    public function testUser()
+    {
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'test@getkirby.com',
+                    'role'  => 'admin'
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+        $this->assertEquals('test@getkirby.com', Find::user('test@getkirby.com')->email());
+    }
+
+    /**
+     * @covers ::user
+     */
+    public function testUserWithAuthentication()
+    {
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'test@getkirby.com',
+                ]
+            ],
+            'options' => [
+                'api' => [
+                    'allowImpersonation' => true,
+                ]
+            ]
+        ]);
+
+        $app->impersonate('test@getkirby.com');
+        $this->assertEquals('test@getkirby.com', Find::user()->email());
+    }
+
+    /**
+     * @covers ::user
+     */
+    public function testUserWithoutAllowedImpersonation()
+    {
+        $app = $this->app->clone([
+            'users' => [
+                [
+                    'email' => 'test@getkirby.com',
+                ]
+            ]
+        ]);
+
+        $app->impersonate('test@getkirby.com');
+
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The user cannot be found');
+
+        Find::user()->email();
+    }
+
+    /**
+     * @covers ::user
+     */
+    public function testUserNotFound()
+    {
+        $this->expectException('Kirby\Exception\NotFoundException');
+        $this->expectExceptionMessage('The user "nope@getkirby.com" cannot be found');
+
+        Find::user('nope@getkirby.com');
+    }
+}

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -133,7 +133,7 @@ abstract class AreaTestCase extends TestCase
 
     public function response(string $path = null, bool $toJson = false)
     {
-        $response = Panel::router($this->app, $path);
+        $response = Panel::router($path);
 
         if ($toJson === true) {
             return json_decode($response->body(), true);

--- a/tests/Panel/Areas/UsersTest.php
+++ b/tests/Panel/Areas/UsersTest.php
@@ -77,7 +77,7 @@ class UsersTest extends AreaTestCase
         $this->assertSame('users', $view['id']);
         $this->assertSame('k-error-view', $view['component']);
         $this->assertSame('Error', $view['title']);
-        $this->assertSame(t('error.file.undefined'), $props['error']);
+        $this->assertSame('The file "no-exist.jpg" cannot be found', $props['error']);
     }
 
     public function testUsersWithRole(): void

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -66,7 +66,7 @@ class PanelTest extends TestCase
     public function testAreas(): void
     {
         // unauthenticated / uninstalled
-        $areas = Panel::areas($this->app);
+        $areas = Panel::areas();
 
         $this->assertArrayHasKey('installation', $areas);
         $this->assertCount(1, $areas);
@@ -134,7 +134,7 @@ class PanelTest extends TestCase
     public function testAssets(): void
     {
         // default asset setup
-        $assets  = Panel::assets($this->app);
+        $assets  = Panel::assets();
         $base    = '/media/panel/' . $this->app->versionHash();
 
         // css
@@ -257,7 +257,7 @@ class PanelTest extends TestCase
             ]
         ]);
 
-        $this->assertNull(Panel::customCss($app));
+        $this->assertNull(Panel::customCss());
 
         // valid
         F::write($this->tmp . '/panel.css', '');
@@ -270,7 +270,7 @@ class PanelTest extends TestCase
             ]
         ]);
 
-        $this->assertTrue(Str::contains(Panel::customCss($app), '/panel.css'));
+        $this->assertTrue(Str::contains(Panel::customCss(), '/panel.css'));
     }
 
     /**
@@ -287,7 +287,7 @@ class PanelTest extends TestCase
             ]
         ]);
 
-        $this->assertNull(Panel::customJs($app));
+        $this->assertNull(Panel::customJs());
 
         // valid
         F::write($this->tmp . '/panel.js', '');
@@ -300,7 +300,7 @@ class PanelTest extends TestCase
             ]
         ]);
 
-        $this->assertTrue(Str::contains(Panel::customJs($app), '/panel.js'));
+        $this->assertTrue(Str::contains(Panel::customJs(), '/panel.js'));
     }
 
     /**
@@ -309,7 +309,7 @@ class PanelTest extends TestCase
     public function testData(): void
     {
         // without custom data
-        $data = Panel::data($this->app);
+        $data = Panel::data();
 
         $this->assertInstanceOf('Closure', $data['$language']);
         $this->assertInstanceOf('Closure', $data['$languages']);
@@ -325,7 +325,7 @@ class PanelTest extends TestCase
      */
     public function testDataWithCustomProps(): void
     {
-        $data = Panel::data($this->app, [
+        $data = Panel::data([
             '$props' => $props = [
                 'foo' => 'bar'
             ]
@@ -350,7 +350,7 @@ class PanelTest extends TestCase
         ]);
 
         // without custom data
-        $data = Panel::data($this->app);
+        $data = Panel::data();
 
         // resolve lazy data
         $data = A::apply($data);
@@ -383,7 +383,7 @@ class PanelTest extends TestCase
         $this->app->impersonate('kirby');
 
         // without custom data
-        $data = Panel::data($this->app);
+        $data = Panel::data();
 
         // resolve lazy data
         $data = A::apply($data);
@@ -407,7 +407,7 @@ class PanelTest extends TestCase
     public function testError(): void
     {
         // without user
-        $error = Panel::error($this->app, 'Test');
+        $error = Panel::error('Test');
 
         $expected = [
             'component' => 'k-error-view',
@@ -422,13 +422,13 @@ class PanelTest extends TestCase
 
         // with user
         $this->app->impersonate('kirby');
-        $error = Panel::error($this->app, 'Test');
+        $error = Panel::error('Test');
 
         $this->assertSame('inside', $error['props']['layout']);
 
         // user without panel access
         $this->app->impersonate('nobody');
-        $error = Panel::error($this->app, 'Test');
+        $error = Panel::error('Test');
 
         $this->assertSame('outside', $error['props']['layout']);
     }
@@ -439,7 +439,7 @@ class PanelTest extends TestCase
     public function testFiber(): void
     {
         // default
-        $fiber = Panel::fiber($this->app, 'k-page-view');
+        $fiber = Panel::fiber('k-page-view');
 
         $expected = [
             '$language' => null,
@@ -562,7 +562,7 @@ class PanelTest extends TestCase
     public function testGlobals(): void
     {
         // defaults
-        $globals = Panel::globals($this->app);
+        $globals = Panel::globals();
 
         $this->assertInstanceOf('Closure', $globals['$config']);
         $this->assertInstanceOf('Closure', $globals['$system']);
@@ -619,7 +619,7 @@ class PanelTest extends TestCase
         ]);
 
         $this->app->impersonate('test@getkirby.com');
-        $globals = Panel::globals($this->app);
+        $globals = Panel::globals();
         $globals = A::apply($globals);
         $this->assertSame('de', $globals['$translation']['code']);
     }
@@ -629,7 +629,7 @@ class PanelTest extends TestCase
      */
     public function testIcons(): void
     {
-        $icons = Panel::icons($this->app);
+        $icons = Panel::icons();
 
         $this->assertNotNull($icons);
         $this->assertTrue(strpos($icons, '<svg', 0) !== false);
@@ -704,7 +704,7 @@ class PanelTest extends TestCase
         ];
 
         // default (no partial request)
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame($data, $result);
     }
@@ -728,7 +728,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame(['a' => 'A'], $result);
 
@@ -746,7 +746,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame(['a' => 'A'], $result);
     }
@@ -771,7 +771,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame(['a' => 'A'], $result);
 
@@ -790,7 +790,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame(['a' => 'A'], $result);
     }
@@ -815,7 +815,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame($data, $result);
 
@@ -835,7 +835,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $this->assertSame($data, $result);
     }
@@ -859,7 +859,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
         $result = A::apply($result);
 
         $expected = [
@@ -894,7 +894,7 @@ class PanelTest extends TestCase
             ]
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $expected = [
             'b' => [
@@ -924,7 +924,7 @@ class PanelTest extends TestCase
             'b' => 'B'
         ];
 
-        $result = Panel::partial($this->app, 'k-test-view', $data);
+        $result = Panel::partial('k-test-view', $data);
 
         $expected = [
             'a' => 'A',
@@ -945,7 +945,7 @@ class PanelTest extends TestCase
         Panel::link($this->app);
 
         // get panel response
-        $response = Panel::render($this->app, 'k-page-view', [
+        $response = Panel::render('k-page-view', [
             'test' => 'Test'
         ]);
 
@@ -970,7 +970,7 @@ class PanelTest extends TestCase
         ]);
 
         // get panel response
-        $response = Panel::render($this->app, 'k-page-view', [
+        $response = Panel::render('k-page-view', [
             'test' => 'Test'
         ]);
 
@@ -990,7 +990,7 @@ class PanelTest extends TestCase
             ]
         ]);
 
-        $result = Panel::router($app, '/');
+        $result = Panel::router('/');
 
         $this->assertNull($result);
     }
@@ -1146,7 +1146,7 @@ class PanelTest extends TestCase
     public function testView(): void
     {
         // defaults
-        $result = Panel::view($this->app);
+        $result = Panel::view();
         $expected = [
             'breadcrumb' => [],
             'path' => '',
@@ -1156,17 +1156,17 @@ class PanelTest extends TestCase
         $this->assertSame($expected, $result);
 
         // with $area
-        $result = Panel::view($this->app, ['search' => 'users']);
+        $result = Panel::view(['search' => 'users']);
         $expected['search'] = 'users';
         $this->assertEquals($expected, $result);
 
         // with $view
-        $result = Panel::view($this->app, null, ['search' => 'files']);
+        $result = Panel::view(null, ['search' => 'files']);
         $expected['search'] = 'files';
         $this->assertEquals($expected, $result);
 
         // wmake sure routes are unset
-        $result = Panel::view($this->app, ['search' => 'files'], ['routes' => ['foo' => 'bar']]);
+        $result = Panel::view(['search' => 'files'], ['routes' => ['foo' => 'bar']]);
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
## Describe the PR

The Panel class methods are no longer passing down the $kirby instance. Each method that needs the $kirby instance will now get it from `App::instance()` instead. This simplifies the method calls quite drastically and doesn't hurt the testability. 

After @lukasbestle suggested to switch to non-static methods and a singleton for the Panel class, I made a few tests and decided that sticking with the static method calls keeps the Panel class a lot easier to use in my opinion. We can discuss this though. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3404

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
