### PR TITLE
`url` component: remove `$originalHandler`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -330,13 +330,9 @@ return [
      * @param \Kirby\Cms\App $kirby Kirby instance
      * @param string $path URL path
      * @param array|string|null $options Array of options for the Uri class
-     * @param Closure $originalHandler Deprecated: Callback function to the original URL handler with `$path` and `$options` as parameters
-     *                                 Use `$kirby->nativeComponent('url')` inside your URL component instead.
      * @return string
-     *
-     * @todo Remove $originalHandler parameter in 3.6.0
      */
-    'url' => function (App $kirby, string $path = null, $options = null, Closure $originalHandler = null): string {
+    'url' => function (App $kirby, string $path = null, $options = null): string {
         $language = null;
 
         // get language from simple string option

--- a/src/Cms/Url.php
+++ b/src/Cms/Url.php
@@ -61,9 +61,6 @@ class Url extends BaseUrl
     public static function to(string $path = null, $options = null): string
     {
         $kirby = App::instance();
-
-        return ($kirby->component('url'))($kirby, $path, $options, function (string $path = null, $options = null) use ($kirby) {
-            return ($kirby->nativeComponent('url'))($kirby, $path, $options);
-        });
+        return ($kirby->component('url'))($kirby, $path, $options);
     }
 }

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -264,24 +264,6 @@ class AppComponentsTest extends TestCase
         $this->assertEquals('test', url('anything'));
     }
 
-    public function testUrlPluginWithOriginalHandler()
-    {
-        $this->kirby->clone([
-            'components' => [
-                'url' => function ($kirby, $path, $options, $originalHandler) {
-                    if ($path === 'test') {
-                        return 'test-path';
-                    }
-
-                    return $originalHandler($path);
-                }
-            ]
-        ]);
-
-        $this->assertEquals('test-path', url('test'));
-        $this->assertEquals('/any/page', url('any/page'));
-    }
-
     public function testUrlPluginWithNativeComponent()
     {
         $this->kirby->clone([

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -208,7 +208,7 @@ class PageTest extends TestCase
     }
 
     /**
-     * @covers ::imageIcon
+     * @covers ::image
      */
     public function testIconFromBlueprint()
     {


### PR DESCRIPTION
## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- `url` component does not receive the deprecated `$originalHandler` parameter anymore. Use `$kirby->nativeComponent('url')` instead.
