### PR TITLE
Store empty string when blocks and layout field empty

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -181,6 +181,13 @@ class BlocksField extends FieldClass
     public function store($value)
     {
         $blocks = $this->blocksToValues((array)$value, 'content');
+
+        // returns empty string to avoid storing empty array as string `[]`
+        // and to consistency work with `$field->isEmpty()`
+        if (empty($blocks) === true) {
+            return '';
+        }
+
         return $this->valueToJson($blocks, $this->pretty());
     }
 

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -146,6 +146,12 @@ class LayoutField extends BlocksField
     {
         $value = Layouts::factory($value, ['parent' => $this->model])->toArray();
 
+        // returns empty string to avoid storing empty array as string `[]`
+        // and to consistency work with `$field->isEmpty()`
+        if (empty($value) === true) {
+            return '';
+        }
+
         foreach ($value as $layoutIndex => $layout) {
             if ($this->settings !== null) {
                 $value[$layoutIndex]['attrs'] = $this->attrsForm($layout['attrs'])->content();

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -234,6 +234,10 @@ class BlocksFieldTest extends TestCase
         ]);
 
         $this->assertSame(json_encode($expected), $field->store($value));
+
+        // empty tests
+        $this->assertSame('', $field->store(null));
+        $this->assertSame('', $field->store([]));
     }
 
     public function testTranslateField()

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -170,6 +170,10 @@ class LayoutFieldTest extends TestCase
         $this->assertIsArray($expected[0]['columns']);
         $this->assertSame('heading', $expected[0]['columns'][0]['blocks'][0]['type']);
         $this->assertSame('A nice heading', $expected[0]['columns'][0]['blocks'][0]['content']['text']);
+
+        // empty tests
+        $this->assertSame('', $field->store(null));
+        $this->assertSame('', $field->store([]));
     }
 
     public function testValidations()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Store empty string (`''`) instead `[]` when blocks and layout field empty to consistency work with `$field->isEmpty()`.

### ⚠️ Notes for @bastianallgeier

I also asked @lukasbestle where it would be better to do this empty check/control, but we could not decide exactly. Since you created these classes, we think you will know the right place. I think the best place is the `store()` method like current implementation. It could also be done in `FieldClass::valueToJson()` but it would not be consistent if the empty string `''` is not valid JSON.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements
- Improved block and layout field value for `isEmpty()` control #3153 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3153 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
