### PR TITLE
Set files `sort` attribute on upload 

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -34,13 +34,19 @@ return [
         'pattern' => '(:all)/files',
         'method'  => 'POST',
         'action'  => function (string $path) {
+            // move_uploaded_file() not working with unit test
+            // @codeCoverageIgnoreStart
             return $this->upload(function ($source, $filename) use ($path) {
                 return $this->parent($path)->createFile([
+                    'content' => [
+                        'sort' => $this->requestBody('sort')
+                    ],
                     'source'   => $source,
                     'template' => $this->requestBody('template'),
                     'filename' => $filename
                 ]);
             });
+            // @codeCoverageIgnoreEnd
         }
     ],
     [

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -223,6 +223,7 @@ return [
                 'max'        => $max,
                 'api'        => $this->parent->apiUrl(true) . '/files',
                 'attributes' => array_filter([
+                    'sort'     => $this->sortable === true ? $total + 1 : null,
                     'template' => $template
                 ])
             ];


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

If files section sortable, sets `sort` attribute as last item.
Otherwise no sort attribute set or write to file content.
Feel free to close the PR if not right implementation.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Sets automatically `sort` attribute on upload if section sortable `#2886`


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #2886

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
