### PR TITLE
Clean up old API stuff

### DIFF
--- a/panel/src/api/files.js
+++ b/panel/src/api/files.js
@@ -1,37 +1,5 @@
 export default (api) => {
   return {
-    breadcrumb(file, route) {
-
-      let parent = null;
-      let breadcrumb = [];
-
-      switch (route) {
-        case "UserFile":
-          breadcrumb.push({
-            label: file.parent.username,
-            link: api.users.link(file.parent.id)
-          });
-          parent = 'users/' + file.parent.id;
-          break;
-        case "SiteFile":
-          parent = "site";
-          break;
-        case "PageFile":
-          breadcrumb = file.parents.map(parent => ({
-            label: parent.title,
-            link: api.pages.link(parent.id)
-          }));
-          parent = api.pages.url(file.parent.id);
-          break;
-      }
-
-      breadcrumb.push({
-        label: file.filename,
-        link: this.link(parent, file.filename)
-      });
-
-      return breadcrumb;
-    },
     async changeName(parent, filename, to) {
       return api.patch(parent + "/files/" + filename + "/name", {
         name: to

--- a/panel/src/api/pages.js
+++ b/panel/src/api/pages.js
@@ -8,21 +8,6 @@ export default (api) => {
         section: section
       });
     },
-    breadcrumb(page, self = true) {
-      var breadcrumb = page.parents.map(parent => ({
-        label: parent.title,
-        link: this.link(parent.id)
-      }));
-
-      if (self === true) {
-        breadcrumb.push({
-          label: page.title,
-          link: this.link(page.id),
-        });
-      }
-
-      return breadcrumb;
-    },
     async changeSlug(id, slug) {
       return api.patch("pages/" + this.id(id) + "/slug", { slug: slug });
     },

--- a/panel/src/api/roles.js
+++ b/panel/src/api/roles.js
@@ -5,16 +5,6 @@ export default (api) => {
     },
     async get(name) {
       return api.get("roles/" + name);
-    },
-    async options(params) {
-      const roles = await this.list(params);
-      return roles.data.map(role => {
-        return {
-          info: role.description || `(${window.panel.$t("role.description.placeholder")})`,
-          text: role.title,
-          value: role.name
-        };
-      });
     }
   }
 };

--- a/panel/src/api/site.js
+++ b/panel/src/api/site.js
@@ -15,20 +15,6 @@ export default (api) => {
     async get(query = { view: "panel" }) {
       return api.get("site", query);
     },
-    async options() {
-      const site    = await api.get("site", {select: "options"});
-      const options = site.options;
-      let result    = [];
-
-      result.push({
-        click: "rename",
-        icon: "title",
-        text: window.panel.$t("rename"),
-        disabled: !options.changeTitle
-      });
-
-      return result;
-    },
     async update(data) {
       return api.post("site", data);
     },

--- a/panel/src/api/translations.js
+++ b/panel/src/api/translations.js
@@ -5,15 +5,6 @@ export default (api) => {
     },
     async get(locale) {
       return api.get("translations/" + locale);
-    },
-    async options() {
-      const translations = await this.list();
-      const options = translations.data.map(translation => ({
-        value: translation.id,
-        text: translation.name
-      }));
-
-      return options;
     }
   }
 };

--- a/panel/src/api/users.js
+++ b/panel/src/api/users.js
@@ -8,14 +8,6 @@ export default (api) => {
         section: section
       });
     },
-    breadcrumb(user) {
-      return [
-        {
-          link: "/users/" + user.id,
-          label: user.username
-        }
-      ];
-    },
     async changeEmail(id, email) {
       return api.patch("users/" + id + "/email", { email: email });
     },

--- a/panel/src/components/Forms/Previews/PagesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/PagesFieldPreview.vue
@@ -2,7 +2,7 @@
   <ul v-if="value" class="k-pages-field-preview">
     <li v-for="page in value" :key="page.id">
       <figure>
-        <k-link :title="page.id" :to="$api.pages.link(page.id)" @click.native.stop>
+        <k-link :title="page.id" :to="page.link" @click.native.stop>
           <k-icon type="page" back="pattern" class="k-pages-field-preview-image" />
           <figcaption>
             {{ page.text }}

--- a/panel/src/components/Forms/Previews/UsersFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UsersFieldPreview.vue
@@ -2,7 +2,7 @@
   <ul v-if="value" class="k-users-field-preview">
     <li v-for="user in value" :key="user.email">
       <figure>
-        <k-link :title="user.email" :to="$api.users.link(user.id)" @click.native.stop>
+        <k-link :title="user.email" :to="user.link" @click.native.stop>
           <k-image
             v-if="user.avatar"
             :src="user.avatar.url"

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -5,6 +5,7 @@
       :data-centered="loading || centered"
       :data-dimmed="dimmed"
       :data-loading="loading"
