### PR TITLE
Select blocks in the correct order

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -295,9 +295,8 @@ export default {
 
       let blocks = [];
 
-      this.selectedOrBatched.forEach(id => {
-        const block = this.find(id);
-        if (block) {
+      this.blocks.forEach(block => {
+        if (this.selectedOrBatched.includes(block.id)) {
           blocks.push(block);
         }
       });


### PR DESCRIPTION
Blocks are now always selected in the original order, no matter in which order they have been selected. 