### PR TITLE
File upload improvements

### DIFF
--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -95,6 +95,15 @@ export default {
       total: 0
     };
   },
+  computed: {
+    limit() {
+      if (this.options.multiple === false) {
+        return 1;
+      }
+
+      return this.options.max;
+    }
+  },
   methods: {
     /**
      * Opens the uploader with the object of given parameters.
@@ -132,14 +141,13 @@ export default {
     },
     upload(files) {
       this.$refs.dialog.open();
-
       this.files = [...files];
       this.completed = {};
       this.errors = [];
       this.hasErrors = false;
 
-      if (this.options.max) {
-        this.files = this.files.slice(0, this.options.max);
+      if (this.limit) {
+        this.files = this.files.slice(0, this.limit);
       }
 
       this.total = this.files.length;

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -81,7 +81,14 @@ class FileRules
     public static function create(File $file, BaseFile $upload): bool
     {
         if ($file->exists() === true) {
-            throw new DuplicateException('The file exists and cannot be overwritten');
+            if ($file->sha1() !== $upload->sha1()) {
+                throw new DuplicateException([
+                    'key'  => 'file.duplicate',
+                    'data' => [
+                        'filename' => $file->filename()
+                    ]
+                ]);
+            }
         }
 
         if ($file->permissions()->create() !== true) {

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -507,6 +507,14 @@ class File
     }
 
     /**
+     * @return string
+     */
+    public function sha1(): string
+    {
+        return sha1_file($this->root);
+    }
+
+    /**
      * Returns the raw size of the file
      *
      * @return int

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -507,6 +507,9 @@ class File
     }
 
     /**
+     * Returns the sha1 hash of the file
+     * @since 3.6.0
+     *
      * @return string
      */
     public function sha1(): string

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -104,7 +104,7 @@ class FileRulesTest extends TestCase
         $file->method('exists')->willReturn(true);
 
         $this->expectException('Kirby\Exception\DuplicateException');
-        $this->expectExceptionMessage('The file exists and cannot be overwritten');
+        $this->expectExceptionMessage('A file with the name "test.jpg" already exists');
 
         $upload = $this->createMock(BaseFile::class);
 

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -581,6 +581,15 @@ class FileTest extends TestCase
     }
 
     /**
+     * @covers ::sha1
+     */
+    public function testSha1()
+    {
+        $file = $this->_file('test.js');
+        $this->assertSame('25f2d6df4f2a30f29f6f80da1e95011044b0b8f7', $file->sha1());
+    }
+
+    /**
      * @covers ::toArray
      * @covers ::__debugInfo
      */


### PR DESCRIPTION
## Describe the PR


## Release notes
- File uploads now check for duplicates via sha1 hashes. This leads to a better upload experience because when you upload the exact same file twice, the upload is simply ignored.
- The files field can now accept new files via drag & drop

## Breaking changes
- none

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