+      :dir="$translation.direction"
       :class="$vnode.data.staticClass"
       class="k-overlay"
       v-on="$listeners"

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -90,17 +90,9 @@ export default {
   },
   methods: {
     action(action, file) {
-
-      switch (action) {
-        case "replace":
-          this.$refs.upload.open({
-            url: this.$urls.api + "/" + this.$api.files.url(file.parent, file.filename),
-            accept: "." + file.extension + "," + file.mime,
-            multiple: false
-          });
-          break;
+      if (action === "replace") {
+        this.replace(file);
       }
-
     },
     drop(files) {
       if (this.add === false) {
@@ -116,7 +108,7 @@ export default {
       return data.map(file => {
         file.sortable = this.options.sortable;
         file.column   = this.column;
-        file.options  = this.$dropdown(this.$api.files.url(file.parent, file.filename), {
+        file.options  = this.$dropdown(file.link, {
           query: {
             view: "list",
             update: this.options.sortable,
@@ -135,8 +127,8 @@ export default {
     },
     replace(file) {
       this.$refs.upload.open({
-        url: this.$urls.api + "/" + this.$api.files.url(file.parent, file.filename),
-        accept: file.mime,
+        url: this.$urls.api + "/" + file.link,
+        accept: "." + file.extension + "," + file.mime,
         multiple: false
       });
     },

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -104,14 +104,14 @@ export default {
           tooltip: this.$t("page.status"),
           disabled: !isEnabled,
           click: () => {
-            this.$dialog(this.$api.pages.url(page.id) + "/changeStatus");
+            this.$dialog(page.link + "/changeStatus");
           }
         };
 
         page.sortable  = page.permissions.sort && this.options.sortable;
         page.deletable = data.length > this.options.min;
         page.column    = this.column;
-        page.options   = this.$dropdown(this.$api.pages.url(page.id), {
+        page.options   = this.$dropdown(page.link, {
           query: {
             view: "list",
             delete: page.deletable,

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -78,11 +78,6 @@ export default {
   props: {
     preview: Object
   },
-  computed: {
-    id() {
-      return this.$api.files.url(this.model.parent, this.model.filename);
-    }
-  },
   methods: {
     action(action) {
       switch (action) {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -36,7 +36,7 @@ export default {
   },
   computed: {
     id() {
-      return this.model.id;
+      return this.model.link;
     },
     isLocked() {
       return this.lock !== false && this.lock.state === "lock";

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -77,11 +77,6 @@ export default {
   extends: ModelView,
   props: {
     status: Object
-  },
-  computed: {
-    id() {
-      return this.$api.pages.url(this.model.id);
-    }
   }
 };
 </script>

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -44,11 +44,6 @@
 import ModelView from "./ModelView.vue";
 
 export default {
-  extends: ModelView,
-  computed: {
-    id() {
-      return "site"
-    }
-  }
+  extends: ModelView
 };
 </script>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -141,9 +141,6 @@ export default {
         }
       ];
     },
-    id() {
-      return this.$api.users.url(this.model.id);
-    },
     uploadApi() {
       return this.$urls.api + "/" + this.id + "/avatar";
     }

--- a/panel/src/components/Views/UsersView.vue
+++ b/panel/src/components/Views/UsersView.vue
@@ -71,7 +71,7 @@ export default {
   computed: {
     items() {
       return this.users.data.map(user => {
-        user.options = this.$dropdown(this.$api.users.url(user.id));
+        user.options = this.$dropdown(user.link);
         return user;
       })
     }

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -335,6 +335,7 @@ class File extends Model
                     'dimensions' => $dimensions->toArray(),
                     'extension'  => $file->extension(),
                     'filename'   => $file->filename(),
+                    'link'       => $this->url(true),
                     'mime'       => $file->mime(),
                     'niceSize'   => $file->niceSize(),
                     'id'         => $id = $file->id(),

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -322,6 +322,7 @@ class Page extends Model
                 'model' => [
                     'content'    => $this->content(),
                     'id'         => $page->id(),
+                    'link'       => $this->url(true),
                     'parent'     => $page->parentModel()->panel()->url(true),
                     'previewUrl' => $page->previewUrl(),
                     'status'     => $page->status(),

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -54,8 +54,9 @@ class Site extends Model
             'blueprint' => 'site',
             'model' => [
                 'content'    => $this->content(),
+                'link'       => $this->url(true),
                 'previewUrl' => $this->model->previewUrl(),
-                'title'      => $this->model->title()->toString()
+                'title'      => $this->model->title()->toString(),
             ]
         ]);
     }

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -190,6 +190,7 @@ class User extends Model
                     'email'    => $user->email(),
                     'id'       => $user->id(),
                     'language' => $this->translation()->name(),
+                    'link'     => $this->url(true),
                     'name'     => $user->name()->toString(),
                     'role'     => $user->role()->title(),
                     'username' => $user->username(),


### PR DESCRIPTION
## Describe the PR

We still used methods like $api.pages.url in many places, which makes no sense with Fiber anymore. I removed all of those instances and also did some more clean up work for old, outdated API helper methods. 

## Bundle

### Before 

```
dist/css/style.css   105.35kb / brotli: 14.79kb
dist/js/index.js     313.23kb / brotli: 60.05kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```

### After

```
dist/css/style.css   105.35kb / brotli: 14.79kb
dist/js/index.js     311.81kb / brotli: 59.67kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```

## Breaking changes
- Removed $api.pages.breadcrumb
- Removed $api.files.breadcrumb
- Removed $api.users.breadcrumb
- Removed $api.site.breadcrumb
- Removed $api.site.options
- Removed $api.roles.options
- Removed $api.translations.options

## Fixes

- Fixed CSS dir issue in dialogs and drawers

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
