### PR TITLE
Introduce more reliable file route pattern

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -1,7 +1,7 @@
 <?php
 
 // routing pattern to match all models with files
-$pattern = '(site|users/.*?|pages/.*?)';
+$pattern = '(site|users/[^/]+|pages/[^/]+)';
 
 /**
  * Files Routes

--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -113,7 +113,7 @@ return [
         }
     ],
     [
-        'pattern' => $pattern . '/search',
+        'pattern' => 'files/search',
         'method'  => 'GET|POST',
         'action'  => function () {
             $files = $this

--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -1,12 +1,15 @@
 <?php
 
+// routing pattern to match all models with files
+$pattern = '(site|users/.*?|pages/.*?)';
+
 /**
  * Files Routes
  */
 return [
 
     [
-        'pattern' => '(:all)/files/(:any)/sections/(:any)',
+        'pattern' => $pattern . '/files/(:any)/sections/(:any)',
         'method'  => 'GET',
         'action'  => function (string $path, string $filename, string $sectionName) {
             if ($section = $this->file($path, $filename)->blueprint()->section($sectionName)) {
@@ -15,7 +18,7 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)/fields/(:any)/(:all?)',
+        'pattern' => $pattern . '/files/(:any)/fields/(:any)/(:all?)',
         'method'  => 'ALL',
         'action'  => function (string $parent, string $filename, string $fieldName, string $path = null) {
             if ($file = $this->file($parent, $filename)) {
@@ -24,14 +27,14 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files',
+        'pattern' => $pattern . '/files',
         'method'  => 'GET',
         'action'  => function (string $path) {
             return $this->parent($path)->files()->sorted();
         }
     ],
     [
-        'pattern' => '(:all)/files',
+        'pattern' => $pattern . '/files',
         'method'  => 'POST',
         'action'  => function (string $path) {
             // move_uploaded_file() not working with unit test
@@ -50,7 +53,7 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files/search',
+        'pattern' => $pattern . '/files/search',
         'method'  => 'GET|POST',
         'action'  => function (string $path) {
             $files = $this->parent($path)->files();
@@ -63,7 +66,7 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files/sort',
+        'pattern' => $pattern . '/files/sort',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
             return $this->parent($path)->files()->changeSort(
@@ -73,21 +76,21 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)',
+        'pattern' => $pattern . '/files/(:any)',
         'method'  => 'GET',
         'action'  => function (string $path, string $filename) {
             return $this->file($path, $filename);
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)',
+        'pattern' => $pattern . '/files/(:any)',
         'method'  => 'PATCH',
         'action'  => function (string $path, string $filename) {
             return $this->file($path, $filename)->update($this->requestBody(), $this->language(), true);
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)',
+        'pattern' => $pattern . '/files/(:any)',
         'method'  => 'POST',
         'action'  => function (string $path, string $filename) {
             return $this->upload(function ($source) use ($path, $filename) {
@@ -96,21 +99,21 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)',
+        'pattern' => $pattern . '/files/(:any)',
         'method'  => 'DELETE',
         'action'  => function (string $path, string $filename) {
             return $this->file($path, $filename)->delete();
         }
     ],
     [
-        'pattern' => '(:all)/files/(:any)/name',
+        'pattern' => $pattern . '/files/(:any)/name',
         'method'  => 'PATCH',
         'action'  => function (string $path, string $filename) {
             return $this->file($path, $filename)->changeName($this->requestBody('name'));
         }
     ],
     [
-        'pattern' => 'files/search',
+        'pattern' => $pattern . '/search',
         'method'  => 'GET|POST',
         'action'  => function () {
             $files = $this

--- a/tests/Cms/Api/routes/PagesRoutesTest.php
+++ b/tests/Cms/Api/routes/PagesRoutesTest.php
@@ -182,6 +182,39 @@ class PagesRoutesTest extends TestCase
         $this->assertSame('c.jpg', $response['data'][2]['filename']);
     }
 
+    public function testFilesOfAPageWithTheSlugFiles()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'files',
+                        'files' => [
+                            [
+                                'filename' => 'c.jpg',
+                            ],
+                            [
+                                'filename' => 'a.jpg',
+                            ],
+                            [
+                                'filename' => 'b.jpg',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $app->impersonate('kirby');
+
+        $response = $app->api()->call('pages/files/files');
+
+        $this->assertCount(3, $response['data']);
+        $this->assertSame('a.jpg', $response['data'][0]['filename']);
+        $this->assertSame('b.jpg', $response['data'][1]['filename']);
+        $this->assertSame('c.jpg', $response['data'][2]['filename']);
+    }
+
     public function testFilesSorted()
     {
         $app = $this->app->clone([


### PR DESCRIPTION
## Describe the PR

The file routes in the API were too greedy and caught everything with /files at the end. This led to a really weird issue when a page had the slug files. 

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3187

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
