### PR TITLE
Improvements: UserView and ButtonGroups

### DIFF
--- a/panel/src/components/Blocks/BlockFigure.vue
+++ b/panel/src/components/Blocks/BlockFigure.vue
@@ -3,11 +3,10 @@
     <k-button
       v-if="isEmpty"
       :icon="emptyIcon"
+      :text="emptyText"
       class="k-block-figure-empty"
       @click="$emit('open')"
-    >
-      {{ emptyText }}
-    </k-button>
+    />
     <span v-else class="k-block-figure-container" @dblclick="$emit('open')">
       <slot />
     </span>

--- a/panel/src/components/Blocks/BlockSelector.vue
+++ b/panel/src/components/Blocks/BlockSelector.vue
@@ -22,12 +22,11 @@
           :key="fieldset.name"
           :disabled="disabled.includes(fieldset.type)"
           :icon="fieldset.icon || 'box'"
+          :text="fieldset.name"
           @keydown.up="navigate(fieldset.index - 1)"
           @keydown.down="navigate(fieldset.index + 1)"
           @click="add(fieldset.type)"
-        >
-          {{ fieldset.name }}
-        </k-button>
+        />
       </div>
     </details>
   </k-dialog>

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -22,31 +22,9 @@
         <slot />
       </div>
 
-      <footer v-if="$slots['footer'] || cancelButton || submitButton" class="k-dialog-footer">
+      <footer v-if="$slots['footer'] || buttons.length" class="k-dialog-footer">
         <slot name="footer">
-          <k-button-group>
-            <span>
-              <k-button
-                v-if="cancelButton"
-                icon="cancel"
-                class="k-dialog-button-cancel"
-                @click="cancel"
-              >
-                {{ cancelButtonLabel }}
-              </k-button>
-            </span>
-            <span>
-              <k-button
-                v-if="submitButtonConfig"
-                :icon="icon"
-                :theme="theme"
-                class="k-dialog-button-submit"
-                @click="submit"
-              >
-                {{ submitButtonLabel }}
-              </k-button>
-            </span>
-          </k-button-group>
+          <k-button-group :buttons="buttons" />
         </slot>
       </footer>
     </div>
