### PR TITLE
More CSS identifiers for the Panel

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -135,6 +135,7 @@ return [
                     'link'     => $panel->url(true),
                     'mime'     => $file->mime(),
                     'parent'   => $file->parent()->panel()->path(),
+                    'template' => $file->template(),
                     'text'     => $text,
                     'url'      => $file->url(),
                 ];

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -169,6 +169,7 @@ return [
                     'parent'      => $item->parentId(),
                     'image'       => $panel->image($this->image, $this->layout),
                     'link'        => $panel->url(true),
+                    'template'    => $item->intendedTemplate()->name(),
                     'status'      => $item->status(),
                     'permissions' => [
                         'sort'         => $permissions->can('sort'),

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -265,7 +265,7 @@
   "field.structure.empty": "No entries yet",
   "field.users.empty": "No users selected yet",
 
-  "file.blueprint": "This file has no blueprint yet. You can define the setup in <strong>/site/blueprints/{template}.yml</strong>",
+  "file.blueprint": "This file has no blueprint yet. You can define the setup in <strong>/site/blueprints/files/{blueprint}.yml</strong>",
   "file.delete.confirm": "Do you really want to delete <br><strong>{filename}</strong>?",
   "file.sort": "Change position",
 
@@ -387,7 +387,7 @@
   "orientation.portrait": "Portrait",
   "orientation.square": "Square",
 
-  "page.blueprint": "This page has no blueprint yet. You can define the setup in <strong>/site/blueprints/{template}.yml</strong>",
+  "page.blueprint": "This page has no blueprint yet. You can define the setup in <strong>/site/blueprints/pages/{blueprint}.yml</strong>",
   "page.changeSlug": "Change URL",
   "page.changeSlug.fromTitle": "Create from title",
   "page.changeStatus": "Change status",
@@ -499,7 +499,7 @@
   "url.placeholder": "https://example.com",
 
   "user": "User",
-  "user.blueprint": "You can define additional sections and form fields for this user role in <strong>/site/blueprints/{blueprint}.yml</strong>",
+  "user.blueprint": "You can define additional sections and form fields for this user role in <strong>/site/blueprints/users/{blueprint}.yml</strong>",
   "user.changeEmail": "Change email",
   "user.changeLanguage": "Change language",
   "user.changeName": "Rename this user",

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -2,8 +2,11 @@
   <div
     :data-dragging="$store.state.drag"
     :data-loading="$store.state.isLoading"
+    :data-language="language"
+    :data-language-default="defaultLanguage"
+    :data-role="$user.role"
     :data-translation="translation"
-    :data-translation-default="defaultTranslation"
+    :data-user="$user.id"
     :dir="$translation.direction"
     class="k-panel k-panel-inside"
     tabindex="0"
@@ -68,17 +71,20 @@ export default {
     }
   },
   computed: {
-    defaultTranslation() {
+    defaultLanguage() {
       return this.$language ? this.$language.default : false;
     },
     dialog() {
       return this.$helper.clone(this.$store.state.dialog);
     },
+    language() {
+      return this.$language ? this.$language.code : null;
+    },
     searchTypes() {
       return search(this);
     },
     translation() {
-      return this.$language ? this.$language.code : null;
+      return this.$translation ? this.$translation.code : null;
     },
   },
   created() {

--- a/panel/src/components/Layout/Item.vue
+++ b/panel/src/components/Layout/Item.vue
@@ -1,6 +1,7 @@
 <template>
   <article
     :class="layout ? 'k-' + layout + '-item' : false"
+    v-bind="data"
     :data-has-figure="Boolean(image)"
     :data-has-info="Boolean(info)"
     :data-has-label="Boolean(label)"
@@ -75,13 +76,15 @@
 export default {
   inheritAttrs: false,
   props: {
+    data: Object,
+    flag: Object,
+    image: [Object, Boolean],
+    info: String,
+    label: String,
     layout: {
       type: String,
       default: "list"
     },
-    image: [Object, Boolean],
-    info: String,
-    label: String,
     link: {
       type: [Boolean, String, Function]
     },
@@ -89,7 +92,6 @@ export default {
       type: [Array, Function]
     },
     sortable: Boolean,
-    flag: Object,
     target: String,
     text: String,
     width: String

--- a/panel/src/components/Layout/Outside.vue
+++ b/panel/src/components/Layout/Outside.vue
@@ -1,19 +1,5 @@
 <template>
-  <div
-    :data-language="language.code"
-    :dir="$translation.direction"
-    class="k-panel k-panel-outside"
-  >
+  <div :dir="$translation.direction" class="k-panel k-panel-outside">
     <slot />
   </div>
 </template>
-
-<script>
-export default {
-  computed: {
-    language() {
-      return this.$language ? this.$language.code : false;
-    }
-  }
-}
-</script>

--- a/panel/src/components/Layout/Outside.vue
+++ b/panel/src/components/Layout/Outside.vue
@@ -1,9 +1,19 @@
 <template>
   <div
-    :data-language="$language.code"
+    :data-language="language.code"
     :dir="$translation.direction"
     class="k-panel k-panel-outside"
   >
     <slot />
   </div>
 </template>
+
+<script>
+export default {
+  computed: {
+    language() {
+      return this.$language ? this.$language.code : false;
+    }
+  }
+}
+</script>

--- a/panel/src/components/Layout/Outside.vue
+++ b/panel/src/components/Layout/Outside.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :dir="$translation.direction" class="k-panel k-panel-outside">
+  <div
+    :data-language="$language.code"
+    :dir="$translation.direction"
+    class="k-panel k-panel-outside"
+  >
     <slot />
   </div>
 </template>

--- a/panel/src/components/Navigation/Languages.vue
+++ b/panel/src/components/Navigation/Languages.vue
@@ -1,5 +1,5 @@
 <template>
-  <k-dropdown v-if="languages.length">
+  <k-dropdown v-if="languages.length" class="k-languages-dropdown">
     <k-button :responsive="true" icon="globe" @click="$refs.languages.toggle()">
       {{ language.name }}
     </k-button>

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -136,8 +136,6 @@ export default {
           }
         };
 
-        console.log(file)
-
         // add data-attributes info for item
         file.data = {
           "data-id": file.id,

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -136,6 +136,14 @@ export default {
           }
         };
 
+        console.log(file)
+
+        // add data-attributes info for item
+        file.data = {
+          "data-id": file.id,
+          "data-template": file.template
+        };
+
         return file;
       });
     },

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -129,6 +129,13 @@ export default {
           }
         };
 
