### PR TITLE
CSS: don't preserve logical properties for now

### DIFF
--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -66,7 +66,7 @@ export default ({ command }) => {
     css: {
       postcss: {
         plugins: [
-          postcssLogical({ preserve: true }),
+          postcssLogical(),
           postcssDirPseudoClass()
         ]
       }


### PR DESCRIPTION
```
BEFORE:
dist/css/style.css   115.28kb / brotli: 15.69kb

AFTER:
dist/css/style.css   107.11kb / brotli: 14.94kb
```