### PR TITLE
Reload translation after login and installation

### DIFF
--- a/panel/src/components/Forms/Login.vue
+++ b/panel/src/components/Forms/Login.vue
@@ -160,7 +160,10 @@ export default {
 
       try {
         await this.$api.auth.login(user);
-        this.$reload();
+
+        this.$reload({
+          globals: ["$system", "$translation"]
+        });
 
       } catch (error) {
         this.issue = error.message;

--- a/panel/src/components/Views/InstallationView.vue
+++ b/panel/src/components/Views/InstallationView.vue
@@ -143,9 +143,11 @@ export default {
     async install() {
       try {
         await this.$api.system.install(this.user);
-        this.$store.dispatch("notification/success", this.$t("welcome") + "!");
-        this.$go("/");
+        await this.$reload({
+          globals: ["$system", "$translation"]
+        });
 
+        this.$store.dispatch("notification/success", this.$t("welcome") + "!");
       } catch (error) {
         this.$store.dispatch("notification/error", error);
       }


### PR DESCRIPTION
## Describe the PR

The translation global needs to be updated after the installation and login. Both views will start with the default panel language which might be different from the actual user language. Only after the login or installation was successful, the user will be authenticated and the correct language will be loaded. 

## Release notes

### Fixes

- Fixed translation bug after login and installation [3725](https://github.com/getkirby/kirby/issues/3725)


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/kirby/issues/3725

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
