### PR TITLE
Set Panel image via blueprint

### DIFF
--- a/panel/src/helpers/color.js
+++ b/panel/src/helpers/color.js
@@ -7,27 +7,13 @@ export default function (string) {
     return `var(--color-gray-800) var(--bg-pattern)`;
   }
 
-  const vars = `/^${[
-    "black",
-    "white",
-    "light",
-    "gray",
-    "red",
-    "orange",
-    "yellow",
-    "green",
-    "aqua",
-    "blue",
-    "purple"
-  ].join("|")}/`;
-
-  if (string.match(vars) === null) {
-    return string;
+  if (
+    string.match(
+      /^(black|white|light|gray|red|orange|yellow|green|aqua|blue|purple})/i
+    ) !== null
+  ) {
+    return `var(--color-${string})`;
   }
 
-  if (string.endsWith("0") === false) {
-    string += "-400";
-  }
-
-  return `var(--color-${string})`;
+  return string;
 }

--- a/panel/src/helpers/color.js
+++ b/panel/src/helpers/color.js
@@ -3,14 +3,30 @@ export default function (string) {
     return;
   }
 
-  const isHex = string.substring(0, 1) === "#";
+  if (string === "pattern") {
+    return `var(--color-gray-800) var(--bg-pattern)`;
+  }
 
