### PR TITLE
Use model id for model views

### DIFF
--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -64,7 +64,7 @@ export default {
     content() {
       this.$store.dispatch("content/create", {
         id: this.id,
-        api: this.$view.path,
+        api: this.id,
         content: this.model.content
       });
     },


### PR DESCRIPTION
## Describe the PR

To use the path for API calls was a very unstable solution. The model id is more reliable as it will always follow the same pattern as the API route. 

I.e. 

```
site
pages/blog+something
users/peter
```

## Related issues/ideas
- Fixes https://github.com/getkirby/kirby/issues/3655