### PR TITLE
`panel.favicon` option

### DIFF
--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -65,7 +65,7 @@ class Document
                 'plugins' => $plugins->url('css'),
                 'custom'  => static::customCss(),
             ],
-            'icons' => [
+            'icons' => $kirby->option('panel.favicon', [
                 'apple-touch-icon' => [
                     'type' => 'image/png',
                     'url'  => $url . '/apple-touch-icon.png',
@@ -78,7 +78,7 @@ class Document
                     'type' => 'image/png',
                     'url'  => $url . '/favicon.png',
                 ]
-            ],
+            ]),
             'js' => [
                 'vendor'       => $url . '/js/vendor.js',
                 'pluginloader' => $url . '/js/plugins.js',

--- a/views/panel.php
+++ b/views/panel.php
@@ -22,7 +22,7 @@
   <?php endforeach ?>
 
   <?php foreach ($assets['icons'] as $rel => $icon): ?>
-  <link nonce="<?= $nonce ?>" rel="<?= $rel ?>" href="<?= $icon['url'] ?>" type="<?= $icon['type'] ?>">
+  <link nonce="<?= $nonce ?>" rel="<?= $rel ?>" href="<?= url($icon['url']) ?>" type="<?= $icon['type'] ?>">
   <?php endforeach ?>
 
   <base href="<?= $panelUrl ?>">


### PR DESCRIPTION


```php
'panel.favicon' => [
    'apple-touch-icon' => [
        'type' => 'image/png',
        'url'  =>  'assets/apple-touch-icon.png',
    ],
    'shortcut icon' => [
        'type' => 'image/svg+xml',
        'url'  => 'assets/favicon.svg',
    ],
    'alternate icon' => [
        'type' => 'image/png',
        'url'  => 'assets/favicon.png',
    ]
]
```

## Release notes

### Feature
- New `panel.favicon` option to customize Panel icons (last white-label step)

## Related issues

- Implements https://github.com/getkirby/kirby/issues/3516
