### PR TITLE
Fix writer field caret position on blocks/layout field 

### DIFF
--- a/panel/src/components/Forms/Blocks/Types/Text.vue
+++ b/panel/src/components/Forms/Blocks/Types/Text.vue
@@ -39,9 +39,6 @@ export default {
   line-height: 1.5em;
   height: 100%;
 }
-.k-block-type-text .k-writer[data-placeholder][data-empty] .ProseMirror {
-  padding: 0;
-}
 .k-block-type-text,
 .k-block-container-type-text,
 .k-block-type-text .k-writer .ProseMirror {

--- a/panel/src/components/Forms/Blocks/Types/Text.vue
+++ b/panel/src/components/Forms/Blocks/Types/Text.vue
@@ -37,5 +37,14 @@ export default {
 .k-block-type-text-input {
   font-size: var(--text-base);
   line-height: 1.5em;
+  height: 100%;
+}
+.k-block-type-text .k-writer[data-placeholder][data-empty] .ProseMirror {
+  padding: 0;
+}
+.k-block-type-text,
+.k-block-container-type-text,
+.k-block-type-text .k-writer .ProseMirror {
+  height: 100%;
 }
 </style>

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -314,6 +314,8 @@ export default {
 .k-writer {
   position: relative;
   width: 100%;
+  grid-template-areas: "content";
+  display: grid;
 }
 .k-writer .ProseMirror {
   overflow-wrap: break-word;
@@ -323,6 +325,7 @@ export default {
   -webkit-font-variant-ligatures: none;
   font-variant-ligatures: none;
   line-height: inherit;
+  grid-area: content;
 }
 .k-writer .ProseMirror:focus {
   outline: 0;
@@ -413,19 +416,12 @@ export default {
 }
 
 .k-writer[data-placeholder][data-empty]::before {
+  grid-area: content;
   content: attr(data-placeholder);
   line-height: inherit;
   color: var(--color-gray-500);
   pointer-events: none;
   white-space: pre-wrap;
   word-wrap: break-word;
-}
-.k-writer[data-placeholder][data-empty] .ProseMirror {
-   position: absolute;
-   left: 0;
-   right: 0;
-   bottom: 0;
-   top: 0;
-   padding: .375rem .5rem;
 }
 </style>


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
Previously, we made absolute while static. That's why there was a regression. Re-adjusted padding and heights while inside the blocks and layout field.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes regressions from 3.6.0-rc.1
- Fix writer field caret position on blocks/layout field #3838
- Fix writer field height on blocks/layout field

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3838

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
