### PR TITLE
Allow defining blueprints in a callback

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -292,6 +292,8 @@ class Blueprint
             return static::$loaded[$name] = Data::read($file);
         } elseif (is_array($file) === true) {
             return static::$loaded[$name] = $file;
+        } elseif (is_callable($file) === true) {
+            return static::$loaded[$name] = $file($kirby);
         }
 
         // neither a valid file nor array data

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -294,6 +294,25 @@ class BlueprintTest extends TestCase
     /**
      * @covers ::factory
      */
+    public function testFactoryWithCallback()
+    {
+        $this->app = $this->app->clone([
+            'blueprints' => [
+                'pages/test' => function () {
+                    return ['title' => 'Test'];
+                }
+            ]
+        ]);
+
+        $blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+
+        $this->assertSame('Test', $blueprint->title());
+        $this->assertSame('pages/test', $blueprint->name());
+    }
+
+    /**
+     * @covers ::factory
+     */
     public function testFactoryForMissingBlueprint()
     {
         $blueprint = Blueprint::factory('notFound', null, new Page(['slug' => 'test']));

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -276,6 +276,7 @@ class BlueprintTest extends TestCase
 
     /**
      * @covers ::factory
+     * @covers ::find
      */
     public function testFactory()
     {
@@ -293,6 +294,7 @@ class BlueprintTest extends TestCase
 
     /**
      * @covers ::factory
+     * @covers ::find
      */
     public function testFactoryWithCallback()
     {

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -280,6 +280,8 @@ class BlueprintTest extends TestCase
      */
     public function testFactory()
     {
+        Blueprint::$loaded = [];
+
         $this->app = $this->app->clone([
             'blueprints' => [
                 'pages/test' => ['title' => 'Test']
@@ -298,6 +300,8 @@ class BlueprintTest extends TestCase
      */
     public function testFactoryWithCallback()
     {
+        Blueprint::$loaded = [];
+
         $this->app = $this->app->clone([
             'blueprints' => [
                 'pages/test' => function () {


### PR DESCRIPTION
## Describe the PR

@texnixe wrote a great cookbook article how to use plugins to create dynamic blueprints in PHP. Unfortunately it does not perform well to add stuff to the blueprint config on plugin load. This can be solved by simply accepting a callback for the blueprint definition. It's a minimal change but with a huge impact. 

## Release notes
- Blueprints can now be defined in a callback function

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
