### PR TITLE
`Str::widont` applies to punctuation with gap

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1176,12 +1176,17 @@ class Str
      */
     public static function widont(string $string = null): string
     {
-        return preg_replace_callback('|([^\s])\s+([^\s]+)\s*$|u', function ($matches) {
+        // Replace space between last word and punctuation
+        $string = preg_replace_callback('|(\S)\s(\S?)$|u', function ($matches) {
+            return $matches[1] . '&nbsp;' . $matches[2];
+        }, $string);
+
+        // Replace space between last two words
+        return preg_replace_callback('|(\s)(?=\S*$)(\S+)|u', function ($matches) {
             if (static::contains($matches[2], '-')) {
-                return $matches[1] . '&nbsp;' . str_replace('-', '&#8209;', $matches[2]);
-            } else {
-                return $matches[1] . '&nbsp;' . $matches[2];
+                $matches[2] = str_replace('-', '&#8209;', $matches[2]);
             }
+            return '&nbsp;' . $matches[2];
         }, $string);
     }
 }

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1064,8 +1064,16 @@ EOT;
      */
     public function testWidont()
     {
+        $this->assertSame('Test', Str::widont('Test'));
+        $this->assertSame('Test?', Str::widont('Test?'));
+        $this->assertSame('Test&nbsp;?', Str::widont('Test ?'));
         $this->assertSame('Test&nbsp;Headline', Str::widont('Test Headline'));
         $this->assertSame('Test Headline&nbsp;With&#8209;Dash', Str::widont('Test Headline With-Dash'));
+        $this->assertSame('Test Headline&nbsp;With&#8209;Dash&nbsp;?', Str::widont('Test Headline With-Dash ?'));
+        $this->assertSame('Omelette du&nbsp;fromage', Str::widont('Omelette du fromage'));
+        $this->assertSame('Omelette du&nbsp;fromage.', Str::widont('Omelette du fromage.'));
+        $this->assertSame('Omelette du&nbsp;fromage?', Str::widont('Omelette du fromage?'));
+        $this->assertSame('Omelette du&nbsp;fromage&nbsp;?', Str::widont('Omelette du fromage ?'));
         $this->assertSame('', Str::widont());
     }
 }


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- `Str::widont`: string ending in a space and punctuation gets properly replaced

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3155

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
