### PR TITLE
More detailed file preview handling for pages in draft mode

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -751,6 +751,32 @@ class File extends ModelWithContent
      */
     public function previewUrl(): string
     {
-        return url($this->id());
+        $parent = $this->parent();
+        $url    = url($this->id());
+
+        switch ($parent::CLASS_ALIAS) {
+            case 'page':
+                $preview = $parent->blueprint()->preview();
+
+                // the page has a custom preview setting,
+                // thus the file is only accessible through
+                // the direct media URL
+                if ($preview !== true) {
+                    return $this->url();
+                }
+
+                // it's more stable to access files for drafts
+                // through their direct URL to avoid conflicts
+                // with draft token verification
+                if ($parent->isDraft() === true) {
+                    return $this->url();
+                }
+
+                return $url;
+            case 'user':
+                return $this->url();
+            default:
+                return $url;
+        }
     }
 }

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -312,6 +312,69 @@ class FileTest extends TestCase
         $this->assertSame('/test/test.pdf', $file->previewUrl());
     }
 
+    public function testPreviewUrlForDraft()
+    {
+        $page = new Page([
+            'slug'    => 'test',
+            'isDraft' => true,
+            'files'   => [
+                [
+                    'filename' => 'test.pdf'
+                ]
+            ]
+        ]);
+
+        $file = $page->file('test.pdf');
+        $this->assertSame($file->url(), $file->previewUrl());
+    }
+
+    public function testPreviewUrlForPageWithCustomPreviewSetting()
+    {
+        $app = new App([
+            'blueprints' => [
+                'pages/test' => [
+                    'options' => [
+                        'preview' => false
+                    ]
+                ]
+            ],
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'test',
+                        'template' => 'test',
+                        'files'    => [
+                            [
+                                'filename' => 'test.pdf'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $file = $app->file('test/test.pdf');
+        $this->assertSame($file->url(), $file->previewUrl());
+    }
+
+    public function testPreviewUrlForUserFile()
+    {
+        $user = new User([
+            'email' => 'test@getkirby.com',
+            'files' => [
+                [
+                    'filename' => 'test.pdf'
+                ]
+            ]
+        ]);
+
+        $file = $user->file('test.pdf');
+        $this->assertSame($file->url(), $file->previewUrl());
+    }
+
     public function testApiUrl()
     {
         $app = new App([


### PR DESCRIPTION
## Describe the PR

File preview URLs are a bit more complicated than we though. Pages in draft mode and users need to keep the direct media URLs to avoid routing issues. 

## Release notes
- Fixed file preview URLs  

## Related issues/ideas
- Fixes #3587 

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
