### PR TITLE
New `A::map` method

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -376,6 +376,19 @@ class A
     }
 
     /**
+     * A simple wrapper around array_map
+     * with a sane argument order
+     *
+     * @param array $array
+     * @param \Closure $map
+     * @return array
+     */
+    public static function map(array $array, Closure $map): array
+    {
+        return array_map($map, $array);
+    }
+
+    /**
      * Move an array item to a new index
      *
      * @param array $array

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -380,10 +380,10 @@ class A
      * with a sane argument order
      *
      * @param array $array
-     * @param \Closure $map
+     * @param callable $map
      * @return array
      */
-    public static function map(array $array, Closure $map): array
+    public static function map(array $array, callable $map): array
     {
         return array_map($map, $array);
     }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -144,6 +144,26 @@ class ATest extends TestCase
     }
 
     /**
+     * @covers ::map
+     */
+    public function testMap()
+    {
+        $array = [
+            'Peter', 'Bob', 'Mary'
+        ];
+
+        $expected = [
+            ['name' => 'Peter'],
+            ['name' => 'Bob'],
+            ['name' => 'Mary']
+        ];
+
+        $this->assertSame($expected, A::map($array, function ($name) {
+            return ['name' => $name];
+        }));
+    }
+
+    /**
      * @covers ::merge
      */
     public function testMerge()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -163,6 +163,22 @@ class ATest extends TestCase
         }));
     }
 
+    public function testMapWithFunction()
+    {
+        $array    = [' A ', 'B ', ' C'];
+        $expected = ['A', 'B', 'C'];
+
+        $this->assertSame($expected, A::map($array, 'trim'));
+    }
+
+    public function testMapWithClassMethod()
+    {
+        $array    = ['a', 'b', 'c'];
+        $expected = ['A', 'B', 'C'];
+
+        $this->assertSame($expected, A::map($array, 'Str::upper'));
+    }
+
     /**
      * @covers ::merge
      */


### PR DESCRIPTION
## Describe the PR

Finally a wrapper for array_map with the array as the first argument. 


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

- New `A::map($array, $callback)` method

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
