### PR TITLE
Accept `null` param on `->panel()->image()` method 

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -660,22 +660,6 @@ class File extends ModelWithContent
     }
 
     /**
-     * Panel icon definition
-     *
-     * @todo Add `deprecated()` helper warning in 3.7.0
-     * @todo Remove in 3.8.0
-     *
-     * @internal
-     * @param array|null $params
-     * @return array
-     * @codeCoverageIgnore
-     */
-    public function panelIcon(array $params = null): array
-    {
-        return $this->panel()->icon($params);
-    }
-
-    /**
      * Returns an array of all actions
      * that can be performed in the Panel
      *

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -663,10 +663,10 @@ abstract class ModelWithContent extends Model
      *
      * @internal
      * @param array|null $params
-     * @return array
+     * @return array|null
      * @codeCoverageIgnore
      */
-    public function panelIcon(array $params = null): array
+    public function panelIcon(array $params = null): ?array
     {
         return $this->panel()->image($params);
     }

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -886,22 +886,6 @@ class User extends ModelWithContent
      */
 
     /**
-     * Panel icon definition
-     *
-     * @todo Add `deprecated()` helper warning in 3.7.0
-     * @todo Remove in 3.8.0
-     *
-     * @internal
-     * @param array $params
-     * @return array
-     * @codeCoverageIgnore
-     */
-    public function panelIcon(array $params = null): array
-    {
-        return $this->panel()->icon($params);
-    }
-
-    /**
      * Returns the full path without leading slash
      *
      * @todo Add `deprecated()` helper warning in 3.7.0

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -117,7 +117,7 @@ abstract class Model
         // merge with defaults and blueprint option
         $settings = array_merge(
             $this->imageDefaults(),
-            $settings,
+            $settings ?? [],
             $this->model->blueprint()->image() ?? [],
         );
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
Although the `->panel()->image()` method accepts `null` as default value, it was throwing an error during array merging. This issue has been fixed.

Also removed the `panelIcon()` method in models. As far as I know, `->panel()->image()` is now used instead of `panel()->icon()` method, so the parent class uses `panelIcon()` method.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes regressions from 3.6.0-beta.3

- Fixed `->panelIcon()` method #3782

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3782

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
