### PR TITLE
Replace field method: No fallback for empty fields

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -498,7 +498,8 @@ return function (App $app) {
          */
         'replace' => function (Field $field, array $data = [], string $fallback = '') use ($app) {
             if ($parent = $field->parent()) {
-                $field->value = $parent->toString($field->value, $data, $fallback);
+                // never pass `null` as the $template to avoid the fallback to the model ID
+                $field->value = $parent->toString($field->value ?? '', $data, $fallback);
             } else {
                 $field->value = Str::template($field->value, array_replace([
                     'kirby' => $app,

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -582,6 +582,10 @@ class FieldMethodsTest extends TestCase
             ]
         ])->value());
 
+        // missing or empty field
+        $this->assertSame('', $this->field(null)->replace(['message' => 'world'])->value());
+        $this->assertSame('', $this->field('')->replace(['message' => 'world'])->value());
+
         // with page
         $page = new Page([
             'slug'    => 'test',
@@ -592,6 +596,7 @@ class FieldMethodsTest extends TestCase
         ]);
 
         $this->assertSame('Title: Hello world', $page->text()->replace()->value());
+        $this->assertSame('', $page->doesNotExist()->replace()->value());
     }
 
     public function testShort()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

See https://github.com/getkirby/kirby/issues/3652#issuecomment-906625670.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

The `replace()` field method no longer returns the model ID for empty fields, instead an empty string is returned as expected.

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3652.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] Add changes to release notes draft in Notion
