### PR TITLE
Prevent layout shift when overlays open

### DIFF
--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -60,10 +60,11 @@ export default {
 
       this.isOpen = false;
       this.$emit("close");
-      this.restoreScrollPosition();
 
-      // enable scrolling of background
-      this.$store.dispatch("preventScrolling", false);
+      // restore scrolling
+      document.body.style.position = "static";
+      document.body.style.top = 0;
+      this.restoreScrollPosition();
 
       // unbind events
       this.$events.$off("keydown.esc", this.close);
@@ -118,27 +119,19 @@ export default {
         // prevent that clicks on the overlay slot trigger close
         document.querySelector(".k-overlay > *").addEventListener("mousedown", e => e.stopPropagation());
 
-        // prevent scrolling of background
-        this.$store.dispatch("preventScrolling", true);
+        // prevent scrolling for the body element
+        document.body.style.position = "fixed";
+        document.body.style.width = "100%";
+        document.body.style.top = -(this.scrollTop) + "px";
 
         this.$emit("ready");
       }, 1)
     },
     restoreScrollPosition() {
-      const view = document.querySelector(".k-panel-view");
-
-      if (view && view.scrollTop) {
-        view.scrollTop = this.scrollTop;
-      }
+      document.documentElement.scrollTop = this.scrollTop;
     },
     storeScrollPosition() {
-      const view = document.querySelector(".k-panel-view");
-
-      if (view && view.scrollTop) {
-        this.scrollTop = view.scrollTop;
-      } else {
-        this.scrollTop = 0;
-      }
+      this.scrollTop = document.documentElement.scrollTop;
     },
   }
 };

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -51,25 +51,29 @@ export default {
       scrollTop: 0
     };
   },
