### PR TITLE
Handle inline HTML more effectively

### DIFF
--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -66,9 +66,7 @@ class Inline
     {
         $html = '';
         foreach ($children as $child) {
-            if ($childHtml = $this->parseNode($child)) {
-                $html .= $childHtml;
-            }
+            $html .= $this->parseNode($child);
         }
         return $html;
     }

--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -66,7 +66,9 @@ class Inline
     {
         $html = '';
         foreach ($children as $child) {
-            $html .= $this->parseNode($child);
+            if ($childHtml = $this->parseNode($child)) {
+                $html .= $childHtml;
+            }
         }
         return $html;
     }
@@ -85,7 +87,7 @@ class Inline
 
         // ignore comments
         if (is_a($node, 'DOMComment') === true) {
-            return '';
+            return null;
         }
 
         // known marks
@@ -106,7 +108,23 @@ class Inline
                 return '<' . $node->tagName . attr($attrs, ' ') . ' />';
             }
 
-            return '<' . $node->tagName . attr($attrs, ' ') . '>' . $this->parseChildren($node->childNodes) . '</' . $node->tagName . '>';
+            $innerHtml = $this->parseChildren($node->childNodes);
+
+            if ($node->tagName === 'p') {
+                // trim the inner HTML for paragraphs
+                $innerHtml = trim($innerHtml);
+
+                // skip empty paragraphs
+                if ($innerHtml === '') {
+                    return null;
+                }
+            }
+
+            if ($innerHtml === '') {
+                return null;
+            }
+
+            return '<' . $node->tagName . attr($attrs, ' ') . '>' . $innerHtml . '</' . $node->tagName . '>';
         }
 
         // unknown marks

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -5,7 +5,6 @@ namespace Kirby\Parsley;
 use DOMNode;
 use Kirby\Parsley\Schema\Plain;
 use Kirby\Toolkit\Dom;
-use Kirby\Toolkit\Str;
 
 /**
  * HTML parser to extract the best possible blocks

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -254,7 +254,7 @@ class Parsley
 
         // merge with previous block
         if ($block['type'] === 'text' && $lastItem && $lastItem['type'] === 'text') {
-            $this->blocks[$lastIndex]['content']['text'] .= "\n\n" . $block['content']['text'];
+            $this->blocks[$lastIndex]['content']['text'] .= ' ' . $block['content']['text'];
 
         // append
         } else {

--- a/src/Parsley/Schema.php
+++ b/src/Parsley/Schema.php
@@ -19,10 +19,10 @@ class Schema
      * Returns the fallback block when no
      * other block type can be detected
      *
-     * @param string $html
+     * @param \Kirby\Parsley\Element|string $element
      * @return array|null
      */
-    public function fallback(string $html): ?array
+    public function fallback($element): ?array
     {
         return null;
     }

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -39,7 +39,7 @@ class Blocks extends Plain
         }
 
         // filter empty blocks and separate text blocks with breaks
