### PR TITLE
Fix parsing logic for entire documents and breaks

### DIFF
--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Parsley;
 
+use Kirby\Toolkit\Html;
+
 class Inline
 {
     protected $html = '';
@@ -56,6 +58,10 @@ class Inline
                 } else {
                     $attrs[$attr] = $defaults[$attr] ?? null;
                 }
+            }
+
+            if (Html::isVoid($node->tagName) === true) {
+                return '<' . $node->tagName . attr($attrs, ' ') . ' />';
             }
 
             return '<' . $node->tagName . attr($attrs, ' ') . '>' . $this->parseChildren($node->childNodes) . '</' . $node->tagName . '>';

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -48,7 +48,10 @@ class Parsley
 
         $this->createNodeRules($this->schema->nodes());
 
-        $this->parseNode($this->body());
+        foreach ($this->doc->childNodes as $childNode) {
+            $this->parseNode($childNode);
+        }
+
         $this->endInlineBlock();
     }
 
@@ -169,8 +172,10 @@ class Parsley
 
     public function parseNode($element)
     {
-        // comments
-        if (is_a($element, 'DOMComment') === true) {
+        $skip = ['DOMComment', 'DOMDocumentType'];
+
+        // unwanted element types
+        if (in_array(get_class($element), $skip) === true) {
             return true;
         }
 
@@ -198,7 +203,7 @@ class Parsley
                 return true;
             }
 
-            if ($element->tagName !== 'body') {
+            if ($element->tagName !== 'body' && $element->tagName !== 'html') {
                 $node = new Element($element, $this->marks);
 
                 if ($block = $this->fallback($node)) {

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -75,9 +75,6 @@ class Blocks extends Plain
             [
                 'tag' => 'a',
                 'attrs' => ['href', 'target', 'title'],
-                'defaults' => [
-                    'rel' => 'noopener noreferrer nofollow'
-                ]
             ],
             [
                 'tag' => 'abbr',

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -75,12 +75,18 @@ class Blocks extends Plain
             [
                 'tag' => 'a',
                 'attrs' => ['href', 'target', 'title'],
+                'defaults' => [
+                    'rel' => 'noopener noreferrer nofollow'
+                ]
             ],
             [
                 'tag' => 'abbr',
             ],
             [
                 'tag' => 'b'
+            ],
+            [
+                'tag' => 'br',
             ],
             [
                 'tag' => 'code'

--- a/tests/Parsley/fixtures/no-body.html
+++ b/tests/Parsley/fixtures/no-body.html
@@ -1,0 +1,4 @@
+<header>
+  <h3>Heading</h3>
+</header>
+<p>Text</p>

--- a/tests/Parsley/fixtures/no-body.php
+++ b/tests/Parsley/fixtures/no-body.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    [
+        'content' => [
+            'level' => 'h3',
+            'text' => 'Heading',
+        ],
+        'type' => 'heading',
+    ],
+    [
+        'content' => [
+            'text' => '<p>Text</p>',
+        ],
+        'type' => 'text',
+    ]
+];

--- a/tests/Parsley/fixtures/skip-empty-paragraph.html
+++ b/tests/Parsley/fixtures/skip-empty-paragraph.html
@@ -3,5 +3,4 @@
 <p><br></p>
 <p>Not empty 2</p>
 <p> </p>
-<p><br /></p>
 <p>Not empty 3</p>

--- a/tests/Parsley/fixtures/skip-empty-paragraph.php
+++ b/tests/Parsley/fixtures/skip-empty-paragraph.php
@@ -3,7 +3,11 @@
 return [
     [
         'content' => [
-            'text' => '<p>Not empty 1</p>' . "\n\n" . '<p>Not empty 2</p>' . "\n\n" . '<p>Not empty 3</p>',
+            'text' =>
+                '<p>Not empty 1</p>' . "\n\n" .
+                '<p><br /></p>' . "\n\n" .
+                '<p>Not empty 2</p>' . "\n\n" .
+                '<p>Not empty 3</p>',
         ],
         'type' => 'text',
     ],


### PR DESCRIPTION
## Describe the PR
Parsley had some weird issues when HTML got pasted that does not have a wrapping body element. It also didn't handle inline breaks very well. This PR fixes both issues. 

## Fixes
- https://github.com/getkirby/kirby/issues/3735