### PR TITLE
Adds new hasType blocks method

### DIFF
--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -100,6 +100,17 @@ class Blocks extends Items
     }
 
     /**
+     * Checks if a given block type exists in the collection
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function hasType(string $type): bool
+    {
+        return $this->filterBy('type', $type)->count() > 0;
+    }
+
+    /**
      * Parse and sanitize various block formats
      *
      * @param array|string $input

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -74,6 +74,20 @@ class BlocksTest extends TestCase
         $this->assertSame('text', $blocks->last()->type());
     }
 
+    public function testHasType()
+    {
+        $input = [
+            [
+                'type' => 'heading'
+            ]
+        ];
+
+        $blocks = Blocks::factory($input);
+
+        $this->assertTrue($blocks->hasType('heading'));
+        $this->assertFalse($blocks->hasType('code'));
+    }
+
     public function testParseJson()
     {
         $input = [


### PR DESCRIPTION

## Describe the PR
Checks if a given block type exists in the collection. Useful if you want to include scripts etc. depending on block types.


## Release notes

### Features

- New `$blocks->hasType()` method


## Breaking changes
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