-  if (isHex || string.startsWith("var(")) {
+  const vars = `/^${[
+    "black",
+    "white",
+    "light",
+    "gray",
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "aqua",
+    "blue",
+    "purple"
+  ].join("|")}/`;
+
+  if (string.match(vars) === null) {
     return string;
   }
 
-  if (string === "pattern") {
-    return `var(--color-gray-800) var(--bg-pattern)`;
+  if (string.endsWith("0") === false) {
+    string += "-400";
   }
 
   return `var(--color-${string})`;

--- a/panel/src/variables.css
+++ b/panel/src/variables.css
@@ -1,5 +1,5 @@
 :root {
-  --color-backdrop: rgba(0,0,0, .6);
+  --color-backdrop: rgba(0, 0, 0, 0.6);
   --color-black: #000;
   --color-light: var(--color-gray-200);
   --color-white: #fff;
@@ -13,46 +13,56 @@
   --color-gray-700: #555;
   --color-gray-800: #333;
   --color-gray-900: #111;
+  --color-gray: var(--color-gray-600);
 
   --color-red-200: #edc1c1;
   --color-red-300: #e3a0a0;
   --color-red-400: #d16464;
   --color-red-600: #c82829;
+  --color-red: var(--color-red-600);
 
   --color-orange-200: #f2d4bf;
   --color-orange-300: #ebbe9e;
   --color-orange-400: #de935f;
   --color-orange-600: #f4861f;
+  --color-orange: var(--color-orange-600);
 
   --color-yellow-200: #f9e8c7;
   --color-yellow-300: #f7e2b8;
   --color-yellow-400: #f0c674;
   --color-yellow-600: #cca000;
+  --color-yellow: var(--color-yellow-600);
 
   --color-green-200: #dce5c2;
   --color-green-300: #c6d49d;
   --color-green-400: #a7bd68;
   --color-green-600: #5d800d;
+  --color-green: var(--color-green-600);
 
   --color-aqua-200: #d0e5e2;
   --color-aqua-300: #bbd9d5;
   --color-aqua-400: #8abeb7;
   --color-aqua-600: #398e93;
+  --color-aqua: var(--color-aqua-600);
 
   --color-blue-200: #cbd7e5;
   --color-blue-300: #b1c2d8;
   --color-blue-400: #7e9abf;
   --color-blue-600: #4271ae;
+  --color-blue: var(--color-blue-600);
 
   --color-purple-200: #e0d4e4;
   --color-purple-300: #d4c3d9;
   --color-purple-400: #b294bb;
   --color-purple-600: #9c48b9;
+  --color-purple: var(--color-purple-600);
 
   --container: 80rem;
 
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  --font-mono: "SFMono-Regular", Consolas, Liberation Mono, Menlo, Courier, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-mono: "SFMono-Regular", Consolas, Liberation Mono, Menlo, Courier,
+    monospace;
 
   --font-normal: 400;
   --font-bold: 600;
@@ -68,19 +78,22 @@
   --rounded-sm: 0.125rem;
   --rounded: 0.25rem;
 
-  --shadow: 0 1px 3px 0 rgba(0,0,0, 0.1), 0 1px 2px 0 rgba(0,0,0, 0.06);
-  --shadow-md: 0 4px 6px -1px rgba(0,0,0, 0.1), 0 2px 4px -1px rgba(0,0,0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0,0,0, 0.1), 0 4px 6px -2px rgba(0,0,0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0,0,0, 0.1), 0 10px 10px -5px rgba(0,0,0, 0.04);
+  --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
   --shadow-outline: currentColor 0 0 0 2px;
-  --shadow-inset: inset 0 2px 4px 0 rgba(0,0,0, 0.06);
+  --shadow-inset: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06);
 
   --spacing-0: 0;
   --spacing-px: 1px;
   --spacing-2px: 2px;
-  --spacing-1: .25rem;
-  --spacing-2: .5rem;
-  --spacing-3: .75rem;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
   --spacing-4: 1rem;
   --spacing-5: 1.25rem;
   --spacing-6: 1.5rem;

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -125,6 +125,19 @@ class File extends Model
     }
 
     /**
+     * Default settings for the file's Panel image
+     *
+     * @return array
+     */
+    protected function imageDefaults(): array
+    {
+        return array_merge(parent::imageDefaults(), [
+            'color' => $this->imageColor(),
+            'icon'  => $this->imageIcon(),
+        ]);
+    }
+
+    /**
      * Returns the Panel icon type
      *
      * @return string

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Form\Form;
+use Kirby\Toolkit\A;
 
 /**
  * Provides information about the model for the Panel
@@ -166,7 +167,14 @@ abstract class Model
             unset($settings['query']);
         }
 
-        return $settings;
+        // resolve remaining options defined as query
+        return A::map($settings, function ($option) {
+            if (is_string($option) === false) {
+                return $option;
+            }
+
+            return $this->model->toString($option);
+        });
     }
 
     /**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -105,7 +105,7 @@ abstract class Model
         // is explicitly set to show the icon
         if ($settings === 'icon') {
             $settings = [];
-        } else if (is_string($settings) === true) {
+        } elseif (is_string($settings) === true) {
             // convert string settings to proper array
             $settings = [
                 'query' => $settings

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -115,12 +115,8 @@ abstract class Model
         // merge with defaults and blueprint option
         $settings = array_merge(
             $this->imageDefaults(),
-            [
-                'color' => $this->imageColor(),
-                'icon'  => $this->imageIcon()
-            ],
             $settings,
-            $this->imageBlueprint(),
+            $this->model->blueprint()->image() ?? [],
         );
 
         if ($image = $this->imageSource($settings['query'] ?? null)) {
@@ -178,52 +174,25 @@ abstract class Model
     }
 
     /**
-     * Settings from blueprint definition
-     * for Panel image
-     *
-     * @return array
-     */
-    public function imageBlueprint(): array
-    {
-        return $this->model->blueprint()->image() ?? [];
-    }
-
-    /**
-     * Returns the Panel icon color
-     *
-     * @return string
-     */
-    protected function imageColor(): string
-    {
-        return 'gray-500';
-    }
-
-    /**
      * Default settings for Panel image
      *
      * @return array
      */
-    public function imageDefaults(): array
+    protected function imageDefaults(): array
     {
         return [
             'back'  => 'pattern',
+            'color' => 'white',
             'cover' => false,
-            'ratio' => '3/2'
+            'icon'  => 'page',
+            'ratio' => '3/2',
         ];
     }
 
     /**
-     * Returns the Panel icon type
-     *
-     * @return string
-     */
-    protected function imageIcon(): string
-    {
-        return 'page';
-    }
-
-    /**
      * Data URI placeholder string for Panel image
+     *
+     * @internal
      *
      * @return string
      */

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -182,7 +182,7 @@ abstract class Model
     {
         return [
             'back'  => 'pattern',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => false,
             'icon'  => 'page',
             'ratio' => '3/2',

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -58,21 +58,6 @@ class Page extends Model
     }
 
     /**
-     * Returns the Panel icon type
-     * according to the blueprint settings
-     *
-     * @return string
-     */
-    protected function imageIcon(): string
-    {
-        if ($icon = $this->model->blueprint()->icon()) {
-            return $icon;
-        }
-
-        return parent::imageIcon();
-    }
-
-    /**
      * Returns the escaped Id, which is
      * used in the panel to make routing work properly
      *
@@ -81,6 +66,22 @@ class Page extends Model
     public function id(): string
     {
         return str_replace('/', '+', $this->model->id());
+    }
+
+    /**
+     * Default settings for the page's Panel image
+     *
+     * @return array
+     */
+    protected function imageDefaults(): array
+    {
+        $defaults = [];
+
+        if ($icon = $this->model->blueprint()->icon()) {
+            $defaults['icon'] = $icon;
+        }
+
+        return array_merge(parent::imageDefaults(), $defaults);
     }
 
     /**

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -30,27 +30,17 @@ class User extends Model
     }
 
     /**
-     * Returns the Panel icon type
-     *
-     * @return string
-     */
-    protected function imageIcon(): string
-    {
-        return 'user';
-    }
-
-    /**
-     * Default settings for Panel image
+     * Default settings for the user's Panel image
      *
      * @return array
      */
-    public function imageDefaults(): array
+    protected function imageDefaults(): array
     {
-        return [
+        return array_merge(parent::imageDefaults(), [
             'back'  => 'black',
-            'cover' => false,
+            'icon'  => 'user',
             'ratio' => '1/1',
-        ];
+        ]);
     }
 
     /**

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -19,7 +19,7 @@ class UserApiModelTest extends ApiModelTestCase
         $image = $this->attr($this->user, 'panelImage');
         $expected = [
             'back' => 'black',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => false,
             'icon'  => 'user',
             'ratio' => '1/1'

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -19,10 +19,10 @@ class UserApiModelTest extends ApiModelTestCase
         $image = $this->attr($this->user, 'panelImage');
         $expected = [
             'back' => 'black',
+            'color' => 'white',
             'cover' => false,
-            'ratio' => '1/1',
-            'color' => 'gray-500',
-            'icon'  => 'user'
+            'icon'  => 'user',
+            'ratio' => '1/1'
         ];
 
         $this->assertSame($expected, $image);

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -207,10 +207,10 @@ class PagesFieldTest extends TestCase
             'id' => 'test',
             'image' => [
                 'back' => 'pattern',
+                'color' => 'white',
                 'cover' => false,
-                'ratio' => '3/2',
-                'color' => 'gray-500',
                 'icon' => 'page',
+                'ratio' => '3/2'
             ],
             'info' => '',
             'link' => '/pages/test',

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -207,7 +207,7 @@ class PagesFieldTest extends TestCase
             'id' => 'test',
             'image' => [
                 'back' => 'pattern',
-                'color' => 'white',
+                'color' => 'gray-500',
                 'cover' => false,
                 'icon' => 'page',
                 'ratio' => '3/2'

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -259,25 +259,7 @@ class FileTest extends TestCase
     }
 
     /**
-     * @covers ::imageIcon
-     */
-    public function testIconDefault()
-    {
-        $page = new ModelPage([
-            'slug' => 'test'
-        ]);
-
-        $file = new ModelFile([
-            'filename' => 'something.jpg',
-            'parent'   => $page
-        ]);
-
-        $image = (new File($file))->image();
-        $this->assertSame('file-image', $image['icon']);
-        $this->assertSame('orange-400', $image['color']);
-    }
-
-    /**
+     * @covers ::imageDefaults
      * @covers ::imageSource
      */
     public function testImage()
@@ -292,7 +274,8 @@ class FileTest extends TestCase
         ]);
 
         $image = (new File($file))->image();
