### PR TITLE
`Str::template()`: deprecate parameters

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -504,7 +504,7 @@ return function (App $app) {
                     'kirby' => $app,
                     'site'  => $app->site(),
                     'page'  => $app->page()
-                ], $data), $fallback);
+                ], $data), ['fallback' => $fallback]);
             }
 
             return $field;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -533,7 +533,7 @@ abstract class ModelWithContent extends Model
             'kirby'             => $this->kirby(),
             'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
             static::CLASS_ALIAS => $this
-        ], $data), $fallback);
+        ], $data), ['fallback' => $fallback]);
 
         return $result;
     }

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -590,7 +590,7 @@ trait PageActions
                     'kirby' => $app,
                     'page'  => $app->page($this->id()),
                     'site'  => $app->site(),
-                ], '');
+                ], ['fallback' => '']);
 
                 return (int)$template;
         }

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -225,7 +225,7 @@ abstract class Sql
             'null'    => $null,
             'default' => $columnDefault['query'],
             'unique'  => $uniqueColumn
-        ], ''));
+        ], ['fallback' => '']));
 
         return [
             'query'    => $query,

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -121,7 +121,11 @@ class Exception extends \Exception
             }
 
             // format message with passed data
-            $message = Str::template($message, $this->data, '-', '{', '}');
+            $message = Str::template($message, $this->data, [
+                'fallback' => '-',
+                'start'    => '{',
+                'end'      => '}'
+            ]);
 
             // handover to Exception parent class constructor
             parent::__construct($message, null, $args['previous'] ?? null);

--- a/src/Filesystem/Filename.php
+++ b/src/Filesystem/Filename.php
@@ -301,6 +301,6 @@ class Filename
             'name'       => $this->name(),
             'attributes' => $this->attributesToString('-'),
             'extension'  => $this->extension()
-        ], '');
+        ], ['fallback' => '']);
     }
 }

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -207,7 +207,11 @@ class I18n
         }
 
         $template = static::translate($key, $fallback, $locale);
-        return Str::template($template, $replace, '-', '{', '}');
+        return Str::template($template, $replace, [
+            'fallback' => '-',
+            'start'    => '{',
+            'end'      => '}'
+        ]);
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -973,16 +973,25 @@ class Str
      *                                    - start: start placeholder
      *                                    - end: end placeholder
      *                                    A simple fallback string is supported for compatibility (but deprecated).
-     * @param string $start Placeholder start characters
-     * @param string $end Placeholder end characters
+     * @param string $start Placeholder start characters (deprecated)
+     * @param string $end Placeholder end characters (deprecated)
      *
-     * @todo Deprecate `string $fallback` and `$start`/`$end` arguments with warning in 3.6.0
      * @todo Remove `$start` and `$end` parameters, rename `$fallback` to `$options` and only support `array` type for `$options` in 3.7.0
      *
      * @return string The filled-in string
      */
     public static function template(string $string = null, array $data = [], $fallback = null, string $start = '{{', string $end = '}}'): string
     {
+        // @codeCoverageIgnoreStart
+        if (
+            is_string($fallback) === true ||
+            $start !== '{{' ||
+            $end !== '}}'
+        ) {
+            deprecated('Str::template(): The $fallback, $start and $end parameters have been deprecated. Please pass an array to the $options parameter instead with `fallback`, `start` or `end` keys: Str::template($string, $data, $options)');
+        }
+        // @codeCoverageIgnoreEnd
+
         $options  = $fallback;
         $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
         $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;


### PR DESCRIPTION

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Deprecations
- `Str::template()`: the parameters `$fallback`, `$start` and `$end` have been deprecated and throw a deprecation warning. Use instead an `$options` array with `fallback`, `start` and/or `end` keys as third parameter.


## Related issues

- https://github.com/getkirby/kirby/issues/3456 - but only one part

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
