### PR TITLE
Fixes writer field empty state

### DIFF
--- a/panel/src/components/Writer/Editor.js
+++ b/panel/src/components/Writer/Editor.js
@@ -373,10 +373,7 @@ export default class Editor extends Emitter {
 
   isEmpty() {
     if (this.state) {
-      // when a new list item or heading is created, textContent length returns 0
-      // checking active nodes to prevent this
-      // empty input means just the paragraph node and its length 0
-      return this.state.doc.textContent.length === 0 && this.activeNodes === ["paragraph"];
+      return this.state.doc.textContent.length === 0;
     }
   }
 

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -143,7 +143,20 @@ export default {
           this.html    = payload.editor.getHTML();
           this.isEmpty = payload.editor.isEmpty();
 
-          this.$emit("input", this.isEmpty === false ? this.html : "");
+          // when a new list item or heading is created, textContent length returns 0
+          // checking active nodes to prevent this issue
+          // empty input means no nodes or just the paragraph node and its length 0
+          if (
+            this.isEmpty &&
+            (
+              payload.editor.activeNodes.length === 0 ||
+              payload.editor.activeNodes.includes("paragraph")
+            )
+          ) {
+            this.html = "";
+          }
+
+          this.$emit("input", this.html);
         }
       },
       extensions: [


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The idea in #3421 is correct but I guess the implementation was wrong. I saw that it caused some minor problems with the `isEmpty()` method in Editor.js. Instead, I applied it elsewhere. In my tests, the existing bug and the problems I saw have been resolved.

- Changes in Editor.js reverted
- The idea in #3421 implemented to Writer.vue

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
None


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
