### PR TITLE
Fix overlay/dialogs/drawers on back navigation

### DIFF
--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -18,6 +18,8 @@ export default {
         this.component = component;
         this.page = page;
         this.key = preserveState ? this.key : Date.now();
+        this.$store.dispatch("navigate");
+        document.documentElement.style.overflow = "visible";
       }
     });
   },

--- a/panel/src/store/modules/drawers.js
+++ b/panel/src/store/modules/drawers.js
@@ -5,7 +5,11 @@ export default {
   },
   mutations: {
     CLOSE(state, id) {
-      state.open = state.open.filter(item => item.id !== id);
+      if (id) {
+        state.open = state.open.filter(item => item.id !== id);
+      } else {
+        state.open = [];
+      }
     },
     GOTO(state, id) {
       state.open = state.open.filter(item => item.id === id);

--- a/panel/src/store/store.js
+++ b/panel/src/store/store.js
@@ -47,6 +47,10 @@ export default new Vuex.Store({
     },
     isLoading(context, loading) {
       context.commit(loading === true ? "START_LOADING" : "STOP_LOADING");
+    },
+    navigate(context) {
+      context.dispatch("dialog", null);
+      context.dispatch("drawers/close");
     }
   },
   modules: {


### PR DESCRIPTION
## Describe the PR
A different approach to solving this problem:
on each Fiber navigation, make sure to remove scroll block and reset view-specific store state (e.g. dialog and drawers).

Instead of https://github.com/getkirby/kirby/pull/3657

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Overlay scroll lock is properly removed in certain situations


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3651

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