+        // add data-attributes info for item
+        page.data = {
+          "data-id": page.id,
+          "data-status": page.status,
+          "data-template": page.template
+        };
+
         return page;
       });
     },

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -17,7 +17,6 @@
             :is="'k-' + section.type + '-section'"
             v-if="exists(section.type)"
             :key="parent + '-column-' + columnIndex + '-section-' + sectionIndex + '-' + blueprint"
-            :blueprint="blueprint"
             :column="column.width"
             :lock="lock"
             :name="section.name"

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -22,12 +22,13 @@
               <k-button
                 :link="model.url"
                 :responsive="true"
+                class="k-file-view-options"
                 icon="open"
                 target="_blank"
               >
                 {{ $t("open") }}
               </k-button>
-              <k-dropdown>
+              <k-dropdown class="k-file-view-options">
                 <k-button
                   :responsive="true"
                   :disabled="isLocked"

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -51,7 +51,7 @@
 
         <k-sections
           :blueprint="blueprint"
-          :empty="$t('file.blueprint', { template: $esc(blueprint) })"
+          :empty="$t('file.blueprint', { blueprint: $esc(blueprint) })"
           :lock="lock"
           :parent="path"
           :tab="tab"

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -1,9 +1,14 @@
 <template>
   <k-inside :lock="lock">
-    <div class="k-file-view">
+    <div
+      :data-locked="isLocked"
+      :data-id="model.id"
+      :data-role="blueprint"
+      class="k-file-view"
+    >
       <k-file-preview :file="model" />
 
-      <k-view :data-locked="isLocked" class="k-file-content">
+      <k-view class="k-file-content">
         <k-header
           :editable="permissions.changeName && !isLocked"
           :tab="tab.name"

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -3,7 +3,7 @@
     <div
       :data-locked="isLocked"
       :data-id="model.id"
-      :data-role="blueprint"
+      :data-template="blueprint"
       class="k-file-view"
     >
       <k-file-preview :file="model" />

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -19,8 +19,9 @@
               v-if="permissions.preview && model.previewUrl"
               :responsive="true"
               :link="model.previewUrl"
-              target="_blank"
+              class="k-page-view-preview"
               icon="open"
+              target="_blank"
             >
               {{ $t('open') }}
             </k-button>
@@ -32,7 +33,7 @@
               :text="status.label"
               @click="$dialog($view.path + '/changeStatus')"
             />
