### PR TITLE
`file::version` component: wrong param type

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -70,7 +70,7 @@ return [
      * Adapt file characteristics
      *
      * @param \Kirby\Cms\App $kirby Kirby instance
-     * @param \Kirby\Cms\File|\Kirby\Cms\FileModifications $file The file object
+     * @param \Kirby\Cms\File|\Kirby\Filesystem\Asset $file The file object
      * @param array $options All thumb options (width, height, crop, blur, grayscale)
      * @return \Kirby\Cms\File|\Kirby\Cms\FileVersion
      */


### PR DESCRIPTION
`FileModification` is a trait and can therefore not be a type.
It is used by `Kirby\Cms\File` and `Kirby\Cms\Asset` - so these could be parameter types here.