### PR TITLE
Allow extending SVG namespaces in Sane

### DIFF
--- a/src/Sane/Svg.php
+++ b/src/Sane/Svg.php
@@ -286,7 +286,7 @@ class Svg extends Xml
         'feTurbulence',
     ];
 
-    protected static $allowedNamespaces = [
+    public static $allowedNamespaces = [
         'xmlns'       => 'http://www.w3.org/2000/svg',
         'xmlns:svg'   => 'http://www.w3.org/2000/svg',
         'xmlns:xlink' => 'http://www.w3.org/1999/xlink'


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements

- The `Kirby\Sane\Svg::$allowedNamespaces` property is now public to allow customizing it to your needs.

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3424.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
