### PR TITLE
Use `calc()`  where `var()` is used in computation #3415

### DIFF
--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import { 
+import {
   autofocus,
   disabled,
   id,
@@ -35,7 +35,7 @@ import {
   required
 } from "@/mixins/props.js";
 
-import { 
+import {
   required as validateRequired,
   minValue as validateMinValue,
   maxValue as validateMaxValue
@@ -182,7 +182,7 @@ export default {
   --value: 0;
   --range: calc(var(--max) - var(--min));
   --ratio: calc((var(--value) - var(--min)) / var(--range));
-  --position: calc(0.5 * var(--range-thumb-size) + var(--ratio) * (100% - var(--range-thumb-size)));
+  --position: calc(0.5 * var(--range-thumb-size) + var(--ratio) * calc(100% - var(--range-thumb-size)));
 
   appearance: none;
   width: 100%;
@@ -221,12 +221,12 @@ export default {
 
 .k-range-input-native::-webkit-slider-runnable-track {
   background: linear-gradient(
-      var(--range-track-color), 
+      var(--range-track-color),
       var(--range-track-color)
     )
-    0 / var(--position) 
-    100% 
-    no-repeat 
+    0 / var(--position)
+    100%
+    no-repeat
     var(--range-track-background);
 }
 

--- a/panel/src/components/Navigation/ButtonGroup.vue
+++ b/panel/src/components/Navigation/ButtonGroup.vue
@@ -7,7 +7,7 @@
 <script>
 /**
  * The Button Group should always be used when two or more buttons are positioned next to each other. The Button Group takes care of consistent margins between buttons.
- * 
+ *
  * @example <k-button-group>
   <k-button icon="edit">Edit</k-button>
   <k-button icon="trash">Delete</k-button>
@@ -27,7 +27,7 @@ export default {}
   margin-right: calc(var(--button-group-padding-horizontal) * -1);
 }
 .k-button-group > .k-dropdown {
-  height: calc(var(--button-group-line-height) + (var(--button-group-padding-vertical) * 2));
+  height: calc(var(--button-group-line-height) + calc(var(--button-group-padding-vertical) * 2));
   display: inline-block;
 }
 .k-button-group > .k-dropdown > .k-button,

--- a/panel/src/components/Writer/Toolbar.vue
+++ b/panel/src/components/Writer/Toolbar.vue
@@ -102,7 +102,7 @@ export default {
   background: var(--color-black);
   height: 30px;
   transform: translateX(-50%) translateY(-.75rem);
-  z-index: var(--z-dropdown) + 1;
+  z-index: calc(var(--z-dropdown) + 1);
   box-shadow: var(--shadow);
   color: var(--color-white);
   border-radius: var(--rounded);


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Used `calc()`  where `var` is used in computation in order to calculate correctly.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
None


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3415 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->
