### PR TITLE
Use dropdown loader in dropdown content component

### DIFF
--- a/panel/src/components/Layout/Item.vue
+++ b/panel/src/components/Layout/Item.vue
@@ -90,7 +90,7 @@ export default {
       type: [Boolean, String, Function]
     },
     options: {
-      type: [Array, Function]
+      type: [Array, Function, String]
     },
     sortable: Boolean,
     target: String,

--- a/panel/src/components/Navigation/DropdownContent.vue
+++ b/panel/src/components/Navigation/DropdownContent.vue
@@ -63,10 +63,7 @@ export default {
     async fetchOptions(ready) {
       if (this.options) {
         if (typeof this.options === "string") {
-          const response = await fetch(this.options);
-          const json = await response.json();
-          return ready(json);
-
+          this.$dropdown(this.options)(ready);
         } else if (typeof this.options === "function") {
           this.options(ready);
 

--- a/panel/src/components/Navigation/OptionsDropdown.vue
+++ b/panel/src/components/Navigation/OptionsDropdown.vue
@@ -60,7 +60,7 @@ export default {
       default: "dots",
     },
     options: {
-      type: [Array, Function],
+      type: [Array, Function, String],
       default() {
         return []
       }


### PR DESCRIPTION
## Describe the PR

`<k-dropdown-content>` always accepted a string as a hidden feature to load dropdowns from a self-defined API endpoint. But the loader was very rough and not inline with our new Fiber dropdown loader. This PR simplifies the dropdown loading via URL quite a bit and also introduces it for `<k-item>`. This leads to much nicer ways to load dynamic dropdowns

`<k-dropdown-content options="/my/custom/dropdown" />`

And in an area you can then simply define the dropdown with

```php
'dropdowns' => [
  'my/custom/dropdown' => function () {
    return [ ... ];
  }
]
```

This also means that loading dynamic dropdowns in items is a lot easier. 

```html
<template>
  <k-items :items="items" />
</template>

<script>
export default {
  computed: {
    items() {
        return [
            {
                text: "Hello world",
                options: "my/custom/dropdown",
            }
        ];
    }
  }
}
</script>
```

## Breaking changes

Defining options for `<k-dropdown-content>` via string now has to follow our Fiber dropdown architecture. It's no longer possible to define a free API endpoint for options anywhere. 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
