### PR TITLE
Revert synchronous fields

### DIFF
--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -348,14 +348,6 @@ abstract class Model
         // this will let the vue component define
         // a proper default value
         if ($tab) {
-            foreach ($tab['columns'] as $columnIndex => $column) {
-                foreach ($column['sections'] as $sectionIndex => $section) {
-                    if (in_array($section['type'], ['info', 'fields']) === true) {
-                        $tab['columns'][$columnIndex]['sections'][$sectionIndex] = $blueprint->section($sectionIndex)->toResponse();
-                    }
-                }
-            }
-
             $props['tab'] = $tab;
         }
 


### PR DESCRIPTION
## Describe the PR
This PR will revert synchronous loading of the fields section for now until we have a solid solution. This PR should close https://github.com/getkirby/kirby/pull/3656 and 

## Related issues/ideas
- Fixes https://github.com/getkirby/kirby/issues/3636

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
