### PR TITLE
Use translation as field name in user language dialog

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -100,17 +100,17 @@ return [
                 'component' => 'k-form-dialog',
                 'props' => [
                     'fields' => [
-                        'language' => Field::translation(['required' => true])
+                        'translation' => Field::translation(['required' => true])
                     ],
                     'submitButton' => t('change'),
                     'value' => [
-                        'language' => $user->language()
+                        'translation' => $user->language()
                     ]
                 ]
             ];
         },
         'submit' => function (string $id) {
-            Find::user($id)->changeLanguage(get('language'));
+            Find::user($id)->changeLanguage(get('translation'));
 
             return [
                 'event'  => 'user.changeLanguage',

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -87,15 +87,15 @@ class UsersDialogsTest extends AreaTestCase
 
         $this->assertFormDialog($dialog);
 
-        $this->assertSame('Language', $props['fields']['language']['label']);
+        $this->assertSame('Language', $props['fields']['translation']['label']);
         $this->assertSame('Change', $props['submitButton']);
-        $this->assertSame('en', $props['value']['language']);
+        $this->assertSame('en', $props['value']['translation']);
     }
 
     public function testChangeLanguageOnSubmit(): void
     {
         $this->submit([
-            'language' => 'de'
+            'translation' => 'de'
         ]);
 
         $dialog = $this->dialog('users/test/changeLanguage');


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

We use "language" as a global query parameter in multi-language sites. Using the same parameter to update the user language resulted in a collision and caused a bug in the changeLanguage dialog. I therefor renamed the field to "translation"

We are back in confusion land with the mixture of language and translation here, but I think we cannot fix this for 3.6 anymore. We should check for 3.7 if we can finally untangle this. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

## Fixed regressions from 3.6.0-rc.1
- Changing the user language no longer collides with changing the content language in multi-language setups [#3844](https://github.com/getkirby/kirby/issues/3844)

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3844

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
