### PR TITLE
Fixes layouts field parsing empty value

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -192,7 +192,7 @@ return function (App $app) {
          * @return \Kirby\Cms\Layouts
          */
         'toLayouts' => function (Field $field) {
-            return Layouts::factory(Data::decode($field->value, 'json'), [
+            return Layouts::factory(Layouts::parse($field->value()), [
                 'parent' => $field->parent()
             ]);
         },

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Data\Data;
+use Throwable;
+
 /**
  * A collection of layouts
  * @since 3.5.0
@@ -36,5 +39,28 @@ class Layouts extends Items
         }
 
         return parent::factory($items, $params);
+    }
+
+    /**
+     * Parse layouts data
+     *
+     * @param array|string $input
+     * @return array
+     */
+    public static function parse($input): array
+    {
+        if (empty($input) === false && is_array($input) === false) {
+            try {
+                $input = Data::decode($input, 'json');
+            } catch (Throwable $e) {
+                return [];
+            }
+        }
+
+        if (empty($input) === true) {
+            return [];
+        }
+
+        return $input;
     }
 }

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -671,4 +671,60 @@ class FieldMethodsTest extends TestCase
         $yaml = Yaml::encode($data);
         $this->assertSame($data, $this->field($yaml)->yaml());
     }
+
+    public function testToBlocks()
+    {
+        $data = [
+            [
+                'content' => [
+                    'text' => 'Hello world'
+                ],
+                'type' => 'heading'
+            ],
+            [
+                'content' => [
+                    'text' => 'Nice blocks'
+                ],
+                'type' => 'text'
+            ]
+        ];
+
+        $field = $this->field(json_encode($data));
+        $blocks = $field->toBlocks();
+
+        $this->assertInstanceOf('\Kirby\Cms\Blocks', $blocks);
+        $this->assertInstanceOf('\Kirby\Cms\Site', $blocks->parent());
+        $this->assertCount(2, $blocks->data());
+
+        $this->assertSame('heading', $blocks->first()->type());
+        $this->assertSame('Hello world', $blocks->first()->content()->data()['text']);
+        $this->assertSame('text', $blocks->last()->type());
+        $this->assertSame('Nice blocks', $blocks->last()->content()->data()['text']);
+    }
+
+    public function testToLayouts()
+    {
+        $data = [
+            [
+                'type'    => 'heading',
+                'content' => ['text' => 'Heading'],
+            ],
+            [
+                'type'    => 'text',
+                'content' => ['text' => 'Text'],
+            ]
+        ];
+
+        $field = $this->field(json_encode($data));
+        $layouts = $field->toLayouts();
+
+        $this->assertInstanceOf('\Kirby\Cms\Layouts', $layouts);
+        $this->assertInstanceOf('\Kirby\Cms\Site', $layouts->parent());
+        $this->assertCount(1, $layouts->data());
+
+        $layout = $layouts->first()->toArray();
+        $this->assertArrayHasKey('attrs', $layout);
+        $this->assertArrayHasKey('columns', $layout);
+        $this->assertArrayHasKey('id', $layout);
+    }
 }

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -48,4 +48,57 @@ class LayoutsTest extends TestCase
         $this->assertEquals('text', $blocks->last()->type());
         $this->assertEquals('Text', $blocks->last()->text());
     }
+
+    public function testParse()
+    {
+        $data = [
+            [
+                'type'    => 'heading',
+                'content' => ['text' => 'Heading'],
+            ],
+            [
+                'type'    => 'text',
+                'content' => ['text' => 'Text'],
+            ]
+        ];
+        $json = json_encode($data);
+
+        $result = Layouts::parse($json);
+        $this->assertSame($data, $result);
+    }
+
+    public function testParseArray()
+    {
+        $data = [
+            [
+                'type'    => 'heading',
+                'content' => ['text' => 'Heading'],
+            ],
+            [
+                'type'    => 'text',
+                'content' => ['text' => 'Text'],
+            ]
+        ];
+
+        $result = Layouts::parse($data);
+        $this->assertSame($data, $result);
+    }
+
+    public function testParseEmpty()
+    {
+        $result = Layouts::parse(null);
+        $this->assertSame([], $result);
+
+        $result = Layouts::parse('');
+        $this->assertSame([], $result);
+
+        $result = Layouts::parse('[]');
+        $this->assertSame([], $result);
+
+        $result = Layouts::parse([]);
+        $this->assertSame([], $result);
+
+        $result = Layouts::parse('invalid json string');
+        $this->assertSame([], $result);
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
We parse it in the Blocks field and it returns empty array even if there is an error, but we did not do it for the Layouts field. I've fixed the issue with parsing layout value that returns empty array if field value empty or an error occured.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed layout field empty when use `->toLayouts()` method

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3482 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
