### PR TITLE
Expose user files via `account` area

### DIFF
--- a/config/areas/account.php
+++ b/config/areas/account.php
@@ -3,6 +3,8 @@
 use Kirby\Cms\Find;
 use Kirby\Panel\Panel;
 
+$dialogs = require __DIR__ . '/files/dialogs.php';
+
 return function ($kirby) {
     return [
         'icon'   => 'account',
@@ -42,6 +44,16 @@ return function ($kirby) {
                     return Find::file('account', $filename)->panel()->route();
                 }
             ]
+        ],
+        'dialogs' => [
+            // change file name
+            'account/files/(:any)/changeName' => $dialogs['changeName'],
+
+            // change file sort
+            'account/files/(:any)/changeSort' => $dialogs['changeSort'],
+
+            // delete file
+            'account/files/(:any)/delete' => $dialogs['delete'],
         ]
     ];
 };

--- a/config/areas/account.php
+++ b/config/areas/account.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cms\Find;
 use Kirby\Panel\Panel;
 
 return function ($kirby) {
@@ -33,6 +34,12 @@ return function ($kirby) {
                     return [
                         'component' => 'k-reset-password-view',
                     ];
+                }
+            ],
+            [
+                'pattern' => 'account/files/(:any)',
+                'action'  => function (string $filename) {
+                    return Find::file('account', $filename)->panel()->route();
                 }
             ]
         ]

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -30,12 +30,14 @@ class File extends Model
                 $breadcrumb = [];
                 break;
             case 'user':
-                $breadcrumb = [
-                    [
-                        'label' => $parent->username(),
-                        'link'  => $parent->panel()->url(true)
-                    ]
-                ];
+                if ($parent->isLoggedIn() === false) {
+                    $breadcrumb = [
+                        [
+                            'label' => $parent->username(),
+                            'link'  => $parent->panel()->url(true)
+                        ]
+                    ];
+                }
                 break;
             case 'page':
                 $breadcrumb = $this->model->parents()->flip()->values(function ($parent) {

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -123,6 +123,10 @@ class User extends Model
      */
     public function path(): string
     {
+        if ($this->model->isLoggedIn() === true) {
+            return 'account';
+        }
+
         return 'users/' . $this->model->id();
     }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- If a logged-in user accesses his own profile in the Panel, always use the `account` area
- Allows access to their own user files for users where access to the `users` area has been disabled


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- User without `users` Panel area access can now access their own user files

### Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- In the `users` Panel area, leads to the `account` area instead of a `users` area view as prior to 3.6.0-alpha.2

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/kirby/issues/2580

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
