### PR TITLE
Assets: fix media thumbs for unprocessed asset files

### DIFF
--- a/src/Cms/FileVersion.php
+++ b/src/Cms/FileVersion.php
@@ -44,6 +44,10 @@ class FileVersion
             return $this->asset()->$method(...$arguments);
         }
 
+        // original method proxy
+        if (method_exists($this->original(), $method)) {
+            return $this->original()->$method(...$arguments);
+        }
         // content fields
         if (is_a($this->original(), 'Kirby\Cms\File') === true) {
             return $this->original()->content()->get($method, $arguments);

--- a/src/Cms/FileVersion.php
+++ b/src/Cms/FileVersion.php
@@ -44,10 +44,6 @@ class FileVersion
             return $this->asset()->$method(...$arguments);
         }
 
-        // original method proxy
-        if (method_exists($this->original(), $method)) {
-            return $this->original()->$method(...$arguments);
-        }
         // content fields
         if (is_a($this->original(), 'Kirby\Cms\File') === true) {
             return $this->original()->content()->get($method, $arguments);
@@ -72,6 +68,16 @@ class FileVersion
     public function kirby()
     {
         return $this->original()->kirby();
+    }
+
+    /**
+     * Returns the absolute Url to the file in the public media folder
+     *
+     * @return string
+     */
+    public function mediaUrl(): string
+    {
+        return $this->url();
     }
 
     /**

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -131,7 +131,7 @@ class Media
                 $options = Data::read($job);
             } catch (Throwable $e) {
                 // no job file found, still run the job
-                // for publically accesible assets
+                // for publicly accessible assets
                 if (is_string($model) === true) {
                     $options = [
                         'filename' => $filename

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -130,9 +130,13 @@ class Media
             try {
                 $options = Data::read($job);
             } catch (Throwable $e) {
-                $options = [
-                    'filename' => $filename
-                ];
+                // no job file found, still run the job
+                // for publically accesible assets
+                if (is_string($model) === true) {
+                    $options = [
+                        'filename' => $filename
+                    ];
+                }
             }
 
             if (empty($options) === true) {

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -48,7 +48,7 @@ class FileVersionTest extends TestCase
         $this->assertSame($mods, $version->modifications());
         $this->assertSame($original, $version->original());
         $this->assertSame($original->kirby(), $version->kirby());
-        $this->assertSame($original->mediaUrl(), $version->mediaUrl());
+        $this->assertSame($version->url(), $version->mediaUrl());
     }
 
     public function testExists()

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -48,6 +48,7 @@ class FileVersionTest extends TestCase
         $this->assertSame($mods, $version->modifications());
         $this->assertSame($original, $version->original());
         $this->assertSame($original->kirby(), $version->kirby());
+        $this->assertSame($original->mediaUrl(), $version->mediaUrl());
     }
 
     public function testExists()

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -139,7 +139,7 @@ class MediaTest extends TestCase
 
         // string model
         $hash = '12345678';
-        $this->assertStringEndsWith('tests/Cms/Media/tmp/media/assets/assets/' . $hash, Media::root($kirby, 'assets', $hash));
+        $this->assertStringEndsWith('tests/Cms/Media/tmp/media/assets/files' . $hash, Media::root($kirby, 'files', $hash));
 
         // file object
         $file  = $kirby->file('test.jpg');

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -6,30 +6,38 @@ use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\Media
+ */
 class MediaTest extends TestCase
 {
     protected $app;
     protected $fixtures;
+    protected $tmp;
 
     public function setUp(): void
     {
         $this->app = new App([
             'roots' => [
-                'index' => $this->fixtures = __DIR__ . '/fixtures/MediaTest',
+                'index' => $this->tmp = __DIR__ . '/tmp',
             ],
         ]);
 
-        Dir::make($this->fixtures);
+        $this->fixtures = __DIR__ . '/fixtures/files';
+        Dir::make($this->tmp);
     }
 
     public function tearDown(): void
     {
-        Dir::remove($this->fixtures);
+        Dir::remove($this->tmp);
     }
 
+    /**
+     * @covers ::link
+     */
     public function testLinkSiteFile()
     {
-        F::write($this->fixtures . '/content/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+        F::write($this->tmp . '/content/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
         $file   = $this->app->file('test.svg');
         $result = Media::link($this->app->site(), $file->mediaHash(), $file->filename());
@@ -39,9 +47,12 @@ class MediaTest extends TestCase
         $this->assertEquals('image/svg+xml', $result->type());
     }
 
+    /**
+     * @covers ::link
+     */
     public function testLinkPageFile()
     {
-        F::write($this->fixtures . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+        F::write($this->tmp . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
         $file   = $this->app->file('projects/test.svg');
         $result = Media::link($this->app->page('projects'), $file->mediaHash(), $file->filename());
@@ -51,9 +62,12 @@ class MediaTest extends TestCase
         $this->assertEquals('image/svg+xml', $result->type());
     }
 
+    /**
+     * @covers ::link
+     */
     public function testLinkWithInvalidHash()
     {
-        F::write($this->fixtures . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+        F::write($this->tmp . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
         // with the correct media token
         $file   = $this->app->file('projects/test.svg');
@@ -69,16 +83,22 @@ class MediaTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * @covers ::link
+     */
     public function testLinkWithoutModel()
     {
         $this->assertFalse(Media::link(null, 'hash', 'filename.jpg'));
     }
 
+    /**
+     * @covers ::publish
+     */
     public function testPublish()
     {
         $site = new Site();
 
-        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+        F::write($src = $this->tmp . '/content/test.jpg', 'nice jpg');
         $file = new File([
             'kirby'    => $this->app,
             'parent'   => $site,
@@ -87,7 +107,7 @@ class MediaTest extends TestCase
 
         $oldToken  = crc32($filename);
         $newToken  = $file->mediaToken();
-        $directory = $this->fixtures . '/media/site';
+        $directory = $this->tmp . '/media/site';
 
         Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
         Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
@@ -106,108 +126,46 @@ class MediaTest extends TestCase
         $this->assertFalse(is_dir($versionB1));
     }
 
-    public function testUnpublish()
+    /**
+     * @covers ::root
+     */
+    public function testRoot()
     {
-        $page = new Page([
-            'slug' => 'test'
-        ]);
+        // copy test image to content
+        Dir::make($this->tmp . '/content');
+        F::copy($this->fixtures . '/../files/test.jpg', $this->tmp . '/content/test.jpg');
 
-        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
-        $file = new File([
-            'kirby'    => $this->app,
-            'parent'   => $page,
-            'filename' => $filename = 'test.jpg'
-        ]);
+        $kirby = $this->app;
 
-        $oldToken  = crc32($filename);
-        $newToken  = $file->mediaToken();
-        $directory = $this->fixtures . '/media/site';
+        // string model
+        $hash = '12345678';
+        $this->assertStringEndsWith('tests/Cms/Media/tmp/media/assets/assets/' . $hash, Media::root($kirby, 'assets', $hash));
 
-        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
-        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
-        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
-        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
+        // file object
+        $file  = $kirby->file('test.jpg');
+        $hash  = $file->mediaHash();
+        $this->assertStringEndsWith('tests/Cms/Media/tmp/media/site/' . $hash, Media::root($kirby, $file, $hash));
 
-        $this->assertTrue(is_dir($versionA1));
-        $this->assertTrue(is_dir($versionA2));
-        $this->assertTrue(is_dir($versionB1));
-        $this->assertTrue(is_dir($versionB2));
-
-        Media::unpublish($directory, $file);
-
-        $this->assertFalse(is_dir($versionA1));
-        $this->assertFalse(is_dir($versionA2));
-        $this->assertFalse(is_dir($versionB1));
-        $this->assertFalse(is_dir($versionB2));
+        // site object
+        $site  = $kirby->site();
+        $hash  = $file->mediaHash();
+        $this->assertStringEndsWith('tests/Cms/Media/tmp/media/site/' . $hash, Media::root($kirby, $site, $hash));
     }
 
-    public function testUnpublishAndIgnore()
-    {
-        $page = new Page([
-            'slug' => 'test'
-        ]);
-
-        F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
-        $file = new File([
-            'kirby'    => $this->app,
-            'parent'   => $page,
-            'filename' => $filename = 'test.jpg'
-        ]);
-
-        $oldToken  = crc32($filename);
-        $newToken  = $file->mediaToken();
-        $directory = $this->fixtures . '/media/site';
-
-        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
-        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
-        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
-        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
-
-        $this->assertTrue(is_dir($versionA1));
-        $this->assertTrue(is_dir($versionA2));
-        $this->assertTrue(is_dir($versionB1));
-        $this->assertTrue(is_dir($versionB2));
-
-        Media::unpublish($directory, $file, $versionB1);
-
-        $this->assertTrue(is_dir($versionB1));
-        $this->assertFalse(is_dir($versionA1));
-        $this->assertFalse(is_dir($versionA2));
-        $this->assertFalse(is_dir($versionB2));
-    }
-
-    public function testUnpublishNonExistingDirectory()
-    {
-        $directory = $this->fixtures . '/does-not-exist';
-
-        $page = new Page([
-            'slug' => 'test'
-        ]);
-
-        $file = new File([
-            'kirby'    => $this->app,
-            'parent'   => $page,
-            'filename' => 'does-not-exist.jpg'
-        ]);
-
-        $this->assertTrue(Media::unpublish($directory, $file));
-    }
-
+    /**
+     * @covers ::thumb
+     */
     public function testThumb()
     {
-        Dir::make($this->fixtures . '/content');
+        Dir::make($this->tmp . '/content');
 
         // copy test image to content
-        F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+        F::copy($this->fixtures . '/../files/test.jpg', $this->tmp . '/content/test.jpg');
 
         // get file object
         $file  = $this->app->file('test.jpg');
         Dir::make(dirname($file->mediaRoot()));
         $this->assertInstanceOf('\Kirby\Cms\File', $file);
-
-        // invalid with no job file
-        $thumb = Media::thumb($file, $file->mediaHash(), $file->filename());
-        $this->assertFalse($thumb);
 
         // invalid with empty job file
         F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', '{}');
@@ -237,24 +195,27 @@ class MediaTest extends TestCase
         $this->assertSame(64, $thumbInfo[1]);
     }
 
+    /**
+     * @covers ::thumb
+     */
     public function testThumbStringModel()
     {
-        Dir::make($this->fixtures . '/content');
+        Dir::make($this->tmp . '/content');
 
         // copy test image to content
-        F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+        F::copy($this->fixtures . '/../files/test.jpg', $this->tmp . '/content/test.jpg');
 
         // get file object
         $file  = $this->app->file('test.jpg');
-        Dir::make($this->fixtures . '/media/assets/site/' . $file->mediaHash());
+        Dir::make($this->tmp . '/media/assets/site/' . $file->mediaHash());
         $this->assertInstanceOf('\Kirby\Cms\File', $file);
 
         // create job file
         $jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-        F::write($this->fixtures . '/media/assets/site/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
+        F::write($this->tmp . '/media/assets/site/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
         // copy to media folder
-        $file->asset()->copy($mediaPath = $this->fixtures . '/media/assets/site/' . $file->mediaHash() . '/' . $file->filename());
+        $file->asset()->copy($mediaPath = $this->tmp . '/media/assets/site/' . $file->mediaHash() . '/' . $file->filename());
 
         $thumb = Media::thumb('site', $file->mediaHash(), $file->filename());
         $this->assertInstanceOf('Kirby\Cms\Response', $thumb);
@@ -265,5 +226,127 @@ class MediaTest extends TestCase
         $thumbInfo = getimagesize($mediaPath);
         $this->assertSame(64, $thumbInfo[0]);
         $this->assertSame(64, $thumbInfo[1]);
+    }
+
+    /**
+     * @covers ::thumb
+     */
+    public function testThumbAssetWithoutJobFile()
+    {
+        Dir::make($this->tmp . '/assets');
+
+        // copy test image to assets
+        F::copy($this->fixtures . '/../files/test.jpg', $this->tmp . '/assets/test.jpg');
+
+        // get asset object
+        $asset  = asset('assets/test.jpg');
+        Dir::make($mediaRoot = $this->tmp . '/media/assets/assets/' . $asset->mediaHash());
+        $this->assertInstanceOf('\Kirby\Filesystem\Asset', $asset);
+
+        $thumb = Media::thumb('assets', $asset->mediaHash(), 'test.jpg');
+        $this->assertInstanceOf('Kirby\Cms\Response', $thumb);
+        $this->assertNotFalse($thumb->body());
+        $this->assertSame(200, $thumb->code());
+        $this->assertSame('image/jpeg', $thumb->type());
+
+        $thumbInfo = getimagesize($mediaRoot . '/test.jpg');
+        $this->assertSame(128, $thumbInfo[0]);
+        $this->assertSame(128, $thumbInfo[1]);
+    }
+
+    /**
+     * @covers ::unpublish
+     */
+    public function testUnpublish()
+    {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        F::write($src = $this->tmp . '/content/test.jpg', 'nice jpg');
+        $file = new File([
+            'kirby'    => $this->app,
+            'parent'   => $page,
+            'filename' => $filename = 'test.jpg'
+        ]);
+
+        $oldToken  = crc32($filename);
+        $newToken  = $file->mediaToken();
+        $directory = $this->tmp . '/media/site';
+
+        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
+        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
+        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
+        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
+
+        $this->assertTrue(is_dir($versionA1));
+        $this->assertTrue(is_dir($versionA2));
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertTrue(is_dir($versionB2));
+
+        Media::unpublish($directory, $file);
+
+        $this->assertFalse(is_dir($versionA1));
+        $this->assertFalse(is_dir($versionA2));
+        $this->assertFalse(is_dir($versionB1));
+        $this->assertFalse(is_dir($versionB2));
+    }
+
+    /**
+     * @covers ::unpublish
+     */
+    public function testUnpublishAndIgnore()
+    {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        F::write($src = $this->tmp . '/content/test.jpg', 'nice jpg');
+        $file = new File([
+            'kirby'    => $this->app,
+            'parent'   => $page,
+            'filename' => $filename = 'test.jpg'
+        ]);
+
+        $oldToken  = crc32($filename);
+        $newToken  = $file->mediaToken();
+        $directory = $this->tmp . '/media/site';
+
+        Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
+        Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
+        Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
+        Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
+
+        $this->assertTrue(is_dir($versionA1));
+        $this->assertTrue(is_dir($versionA2));
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertTrue(is_dir($versionB2));
+
+        Media::unpublish($directory, $file, $versionB1);
+
+        $this->assertTrue(is_dir($versionB1));
+        $this->assertFalse(is_dir($versionA1));
+        $this->assertFalse(is_dir($versionA2));
+        $this->assertFalse(is_dir($versionB2));
+    }
+
+    /**
+     * @covers ::unpublish
+     */
+    public function testUnpublishNonExistingDirectory()
+    {
+        $directory = $this->tmp . '/does-not-exist';
+
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        $file = new File([
+            'kirby'    => $this->app,
+            'parent'   => $page,
+            'filename' => 'does-not-exist.jpg'
+        ]);
+
+        $this->assertTrue(Media::unpublish($directory, $file));
     }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- `Media::thumb()` doesn't give up anymore if no job file for an asset is found but instead copies over the full source file
- `FileVersion->mediaUrl()` returns its `->url()` now since they are the same 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- Media files for assets (using `asset()`) without processing are working now

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None to my knowledge

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #2467

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
