### PR TITLE
Use new `this.$language` instead `this.$languages.current`

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -53,7 +53,7 @@ export default {
   data() {
     return {
       slug: this.sluggify(this.value),
-      slugs: this.$languages.current ? this.$languages.current.rules : this.$system.slugs,
+      slugs: this.$language ? this.$language.rules : this.$system.slugs,
       syncValue: null
     };
   },


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes Regressions

- Fixed `this.$languages.current` usage with new `this.$language` syntax