### PR TITLE
Page status check for unlisted pages

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -67,6 +67,22 @@ return [
                 ];
             }
 
+            if ($status === 'draft') {
+                $errors = $page->errors();
+
+                // switch to the error dialog if there are
+                // errors and the draft cannot be published
+                if (count($errors) > 0) {
+                    return [
+                        'component' => 'k-error-dialog',
+                        'props'     => [
+                            'message' => t('error.page.changeStatus.incomplete'),
+                            'details' => $errors,
+                        ]
+                    ];
+                }
+            }
+
             $fields = [
                 'status' => [
                     'label'    => t('page.changeStatus.select'),

--- a/panel/src/components/Dialogs/ErrorDialog.vue
+++ b/panel/src/components/Dialogs/ErrorDialog.vue
@@ -1,16 +1,17 @@
 <template>
   <k-dialog
-    v-if="notification"
     ref="dialog"
     :cancel-button="false"
+    :size="size"
     :visible="true"
     class="k-error-dialog"
-    @close="exit"
+    @cancel="$emit('cancel')"
+    @close="$emit('close')"
     @submit="$refs.dialog.close()"
   >
-    <k-text>{{ notification.message }}</k-text>
-    <dl v-if="notification.details && Object.keys(notification.details).length" class="k-error-details">
-      <template v-for="(detail, index) in notification.details">
+    <k-text>{{ message }}</k-text>
+    <dl v-if="detailsList.length" class="k-error-details">
+      <template v-for="(detail, index) in detailsList">
         <dt :key="'detail-label-' + index">
           {{ detail.label }}
         </dt>
@@ -36,27 +37,17 @@ import DialogMixin from "@/mixins/dialog.js";
 
 export default {
   mixins: [DialogMixin],
-  computed: {
-    notification() {
-      let notification = this.$store.state.notification;
-
-      if (notification.type === "error") {
-        return notification;
-      }
-
-      return null;
+  props: {
+    details: [Object, Array],
+    message: String,
+    size: {
+      type: String,
+      default: "medium"
     }
   },
-  methods: {
-    enter() {
-      this.$nextTick(() => {
-        if (this.$el && this.$el.querySelector) {
-          this.$el.querySelector(".k-dialog-footer .k-button").focus();
-        }
-      });
-    },
-    exit() {
-      this.$store.dispatch("notification/close");
+  computed: {
+    detailsList() {
+      return Array.isArray(this.details) ? this.details : Object.values(this.details);
     }
   }
 };

--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -12,9 +12,6 @@
   >
     <slot />
 
-    <!-- Error dialog -->
-    <k-error-dialog />
-
     <!-- Fiber dialogs -->
     <template v-if="$store.state.dialog && $store.state.dialog.props">
       <k-fiber-dialog v-bind="dialog" />

--- a/panel/src/store/modules/notification.js
+++ b/panel/src/store/modules/notification.js
@@ -52,10 +52,13 @@ export default {
         payload = { message: payload };
       }
 
-      context.dispatch("open", {
-        type: "error",
-        ...payload
-      });
+      context.dispatch("dialog", {
+        component: "k-error-dialog",
+        props: payload,
+      }, {root: true});
+
+      context.dispatch("close");
+
     }
   }
 };

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -169,24 +169,10 @@ class PageRules
             return true;
         }
 
-        if ($page->permissions()->changeStatus() !== true) {
-            throw new PermissionException([
-                'key'  => 'page.changeStatus.permission',
-                'data' => [
-                    'slug' => $page->slug()
-                ]
-            ]);
-        }
+        static::publish($page);
 
         if ($position !== null && $position < 0) {
             throw new InvalidArgumentException(['key' => 'page.num.invalid']);
-        }
-
-        if ($page->isDraft() === true && empty($page->errors()) === false) {
-            throw new PermissionException([
-                'key'     => 'page.changeStatus.incomplete',
-                'details' => $page->errors()
-            ]);
         }
 
         return true;
@@ -201,14 +187,7 @@ class PageRules
      */
     public static function changeStatusToUnlisted(Page $page)
     {
-        if ($page->permissions()->changeStatus() !== true) {
-            throw new PermissionException([
-                'key'  => 'page.changeStatus.permission',
-                'data' => [
-                    'slug' => $page->slug()
-                ]
-            ]);
-        }
+        static::publish($page);
 
         return true;
     }
@@ -372,6 +351,34 @@ class PageRules
         }
 
         self::validateSlugLength($slug);
+
+        return true;
+    }
+
+    /**
+     * Check if the page can be published
+     * (status change from draft to listed or unlisted)
+     *
+     * @param Page $page
+     * @return bool
+     */
+    public static function publish(Page $page): bool
+    {
+        if ($page->permissions()->changeStatus() !== true) {
+            throw new PermissionException([
+                'key'  => 'page.changeStatus.permission',
+                'data' => [
+                    'slug' => $page->slug()
+                ]
+            ]);
+        }
+
+        if ($page->isDraft() === true && empty($page->errors()) === false) {
+            throw new PermissionException([
+                'key'     => 'page.changeStatus.incomplete',
+                'details' => $page->errors()
+            ]);
+        }
 
         return true;
     }


### PR DESCRIPTION
## Describe the PR

So far, we've already checked if a page has errors when you wanted to switch from draft to listed. But that check didn't happen from draft to unlisted. I added a new `PageRules::publish()` method for the check as a first step. The changeStatus dialog now also shows a proper list of errors when it cannot be used. This is possible through a new and simplified error dialog setup. Error dialogs can now either be opened in Vue via the good old $store.dispatch("notification/error") or they can be created as Fiber a dialog: 

```php
return [
  'component' => 'k-error-dialog', 
  'messasge' => 'Something’s wrong',
  'details' => [
      ['label' => 'Error 1', 'message' => 'Error description 1'],
      ['label' => 'Error 2', 'message' => 'Error description 2'],
  ]
];
```

This is super handy, because you can now decided between throwing a simple Exception in dialogs to show the red alert bar, or you can switch to the full blown error dialog with detailed messages. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Features

#### k-error-dialog

You can now create a full blown error dialog with detailed error messages. 

```php
return [
  'component' => 'k-error-dialog', 
  'messasge' => 'Something’s wrong',
  'details' => [
      ['label' => 'Error 1', 'message' => 'Error description 1'],
      ['label' => 'Error 2', 'message' => 'Error description 2'],
  ]
];
```

### Fixes
- It's no longer possible to switch from draft to unlisted page if there are page errors #3781


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3781

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
