### PR TITLE
`Upload.vue`: Add method parameter on `this.$helper.upload()` call

### DIFF
--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -155,6 +155,7 @@ export default {
         this.$helper.upload(file, {
           url: this.options.url,
           attributes: this.options.attributes,
+          method: this.options.method,
           headers: {
             "X-CSRF": window.panel.$system.csrf
           },


### PR DESCRIPTION
The component use the upload helper, and the method param was omitted on the helper call.

## Describe the PR
- Fix using the method parameter on upload helper call

## Release notes
- Fix method parameter for `k-upload` component



## Breaking changes
- None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
