### PR TITLE
Allow multiline placeholder for writer field

### DIFF
--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -414,9 +414,18 @@ export default {
 
 .k-writer[data-placeholder][data-empty]::before {
   content: attr(data-placeholder);
-  position: absolute;
   line-height: inherit;
   color: var(--color-gray-500);
   pointer-events: none;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.k-writer[data-placeholder][data-empty] .ProseMirror {
+   position: absolute;
+   left: 0;
+   right: 0;
+   bottom: 0;
+   top: 0;
+   padding: .375rem .5rem;
 }
 </style>


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
Currently while the field was empty, placeholder position absolute, prosemirror was static. Since the height of the placeholder cannot be adjusted when it is absolute, swapped. So now placeholder static, prosemirror absolute when only field is empty.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes
- Fixed multiline placeholder for writer field #3470 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3470 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
