### PR TITLE
Accept emails and phone numbers in the Dom sanitizer

### DIFF
--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -295,6 +295,28 @@ class Dom
             return 'Invalid data URI';
         }
 
+        // allow valid email addresses
+        if (Str::startsWith($url, 'mailto:') === true) {
+            $address = Str::after($url, 'mailto:');
+
+            if (empty($address) || V::email($address) === true) {
+                return true;
+            }
+
+            return 'Invalid email address';
+        }
+
+        // allow valid telephone numbers
+        if (Str::startsWith($url, 'tel:') === true) {
+            $address = Str::after($url, 'tel:');
+
+            if (empty($address) || preg_match('!^(\+|)[0-9]+$!', $address)) {
+                return true;
+            }
+
+            return 'Invalid telephone number';
+        }
+
         return 'Unknown URL type';
     }
 

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -310,7 +310,7 @@ class Dom
         if (Str::startsWith($url, 'tel:') === true) {
             $address = Str::after($url, 'tel:');
 
-            if (empty($address) || preg_match('!^(\+|)[0-9]+$!', $address)) {
+            if (empty($address) || preg_match('!^[+]?[0-9]+$!', $address)) {
                 return true;
             }
 

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -60,6 +60,11 @@ class DomTest extends TestCase
             ['data:image/jpeg;base64,test', 'Invalid data URI', [
                 'allowedDataUris' => []
             ]],
+            
+            // forbidden data uri
+            ['data:image/png;base64,test', 'Invalid data URI', [
+                'allowedDataUris' => ['data:image/jpeg;base64']
+            ]],
 
             // forbidden URL when no domains are accepted
             ['https://getkirby.com', 'The hostname "getkirby.com" is not allowed', [
@@ -87,6 +92,9 @@ class DomTest extends TestCase
 
             // forbidden URL type
             ['ftp:test', 'Unknown URL type'],
+            
+            // forbidden URL type
+            ['ftp://test', 'Unknown URL type'],
         ];
     }
 

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+/**
+ * @coversDefaultClass Kirby\Toolkit\Dom
+ */
+class DomTest extends TestCase
+{
+    public function urlProvider()
+    {
+        return [
+            // allowed empty url
+            ['', true],
+
+            // allowed path
+            ['/', true],
+
+            // allowed path
+            ['/some/path', true],
+
+            // allowed fragment
+            ['#', true],
+
+            // allowed fragment
+            ['#test-fragment', true],
+
+            // allowed data uri
+            ['data:image/jpeg;base64,test', true, [
+                'allowedDataUris' => [
+                    'data:image/jpeg;base64'
+                ]
+            ]],
+
+            // allowed URL when all domains are accepted
+            ['http://getkirby.com', true, [
+                'allowedDomains' => true
+            ]],
+
+            // allowed URL when the domain is accepted
+            ['http://getkirby.com', true, [
+                'allowedDomains' => [
+                    'getkirby.com'
+                ]
+            ]],
+
+            // allowed empty email address
+            ['mailto:', true],
+
+            // allowed valid email address
+            ['mailto:test@getkirby.com', true],
+
+            // allowed empty phone number
+            ['tel:', true],
+
+            // allowed phone number
+            ['tel:+491122334455', true],
+
+            // forbidden data uri
+            ['data:image/jpeg;base64,test', 'Invalid data URI', [
+                'allowedDataUris' => []
+            ]],
+
+            // forbidden URL when no domains are accepted
+            ['https://getkirby.com', 'The hostname "getkirby.com" is not allowed', [
+                'allowedDomains' => []
+            ]],
+
+            // forbidden URL when the particular domain is not accepted
+            ['https://google.com', 'The hostname "google.com" is not allowed', [
+                'allowedDomains' => [
+                    'getkirby.com'
+                ]
+            ]],
+
+            // forbidden invalid email address
+            ['mailto:test', 'Invalid email address'],
+
+            // forbidden phone numbers
+            ['tel:test', 'Invalid telephone number'],
+
+            // forbidden phone numbers - too much formatting
+            ['tel:+49 (0) 1234 5678', 'Invalid telephone number'],
+
+            // forbidden phone numbers - invalid plus sign position
+            ['tel:491234+5678', 'Invalid telephone number'],
+
+            // forbidden URL type
+            ['ftp:test', 'Unknown URL type'],
+        ];
+    }
+
+    /**
+     * @dataProvider urlProvider
+     * @covers ::isAllowedUrl
+     */
+    public function testIsAllowedUrl(string $url, $expected, array $options = [])
+    {
+        $dom = new Dom('Test');
+        $this->assertSame($expected, $dom->isAllowedUrl($url, $options));
+    }
+}

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -104,7 +104,6 @@ class DomTest extends TestCase
      */
     public function testIsAllowedUrl(string $url, $expected, array $options = [])
     {
-        $dom = new Dom('Test');
-        $this->assertSame($expected, $dom->isAllowedUrl($url, $options));
+        $this->assertSame($expected, Dom::isAllowedUrl($url, $options));
     }
 }


### PR DESCRIPTION
## Describe the PR

The new DOM sanitizer class killed all email address and telephone numbers. I've added additional checks for such addresses and wrote tests. 

@lukasbestle could you have a look if this is how you would have done it? 

## Related issues

- Fixes: https://github.com/getkirby/kirby/issues/3754
