### PR TITLE
Hide paragraph while loading certain nodes

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -63,6 +63,10 @@ export default {
     },
     marks: {
       type: Array
+    },
+    isParagraphNodeHidden: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -73,8 +77,15 @@ export default {
       return this.buttons("mark");
     },
     nodeButtons() {
-      return this.buttons("node");
-    }
+      let nodeButtons = this.buttons("node");
+
+      // remove the paragraph when certain nodes are requested to be loaded
+      if (this.isParagraphNodeHidden === true && nodeButtons.paragraph) {
+        delete nodeButtons.paragraph;
+      }
+
+      return nodeButtons;
+    },
   },
   methods: {
     buttons(type) {

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -15,6 +15,7 @@
         :active-marks="toolbar.marks"
         :active-nodes="toolbar.nodes"
         :active-node-attrs="toolbar.nodeAttrs"
+        :is-paragraph-node-hidden="isParagraphNodeHidden"
         :style="{
           'bottom': toolbar.position.bottom + 'px',
           'inset-inline-start': toolbar.position.left + 'px'
@@ -58,7 +59,6 @@ import Heading from "./Nodes/Heading";
 import HorizontalRule from "./Nodes/HorizontalRule";
 import ListItem from "./Nodes/ListItem";
 import OrderedList from "./Nodes/OrderedList";
-import Paragraph from "./Nodes/Paragraph";
 
 // Extensions
 import History from "./Extensions/History.js";
@@ -95,7 +95,6 @@ export const props = {
       type: [Array, Boolean],
       default() {
         return [
-          "paragraph",
           "heading",
           "bulletList",
           "orderedList"
@@ -126,6 +125,11 @@ export default {
       isEmpty: true,
       toolbar: false
     };
+  },
+  computed: {
+    isParagraphNodeHidden() {
+      return Array.isArray(this.nodes) === true && this.nodes.length !== 3 && this.nodes.includes("paragraph") === false;
+    }
   },
   watch: {
     value(newValue, oldValue) {
@@ -248,8 +252,7 @@ export default {
         orderedList: new OrderedList,
         heading: new Heading,
         horizontalRule: new HorizontalRule,
-        listItem: new ListItem,
-        paragraph: new Paragraph
+        listItem: new ListItem
       }, this.nodes, (allowed, installed) => {
 
         // install the list item when there's a list available


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

![image_27](https://user-images.githubusercontent.com/3393422/134822132-38597ea1-6e27-4629-b211-890812f49cdb.png)

As in the image above, since the paragraph is a core node, it was also coming up while loading certain nodes. This solves the problem.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
None


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Related PR #3449

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] ~Add changes to release notes draft in Notion~