-            <k-dropdown>
+            <k-dropdown class="k-page-view-options">
               <k-button
                 :responsive="true"
                 :disabled="isLocked === true"

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -1,6 +1,11 @@
 <template>
   <k-inside :lock="lock">
-    <k-view :data-locked="isLocked" class="k-page-view">
+    <k-view
+      :data-locked="isLocked"
+      :data-id="model.id"
+      :data-template="blueprint"
+      class="k-page-view"
+    >
       <k-header
         :editable="permissions.changeTitle && !isLocked"
         :tab="tab.name"

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -57,7 +57,7 @@
 
       <k-sections
         :blueprint="blueprint"
-        :empty="$t('page.blueprint', { template: $esc(blueprint) })"
+        :empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
         :lock="lock"
         :parent="$api.pages.url(model.id)"
         :tab="tab"

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -18,7 +18,7 @@
             <k-button
               :responsive="true"
               :link="model.previewUrl"
-              class="k-site-view-opreviewptions"
+              class="k-site-view-preview"
               icon="open"
               target="_blank"
             >

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -1,6 +1,11 @@
 <template>
   <k-inside :lock="lock">
-    <k-view :data-locked="isLocked" class="k-site-view">
+    <k-view
+      :data-locked="isLocked"
+      data-id="/"
+      data-template="site"
+      class="k-site-view"
+    >
       <k-header
         :editable="permissions.changeTitle && !isLocked"
         :tabs="tabs"

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -18,8 +18,9 @@
             <k-button
               :responsive="true"
               :link="model.previewUrl"
-              target="_blank"
+              class="k-site-view-opreviewptions"
               icon="open"
+              target="_blank"
             >
               {{ $t('open') }}
             </k-button>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -83,7 +83,7 @@
 
           <template #left>
             <k-button-group>
-              <k-dropdown>
+              <k-dropdown class="k-user-view-options">
                 <k-button :disabled="isLocked" icon="cog" @click="$refs.settings.toggle()">
                   {{ $t('settings') }}
                 </k-button>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -1,6 +1,11 @@
 <template>
   <k-inside :lock="lock">
