### PR TITLE
Fix manually sorting via `changePosition` 

### DIFF
--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -48,7 +48,7 @@ return [
             return $file->next();
         },
         'nextWithTemplate' => function (File $file) {
-            $files = $file->templateSiblings()->sort('sort', 'asc', 'filename', 'asc');
+            $files = $file->templateSiblings()->sorted();
             $index = $files->indexOf($file);
 
             return $files->nth($index + 1);
@@ -76,7 +76,7 @@ return [
             return $file->prev();
         },
         'prevWithTemplate' => function (File $file) {
-            $files = $file->templateSiblings()->sort('sort', 'asc', 'filename', 'asc');
+            $files = $file->templateSiblings()->sorted();
             $index = $files->indexOf($file);
 
             return $files->nth($index - 1);

--- a/config/api/models/Page.php
+++ b/config/api/models/Page.php
@@ -27,7 +27,7 @@ return [
             return $page->errors();
         },
         'files' => function (Page $page) {
-            return $page->files()->sort('sort', 'asc', 'filename', 'asc');
+            return $page->files()->sorted();
         },
         'hasChildren' => function (Page $page) {
             return $page->hasChildren();

--- a/config/api/models/Site.php
+++ b/config/api/models/Site.php
@@ -24,7 +24,7 @@ return [
             return $site->drafts();
         },
         'files' => function (Site $site) {
-            return $site->files()->sort('sort', 'asc', 'filename', 'asc');
+            return $site->files()->sorted();
         },
         'options' => function (Site $site) {
             return $site->permissions()->toArray();

--- a/config/api/models/User.php
+++ b/config/api/models/User.php
@@ -24,7 +24,7 @@ return [
             return $user->email();
         },
         'files' => function (User $user) {
-            return $user->files()->sort('sort', 'asc', 'filename', 'asc');
+            return $user->files()->sorted();
         },
         'id' => function (User $user) {
             return $user->id();

--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -27,7 +27,7 @@ return [
         'pattern' => '(:all)/files',
         'method'  => 'GET',
         'action'  => function (string $path) {
-            return $this->parent($path)->files()->sort('sort', 'asc', 'filename', 'asc');
+            return $this->parent($path)->files()->sorted();
         }
     ],
     [

--- a/config/areas/files/dialogs.php
+++ b/config/areas/files/dialogs.php
@@ -78,7 +78,7 @@ return [
         },
         'submit' => function (string $path, string $filename) {
             $file     = Find::file($path, $filename);
-            $files    = $file->siblings()->sortBy('sort', 'asc');
+            $files    = $file->siblings()->sorted();
             $ids      = $files->keys();
             $newIndex = (int)(get('position')) - 1;
 

--- a/config/areas/files/dialogs.php
+++ b/config/areas/files/dialogs.php
@@ -81,14 +81,7 @@ return [
             $files    = $file->siblings()->sorted();
             $ids      = $files->keys();
             $newIndex = (int)(get('position')) - 1;
-
-            // use file sort value if exists
-            // otherwise use index from collection
-            if ($file->sort()->exists() === true) {
-                $oldIndex = $file->sort()->int() - 1;
-            } else {
-                $oldIndex = $files->indexOf($file);
-            }
+            $oldIndex = $files->indexOf($file);
 
             array_splice($ids, $oldIndex, 1);
             array_splice($ids, $newIndex, 0, $file->id());

--- a/config/areas/files/dialogs.php
+++ b/config/areas/files/dialogs.php
@@ -78,10 +78,17 @@ return [
         },
         'submit' => function (string $path, string $filename) {
             $file     = Find::file($path, $filename);
-            $files    = $file->siblings();
+            $files    = $file->siblings()->sortBy('sort', 'asc');
             $ids      = $files->keys();
-            $oldIndex = $files->indexOf($file);
             $newIndex = (int)(get('position')) - 1;
+
+            // use file sort value if exists
+            // otherwise use index from collection
+            if ($file->sort()->exists() === true) {
+                $oldIndex = $file->sort()->int() - 1;
+            } else {
+                $oldIndex = $files->indexOf($file);
+            }
 
             array_splice($ids, $oldIndex, 1);
             array_splice($ids, $newIndex, 0, $file->id());

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -91,7 +91,7 @@ return [
             if ($this->sortBy) {
                 $files = $files->sort(...$files::sortArgs($this->sortBy));
             } else {
-                $files = $files->sort('sort', 'asc', 'filename', 'asc');
+                $files = $files->sorted();
             }
 
             // flip

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -155,6 +155,17 @@ class Files extends Collection
     }
 
     /**
+     * Returns the collection sorted by
+     * the sort number and the filename
+     *
+     * @return static
+     */
+    public function sorted()
+    {
+        return $this->sort('sort', 'asc', 'filename', 'asc');
+    }
+
+    /**
      * Filter all files by the given template
      *
      * @param null|string|array $template

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -46,7 +46,7 @@ class Field
         $index   = 0;
         $options = [];
 
-        foreach ($file->siblings(false) as $sibling) {
+        foreach ($file->siblings(false)->sorted() as $sibling) {
             $index++;
 
             $options[] = [

--- a/tests/Cms/Api/models/FileApiModelTest.php
+++ b/tests/Cms/Api/models/FileApiModelTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Cms\Api\ApiModelTestCase;
+
+class FileApiModelTest extends ApiModelTestCase
+{
+    public function testNextWithTemplate()
+    {
+        $page = new Page([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'a.jpg', 'content' => ['template' => 'test']],
+                ['filename' => 'b.jpg', 'content' => ['template' => 'test']],
+            ]
+        ]);
+
+        $next = $this->attr($page->file('a.jpg'), 'nextWithTemplate');
+        $this->assertSame('b.jpg', $next['filename']);
+    }
+
+    public function testPrevWithTemplate()
+    {
+        $page = new Page([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'a.jpg', 'content' => ['template' => 'test']],
+                ['filename' => 'b.jpg', 'content' => ['template' => 'test']],
+            ]
+        ]);
+
+        $next = $this->attr($page->file('b.jpg'), 'prevWithTemplate');
+        $this->assertSame('a.jpg', $next['filename']);
+    }
+}

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -14,6 +14,22 @@ class UserApiModelTest extends ApiModelTestCase
         $this->user = new User(['email' => 'test@getkirby.com']);
     }
 
+    public function testFiles()
+    {
+        $user = new User([
+            'email' => 'test@getkirby.com',
+            'files' => [
+                ['filename' => 'a.jpg'],
+                ['filename' => 'b.jpg'],
+            ]
+        ]);
+
+        $model = $this->api->resolve($user)->select('files')->toArray();
+
+        $this->assertEquals('a.jpg', $model['files'][0]['filename']);
+        $this->assertEquals('b.jpg', $model['files'][1]['filename']);
+    }
+
     public function testImage()
     {
         $image = $this->attr($this->user, 'panelImage');

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -148,4 +148,50 @@ class FilesTest extends TestCase
 
         Dir::remove($tmp);
     }
+
+    /**
+     * @covers ::sorted
+     */
+    public function testSortedByFilename()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'files' => [
+                    ['filename' => 'b.jpg'],
+                    ['filename' => 'a.jpg']
+                ]
+            ]
+        ]);
+
+        $files = $app->site()->files()->sorted();
+
+        $this->assertSame('a.jpg', $files->first()->filename());
+        $this->assertSame('b.jpg', $files->last()->filename());
+    }
+
+    /**
+     * @covers ::sorted
+     */
+    public function testSortedBySort()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'files' => [
+                    ['filename' => 'a.jpg', 'content' => ['sort' => 2]],
+                    ['filename' => 'b.jpg', 'content' => ['sort' => 1]]
+                ]
+            ]
+        ]);
+
+        $files = $app->site()->files()->sorted();
+
+        $this->assertSame('b.jpg', $files->first()->filename());
+        $this->assertSame('a.jpg', $files->last()->filename());
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The problem was that it was trying to sort without using the `Sort` content value of file. I fixed it and works great but I'm not sure it's the right implementation. Need your review @distantnative 


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Fix manually sorting via `changePosition`  `#3589`


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3589

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
