### PR TITLE
Fix converting files when a language gets deleted #3588

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -246,14 +246,16 @@ class Language extends Model
             throw new Exception('The language could not be deleted');
         }
 
+        if ($isLast === true) {
+            $this->converter($code, '');
+        } else {
+            $this->deleteContentFiles($code);
+        }
+
         // get the original language collection and remove the current language
         $kirby->languages(false)->remove($code);
 
-        if ($isLast === true) {
-            return $this->converter($code, '');
-        } else {
-            return $this->deleteContentFiles($code);
-        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

Languages get deleted correctly again. 

## Release notes

### Fixed regressions from 3.6.0-alpha.2 
- Languages get deleted without error again

## Breaking changes
None

## Related issues/ideas
- Fixes #3588

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
