### PR TITLE
Don't cache fiber response

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -201,7 +201,8 @@ class Panel
     public static function json(array $data, int $code = 200)
     {
         return Response::json($data, $code, get('_pretty'), [
-            'X-Fiber' => 'true'
+            'X-Fiber' => 'true',
+            'Cache-Control' => 'no-store'
         ]);
     }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
I think the issue is that the response is cached by the browser. I fixed it by adding cache control to the response as we did with the request.

https://github.com/getkirby/kirby/blob/develop/panel/src/fiber/index.js#L179

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes regressions from 3.6.0-beta.3
- Fixed page rendering json string #3734 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3734 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
