### PR TITLE
Add `data-id` for drawer and blocks

### DIFF
--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -6,6 +6,7 @@
     @open="onOpen"
   >
     <div
+      :data-id="id"
       :data-nested="nested"
       class="k-drawer"
       @mousedown="click = true"
@@ -59,6 +60,7 @@
 export default {
   inheritAttrs: false,
   props: {
+    id: String,
     icon: String,
     tab: String,
     tabs: Object,

--- a/panel/src/components/Drawers/FormDrawer.vue
+++ b/panel/src/components/Drawers/FormDrawer.vue
@@ -1,5 +1,6 @@
 <template>
   <k-drawer
+    :id="id"
     ref="drawer"
     :icon="icon"
     :tabs="tabs"
@@ -40,6 +41,7 @@ export default {
       }
     },
     icon: String,
+    id: String,
     tabs: Object,
     title: String,
     type: String,

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -5,6 +5,7 @@
     :data-batched="isBatched"
     :data-disabled="fieldset.disabled"
     :data-hidden="isHidden"
+    :data-id="id"
     :data-last-in-batch="isLastInBatch"
     :data-selected="isSelected"
     :data-translate="fieldset.translate"
@@ -35,6 +36,7 @@
 
     <k-form-drawer
       v-if="isEditable && !isBatched"
+      :id="id"
       ref="drawer"
       :icon="fieldset.icon || 'box'"
       :tabs="tabs"


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
When working with blocks, we do not know which block we are in. Blocks and drawer are now marked with id. If `id` doesn't send, no attribute is added. Feel free to close PR if doesn't make sense.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements
- Add `data-id` for drawer and blocks


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
