### PR TITLE
Fixes drag handle for picker fields #3553

### DIFF
--- a/panel/src/components/Layout/Items.vue
+++ b/panel/src/components/Layout/Items.vue
@@ -15,7 +15,7 @@
         v-for="(item, itemIndex) in items"
         :key="item.id || itemIndex"
         v-bind="item"
-        :class="{'k-draggable-item': item.sortable}"
+        :class="{'k-draggable-item': sortable && item.sortable}"
         :image="imageOptions(item)"
         :layout="layout"
         :sortable="sortable && item.sortable"

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -295,14 +295,15 @@ abstract class Model
         //       no longer needed in 3.6
 
         return [
-            'id'    => $this->model->id(),
-            'image' => $this->image(
+            'id'       => $this->model->id(),
+            'image'    => $this->image(
                 $params['image'] ?? [],
                 $params['layout'] ?? 'list'
             ),
-            'info'  => $this->model->toString($params['info'] ?? false),
-            'link'  => $this->url(true),
-            'text'  => $this->model->toString($params['text'] ?? false),
+            'info'     => $this->model->toString($params['info'] ?? false),
+            'link'     => $this->url(true),
+            'sortable' => true,
+            'text'     => $this->model->toString($params['text'] ?? false)
         ];
     }
 

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -214,6 +214,7 @@ class PagesFieldTest extends TestCase
             ],
             'info' => '',
             'link' => '/pages/test',
+            'sortable' => true,
             'text' => 'Test Title',
             'dragText' => '(link: test text: Test Title)',
             'hasChildren' => false,


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

`item.sortable` is related for sections (model permissions). I've fixed the issue with checking `sortable` definition. Page/User/File fields items no need sort permission.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Regression Fixes

- Fixed drag handle for picker fields `#3553`


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3553 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
