### PR TITLE
Fix images in picker field previews

### DIFF
--- a/panel/src/components/Forms/Previews/FilesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FilesFieldPreview.vue
@@ -2,8 +2,7 @@
   <ul v-if="value" class="k-files-field-preview">
     <li v-for="file in value" :key="file.url">
       <k-link :title="file.filename" :to="file.link" @click.native.stop>
-        <k-image v-if="file.type === 'image'" v-bind="imageOptions(file)" />
-        <k-icon v-else v-bind="file.icon" />
+        <k-item-image :image="file.image" layout="list" />
       </k-link>
     </li>
   </ul>
@@ -12,24 +11,7 @@
 <script>
 export default {
   props: {
-    value: Array,
-    field: Object
-  },
-  methods: {
-    imageOptions(file) {
-      if (!file.src) {
-        return {
-          src: file.url
-        };
-      }
-
-      return {
-        ...file,
-        back: "pattern",
-        cover: false,
-        ...this.field.image || {}
-      }
-    }
+    value: Array
   }
 }
 </script>
@@ -45,6 +27,7 @@ export default {
   line-height: 0;
 }
 .k-files-field-preview li .k-icon {
+  --size: .85rem;
   height: 100%;
 }
 </style>

--- a/panel/src/components/Forms/Previews/PagesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/PagesFieldPreview.vue
@@ -3,7 +3,11 @@
     <li v-for="page in value" :key="page.id">
       <figure>
         <k-link :title="page.id" :to="page.link" @click.native.stop>
-          <k-icon type="page" back="pattern" class="k-pages-field-preview-image" />
+          <k-item-image
+            :image="page.image"
+            layout="list"
+            class="k-pages-field-preview-image"
+          />
           <figcaption>
             {{ page.text }}
           </figcaption>
@@ -39,7 +43,9 @@ export default {
 .k-pages-field-preview-image {
   width: 1.525rem;
   height: 1.525rem;
-  color: var(--color-gray-500) !important;
+}
+.k-pages-field-preview-image .k-icon {
+  --size: .85rem;
 }
 .k-pages-field-preview figcaption {
   flex-grow: 1;

--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -62,6 +62,7 @@ export default {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  font-size: var(--size);
 }
 .k-icon[data-size="medium"] {
   --size: 2rem;
@@ -100,7 +101,7 @@ export default {
 /* fix emoji alignment on high-res screens */
 @media only screen and (-webkit-min-device-pixel-ratio: 2), not all, not all, not all, only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
   .k-icon-emoji {
-    font-size: 1.25rem;
+    font-size: 1.25em;
   }
 }
 


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed regression
- Picker field preview images respect options (e.g. `back` etc.) again

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3551

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
