### PR TITLE
Add option 'languages.fallback' for autodetection

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -562,7 +562,11 @@ class App
             }
         }
 
-        return $this->defaultLanguage();
+        if ($fallbackLanguage = $languages->findBy('code', $this->option('languages.fallback'))) {
+            return $fallbackLanguage;
+        } else {
+            return $this->defaultLanguage();
+        }
     }
 
     /**


### PR DESCRIPTION
## Describe the PR
You might want another language as default for editing in the panel than the one used for auto-detection on the website. This pull request introduces an option to set the fallback language that's being used for auto-detecting the preferred language of the visitor so that you're free to choose which language should be the default for your editors.

## Release notes
New option 'languages.fallback' if you want the language auto-detection to fallback to another language than your default language.

## Breaking changes
None

## Related issues/ideas
- https://kirby.nolt.io/253
- https://github.com/getkirby/ideas/issues/143

## Ready?
- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