@@ -105,6 +83,30 @@ export default {
     };
   },
   computed: {
+    buttons() {
+      let buttons = [];
+
+      if (this.cancelButton) {
+        buttons.push({
+          icon: "cancel",
+          text: this.cancelButtonLabel,
+          class: "k-dialog-button-cancel",
+          click: this.cancel
+        });
+      }
+
+      if (this.submitButtonConfig) {
+        buttons.push({
+          icon: this.icon,
+          text: this.submitButtonLabel,
+          theme: this.theme,
+          class: "k-dialog-button-submit",
+          click: this.submit
+        });
+      }
+
+      return buttons;
+    },
     cancelButtonLabel() {
       if (this.cancelButton === false) {
         return false;

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -18,9 +18,11 @@
           </h2>
           <ul v-else class="k-drawer-breadcrumb">
             <li v-for="crumb in breadcrumb" :key="crumb.id">
-              <k-button :icon="crumb.icon" @click="goTo(crumb.id)">
-                {{ crumb.title }}
-              </k-button>
+              <k-button
+                :icon="crumb.icon"
+                :text="crumb.title"
+                @click="goTo(crumb.id)"
+              />
             </li>
           </ul>
           <nav
@@ -31,11 +33,10 @@
               v-for="tabButton in tabs"
               :key="tabButton.name"
               :current="tab == tabButton.name"
+              :text="tabButton.label"
               class="k-drawer-tab"
               @click.stop="$emit('tab', tabButton.name)"
-            >
-              {{ tabButton.label }}
-            </k-button>
+            />
           </nav>
           <nav class="k-drawer-options">
             <slot name="options" />

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -42,19 +42,16 @@
             <k-button
               v-if="day"
               :disabled="isDisabled(day)"
+              :text="day"
               @click="select(day)"
-            >
-              {{ day }}
-            </k-button>
+            />
           </td>
         </tr>
       </tbody>
       <tfoot>
         <tr>
           <td class="k-calendar-today" colspan="7">
-            <k-button @click="select('today')">
-              {{ $t("today") }}
-            </k-button>
+            <k-button :text="$t('today')" @click="select('today')" />
           </td>
         </tr>
       </tfoot>

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -5,11 +5,10 @@
         <k-button
           v-if="more && !disabled"
           :icon="btnIcon"
+          :text="btnLabel"
           class="k-field-options-button"
           @click="open"
-        >
-          {{ btnLabel }}
-        </k-button>
+        />
       </k-button-group>
     </template>
 

--- a/panel/src/components/Forms/Field/SlugField.vue
+++ b/panel/src/components/Forms/Field/SlugField.vue
@@ -8,9 +8,7 @@
     class="k-slug-field"
   >
     <template v-if="wizard && wizard.text" #options>
-      <k-button icon="wand" @click="onWizard">
-        {{ wizard.text }}
-      </k-button>
+      <k-button :text="wizard.text" icon="wand" @click="onWizard" />
     </template>
 
     <k-input

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -6,11 +6,10 @@
         v-if="more && currentIndex === null"
         :id="_uid"
         ref="add"
+        :text="$t('add')"
         icon="add"
         @click="add"
-      >
-        {{ $t("add") }}
-      </k-button>
+      />
     </template>
 
     <!-- Form -->
@@ -26,9 +25,12 @@
           @submit="submit"
         />
         <footer class="k-structure-form-buttons">
-          <k-button class="k-structure-form-cancel-button" icon="cancel" @click="close">
-            {{ $t('cancel') }}
-          </k-button>
+          <k-button
+            :text="$t('cancel')"
+            icon="cancel"
+            class="k-structure-form-cancel-button"
+            @click="close"
+          />
           <k-pagination
             v-if="currentIndex !== 'new'"
             :dropdown="false"
@@ -39,9 +41,12 @@
             :validate="beforePaginate"
             @paginate="paginate"
           />
-          <k-button class="k-structure-form-submit-button" icon="check" @click="submit">
-            {{ $t(currentIndex !== 'new' ? 'confirm' : 'add') }}
-          </k-button>
+          <k-button
+            :text="$t(currentIndex !== 'new' ? 'confirm' : 'add')"
+            icon="check"
+            class="k-structure-form-submit-button"
+            @click="submit"
+          />
         </footer>
       </section>
     </template>

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -5,11 +5,10 @@
         <k-button
           v-if="more && !disabled"
           :icon="btnIcon"
+          :text="btnLabel"
           class="k-field-options-button"
           @click="open"
-        >
-          {{ btnLabel }}
-        </k-button>
+        />
       </k-button-group>
     </template>
 

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -6,19 +6,17 @@
       </p>
       <span class="k-form-lock-buttons">
         <k-button
+          :text="$t('download')"
           icon="download"
           class="k-form-button"
           @click="onDownload"
-        >
-          {{ $t("download") }}
-        </k-button>
+        />
         <k-button
+          :text="$t('confirm')"
           icon="check"
           class="k-form-button"
           @click="onResolve"
-        >
-          {{ $t("confirm") }}
-        </k-button>
+        />
       </span>
     </k-view>
 
@@ -36,31 +34,28 @@
       />
       <k-button
         v-else
+        :text="$t('lock.unlock')"
         icon="unlock"
         class="k-form-button"
         @click="onUnlock()"
-      >
-        {{ $t('lock.unlock') }}
-      </k-button>
+      />
     </k-view>
 
     <k-view v-else-if="mode === 'changes'">
       <k-button
         :disabled="isDisabled"
+        :text="$t('revert')"
         icon="undo"
         class="k-form-button"
         @click="onRevert"
-      >
-        {{ $t("revert") }}
-      </k-button>
+      />
       <k-button
         :disabled="isDisabled"
+        :text="$t('save')"
         icon="check"
         class="k-form-button"
         @click="onSave"
-      >
-        {{ $t("save") }}
-      </k-button>
+      />
     </k-view>
 
     <k-dialog

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -74,11 +74,10 @@
 
         <k-button
           v-if="visible.length < filtered.length"
+          :text="`${$t('search.all')} (${filtered.length})`"
           class="k-multiselect-more"
           @click.stop="limit = false"
-        >
-          {{ $t("search.all") }} ({{ filtered.length }})
-        </k-button>
+        />
       </k-dropdown-content>
     </template>
   </k-draggable>

--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -45,11 +45,11 @@
       <template #footer>
         <template v-if="errors.length > 0">
           <k-button-group
-            :buttons="{
+            :buttons="[{
               icon: 'check',
               text: $t('confirm'),
               click: () => $refs.dialog.close()
-            }"
+            }]"
           />
         </template>
       </template>

