### PR TITLE
`k-file-preview`: clean CSS, details from backend

### DIFF
--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -113,6 +113,7 @@ export default {
 @media screen and (min-width: 65em) {
   .k-file-preview-layout {
     grid-template-columns: 33.333% auto;
+    align-items: center;
   }
   .k-file-preview-details {
     padding: 3rem;

--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -3,64 +3,30 @@
     <k-view class="k-file-preview-layout">
       <div class="k-file-preview-image">
         <k-link
-          :to="file.previewUrl"
+          :to="url"
           :title="$t('open')"
           class="k-file-preview-image-link"
           target="_blank"
         >
-          <k-image
-            v-if="file.panelImage && file.panelImage.src"
-            :src="file.panelImage.src"
-            :srcset="file.panelImage.srcset"
-            back="none"
-          />
-          <k-icon
-            v-else-if="file.panelImage"
-            :type="file.panelImage.icon"
-            :style="{ color: file.panelImage.color }"
-            class="k-file-preview-icon"
-          />
-          <span v-else class="k-file-preview-placeholder" />
+          <k-item-image :image="image" layout="card" />
         </k-link>
       </div>
       <div class="k-file-preview-details">
         <ul>
-          <li>
-            <h3>{{ $t("template") }}</h3>
-            <p>{{ file.template || "—" }}</p>
-          </li>
-          <li>
-            <h3>{{ $t("mime") }}</h3>
-            <p>{{ file.mime }}</p>
-          </li>
-          <li>
-            <h3>{{ $t("url") }}</h3>
+          <li v-for="detail in details" :key="detail.title">
+            <h3>{{ detail.title }}</h3>
             <p>
-              <k-link :to="file.previewUrl" tabindex="-1" target="_blank">
-                /{{ file.id }}
+              <k-link
+                v-if="detail.link"
+                :to="detail.link"
+                tabindex="-1"
+                target="_blank"
+              >
+                /{{ detail.text }}
               </k-link>
-            </p>
-          </li>
-          <li>
-            <h3>{{ $t("size") }}</h3>
-            <p>{{ file.niceSize }}</p>
-          </li>
-          <li>
-            <h3>{{ $t("dimensions") }}</h3>
-            <p v-if="file.dimensions && (file.dimensions.width || file.dimensions.height)">
-              {{ file.dimensions.width }}&times;{{ file.dimensions.height }} {{ $t("pixel") }}
-            </p>
-            <p v-else>
-              —
-            </p>
-          </li>
-          <li>
-            <h3>{{ $t("orientation") }}</h3>
-            <p v-if="file.dimensions && file.dimensions.orientation">
-              {{ $t("orientation." + file.dimensions.orientation) }}
-            </p>
-            <p v-else>
-              —
+              <template v-else>
+                {{ detail.text }}
+              </template>
             </p>
           </li>
         </ul>
@@ -72,8 +38,10 @@
 <script>
 export default {
   props: {
-    file: Object
-  },
+    details: Array,
+    image: Object,
+    url: String,
+  }
 };
 </script>
 <style>
@@ -82,97 +50,34 @@ export default {
 }
 .k-file-preview-layout {
   display: grid;
-}
-@media screen and (max-width: 65em) {
-  .k-file-preview-layout {
-    padding: 0 !important;
-  }
-}
-@media screen and (min-width: 30em) {
-  .k-file-preview-layout {
-    grid-template-columns: 50% auto;
-  }
-}
-@media screen and (min-width: 65em) {
-  .k-file-preview-layout {
-    display: flex;
-    align-items: center;
-  }
+  grid-template-columns: 50% auto;
 }
 .k-file-preview-layout > * {
   min-width: 0;
 }
+
 .k-file-preview-image {
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: var(--bg-pattern);
 }
-@media screen and (min-width: 65em) {
-  .k-file-preview-image {
-    width: 33.33%;
-  }
-}
-@media screen and (min-width: 90em) {
-  .k-file-preview-image {
-    width: 25%;
-  }
-}
-
-.k-file-preview-image .k-image span {
-  overflow: hidden;
-  padding-block-end: 66.66%;
-}
-@media screen and (min-width: 30em) and (max-width: 65em) {
-  .k-file-preview-image .k-image span {
-    position: absolute;
-    inset: 0;
-    padding-block-end: 0 !important;
-  }
-}
-
-@media screen and (min-width: 65em) {
-  .k-file-preview-image .k-image span {
-    padding-block-end: 100%;
-  }
-}
-.k-file-preview-placeholder {
-  display: block;
-  padding-block-end: 100%;
-}
-.k-file-preview-image img {
-  padding: 3rem;
-}
-
 .k-file-preview-image-link {
   display: block;
+  width: 100%;
+  padding: min(4vw, 3rem);
   outline: 0;
 }
-.k-file-preview-image-link.k-link[data-tabbed] {
+.k-file-preview-image-link[data-tabbed] {
   box-shadow: none;
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }
 
-.k-file-preview-icon {
-  position: relative;
-  display: block;
-  padding-block-end: 100%;
-  overflow: hidden;
-  color: rgba(255, 255, 255, .5);
-}
-.k-file-preview-icon svg {
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 50%;
-  transform: translate(-50%, -50%) scale(4);
-}
 .k-file-preview-details {
   padding: 1.5rem;
   flex-grow: 1;
-}
-@media screen and (min-width: 65em) {
-  .k-file-preview-details {
-    padding: 3rem;
-  }
 }
 .k-file-preview-details ul {
   line-height: 1.5em;
@@ -181,29 +86,41 @@ export default {
   grid-gap: 1.5rem 3rem;
   grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
 }
-
-@media screen and (min-width: 30em) {
-  .k-file-preview-details ul {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  }
-}
-
 .k-file-preview-details h3 {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--color-gray-500);
 }
-.k-file-preview-details p {
+.k-file-preview-details p,
+.k-file-preview-details a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   color: rgba(255, 255, 255, .75);
   font-size: var(--text-sm);
 }
-.k-file-preview-details p a {
-  display: block;
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+
+@media screen and (min-width: 30em) {
+  .k-file-preview-details ul {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+}
+@media screen and (max-width: 65em) {
+  .k-file-preview-layout {
+    padding: 0 !important;
+  }
+}
+@media screen and (min-width: 65em) {
+  .k-file-preview-layout {
+    grid-template-columns: 33.333% auto;
+  }
+  .k-file-preview-details {
+    padding: 3rem;
+  }
+}
+@media screen and (min-width: 90em) {
+  .k-file-preview-layout {
+    grid-template-columns: 25% auto;
+  }
 }
 </style>

--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -8,7 +8,7 @@
           class="k-file-preview-image-link"
           target="_blank"
         >
-          <k-item-image :image="image" layout="card" />
+          <k-item-image :image="image" layout="cards" />
         </k-link>
       </div>
       <div class="k-file-preview-details">

--- a/panel/src/components/Views/FileView.spec.js
+++ b/panel/src/components/Views/FileView.spec.js
@@ -42,7 +42,7 @@ describe("FileView", () => {
       cy.get("@info").find("li:nth-child(5)").should("contain", "Dimensions");
       cy.get("@info")
         .find("li:nth-child(5)")
-        .should("contain", "933×1400 Pixel");
+        .should("contain", "933 × 1400 Pixel");
 
       cy.get("@info").find("li:nth-child(6)").should("contain", "Orientation");
       cy.get("@info").find("li:nth-child(6)").should("contain", "Portrait");

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -6,7 +6,7 @@
       :data-template="blueprint"
       class="k-file-view"
     >
-      <k-file-preview :file="model" />
+      <k-file-preview v-bind="preview" />
 
       <k-view class="k-file-content">
         <k-header
@@ -77,6 +77,9 @@ import ModelView from "./ModelView.vue";
 
 export default {
   extends: ModelView,
+  props: {
+    preview: Object
+  },
   computed: {
     id() {
       return this.$api.files.url(this.model.parent, this.model.filename);

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -20,7 +20,7 @@
           <template #left>
             <k-button-group>
               <k-button
-                :link="model.previewUrl"
+                :link="preview.url"
                 :responsive="true"
                 class="k-file-view-options"
                 icon="open"

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -342,7 +342,10 @@ class File extends Model
                     'type'       => $file->type(),
                 ],
                 'preview' => [
-                    'image'   => $this->image(['back' => 'transparent'], 'cards'),
+                    'image'   => $this->image([
+                        'back'  => 'transparent',
+                        'ratio' => '1/1'
+                    ], 'cards'),
                     'url'     => $url = $file->previewUrl(),
                     'details' => [
                         [

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -315,13 +315,15 @@ class File extends Model
      */
     public function props(): array
     {
-        $file     = $this->model;
-        $siblings = $file->templateSiblings()->sortBy(
+        $file       = $this->model;
+        $dimensions = $file->dimensions();
+        $siblings   = $file->templateSiblings()->sortBy(
             'sort',
             'asc',
             'filename',
             'asc'
         );
+
 
         return array_merge(
             parent::props(),
@@ -330,16 +332,16 @@ class File extends Model
                 'blueprint' => $this->model->template() ?? 'default',
                 'model' => [
                     'content'    => $this->content(),
-                    'dimensions' => $file->dimensions()->toArray(),
+                    'dimensions' => $dimensions->toArray(),
                     'extension'  => $file->extension(),
                     'filename'   => $file->filename(),
                     'mime'       => $file->mime(),
                     'niceSize'   => $file->niceSize(),
                     'id'         => $id = $file->id(),
                     'parent'     => $file->parent()->panel()->path(),
-                    'url'        => $file->url(),
                     'template'   => $file->template(),
                     'type'       => $file->type(),
+                    'url'        => $file->url(),
                 ],
                 'preview' => [
                     'image'   => $this->image([
@@ -367,11 +369,11 @@ class File extends Model
                         ],
                         [
                             'title' => t('dimensions'),
-                            'text'  => $file->dimensions() ? $file->dimensions()->width() . '×' . $file->dimensions()->height() . ' ' . t('pixel') : '—'
+                            'text'  => $file->type() === 'image' ? $file->dimensions() . ' ' . t('pixel') : '—'
                         ],
                         [
                             'title' => t('orientation'),
-                            'text'  => $file->dimensions() ? t('orientation.' . $file->dimensions()->orientation()) : '—'
+                            'text'  => $file->type() === 'image' ? t('orientation.' . $dimensions->orientation()) : '—'
                         ],
                     ]
                 ]

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -333,15 +333,44 @@ class File extends Model
                     'dimensions' => $file->dimensions()->toArray(),
                     'extension'  => $file->extension(),
                     'filename'   => $file->filename(),
-                    'id'         => $file->id(),
                     'mime'       => $file->mime(),
                     'niceSize'   => $file->niceSize(),
+                    'id'         => $id = $file->id(),
                     'parent'     => $file->parent()->panel()->path(),
-                    'panelImage' => $this->image([], 'cards'),
-                    'previewUrl' => $file->previewUrl(),
                     'url'        => $file->url(),
                     'template'   => $file->template(),
                     'type'       => $file->type(),
+                ],
+                'preview' => [
+                    'image'   => $this->image(['back' => 'transparent'], 'cards'),
+                    'url'     => $url = $file->previewUrl(),
+                    'details' => [
+                        [
+                            'title' => t('template'),
+                            'text'  => $file->template() ?? '—'
+                        ],
+                        [
+                            'title' => t('mime'),
+                            'text'  => $file->mime()
+                        ],
+                        [
+                            'title' => t('url'),
+                            'text'  => $id,
+                            'link'  => $url
+                        ],
+                        [
+                            'title' => t('size'),
+                            'text'  => $file->niceSize()
+                        ],
+                        [
+                            'title' => t('dimensions'),
+                            'text'  => $file->dimensions() ? $file->dimensions()->width() . '×' . $file->dimensions()->height() . ' ' . t('pixel') : '—'
+                        ],
+                        [
+                            'title' => t('orientation'),
+                            'text'  => $file->dimensions() ? t('orientation.' . $file->dimensions()->orientation()) : '—'
+                        ],
+                    ]
                 ]
             ]
         );

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -658,11 +658,15 @@ class FileTest extends TestCase
         $this->assertArrayHasKey('mime', $props['model']);
         $this->assertArrayHasKey('niceSize', $props['model']);
         $this->assertArrayHasKey('parent', $props['model']);
-        $this->assertArrayHasKey('panelImage', $props['model']);
-        $this->assertArrayHasKey('previewUrl', $props['model']);
         $this->assertArrayHasKey('url', $props['model']);
         $this->assertArrayHasKey('template', $props['model']);
         $this->assertArrayHasKey('type', $props['model']);
+
+        $this->assertArrayHasKey('preview', $props);
+        $this->assertArrayHasKey('image', $props['preview']);
+        $this->assertArrayHasKey('url', $props['preview']);
+        $this->assertArrayHasKey('details', $props['preview']);
+        $this->assertCount(6, $props['preview']['details']);
 
         // inherited props
         $this->assertArrayHasKey('blueprint', $props);


### PR DESCRIPTION
```
BEFORE
dist/css/style.css   107.11kb / brotli: 14.94kb
dist/js/index.js     316.29kb / brotli: 60.18kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

AFTER
dist/css/style.css   106.27kb / brotli: 14.87kb
dist/js/index.js     315.29kb / brotli: 60.03kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```