### PR TITLE
Remote: Use system CA if configured in php.ini

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -104,6 +104,13 @@ class Remote
     {
         $defaults = static::$defaults;
 
+        // use the system CA store by default if
+        // one has been configured in php.ini
+        $cainfo = ini_get('curl.cainfo');
+        if (empty($cainfo) === false && is_file($cainfo) === true) {
+            $defaults['ca'] = self::CA_SYSTEM;
+        }
+
         // update the defaults with App config if set;
         // request the App instance lazily
         $app = App::instance(null, true);

--- a/tests/Http/mocks.php
+++ b/tests/Http/mocks.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kirby\Http;
+
+class IniStore
+{
+    public static $data = [];
+}
+
+/**
+ * Mock for the PHP ini_get() function to ensure reliable testing
+ *
+ * @param string $option
+ * @return string|false
+ */
+function ini_get(string $option)
+{
+    if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+        throw new Exception('Mock ini_get() function was loaded outside of the test environment. This should never happen.');
+    }
+
+    return IniStore::$data[$option] ?? \ini_get($option) ?? false;
+}
+
+/**
+ * Mock for the PHP ini_set() function to ensure reliable testing
+ *
+ * @param string $option
+ * @param string $value
+ * @return void
+ */
+function ini_set(string $option, string $value): void
+{
+    if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+        throw new Exception('Mock ini_set() function was loaded outside of the test environment. This should never happen.');
+    }
+
+    IniStore::$data[$option] = $value;
+}
+
+/**
+ * Mock for the PHP ini_restore() function to ensure reliable testing
+ *
+ * @param string $option
+ * @return void
+ */
+function ini_restore(string $option): void
+{
+    if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+        throw new Exception('Mock ini_restore() function was loaded outside of the test environment. This should never happen.');
+    }
+
+    unset(IniStore::$data[$option]);
+}


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The system CA bundle can be expected to be updated from distribution packages, so it will be the most up to date. If a bundle is configured in `php.ini`, it should be preferred and the bundle we ship with Kirby should be ignored.

Inspired by https://blog.uberspace.de/multiple-ca-listen-mehr-chaos-als-gedacht/.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements

- The `Remote` class now by default prefers the system certificate authority bundle (CA bundle) for verifying remote TLS connections if a bundle is configured in `php.ini` (`curl.cainfo` option). If no bundle is configured, Kirby will still use its internal CA bundle.

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