--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -44,11 +44,13 @@
       </template>
       <template #footer>
         <template v-if="errors.length > 0">
-          <k-button-group>
-            <k-button icon="check" @click="$refs.dialog.close()">
-              {{ $t("confirm") }}
-            </k-button>
-          </k-button-group>
+          <k-button-group
+            :buttons="{
+              icon: 'check',
+              text: $t('confirm'),
+              click: () => $refs.dialog.close()
+            }"
+          />
         </template>
       </template>
     </k-dialog>

--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -15,6 +15,7 @@
       ref="dialog"
       :cancel-button="false"
       :submit-button="false"
+      class="k-upload-dialog"
       size="medium"
     >
       <template v-if="errors.length > 0">
@@ -194,7 +195,7 @@ export default {
   inset-inline-start: -3000px;
 }
 
-.k-upload .k-headline {
+.k-upload-dialog .k-headline {
   margin-block-end: .75rem;
 }
 

--- a/panel/src/components/Misc/Fatal.vue
+++ b/panel/src/components/Misc/Fatal.vue
@@ -8,10 +8,9 @@
         <k-button
           slot="right"
           icon="cancel"
+          text="Close"
           @click="$store.dispatch('fatal', false)"
-        >
-          Close
-        </k-button>
+        />
       </k-bar>
       <iframe ref="iframe" class="k-fatal-iframe" />
     </div>

--- a/panel/src/components/Misc/StatusIcon.vue
+++ b/panel/src/components/Misc/StatusIcon.vue
@@ -3,14 +3,11 @@
     :disabled="disabled"
     :icon="icon"
     :responsive="responsive"
+    :text="text"
     :tooltip="title"
     :class="'k-status-icon k-status-icon-' + status"
     @click="onClick"
-  >
-    <template v-if="text">
-      {{ text }}
-    </template>
-  </k-button>
+  />
 </template>
 
 <script>

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -21,6 +21,10 @@ export default {
   props: {
     autofocus: Boolean,
     /**
+     * Pass instead of a link URL to be triggered on clicking the button
+     */
+    click: Function,
+    /**
      * Sets the `aria-current` attribute. Especially useful in connection with a `link` attribute.
      */
     current: [String, Boolean],

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -5,7 +5,10 @@
     v-bind="$props"
     v-on="$listeners"
   >
-    <slot />
+    <template v-if="text">
+      {{ text }}
+    </template>
+    <slot v-else />
   </component>
 </template>
 
@@ -45,6 +48,10 @@ export default {
      */
     target: String,
     tabindex: String,
+    /**
+     * Use either the default slot or this prop for the button text
+     */
+    text: String,
     /**
      * With the theme you can control the general design of the button.
      * @values positive, negative

--- a/panel/src/components/Navigation/ButtonGroup.vue
+++ b/panel/src/components/Navigation/ButtonGroup.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="k-button-group">
-    <slot />
+    <slot v-if="$slots.default" />
+    <k-button
+      v-for="(button, index) in buttons"
+      v-else
+      :key="index"
+      v-bind="button"
+    />
   </div>
 </template>
 
@@ -13,7 +19,15 @@
   <k-button icon="trash">Delete</k-button>
 </k-button-group>
  */
-export default {}
+export default {
+  props: {
+    /**
+     * Either pass the buttons as default slot
+     * or as an array to this prop
+     */
+    buttons: Array
+  }
+}
 </script>
 
 <style>

--- a/panel/src/components/Navigation/ButtonNative.vue
+++ b/panel/src/components/Navigation/ButtonNative.vue
@@ -11,6 +11,7 @@
     :type="type"
     class="k-button"
     v-on="$listeners"
+    @click="click"
   >
     <k-icon
       v-if="icon"
@@ -30,6 +31,10 @@ export default {
   inheritAttrs: false,
   props: {
     autofocus: Boolean,
+    click: {
+      type: Function,
+      default: () => {}
+    },
     current: [String, Boolean],
     icon: String,
     id: [String, Number],

--- a/panel/src/components/Navigation/Languages.vue
+++ b/panel/src/components/Navigation/Languages.vue
@@ -1,8 +1,11 @@
 <template>
   <k-dropdown v-if="languages.length" class="k-languages-dropdown">
-    <k-button :responsive="true" icon="globe" @click="$refs.languages.toggle()">
-      {{ language.name }}
-    </k-button>
+    <k-button
+      :text="language.name"
+      :responsive="true"
+      icon="globe"
+      @click="$refs.languages.toggle()"
+    />
     <k-dropdown-content v-if="languages" ref="languages">
       <k-dropdown-item @click="change(defaultLanguage)">
         {{ defaultLanguage.name }}

--- a/panel/src/components/Navigation/PrevNext.vue
+++ b/panel/src/components/Navigation/PrevNext.vue
@@ -1,8 +1,11 @@
 <template>
-  <k-button-group class="k-prev-next">
-    <k-button v-bind="button(prev)" icon="angle-left" />
-    <k-button v-bind="button(next)" icon="angle-right" />
-  </k-button-group>
+  <k-button-group
+    :buttons="[
+      { ...button(prev), icon: 'angle-left' },
+      { ...button(next), icon: 'angle-right' }
+    ]"
+    class="k-prev-next"
+  />
 </template>
 
 <script>

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -4,9 +4,11 @@
       <div class="k-search-input">
         <!-- Type select -->
         <k-dropdown class="k-search-types">
-          <k-button :icon="currentType.icon" @click="$refs.types.toggle()">
-            {{ currentType.label }}:
-          </k-button>
+          <k-button
+            :icon="currentType.icon"
+            :text="currentType.label"
+            @click="$refs.types.toggle()"
+          />
           <k-dropdown-content ref="types">
             <k-dropdown-item
               v-for="(typeItem, typeIndex) in types"

--- a/panel/src/components/Navigation/Topbar.vue
+++ b/panel/src/components/Navigation/Topbar.vue
@@ -29,15 +29,13 @@
 
         <div class="k-topbar-signals">
           <!-- notifications -->
-          <template v-if="notification">
-            <k-button
-              class="k-topbar-notification k-topbar-signals-button"
-              theme="positive"
-              @click="$store.dispatch('notification/close')"
-            >
-              {{ notification.message }}
-            </k-button>
-          </template>
+          <k-button
+            v-if="notification"
+            :text="notification.message"
+            theme="positive"
+            class="k-topbar-notification k-topbar-signals-button"
+            @click="$store.dispatch('notification/close')"
+          />
 
           <!-- registration -->
           <k-registration v-else-if="!license" />

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -8,11 +8,10 @@
       <k-headline>
         {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
       </k-headline>
-      <k-button-group v-if="add">
-        <k-button icon="upload" @click="upload">
-          {{ $t("add") }}
-        </k-button>
-      </k-button-group>
+      <k-button-group
+        v-if="add"
+        :buttons="[{ text: $t('add'), icon: 'upload', click: upload }]"
+      />
     </header>
 
     <template v-if="error">

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -9,11 +9,10 @@
         {{ headline }} <abbr v-if="options.min" :title="$t('section.required')">*</abbr>
       </k-headline>
 
-      <k-button-group v-if="add">
-        <k-button icon="add" @click="create">
-          {{ $t("add") }}
-        </k-button>
-      </k-button-group>
+      <k-button-group
+        v-if="add"
+        :buttons="[{ text: $t('add'), icon: 'add', click: create }]"
+      />
     </header>
 
     <template v-if="error">

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -22,21 +22,19 @@
               <k-button
                 :link="model.previewUrl"
                 :responsive="true"
-                class="k-file-view-options"
+                :text="$t('open')"
                 icon="open"
                 target="_blank"
-              >
-                {{ $t("open") }}
-              </k-button>
+                class="k-file-view-options"
+              />
               <k-dropdown class="k-file-view-options">
                 <k-button
-                  :responsive="true"
                   :disabled="isLocked"
+                  :responsive="true"
+                  :text="$t('settings')"
                   icon="cog"
                   @click="$refs.settings.toggle()"
-                >
-                  {{ $t('settings') }}
-                </k-button>
+                />
                 <k-dropdown-content
                   ref="settings"
                   :options="$dropdown(id)"

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -15,9 +15,7 @@
           {{ $t("installation") }}
         </h1>
         <k-fieldset v-model="user" :fields="fields" :novalidate="true" />
-        <k-button type="submit" icon="check">
-          {{ $t("install") }}
-        </k-button>
+        <k-button :text="$t('install')" type="submit" icon="check" />
       </form>
 
       <!-- not meeting requirements -->
@@ -82,9 +80,7 @@
           </li>
         </ul>
 
-        <k-button icon="refresh" @click="$reload">
-          {{ $t('retry') }}
-        </k-button>
+        <k-button :text="$t('retry')" icon="refresh" @click="$reload" />
       </div>
     </k-view>
   </k-outside>

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -17,14 +17,13 @@
           <k-button-group>
             <k-button
               v-if="permissions.preview && model.previewUrl"
-              :responsive="true"
               :link="model.previewUrl"
-              class="k-page-view-preview"
+              :responsive="true"
+              :text="$t('open')"
               icon="open"
               target="_blank"
-            >
-              {{ $t('open') }}
-            </k-button>
+              class="k-page-view-preview"
+            />
             <k-status-icon
               v-if="status"
               :status="model.status"
@@ -35,13 +34,12 @@
             />
             <k-dropdown class="k-page-view-options">
               <k-button
-                :responsive="true"
                 :disabled="isLocked === true"
+                :responsive="true"
+                :text="$t('settings')"
                 icon="cog"
                 @click="$refs.settings.toggle()"
-              >
-                {{ $t('settings') }}
-              </k-button>
+              />
               <k-dropdown-content
                 ref="settings"
                 :options="$dropdown(id)"

--- a/panel/src/components/Views/SettingsView.vue
+++ b/panel/src/components/Views/SettingsView.vue
@@ -47,9 +47,11 @@
           <section class="k-languages-section">
             <header class="k-settings-view-section-header">
               <k-headline>{{ $t('languages.secondary') }}</k-headline>
-              <k-button icon="add" @click="$dialog('languages/create')">
-                {{ $t('language.create') }}
-              </k-button>
+              <k-button
+                :text="$t('language.create')"
+                icon="add"
+                @click="$dialog('languages/create')"
+              />
             </header>
             <k-collection
               v-if="secondaryLanguages.length"
@@ -64,9 +66,11 @@
         <template v-else-if="languages.length === 0">
           <header class="k-settings-view-section-header">
             <k-headline>{{ $t('languages') }}</k-headline>
-            <k-button icon="add" @click="$dialog('languages/create')">
-              {{ $t('language.create') }}
-            </k-button>
+            <k-button
+              :text="$t('language.create')"
+              icon="add"
+              @click="$dialog('languages/create')"
+            />
           </header>
           <k-empty icon="globe" @click="$dialog('languages/create')">
             {{ $t('languages.empty') }}

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -16,14 +16,13 @@
         <template #left>
           <k-button-group>
             <k-button
-              :responsive="true"
               :link="model.previewUrl"
-              class="k-site-view-preview"
+              :responsive="true"
+              :text="$t('open')"
               icon="open"
               target="_blank"
-            >
-              {{ $t('open') }}
-            </k-button>
+              class="k-site-view-preview"
+            />
             <k-languages-dropdown />
           </k-button-group>
         </template>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -54,9 +54,12 @@
           <template #left>
             <k-button-group>
               <k-dropdown class="k-user-view-options">
-                <k-button :disabled="isLocked" icon="cog" @click="$refs.settings.toggle()">
-                  {{ $t('settings') }}
-                </k-button>
+                <k-button
+                  :disabled="isLocked"
+                  :text="$t('settings')"
+                  icon="cog"
+                  @click="$refs.settings.toggle()"
+                />
                 <k-dropdown-content
                   ref="settings"
                   :options="$dropdown(id)"

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -8,64 +8,34 @@
     >
       <div class="k-user-profile">
         <k-view>
-          <template v-if="model.avatar">
-            <k-dropdown>
-              <k-button
-                :tooltip="$t('avatar')"
-                :disabled="isLocked"
-                class="k-user-view-image"
-                @click="$refs.picture.toggle()"
-              >
-                <k-image
-                  v-if="model.avatar"
-                  :cover="true"
-                  :src="model.avatar"
-                  ratio="1/1"
-                />
-              </k-button>
-              <k-dropdown-content ref="picture">
-                <k-dropdown-item icon="upload" @click="$refs.upload.open()">
-                  {{ $t('change') }}
-                </k-dropdown-item>
-                <k-dropdown-item icon="trash" @click="deleteAvatar">
-                  {{ $t('delete') }}
-                </k-dropdown-item>
-              </k-dropdown-content>
-            </k-dropdown>
-          </template>
-          <template v-else>
+          <k-dropdown>
             <k-button
               :tooltip="$t('avatar')"
+              :disabled="isLocked"
               class="k-user-view-image"
-              @click="$refs.upload.open()"
+              @click="onAvatar"
             >
-              <k-icon type="user" />
+              <k-image
+                v-if="model.avatar"
+                :cover="true"
+                :src="model.avatar"
+                ratio="1/1"
+              />
+              <k-icon
+                v-else
+                back="gray-900"
+                color="gray-200"
+                type="user"
+              />
             </k-button>
-          </template>
+            <k-dropdown-content
+              v-if="model.avatar"
+              ref="picture"
+              :options="avatarOptions"
+            />
+          </k-dropdown>
 
-          <k-button-group>
-            <k-button
-              :disabled="!permissions.changeEmail || isLocked"
-              icon="email"
-              @click="$dialog(id + '/changeEmail')"
-            >
-              {{ $t("email") }}: {{ model.email }}
-            </k-button>
-            <k-button
-              :disabled="!permissions.changeRole || isLocked"
-              icon="bolt"
-              @click="$dialog(id + '/changeRole')"
-            >
-              {{ $t("role") }}: {{ model.role }}
-            </k-button>
-            <k-button
-              :disabled="!permissions.changeLanguage || isLocked"
-              icon="globe"
-              @click="$dialog(id + '/changeLanguage')"
-            >
-              {{ $t("language") }}: {{ model.language }}
-            </k-button>
-          </k-button-group>
+          <k-button-group :buttons="buttons" />
         </k-view>
       </div>
 
@@ -132,6 +102,42 @@ export default {
   extends: ModelView,
   prevnext: true,
   computed: {
+    avatarOptions() {
+      return [
+        {
+          icon: "upload",
+          text: this.$t("change"),
+          click: () => this.$refs.upload.open()
+        },
+        {
+          icon: "trash",
+          text: this.$t("delete"),
+          click: this.deleteAvatar
+        }
+      ];
+    },
+    buttons() {
+      return [
+        {
+          icon: "email",
+          text: `${this.$t('email')}: ${this.model.email}`,
+          disabled: !this.permissions.changeEmail || this.isLocked,
+          click: () => this.$dialog(this.id + '/changeEmail')
+        },
+        {
+          icon: "bolt",
+          text: `${this.$t('role')}: ${this.model.role}`,
+          disabled: !this.permissions.changeRole || this.isLocked,
+          click: () => this.$dialog(this.id + '/changeRole')
+        },
+        {
+          icon: "globe",
+          text: `${this.$t('language')}: ${this.model.language}`,
+          disabled: !this.permissions.changeLanguage || this.isLocked,
+          click: () => this.$dialog(this.id + '/changeLanguage')
+        }
+      ];
+    },
     id() {
       return this.$api.users.url(this.model.id);
     },
@@ -145,6 +151,13 @@ export default {
       this.avatar = null;
       this.$store.dispatch("notification/success", ":)");
       this.$reload();
+    },
+    onAvatar() {
+      if (this.model.avatar) {
+        this.$refs.picture.toggle();
+      } else {
+        this. $refs.upload.open();
+      }
     },
     uploadedAvatar() {
       this.$store.dispatch("notification/success", ":)");
@@ -174,30 +187,23 @@ export default {
   overflow: hidden;
   white-space: nowrap;
 }
-.k-user-profile .k-button-group .k-button[disabled] {
-  opacity: 1;
-}
 
-.k-user-profile .k-dropdown-content {
-  margin-block-start: .5rem;
-  inset-inline-start: 50%;
-  transform: translateX(-50%);
+.k-user-view-image .k-image,
+.k-user-view-image .k-icon {
+  width: 5rem;
+  height: 5rem;
+  line-height: 0;
+}
+.k-user-view-image[data-disabled] {
+  opacity: 1;
 }
 .k-user-view-image .k-image {
   display: block;
-  width: 4rem;
-  height: 4rem;
-  line-height: 0;
 }
 .k-user-view-image .k-button-text {
   opacity: 1;
 }
-.k-user-view-image .k-icon {
-  width: 4rem;
-  height: 4rem;
-  background: var(--color-gray-900);
-  color: var(--color-gray-500);
-}
+
 .k-user-name-placeholder {
   color: var(--color-gray-500);
   transition: color .3s;

--- a/panel/src/components/Views/UsersView.vue
+++ b/panel/src/components/Views/UsersView.vue
@@ -5,15 +5,14 @@
         {{ $t('view.users') }}
 
         <template #left>
-          <k-button-group>
-            <k-button
-              :disabled="$permissions.users.create === false"
-              icon="add"
-              @click="$dialog('users/create')"
-            >
-              {{ $t('user.create') }}
-            </k-button>
-          </k-button-group>
+          <k-button-group
+            :buttons="[{
+              disbaled: $permissions.users.create === false,
+              text: $t('user.create'),
+              icon: 'add',
+              click: () => $dialog('users/create')
+            }]"
+          />
         </template>
 
         <template #right>
@@ -21,11 +20,10 @@
             <k-dropdown>
               <k-button
                 :responsive="true"
+                :text="`${$t('role')}: ${role ? role.title : $t('role.all')}`"
                 icon="funnel"
                 @click="$refs.roles.toggle()"
-              >
-                {{ $t("role") }}: {{ role ? role.title : $t("role.all") }}
-              </k-button>
+              />
               <k-dropdown-content ref="roles" align="right">
                 <k-dropdown-item icon="bolt" link="/users">
                   {{ $t("role.all") }}


### PR DESCRIPTION
- `k-button` allows passing text via prop
- `k-button` support click callback via prop
- Uses `k-button` more with `text` prop instead slot
- `k-button-group` allows passing buttons via prop
- Uses `k-button-group` more with `buttons` prop instead slot
- Refactors `k-user-view`

```
BEFORE
dist/css/style.css   107.11kb / brotli: 14.94kb
dist/js/index.js     316.29kb / brotli: 60.18kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

AFTER
dist/css/style.css   106.85kb / brotli: 14.92kb
dist/js/index.js     314.61kb / brotli: 60.28kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```