### PR TITLE
Fix `keyup` event on multiple block selection

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -35,7 +35,7 @@
           @chooseToPrepend="choose(index)"
           @copy="copy()"
           @confirmToRemoveSelected="confirmToRemoveSelected"
-          @click.native.stop="select(block)"
+          @click.native.stop="select(block, $event)"
           @duplicate="duplicate(block, index)"
           @focus="select(block)"
           @hide="hide(block)"
@@ -567,7 +567,15 @@ export default {
     save() {
       this.$emit("input", this.blocks);
     },
-    select(block) {
+    select(block, event = null) {
+      // checks the event just before selecting the block
+      // especially since keyup doesn't trigger in with
+      // `ctrl/alt/cmd + tab` or `ctrl/alt/cmd + click` combinations
+      // for ex: clicking outside of webpage or another browser tab
+      if (event && this.isMultiSelectKey) {
+        this.onKey(event);
+      }
+
       if (block && this.isMultiSelectKey) {
         this.addToBatch(block);
         this.current = null;


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

This bug has existed since 3.5. It emerged with the increasing use of CTRL 😅 

Checks the click event just before selecting the block, especially since keyup doesn't trigger in with `ctrl/alt/cmd + tab` or `ctrl/alt/cmd + click` combinations. For ex: clicking outside of webpage or another browser tab.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Fixed multiple blocks selection when switching browser tabs while shortkeys pressed #3800 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3800

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
