### PR TITLE
Add referrerpolicy to the video block

### DIFF
--- a/panel/src/components/Blocks/Types/Video.vue
+++ b/panel/src/components/Blocks/Types/Video.vue
@@ -9,7 +9,7 @@
     @update="update"
   >
     <k-aspect-ratio ratio="16/9">
-      <iframe v-if="video" :src="video" />
+      <iframe v-if="video" :src="video" referrerpolicy="strict-origin-when-cross-origin" />
     </k-aspect-ratio>
   </k-block-figure>
 </template>


### PR DESCRIPTION
## Describe the PR

The Video block does not show domain-restricted clips in Panel. With this fix we can solve the problem without compromising the privacy/security of Panel users. 

## Related issue

https://github.com/getkirby/kirby/issues/3257