### PR TITLE
`toggle` field: fix for missing `text` prop

### DIFF
--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -35,7 +35,11 @@ return [
                 return $value;
             }
 
-            return $model->toSafeString(I18n::translate($value, $value));
+            if (empty($value) === false) {
+                return $model->toSafeString(I18n::translate($value, $value));
+            }
+
+            return $value;
         },
     ],
     'computed' => [

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -540,7 +540,7 @@ abstract class ModelWithContent extends Model
     public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
     {
         if ($template === null) {
-            return $this->id();
+            return $this->id() ?? '';
         }
 
         if ($handler !== 'template' && $handler !== 'safeTemplate') {

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -169,4 +169,13 @@ class ModelWithContentTest extends TestCase
             ]
         ], $model->blueprints('menu'));
     }
+
+    public function testToStringWithoutValue()
+    {
+        $model = new Site();
+        $this->assertSame('', $model->toString());
+
+        $model = new Page(['slug' => 'foo']);
+        $this->assertSame('foo', $model->toString());
+    }
 }


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Toggle field: show on/off as defaults when no `text` prop is defined

### Fixed regression
- Toggle field without `text` prop on `site` working again

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3696

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