-        $text = implode('<br /><br />', array_filter($text));
+        $text = implode('', array_filter($text));
 
         // get the citation from the footer
         if ($footer = $node->find('footer')) {
@@ -59,20 +59,32 @@ class Blocks extends Plain
      * Creates the fallback block type
      * if no other block can be found
      *
-     * @param string $html
+     * @param \Kirby\Parsley\Element|string $element
      * @return array|null
      */
-    public function fallback(string $html): ?array
+    public function fallback($element): ?array
     {
-        $html = trim($html);
+        if (is_a($element, Element::class) === true) {
+            $html = $element->innerHtml();
 
-        if (Str::length($html) === 0) {
+            if (Str::contains($html, '<p>') === false) {
+                $html = '<p>' . $html . '</p>';
+            }
+        } elseif (is_string($element) === true) {
+            $html = trim($element);
+
+            if (Str::length($html) === 0) {
+                return null;
+            }
+
+            $html = '<p>' . $html . '</p>';
+        } else {
             return null;
         }
 
         return [
             'content' => [
-                'text' => '<p>' . $html . '</p>',
+                'text' => $html,
             ],
             'type' => 'text',
         ];
@@ -250,6 +262,9 @@ class Blocks extends Plain
             ],
             [
                 'tag' => 'i',
+            ],
+            [
+                'tag' => 'p',
             ],
             [
                 'tag' => 'strike',

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -67,6 +67,8 @@ class Blocks extends Plain
         if (is_a($element, Element::class) === true) {
             $html = $element->innerHtml();
 
+            // wrap the inner HTML in a p tag if it doesn't
+            // contain one yet.
             if (Str::contains($html, '<p>') === false) {
                 $html = '<p>' . $html . '</p>';
             }

--- a/src/Parsley/Schema/Plain.php
+++ b/src/Parsley/Schema/Plain.php
@@ -42,10 +42,10 @@ class Plain extends Schema
         }
 
         return [
-            'type' => 'text',
             'content' => [
                 'text' => $text
-            ]
+            ],
+            'type' => 'text',
         ];
     }
 

--- a/src/Parsley/Schema/Plain.php
+++ b/src/Parsley/Schema/Plain.php
@@ -23,14 +23,20 @@ class Plain extends Schema
      * Creates the fallback block type
      * if no other block can be found
      *
-     * @param string $html
+     * @param \Kirby\Parsley\Element|string $element
      * @return array|null
      */
-    public function fallback(string $html): ?array
+    public function fallback($element): ?array
     {
-        $text = trim($html);
+        if (is_a($element, Element::class) === true) {
+            $text = $element->innerText();
+        } elseif (is_string($element) === true) {
+            $text = trim($element);
 
-        if (Str::length($text) === 0) {
+            if (Str::length($text) === 0) {
+                return null;
+            }
+        } else {
             return null;
         }
 
@@ -50,6 +56,13 @@ class Plain extends Schema
      */
     public function skip(): array
     {
-        return ['head', 'meta', 'script', 'style'];
+        return [
+            'base',
+            'link',
+            'meta',
+            'script',
+            'style',
+            'title'
+        ];
     }
 }

--- a/src/Parsley/Schema/Plain.php
+++ b/src/Parsley/Schema/Plain.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Parsley\Schema;
 
+use Kirby\Parsley\Element;
 use Kirby\Parsley\Schema;
 use Kirby\Toolkit\Str;
 

--- a/tests/Parsley/InlineTest.php
+++ b/tests/Parsley/InlineTest.php
@@ -22,7 +22,7 @@ class InlineTest extends TestCase
         $element = new Inline($comment);
 
         $this->assertInstanceOf('DOMComment', $comment);
-        $this->assertSame('', $element->parseNode($comment));
+        $this->assertSame(null, $element->parseNode($comment));
     }
 
     /**

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -57,7 +57,7 @@ class BlocksTest extends TestCase
         $expected = [
             'content' => [
                 'citation' => null,
-                'text'     => '<b>Bold</b> <i>Italic</i>'
+                'text'     => '<p><b>Bold</b> <i>Italic</i></p>'
             ],
             'type' => 'quote',
         ];
@@ -78,7 +78,7 @@ class BlocksTest extends TestCase
         $expected = [
             'content' => [
                 'citation' => null,
-                'text'     => 'A<br /><br />B'
+                'text'     => '<p>A</p><p>B</p>'
             ],
             'type' => 'quote',
         ];
@@ -532,7 +532,14 @@ class BlocksTest extends TestCase
      */
     public function testSkip()
     {
-        return $this->assertSame(['head', 'meta', 'script', 'style'], $this->schema->skip());
+        return $this->assertSame([
+            'base',
+            'link',
+            'meta',
+            'script',
+            'style',
+            'title'
+        ], $this->schema->skip());
     }
 
     public function testTable()

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -122,6 +122,70 @@ class BlocksTest extends TestCase
         return $this->assertSame($expected, $this->schema->fallback('Test'));
     }
 
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForDomElement()
+    {
+        $dom = new Dom('<p><b>Bold</b> <i>Italic</i></p>');
+        $p        = $dom->query('//p')[0];
+        $el       = new Element($p, [
+            ['tag' => 'b'],
+            ['tag' => 'i'],
+            ['tag' => 'p'],
+        ]);
+        $fallback = $this->schema->fallback($el);
+
+        $expected = [
+            'content' => [
+                'text' => '<p><b>Bold</b> <i>Italic</i></p>',
+            ],
+            'type' => 'text'
+        ];
+
+        $this->assertSame($expected, $fallback);
+    }
+
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForDomElementWithParagraphs()
+    {
+        $dom = new Dom('<div><p>A</p><p>B</p></div>');
+        $p        = $dom->query('//div')[0];
+        $el       = new Element($p, [
+            ['tag' => 'b'],
+            ['tag' => 'i'],
+            ['tag' => 'p'],
+        ]);
+        $fallback = $this->schema->fallback($el);
+
+        $expected = [
+            'content' => [
+                'text' => '<p>A</p><p>B</p>',
+            ],
+            'type' => 'text'
+        ];
+
+        $this->assertSame($expected, $fallback);
+    }
+
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForEmptyContent()
+    {
+        return $this->assertNull($this->schema->fallback(''));
+    }
+
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForInvalidContent()
+    {
+        return $this->assertNull($this->schema->fallback([]));
+    }
+
     public function testHeading()
     {
         $html = <<<HTML

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -60,6 +60,13 @@ class PlainTest extends TestCase
      */
     public function testSkip()
     {
-        return $this->assertSame(['head', 'meta', 'script', 'style'], $this->schema->skip());
+        return $this->assertSame([
+            'base',
+            'link',
+            'meta',
+            'script',
+            'style',
+            'title'
+        ], $this->schema->skip());
     }
 }

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -46,7 +46,6 @@ class PlainTest extends TestCase
      */
     public function testFallbackForDomElement()
     {
-
         $dom      = new Dom('<p>Test</p>');
         $p        = $dom->query('//p')[0];
         $el       = new Element($p);

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Parsley\Schema;
 
+use Kirby\Parsley\Element;
+use Kirby\Toolkit\Dom;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,10 +24,10 @@ class PlainTest extends TestCase
     public function testFallback()
     {
         $expected = [
-            'type' => 'text',
             'content' => [
                 'text' => 'Test'
-            ]
+            ],
+            'type' => 'text',
         ];
 
         return $this->assertSame($expected, $this->schema->fallback('Test'));
@@ -37,6 +39,35 @@ class PlainTest extends TestCase
     public function testFallbackForEmptyContent()
     {
         return $this->assertNull($this->schema->fallback(''));
+    }
+
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForDomElement()
+    {
+
+        $dom      = new Dom('<p>Test</p>');
+        $p        = $dom->query('//p')[0];
+        $el       = new Element($p);
+        $fallback = $this->schema->fallback($el);
+
+        $expected = [
+            'content' => [
+                'text' => 'Test',
+            ],
+            'type' => 'text'
+        ];
+
+        $this->assertSame($expected, $fallback);
+    }
+
+    /**
+     * @covers ::fallback
+     */
+    public function testFallbackForInvalidContent()
+    {
+        $this->assertNull($this->schema->fallback([]));
     }
 
     /**

--- a/tests/Parsley/fixtures/document.html
+++ b/tests/Parsley/fixtures/document.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Test Title</title>
+    </head>
+    <body>
+        Test body
+    </body>
+</html>

--- a/tests/Parsley/fixtures/document.php
+++ b/tests/Parsley/fixtures/document.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    [
+        'content' => [
+            'text' => '<p>Test body</p>',
+        ],
+        'type' => 'text',
+    ],
+];

--- a/tests/Parsley/fixtures/head.html
+++ b/tests/Parsley/fixtures/head.html
@@ -1,0 +1,5 @@
+<head>
+    <title>Test Title</title>
+</head>
+
+Test body

--- a/tests/Parsley/fixtures/head.php
+++ b/tests/Parsley/fixtures/head.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    [
+        'content' => [
+            'text' => '<p>Test body</p>',
+        ],
+        'type' => 'text',
+    ],
+];

--- a/tests/Parsley/fixtures/meta.html
+++ b/tests/Parsley/fixtures/meta.html
@@ -1,0 +1,1 @@
+<meta charset='utf-8'><span>Test<span>

--- a/tests/Parsley/fixtures/meta.php
+++ b/tests/Parsley/fixtures/meta.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    [
+        'content' => [
+            'text'  => '<p>Test</p>',
+        ],
+        'type' => 'text',
+    ]
+];

--- a/tests/Parsley/fixtures/skip-empty-paragraph.html
+++ b/tests/Parsley/fixtures/skip-empty-paragraph.html
@@ -1,5 +1,4 @@
 <p>Not empty 1</p>
-<p></p>
 <p><br></p>
 <p>Not empty 2</p>
 <p> </p>

--- a/tests/Parsley/fixtures/skip-empty-paragraph.php
+++ b/tests/Parsley/fixtures/skip-empty-paragraph.php
@@ -4,9 +4,10 @@ return [
     [
         'content' => [
             'text' =>
-                '<p>Not empty 1</p>' . "\n\n" .
-                '<p><br /></p>' . "\n\n" .
-                '<p>Not empty 2</p>' . "\n\n" .
+                '<p>Not empty 1</p>' . "\n" .
+                '<p><br /></p>' . "\n" .
+                '<p>Not empty 2</p>' . "\n" .
+                "\n" .
                 '<p>Not empty 3</p>',
         ],
         'type' => 'text',


### PR DESCRIPTION
## Describe the PR

The inline element parser of Parsley was behaving oddly with nested multiple paragraphs. Parsley also didn't really handle head elements correctly yet. This PR fixes both issues. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes 

- Fixes copy & paste issues for single paragraphs https://github.com/getkirby/kirby/issues/3813

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- https://github.com/getkirby/kirby/issues/3813

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
