### PR TITLE
Fix Panel areas default access #3487

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -114,7 +114,7 @@ class Panel
         $permissions = $user->role()->permissions()->toArray()['access'];
 
         // check for general panel access
-        if (($permissions['panel'] ?? false) !== true) {
+        if (($permissions['panel'] ?? true) !== true) {
             throw new PermissionException(['key' => 'access.panel']);
         }
 

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -322,7 +322,7 @@ class View
                 continue;
             }
 
-            $access   = $permissions['access'][$areaId] ?? false;
+            $access   = $permissions['access'][$areaId] ?? true;
             $disabled = $menuSetting === 'disabled' || $access === false;
 
             $menu[] = [


### PR DESCRIPTION
As of our docs, permissions should be true by default:

> You don't have to set all permissions for each role. Each permission is set to true by default, if not specified otherwise.
https://getkirby.com/docs/guide/users/permission

This should be applied to our Panel permissions then as well.

## Related issue
Fixes #3487 