### PR TITLE
Fixes `offsetTop` error on new `dropup` feature

### DIFF
--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -371,6 +371,12 @@ export default {
     .k-tags-input .k-dropdown-content {
       top: calc(100% + .5rem + 2px);
     }
+    /* don't apply dropup feature to tags */
+    .k-tags-input .k-dropdown-content[data-dropup] {
+      top: calc(100% + .5rem + 2px);
+      bottom: initial;
+      margin-bottom: initial;
+    }
   }
 
   /* Multiselect */

--- a/panel/src/components/Navigation/DropdownContent.vue
+++ b/panel/src/components/Navigation/DropdownContent.vue
@@ -133,18 +133,19 @@ export default {
       this.$nextTick(() => {
         const view = document.querySelector(".k-panel-view");
 
-        if (view && this.$el && this.$el.querySelector) {
-          // window height without padding (6rem = 96px)
-          let windowHeight = view.clientHeight - 96;
+        if (view && this.$el) {
+          // window height without padding (6rem)
+          // doesn't included form-buttons bar (2.5rem = 40px)
+          let windowHeight = view.clientHeight - 40;
 
           // dropdown content position relative to the viewport
           let scrollTop = this.$el.getBoundingClientRect().top || 0;
 
-          // last dropdown item relative offset
-          let offsetTop = this.$el.querySelector(".k-dropdown-item:last-child").offsetTop || 0;
+          // dropdown content height
+          let dropdownHeight = this.$el.clientHeight;
 
           // activate the dropup if the last item overflows to the bottom of the screen
-          this.dropup = (scrollTop + offsetTop) > windowHeight;
+          this.dropup = (scrollTop + dropdownHeight) > windowHeight;
         }
       });
     },


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Getting `Cannot read property 'offsetTop' of null` error (especially date and tags field) when dropdown doesn't contains `.k-dropdown-item`.
- I've fixed with getting dropdown content height for global solution instead last menu item position.
- Also disabled for autocomplete dropdown in tags field because tags working with multi-line and dropup doesn't working properly after first line.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
None


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
