### PR TITLE
Overwritable default block previews 

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -160,18 +160,22 @@ export default {
         return false;
       }
 
-      let component = "k-block-type-" + this.type;
+      let component;
 
-      if (this.$helper.isComponent(component)) {
-        return component;
-      }
-
+      // custom preview
       if (this.fieldset.preview) {
         component = "k-block-type-" + this.fieldset.preview;
 
         if (this.$helper.isComponent(component)) {
           return component;
         }
+      }
+
+      // default preview
+      component = "k-block-type-" + this.type;
+
+      if (this.$helper.isComponent(component)) {
+        return component;
       }
 
       return false;


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The type was checked first, then the custom preview. Their places have been swapped.

I also did not implement the `(this.fieldset.preview || this.type)` control that Nico suggested. Because if `preview` is defined and component is not found, `type` cannot be used as fallback.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements

- Now default block previews are overwritable #3776

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3776

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
