### PR TITLE
Use `ratio` helper for structure column width

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -562,7 +562,7 @@ export default {
 
 <style>
 .k-structure-field {
-  --structure-item-height: 38px;
+  --item-height: 38px;
 }
 
 .k-structure-table {
@@ -592,7 +592,7 @@ export default {
   inset-block-start: 0;
   inset-inline: 0;
   width: 100%;
-  height: var(--structure-item-height);
+  height: var(--item-height);
   padding: 0 .75rem;
   background: #fff;
   color: var(--color-gray-600);
@@ -603,7 +603,7 @@ export default {
 
 .k-structure-table th:last-child,
 .k-structure-table td:last-child {
-  width: var(--structure-item-height);
+  width: var(--item-height);
   border-inline-end: 0;
 }
 
@@ -644,38 +644,15 @@ export default {
   align-items: flex-end;
 }
 
-/* column widths */
-.k-structure-table .k-structure-table-column[data-width="1/2"] {
-  width: 50%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/3"] {
-  width: 33.33%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/4"] {
-  width: 25%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/5"] {
-  width: 20%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/6"] {
-  width: 16.66%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/8"] {
-  width: 12.5%;
-}
-.k-structure-table .k-structure-table-column[data-width="1/9"] {
-  width: 11.11%;
-}
-.k-structure-table .k-structure-table-column[data-width="2/3"] {
-  width: 66.66%;
-}
-.k-structure-table .k-structure-table-column[data-width="3/4"] {
-  width: 75%;
+.k-structure-table .k-structure-table-index,
+.k-structure-table .k-sort-handle,
+.k-structure-table .k-structure-table-options,
+.k-structure-table .k-structure-table-options-button {
+  width: var(--item-height);
+  height: var(--item-height);
 }
 
 .k-structure-table .k-structure-table-index {
-  width: var(--structure-item-height);
-  height: var(--structure-item-height);
   text-align: center;
 }
 .k-structure-table .k-structure-table-index-number {
@@ -684,12 +661,7 @@ export default {
   padding-block-start: .15rem;
 }
 
-.k-structure-table .k-sort-handle {
-  width: var(--structure-item-height);
-  height: var(--structure-item-height);
-  display: none;
-}
-
+.k-structure-table .k-sort-handle,
 .k-structure-table[data-sortable] tr:hover .k-structure-table-index-number {
   display: none;
 }
@@ -699,13 +671,7 @@ export default {
 
 .k-structure-table .k-structure-table-options {
   position: relative;
-  width: var(--structure-item-height);
   text-align: center;
-  height: var(--structure-item-height);
-}
-.k-structure-table .k-structure-table-options-button {
-  width: var(--structure-item-height);
-  height: var(--structure-item-height);
 }
 
 .k-structure-table .k-structure-table-text {

--- a/panel/src/helpers/ratio.js
+++ b/panel/src/helpers/ratio.js
@@ -1,17 +1,31 @@
-export default (ratio = "3/2") => {
-  const parts = String(ratio).split("/");
+/**
+ * Returns a percentage string fro the provided fraction
+ *
+ * @param {String} fraction fraction to convert to a percentage
+ * @param {String} fallback default value if fraction cannot be parsed
+ * @param {Boolean} vertical Whether the fraction is applied to
+ *                           vertical or horizontal orientation
+ */
+export default (fraction = "3/2", fallback = "100%", vertical = true) => {
+  const parts = String(fraction).split("/");
 
   if (parts.length !== 2) {
-    return "100%";
+    return fallback;
   }
 
   const a = Number(parts[0]);
   const b = Number(parts[1]);
-  let padding = 100;
+  let result = 100;
 
   if (a !== 0 && b !== 0) {
-    padding = 100 / a * b;
+    if (vertical) {
+      result = result / a * b;
+    } else {
+      result = result / b * a;
+    }
+
+    result = parseFloat(String(result)).toFixed(2);
   }
 
-  return padding + '%';
+  return result + '%';
 };

--- a/panel/src/helpers/ratio.spec.js
+++ b/panel/src/helpers/ratio.spec.js
@@ -3,7 +3,7 @@ import ratio from "./ratio.js";
 describe("$helper.ratio()", () => {
   it("should return default ratio", () => {
     const result = ratio();
-    expect(result).to.equal("66.66666666666667%");
+    expect(result).to.equal("66.67%");
   });
 
   it("should return padding for 16/9", () => {

--- a/panel/src/mixins/forms/structure.js
+++ b/panel/src/mixins/forms/structure.js
@@ -52,19 +52,7 @@ export default {
       return this.$helper.isComponent(`k-${type}-field-preview`);
     },
     width(fraction) {
-      if (!fraction) {
-        return "auto";
-      }
-      const parts = fraction.toString().split("/");
-
-      if (parts.length !== 2) {
-        return "auto";
-      }
-
-      const a = Number(parts[0]);
-      const b = Number(parts[1]);
-
-      return parseFloat(String(100 / b * a)).toFixed(2) + "%";
+      return fraction ? this.$helper.ratio(fraction, "auto", false) : "auto";
     }
   }
 }


### PR DESCRIPTION
```
BEFORE
dist/css/style.css   105.35kb / brotli: 14.79kb
dist/js/index.js     313.23kb / brotli: 60.05kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb

AFTER
dist/css/style.css   104.55kb / brotli: 14.75kb
dist/js/index.js     313.17kb / brotli: 59.97kb
dist/js/vendor.js    379.32kb / brotli: 103.63kb
```