### PR TITLE
CSS: use `top` and `bottom` again

### DIFF
--- a/panel/src/components/Blocks/Block.vue
+++ b/panel/src/components/Blocks/Block.vue
@@ -221,10 +221,9 @@ export default {
   position: relative;
   padding: .75rem;
   background: var(--color-white);
-  border-block-end: 1px dashed rgba(0, 0, 0, .1);
 }
-.k-block-container:last-of-type {
-  border-block-end: 0;
+.k-block-container:not(:last-of-type) {
+  border-bottom: 1px dashed rgba(0, 0, 0, .1);
 }
 .k-block-container:focus {
   outline: 0;
@@ -232,7 +231,7 @@ export default {
 
 .k-block-container[data-batched] {
   z-index: 2;
-  border-block-end-color: transparent;
+  border-bottom-color: transparent;
 }
 .k-block-container[data-batched]::after {
   position: absolute;
@@ -246,14 +245,14 @@ export default {
 .k-block-container[data-selected] {
   z-index: 2;
   box-shadow: var(--color-focus) 0 0 0 1px, var(--color-focus-outline) 0 0 0 3px;
-  border-block-end-color: transparent;
+  border-bottom-color: transparent;
 }
 .k-block-container .k-block-options {
   display: none;
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline-end: .75rem;
-  margin-block-start: calc(-1.75rem + 2px);
+  margin-top: calc(-1.75rem + 2px);
 }
 .k-block-container[data-last-in-batch] .k-block-options,
 .k-block-container[data-selected] .k-block-options {

--- a/panel/src/components/Blocks/BlockFigure.vue
+++ b/panel/src/components/Blocks/BlockFigure.vue
@@ -57,7 +57,7 @@ export default {
   background: var(--color-black);
 }
 .k-block-figure figcaption {
-  padding-block-start: .5rem;
+  padding-top: .5rem;
   color: var(--color-gray-600);
   font-size: var(--text-sm);
   text-align: center;

--- a/panel/src/components/Blocks/BlockOptions.vue
+++ b/panel/src/components/Blocks/BlockOptions.vue
@@ -134,7 +134,7 @@ export default {
   background: var(--color-gray-100);
 }
 .k-block-options .k-dropdown-content {
-  margin-block-start: .5rem;
+  margin-top: .5rem;
 }
 </style>
 

--- a/panel/src/components/Blocks/BlockSelector.vue
+++ b/panel/src/components/Blocks/BlockSelector.vue
@@ -121,10 +121,10 @@ export default {
   color: var(--color-white);
 }
 .k-block-selector .k-headline {
-  margin-block-end: 1rem;
+  margin-bottom: 1rem;
 }
 .k-block-selector details:not(:last-of-type) {
-  margin-block-end: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 .k-block-selector summary {
   font-size: var(--text-xs);
@@ -143,7 +143,7 @@ export default {
 .k-block-types {
   display: grid;
   grid-gap: 2px;
-  margin-block-start: .75rem;
+  margin-top: .75rem;
   grid-template-columns: repeat(1, 1fr);
 }
 .k-block-types .k-button {

--- a/panel/src/components/Blocks/Types/Code.vue
+++ b/panel/src/components/Blocks/Types/Code.vue
@@ -64,11 +64,11 @@ export default {
   font-size: var(--text-sm);
   position: absolute;
   inset-inline-end: 0;
-  inset-block-end: 0;
+  bottom: 0;
 }
 .k-block-type-code-editor-language .k-icon {
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline-start: 0;
   height: 1.5rem;
   display: flex;

--- a/panel/src/components/Blocks/Types/Gallery.vue
+++ b/panel/src/components/Blocks/Types/Gallery.vue
@@ -34,7 +34,7 @@ export default {}
   cursor: pointer;
 }
 .k-block-type-gallery li:empty {
-  padding-block-end: 100%;
+  padding-bottom: 100%;
   background: var(--color-background);
 }
 .k-block-type-gallery li {

--- a/panel/src/components/Blocks/Types/Line.vue
+++ b/panel/src/components/Blocks/Types/Line.vue
@@ -17,6 +17,6 @@ export default {
 .k-block-type-line hr {
   margin-block: .75rem;
   border: 0;
-  border-block-start: 2px solid var(--color-gray-400);
+  border-top: 2px solid var(--color-gray-400);
 }
 </style>

--- a/panel/src/components/Blocks/Types/Quote.vue
+++ b/panel/src/components/Blocks/Types/Quote.vue
@@ -50,7 +50,7 @@ export default {
 }
 .k-block-type-quote-text {
   font-size: var(--text-xl);
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
   line-height: 1.25em;
 }
 .k-block-type-quote-citation {

--- a/panel/src/components/Blocks/Types/Table.vue
+++ b/panel/src/components/Blocks/Types/Table.vue
@@ -92,15 +92,15 @@ export default {
   line-height: 1.5em;
   padding: .5rem .75rem;
   font-size: var(--text-sm);
-  border-block-end: 1px solid var(--color-gray-300);
+}
+.k-block-type-table-preview tr:not(:last-child) td,
+.k-block-type-table-preview th {
+    border-bottom: 1px solid var(--color-gray-300);
 }
 .k-block-type-table-preview th {
   background: var(--color-gray-100);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-}
-.k-block-type-table-preview tr:last-child td {
-  border-block-end: 0;
 }
 .k-block-type-table-preview-empty {
   color: var(--color-gray-600);

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -327,12 +327,12 @@ export default {
 }
 
 .k-dialog-body .k-fieldset {
-  padding-block-end: .5rem;
+  padding-bottom: .5rem;
 }
 
 .k-dialog-footer {
   padding: 0;
-  border-block-start: 1px solid var(--color-gray-300);
+  border-top: 1px solid var(--color-gray-300);
   border-end-start-radius: var(--rounded-xs);
   border-end-end-radius: var(--rounded-xs);
   line-height: 1;
@@ -361,7 +361,7 @@ export default {
 
 /** Pagination **/
 .k-dialog-pagination {
-  margin-block-end: -1.5rem;
+  margin-bottom: -1.5rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -369,7 +369,7 @@ export default {
 
 /** Dialog search field **/
 .k-dialog-search {
-  margin-block-end: .75rem;
+  margin-bottom: .75rem;
 }
 
 .k-dialog-search.k-input {

--- a/panel/src/components/Dialogs/ErrorDialog.vue
+++ b/panel/src/components/Dialogs/ErrorDialog.vue
@@ -70,11 +70,11 @@ export default {
   padding: 1rem;
   font-size: var(--text-sm);
   line-height: 1.25em;
-  margin-block-start: .75rem;
+  margin-top: .75rem;
 }
 .k-error-details dt {
   color: var(--color-negative-light);
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
 }
 .k-error-details dd {
   overflow: hidden;
@@ -82,11 +82,11 @@ export default {
   text-overflow: ellipsis;
 }
 .k-error-details dd:not(:last-of-type) {
-  margin-block-end: 1.5em;
+  margin-bottom: 1.5em;
 }
 .k-error-details li:not(:last-child) {
-  border-block-end: 1px solid var(--color-background);
-  padding-block-end: .25rem;
-  margin-block-end: .25rem;
+  border-bottom: 1px solid var(--color-background);
+  padding-bottom: .25rem;
+  margin-bottom: .25rem;
 }
 </style>

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -117,7 +117,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
   padding-inline-end: 38px;
 }
 .k-pages-dialog-navbar .k-button {

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -218,7 +218,7 @@ export default {
 }
 .k-drawer-tab.k-button[aria-current]::after {
   position: absolute;
-  inset-block-end: -1px;
+  bottom: -1px;
   inset-inline: .75rem;
   content: "";
   background: var(--color-black);

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -341,7 +341,7 @@ export default {
   table-layout: fixed;
   width: 100%;
   min-width: 15rem;
-  padding-block-start: .5rem;
+  padding-top: .5rem;
 }
 
 .k-calendar-input > nav {
@@ -419,7 +419,7 @@ export default {
 }
 .k-calendar-today {
   text-align: center;
-  padding-block-start: .5rem;
+  padding-top: .5rem;
 }
 .k-calendar-today .k-button {
   color: var(--color-focus-light);

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -97,7 +97,7 @@ export default {
 }
 .k-field-options {
   position: absolute;
-  inset-block-start: calc(-.5rem - 1px);
+  top: calc(-.5rem - 1px);
   inset-inline-end: 0;
 }
 .k-field-options.k-button-group .k-dropdown {
@@ -123,6 +123,6 @@ export default {
   display: block;
 }
 .k-field-help {
-  padding-block-start: .5rem;
+  padding-top: .5rem;
 }
 </style>

--- a/panel/src/components/Forms/Field/HeadlineField.vue
+++ b/panel/src/components/Forms/Field/HeadlineField.vue
@@ -42,13 +42,13 @@ body {
 }
 .k-headline-field {
   position: relative;
-  padding-block-start: 1.5rem;
+  padding-top: 1.5rem;
 
 }
 /* don't add the top padding,
 if the headline is the very first form element */
 .k-fieldset > .k-grid .k-column:first-child .k-headline-field {
-  padding-block-start: 0;
+  padding-top: 0;
 }
 
 .k-headline-field .k-headline[data-numbered]::before {

--- a/panel/src/components/Forms/Field/InfoField.vue
+++ b/panel/src/components/Forms/Field/InfoField.vue
@@ -51,7 +51,7 @@ export default {
 
 <style>
 .k-info-field .k-headline {
-  padding-block-end: .75rem;
+  padding-bottom: .75rem;
   line-height: 1.25rem;
 }
 </style>

--- a/panel/src/components/Forms/Field/LineField.vue
+++ b/panel/src/components/Forms/Field/LineField.vue
@@ -19,8 +19,8 @@ export default {}
 .k-line-field::after {
   position: absolute;
   content: "";
-  inset-block-start: 50%;
-  margin-block-start: -1px;
+  top: 50%;
+  margin-top: -1px;
   inset-inline: 0;
   height: 1px;
   background: var(--color-border);

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -576,11 +576,15 @@ export default {
 }
 .k-structure-table th,
 .k-structure-table td {
-  border-block-end: 1px solid var(--color-background);
   border-inline-end: 1px solid var(--color-background);
   line-height: 1.25em;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.k-structure-table th,
+.k-structure-table tr:not(:last-child) td {
+  border-bottom: 1px solid var(--color-background);
 }
 
 .k-structure-table td:last-child {
@@ -589,7 +593,7 @@ export default {
 
 .k-structure-table th {
   position: sticky;
-  inset-block-start: 0;
+  top: 0;
   inset-inline: 0;
   width: 100%;
   height: var(--item-height);
@@ -605,10 +609,6 @@ export default {
 .k-structure-table td:last-child {
   width: var(--item-height);
   border-inline-end: 0;
-}
-
-.k-structure-table tr:last-child td {
-  border-block-end: 0;
 }
 
 .k-structure-table tbody tr:hover td {
@@ -655,7 +655,7 @@ export default {
 .k-structure-table .k-structure-table-index-number {
   font-size: var(--text-xs);
   color: var(--color-gray-500);
-  padding-block-start: .15rem;
+  padding-top: .15rem;
 }
 
 .k-structure-table .k-sort-handle,
@@ -682,7 +682,7 @@ export default {
   background: var(--color-white);
   box-shadow: rgba(17, 17, 17, .25) 0 5px 10px;
   outline: 2px solid var(--color-focus);
-  margin-block-end: 2px;
+  margin-bottom: 2px;
   cursor: grabbing;
   cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
@@ -694,7 +694,7 @@ export default {
 [data-disabled] .k-structure-table th,
 [data-disabled] .k-structure-table td {
   background: var(--color-background);
-  border-block-end: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
   border-inline-end: 1px solid var(--color-border);
 }
 [data-disabled] .k-structure-table td:last-child {
@@ -715,7 +715,7 @@ export default {
   position: relative;
   z-index: 3;
   border-radius: var(--rounded-xs);
-  margin-block-end: 1px;
+  margin-bottom: 1px;
   box-shadow: rgba(17, 17, 17, .05) 0 0 0 3px;
   border: 1px solid var(--color-border);
   background: var(--color-background);
@@ -726,7 +726,7 @@ export default {
 }
 
 .k-structure-form-buttons {
-  border-block-start: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
   display: flex;
   justify-content: space-between;
 }

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -278,7 +278,7 @@ export default {
 <style>
 .k-form-buttons {
   position: fixed;
-  inset-block-end: 0;
+  bottom: 0;
   inset-inline: 0;
   z-index: var(--z-navigation);
 }

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -250,7 +250,7 @@ export default {
 .k-input[data-theme="field"][data-type="checkboxes"] .k-checkboxes-input {
   display: grid;
   grid-template-columns: 1fr;
-  margin-block-end: -1px;
+  margin-bottom: -1px;
   margin-inline-end: -1px;
 }
 @media screen and (min-width: 65em) {
@@ -260,7 +260,7 @@ export default {
 }
 .k-input[data-theme="field"][data-type="checkboxes"] .k-checkboxes-input li {
   border-inline-end: 1px solid var(--color-background);
-  border-block-end: 1px solid var(--color-background);
+  border-bottom: 1px solid var(--color-background);
 }
 .k-input[data-theme="field"][data-type="checkboxes"] .k-checkboxes-input label {
   display: block;
@@ -268,9 +268,9 @@ export default {
   padding: var(--field-input-padding) var(--field-input-padding);
 }
 .k-input[data-theme="field"][data-type="checkboxes"] .k-checkbox-input-icon {
-  inset-block-start: calc((var(--field-input-height) - var(--field-input-font-size)) / 2);
+  top: calc((var(--field-input-height) - var(--field-input-font-size)) / 2);
   inset-inline-start: var(--field-input-padding);
-  margin-block-start: 0px;
+  margin-top: 0px;
 }
 
 /* Radio */
@@ -287,7 +287,7 @@ export default {
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input {
   display: grid;
   grid-template-columns: 1fr;
-  margin-block-end: -1px;
+  margin-bottom: -1px;
   margin-inline-end: -1px;
 }
 @media screen and (min-width: 65em) {
@@ -297,7 +297,7 @@ export default {
 }
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input li {
   border-inline-end: 1px solid var(--color-background);
-  border-block-end: 1px solid var(--color-background);
+  border-bottom: 1px solid var(--color-background);
 }
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input label {
   display: block;
@@ -307,16 +307,16 @@ export default {
   padding: calc((var(--field-input-height) - var(--field-input-line-height)) / 2) var(--field-input-padding);
 }
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input label::before {
-  inset-block-start: calc((var(--field-input-height) - 1rem) / 2);
+  top: calc((var(--field-input-height) - 1rem) / 2);
   inset-inline-start: var(--field-input-padding);
-  margin-block-start: -1px;
+  margin-top: -1px;
 }
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input .k-radio-input-info {
   display: block;
   font-size: var(--text-sm);
   color: var(--color-gray-600);
   line-height: var(--field-input-line-height);
-  padding-block-start: calc(var(--field-input-line-height) / 10);
+  padding-top: calc(var(--field-input-line-height) / 10);
 }
 .k-input[data-theme="field"][data-type="radio"] .k-radio-input .k-icon {
   width: var(--field-input-height);
@@ -347,7 +347,7 @@ export default {
 }
 .k-input[data-theme="field"][data-type="tags"] .k-tag {
   margin-inline-end: .25rem;
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
   height: 1.75rem;
   font-size: var(--text-sm);
 }
@@ -356,16 +356,16 @@ export default {
   padding: 0 .25rem;
   height: 1.75rem;
   line-height: 1;
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
 }
 .k-input[data-theme="field"][data-type="tags"] .k-tags-input .k-dropdown-content {
-  inset-block-start: calc(100% + .5rem + 2px);
+  top: calc(100% + .5rem + 2px);
 }
 /* don't apply dropup feature to tags */
 .k-input[data-theme="field"][data-type="tags"] .k-tags-input .k-dropdown-content[data-dropup] {
-  inset-block-start: calc(100% + .5rem + 2px);
-  inset-block-end: initial;
-  margin-block-end: initial;
+  top: calc(100% + .5rem + 2px);
+  bottom: initial;
+  margin-bottom: initial;
 }
 
 /* Multiselect */
@@ -378,7 +378,7 @@ export default {
 }
 .k-input[data-theme="field"][data-type="multiselect"] .k-tag {
   margin-inline-end: .25rem;
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
   height: 1.75rem;
   font-size: var(--text-sm);
 }

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -350,10 +350,10 @@ export default {
 }
 
 .k-multiselect-search {
-  margin-block-start: 0 !important;
+  margin-top: 0 !important;
   color: var(--color-white);
   background: var(--color-gray-900);
-  border-block-end: 1px dashed rgba(255, 255, 255, .2);
+  border-bottom: 1px dashed rgba(255, 255, 255, .2);
 }
 .k-multiselect-search > .k-button-text {
   flex: 1;
@@ -413,7 +413,7 @@ export default {
   padding: .75rem;
   color: rgba(255, 255, 255, .8);
   text-align: center;
-  border-block-start: 1px dashed rgba(255, 255, 255, .2);
+  border-top: 1px dashed rgba(255, 255, 255, .2);
 }
 .k-multiselect-more:hover {
   color: var(--color-white);

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -107,7 +107,7 @@ export default {
 }
 .k-radio-input label::before {
   position: absolute;
-  inset-block-start: .175em;
+  top: .175em;
   inset-inline-start: 0;
   content: "";
   width: 1rem;

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -239,7 +239,7 @@ export default {
   background: var(--range-track-color);
 }
 .k-range-input-native::-webkit-slider-thumb {
-  margin-block-start: calc(0.5 * (var(--range-track-height) - var(--range-thumb-size)));
+  margin-top: calc(0.5 * (var(--range-track-height) - var(--range-thumb-size)));
 }
 
 .k-range-input-native::-webkit-slider-thumb {
@@ -270,7 +270,7 @@ export default {
   cursor: pointer;
 }
 .k-range-input-native::-ms-thumb {
-  margin-block-start: 0;
+  margin-top: 0;
 }
 .k-range-input-native::-ms-tooltip {
   display: none;
@@ -325,7 +325,7 @@ export default {
 }
 .k-range-input-tooltip::after {
   position: absolute;
-  inset-block-start: 50%;
+  top: 50%;
   inset-inline-start: -5px;
   width: 0;
   height: 0;

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -343,16 +343,16 @@ export default {
 }
 
 .k-toolbar {
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
   color: #aaa;
 }
 .k-textarea-input:focus-within .k-toolbar {
   position: sticky;
-  inset-block-start: 0;
+  top: 0;
   inset-inline: 0;
   z-index: 1;
   box-shadow: rgba(0, 0, 0, .05) 0 2px 5px;
-  border-block-end: 1px solid rgba(0 ,0 ,0 , .1);
+  border-bottom: 1px solid rgba(0 ,0 ,0 , .1);
   color: #000;
 }
 </style>

--- a/panel/src/components/Forms/LoginAlert.vue
+++ b/panel/src/components/Forms/LoginAlert.vue
@@ -12,7 +12,7 @@
   justify-content: space-between;
   align-items: center;
   min-height: 38px;
-  margin-block-end: 2rem;
+  margin-bottom: 2rem;
   background: var(--color-negative);
   color: var(--color-white);
   font-size: var(--text-sm);

--- a/panel/src/components/Forms/LoginCode.vue
+++ b/panel/src/components/Forms/LoginCode.vue
@@ -104,7 +104,7 @@ export default {
 <style>
 .k-login-code-form .k-user-info {
   height: 38px;
-  margin-block-end: 2.25rem;
+  margin-bottom: 2.25rem;
   padding: .5rem;
   background: var(--color-white);
   border-radius: var(--rounded-xs);

--- a/panel/src/components/Forms/Previews/WriterFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/WriterFieldPreview.vue
@@ -18,6 +18,6 @@ export default {
   line-height: 1.5em;
 }
 .k-writer-field-preview p:not(:last-child) {
-  margin-block-end: 1.5em;
+  margin-bottom: 1.5em;
 }
 </style>

--- a/panel/src/components/Forms/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar.vue
@@ -260,12 +260,12 @@ export default {
 <style>
 .k-toolbar {
   background: var(--color-white);
-  border-block-end: 1px solid var(--color-background);
+  border-bottom: 1px solid var(--color-background);
   height: 38px;
 }
 .k-toolbar-wrapper {
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline: 0;
   max-width: 100%;
 }

--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -199,12 +199,12 @@ export default {
 <style>
 .k-upload input {
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline-start: -3000px;
 }
 
 .k-upload-dialog .k-headline {
-  margin-block-end: .75rem;
+  margin-bottom: .75rem;
 }
 
 .k-upload-list,
@@ -222,7 +222,7 @@ export default {
   border-radius: var(--rounded-xs);
 }
 .k-upload-error-list li:not(:last-child) {
-  margin-block-end: 2px;
+  margin-bottom: 2px;
 }
 .k-upload-error-filename {
   color: var(--color-negative);

--- a/panel/src/components/Layout/AspectRatio.vue
+++ b/panel/src/components/Layout/AspectRatio.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     :data-cover="cover"
-    :style="{ 'padding-block-end': ratioPadding }"
+    :style="{ 'padding-bottom': ratioPadding }"
     class="k-aspect-ratio"
   >
     <slot />
@@ -27,7 +27,7 @@ export default {
   position: relative;
   display: block;
   overflow: hidden;
-  padding-block-end: 100%;
+  padding-bottom: 100%;
 }
 .k-aspect-ratio > * {
   position: absolute !important;

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -98,7 +98,7 @@ export default {
   border: 1px dashed var(--color-border);
 }
 .k-box[data-theme="empty"] .k-icon {
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
   color: var(--color-gray-500);
 }
 .k-box[data-theme="empty"] p {

--- a/panel/src/components/Layout/Column.vue
+++ b/panel/src/components/Layout/Column.vue
@@ -31,7 +31,7 @@ export default {
 
 .k-column[data-sticky] > div {
   position: sticky;
-  inset-block-start: 4vh;
+  top: 4vh;
   z-index: 2;
 }
 

--- a/panel/src/components/Layout/Empty.vue
+++ b/panel/src/components/Layout/Empty.vue
@@ -77,7 +77,7 @@ button.k-empty:focus {
   flex-direction: column;
 }
 .k-empty[data-layout="cards"] .k-icon {
-  margin-block-end: 1rem;
+  margin-bottom: 1rem;
 }
 .k-empty[data-layout="cards"] .k-icon svg {
   width: 2rem;

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -72,17 +72,17 @@ export default {
 
 <style>
 .k-header {
-  padding-block-start: 4vh;
-  margin-block-end: 2rem;
-  border-block-end: 1px solid var(--color-border);
+  padding-top: 4vh;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid var(--color-border);
 }
 .k-header .k-headline {
   min-height: 1.25em;
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
   word-wrap: break-word;
 }
 .k-header .k-header-buttons {
-  margin-block-start: -.5rem;
+  margin-top: -.5rem;
   height: 3.25rem;
 }
 .k-header .k-headline-editable {

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -111,12 +111,12 @@ export default {
 
 <style>
 .k-panel-view {
-  padding-block-start: 2.5rem;
-  padding-block-end: 6rem;
+  padding-top: 2.5rem;
+  padding-bottom: 6rem;
 }
 .k-panel-header {
   position: fixed;
-  inset-block-start: 0;
+  top: 0;
   inset-inline: 0;
   z-index: var(--z-navigation);
 }

--- a/panel/src/components/Layout/Item.vue
+++ b/panel/src/components/Layout/Item.vue
@@ -305,7 +305,7 @@ export default {
   word-wrap: break-word;
 }
 .k-cards-item .k-item-info {
-  padding-block-start: .125rem;
+  padding-top: .125rem;
 }
 .k-cards-item .k-item-footer {
   width: auto;

--- a/panel/src/components/Layout/Items.vue
+++ b/panel/src/components/Layout/Items.vue
@@ -165,7 +165,7 @@ export default {
  * List
  */
 .k-list-items .k-list-item:not(:last-child) {
-  margin-block-end: 2px;
+  margin-bottom: 2px;
 }
 
 </style>

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -126,7 +126,7 @@ export default {
 .k-tabs {
   position: relative;
   background: #e9e9e9;
-  border-block-start: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
   border-inline: 1px solid var(--color-border);
 }
 .k-tabs nav {
@@ -164,7 +164,7 @@ export default {
   }
 }
 .k-tab-button.k-button > .k-button-text {
-  padding-block-start: .375rem;
+  padding-top: .375rem;
   padding-inline-start: 0;
   font-size: 10px;
   overflow: hidden;
@@ -175,7 +175,7 @@ export default {
 @media screen and (min-width: 30em) {
   .k-tab-button.k-button > .k-button-text {
     font-size: var(--text-xs);
-    padding-block-start: 0;
+    padding-top: 0;
   }
 }
 .k-tab-button:last-child {
@@ -199,19 +199,19 @@ export default {
 
 .k-tab-button[aria-current]::before {
   inset-inline: -1px;
-  inset-block-start: -1px;
+  top: -1px;
   height: 2px;
   background: var(--color-black);
 }
 
 .k-tab-button[aria-current]::after {
   inset-inline: 0;
-  inset-block-end: -1px;
+  bottom: -1px;
   height: 1px;
   background: var(--color-background);
 }
 .k-tabs-dropdown {
-  inset-block-start: 100%;
+  top: 100%;
   inset-inline-end: 0;
 }
 .k-tabs-badge {

--- a/panel/src/components/Layouter/Layout.vue
+++ b/panel/src/components/Layouter/Layout.vue
@@ -129,7 +129,7 @@ export default {
   padding-inline-end: 0;
 }
 .k-layout:not(:last-of-type) {
-  margin-block-end: 1px;
+  margin-bottom: 1px;
 }
 .k-layout:focus {
   outline: 0;
@@ -156,7 +156,7 @@ export default {
   height: var(--layout-toolbar-width);
 }
 .k-layout-toolbar .k-sort-handle {
-  margin-block-start: auto;
+  margin-top: auto;
   color: currentColor;
 }
 
@@ -167,6 +167,6 @@ export default {
   background: var(--color-gray-300);
 }
 .k-layout:not(:first-child) .k-layout-columns.k-grid {
-  border-block-start: 0;
+  border-top: 0;
 }
 </style>

--- a/panel/src/components/Layouter/Layouts.vue
+++ b/panel/src/components/Layouter/Layouts.vue
@@ -203,8 +203,8 @@ export default {
 }
 .k-layout-selector .k-headline {
   line-height: 1;
-  margin-block-start: -.25rem;
-  margin-block-end: 1.5rem;
+  margin-top: -.25rem;
+  margin-bottom: 1.5rem;
 }
 .k-layout-selector ul {
   display: grid;
@@ -222,7 +222,7 @@ export default {
   outline-offset: 2px;
 }
 .k-layout-selector-option:last-child {
-  margin-block-end: 0;
+  margin-bottom: 0;
 }
 .k-layout-selector-option .k-column {
   display: flex;

--- a/panel/src/components/Misc/Fatal.vue
+++ b/panel/src/components/Misc/Fatal.vue
@@ -68,7 +68,7 @@ export default {
   border-radius: var(--rounded);
 }
 .k-fatal-box .k-bar {
-  margin-block-end: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
 }
 .k-fatal-iframe {
   border: 0;

--- a/panel/src/components/Misc/Image.vue
+++ b/panel/src/components/Misc/Image.vue
@@ -6,7 +6,7 @@
     class="k-image"
     v-on="$listeners"
   >
-    <span :style="'padding-block-end:' + ratioPadding">
+    <span :style="'padding-bottom:' + ratioPadding">
       <img
         v-if="loaded"
         :key="src"
@@ -101,7 +101,7 @@ export default {
   position: relative;
   display: block;
   line-height: 0;
-  padding-block-end: 100%;
+  padding-bottom: 100%;
 }
 .k-image img {
   position: absolute;
@@ -112,7 +112,7 @@ export default {
 }
 .k-image-error {
   position: absolute;
-  inset-block-start: 50%;
+  top: 50%;
   inset-inline-start: 50%;
   transform: translate(-50%, -50%);
   color: var(--color-white);

--- a/panel/src/components/Misc/Text.vue
+++ b/panel/src/components/Misc/Text.vue
@@ -51,13 +51,13 @@ export default {
 .k-text p,
 .k-text > ol,
 .k-text > ul {
-  margin-block-end: 1.5em;
+  margin-bottom: 1.5em;
 }
 .k-text a {
   text-decoration: underline;
 }
 .k-text > *:last-child {
-  margin-block-end: 0;
+  margin-bottom: 0;
 }
 
 .k-text[data-size="tiny"] {

--- a/panel/src/components/Navigation/ButtonGroup.vue
+++ b/panel/src/components/Navigation/ButtonGroup.vue
@@ -32,24 +32,24 @@ export default {
 
 <style>
 .k-button-group {
-  --button-group-padding-horizontal: .75rem;
-  --button-group-padding-vertical: 1rem;
-  --button-group-line-height: 1rem;
+  --padding-x: .75rem;
+  --padding-y: 1rem;
+  --line-height: 1rem;
 
   font-size: 0;
-  margin-inline: calc(var(--button-group-padding-horizontal) * -1);
+  margin: 0 calc(var(--padding-x) * -1);
 }
 .k-button-group > .k-dropdown {
-  height: calc(var(--button-group-line-height) + calc(var(--button-group-padding-vertical) * 2));
+  height: calc(var(--line-height) + (var(--padding-y) * 2));
   display: inline-block;
 }
 .k-button-group > .k-dropdown > .k-button,
 .k-button-group > .k-button {
-  padding: var(--button-group-padding-vertical) var(--button-group-padding-horizontal);
-  line-height: var(--button-group-line-height);
+  padding: var(--padding-y) var(--padding-x);
+  line-height: var(--line-height);
 }
 .k-button-group .k-dropdown-content {
-  inset-block-start: calc(100% + 1px);
-  margin: 0 var(--button-group-padding-horizontal);
+  top: calc(100% + 1px);
+  margin: 0 var(--padding-x);
 }
 </style>

--- a/panel/src/components/Navigation/DropdownContent.vue
+++ b/panel/src/components/Navigation/DropdownContent.vue
@@ -260,23 +260,25 @@ export default {
   box-shadow: var(--shadow-lg);
   border-radius: var(--rounded-xs);
   text-align: start;
-  margin-block-end: 6rem;
+  margin-bottom: 6rem;
+}
+.k-dropdown-content[data-align="left"] {
+  inset-inline-start: 0;
 }
 .k-dropdown-content[data-align="right"] {
-  inset-inline-start: auto;
   inset-inline-end: 0;
 }
 .k-dropdown-content > .k-dropdown-item:first-child {
-  margin-block-start: .5rem;
+  margin-top: .5rem;
 }
 .k-dropdown-content > .k-dropdown-item:last-child {
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
 }
 
 .k-dropdown-content[data-dropup] {
-  inset-block-start: auto;
-  inset-block-end: 100%;
-  margin-block-end: .5rem;
+  top: auto;
+  bottom: 100%;
+  margin-bottom: .5rem;
 }
 
 .k-dropdown-content hr {

--- a/panel/src/components/Navigation/Pagination.vue
+++ b/panel/src/components/Navigation/Pagination.vue
@@ -289,7 +289,7 @@ export default {
 
 .k-dropdown-content.k-pagination-selector {
   position: absolute;
-  inset-block-start: 100%;
+  top: 100%;
   inset-inline-start: 50%;
   transform: translateX(-50%);
   background: var(--color-black);

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -203,13 +203,8 @@ export default {
 <style>
 .k-search {
   max-width: 30rem;
-  margin: 0 auto;
+  margin: 2.5rem auto;
   box-shadow: var(--shadow-lg);
-}
-@media screen and (min-width: 65em) {
-  .k-search {
-    margin: 2.5rem auto;
-  }
 }
 .k-search-input {
   background: var(--color-light);
@@ -220,7 +215,7 @@ export default {
   display: flex;
 }
 .k-search-types > .k-button {
-  padding: 0 0 0 1rem;
+  padding-inline-start: 1rem;
   font-size: var(--text-base);
   line-height: 1;
   height: 2.5rem;
@@ -256,13 +251,10 @@ export default {
   background: var(--color-light);
 }
 .k-search .k-item:not(:last-child) {
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
 }
 .k-search .k-item[data-selected] {
   outline: 2px solid var(--color-focus);
-}
-.k-search .k-item-title {
-  font-size: var(--text-sm);
 }
 .k-search .k-item-info {
   font-size: var(--text-xs);

--- a/panel/src/components/Navigation/Topbar.vue
+++ b/panel/src/components/Navigation/Topbar.vue
@@ -147,7 +147,7 @@ export default {
 
 .k-topbar-signals {
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline-end: 0;
   background: var(--bg);
   height: 2.5rem;
@@ -157,8 +157,8 @@ export default {
 .k-topbar-signals::before {
   position: absolute;
   content: "";
-  inset-block-start: -0.5rem;
-  inset-block-end: 0;
+  top: -0.5rem;
+  bottom: 0;
   width: .5rem;
   background: -webkit-linear-gradient(
     inline-start,

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -63,7 +63,7 @@ export default {
 
 <style>
 .k-fields-issue-headline {
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
 }
 .k-fields-section input[type="submit"] {
   display: none;

--- a/panel/src/components/Sections/InfoSection.vue
+++ b/panel/src/components/Sections/InfoSection.vue
@@ -25,7 +25,7 @@ export default {
 <style>
 
 .k-info-section-headline {
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
 }
 
 </style>

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -79,10 +79,10 @@ export default {
 
 <style>
 .k-sections {
-  padding-block-end: 3rem;
+  padding-bottom: 3rem;
 }
 .k-section {
-  padding-block-end: 3rem;
+  padding-bottom: 3rem;
 }
 .k-section-header {
   position: relative;
@@ -92,12 +92,12 @@ export default {
 }
 .k-section-header .k-headline {
   line-height: 1.25rem;
-  padding-block-end: .75rem;
+  padding-bottom: .75rem;
   min-height: 2rem;
 }
 .k-section-header .k-button-group {
   position: absolute;
-  inset-block-start: -.875rem;
+  top: -.875rem;
   inset-inline-end: 0;
 }
 </style>

--- a/panel/src/components/Views/ErrorView.vue
+++ b/panel/src/components/Views/ErrorView.vue
@@ -44,6 +44,6 @@ export default {
   display: inline-block;
 }
 .k-error-view-content p:not(:last-child) {
-  margin-block-end: .75rem;
+  margin-bottom: .75rem;
 }
 </style>

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -157,10 +157,10 @@ export default {
 <style>
 .k-installation-view .k-button {
   display: block;
-  margin-block-start: 1.5rem;
+  margin-top: 1.5rem;
 }
 .k-installation-view .k-headline {
-  margin-block-end: .75rem;
+  margin-bottom: .75rem;
 }
 .k-installation-issues {
   line-height: 1.5em;
@@ -175,7 +175,7 @@ export default {
 
 .k-installation-issues .k-icon {
   position: absolute;
-  inset-block-start: calc(1.5rem + 2px);
+  top: calc(1.5rem + 2px);
   inset-inline-start: 1.5rem;
 }
 
@@ -183,7 +183,7 @@ export default {
   fill: var(--color-negative);
 }
 .k-installation-issues li:not(:last-child) {
-  margin-block-end: 2px;
+  margin-bottom: 2px;
 }
 .k-installation-issues li code {
   font: inherit;

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -46,7 +46,7 @@ export default {
 
 .k-login-toggler {
   position: absolute;
-  inset-block-start: 0;
+  top: 0;
   inset-inline-end: 0;
   z-index: 1;
 

--- a/panel/src/components/Views/ResetPasswordView.vue
+++ b/panel/src/components/Views/ResetPasswordView.vue
@@ -107,7 +107,7 @@ export default {
 <style>
 .k-password-reset-view .k-user-info {
   height: 38px;
-  margin-block-end: 2.25rem;
+  margin-bottom: 2.25rem;
   padding: .5rem;
   background: var(--color-white);
   border-radius: var(--rounded-xs);

--- a/panel/src/components/Views/SettingsView.vue
+++ b/panel/src/components/Views/SettingsView.vue
@@ -136,13 +136,13 @@ export default {
 
 <style>
 .k-settings-view section {
-  margin-block-end: 3rem;
+  margin-bottom: 3rem;
 }
 .k-settings-view .k-header {
-  margin-block-end: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 .k-settings-view-section-header {
-  margin-block-end: .5rem;
+  margin-bottom: .5rem;
   display: flex;
   justify-content: space-between;
 }
@@ -160,7 +160,7 @@ export default {
 .k-system-info-box dt {
   font-size: var(--text-sm);
   color: var(--color-gray-600);
-  margin-block-end: .25rem;
+  margin-bottom: .25rem;
 }
 .k-system-unregistered {
   color: var(--color-negative);
@@ -168,6 +168,6 @@ export default {
 }
 
 .k-languages-section {
-  margin-block-end: 2rem;
+  margin-bottom: 2rem;
 }
 </style>

--- a/panel/src/components/Writer/Toolbar.vue
+++ b/panel/src/components/Writer/Toolbar.vue
@@ -134,12 +134,12 @@ export default {
 .k-writer-toolbar-button.k-writer-toolbar-nodes::after {
   content: "";
   margin-inline-start: .5rem;
-  border-block-start: 4px solid var(--color-white);
+  border-top: 4px solid var(--color-white);
   border-inline: 4px solid transparent;
 }
 .k-writer-toolbar .k-dropdown-content {
   color: var(--color-black);
   background: var(--color-white);
-  margin-block-start: .5rem;
+  margin-top: .5rem;
 }
 </style>

--- a/panel/src/components/Writer/Writer.vue
+++ b/panel/src/components/Writer/Writer.vue
@@ -15,7 +15,7 @@
         :active-marks="toolbar.marks"
         :active-nodes="toolbar.nodes"
         :style="{
-          'inset-block-end': toolbar.position.bottom + 'px',
+          'bottom': toolbar.position.bottom + 'px',
           'inset-inline-start': toolbar.position.left + 'px'
         }"
         @command="editor.command($event)"
@@ -317,7 +317,7 @@ export default {
   text-decoration: underline;
 }
 .k-writer .ProseMirror > *:last-child {
-  margin-block-end: 0;
+  margin-bottom: 0;
 }
 .k-writer .ProseMirror p,
 .k-writer .ProseMirror ul,
@@ -325,7 +325,7 @@ export default {
 .k-writer .ProseMirror h1,
 .k-writer .ProseMirror h2,
 .k-writer .ProseMirror h3 {
-  margin-block-end: .75rem;
+  margin-bottom: .75rem;
 }
 
 .k-writer .ProseMirror h1 {


### PR DESCRIPTION
We will only support LTR/RTL via logical properties, no vertical directions

```
BEFORE
dist/css/style.css   105.35kb / brotli: 14.79kb
dist/js/index.js     313.23kb / brotli: 60.05kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

AFTER
dist/css/style.css   105.10kb / brotli: 14.78kb
dist/js/index.js     313.22kb / brotli: 60.01kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```