### PR TITLE
Texnixe/feature layouts methods

### DIFF
--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -42,6 +42,17 @@ class Layouts extends Items
     }
 
     /**
+     * Checks if a given block type exists in the layouts collection
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function hasBlockType(string $type): bool
+    {
+        return $this->toBlocks()->hasType($type);
+    }
+
+    /**
      * Parse layouts data
      *
      * @param array|string $input
@@ -62,5 +73,27 @@ class Layouts extends Items
         }
 
         return $input;
+    }
+
+    /**
+     * Converts layouts to blocks
+     *
+     * @return \Kirby\Cms\Blocks
+     */
+    public function toBlocks()
+    {
+        $blocks = [];
+
+        if ($this->isNotEmpty() === true) {
+            foreach ($this->data() as $layout) {
+                foreach ($layout->columns() as $column) {
+                    foreach ($column->blocks() as $block) {
+                        $blocks[] = $block->toArray();
+                    }
+                }
+            }
+        }
+
+        return Blocks::factory($blocks);
     }
 }

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -49,6 +49,23 @@ class LayoutsTest extends TestCase
         $this->assertEquals('Text', $blocks->last()->text());
     }
 
+    public function testHasBlockType()
+    {
+        $layouts = Layouts::factory([
+            [
+                'type'    => 'heading',
+                'content' => ['text' => 'Heading'],
+            ],
+            [
+                'type'    => 'text',
+                'content' => ['text' => 'Text'],
+            ]
+        ]);
+
+        $this->assertTrue($layouts->hasBlockType('heading'));
+        $this->assertFalse($layouts->hasBlockType('code'));
+    }
+
     public function testParse()
     {
         $data = [
@@ -100,5 +117,24 @@ class LayoutsTest extends TestCase
 
         $result = Layouts::parse('invalid json string');
         $this->assertSame([], $result);
+    }
+
+    public function testToBlocks()
+    {
+        $data = [
+            [
+                'type'    => 'heading',
+                'content' => ['text' => 'Heading'],
+            ],
+            [
+                'type'    => 'text',
+                'content' => ['text' => 'Text'],
+            ]
+        ];
+
+        $blocks = Layouts::factory($data)->toBlocks();
+
+        $this->assertCount(2, $blocks);
+        $this->assertInstanceOf('Kirby\Cms\Blocks', $blocks);
     }
 }


### PR DESCRIPTION
## Describe the PR
Adds new `toBlocks()` and `hasBlockType()` Layouts methods. Useful if you need to check if the layouts field contains a given block type, to load scripts conditionally (similar to  new `hasBlock()` Blocks method). The `toBlocks()` method makes it easy to filter blocks from layouts.



## Release notes

### Features

- New `$layouts->toBlocks()` method
- new `$layouts->hasBlockType()` method



## Breaking changes
none



## Related issues/ideas
https://github.com/getkirby/kirby/pull/3555#pullrequestreview-712122102


## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