-    <div :data-locked="isLocked" class="k-user-view">
+    <div
+      :data-locked="isLocked"
+      :data-id="model.id"
+      :data-template="blueprint"
+      class="k-user-view"
+    >
       <div class="k-user-profile">
         <k-view>
           <template v-if="model.avatar">

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -268,6 +268,7 @@ class File extends Model
             parent::props(),
             $this->prevNext(),
             [
+                'blueprint' => $this->model->template(),
                 'model' => [
                     'content'    => $this->content(),
                     'dimensions' => $file->dimensions()->toArray(),

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -321,7 +321,6 @@ abstract class Model
         $tab       = $blueprint->tab(get('tab')) ?? $tabs[0] ?? null;
 
         $props = [
-            'blueprint'   => $blueprint->name(),
             'lock'        => $this->lock(),
             'permissions' => $this->model->permissions()->toArray(),
             'tabs'        => $tabs,

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -227,6 +227,7 @@ class Page extends Model
             parent::props(),
             $this->prevNext(),
             [
+                'blueprint' => $this->model->intendedTemplate()->name(),
                 'model' => [
                     'content'    => $this->content(),
                     'id'         => $page->id(),

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -51,6 +51,7 @@ class Site extends Model
     public function props(): array
     {
         return array_merge(parent::props(), [
+            'blueprint' => 'site',
             'model' => [
                 'content'    => $this->content(),
                 'previewUrl' => $this->model->previewUrl(),

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -85,37 +85,6 @@ class User extends Model
     }
 
     /**
-     * Returns the data array for the
-     * view's component props
-     *
-     * @internal
-     *
-     * @return array
-     */
-    public function props(): array
-    {
-        $user   = $this->model;
-        $avatar = $user->avatar();
-
-        return array_merge(
-            parent::props(),
-            $this->prevNext(),
-            [
-                'model' => [
-                    'avatar'   => $avatar ? $avatar->url() : null,
-                    'content'  => $this->content(),
-                    'email'    => $user->email(),
-                    'id'       => $user->id(),
-                    'language' => $this->translation()->name(),
-                    'name'     => $user->name()->toString(),
-                    'role'     => $user->role()->title(),
-                    'username' => $user->username(),
-                ]
-            ]
-        );
-    }
-
-    /**
      * Returns navigation array with
      * previous and next user
      *
@@ -137,6 +106,38 @@ class User extends Model
                 return $prev ? $prev->panel()->toLink('username') : null;
             }
         ];
+    }
+
+    /**
+     * Returns the data array for the
+     * view's component props
+     *
+     * @internal
+     *
+     * @return array
+     */
+    public function props(): array
+    {
+        $user   = $this->model;
+        $avatar = $user->avatar();
+
+        return array_merge(
+            parent::props(),
+            $this->prevNext(),
+            [
+                'blueprint' => $this->model->role()->name(),
+                'model' => [
+                    'avatar'   => $avatar ? $avatar->url() : null,
+                    'content'  => $this->content(),
+                    'email'    => $user->email(),
+                    'id'       => $user->id(),
+                    'language' => $this->translation()->name(),
+                    'name'     => $user->name()->toString(),
+                    'role'     => $user->role()->title(),
+                    'username' => $user->username(),
+                ]
+            ]
+        );
     }
 
     /**

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -36,7 +36,7 @@ class SiteTest extends AreaTestCase
         $props = $view['props'];
         $model = $props['model'];
 
-        $this->assertSame('Page', $props['blueprint']);
+        $this->assertSame('default', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
         $this->assertArrayNotHasKey('tab', $props);
@@ -80,7 +80,8 @@ class SiteTest extends AreaTestCase
             ],
             'files' => [
                 [
-                    'filename' => 'test.jpg'
+                    'filename' => 'test.jpg',
+                    'template' => 'image'
                 ]
             ]
         ]);
@@ -89,7 +90,7 @@ class SiteTest extends AreaTestCase
         $props = $view['props'];
         $model = $props['model'];
 
-        $this->assertSame('File', $props['blueprint']);
+        $this->assertSame('image', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
         $this->assertArrayNotHasKey('tab', $props);
@@ -140,7 +141,8 @@ class SiteTest extends AreaTestCase
             'site' => [
                 'files' => [
                     [
-                        'filename' => 'test.jpg'
+                        'filename' => 'test.jpg',
+                        'template' => 'image'
                     ]
                 ]
             ]
@@ -152,7 +154,7 @@ class SiteTest extends AreaTestCase
         $props = $view['props'];
         $model = $props['model'];
 
-        $this->assertSame('File', $props['blueprint']);
+        $this->assertSame('image', $props['blueprint']);
         $this->assertSame(['state' => null], $props['lock']);
 
         $this->assertArrayNotHasKey('tab', $props);

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -423,7 +423,6 @@ class ModelTest extends TestCase
         $app->impersonate('kirby');
 
         $props = $this->panel($site)->props();
-        $this->assertSame('site', $props['blueprint']);
         $this->assertSame('main', $props['tabs'][0]['name']);
         $this->assertSame('main', $props['tab']['name']);
         $this->assertTrue($props['permissions']['update']);


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Integrates most features of Panel View Extended in the core (but via CSS selectors only)
- Fixes blueprint info messages


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- Added more CSS selectors for customising the Panel
  - `.k-panel[data-language]` for the current content translation language
  - `.k-panel[data-default-language]` for the default content translation language
  - `.k-panel[data-translation]` for the current Panel UI/user language
  - `.k-panel[data-role]` for current user role
  - `.k-panel[data-user]` for current user ID
  - `.k-page-view[data-id]` for page ID
  - `.k-page-view[data-template]` for page's intended template
  - `.k-file-view[data-id]` for file ID
  - `.k-file-view[data-template]` for file's template
  - `.k-user-view[data-id]` for user ID
  - `.k-user-view[data-role]` for user's role
  - `.k-site-view[data-id]` for site ID (`/`)
  - `.k-site-view[data-template]` for site's template (`site`)
  - `.k-languages-dropdown` for content translation language dropdown
  - `.k-page-view-options`, `.k-file-view-options` and `.k-user-view-options` for options dropdown on model views
  - `.k-page-view-preview`, `.k-file-view-preview`, `.k-site-view-preview ` and `.k-user-view-preview ` for preview button on model views
  - `.k-pages-section .k-item[data-id]`, `.k-pages-section .k-item[data-status]` and `.k-pages-section .k-item[data-template]`
  - `.k-files-section .k-item[data-id]` and `.k-files-section .k-item[data-template]`
  - `.k-status-icon .k-status-icon-{status}` for the page's status button


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- `.k-panel[data-translation]` is now `.k-panel[data-language]`
- `.k-panel[data-default-translation]` is now `.k-panel[data-default-translation]`


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/kirby/issues/3322
- Implements https://github.com/getkirby/kirby/issues/3489

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
