### PR TITLE
Improve accuracy of `HasChildren` docblocks

### DIFF
--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -17,21 +17,21 @@ use Kirby\Toolkit\Str;
 trait HasChildren
 {
     /**
-     * The Pages collection
+     * The list of available published children
      *
      * @var \Kirby\Cms\Pages
      */
     public $children;
 
     /**
-     * The list of available drafts
+     * The list of available draft children
      *
      * @var \Kirby\Cms\Pages
      */
     public $drafts;
 
     /**
-     * Returns the Pages collection
+     * Returns all published children
      *
      * @return \Kirby\Cms\Pages
      */
@@ -45,7 +45,7 @@ trait HasChildren
     }
 
     /**
-     * Returns all children and drafts at the same time
+     * Returns all published and draft children at the same time
      *
      * @return \Kirby\Cms\Pages
      */
@@ -55,8 +55,8 @@ trait HasChildren
     }
 
     /**
-     * Return a list of ids for the model's
-     * toArray method
+     * Returns a list of IDs for the model's
+     * `toArray` method
      *
      * @return array
      */
@@ -66,7 +66,7 @@ trait HasChildren
     }
 
     /**
-     * Searches for a child draft by id
+     * Searches for a draft child by ID
      *
      * @param string $path
      * @return \Kirby\Cms\Page|null
@@ -100,7 +100,7 @@ trait HasChildren
     }
 
     /**
-     * Return all drafts of the model
+     * Returns all draft children
      *
      * @return \Kirby\Cms\Pages
      */
@@ -124,7 +124,7 @@ trait HasChildren
     }
 
     /**
-     * Finds one or multiple children by id
+     * Finds one or multiple published children by ID
      *
      * @param string ...$arguments
      * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
@@ -135,7 +135,7 @@ trait HasChildren
     }
 
     /**
-     * Finds a single page or draft
+     * Finds a single published or draft child
      *
      * @param string $path
      * @return \Kirby\Cms\Page|null
@@ -146,7 +146,7 @@ trait HasChildren
     }
 
     /**
-     * Returns a collection of all children of children
+     * Returns a collection of all published children of published children
      *
      * @return \Kirby\Cms\Pages
      */
@@ -156,7 +156,7 @@ trait HasChildren
     }
 
     /**
-     * Checks if the model has any children
+     * Checks if the model has any published children
      *
      * @return bool
      */
@@ -166,7 +166,7 @@ trait HasChildren
     }
 
     /**
-     * Checks if the model has any drafts
+     * Checks if the model has any draft children
      *
      * @return bool
      */
@@ -198,7 +198,7 @@ trait HasChildren
     /**
      * Creates a flat child index
      *
-     * @param bool $drafts
+     * @param bool $drafts If set to `true`, draft children are included
      * @return \Kirby\Cms\Pages
      */
     public function index(bool $drafts = false)
@@ -211,7 +211,7 @@ trait HasChildren
     }
 
     /**
-     * Sets the Children collection
+     * Sets the published children collection
      *
      * @param array|null $children
      * @return $this
@@ -226,7 +226,7 @@ trait HasChildren
     }
 
     /**
-     * Sets the Drafts collection
+     * Sets the draft children collection
      *
      * @param array|null $drafts
      * @return $this


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The docblocks were not very clear on the difference of published and draft children and on which method returns what.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Partly fixes https://github.com/getkirby/getkirby.com/issues/1484.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [ ] ~Add changes to release notes draft in Notion~
