### PR TITLE
Extending blocks and layout methods

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -46,6 +46,8 @@ trait AppPlugins
         'api' => [],
         'areas' => [],
         'authChallenges' => [],
+        'blockMethods' => [],
+        'blocksMethods' => [],
         'blueprints' => [],
         'cacheTypes' => [],
         'collections' => [],
@@ -59,6 +61,9 @@ trait AppPlugins
         'filesMethods' => [],
         'fields' => [],
         'hooks' => [],
+        'layoutMethods' => [],
+        'layoutColumnMethods' => [],
+        'layoutsMethods' => [],
         'pages' => [],
         'pageMethods' => [],
         'pagesMethods' => [],
@@ -152,6 +157,28 @@ trait AppPlugins
     protected function extendAuthChallenges(array $challenges): array
     {
         return $this->extensions['authChallenges'] = Auth::$challenges = array_merge(Auth::$challenges, $challenges);
+    }
+
+    /**
+     * Registers additional block methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendBlockMethods(array $methods): array
+    {
+        return $this->extensions['blockMethods'] = Block::$methods = array_merge(Block::$methods, $methods);
+    }
+
+    /**
+     * Registers additional blocks methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendBlocksMethods(array $methods): array
+    {
+        return $this->extensions['blockMethods'] = Blocks::$methods = array_merge(Blocks::$methods, $methods);
     }
 
     /**
@@ -362,6 +389,39 @@ trait AppPlugins
     protected function extendMarkdown(Closure $markdown)
     {
         return $this->extensions['markdown'] = $markdown;
+    }
+
+    /**
+     * Registers additional layout methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendLayoutMethods(array $methods): array
+    {
+        return $this->extensions['layoutMethods'] = Layout::$methods = array_merge(Layout::$methods, $methods);
+    }
+
+    /**
+     * Registers additional layout column methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendLayoutColumnMethods(array $methods): array
+    {
+        return $this->extensions['layoutColumnMethods'] = LayoutColumn::$methods = array_merge(LayoutColumn::$methods, $methods);
+    }
+
+    /**
+     * Registers additional layouts methods
+     *
+     * @param array $methods
+     * @return array
+     */
+    protected function extendLayoutsMethods(array $methods): array
+    {
+        return $this->extensions['layoutsMethods'] = Layouts::$methods = array_merge(Layouts::$methods, $methods);
     }
 
     /**

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -22,6 +22,8 @@ class Block extends Item
 {
     const ITEMS_CLASS = '\Kirby\Cms\Blocks';
 
+    use HasMethods;
+
     /**
      * @var \Kirby\Cms\Content
      */
@@ -46,6 +48,11 @@ class Block extends Item
      */
     public function __call(string $method, array $args = [])
     {
+        // block methods
+        if ($this->hasMethod($method)) {
+            return $this->callMethod($method, $args);
+        }
+
         return $this->content()->get($method);
     }
 

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -17,6 +17,8 @@ class Layout extends Item
 {
     const ITEMS_CLASS = '\Kirby\Cms\Layouts';
 
+    use HasMethods;
+
     /**
      * @var \Kirby\Cms\Content
      */
@@ -36,6 +38,11 @@ class Layout extends Item
      */
     public function __call(string $method, array $args = [])
     {
+        // layout methods
+        if ($this->hasMethod($method) === true) {
+            return $this->callMethod($method, $args);
+        }
+
         return $this->attrs()->get($method);
     }
 

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -19,6 +19,8 @@ class LayoutColumn extends Item
 {
     const ITEMS_CLASS = '\Kirby\Cms\LayoutColumns';
 
+    use HasMethods;
+
     /**
      * @var \Kirby\Cms\Blocks
      */
@@ -43,6 +45,21 @@ class LayoutColumn extends Item
         ]);
 
         $this->width = $params['width'] ?? '1/1';
+    }
+
+    /**
+     * Magic getter function
+     *
+     * @param string $method
+     * @param mixed $args
+     * @return mixed
+     */
+    public function __call(string $method, $args)
+    {
+        // layout column methods
+        if ($this->hasMethod($method) === true) {
+            return $this->callMethod($method, $args);
+        }
     }
 
     /**

--- a/tests/Cms/Blocks/BlockMethodsTest.php
+++ b/tests/Cms/Blocks/BlockMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class BlockMethodsTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'blockMethods' => [
+                'test' => function () {
+                    return 'block method';
+                }
+            ]
+        ]);
+    }
+
+    public function testBlockMethod()
+    {
+        $block = new Block(['type' => 'test']);
+        $this->assertSame('block method', $block->test());
+    }
+}

--- a/tests/Cms/Blocks/BlocksMethodsTest.php
+++ b/tests/Cms/Blocks/BlocksMethodsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class BlocksMethodsTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'blocksMethods' => [
+                'test' => function () {
+                    return 'blocks method';
+                }
+            ]
+        ]);
+    }
+
+    public function testBlocksMethod()
+    {
+        $input = [
+            ['type' => 'heading']
+        ];
+
+        $blocks = Blocks::factory($input);
+        $this->assertSame('blocks method', $blocks->test());
+    }
+}

--- a/tests/Cms/Layouts/LayoutColumnMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutColumnMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class LayoutColumnMethodsTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'layoutColumnMethods' => [
+                'test' => function () {
+                    return 'layout column method';
+                }
+            ]
+        ]);
+    }
+
+    public function testLayoutColumnMethod()
+    {
+        $column = new LayoutColumn();
+        $this->assertSame('layout column method', $column->test());
+    }
+}

--- a/tests/Cms/Layouts/LayoutMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class LayoutMethodsTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'layoutMethods' => [
+                'test' => function () {
+                    return 'layout method';
+                }
+            ]
+        ]);
+    }
+
+    public function testLayoutMethod()
+    {
+        $layout = new Layout();
+        $this->assertSame('layout method', $layout->test());
+    }
+}

--- a/tests/Cms/Layouts/LayoutsMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutsMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class LayoutsMethodsTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'layoutsMethods' => [
+                'test' => function () {
+                    return 'layouts method';
+                }
+            ]
+        ]);
+    }
+
+    public function testLayoutsMethod()
+    {
+        $layouts = Layouts::factory();
+        $this->assertSame('layouts method', $layouts->test());
+    }
+}


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

It provides a more manageable and flexible structure by adding custom methods to the game changer block and layout fields that come with Kirby 3.5.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Features
- Extends blocks and layout methods
  - layoutsMethods
  - layoutMethods
  - layoutColumnMethods
  - blocksMethods
  - blockMethods

#### Sample Usage from Plugin

````php
<?php

Kirby::plugin('my/blocksLayoutMethods', [
    'blockMethods' => [
        'test' => function () {
            return 'block method';
        }
    ],
    'blocksMethods' => [
        'test' => function () {
            return 'blocks method';
        }
    ],
    'layoutMethods' => [
        'test' => function () {
            return 'layout method';
        }
    ],
    'layoutColumnMethods' => [
        'test' => function () {
            return 'layout column method';
        }
    ],
    'layoutsMethods' => [
        'test' => function () {
            return 'layouts method';
        }
    ]
]);
````

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Implements https://kirby.nolt.io/228

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
