### PR TITLE
Use filemtime again for F::modified

### DIFF
--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -473,10 +473,7 @@ class F
             return false;
         }
 
-        $stat     = stat($file);
-        $mtime    = $stat['mtime'] ?? 0;
-        $ctime    = $stat['ctime'] ?? 0;
-        $modified = max([$mtime, $ctime]);
+        $modified = filemtime($file);
 
         if (is_null($format) === true) {
             return $modified;


### PR DESCRIPTION
## Describe the PR
Uses filemtime again for F::modified instead of a max between mtime and ctime. 
Check out https://github.com/getkirby/kirby/issues/3646 for more details. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Fixed unstable links / hashes for media files [#3646](https://github.com/getkirby/kirby/issues/3646)

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
- `F::modified()` does no longer calculate a maximum between mtime and ctime for file changes. This could in theory lead to different results in some scenarios. 

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/kirby/issues/3646

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
