### PR TITLE
Fix tabbed link styling

### DIFF
--- a/panel/src/components/Navigation/Link.vue
+++ b/panel/src/components/Navigation/Link.vue
@@ -118,7 +118,6 @@ export default {
   outline: none;
 }
 .k-link[data-tabbed] {
-  outline: none;
   box-shadow: var(--shadow-outline);
 }
 </style>

--- a/panel/src/components/Navigation/Link.vue
+++ b/panel/src/components/Navigation/Link.vue
@@ -117,7 +117,7 @@ export default {
 .k-link {
   outline: none;
 }
-.k-link [data-tabbed] {
+.k-link[data-tabbed] {
   outline: none;
   box-shadow: var(--shadow-outline);
 }


### PR DESCRIPTION
## Describe the PR

We made a small mistake when moving from SCSS to CSS. See https://github.com/getkirby/kirby/blob/38afb2d650f3764d23d732b23ae8f04ab9ffba69/panel/src/main.scss#L168-L174



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed regressions from alpha.2
- Styling for tabbed link highlighting works again


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3576
