### PR TITLE
Default model for blocks

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -188,6 +188,15 @@ class Block extends Item
             }
         }
 
+        // default model for blocks
+        if ($class = (static::$models['Kirby\Cms\Block'] ?? null)) {
+            $object = new $class($params);
+
+            if (is_a($object, 'Kirby\Cms\Block') === true) {
+                return $object;
+            }
+        }
+
         return new static($params);
     }
 

--- a/tests/Cms/Blocks/BlockModelsTest.php
+++ b/tests/Cms/Blocks/BlockModelsTest.php
@@ -18,6 +18,14 @@ class TextBlock extends Block
     }
 }
 
+class DefaultBlock extends Block
+{
+    public function test(): string
+    {
+        return $this->id();
+    }
+}
+
 class BlockModelsTest extends TestCase
 {
     public function setUp(): void
@@ -63,5 +71,33 @@ class BlockModelsTest extends TestCase
         $this->assertArrayNotHasKey('image', Block::$models);
         $this->assertInstanceOf(Block::class, $block);
         $this->assertFalse(method_exists($block, 'test'));
+    }
+
+    public function testDefaultBlockModel()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null',
+            ],
+            'blockModels' => [
+                'Kirby\Cms\Block' => DefaultBlock::class
+            ]
+        ]);
+
+        $block = Block::factory(['type' => 'code']);
+        $this->assertInstanceOf(DefaultBlock::class, $block);
+        $this->assertSame($block->id(), $block->test());
+
+        $block = Block::factory(['type' => 'image']);
+        $this->assertInstanceOf(DefaultBlock::class, $block);
+        $this->assertSame($block->id(), $block->test());
+
+        $block = Block::factory(['type' => 'list']);
+        $this->assertInstanceOf(DefaultBlock::class, $block);
+        $this->assertSame($block->id(), $block->test());
+
+        $block = Block::factory(['type' => 'gallery']);
+        $this->assertInstanceOf(DefaultBlock::class, $block);
+        $this->assertSame($block->id(), $block->test());
     }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

In addition to the PR on #3740;

When defining a custom model, the `Kirby\Cms\Block` index represents the default block model.
I chose the `Kirby\Cms\Block` class name to avoid confusion with type names and to be clear for developers.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Features
- Default model for blocks

````php
<?php

use Kirby\Cms\Block;

class DefaultBlock extends Block
{
    public function id(): string
    {
        return 'custom id';
    }
}

class HeadingBlock extends DefaultBlock 
{
    public function test(): string
    {
        return 'Hello World!';
    }
}

Kirby::plugin('my/blockModels', [
    'blockModels' => [
        'Kirby\\Cms\\Block' => DefaultBlock::class
        'heading' => HeadingBlock::class
    ]
]);
````

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
