### PR TITLE
Remove outline and set panel to full height

### DIFF
--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -39,3 +39,10 @@ strong,
 b {
   font-weight: var(--font-bold);
 }
+
+.k-panel {
+  min-height: 100vh;
+}
+.k-panel:focus {
+  outline: 0;
+}


### PR DESCRIPTION
## Describe the PR

The k-panel div is focusable in the k-inside component. That leads to a weird looking outline when the element is clicked or tabbed. This PR removes the outline and sets the min height of the div to 100vh.