-
+        $this->assertSame('file-image', $image['icon']);
+        $this->assertSame('orange-400', $image['color']);
         $this->assertSame('3/2', $image['ratio']);
         $this->assertSame('pattern', $image['back']);
         $this->assertTrue(array_key_exists('url', $image));
@@ -319,10 +302,10 @@ class FileTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'pattern',
-            'cover' => false,
-            'ratio' => '3/2',
             'color' => 'orange-400',
+            'cover' => false,
             'icon' => 'file-image',
+            'ratio' => '3/2',
             'url' => '/media/site/' . $hash . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => '/media/site/' . $hash . '/test-38x.jpg 38w, /media/site/' . $hash . '/test-76x.jpg 76w'
@@ -331,10 +314,10 @@ class FileTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'pattern',
-            'cover' => true,
-            'ratio' => '3/2',
             'color' => 'orange-400',
+            'cover' => true,
             'icon' => 'file-image',
+            'ratio' => '3/2',
             'url' => '/media/site/' . $hash . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => '/media/site/' . $hash . '/test-38x38.jpg 1x, /media/site/' . $hash . '/test-76x76.jpg 2x'

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -69,6 +69,14 @@ class CustomPanelModel extends Model
     }
 }
 
+class ModelSiteWithImageMethod extends ModelSite
+{
+    public function panelBack()
+    {
+        return 'blue';
+    }
+}
+
 /**
  * @coversDefaultClass \Kirby\Panel\Model
  */
