### PR TITLE
Fixes autofocus writer and list field

### DIFF
--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -36,6 +36,7 @@ export default {
   inheritAttrs: false,
   props: {
     after: String,
+    autofocus: Boolean,
     before: String,
     disabled: Boolean,
     type: String,

--- a/panel/src/components/Forms/Input/ListInput.vue
+++ b/panel/src/components/Forms/Input/ListInput.vue
@@ -16,6 +16,7 @@ import ListDoc from "@/components/Writer/Nodes/ListDoc";
 export default {
   inheritAttrs: false,
   props: {
+    autofocus: Boolean,
     marks: {
       type: [Array, Boolean],
       default: true

--- a/panel/src/components/Writer/Editor.js
+++ b/panel/src/components/Writer/Editor.js
@@ -260,6 +260,7 @@ export default class Editor extends Emitter {
 
     // prepare event information for all following events
     const payload = {
+      editor: this,
       getHTML: this.getHTML.bind(this),
       getJSON: this.getJSON.bind(this),
       state: this.state,

--- a/panel/src/components/Writer/Marks/Link.js
+++ b/panel/src/components/Writer/Marks/Link.js
@@ -16,7 +16,7 @@ export default class Link extends Mark {
   commands() {
     return {
       "link": () => {
-        this.editor.emit("link");
+        this.editor.emit("link", this.editor);
       },
       "insertLink": (attrs = {}) => {
         if (attrs.href) {

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -63,6 +63,7 @@ export default {
     "k-writer-toolbar": ToolbarComponent,
   },
   props: {
+    autofocus: Boolean,
     breaks: Boolean,
     code: Boolean,
     disabled: Boolean,
@@ -120,13 +121,14 @@ export default {
   },
   mounted() {
     this.editor = new Editor({
+      autofocus: this.autofocus,
       content: this.value,
       editable: !this.disabled,
       element: this.$el,
       emptyDocument: this.emptyDocument,
       events: {
-        link: () => {
-          this.$refs.linkDialog.open(this.editor.getMarkAttrs("link"));
+        link: (editor) => {
+          this.$refs.linkDialog.open(editor.getMarkAttrs("link"));
         },
         toolbar: (toolbar) => {
           this.toolbar = toolbar;
@@ -137,9 +139,9 @@ export default {
             });
           }
         },
-        update: () => {
-          this.html    = this.editor.getHTML();
-          this.isEmpty = this.editor.isEmpty();
+        update: (payload) => {
+          this.html    = payload.editor.getHTML();
+          this.isEmpty = payload.editor.isEmpty();
 
           this.$emit("input", this.isEmpty === false ? this.html : "");
         }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Added missing `autofocus` prop
- Fixed with injecting editor self in payload since we call the `this.editor` as a callback in the events prop while `new Editor` instance. (Especially when autofocus enabled)
- The `after` and `before` prop is not removed (was mentioned in issue) as it is also present in other fields like textarea field.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes
- Fixed autofocus `list` and `writer` field #3122 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3122 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
