### PR TITLE
Fix overlay scroll when destroyed not closed #3651

### DIFF
--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -51,16 +51,26 @@ export default {
       scrollTop: 0
     };
   },
+  destroyed() {
+    // make sure scrolling is enabled again
+    // when overlay is destroyed without closing it
+    this.close(true);
+  },
   methods: {
-    close() {
+    close(destroyed = false) {
       // it makes it run once
       if (this.isOpen === false) {
         return;
       }
 
       this.isOpen = false;
-      this.$emit("close");
-      this.restoreScrollPosition();
+
+      // no need for event and restoring scroll
+      // when closed due to navigating away from view
+      if (destroyed === false) {
+        this.$emit("close");
+        this.restoreScrollPosition();
+      }
 
       // enable scrolling of background
       document.documentElement.style.overflow = "visible";

--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -18,6 +18,7 @@ export default {
         this.component = component;
         this.page = page;
         this.key = preserveState ? this.key : Date.now();
+        this.$store.dispatch("dialog", false);
       }
     });
   },


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

There are situations where the Overlay component disappears without calling the `close` method (e.g. navigation away from view via back button). This PR ensures that the scroll lock is removed when the overlay component is destroyed.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Overlay scroll lock is properly removed in certain situations



## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3651

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