@@ -326,24 +334,49 @@ class ModelTest extends TestCase
     }
 
     /**
-     * @covers ::toLink
+     * @covers ::image
      */
-    public function testToLink()
+    public function testImageWithBlueprint()
     {
-        $panel = $this->panel([
-            'content' => [
-                'title'  => $title = 'Kirby Kirby Kirby',
-                'author' => $author = 'Bastian Allgeier'
+        $app  = $this->app->clone([
+            'blueprints' => [
+                'pages/test' => [
+                    'icon' => 'heart',
+                    'image'  => [
+                        'back' => 'red',
+                        'ratio' => '1/2'
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'template' => 'test'
+                    ]
+                ]
             ]
         ]);
 
-        $toLink = $panel->toLink();
-        $this->assertSame('/custom', $toLink['link']);
-        $this->assertSame($title, $toLink['tooltip']);
+        $panel = $app->page('test')->panel();
+        $image = $panel->image(['ratio' => '1/1', 'color' => 'yellow']);
+        $this->assertSame('red', $image['back']);
+        $this->assertSame('yellow', $image['color']);
+        $this->assertSame('heart', $image['icon']);
+        $this->assertSame('1/2', $image['ratio']);
+        $this->assertArrayNotHasKey('query', $image);
+        $this->assertArrayNotHasKey('url', $image);
+    }
 
-        $toLink = $panel->toLink('author');
-        $this->assertSame('/custom', $toLink['link']);
-        $this->assertSame($author, $toLink['tooltip']);
+    /**
+     * @covers ::image
+     */
+    public function testImageWithQuery()
+    {
+        $site  = new ModelSiteWithImageMethod();
+        $panel = new CustomPanelModel($site);
+        $image = $panel->image([ 'back' => '{{ site.panelBack }}']);
+        $this->assertSame('blue', $image['back']);
     }
 
     /**
@@ -423,6 +456,27 @@ class ModelTest extends TestCase
         $props = $this->panel($site)->props();
         $this->assertSame('foo', get('tab'));
         $this->assertSame('main', $props['tab']['name']);
+    }
+
+    /**
+     * @covers ::toLink
+     */
+    public function testToLink()
+    {
+        $panel = $this->panel([
+            'content' => [
+                'title'  => $title = 'Kirby Kirby Kirby',
+                'author' => $author = 'Bastian Allgeier'
+            ]
+        ]);
+
+        $toLink = $panel->toLink();
+        $this->assertSame('/custom', $toLink['link']);
+        $this->assertSame($title, $toLink['tooltip']);
+
+        $toLink = $panel->toLink('author');
+        $this->assertSame('/custom', $toLink['link']);
+        $this->assertSame($author, $toLink['tooltip']);
     }
 
     /**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -232,30 +232,8 @@ class ModelTest extends TestCase
     }
 
     /**
-     * @covers ::imageIcon
-     */
-    public function testIcon()
-    {
-        $panel = $this->panel();
-
-        $image  = $panel->image();
-        $this->assertArrayHasKey('icon', $image);
-        $this->assertArrayHasKey('ratio', $image);
-        $this->assertArrayHasKey('color', $image);
-        $this->assertArrayHasKey('back', $image);
-        $this->assertSame('page', $image['icon']);
-        $this->assertSame('pattern', $image['back']);
-
-        $image  = $panel->image([
-            'icon'  => $type = 'heart',
-            'ratio' => $ratio = '16/9'
-        ]);
-        $this->assertSame($type, $image['icon']);
-        $this->assertSame($ratio, $image['ratio']);
-    }
-
-    /**
      * @covers ::image
+     * @covers ::imageDefaults
      * @covers ::imageSource
      */
     public function testImage()
@@ -268,11 +246,13 @@ class ModelTest extends TestCase
 
         // defaults
         $image = $panel->image();
-        $this->assertArrayHasKey('ratio', $image);
         $this->assertArrayHasKey('back', $image);
         $this->assertArrayHasKey('cover', $image);
-        $this->assertSame('3/2', $image['ratio']);
+        $this->assertArrayHasKey('icon', $image);
+        $this->assertArrayHasKey('ratio', $image);
         $this->assertSame(false, $image['cover']);
+        $this->assertSame('page', $image['icon']);
+        $this->assertSame('3/2', $image['ratio']);
 
         // deactivate
         $this->assertNull($panel->image(false));
@@ -321,14 +301,16 @@ class ModelTest extends TestCase
 
         // full options
         $image = $panel->image([
-            'ratio' => '16/9',
+            'cover' => true,
+            'icon'  => $icon = 'heart',
             'query' => 'site.image',
-            'cover' => true
+            'ratio' => $ratio = '16/9'
         ]);
         $this->assertArrayHasKey('url', $image);
         $this->assertArrayHasKey('src', $image);
         $this->assertArrayHasKey('srcset', $image);
-        $this->assertSame('16/9', $image['ratio']);
+        $this->assertSame($icon, $image['icon']);
+        $this->assertSame($ratio, $image['ratio']);
         $this->assertStringContainsString('test-38x38.jpg 1x', $image['srcset']);
         $this->assertStringContainsString('test-76x76.jpg 2x', $image['srcset']);
     }

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -301,7 +301,7 @@ class PageTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'pattern',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => false,
             'icon' => 'page',
             'ratio' => '3/2',
@@ -313,7 +313,7 @@ class PageTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'pattern',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => true,
             'icon' => 'page',
             'ratio' => '3/2',

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -225,23 +225,6 @@ class PageTest extends TestCase
     }
 
     /**
-     * @covers ::imageIcon
-     */
-    public function testIconWithEmoji()
-    {
-        $page = new ModelPage([
-            'slug' => 'test',
-            'blueprint' => [
-                'name' => 'test',
-                'icon' => $emoji = '❤️'
-            ]
-        ]);
-
-        $image = (new Page($page))->image();
-        $this->assertSame($emoji, $image['icon']);
-    }
-
-    /**
      * @covers ::id
      */
     public function testId()
@@ -274,6 +257,24 @@ class PageTest extends TestCase
     }
 
     /**
+     * @covers ::image
+     * @covers ::imageDefaults
+     */
+    public function testImageBlueprintIconWithEmoji()
+    {
+        $page = new ModelPage([
+            'slug' => 'test',
+            'blueprint' => [
+                'name' => 'test',
+                'icon' => $emoji = '❤️'
+            ]
+        ]);
+
+        $image = (new Page($page))->image();
+        $this->assertSame($emoji, $image['icon']);
+    }
+
+    /**
      * @covers ::imageSource
      */
     public function testImageCover()
