### PR TITLE
Str::template() callback support for 3.5.7

### DIFF
--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -24,7 +24,8 @@
         />
       </svg>
     </span>
-    <span class="k-checkbox-input-label" v-text="label" />
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <span class="k-checkbox-input-label" v-html="label" />
   </label>
 </template>
 

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -9,7 +9,8 @@
       type="checkbox"
       @change="onInput($event.target.checked)"
     >
-    <span class="k-toggle-input-label" v-text="label" />
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <span class="k-toggle-input-label" v-html="label" />
   </label>
 </template>
 

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -7,6 +7,7 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Remote;
 use Kirby\Http\Url;
+use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\Properties;
 use Kirby\Toolkit\Query;
 use Kirby\Toolkit\Str;
@@ -86,10 +87,14 @@ class OptionsApi
      * @param array $data
      * @return string
      */
-    protected function field(string $field, array $data)
+    protected function field(string $field, array $data): string
     {
         $value = $this->$field();
-        return Str::template($value, $data);
+        return Str::template($value, $data, [
+            'callback' => function ($result) {
+                return Escape::html($result);
+            }
+        ]);
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -965,11 +965,12 @@ class Str
      * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values
-     * @param string|array|null $options An options that contains:
-     *                                   - fallback: if a token does not have any matches
-     *                                   - callback: to be able to handle each matching result
-     *                                   - start: start placeholder
-     *                                   - end: end placeholder
+     * @param string|array|null $fallback An options array that contains:
+     *                                    - fallback: if a token does not have any matches
+     *                                    - callback: to be able to handle each matching result
+     *                                    - start: start placeholder
+     *                                    - end: end placeholder
+     *                                    A simple fallback string is supported for compatibility (but deprecated).
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
      *
@@ -978,8 +979,9 @@ class Str
      *
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], $options = null, string $start = '{{', string $end = '}}'): string
+    public static function template(string $string = null, array $data = [], $fallback = null, string $start = '{{', string $end = '}}'): string
     {
+        $options  = $fallback;
         $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
         $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
         $start    = (string)($options['start'] ?? $start);

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1008,7 +1008,7 @@ class Str
 
             // callback on result if given
             if ($callback !== null) {
-                $result = $callback((string)$result, $data);
+                $result = $callback((string)$result, $query, $data);
             }
 
             // if we still don't have a result, keep the original placeholder

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -974,8 +974,8 @@ class Str
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
      *
-     * @todo Remove stringable type for `$options` param in 3.7.0, will only array supports
-     * @todo Remove `$start` and `$end` parameters in 3.8.0
+     * @todo Deprecate `string $fallback` and `$start`/`$end` arguments with warning in 3.6.0
+     * @todo Remove `$start` and `$end` parameters, rename `$fallback` to `$options` and only support `array` type for `$options` in 3.7.0
      *
      * @return string The filled-in string
      */

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -962,17 +962,30 @@ class Str
      *
      * </code>
      *
-     * @param string $string The string with placeholders
+     * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values
-     * @param string $fallback A fallback if a token does not have any matches
+     * @param string|array|null $options An options that contains:
+     *                                   - fallback: if a token does not have any matches
+     *                                   - callback: to be able to handle each matching result
+     *                                   - start: start placeholder
+     *                                   - end: end placeholder
      * @param string $start Placeholder start characters
      * @param string $end Placeholder end characters
+     *
+     * @todo Remove stringable type for `$options` param in 3.7.0, will only array supports
+     * @todo Remove `$start` and `$end` parameters in 3.8.0
+     *
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], string $fallback = null, string $start = '{{', string $end = '}}'): string
+    public static function template(string $string = null, array $data = [], $options = null, string $start = '{{', string $end = '}}'): string
     {
-        return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback) {
+        $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
+        $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
+        $start    = (string)($options['start'] ?? $start);
+        $end      = (string)($options['end'] ?? $end);
+
+        return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback, $callback) {
             $query = trim($match[1]);
 
             // if the placeholder contains a dot, it is a query
@@ -989,6 +1002,11 @@ class Str
             // if we don't have a result, use the fallback if given
             if ($result === null && $fallback !== null) {
                 $result = $fallback;
+            }
+
+            // callback on result if given
+            if ($callback !== null) {
+                $result = $callback((string)$result, $data);
             }
 
             // if we still don't have a result, keep the original placeholder


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

I've cherry-picked the original PR #3279 and made some improvements in the subsequent commits. Please see the commit descriptions for more details.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Features
- Support for custom callbacks for `Str::template()` (e.g. to escape query output)

### Enhancements
- `Str::template()` now supports an `$options` array that can contain `fallback`, `callback`, `start`, `end` attributes. We plan to deprecate the old `$fallback`, `$start` and `$end` arguments in 3.6.0.

### Fixes
- Toggle and checkbox field labels support HTML again

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- See https://github.com/getkirby/kirby/pull/3279#issuecomment-860625418

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
