### PR TITLE
Fix for creating extra content files when changing a template

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -286,6 +286,10 @@ trait PageActions
                 ]);
 
                 foreach ($this->kirby()->languages()->codes() as $code) {
+                    if ($oldPage->translation($code)->exists() !== true) {
+                        continue;
+                    }
+
                     $content = $oldPage->content($code)->convertTo($template);
 
                     if (F::remove($oldPage->contentFile($code)) !== true) {


### PR DESCRIPTION
## Describe the PR
Fixes #3674 by not saving content files for untranslated languages when changing a page's template. This is a similar fix to #2517.


## Release notes
### Fixes
- Changing a page's template no longer creates content files for untranslated languages


## Breaking changes
None


## Related issues/ideas

- Fixes #3674

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