@@ -300,10 +301,10 @@ class PageTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'pattern',
+            'color' => 'white',
             'cover' => false,
-            'ratio' => '3/2',
-            'color' => 'gray-500',
             'icon' => 'page',
+            'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
@@ -312,10 +313,10 @@ class PageTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'pattern',
+            'color' => 'white',
             'cover' => true,
-            'ratio' => '3/2',
-            'color' => 'gray-500',
             'icon' => 'page',
+            'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -86,7 +86,7 @@ class SiteTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'pattern',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => false,
             'icon' => 'page',
             'ratio' => '3/2',
@@ -98,7 +98,7 @@ class SiteTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'pattern',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => true,
             'icon' => 'page',
             'ratio' => '3/2',

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -86,10 +86,10 @@ class SiteTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'pattern',
+            'color' => 'white',
             'cover' => false,
-            'ratio' => '3/2',
-            'color' => 'gray-500',
             'icon' => 'page',
+            'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
@@ -98,10 +98,10 @@ class SiteTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'pattern',
+            'color' => 'white',
             'cover' => true,
-            'ratio' => '3/2',
-            'color' => 'gray-500',
             'icon' => 'page',
+            'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -113,7 +113,7 @@ class UserTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'black',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => false,
             'icon' => 'user',
             'ratio' => '1/1',
