### PR TITLE
Enhancements to page position UI

### DIFF
--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -122,11 +122,8 @@ class Field
 
         // if only one available option,
         // hide field when not in debug mode
-        if (count($options) < 2 && option('debug') !== true) {
-            return array_merge([
-                'type'   => 'hidden',
-                'value'  => $options[0],
-            ], $props);
+        if (count($options) < 2) {
+            return static::hidden();
         }
 
         return array_merge([

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -120,11 +120,20 @@ class Field
             'text'  => $index
         ];
 
+        // if only one available option,
+        // hide field when not in debug mode
+        if (count($options) < 2 && option('debug') !== true) {
+            return array_merge([
+                'type'   => 'hidden',
+                'value'  => $options[0],
+            ], $props);
+        }
+
         return array_merge([
-            'label'   => t('page.changeStatus.position'),
-            'type'    => 'select',
-            'empty'   => false,
-            'options' => $options
+            'label'    => t('page.changeStatus.position'),
+            'type'     => 'select',
+            'empty'    => false,
+            'options'  => $options,
         ], $props);
     }
 

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -121,11 +121,13 @@ class Page extends Model
         ];
 
         if ($view === 'list') {
+            $siblings = $page->parentModel()->children()->listed()->not($page);
+
             $result[] = [
                 'dialog'   => $url . '/changeSort',
                 'icon'     => 'sort',
                 'text'     => t('page.sort'),
-                'disabled' => $this->isDisabledDropdownOption('sort', $options, $permissions)
+                'disabled' => $siblings->count() < 2 || $this->isDisabledDropdownOption('sort', $options, $permissions)
             ];
         }
 

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -120,16 +120,14 @@ class Page extends Model
             'disabled' => $this->isDisabledDropdownOption('changeStatus', $options, $permissions)
         ];
 
-        if ($view === 'list') {
-            $siblings = $page->parentModel()->children()->listed()->not($page);
+        $siblings = $page->parentModel()->children()->listed()->not($page);
 
-            $result[] = [
-                'dialog'   => $url . '/changeSort',
-                'icon'     => 'sort',
-                'text'     => t('page.sort'),
-                'disabled' => $siblings->count() < 2 || $this->isDisabledDropdownOption('sort', $options, $permissions)
-            ];
-        }
+        $result[] = [
+            'dialog'   => $url . '/changeSort',
+            'icon'     => 'sort',
+            'text'     => t('page.sort'),
+            'disabled' => $siblings->count() === 0 || $this->isDisabledDropdownOption('sort', $options, $permissions)
+        ];
 
         $result[] = [
             'dialog'   => $url . '/changeTemplate',

--- a/tests/Panel/Areas/PageDialogsTest.php
+++ b/tests/Panel/Areas/PageDialogsTest.php
@@ -16,7 +16,9 @@ class PageDialogsTest extends AreaTestCase
         $this->app([
             'site' => [
                 'children' => [
-                    ['slug' => 'test']
+                    ['slug' => 'test'],
+                    ['slug' => 'a', 'num' => 1],
+                    ['slug' => 'b', 'num' => 2]
                 ]
             ]
         ]);
@@ -30,7 +32,7 @@ class PageDialogsTest extends AreaTestCase
 
         $this->assertSame('Please select a position', $props['fields']['position']['label']);
         $this->assertSame('Change', $props['submitButton']);
-        $this->assertSame(1, $props['value']['position']);
+        $this->assertSame(3, $props['value']['position']);
     }
 
     public function testChangeSortDisabled(): void
@@ -89,7 +91,9 @@ class PageDialogsTest extends AreaTestCase
         $this->app([
             'site' => [
                 'children' => [
-                    ['slug' => 'test']
+                    ['slug' => 'test'],
+                    ['slug' => 'a', 'num' => 1],
+                    ['slug' => 'b', 'num' => 2]
                 ]
             ]
         ]);
@@ -113,7 +117,7 @@ class PageDialogsTest extends AreaTestCase
         $this->assertSame('Change', $props['submitButton']);
 
         $this->assertSame('unlisted', $props['value']['status']);
-        $this->assertSame(1, $props['value']['position']);
+        $this->assertSame(3, $props['value']['position']);
     }
 
     public function testChangeStatusForDraft(): void

--- a/tests/Panel/Areas/PageDropdownsTest.php
+++ b/tests/Panel/Areas/PageDropdownsTest.php
@@ -53,13 +53,17 @@ class PageDropdownsTest extends AreaTestCase
         $this->assertSame('/pages/test/changeStatus', $status['dialog']);
         $this->assertSame('Change status', $status['text']);
 
-        $template = $options[5];
+        $position = $options[5];
+        $this->assertSame('/pages/test/changeSort', $position['dialog']);
+        $this->assertSame('Change position', $position['text']);
+
+        $template = $options[6];
         $this->assertSame('/pages/test/changeTemplate', $template['dialog']);
         $this->assertSame('Change template', $template['text']);
 
-        $this->assertSame('-', $options[6]);
+        $this->assertSame('-', $options[7]);
 
-        $delete = $options[7];
+        $delete = $options[8];
         $this->assertSame('/pages/test/delete', $delete['dialog']);
         $this->assertSame('Delete', $delete['text']);
     }
@@ -88,10 +92,5 @@ class PageDropdownsTest extends AreaTestCase
         $this->assertSame('/test', $preview['link']);
         $this->assertSame('_blank', $preview['target']);
         $this->assertSame('Open', $preview['text']);
-
-        $sort = $options[6];
-
-        $this->assertSame('/pages/test/changeStatus', $sort['dialog']);
-        $this->assertSame('Change status', $sort['text']);
     }
 }

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -176,6 +176,27 @@ class FieldTest extends TestCase
     }
 
     /**
+     * @covers ::pagePosition
+     * @return void
+     */
+    public function testPagePositionWithNotEnoughOptions(): void
+    {
+        $this->app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    ['slug' => 'a', 'num' => 1],
+                ]
+            ]
+        ]);
+
+        $site  = $this->app->site();
+        $page  = $site->find('a');
+        $field = Field::pagePosition($page);
+
+        $this->assertSame('hidden', $field['type']);
+    }
+
+    /**
      * @covers ::password
      * @return void
      */


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- Page position field is hidden from dialogs when only one option available (except when in `debug` mode)
- Sort page is disabled in page dropdown when only one option would be available

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3609

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