+  destroyed() {
+    // make sure that the close events are properly triggered
+    // if a dialog has not been closed by the close method
+    this.close(true);
+  },
   methods: {
-    close() {
+    close(force = false) {
       // it makes it run once
       if (this.isOpen === false) {
         return;
       }
 
       this.isOpen = false;
-      this.$emit("close");
 
       // restore scrolling
-      if (document.querySelectorAll('.k-overlay').length === 1) {
-        document.body.style.position = "static";
-        document.body.style.top = 0;
+      if (force === true || document.querySelectorAll('.k-overlay').length === 1) {
+        this.restoreOverflow();
         this.restoreScrollPosition();
       }
 
       // unbind events
       this.$events.$off("keydown.esc", this.close);
+      this.$emit("close");
     },
     focus() {
       let target = this.$refs.overlay.querySelector(`
@@ -130,6 +134,10 @@ export default {
 
         this.$emit("ready");
       }, 1)
+    },
+    restoreOverflow() {
+      document.body.style.position = "static";
+      document.body.style.top = 0;
     },
     restoreScrollPosition() {
       document.documentElement.scrollTop = this.scrollTop;

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -63,7 +63,7 @@ export default {
       this.restoreScrollPosition();
 
       // enable scrolling of background
-      document.documentElement.style.overflow = "visible";
+      this.$store.dispatch("preventScrolling", false);
 
       // unbind events
       this.$events.$off("keydown.esc", this.close);
@@ -119,7 +119,7 @@ export default {
         document.querySelector(".k-overlay > *").addEventListener("mousedown", e => e.stopPropagation());
 
         // prevent scrolling of background
-        document.documentElement.style.overflow = "hidden";
+        this.$store.dispatch("preventScrolling", true);
 
         this.$emit("ready");
       }, 1)

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -62,9 +62,11 @@ export default {
       this.$emit("close");
 
       // restore scrolling
-      document.body.style.position = "static";
-      document.body.style.top = 0;
-      this.restoreScrollPosition();
+      if (document.querySelectorAll('.k-overlay').length === 1) {
+        document.body.style.position = "static";
+        document.body.style.top = 0;
+        this.restoreScrollPosition();
+      }
 
       // unbind events
       this.$events.$off("keydown.esc", this.close);
@@ -103,12 +105,19 @@ export default {
         return;
       }
 
-      this.storeScrollPosition();
       this.isOpen = true;
       this.$emit("open");
 
       // bind events
       this.$events.$on("keydown.esc", this.close);
+
+      // prevent scrolling for the body element
+      if (document.body.style.position !== "fixed") {
+        this.storeScrollPosition();
+        document.body.style.position = "fixed";
+        document.body.style.width = "100%";
+        document.body.style.top = -(this.scrollTop) + "px";
+      }
 
       setTimeout(() => {
         // autofocus
@@ -118,11 +127,6 @@ export default {
 
         // prevent that clicks on the overlay slot trigger close
         document.querySelector(".k-overlay > *").addEventListener("mousedown", e => e.stopPropagation());
-
-        // prevent scrolling for the body element
-        document.body.style.position = "fixed";
-        document.body.style.width = "100%";
-        document.body.style.top = -(this.scrollTop) + "px";
 
         this.$emit("ready");
       }, 1)

--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -4,6 +4,7 @@
     :data-loading="$store.state.isLoading"
     :data-language="language"
     :data-language-default="defaultLanguage"
+    :data-prevent-scrolling="$store.state.preventScrolling"
     :data-role="role"
     :data-translation="$translation.code"
     :data-user="user"
@@ -109,6 +110,10 @@ export default {
 .k-panel[data-loading]::after,
 .k-panel[data-dragging] {
   user-select: none;
+}
+.k-panel[data-prevent-scrolling] {
+  position: fixed;
+  width: 100%;
 }
 @keyframes LoadingCursor {
   100% { cursor: progress; }

--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -4,7 +4,6 @@
     :data-loading="$store.state.isLoading"
     :data-language="language"
     :data-language-default="defaultLanguage"
-    :data-prevent-scrolling="$store.state.preventScrolling"
     :data-role="role"
     :data-translation="$translation.code"
     :data-user="user"
@@ -110,10 +109,6 @@ export default {
 .k-panel[data-loading]::after,
 .k-panel[data-dragging] {
   user-select: none;
-}
-.k-panel[data-prevent-scrolling] {
-  position: fixed;
-  width: 100%;
 }
 @keyframes LoadingCursor {
   100% { cursor: progress; }

--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -82,7 +82,6 @@ export default {
      * blocked overflow style
      */
     navigate() {
-      document.documentElement.style.overflow = "visible";
       this.$store.dispatch("navigate");
     },
 

--- a/panel/src/store/store.js
+++ b/panel/src/store/store.js
@@ -15,7 +15,7 @@ export default new Vuex.Store({
     dialog: null,
     drag: null,
     fatal: false,
-    isLoading: false,
+    isLoading: false
   },
   mutations: {
     SET_DIALOG(state, dialog) {
@@ -64,6 +64,10 @@ export default new Vuex.Store({
       context.commit("SET_LOADING", loading === true);
     },
     navigate(context) {
+      // always make sure that scrolling is activated again
+      document.body.style.position = "static";
+      document.body.style.top = 0;
+
       context.dispatch("dialog", null);
       context.dispatch("drawers/close");
     },

--- a/panel/src/store/store.js
+++ b/panel/src/store/store.js
@@ -16,7 +16,6 @@ export default new Vuex.Store({
     drag: null,
     fatal: false,
     isLoading: false,
-    preventScrolling: false,
   },
   mutations: {
     SET_DIALOG(state, dialog) {
@@ -30,9 +29,6 @@ export default new Vuex.Store({
     },
     SET_LOADING(state, loading) {
       state.isLoading = loading;
-    },
-    SET_PREVENT_SCROLLING(state, preventScrolling) {
-      state.preventScrolling = preventScrolling;
     }
   },
   actions: {
@@ -71,9 +67,6 @@ export default new Vuex.Store({
       context.dispatch("dialog", null);
       context.dispatch("drawers/close");
     },
-    preventScrolling(context, preventScrolling) {
-      context.commit("SET_PREVENT_SCROLLING", preventScrolling);
-    }
   },
   modules: {
     content: content,

--- a/panel/src/store/store.js
+++ b/panel/src/store/store.js
@@ -15,7 +15,8 @@ export default new Vuex.Store({
     dialog: null,
     drag: null,
     fatal: false,
-    isLoading: false
+    isLoading: false,
+    preventScrolling: false,
   },
   mutations: {
     SET_DIALOG(state, dialog) {
@@ -29,6 +30,9 @@ export default new Vuex.Store({
     },
     SET_LOADING(state, loading) {
       state.isLoading = loading;
+    },
+    SET_PREVENT_SCROLLING(state, preventScrolling) {
+      state.preventScrolling = preventScrolling;
     }
   },
   actions: {
@@ -66,6 +70,9 @@ export default new Vuex.Store({
     navigate(context) {
       context.dispatch("dialog", null);
       context.dispatch("drawers/close");
+    },
+    preventScrolling(context, preventScrolling) {
+      context.commit("SET_PREVENT_SCROLLING", preventScrolling);
     }
   },
   modules: {

--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -18,13 +18,13 @@ noscript {
 html {
   font-family: var(--font-sans);
   background: var(--color-background);
+  overflow-y: scroll;
 }
 
 html,
 body {
   color: var(--color-gray-900);
   min-height: 100vh;
-  overflow-y: scroll;
 }
 
 a {


### PR DESCRIPTION
## Describe the PR

Scrolling is now disabled with a new `preventScrolling` store action that activates a new data-prevent-scrolling attribute on the panel component. This makes it possible to use simple CSS rules for the styling. To prevent scrolling the body is now fixed instead of hiding the overflow. This will no longer lead to a layout shift due to a missing scrollbar. 


## Release notes

## Fixes 

- Fixed layout shift when opening overlays #3823
- Fixed dialog reset when dialogs are not closed properly https://github.com/getkirby/kirby/issues/3923

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- None 

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3823

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
