### PR TITLE
`v-html` fixes

### DIFF
--- a/config/areas/files/dialogs.php
+++ b/config/areas/files/dialogs.php
@@ -3,6 +3,7 @@
 use Kirby\Cms\Find;
 use Kirby\Panel\Field;
 use Kirby\Panel\Panel;
+use Kirby\Toolkit\Escape;
 
 /**
  * Shared file dialogs
@@ -100,9 +101,8 @@ return [
             return [
                 'component' => 'k-remove-dialog',
                 'props' => [
-                    // todo: escape placeholder (output with `v-html`)
                     'text' => tt('file.delete.confirm', [
-                        'filename' => $file->filename()
+                        'filename' => Escape::html($file->filename())
                     ]),
                 ]
             ];

--- a/config/areas/settings/dialogs.php
+++ b/config/areas/settings/dialogs.php
@@ -3,6 +3,7 @@
 use Kirby\Cms\Find;
 use Kirby\Panel\Field;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\Escape;
 
 $languageDialogFields = [
     'name' => [
@@ -75,9 +76,8 @@ return [
             return [
                 'component' => 'k-remove-dialog',
                 'props' => [
-                    // todo: escape placeholder (output with `v-html`)
                     'text' => tt('language.delete.confirm', [
-                        'name' => $language->name()
+                        'name' => Escape::html($language->name())
                     ])
                 ]
             ];

--- a/config/areas/settings/views.php
+++ b/config/areas/settings/views.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\Escape;
+
 return [
     [
         'pattern' => 'settings',
@@ -21,12 +23,11 @@ return [
                 'component' => 'k-settings-view',
                 'props'     => [
                     'languages' => $kirby->languages()->values(function ($language) {
-                        // todo: probably escape info and text (output with `v-html`)
                         return [
                             'default' => $language->isDefault(),
                             'id'      => $language->code(),
-                            'info'    => $language->code(),
-                            'text'    => $language->name(),
+                            'info'    => Escape::html($language->code()),
+                            'text'    => Escape::html($language->name()),
                         ];
                     }),
                     'license' => $license,

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -322,8 +322,9 @@ return [
     'pages/(:any)/delete' => [
         'load' => function (string $id) {
             $page = Find::page($id);
-            // todo: escape placeholder (output with `v-html`)
-            $text = tt('page.delete.confirm', ['title' => $page->title()->value()]);
+            $text = tt('page.delete.confirm', [
+                'title' => Escape::html($page->title()->value())
+            ]);
 
             if ($page->childrenAndDrafts()->count() > 0) {
                 return [
@@ -347,14 +348,14 @@ return [
                         'theme'        => 'negative',
                     ]
                 ];
-            } else {
-                return [
-                    'component' => 'k-remove-dialog',
-                    'props' => [
-                        'text' => $text
-                    ]
-                ];
             }
+
+            return [
+                'component' => 'k-remove-dialog',
+                'props' => [
+                    'text' => $text
+                ]
+            ];
         },
         'submit' => function (string $id) {
             $page     = Find::page($id);

--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\Escape;
+
 return [
     'pages' => [
         'label' => t('pages'),
@@ -16,9 +18,9 @@ return [
             foreach ($pages as $page) {
                 $results[] = [
                     'image' => $page->panel()->image(),
-                    'text' => $page->title()->value(),
+                    'text' => Escape::html($page->title()->value()),
                     'link' => $page->panel()->url(true),
-                    'info' => $page->id()
+                    'info' => Escape::html($page->id())
                 ];
             }
 
@@ -41,9 +43,9 @@ return [
             foreach ($files as $file) {
                 $results[] = [
                     'image' => $file->panel()->image(),
-                    'text'  => $file->filename(),
+                    'text'  => Escape::html($file->filename()),
                     'link'  => $file->panel()->url(true),
-                    'info'  => $file->id()
+                    'info'  => Escape::html($file->id())
                 ];
             }
 

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -5,6 +5,7 @@ use Kirby\Cms\UserRules;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Field;
 use Kirby\Panel\Panel;
+use Kirby\Toolkit\Escape;
 
 $files = require __DIR__ . '/../files/dialogs.php';
 
@@ -229,9 +230,8 @@ return [
             return [
                 'component' => 'k-remove-dialog',
                 'props' => [
-                    // todo: escape placeholder (output with `v-html`)
                     'text' => tt('user.delete.confirm', [
-                        'email' => $user->email()
+                        'email' => Escape::html($user->email())
                     ])
                 ]
             ];

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Toolkit\Escape;
+
 return [
     'users' => [
         'label' => t('users'),
@@ -11,9 +13,9 @@ return [
             foreach ($users as $user) {
                 $results[] = [
                     'image' => $user->panel()->image(),
-                    'text'  => $user->username(),
+                    'text'  => Escape::html($user->username()),
                     'link'  => $user->panel()->url(true),
-                    'info'  => $user->role()->title()
+                    'info'  => Escape::html($user->role()->title())
                 ];
             }
 

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\Find;
+use Kirby\Toolkit\Escape;
 
 return [
     [
@@ -38,13 +39,12 @@ return [
 
                         return [
                             'data' => $users->values(function ($user) {
-                                // todo: probably escape info and text (output with `v-html`)
                                 return [
                                     'id'    => $user->id(),
                                     'image' => $user->panel()->image(),
-                                    'info'  => $user->role()->title(),
+                                    'info'  => Escape::html($user->role()->title()),
                                     'link'  => $user->panel()->url(true),
-                                    'text'  => $user->username()
+                                    'text'  => Escape::html($user->username())
                                 ];
                             }),
                             'pagination' => $users->pagination()->toArray()

--- a/config/fields/info.php
+++ b/config/fields/info.php
@@ -34,7 +34,7 @@ return [
     'computed' => [
         'text' => function () {
             if ($text = $this->text) {
-                $text = $this->model()->toString($text);
+                $text = $this->model()->toSafeString($text);
                 $text = $this->kirby()->kirbytext($text);
                 return $text;
             }

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -21,19 +21,21 @@ return [
          * Sets the text next to the toggle. The text can be a string or an array of two options. The first one is the negative text and the second one the positive. The text will automatically switch when the toggle is triggered.
          */
         'text' => function ($value = null) {
+            $model = $this->model();
+
             if (is_array($value) === true) {
                 if (A::isAssociative($value) === true) {
-                    return I18n::translate($value, $value);
+                    return $model->toSafeString(I18n::translate($value, $value));
                 }
 
                 foreach ($value as $key => $val) {
-                    $value[$key] = I18n::translate($val, $val);
+                    $value[$key] = $model->toSafeString(I18n::translate($val, $val));
                 }
 
                 return $value;
             }
 
-            return I18n::translate($value, $value);
+            return $model->toSafeString(I18n::translate($value, $value));
         },
     ],
     'computed' => [

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kirby\Cms\File;
-use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\I18n;
 
 return [
@@ -118,26 +117,19 @@ return [
             foreach ($this->files as $file) {
                 $panel = $file->panel();
 
-                // escape the default text
-                // TODO: no longer needed in 3.6
-                $text = $file->toString($this->text);
-                if ($this->text === '{{ file.filename }}') {
-                    $text = Escape::html($text);
-                }
-
                 $data[] = [
-                    'dragText' => $panel->dragText('auto', $dragTextAbsolute),
+                    'dragText'  => $panel->dragText('auto', $dragTextAbsolute),
                     'extension' => $file->extension(),
-                    'filename' => $file->filename(),
-                    'id'       => $file->id(),
-                    'image'    => $panel->image($this->image, $this->layout),
-                    'info'     => $file->toString($this->info ?? false),
-                    'link'     => $panel->url(true),
-                    'mime'     => $file->mime(),
-                    'parent'   => $file->parent()->panel()->path(),
-                    'template' => $file->template(),
-                    'text'     => $text,
-                    'url'      => $file->url(),
+                    'filename'  => $file->filename(),
+                    'id'        => $file->id(),
+                    'image'     => $panel->image($this->image, $this->layout),
+                    'info'      => $file->toSafeString($this->info ?? false),
+                    'link'      => $panel->url(true),
+                    'mime'      => $file->mime(),
+                    'parent'    => $file->parent()->panel()->path(),
+                    'template'  => $file->template(),
+                    'text'      => $file->toSafeString($this->text),
+                    'url'       => $file->url(),
                 ];
             }
 

--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -17,7 +17,7 @@ return [
     'computed' => [
         'text' => function () {
             if ($this->text) {
-                $text = $this->model()->toString($this->text);
+                $text = $this->model()->toSafeString($this->text);
                 $text = $this->kirby()->kirbytext($text);
                 return $text;
             }

--- a/config/sections/mixins/empty.php
+++ b/config/sections/mixins/empty.php
@@ -14,7 +14,7 @@ return [
     'computed' => [
         'empty' => function () {
             if ($this->empty) {
-                return $this->model()->toString($this->empty);
+                return $this->model()->toSafeString($this->empty);
             }
         }
     ]

--- a/config/sections/mixins/help.php
+++ b/config/sections/mixins/help.php
@@ -14,7 +14,7 @@ return [
     'computed' => [
         'help' => function () {
             if ($this->help) {
-                $help = $this->model()->toString($this->help);
+                $help = $this->model()->toSafeString($this->help);
                 $help = $this->kirby()->kirbytext($help);
                 return $help;
             }

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\Blueprint;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\I18n;
 
 return [
@@ -154,29 +153,22 @@ return [
                 $panel       = $item->panel();
                 $permissions = $item->permissions();
 
-                // escape the default text
-                // TODO: no longer needed in 3.6
-                $text = $item->toString($this->text);
-                if ($this->text === '{{ page.title }}') {
-                    $text = Escape::html($text);
-                }
-
                 $data[] = [
-                    'id'          => $item->id(),
                     'dragText'    => $panel->dragText(),
-                    'text'        => $text,
-                    'info'        => $item->toString($this->info ?? false),
-                    'parent'      => $item->parentId(),
+                    'id'          => $item->id(),
                     'image'       => $panel->image($this->image, $this->layout),
+                    'info'        => $item->toSafeString($this->info ?? false),
                     'link'        => $panel->url(true),
-                    'template'    => $item->intendedTemplate()->name(),
-                    'status'      => $item->status(),
+                    'parent'      => $item->parentId(),
                     'permissions' => [
                         'sort'         => $permissions->can('sort'),
                         'changeSlug'   => $permissions->can('changeSlug'),
                         'changeStatus' => $permissions->can('changeStatus'),
                         'changeTitle'  => $permissions->can('changeTitle'),
-                    ]
+                    ],
+                    'status'      => $item->status(),
+                    'template'    => $item->intendedTemplate()->name(),
+                    'text'        => $item->toSafeString($this->text),
                 ];
             }
 

--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -7,7 +7,7 @@
     @submit="submit"
   >
     <template v-if="issue">
-      <k-box :text="issue" :html="false" theme="negative" />
+      <k-box :text="issue" theme="negative" />
     </template>
 
     <template v-else>

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -7,7 +7,7 @@
     @submit="submit"
   >
     <template v-if="issue">
-      <k-box :text="issue" :html="false" theme="negative" />
+      <k-box :text="issue" theme="negative" />
     </template>
     <template v-else>
       <header v-if="model" class="k-pages-dialog-navbar">

--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -7,7 +7,7 @@
     @submit="submit"
   >
     <template v-if="issue">
-      <k-box :text="issue" :html="false" theme="negative" />
+      <k-box :text="issue" theme="negative" />
     </template>
 
     <template v-else>

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -14,8 +14,7 @@
       <!-- eslint-disable vue/no-v-html -->
       <label v-if="option.info" :for="id + '-' + index">
         <span class="k-radio-input-text" v-html="option.text" />
-        <!-- @todo support (escaped) HTML in the info prop in 3.6.0 -->
-        <span class="k-radio-input-info">{{ option.info }}</span>
+        <span class="k-radio-input-info" v-html="option.info" />
       </label>
       <label v-else :for="id + '-' + index" v-html="option.text" />
       <!-- eslint-enable vue/no-v-html -->

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -32,12 +32,11 @@ export default {
      */
     text: String,
     /**
-     * If set to `false`, the `text` is rendered as text only
-     * @todo Switch default value to `false` in 3.6.0
+     * If set to `true`, the `text` is rendered as HTML code, otherwise as plain text
      */
     html: {
       type: Boolean,
-      default: true
+      default: false
     }
   }
 };

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -516,20 +516,38 @@ abstract class ModelWithContent extends Model
     }
 
     /**
-     * String template builder
+     * String template builder with automatic HTML escaping
      *
-     * @param string|null $template
+     * @param string|null $template Template string or `null` to use the model ID
      * @param array $data
      * @param string $fallback Fallback for tokens in the template that cannot be replaced
      * @return string
      */
-    public function toString(string $template = null, array $data = [], string $fallback = ''): string
+    public function toSafeString(string $template = null, array $data = [], string $fallback = ''): string
+    {
+        return $this->toString($template, $data, $fallback, 'safeTemplate');
+    }
+
+    /**
+     * String template builder
+     *
+     * @param string|null $template Template string or `null` to use the model ID
+     * @param array $data
+     * @param string $fallback Fallback for tokens in the template that cannot be replaced
+     * @param string $handler For internal use
+     * @return string
+     */
+    public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
     {
         if ($template === null) {
             return $this->id();
         }
 
-        $result = Str::template($template, array_replace([
+        if ($handler !== 'template' && $handler !== 'safeTemplate') {
+            throw new InvalidArgumentException('Invalid toString handler'); // @codeCoverageIgnore
+        }
+
+        $result = Str::$handler($template, array_replace([
             'kirby'             => $this->kirby(),
             'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
             static::CLASS_ALIAS => $this

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -832,13 +832,13 @@ class User extends ModelWithContent
      * @param string $fallback Fallback for tokens in the template that cannot be replaced
      * @return string
      */
-    public function toString(string $template = null, array $data = [], string $fallback = ''): string
+    public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
     {
         if ($template === null) {
             $template = $this->email();
         }
 
-        return parent::toString($template, $data);
+        return parent::toString($template, $data, $fallback, $handler);
     }
 
     /**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -238,7 +238,7 @@ class Field extends Component
                 'help' => function () {
                     /** @var \Kirby\Form\Field $this */
                     if ($this->help) {
-                        $help = $this->model()->toString($this->help);
+                        $help = $this->model()->toSafeString($this->help);
                         $help = $this->kirby()->kirbytext($help);
                         return $help;
                     }

--- a/src/Form/OptionsApi.php
+++ b/src/Form/OptionsApi.php
@@ -7,7 +7,6 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Remote;
 use Kirby\Http\Url;
-use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\Properties;
 use Kirby\Toolkit\Query;
 use Kirby\Toolkit\Str;
@@ -90,11 +89,7 @@ class OptionsApi
     protected function field(string $field, array $data): string
     {
         $value = $this->$field();
-        return Str::template($value, $data, [
-            'callback' => function ($result) {
-                return Escape::html($result);
-            }
-        ]);
+        return Str::safeTemplate($value, $data);
     }
 
     /**

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -6,7 +6,6 @@ use Kirby\Cms\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Collection;
-use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Properties;
 use Kirby\Toolkit\Query;
@@ -103,26 +102,7 @@ class OptionsQuery
             $value = $value[$object];
         }
 
-        $result = Str::template($value, $data);
-
-        // escape the default queries for the `text` field
-        // TODO: remove after default escape implemented for query templates in 3.6
-        if ($field === 'text') {
-            $defaults = [
-                'arrayItem'     => '{{ arrayItem.value }}',
-                'block'         => '{{ block.type }}: {{ block.id }}',
-                'file'          => '{{ file.filename }}',
-                'page'          => '{{ page.title }}',
-                'structureItem' => '{{ structureItem.title }}',
-                'user'          => '{{ user.username }}',
-            ];
-
-            if (isset($defaults[$object]) && $value === $defaults[$object]) {
-                $result = Escape::html($result);
-            }
-        }
-
-        return $result;
+        return Str::safeTemplate($value, $data);
     }
 
     /**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -308,9 +308,6 @@ abstract class Model
      */
     public function pickerData(array $params = []): array
     {
-        // todo: in 3.5.7 this method would have escaped the default text;
-        //       no longer needed in 3.6
-
         return [
             'id'       => $this->model->id(),
             'image'    => $this->image(

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -317,10 +317,10 @@ abstract class Model
                 $params['image'] ?? [],
                 $params['layout'] ?? 'list'
             ),
-            'info'     => $this->model->toString($params['info'] ?? false),
+            'info'     => $this->model->toSafeString($params['info'] ?? false),
             'link'     => $this->url(true),
             'sortable' => true,
-            'text'     => $this->model->toString($params['text'] ?? false)
+            'text'     => $this->model->toSafeString($params['text'] ?? false),
         ];
     }
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -731,6 +731,53 @@ class Str
     }
 
     /**
+     * Replaces placeholders in string with values from the data array
+     * and escapes HTML in the results in `{{ }}` placeholders
+     * while leaving HTML special characters untouched in `{< >}` placeholders
+     *
+     * @since 3.6.0
+     *
+     * @param string|null $string The string with placeholders
+     * @param array $data Associative array with placeholders as
+     *                    keys and replacements as values.
+     *                    Supports query syntax.
+     * @param array $options An options array that contains:
+     *                       - fallback: if a token does not have any matches
+     *                       - callback: to be able to handle each matching result (escaping is applied after the callback)
+     *
+     * @return string The filled-in and partially escaped string
+     */
+    public static function safeTemplate(string $string = null, array $data = [], array $options = []): string
+    {
+        $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
+        $fallback = $options['fallback'] ?? '';
+
+        // replace and escape
+        $string = static::template($string, $data, [
+            'start'    => '{{',
+            'end'      => '}}',
+            'callback' => function ($result, $query, $data) use ($callback) {
+                if ($callback !== null) {
+                    $result = $callback($result, $query, $data);
+                }
+
+                return Escape::html($result);
+            },
+            'fallback' => $fallback
+        ]);
+
+        // replace unescaped (specifically marked placeholders)
+        $string = static::template($string, $data, [
+            'start'    => '{<',
+            'end'      => '>}',
+            'callback' => $callback,
+            'fallback' => $fallback
+        ]);
+
+        return $string;
+    }
+
+    /**
      * Shortens a string and adds an ellipsis if the string is too long
      *
      * <code>
@@ -765,44 +812,6 @@ class Str
         }
 
         return static::substr($string, 0, $length) . $appendix;
-    }
-
-    /**
-     * Convert a string to a safe version to be used in a URL
-     *
-     * @param string $string The unsafe string
-     * @param string $separator To be used instead of space and
-     *                          other non-word characters.
-     * @param string $allowed List of all allowed characters (regex)
-     * @param int $maxlength The maximum length of the slug
-     * @return string The safe string
-     */
-    public static function slug(string $string = null, string $separator = null, string $allowed = null, int $maxlength = 128): string
-    {
-        $separator = $separator ?? static::$defaults['slug']['separator'];
-        $allowed   = $allowed   ?? static::$defaults['slug']['allowed'];
-
-        $string = trim($string);
-        $string = static::lower($string);
-        $string = static::ascii($string);
-
-        // replace spaces with simple dashes
-        $string = preg_replace('![^' . $allowed . ']!i', $separator, $string);
-
-        if (strlen($separator) > 0) {
-            // remove double separators
-            $string = preg_replace('![' . preg_quote($separator) . ']{2,}!', $separator, $string);
-        }
-
-        // replace slashes with dashes
-        $string = str_replace('/', $separator, $string);
-
-        // trim leading and trailing non-word-chars
-        $string = preg_replace('!^[^a-z0-9]+!', '', $string);
-        $string = preg_replace('![^a-z0-9]+$!', '', $string);
-
-        // cut the string after the given maxlength
-        return static::short($string, $maxlength, false);
     }
 
     /**
@@ -876,6 +885,44 @@ class Str
         }
 
         return compact('matches', 'percent');
+    }
+
+    /**
+     * Convert a string to a safe version to be used in a URL
+     *
+     * @param string $string The unsafe string
+     * @param string $separator To be used instead of space and
+     *                          other non-word characters.
+     * @param string $allowed List of all allowed characters (regex)
+     * @param int $maxlength The maximum length of the slug
+     * @return string The safe string
+     */
+    public static function slug(string $string = null, string $separator = null, string $allowed = null, int $maxlength = 128): string
+    {
+        $separator = $separator ?? static::$defaults['slug']['separator'];
+        $allowed   = $allowed   ?? static::$defaults['slug']['allowed'];
+
+        $string = trim($string);
+        $string = static::lower($string);
+        $string = static::ascii($string);
+
+        // replace spaces with simple dashes
+        $string = preg_replace('![^' . $allowed . ']!i', $separator, $string);
+
+        if (strlen($separator) > 0) {
+            // remove double separators
+            $string = preg_replace('![' . preg_quote($separator) . ']{2,}!', $separator, $string);
+        }
+
+        // replace slashes with dashes
+        $string = str_replace('/', $separator, $string);
+
+        // trim leading and trailing non-word-chars
+        $string = preg_replace('!^[^a-z0-9]+!', '', $string);
+        $string = preg_replace('![^a-z0-9]+$!', '', $string);
+
+        // cut the string after the given maxlength
+        return static::short($string, $maxlength, false);
     }
 
     /**
@@ -955,7 +1002,7 @@ class Str
     }
 
     /**
-     * Replaces placeholders in string with value from array
+     * Replaces placeholders in string with values from the data array
      *
      * <code>
      *
@@ -966,7 +1013,8 @@ class Str
      *
      * @param string|null $string The string with placeholders
      * @param array $data Associative array with placeholders as
-     *                    keys and replacements as values
+     *                    keys and replacements as values.
+     *                    Supports query syntax.
      * @param string|array|null $fallback An options array that contains:
      *                                    - fallback: if a token does not have any matches
      *                                    - callback: to be able to handle each matching result

--- a/tests/Form/Fields/ToggleFieldTest.php
+++ b/tests/Form/Fields/ToggleFieldTest.php
@@ -19,30 +19,30 @@ class ToggleFieldTest extends TestCase
     public function testText()
     {
         $field = $this->field('toggle', [
-            'text' => 'Yay'
+            'text' => 'Yay {{ page.slug }}'
         ]);
 
-        $this->assertEquals('Yay', $field->text());
+        $this->assertEquals('Yay test', $field->text());
     }
 
     public function testTextWithTranslation()
     {
         $props = [
             'text' => [
-                'en' => 'Yay',
-                'de' => 'Ja'
+                'en' => 'Yay {{ page.slug }}',
+                'de' => 'Ja {{ page.slug }}'
             ]
         ];
 
         I18n::$locale = 'en';
 
         $field = $this->field('toggle', $props);
-        $this->assertEquals('Yay', $field->text());
+        $this->assertEquals('Yay test', $field->text());
 
         I18n::$locale = 'de';
 
         $field = $this->field('toggle', $props);
-        $this->assertEquals('Ja', $field->text());
+        $this->assertEquals('Ja test', $field->text());
     }
 
     public function testBooleanDefaultValue()
@@ -66,31 +66,31 @@ class ToggleFieldTest extends TestCase
     {
         $field = $this->field('toggle', [
             'text' => [
-                'Yes',
-                'No'
+                'Yes {{ page.slug }}',
+                'No {{ page.slug }}'
             ]
         ]);
 
-        $this->assertEquals(['Yes', 'No'], $field->text());
+        $this->assertEquals(['Yes test', 'No test'], $field->text());
     }
 
     public function testTextToggleWithTranslation()
     {
         $props = [
             'text' => [
-                ['en' => 'Yes', 'de' => 'Ja'],
-                ['en' => 'No', 'de' => 'Nein']
+                ['en' => 'Yes {{ page.slug }}', 'de' => 'Ja {{ page.slug }}'],
+                ['en' => 'No {{ page.slug }}', 'de' => 'Nein {{ page.slug }}']
             ]
         ];
 
         I18n::$locale = 'en';
 
         $field = $this->field('toggle', $props);
-        $this->assertEquals(['Yes', 'No'], $field->text());
+        $this->assertEquals(['Yes test', 'No test'], $field->text());
 
         I18n::$locale = 'de';
 
         $field = $this->field('toggle', $props);
-        $this->assertEquals(['Ja', 'Nein'], $field->text());
+        $this->assertEquals(['Ja test', 'Nein test'], $field->text());
     }
 }

--- a/tests/Panel/Areas/SiteSearchesTest.php
+++ b/tests/Panel/Areas/SiteSearchesTest.php
@@ -50,7 +50,10 @@ class SiteSearchesTest extends AreaTestCase
             'site' => [
                 'children' => [
                     [
-                        'slug' => 'test',
+                        'slug'    => 'test',
+                        'content' => [
+                            'title' => 'Test <strong>Page'
+                        ]
                     ]
                 ]
             ],
@@ -76,7 +79,7 @@ class SiteSearchesTest extends AreaTestCase
         ];
 
         $this->assertSame($image, $results[0]['image']);
-        $this->assertSame('test', $results[0]['text']);
+        $this->assertSame('Test &lt;strong&gt;Page', $results[0]['text']);
         $this->assertSame('/pages/test', $results[0]['link']);
         $this->assertSame('test', $results[0]['info']);
     }

--- a/tests/Panel/Areas/UsersSearchesTest.php
+++ b/tests/Panel/Areas/UsersSearchesTest.php
@@ -7,6 +7,15 @@ class UsersSearchesTest extends AreaTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->app([
+            'roles' => [
+                [
+                    'id'    => 'admin',
+                    'name'  => 'admin',
+                    'title' => '<strong>Admin'
+                ]
+            ]
+        ]);
         $this->install();
         $this->login();
     }
@@ -38,6 +47,6 @@ class UsersSearchesTest extends AreaTestCase
         $this->assertSame($image, $results[0]['image']);
         $this->assertSame('test@getkirby.com', $results[0]['text']);
         $this->assertSame('/users/test', $results[0]['link']);
-        $this->assertSame('Admin', $results[0]['info']);
+        $this->assertSame('&lt;strong&gt;Admin', $results[0]['info']);
     }
 }

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -648,6 +648,49 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::safeTemplate
+     */
+    public function testSafeTemplate()
+    {
+        $original = 'This is a {{ test }} with {< html >} and {{ normal }} text.';
+        $expected = 'This is a awesome Test with <b>HTML</b> and &lt;b&gt;normal&lt;/b&gt; text.';
+
+        $this->assertSame($expected, Str::safeTemplate($original, [
+            'test'   => 'awesome Test',
+            'html'   => '<b>HTML</b>',
+            'normal' => '<b>normal</b>'
+        ]));
+
+        // fallback
+        $this->assertSame('From - to -', Str::safeTemplate(
+            'From {{ a }} to {{ b }}',
+            [],
+            ['fallback' => '-']
+        ));
+
+        // callback
+        $data = [
+            'test' => '<test>',
+            'html' => '<html>'
+        ];
+        $this->assertSame('This is a &lt;test&gt; with <html>', Str::safeTemplate(
+            'This is a {{ test }} with {< html >}',
+            $data,
+            ['callback' => true]
+        ));
+        $this->assertSame('This is a &lt;TEST&gt; with <HTML>', Str::safeTemplate(
+            'This is a {{ test }} with {< html >}',
+            $data,
+            [
+                'callback' => function ($result, $query, $callbackData) use ($data) {
+                    $this->assertSame($data, $callbackData);
+                    return strtoupper($result);
+                }
+            ]
+        ));
+    }
+
+    /**
      * @covers ::short
      */
     public function testShort()


### PR DESCRIPTION
# Status: ready for review 🚀

- [x] New `Str::safeTemplate()` method (@distantnative)
- [x] First draft of `$model->toSafeString()` (@distantnative)
- [x] Review all `v-html` usage again (@lukasbestle)
- [x] Use `Str::safeTemplate()`/`->toSafeString()` wherever values end up in `v-html`
- [x] Finalize `$model->toSafeString()`
- [x] Review further fixes listed in Notion

# Release notes

## Breaking changes
- Several blueprint options that use the query syntax were updated to escape the placeholder values against raw HTML output that may lead to XSS attacks. HTML code directly in the query (like `This is <strong>{{ page.important }}</strong>`) still works as normal. If placeholders need to return HTML, you can use the new `{< site.myMethodWithHtml >}` syntax. In this case you need to ensure manually that the returned HTML code is safe. With the `{{ }}` syntax, Kirby performs the escaping for you.
- The `<k-box text="..." />` property is now rendered as plain text by default instead of as HTML code. For the previous behavior use `<k-box text="..." :html="true" />`.

## Features
- New `Str::safeTemplate()` method that escapes HTML from all regular query placeholders, allows HTML with new `{< site.myMethodWithHtml >}` syntax
- New `$model->toSafeString()` method that uses `Str::safeTemplate()` instead of `Str::template()`

## Enhancements
- The `toggle` field now supports the query syntax in the `text` property
- The `RadioInput` component now supports (escaped) HTML in the `info` property for radio options.