### PR TITLE
Use `file.previewUrl` in file view

### DIFF
--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -3,7 +3,7 @@
     <k-view class="k-file-preview-layout">
       <div class="k-file-preview-image">
         <k-link
-          :to="file.url"
+          :to="file.previewUrl"
           :title="$t('open')"
           class="k-file-preview-image-link"
           target="_blank"
@@ -36,7 +36,7 @@
           <li>
             <h3>{{ $t("url") }}</h3>
             <p>
-              <k-link :to="file.url" tabindex="-1" target="_blank">
+              <k-link :to="file.previewUrl" tabindex="-1" target="_blank">
                 /{{ file.id }}
               </k-link>
             </p>


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- File view uses stable preview link for files (instead of media folder URL)


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3201
