### PR TITLE
`page.create` dialog: fix single template value

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -263,7 +263,7 @@ return [
             $blueprints = $view->blueprints($section);
 
             // the pre-selected template
-            $template = null;
+            $template = $blueprints[0]['name'] ?? $blueprints[0]['value'] ?? null;
 
             $fields = [
                 'parent' => Field::hidden(),
@@ -275,16 +275,16 @@ return [
                     'required' => true,
                     'sync'     => 'title',
                     'path'     => empty($model->id()) === false ? '/' . $model->id() . '/' : '/'
-                ])
+                ]),
+                'template' => Field::hidden()
             ];
 
+            // only show template field if > 1 templates available
+            // or when in debug mode
             if (count($blueprints) > 1 || option('debug') === true) {
                 $fields['template'] = Field::template($blueprints, [
                     'required' => true
                 ]);
-
-                // preselect the first available template
-                $template = $fields['template']['options'][0]['value'];
             }
 
             return [

--- a/tests/Panel/Areas/PageDialogsTest.php
+++ b/tests/Panel/Areas/PageDialogsTest.php
@@ -482,13 +482,13 @@ class PageDialogsTest extends AreaTestCase
         $this->assertSame('title', $props['fields']['slug']['sync']);
 
         // there's only the default template for now
-        $this->assertArrayNotHasKey('template', $props['fields']);
+        $this->assertSame('hidden', $props['fields']['template']['type']);
 
         $this->assertSame('Create draft', $props['submitButton']);
 
         $this->assertSame('site', $props['value']['parent']);
         $this->assertSame('', $props['value']['slug']);
-        $this->assertNull($props['value']['template']);
+        $this->assertSame('Page', $props['value']['template']);
         $this->assertSame('', $props['value']['title']);
     }
 


### PR DESCRIPTION

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Page create dialog: correct template used when not in `debug` mode and only one template is allowed


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3644

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
