### PR TITLE
Return plugin asset response instead of redirect

### DIFF
--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -67,9 +67,6 @@ class PluginAssets
 
                 $target = $plugin->mediaRoot() . '/' . $filename;
 
-                // create the plugin directory first
-                Dir::make($plugin->mediaRoot(), true);
-
                 // create a symlink if possible
                 F::link($source, $target, 'symlink');
 

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -66,15 +66,14 @@ class PluginAssets
                 static::clean($pluginName);
 
                 $target = $plugin->mediaRoot() . '/' . $filename;
-                $url    = $plugin->mediaUrl() . '/' . $filename;
 
                 // create the plugin directory first
                 Dir::make($plugin->mediaRoot(), true);
 
-                if (F::link($source, $target, 'symlink') === true) {
-                    return Response::redirect($url);
-                }
+                // create a symlink if possible
+                F::link($source, $target, 'symlink');
 
+                // return the file response
                 return Response::file($source);
             }
         }

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -51,7 +51,7 @@ class PluginAssetsTest extends TestCase
         $response = PluginAssets::resolve('test/test', 'test.css');
 
         $this->assertTrue(is_link($this->fixtures . '/media/plugins/test/test/test.css'));
-        $this->assertEquals(302, $response->code());
-        $this->assertEquals('/media/plugins/test/test/test.css', (string)$response->headers()['Location']);
+        $this->assertEquals(200, $response->code());
+        $this->assertEquals('text/css', $response->type());
     }
 }


### PR DESCRIPTION
## Describe the PR

Returning a plugin asset directly after requesting it makes a lot more sense than creating a redirect. 

