### PR TITLE
Allow custom attributes on video helper

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -314,6 +314,21 @@ return [
                     $video = Html::tag('video', [$source], $attrs);
                 }
             } else {
+                // removes attributes that providers (youtube and vimeo) don't support in iframe
+                if (
+                    Str::contains($tag->value, 'youtu', true) === true ||
+                    Str::contains($tag->value, 'vimeo', true) === true
+                ) {
+                    unset(
+                        $attrs['autoplay'],
+                        $attrs['controls'],
+                        $attrs['loop'],
+                        $attrs['muted'],
+                        $attrs['poster'],
+                        $attrs['preload']
+                    );
+                }
+
                 $video = Html::video(
                     $tag->value,
                     $options,

--- a/config/tags.php
+++ b/config/tags.php
@@ -285,26 +285,41 @@ return [
                 }
             }
 
-            // converts tag attributes to supported formats (listed below) to output correct html
-            // booleans: autoplay, controls, loop, muted
-            // strings : height, poster, preload, width
-            // for ex  : `autoplay` will not work if `false` is a `string` instead of a `boolean`
-            $attrs = [
-                'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
-                'controls' => Str::toType($tag->controls ?? true, 'bool'),
-                'height'   => $tag->height,
-                'loop'     => Str::toType($tag->loop, 'bool'),
-                'muted'    => Str::toType($tag->muted ?? $autoplay, 'bool'),
-                'poster'   => $tag->poster,
-                'preload'  => $tag->preload,
-                'width'    => $tag->width
-            ];
-
-            // handles local and remote video file
-            if (
+            // checks video is local or provider(remote)
+            $isLocalVideo = (
                 Str::startsWith($tag->value, 'http://') !== true &&
                 Str::startsWith($tag->value, 'https://') !== true
-            ) {
+            );
+            $isProviderVideo = (
+                $isLocalVideo === false &&
+                (
+                    Str::contains($tag->value, 'youtu', true) === true ||
+                    Str::contains($tag->value, 'vimeo', true) === true
+                )
+            );
+
+            // default attributes for local and remote videos
+            $attrs = [
+                'height' => $tag->height,
+                'width'  => $tag->width
+            ];
+
+            // don't use attributes that iframe doesn't support
+            if ($isProviderVideo === false) {
+                // converts tag attributes to supported formats (listed below) to output correct html
+                // booleans: autoplay, controls, loop, muted
+                // strings : poster, preload
+                // for ex  : `autoplay` will not work if `false` is a `string` instead of a `boolean`
+                $attrs['autoplay'] = $autoplay = Str::toType($tag->autoplay, 'bool');
+                $attrs['controls'] = Str::toType($tag->controls ?? true, 'bool');
+                $attrs['loop']     = Str::toType($tag->loop, 'bool');
+                $attrs['muted']    = Str::toType($tag->muted ?? $autoplay, 'bool');
+                $attrs['poster']   = $tag->poster;
+                $attrs['preload']  = $tag->preload;
+            }
+
+            // handles local and remote video file
+            if ($isLocalVideo === true) {
                 // handles local video file
                 if ($tag->file = $tag->file($tag->value)) {
                     $source = Html::tag('source', null, [
@@ -314,21 +329,6 @@ return [
                     $video = Html::tag('video', [$source], $attrs);
                 }
             } else {
-                // removes attributes that providers (youtube and vimeo) don't support in iframe
-                if (
-                    Str::contains($tag->value, 'youtu', true) === true ||
-                    Str::contains($tag->value, 'vimeo', true) === true
-                ) {
-                    unset(
-                        $attrs['autoplay'],
-                        $attrs['controls'],
-                        $attrs['loop'],
-                        $attrs['muted'],
-                        $attrs['poster'],
-                        $attrs['preload']
-                    );
-                }
-
                 $video = Html::video(
                     $tag->value,
                     $options,

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -453,21 +453,29 @@ class Html extends Xml
     }
 
     /**
-     * Generates a list of allowed attributes
+     * Generates a list of attributes
      * for video iframes
      *
      * @param array $attr
      * @return array
      */
-    public static function videoAttr($attr): array
+    public static function videoAttr(array $attr = []): array
     {
-        return [
-            // allow fullscreen mode by default
-            'allowfullscreen' => $attr['allowfullscreen'] ?? true,
-            'class'           => $attr['class'] ?? null,
-            'height'          => $attr['height'] ?? null,
-            'width'           => $attr['width'] ?? null,
-        ];
+        // allow fullscreen mode by default
+        // and use new `allow` attribute
+        if (
+            isset($attr['allow']) === false &&
+            ($attr['allowfullscreen'] ?? true) === true
+        ) {
+            $attr['allow'] = 'fullscreen';
+        }
+
+        // remove deprecated attribute
+        if (isset($attr['allowfullscreen']) === true) {
+            unset($attr['allowfullscreen']);
+        }
+
+        return $attr;
     }
 
     /**

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -754,7 +754,7 @@ class HelpersTest extends TestCase
     public function testVideo()
     {
         $video    = video('https://youtube.com/watch?v=xB3s_f7PzYk');
-        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -767,7 +767,7 @@ class HelpersTest extends TestCase
             ]
         ]);
 
-        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -780,7 +780,7 @@ class HelpersTest extends TestCase
             ]
         ]);
 
-        $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -788,7 +788,7 @@ class HelpersTest extends TestCase
     public function testVimeo()
     {
         $video    = vimeo('https://vimeo.com/335292911');
-        $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -796,7 +796,7 @@ class HelpersTest extends TestCase
     public function testVimeoWithOptions()
     {
         $video    = vimeo('https://vimeo.com/335292911', ['controls' => 0]);
-        $expected = '<iframe allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -812,7 +812,7 @@ class HelpersTest extends TestCase
     public function testYoutube()
     {
         $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk');
-        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -820,7 +820,7 @@ class HelpersTest extends TestCase
     public function testYoutubeWithOptions()
     {
         $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
-        $expected = '<iframe allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -604,7 +604,7 @@ class KirbyTagsTest extends TestCase
 
         $page  = $kirby->page('test');
 
-        $expected = '<figure class="video"><iframe allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
+        $expected = '<figure class="video"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
         $this->assertSame($expected, $page->text()->kt()->value());
     }
 

--- a/tests/Text/fixtures/kirbytext/video-width-and-height/expected.html
+++ b/tests/Text/fixtures/kirbytext/video-width-and-height/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allowfullscreen height="200" src="https://player.vimeo.com/video/115805751" width="200"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" height="200" src="https://player.vimeo.com/video/115805751" width="200"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/video-youtube/expected.html
+++ b/tests/Text/fixtures/kirbytext/video-youtube/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/vimeo/expected.html
+++ b/tests/Text/fixtures/kirbytext/vimeo/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allowfullscreen src="https://player.vimeo.com/video/115805751"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" src="https://player.vimeo.com/video/115805751"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/youtube/expected.html
+++ b/tests/Text/fixtures/kirbytext/youtube/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -457,6 +457,7 @@ class HtmlTest extends TestCase
      * @covers       ::video
      * @covers       ::youtube
      * @covers       ::vimeo
+     * @covers       ::videoAttr
      * @dataProvider videoProvider
      */
     public function testVideo($url, $src)
@@ -469,12 +470,12 @@ class HtmlTest extends TestCase
 
         // plain
         $html = Html::video($url);
-        $expected = '<iframe allowfullscreen src="' . $src . '"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
 
         // with attributes
         $html = Html::video($url, [], ['class' => 'video']);
-        $expected = '<iframe allowfullscreen class="video" src="' . $src . '"></iframe>';
+        $expected = '<iframe allow="fullscreen" class="video" src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
 
         // with options
@@ -484,7 +485,7 @@ class HtmlTest extends TestCase
         ];
         $html = Html::video($url, $options);
         $char = Str::contains($src, '?') === true ? '&amp;' : '?';
-        $expected = '<iframe allowfullscreen src="' . $src . $char . 'foo=bar"></iframe>';
+        $expected = '<iframe allow="fullscreen" src="' . $src . $char . 'foo=bar"></iframe>';
         $this->assertSame($expected, $html);
 
         // with attributes and options
@@ -493,7 +494,27 @@ class HtmlTest extends TestCase
             'youtube' => ['foo' => 'bar']
         ];
         $html = Html::video($url, $options, ['class' => 'video']);
-        $expected = '<iframe allowfullscreen class="video" src="' . $src . $char . 'foo=bar"></iframe>';
+        $expected = '<iframe allow="fullscreen" class="video" src="' . $src . $char . 'foo=bar"></iframe>';
+        $this->assertSame($expected, $html);
+
+        // allow attribute
+        $html = Html::video($url, [], ['allow' => 'camera \'none\'; microphone \'none\'']);
+        $expected = '<iframe allow="camera &#039;none&#039;; microphone &#039;none&#039;" src="' . $src . '"></iframe>';
+        $this->assertSame($expected, $html);
+
+        // allow fullscreen enabled
+        $html = Html::video($url, [], ['allow' => 'fullscreen']);
+        $expected = '<iframe allow="fullscreen" src="' . $src . '"></iframe>';
+        $this->assertSame($expected, $html);
+
+        // legacy allow fullscreen enabled
+        $html = Html::video($url, [], ['allowfullscreen' => true]);
+        $expected = '<iframe allow="fullscreen" src="' . $src . '"></iframe>';
+        $this->assertSame($expected, $html);
+
+        // legacy allow fullscreen disabled
+        $html = Html::video($url, [], ['allowfullscreen' => false]);
+        $expected = '<iframe src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
     }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Custom attributes can now be added to iframes for video helper. For fullscreen mode, the deprecated `allowfullscreen` attribute has been changed to the new `allow` attribute.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements

- Custom iframe attributes allowed on video helper


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
