### PR TITLE
Global options for all kirbytags

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
-use Kirby\Text\KirbyTag;
 use Kirby\Toolkit\Str;
 
 /**
@@ -251,29 +250,6 @@ return [
             'width',
         ],
         'html' => function ($tag) {
-            // all available video tag attributes
-            $availableAttrs = KirbyTag::$types[$tag->type]['attr'];
-
-            // global video tag options
-            $attrs   = $tag->kirby()->option('kirbytext.video', []);
-            $options = $attrs['options'] ?? [];
-
-            // removes options from attributes
-            if (isset($attrs['options']) === true) {
-                unset($attrs['options']);
-            }
-
-            // injects default values from global options
-            // applies only defined attributes to safely update tag props
-            foreach ($attrs as $key => $value) {
-                if (
-                    in_array($key, $availableAttrs) === true &&
-                    (isset($tag->{$key}) === false || $tag->{$key} === null)
-                ) {
-                    $tag->{$key} = $value;
-                }
-            }
-
             // checks and gets if poster is local file
             if (
                 empty($tag->poster) === false &&
@@ -331,7 +307,7 @@ return [
             } else {
                 $video = Html::video(
                     $tag->value,
-                    $options,
+                    $tag->kirby()->option('kirbytext.video.options', []),
                     $attrs
                 );
             }

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -46,9 +46,20 @@ class KirbyTag
             $type = static::$aliases[$type];
         }
 
+        $kirby    = $data['kirby'] ?? App::instance();
+        $defaults = $kirby->option('kirbytext.' . $type, []);
+        $attrs    = array_replace($defaults, $attrs);
+
+        // all available tag attributes
+        $availableAttrs = static::$types[$type]['attr'] ?? [];
+
         foreach ($attrs as $attrName => $attrValue) {
             $attrName = strtolower($attrName);
-            $this->$attrName = $attrValue;
+
+            // applies only defined attributes to safely update
+            if (in_array($attrName, $availableAttrs) === true) {
+                $this->{$attrName} = $attrValue;
+            }
         }
 
         $this->attrs   = $attrs;

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -631,4 +631,66 @@ class KirbyTagsTest extends TestCase
         $expected = '<figure class="video"><video controls><source src="https://getkirby.com/sample.mp4" type="video/mp4"></video></figure>';
         $this->assertSame($expected, $page->text()->kt()->value());
     }
+
+    public function globalOptionsProvider(): array
+    {
+        return [
+            [
+                '(image: image.jpg link: https://getkirby.com/)',
+                '<figure><a href="https://getkirby.com/" rel="nofollow"><img alt="" class="image-class" src="/image.jpg"></a></figure>'
+            ],
+            [
+                '(link: http://wikipedia.org text: Wikipedia)',
+                '<p><a class="link-class" href="http://wikipedia.org" rel="noopener noreferrer" target="_blank">Wikipedia</a></p>'
+            ],
+            [
+                '(tel: +49123456789)',
+                '<p><a class="phone" href="tel:+49123456789">+49123456789</a></p>'
+            ],
+            [
+                '(twitter: @getkirby)',
+                '<p><a href="https://twitter.com/getkirby" rel="nofollow" target="_blank">@getkirby</a></p>'
+            ],
+            [
+                '(video: https://www.youtube.com/watch?v=VhP7ZzZysQg)',
+                '<figure class="video-class"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider globalOptionsProvider
+     */
+    public function testGlobalOptions($kirbytext, $expected)
+    {
+        $kirby = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'options' => [
+                'kirbytext' => [
+                    'image' => [
+                        'rel' => 'nofollow',
+                        'imgclass' => 'image-class'
+                    ],
+                    'link' => [
+                        'class' => 'link-class',
+                        'target' => '_blank'
+                    ],
+                    'tel' => [
+                        'class' => 'phone'
+                    ],
+                    'twitter' => [
+                        'rel' => 'nofollow',
+                        'target' => '_blank',
+                    ],
+                    'video' => [
+                        'class' => 'video-class',
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertSame($expected, $kirby->kirbytext($kirbytext));
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The feature that we did only for `video` tag has been developed for all kirbytags. Global values can now be set for all kirbytags.

````php
return [
    'kirbytext' => [
        'video' => [
            'class' => 'video',
        ],
        'image' => [
            'imgclass' => 'margin-5'
        ],
        'link' => [
            'rel' => 'nofollow'
        ],
        ...
    ]
];
````

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Features
- Global options for all kirbytags


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
