### PR TITLE
Fix dropdown z-index issue and JSON problem

### DIFF
--- a/panel/src/variables.css
+++ b/panel/src/variables.css
@@ -137,11 +137,11 @@
   --z-loader: 1000;
   --z-notification: 900;
   --z-dialog: 800;
-  --z-dropdown: 700;
-  --z-drawer: 600;
-  --z-dropzone: 500;
-  --z-toolbar: 400;
-  --z-navigation: 300;
+  --z-navigation: 700;
+  --z-dropdown: 600;
+  --z-drawer: 500;
+  --z-dropzone: 400;
+  --z-toolbar: 300;
   --z-content: 200;
   --z-background: 100;
 

--- a/views/panel.php
+++ b/views/panel.php
@@ -48,7 +48,7 @@
 
   <script nonce="<?= $nonce ?>">
     // Panel state
-    const json = <?= json_encode($fiber, JSON_UNESCAPED_SLASHES) ?>;
+    const json = <?= json_encode($fiber) ?>;
 
     window.panel = JSON.parse(JSON.stringify(json));
 


### PR DESCRIPTION
## Describe the PR

The dropdown z-index was too high and dropdown buttons were positioned over the save bar. 
This PR also fixes a problem with HTML in the Fiber response leaking into the document.

## Release notes

### Fixes 
- Dropdowns and dropdown buttons no longer appear above the save bar. 

## Breaking changes
none

## Related issues/ideas
- Fixes #3554

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
