### PR TITLE
Add “crop” to the filename

### DIFF
--- a/src/Filesystem/Filename.php
+++ b/src/Filesystem/Filename.php
@@ -139,7 +139,7 @@ class Filename
                     $result[] = $value;
                     break;
                 case 'crop':
-                    $result[] = ($value === 'center') ? null : $key . '-' . $value;
+                    $result[] = ($value === 'center') ? 'crop' : $key . '-' . $value;
                     break;
                 default:
                     $result[] = $key . $value;

--- a/tests/Filesystem/FilenameTest.php
+++ b/tests/Filesystem/FilenameTest.php
@@ -62,7 +62,7 @@ class FilenameTest extends TestCase
                 ]
             ],
             [
-                '',
+                '-crop',
                 [
                     'crop' => 'center',
                 ]

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -322,7 +322,7 @@ class FileTest extends TestCase
             'ratio' => '3/2',
             'url' => '/media/site/' . $hash . '/test.jpg',
             'src' => Model::imagePlaceholder(),
-            'srcset' => '/media/site/' . $hash . '/test-38x38.jpg 1x, /media/site/' . $hash . '/test-76x76.jpg 2x'
+            'srcset' => '/media/site/' . $hash . '/test-38x38-crop.jpg 1x, /media/site/' . $hash . '/test-76x76-crop.jpg 2x'
         ], $panel->image(['cover' => true]));
     }
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -311,8 +311,8 @@ class ModelTest extends TestCase
         $this->assertArrayHasKey('srcset', $image);
         $this->assertSame($icon, $image['icon']);
         $this->assertSame($ratio, $image['ratio']);
-        $this->assertStringContainsString('test-38x38.jpg 1x', $image['srcset']);
-        $this->assertStringContainsString('test-76x76.jpg 2x', $image['srcset']);
+        $this->assertStringContainsString('test-38x38-crop.jpg 1x', $image['srcset']);
+        $this->assertStringContainsString('test-76x76-crop.jpg 2x', $image['srcset']);
     }
 
     /**

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -319,7 +319,7 @@ class PageTest extends TestCase
             'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
-            'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
+            'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
         ], $panel->image(['cover' => true]));
     }
 

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -104,7 +104,7 @@ class SiteTest extends TestCase
             'ratio' => '3/2',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
-            'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
+            'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
         ], $panel->image(['cover' => true]));
     }
 

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -131,7 +131,7 @@ class UserTest extends TestCase
             'ratio' => '1/1',
             'url' => $mediaUrl . '/test.jpg',
             'src' => Model::imagePlaceholder(),
-            'srcset' => $mediaUrl . '/test-38x38.jpg 1x, ' . $mediaUrl . '/test-76x76.jpg 2x'
+            'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
         ], $panel->image(['cover' => true]));
     }
 


### PR DESCRIPTION
## Describe the PR

There was a potential filename collision when dimensions of cropped and resized images matched. This PR fixes the issue by adding the "crop" keyword to the filename, even if the image is only cropped from the center. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Fixed filename collision for cropped image files #3418 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- The crop keyword is now always present in filenames for cropped files. All center cropped files need to be regenerated. 

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3418 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
