### PR TITLE
Fixes slug field in structure field

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -90,7 +90,7 @@ export default {
   methods: {
     sluggify(value) {
       return this.$helper.slug(
-        value.trim(),
+        value,
         [this.slugs, this.$system.ascii],
         this.allow
       );

--- a/panel/src/helpers/slug.js
+++ b/panel/src/helpers/slug.js
@@ -1,6 +1,10 @@
 import "./regex.js";
 
 export default (string, rules = [], allowed = "") => {
+  if (!string) {
+    return "";
+  }
+
   const separator = "-";
   allowed = "a-z0-9" + allowed;
   string  = string.trim().toLowerCase();

--- a/panel/src/helpers/slug.spec.js
+++ b/panel/src/helpers/slug.spec.js
@@ -67,4 +67,19 @@ describe("$helper.slug()", () => {
     expect(resultB).to.equal("a-b");
   });
 
+  it("should return empty string when no param sent", () => {
+    const result = slug();
+    expect(result).to.equal("");
+  });
+
+  it("should return empty string when null param sent", () => {
+    const result = slug(null);
+    expect(result).to.equal("");
+  });
+
+  it("should return empty string when undefined param sent", () => {
+    const result = slug(undefined);
+    expect(result).to.equal("");
+  });
+
 });


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
`null` value was trimming and fixed with checking empty string.

Alternatively, we can move the empty check to slug helper if you want.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes regressions from 3.6.0-rc.1
- Fixed slug field in structure field #3826

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3826 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
