### PR TITLE
Set 5 minutes timeout for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         php: [ "7.3", "7.4", "8.0" ]
@@ -105,6 +106,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       php: "8.0"
       extensions: mbstring, ctype, curl, gd, apcu, memcached
@@ -209,6 +211,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       php: "8.0"
       extensions: mbstring, ctype, curl, gd, apcu, memcached
@@ -276,6 +279,7 @@ jobs:
     name: Coding Style & Frontend Analysis
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       php: "8.0"
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The default timeout is 6 hours when an issue occurs in GitHub actions. In this PR, the time is set to 5 minutes.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None