### PR TITLE
Update removed `settings` permission with `system`

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -83,7 +83,7 @@ return [
         'version' => function () {
             $user = $this->user();
 
-            if ($user && $user->role()->permissions()->for('access', 'settings') === true) {
+            if ($user && $user->role()->permissions()->for('access', 'system') === true) {
                 return $this->kirby()->version();
             } else {
                 return null;


### PR DESCRIPTION
Since the `settings` permission has been removed, only those with `system` permission can now see the Kirby version.