### PR TITLE
Duplicate dialog: translations toggle

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -386,6 +386,7 @@ return [
     'pages/(:any)/duplicate' => [
         'load' => function (string $id) {
             $page            = Find::page($id);
+            $language        = $page->kirby()->defaultLanguage()->code();
 
             $hasTranslations = $page->translations()->count() > 0;
             $hasChildren     = $page->hasChildren();
@@ -441,12 +442,12 @@ return [
                     'fields'       => $fields,
                     'submitButton' => t('duplicate'),
                     'value' => [
-                        'slug'     => $page->slug() . '-' . Str::slug(t('page.duplicate.appendix')),
-                        'title'    => $page->title() . ' ' . t('page.duplicate.appendix')
-                    ]
                         'translations' => false,
                         'children'     => false,
                         'files'        => false,
+                        'slug'         => $page->slug($language) . '-' . Str::slug(t('page.duplicate.appendix')),
+                        'title'        => $page->content($language)->get('title') . ' ' . t('page.duplicate.appendix')
+                    ],
                     'size' => $toggles > 2 ? 'large' : 'medium'
                 ]
             ];

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -386,14 +386,15 @@ return [
     'pages/(:any)/duplicate' => [
         'load' => function (string $id) {
             $page            = Find::page($id);
-            $language        = $page->kirby()->defaultLanguage()->code();
-
             $hasTranslations = $page->translations()->count() > 0;
             $hasChildren     = $page->hasChildren();
             $hasFiles        = $page->hasFiles();
-
             $toggles         = count(array_filter([$hasTranslations, $hasChildren, $hasFiles]));
             $togglesWidth    = '1/' . $toggles;
+
+            if ($language = $page->kirby()->defaultLanguage()) {
+                $language = $language->code();
+            }
 
             $fields = [
                 'title' => Field::title([

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -386,9 +386,13 @@ return [
     'pages/(:any)/duplicate' => [
         'load' => function (string $id) {
             $page            = Find::page($id);
+
+            $hasTranslations = $page->translations()->count() > 0;
             $hasChildren     = $page->hasChildren();
             $hasFiles        = $page->hasFiles();
-            $toggleWidth     = '1/' . count(array_filter([$hasChildren, $hasFiles]));
+
+            $toggles         = count(array_filter([$hasTranslations, $hasChildren, $hasFiles]));
+            $togglesWidth    = '1/' . $toggles;
 
             $fields = [
                 'title' => Field::title([
@@ -404,12 +408,21 @@ return [
                 ])
             ];
 
+            if ($hasTranslations === true) {
+                $fields['translations'] = [
+                    'label'    => t('page.duplicate.translations'),
+                    'type'     => 'toggle',
+                    'required' => true,
+                    'width'    => $togglesWidth
+                ];
+            }
+
             if ($hasFiles === true) {
                 $fields['files'] = [
                     'label'    => t('page.duplicate.files'),
                     'type'     => 'toggle',
                     'required' => true,
-                    'width'    => $toggleWidth
+                    'width'    => $togglesWidth
                 ];
             }
 
@@ -418,7 +431,7 @@ return [
                     'label'    => t('page.duplicate.pages'),
                     'type'     => 'toggle',
                     'required' => true,
-                    'width'    => $toggleWidth
+                    'width'    => $togglesWidth
                 ];
             }
 
@@ -428,19 +441,22 @@ return [
                     'fields'       => $fields,
                     'submitButton' => t('duplicate'),
                     'value' => [
-                        'children' => false,
-                        'files'    => false,
                         'slug'     => $page->slug() . '-' . Str::slug(t('page.duplicate.appendix')),
                         'title'    => $page->title() . ' ' . t('page.duplicate.appendix')
                     ]
+                        'translations' => false,
+                        'children'     => false,
+                        'files'        => false,
+                    'size' => $toggles > 2 ? 'large' : 'medium'
                 ]
             ];
         },
         'submit' => function (string $id) {
             $newPage = Find::page($id)->duplicate(get('slug'), [
-                'children' => (bool)get('children'),
-                'files'    => (bool)get('files'),
-                'title'    => (string)get('title'),
+                'children'     => (bool)get('children'),
+                'translations' => (bool)get('translations'),
+                'files'        => (bool)get('files'),
+                'title'        => (string)get('title'),
             ]);
 
             return [

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -402,6 +402,7 @@
   "page.duplicate.appendix": "Copy",
   "page.duplicate.files": "Copy files",
   "page.duplicate.pages": "Copy pages",
+  "page.duplicate.translations": "Copy translations",
   "page.sort": "Change position",
   "page.status": "Status",
   "page.status.draft": "Draft",

--- a/tests/Panel/Areas/PageDialogsTest.php
+++ b/tests/Panel/Areas/PageDialogsTest.php
@@ -747,6 +747,53 @@ class PageDialogsTest extends AreaTestCase
         $this->assertSame('test-copy', $props['value']['slug']);
     }
 
+    protected function assertDuplicateDialogTranslations(array $props, string $width = '1/1'): void
+    {
+        $this->assertSame('toggle', $props['fields']['translations']['type']);
+        $this->assertSame('Copy translations', $props['fields']['translations']['label']);
+        $this->assertSame($width, $props['fields']['translations']['width']);
+    }
+
+    public function testDuplicateWithTranslations(): void
+    {
+        $this->app([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => []
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => []
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->login();
+
+        $dialog = $this->dialog('pages/test/duplicate');
+        $props  = $dialog['props'];
+
+        $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogTranslations($props);
+    }
+
+    protected function assertDuplicateDialogChildren(array $props, string $width = '1/1'): void
+    {
+        $this->assertSame('toggle', $props['fields']['children']['type']);
+        $this->assertSame('Copy pages', $props['fields']['children']['label']);
+
+        $this->assertSame($width, $props['fields']['children']['width']);
+    }
+
     public function testDuplicateWithChildren(): void
     {
         $this->app([
@@ -768,10 +815,16 @@ class PageDialogsTest extends AreaTestCase
         $props  = $dialog['props'];
 
         $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogChildren($props);
+    }
 
-        $this->assertSame('toggle', $props['fields']['children']['type']);
-        $this->assertSame('Copy pages', $props['fields']['children']['label']);
-        $this->assertSame('1/1', $props['fields']['children']['width']);
+    protected function assertDuplicateDialogFiles(array $props, string $width = '1/1'): void
+    {
+        $this->assertSame('toggle', $props['fields']['files']['type']);
+        $this->assertSame('Copy files', $props['fields']['files']['label']);
+
+        $this->assertSame($width, $props['fields']['files']['width']);
     }
 
     public function testDuplicateWithFiles(): void
@@ -795,10 +848,80 @@ class PageDialogsTest extends AreaTestCase
         $props  = $dialog['props'];
 
         $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogFiles($props);
+    }
 
-        $this->assertSame('toggle', $props['fields']['files']['type']);
-        $this->assertSame('Copy files', $props['fields']['files']['label']);
-        $this->assertSame('1/1', $props['fields']['files']['width']);
+    public function testDuplicateWithTranslationsAndChildren(): void
+    {
+        $this->app([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => []
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => []
+                            ]
+                        ],
+                        'children' => [
+                            ['slug' => 'test-child']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->login();
+
+        $dialog = $this->dialog('pages/test/duplicate');
+        $props  = $dialog['props'];
+
+        $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogTranslations($props, '1/2');
+        $this->assertDuplicateDialogChildren($props, '1/2');
+    }
+
+    public function testDuplicateWithTranslationsAndFiles(): void
+    {
+        $this->app([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => []
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => []
+                            ]
+                        ],
+                        'files' => [
+                            ['filename' => 'test.jpg']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->login();
+
+        $dialog = $this->dialog('pages/test/duplicate');
+        $props  = $dialog['props'];
+
+        $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogTranslations($props, '1/2');
+        $this->assertDuplicateDialogFiles($props, '1/2');
     }
 
     public function testDuplicateWithChildrenAndFiles(): void
@@ -825,14 +948,49 @@ class PageDialogsTest extends AreaTestCase
         $props  = $dialog['props'];
 
         $this->assertFormDialog($dialog);
+        $this->assertSame('medium', $props['size']);
+        $this->assertDuplicateDialogChildren($props, '1/2');
+        $this->assertDuplicateDialogFiles($props, '1/2');
+    }
 
-        $this->assertSame('toggle', $props['fields']['children']['type']);
-        $this->assertSame('Copy pages', $props['fields']['children']['label']);
-        $this->assertSame('1/2', $props['fields']['children']['width']);
+    public function testDuplicateWithTranslationsAndChildrenAndFiles(): void
+    {
+        $this->app([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'translations' => [
+                            [
+                                'code' => 'en',
+                                'content' => []
+                            ],
+                            [
+                                'code' => 'de',
+                                'content' => []
+                            ]
+                        ],
+                        'children' => [
+                            ['slug' => 'test-child']
+                        ],
+                        'files' => [
+                            ['filename' => 'test.jpg']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
 
-        $this->assertSame('toggle', $props['fields']['files']['type']);
-        $this->assertSame('Copy files', $props['fields']['files']['label']);
-        $this->assertSame('1/2', $props['fields']['files']['width']);
+        $this->login();
+
+        $dialog = $this->dialog('pages/test/duplicate');
+        $props  = $dialog['props'];
+
+        $this->assertFormDialog($dialog);
+        $this->assertSame('large', $props['size']);
+        $this->assertDuplicateDialogTranslations($props, '1/3');
+        $this->assertDuplicateDialogChildren($props, '1/3');
+        $this->assertDuplicateDialogFiles($props, '1/3');
     }
 
     public function testDuplicateOnSubmit(): void


### PR DESCRIPTION
## Describe the PR

See features below.
Also fixes a bug where title and slug values where filled by the current non-default content translation.

- [ ] Unit tests for `PageActions::copy()`
- [ ] Unit tests for `PageActions::duplicate()`

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Features
- Duplicate dialog: has now option to copy or not copy over translations
- Options for `Kirby\Cms\PageActions::copy()` and `Kirby\Cms\PageActions::duplicate()` to exclude translations

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- `Kirby\Cms\PageActions::duplicate()` now ignores translations by default 


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- https://kirby.nolt.io/117

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
