### PR TITLE
Automatic `api.csrf` via `panel.dev` option

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -62,21 +62,26 @@ function csrf(?string $check = null)
 {
     $session = App::instance()->session();
 
-    // check explicitly if there have been no arguments at all;
+    // no arguments, generate/return a token
+    // (check explicitly if there have been no arguments at all;
     // checking for null introduces a security issue because null could come
-    // from user input or bugs in the calling code!
+    // from user input or bugs in the calling code!)
     if (func_num_args() === 0) {
-        // no arguments, generate/return a token
-
         $token = $session->get('kirby.csrf');
+
         if (is_string($token) !== true) {
             $token = bin2hex(random_bytes(32));
             $session->set('kirby.csrf', $token);
         }
 
         return $token;
-    } elseif (is_string($check) === true && is_string($session->get('kirby.csrf')) === true) {
-        // argument has been passed, check the token
+    }
+
+    // argument has been passed, check the token
+    if (
+        is_string($check) === true &&
+        is_string($session->get('kirby.csrf')) === true
+    ) {
         return hash_equals($session->get('kirby.csrf'), $check) === true;
     }
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -168,18 +168,23 @@ class Auth
     /**
      * Returns the csrf token if it exists and if it is valid
      *
+     * @param bool $validate
      * @return string|false
      */
-    public function csrf()
+    public function csrf(bool $validate = true)
     {
         // get the csrf from the header
         $fromHeader = $this->kirby->request()->csrf();
 
         // check for a predefined csrf or use the one from session
-        $fromSession = $this->kirby->option('api.csrf', csrf());
+        $isDev       = $this->kirby->option('panel.dev', false) !== false;
+        $fromSession = $this->kirby->option('api.csrf', $isDev ? 'dev' : csrf());
 
         // compare both tokens
-        if (hash_equals((string)$fromSession, (string)$fromHeader) !== true) {
+        if (
+            $validate === true &&
+            hash_equals((string)$fromSession, (string)$fromHeader) !== true
+        ) {
             return false;
         }
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -168,27 +168,34 @@ class Auth
     /**
      * Returns the csrf token if it exists and if it is valid
      *
-     * @param bool $validate
      * @return string|false
      */
-    public function csrf(bool $validate = true)
+    public function csrf()
     {
         // get the csrf from the header
         $fromHeader = $this->kirby->request()->csrf();
 
         // check for a predefined csrf or use the one from session
-        $isDev       = $this->kirby->option('panel.dev', false) !== false;
-        $fromSession = $this->kirby->option('api.csrf', $isDev ? 'dev' : csrf());
+        $fromSession = $this->csrfFromSession();
 
         // compare both tokens
-        if (
-            $validate === true &&
-            hash_equals((string)$fromSession, (string)$fromHeader) !== true
-        ) {
+        if (hash_equals((string)$fromSession, (string)$fromHeader) !== true) {
             return false;
         }
 
         return $fromSession;
+    }
+
+    /**
+     * Returns either predefined csrf or the one from session
+     * @since 3.6.0
+     *
+     * @return string
+     */
+    public function csrfFromSession(): string
+    {
+        $isDev = $this->kirby->option('panel.dev', false) !== false;
+        return $this->kirby->option('api.csrf', $isDev ? 'dev' : csrf());
     }
 
     /**

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -287,7 +287,7 @@ class View
 
                 return [
                     'ascii'   => Str::$ascii,
-                    'csrf'    => $kirby->option('api.csrf') ?? csrf(),
+                    'csrf'    => $kirby->auth()->csrf(false),
                     'isLocal' => $kirby->system()->isLocal(),
                     'locales' => $locales,
                     'slugs'   => Str::$language,

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -287,7 +287,7 @@ class View
 
                 return [
                     'ascii'   => Str::$ascii,
-                    'csrf'    => $kirby->auth()->csrf(false),
+                    'csrf'    => $kirby->auth()->csrfFromSession(),
                     'isLocal' => $kirby->system()->isLocal(),
                     'locales' => $locales,
                     'slugs'   => Str::$language,

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -113,6 +113,7 @@ class AuthCsrfTest extends TestCase
 
     /**
      * @covers ::csrf
+     * @covers ::csrfFromSession
      */
     public function testCsrfFromOption3()
     {
@@ -131,6 +132,7 @@ class AuthCsrfTest extends TestCase
 
     /**
      * @covers ::csrf
+     * @covers ::csrfFromSession
      */
     public function testCsrfFromOption4()
     {
@@ -148,9 +150,9 @@ class AuthCsrfTest extends TestCase
     }
 
     /**
-     * @covers ::csrf
+     * @covers ::csrfFromSession
      */
-    public function testCsrfFromPanelDevOption()
+    public function testCsrfFromSessionPanelDevOption()
     {
         $this->app = $this->app->clone([
             'options' => [
@@ -158,6 +160,6 @@ class AuthCsrfTest extends TestCase
             ]
         ]);
         $this->auth = new Auth($this->app);
-        $this->assertSame('dev', $this->auth->csrf(false));
+        $this->assertSame('dev', $this->auth->csrfFromSession());
     }
 }

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -146,4 +146,18 @@ class AuthCsrfTest extends TestCase
         $_GET = ['csrf' => 'invalid-csrf'];
         $this->assertFalse($this->auth->csrf());
     }
+
+    /**
+     * @covers ::csrf
+     */
+    public function testCsrfFromPanelDevOption()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'panel.dev' => true
+            ]
+        ]);
+        $this->auth = new Auth($this->app);
+        $this->assertSame('dev', $this->auth->csrf(false));
+    }
 }


### PR DESCRIPTION
## Status: ready for review 👀
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

 If `panel.dev` is set, sets `api.csrf` automatically to `dev`


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3363