@@ -125,7 +125,7 @@ class UserTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'black',
-            'color' => 'white',
+            'color' => 'gray-500',
             'cover' => true,
             'icon' => 'user',
             'ratio' => '1/1',

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -55,19 +55,7 @@ class UserTest extends TestCase
     }
 
     /**
-     * @covers ::imageIcon
-     */
-    public function testIconDefault()
-    {
-        $user = new ModelUser([
-            'email' => 'test@getkirby.com',
-        ]);
-
-        $image = (new User($user))->image();
-        $this->assertSame('user', $image['icon']);
-    }
-
-    /**
+     * @covers ::imageDefaults
      * @covers ::imageSource
      */
     public function testImage()
@@ -77,6 +65,7 @@ class UserTest extends TestCase
         ]);
 
         $image = (new User($user))->image();
+        $this->assertSame('user', $image['icon']);
         $this->assertFalse(isset($image['url']));
     }
 
@@ -124,10 +113,10 @@ class UserTest extends TestCase
         // cover disabled as default
         $this->assertSame([
             'back' => 'black',
+            'color' => 'white',
             'cover' => false,
-            'ratio' => '1/1',
-            'color' => 'gray-500',
             'icon' => 'user',
+            'ratio' => '1/1',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
@@ -136,10 +125,10 @@ class UserTest extends TestCase
         // cover enabled
         $this->assertSame([
             'back' => 'black',
+            'color' => 'white',
             'cover' => true,
-            'ratio' => '1/1',
-            'color' => 'gray-500',
             'icon' => 'user',
+            'ratio' => '1/1',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Allows defining the Panel image options per blueprint (query, back, cover, icon...).
- Use case: e.g. only using solid background colors and wanting to differentiate pages based on template
- All Panel image options now also support query syntax

### To decide

- [x] Should blueprint settings overrule sections settings (implementation of this PR currently) or the other way around?


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Features
- Define the Panel preview image (for page, file or user) now also in the blueprint via the `image` option and not only per section
- All Panel preview image options (`back`, `color`, `cover`, `ratio`, `icon`) now support Query syntax
```yaml
image:
  back: "{{ page.panelBack }}"
  icon: false
```
- Panel image `back` and `color` options now support shorthands for core CSS color variables as well as HEX codes and all other native CSS color properties (e.g. even gradients)
```yaml
image:
  back: "linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 35%, rgba(0,212,255,1) 100%);"
```


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Implements https://kirby.nolt.io/104

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
