### PR TITLE
`$files->size()` and `$files->niceSize()`

### DIFF
--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Filesystem\F;
 
 /**
  * The `$files` object extends the general
@@ -126,6 +127,31 @@ class Files extends Collection
     public function findByKey(string $key)
     {
         return $this->findById($key);
+    }
+
+    /**
+     * Returns the file size for all
+     * files in the collection in a
+     * human-readable format
+     *
+     * @return string
+     */
+    public function niceSize(): string
+    {
+        return F::niceSize($this->size());
+    }
+
+    /**
+     * Returns the raw size for all
+     * files in the collection
+     *
+     * @return int
+     */
+    public function size(): int
+    {
+        return F::size($this->values(function ($file) {
+            return $file->root();
+        }));
     }
 
     /**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -561,7 +561,7 @@ class Dir
      * Gets the size of the directory
      *
      * @param string $dir The path of the directory
-     * @param bool $rescursive Include all subfolders and their files
+     * @param bool $recursive Include all subfolders and their files
      * @return mixed
      */
     public static function size(string $dir, bool $recursive = true)

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -558,27 +558,25 @@ class Dir
     }
 
     /**
-     * Gets the size of the directory and all subfolders and files
+     * Gets the size of the directory
      *
      * @param string $dir The path of the directory
+     * @param bool $rescursive Include all subfolders and their files
      * @return mixed
      */
-    public static function size(string $dir)
+    public static function size(string $dir, bool $recursive = true)
     {
         if (is_dir($dir) === false) {
             return false;
         }
 
-        $size  = 0;
-        $items = static::read($dir);
+        // Get size for all direct files
+        $size = F::size(static::files($dir, null, true));
 
-        foreach ($items as $item) {
-            $root = $dir . '/' . $item;
-
-            if (is_dir($root) === true) {
-                $size += static::size($root);
-            } elseif (is_file($root) === true) {
-                $size += F::size($root);
+        // if recursive, add sizes of all subdirectories
+        if ($recursive === true) {
+            foreach (static::dirs($dir, null, true) as $subdir) {
+                $size += static::size($subdir);
             }
         }
 

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -531,7 +531,7 @@ class F
     /**
      * Converts an integer size into a human readable format
      *
-     * @param mixed $size The file size or a file path
+     * @param mixed $size The file size, a file path or array of paths
      * @param string|null|false $locale Locale for number formatting,
      *                                  `null` for the current locale,
      *                                  `false` to disable number formatting
@@ -540,7 +540,7 @@ class F
     public static function niceSize($size, $locale = null): string
     {
         // file mode
-        if (is_string($size) === true && file_exists($size) === true) {
+        if (is_string($size) === true || is_array($size) === true) {
             $size = static::size($size);
         }
 
@@ -755,13 +755,19 @@ class F
     }
 
     /**
-     * Returns the size of a file.
+     * Returns the size of a file or an array of files.
      *
-     * @param mixed $file The path
+     * @param string|array $file file path or array of paths
      * @return int
      */
-    public static function size(string $file): int
+    public static function size($file): int
     {
+        if (is_array($file) === true) {
+            return array_reduce($file, function ($total, $file) {
+                return $total + F::size($file);
+            }, 0);
+        }
+
         try {
             return filesize($file);
         } catch (Throwable $e) {

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
+
 class FilesTest extends TestCase
 {
     public function testAddFile()
@@ -106,5 +109,40 @@ class FilesTest extends TestCase
         $site  = new Site();
         $files = new Files();
         $files->add($site);
+    }
+
+    /**
+     * @covers ::niceSize
+     * @covers ::size
+     */
+    public function testSize()
+    {
+        $tmp = __DIR__ . '/tmp';
+        Dir::make($tmp);
+
+        $app = new App([
+            'roots' => [
+                'index' => $tmp
+            ],
+            'site' => [
+                'children' => [
+                    ['slug' => 'test']
+                ]
+            ]
+        ]);
+
+        F::write($a = $tmp . '/content/test/a.txt', 'foo');
+        F::write($b = $tmp . '/content/test/b.txt', 'bar');
+
+        $files = Files::factory([
+            ['filename' => 'a.txt', 'root' => $a],
+            ['filename' => 'b.txt', 'root' => $b]
+        ], $app->page('test'));
+
+
+        $this->assertSame(6, $files->size());
+        $this->assertSame('6 B', $files->niceSize());
+
+        Dir::remove($tmp);
     }
 }

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -658,6 +658,7 @@ class DirTest extends TestCase
         F::write($this->tmp . '/testfile-3.txt', Str::random(5));
 
         $this->assertSame(15, Dir::size($this->tmp));
+        $this->assertSame(15, Dir::size($this->tmp, false));
         $this->assertSame('15 B', Dir::niceSize($this->tmp));
 
         Dir::remove($this->tmp);
@@ -677,6 +678,7 @@ class DirTest extends TestCase
         F::write($this->tmp . '/sub/sub/testfile-3.txt', Str::random(5));
 
         $this->assertSame(15, Dir::size($this->tmp));
+        $this->assertSame(5, Dir::size($this->tmp, false));
         $this->assertSame('15 B', Dir::niceSize($this->tmp));
 
         Dir::remove($this->tmp);

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -608,7 +608,6 @@ class FTest extends TestCase
         $this->assertSame(4, F::size($a));
         $this->assertSame(4, F::size($b));
         $this->assertSame(8, F::size([$a, $b]));
-
     }
 
     /**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -451,9 +451,16 @@ class FTest extends TestCase
     {
         $locale = I18n::$locale;
 
-        F::write($this->tmp, 'test');
-        $this->assertSame('4 B', F::niceSize($this->tmp));
+        F::write($a = $this->fixtures . '/a.txt', 'test');
+        F::write($b = $this->fixtures . '/b.txt', 'test');
 
+        // for file path
+        $this->assertSame('4 B', F::niceSize($a));
+
+        // for array of file paths
+        $this->assertSame('8 B', F::niceSize([$a, $b]));
+
+        // for int
         $this->assertSame('4 B', F::niceSize(4));
         $this->assertSame('4 KB', F::niceSize(4096));
         $this->assertSame('4 KB', F::niceSize(4100));
@@ -595,9 +602,13 @@ class FTest extends TestCase
      */
     public function testSize()
     {
-        F::write($this->tmp, 'test');
+        F::write($a = $this->fixtures . '/a.txt', 'test');
+        F::write($b = $this->fixtures . '/b.txt', 'test');
 
-        $this->assertSame(4, F::size($this->tmp));
+        $this->assertSame(4, F::size($a));
+        $this->assertSame(4, F::size($b));
+        $this->assertSame(8, F::size([$a, $b]));
+
     }
 
     /**


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhacements
- New `$files->size()` and `$files->niceSize()` methods
- `F::size` and `F::niceSize` accept array of file paths
- `Dir::size()` has new `$recusrive` parameter


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- `F::niceSize()` doesn't check anymore whether file exists (although unclear to me how it worked previously when that check failed)

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Implements https://kirby.nolt.io/210

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
