### PR TITLE
Todos on copy/paste

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -9,6 +9,7 @@
   "collapse": "Collapse",
   "collapse.all": "Collapse All",
   "copy": "Copy",
+  "copy.all": "Copy all",
   "create": "Create",
 
   "date": "Date",

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -502,6 +502,12 @@ export default {
       const availableFieldsets = Object.keys(this.fieldsets);
       blocks = blocks.filter(block => availableFieldsets.includes(block.type));
 
+      // respect max limit
+      if (this.max) {
+        const maxBlocksLimit = this.max - this.blocks.length;
+        blocks = blocks.slice(0, maxBlocksLimit);
+      }
+
       if (this.selected !== null) {
         const index = this.findIndex(this.selected)
         this.blocks.splice(index + 1, 0, ...blocks);

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -498,6 +498,10 @@ export default {
         blocks = await this.$api.post(this.endpoints.field + "/paste", { html: input });
       }
 
+      // filters only supported blocks
+      const availableFieldsets = Object.keys(this.fieldsets);
+      blocks = blocks.filter(block => availableFieldsets.includes(block.type));
+
       if (this.selected !== null) {
         const index = this.findIndex(this.selected)
         this.blocks.splice(index + 1, 0, ...blocks);

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -440,29 +440,6 @@ export default {
         }
       }
 
-      // when there are no blocks, pasting should only
-      // be possible when the selector is open
-      if (this.blocks.length === 0) {
-        if (this.$refs.selector.isOpen() === false) {
-          return false;
-        }
-
-      // when there are blocks, pasting should only
-      // be possible when a block is active and
-      // the cursor is not in a text area
-      } else {
-
-        // only paste if something is selected
-        if (!this.selected && this.batch.length === 0) {
-          return false;
-        }
-
-        // only paste if the cursor is not in a text field
-        if (clipboardEvent.target.closest('.k-writer, input, textarea, [contenteditable]')) {
-          return false;
-        }
-      }
-
       clipboardEvent.preventDefault();
 
       let blocks = null;
@@ -476,7 +453,30 @@ export default {
 
       // get regular HTML or plain text content from the clipboard
       if (blocks === null) {
-        blocks = clipboardEvent.clipboardData.getData("text/html") || clipboardEvent.clipboardData.getData("text/plain");
+        blocks = clipboardEvent.clipboardData.getData("text/html") || clipboardEvent.clipboardData.getData("text/plain") || null;
+      }
+
+      // when there are no blocks, pasting should only
+      // be possible when the selector is open
+      if (this.blocks.length === 0) {
+        if (this.$refs.selector.isOpen() === false) {
+          return false;
+        }
+
+      // when there are blocks, pasting should only
+      // be possible when a block is active and
+      // the cursor is not in a text area
+      } else {
+
+        // only paste if something is selected and there are blocks
+        if (!this.selected && this.batch.length === 0 && blocks === null) {
+          return false;
+        }
+
+        // only paste if the cursor is not in a text field
+        if (clipboardEvent.target.closest('.k-writer, input, textarea, [contenteditable]')) {
+          return false;
+        }
       }
 
       this.paste(blocks);
@@ -489,7 +489,7 @@ export default {
       // we can import them directly without sending them to the API
       if (Array.isArray(input)) {
         blocks = input.map(block => {
-          // each block needs a new unique id to avoid collissions
+          // each block needs a new unique id to avoid collisions
           block.id = this.$helper.uuid();
           return block;
         });

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -256,6 +256,19 @@ export default {
     confirmToRemoveAll() {
       this.$refs.removeAll.open();
     },
+    copyAll() {
+      // select all
+      this.batch = Object.values(this.blocks).map(block => block.id);
+
+      // trigger copy event
+      document.execCommand('copy');
+
+      // a sign that it has been copied
+      this.$store.dispatch("notification/success", ":)");
+
+      // deselect all
+      this.batch = [];
+    },
     confirmToRemoveSelected() {
       this.$refs.removeSelected.open();
     },

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -14,6 +14,9 @@
           <k-dropdown-item :disabled="isEmpty" icon="trash" @click="$refs.blocks.confirmToRemoveAll()">
             {{ $t('delete.all') }}
           </k-dropdown-item>
+          <k-dropdown-item :disabled="isEmpty" icon="copy" @click="$refs.blocks.copyAll()">
+            {{ $t('copy.all') }}
+          </k-dropdown-item>
         </k-dropdown-content>
       </k-dropdown>
     </template>


### PR DESCRIPTION
### Todos on #3712

- [x] Paste does not work if the block field is not empty. (only through the add dialog)
- [x] Unsupported block types can be pasted
- [x] Paste doesn't respect max option
- [ ] If only one block type available, it cannot be pasted because the selection dialog will not open.
- [ ] Copy any block that is not a code block. Then try to copy the code block as single or multiple. It is not copied.

### Possible features

- [x] Copy all button