### PR TITLE
Layouts: Smaller min-height

### DIFF
--- a/panel/src/components/Layouter/Column.vue
+++ b/panel/src/components/Layouter/Column.vue
@@ -44,7 +44,6 @@ export default {
   display: flex;
   flex-direction: column;
   background: var(--color-white);
-  min-height: 6rem;
 }
 .k-layout-column:focus {
   outline: 0;
@@ -55,7 +54,12 @@ export default {
   padding: 0;
   height: 100%;
   background: var(--color-white);
+  min-height: 4rem;
 }
+.k-layout-column .k-blocks[data-empty="true"] {
+  min-height: 6rem;
+}
+
 .k-layout-column .k-blocks-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Applies `min-height: 6rem` only to empty layout columns, `min-height: 4rem` to filled columns

## Release notes

### Fix
- Improved `min-height` for layout columns

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3381
