### PR TITLE
Fix coverage annotation warnings in PHPUnit

### DIFF
--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -5,6 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\Files
+ */
 class FilesTest extends TestCase
 {
     public function testAddFile()

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -382,7 +382,7 @@ class ViewTest extends TestCase
     }
 
     /**
-     * @covers ::erro
+     * @covers ::error
      */
     public function testErrorWithCustomCode(): void
     {


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

PHPUnit throws warnings on invalid annotations. These don't make CI fail, I noticed them while creating the other PR.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None