### PR TITLE
Validate empty password

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -178,7 +178,7 @@ return [
             $passwordConfirmation = get('passwordConfirmation');
 
             // validate the password
-            UserRules::validPassword($user, $password);
+            UserRules::validPassword($user, $password ?? '');
 
             // compare passwords
             if ($password !== $passwordConfirmation) {


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
`UserRules::validPassword` method doesn't accept `null` password. Fixed with passing empty string if `null`.

### 💡 Idea

Why don't we accept `null` in all methods in `UserRules` class. After all, if it's a validating class and `null` is invalid, so we can accept a `null` parameter and say it is invalid. 

Why do we use these methods when calling?  `$email ?? ''` or `$password ?? ''` Wouldn't it be better/stabil if we send `null` directly?


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Throw correct error message again when the password is empty `#3716`

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3716 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
