### PR TITLE
Improve permssion handling for changing roles

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -29,7 +29,7 @@ return [
                         'language' => Field::translation([
                             'required' => true
                         ]),
-                        'role' => Field::role([
+                        'role' => Field::role($kirby->roles()->canBeCreated(), [
                             'required' => true
                         ])
                     ],
@@ -206,14 +206,14 @@ return [
                 'component' => 'k-form-dialog',
                 'props' => [
                     'fields' => [
-                        'role' => Field::role([
+                        'role' => Field::role($user->roles(), [
                             'label'    => t('user.changeRole.select'),
                             'required' => true,
                         ])
                     ],
                     'submitButton' => t('user.changeRole'),
                     'value' => [
-                        'role' => $user->role()->name()
+                        'role' => $user->role()->id()
                     ]
                 ]
             ];

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -111,9 +111,12 @@ class UserRules
      */
     public static function changeRole(User $user, string $role): bool
     {
+        $kirby       = $user->kirby();
+        $currentUser = $kirby->user();
+
         // protect admin from role changes by non-admin
         if (
-            $user->kirby()->user()->isAdmin() === false &&
+            $currentUser->isAdmin() === false &&
             $user->isAdmin() === true
         ) {
             throw new PermissionException([
@@ -124,7 +127,7 @@ class UserRules
 
         // prevent non-admins making a user to admin
         if (
-            $user->kirby()->user()->isAdmin() === false &&
+            $currentUser->isAdmin() === false &&
             $role === 'admin'
         ) {
             throw new PermissionException([

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
+use Kirby\Cms\Roles;
 
 /**
  * Provides common field prop definitions
@@ -150,24 +151,16 @@ class Field
     /**
      * User role radio buttons
      *
+     * @param \Kirby\Cms\Roles $roles
      * @param array $props
      * @return array
      */
-    public static function role(array $props = []): array
+    public static function role(Roles $roles, array $props = []): array
     {
-        $kirby   = kirby();
-        $user    = $kirby->user();
-        $isAdmin = $user && $user->isAdmin();
-        $roles   = [];
+        $options = [];
 
-        foreach ($kirby->roles() as $role) {
-            // exclude the admin role, if the user
-            // is not allowed to change role to admin
-            if ($role->name() === 'admin' && $isAdmin === false) {
-                continue;
-            }
-
-            $roles[] = [
+        foreach ($roles as $role) {
+            $options[] = [
                 'text'  => $role->title(),
                 'info'  => $role->description() ?? t('role.description.placeholder'),
                 'value' => $role->name()
@@ -176,8 +169,8 @@ class Field
 
         return array_merge([
             'label'    => t('role'),
-            'type'     => count($roles) <= 1 ? 'hidden' : 'radio',
-            'options'  => $roles
+            'type'     => count($options) <= 1 ? 'hidden' : 'radio',
+            'options'  => $options
         ], $props);
     }
 

--- a/tests/Cms/Users/UserMethodsTest.php
+++ b/tests/Cms/Users/UserMethodsTest.php
@@ -314,5 +314,4 @@ class UserMethodsTest extends TestCase
 
         $this->assertCount(0, $user->roles());
     }
-
 }

--- a/tests/Cms/Users/UserMethodsTest.php
+++ b/tests/Cms/Users/UserMethodsTest.php
@@ -288,16 +288,16 @@ class UserMethodsTest extends TestCase
             'roles' => [
                 ['name' => 'admin'],
                 ['name' => 'editor'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin']
             ]
         ]);
 
-        $user = new User([
-            'email' => 'user@domain.com',
-            'role'  => 'admin'
-        ]);
+        $admin = $this->app->impersonate('admin@getkirby.com');
 
-        $this->assertCount(1, $user->roles());
-        $this->assertSame('admin', $user->roles()->first()->id());
+        $this->assertCount(1, $admin->roles());
+        $this->assertSame('admin', $admin->roles()->first()->id());
     }
 
     /**

--- a/tests/Cms/Users/UserMethodsTest.php
+++ b/tests/Cms/Users/UserMethodsTest.php
@@ -2,18 +2,24 @@
 
 namespace Kirby\Cms;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\User
+ */
 class UserMethodsTest extends TestCase
 {
     public function setUp(): void
     {
         // make sure field methods are loaded
-        new App([
+        $this->app = new App([
             'roots' => [
                 'index' => '/dev/null'
             ]
         ]);
     }
 
+    /**
+     * @covers ::id
+     */
     public function testId()
     {
         $user = new User([
@@ -23,6 +29,9 @@ class UserMethodsTest extends TestCase
         $this->assertEquals('test', $user->id());
     }
 
+    /**
+     * @covers ::language
+     */
     public function testLanguage()
     {
         $user = new User([
@@ -33,7 +42,10 @@ class UserMethodsTest extends TestCase
         $this->assertEquals('en', $user->language());
     }
 
-    public function testDefaultLanguage()
+    /**
+     * @covers ::language
+     */
+    public function testLanguageDefault()
     {
         $user = new User([
             'email' => 'user@domain.com',
@@ -42,9 +54,12 @@ class UserMethodsTest extends TestCase
         $this->assertEquals('en', $user->language());
     }
 
+    /**
+     * @covers ::role
+     */
     public function testRole()
     {
-        $kirby = new App([
+        $this->app = $this->app->clone([
             'roles' => [
                 ['name' => 'editor', 'title' => 'Editor']
             ]
@@ -53,13 +68,16 @@ class UserMethodsTest extends TestCase
         $user = new User([
             'email' => 'user@domain.com',
             'role'  => 'editor',
-            'kirby' => $kirby
+            'kirby' => $this->app
         ]);
 
         $this->assertEquals('editor', $user->role()->name());
     }
 
-    public function testDefaultRole()
+    /**
+     * @covers ::role
+     */
+    public function testRoleDefault()
     {
         $user = new User([
             'email' => 'user@domain.com',
@@ -67,4 +85,234 @@ class UserMethodsTest extends TestCase
 
         $this->assertEquals('nobody', $user->role()->name());
     }
+
+    /**
+     * When there's no authenticated user
+     * the roles collection must only contain
+     * the already assigned role of the user
+     *
+     * @covers ::roles
+     */
+    public function testRolesWithoutAuthenticatedUser()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+            ]
+        ]);
+
+        $user = new User([
+            'email' => 'user@domain.com',
+            'role'  => 'editor'
+        ]);
+
+        $this->assertCount(1, $user->roles());
+        $this->assertSame('editor', $user->roles()->first()->id());
+    }
+
+    /**
+     * When there are two admins or more,
+     * one admin can assign any other role to the
+     * other admin
+     *
+     * @covers ::roles
+     */
+    public function testRolesForAdmin()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+            ],
+            'users' => [
+                ['email' => 'admin1@getkirby.com', 'role' => 'admin'],
+                ['email' => 'admin2@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+            ]
+        ]);
+
+        $this->app->impersonate('admin2@getkirby.com');
+
+        $admin1 = $this->app->user('admin1@getkirby.com');
+
+        $this->assertCount(2, $admin1->roles());
+        $this->assertSame('admin', $admin1->roles()->first()->id());
+        $this->assertSame('editor', $admin1->roles()->last()->id());
+
+        $editor = $this->app->user('admin1@getkirby.com');
+
+        $this->assertCount(2, $editor->roles());
+        $this->assertSame('admin', $editor->roles()->first()->id());
+        $this->assertSame('editor', $editor->roles()->last()->id());
+    }
+
+    /**
+     * @covers ::roles
+     */
+    public function testRolesForEditorWithDefaultPermissions()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+                ['name' => 'client'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client'],
+            ]
+        ]);
+
+        $this->app->impersonate('editor@getkirby.com');
+
+        $admin = $this->app->user('admin@getkirby.com');
+
+        $this->assertCount(1, $admin->roles());
+        $this->assertSame('admin', $admin->roles()->first()->id());
+
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertCount(2, $client->roles());
+        $this->assertSame('client', $client->roles()->first()->id());
+        $this->assertSame('editor', $client->roles()->last()->id());
+    }
+
+    /**
+     * When the user does not have permissions to change the role
+     * of any user, they should only get back a collection with
+     * their own role
+     *
+     * @covers ::roles
+     */
+    public function testRolesForEditorWithBlockedPermissions()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                [
+                    'name' => 'admin'
+                ],
+                [
+                    'name' => 'editor',
+                    'permissions' => [
+                        'users' => [
+                            'changeRole' => false
+                        ]
+                    ]
+                ],
+                [
+                    'name' => 'client'
+                ],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client'],
+            ]
+        ]);
+
+        $this->app->impersonate('editor@getkirby.com');
+
+        $admin = $this->app->user('admin@getkirby.com');
+
+        $this->assertCount(1, $admin->roles());
+        $this->assertSame('admin', $admin->roles()->first()->id());
+
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertCount(1, $client->roles());
+        $this->assertSame('client', $client->roles()->first()->id());
+    }
+
+    /**
+     * Change role permissions are blocked on the global blueprint
+     * level but then again allowed for the individual role
+     *
+     * @covers ::roles
+     */
+    public function testRolesForEditorWithExplicitPermissions()
+    {
+        $this->app = $this->app->clone([
+            'blueprints' => [
+                'users/client' => [
+                    'options' => [
+                        'changeRole' => [
+                            '*'      => false,
+                            'editor' => true
+                        ]
+                    ]
+                ],
+            ],
+            'roles' => [
+                [
+                    'name' => 'admin'
+                ],
+                [
+                    'name' => 'editor',
+                    'permissions' => [
+                        'users' => [
+                            'changeRole' => false
+                        ]
+                    ]
+                ],
+                [
+                    'name' => 'client'
+                ],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client'],
+            ]
+        ]);
+
+        $this->app->impersonate('editor@getkirby.com');
+
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertCount(2, $client->roles());
+        $this->assertSame('client', $client->roles()->first()->id());
+        $this->assertSame('editor', $client->roles()->last()->id());
+    }
+
+    /**
+     * When only one admin is left, the role
+     * of that admin cannot be changed anymore
+     *
+     * @covers ::roles
+     */
+    public function testRolesForLastAdmin()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+            ]
+        ]);
+
+        $user = new User([
+            'email' => 'user@domain.com',
+            'role'  => 'admin'
+        ]);
+
+        $this->assertCount(1, $user->roles());
+        $this->assertSame('admin', $user->roles()->first()->id());
+    }
+
+    /**
+     * When the user has the nobody role,
+     * they cannot be promoted to the admin role
+     *
+     * @covers ::roles
+     */
+    public function testRolesWithoutOptions()
+    {
+        $user = new User([
+            'email' => 'user@domain.com',
+        ]);
+
+        $this->assertCount(0, $user->roles());
+    }
+
 }

--- a/tests/Cms/Users/UserPermissionsTest.php
+++ b/tests/Cms/Users/UserPermissionsTest.php
@@ -6,6 +6,18 @@ use PHPUnit\Framework\TestCase;
 
 class UserPermissionsTest extends TestCase
 {
+
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+    }
+
     public function actionProvider()
     {
         return [
@@ -120,20 +132,166 @@ class UserPermissionsTest extends TestCase
         $this->assertFalse($perms->can($action));
     }
 
-    public function testChangeSingleRole()
+    public function testChangeRole()
     {
-        new App([
-            'roots' => [
-                'index' => '/dev/null'
-            ],
+        $this->app = $this->app->clone([
             'roles' => [
-                ['name' => 'admin']
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor']
             ]
         ]);
 
-        $user  = new User(['email' => 'test@getkirby.com']);
-        $perms = $user->permissions();
+        // authenticate the admin
+        $this->app->impersonate('admin@getkirby.com');
 
-        $this->assertFalse($perms->can('changeRole'));
+        $editor = $this->app->user('editor@getkirby.com');
+        $this->assertTrue($editor->permissions()->changeRole());
     }
+
+    public function testChangeRoleOfLastAdmin()
+    {
+        $this->app = $this->app->clone([
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+            ]
+        ]);
+
+        $admin = $this->app->impersonate('admin@getkirby.com');
+        $this->assertFalse($admin->permissions()->changeRole());
+    }
+
+    public function testChangeRoleOfAdminWithoutAlternativeRole()
+    {
+        $this->app = $this->app->clone([
+            'users' => [
+                ['email' => 'admin1@getkirby.com', 'role' => 'admin'],
+                ['email' => 'admin2@getkirby.com', 'role' => 'admin'],
+            ]
+        ]);
+
+        $this->app->impersonate('admin1@getkirby.com');
+        $admin2 = $this->app->user('admin2@getkirby.com');
+        $this->assertFalse($admin2->permissions()->changeRole());
+    }
+
+    public function testChangeRoleOfAdminsAsEditor()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+                ['name' => 'client'],
+            ],
+            'users' => [
+                ['email' => 'admin1@getkirby.com', 'role' => 'admin'],
+                ['email' => 'admin2@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor']
+            ]
+        ]);
+
+        // authenticate the editor
+        $this->app->impersonate('editor@getkirby.com');
+
+        // collect the admins
+        $admin1 = $this->app->user('admin1@getkirby.com');
+        $admin2 = $this->app->user('admin2@getkirby.com');
+
+        $this->assertFalse($admin1->permissions()->changeRole());
+        $this->assertFalse($admin2->permissions()->changeRole());
+    }
+
+    public function testChangeRoleOfClientAsEditor()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor'],
+                ['name' => 'client'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client']
+            ]
+        ]);
+
+        // authenticate the editor
+        $this->app->impersonate('editor@getkirby.com');
+
+        // get the client
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertTrue($client->permissions()->changeRole());
+    }
+
+    public function testChangeRoleOfClientAsEditorWithBlockedPermissions()
+    {
+        $this->app = $this->app->clone([
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor', 'permissions' => [
+                    'users' => [
+                        'changeRole' => false
+                    ]
+                ]],
+                ['name' => 'client'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client']
+            ]
+        ]);
+
+        // authenticate the editor
+        $this->app->impersonate('editor@getkirby.com');
+
+        // get the client
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertFalse($client->permissions()->changeRole());
+    }
+
+    public function testChangeRoleOfClientAsEditorWithExplicitPermissions()
+    {
+        $this->app = $this->app->clone([
+            'blueprints' => [
+                'users/client' => [
+                    'options' => [
+                        'changeRole' => [
+                            '*' => false,
+                            'editor' => true
+                        ]
+                    ]
+                ]
+            ],
+            'roles' => [
+                ['name' => 'admin'],
+                ['name' => 'editor', 'permissions' => [
+                    'users' => [
+                        'changeRole' => false
+                    ]
+                ]],
+                ['name' => 'client'],
+            ],
+            'users' => [
+                ['email' => 'admin@getkirby.com', 'role' => 'admin'],
+                ['email' => 'editor@getkirby.com', 'role' => 'editor'],
+                ['email' => 'client@getkirby.com', 'role' => 'client']
+            ]
+        ]);
+
+        // authenticate the editor
+        $this->app->impersonate('editor@getkirby.com');
+
+        // get the client
+        $client = $this->app->user('client@getkirby.com');
+
+        $this->assertTrue($client->permissions()->changeRole());
+    }
+
 }

--- a/tests/Cms/Users/UserPermissionsTest.php
+++ b/tests/Cms/Users/UserPermissionsTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 class UserPermissionsTest extends TestCase
 {
-
     protected $app;
 
     public function setUp(): void
@@ -293,5 +292,4 @@ class UserPermissionsTest extends TestCase
 
         $this->assertTrue($client->permissions()->changeRole());
     }
-
 }

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -225,7 +225,8 @@ class FieldTest extends TestCase
      */
     public function testRole(): void
     {
-        $field = Field::role();
+        // without options
+        $field = Field::role(new \Kirby\Cms\Roles());
         $expected = [
             'label'   => 'Role',
             'type'    => 'hidden',
@@ -234,7 +235,7 @@ class FieldTest extends TestCase
 
         $this->assertSame($expected, $field);
 
-        // without authenticated user
+        // with roles from the app instance
         $this->app = $this->app->clone([
             'blueprints' => [
                 'users/admin'  => [
@@ -254,30 +255,7 @@ class FieldTest extends TestCase
             ]
         ]);
 
-        $field = Field::role();
-        $expected = [
-            'label'   => 'Role',
-            'type'    => 'radio',
-            'options' => [
-                [
-                    'text' => 'Client',
-                    'info' => 'No description',
-                    'value' => 'client'
-                ],
-                [
-                    'text' => 'Editor',
-                    'info' => 'Editor description',
-                    'value' => 'editor'
-                ],
-            ]
-        ];
-
-        $this->assertSame($expected, $field);
-
-        // with authenticated admin
-        $this->app->impersonate('kirby');
-
-        $field = Field::role();
+        $field = Field::role($this->app->roles());
         $expected = [
             'label'   => 'Role',
             'type'    => 'radio',


### PR DESCRIPTION
## Describe the PR

The changeRole permissions are pretty complex and so far they haven't been working great at all. This PR is fixing this. 

I'm trying my best to describe all the cases. 

### Admins

Admins can change the roles of all other users, no matter what their permission setup looks like. They got super powers. But an admin cannot change its own role if they are the last admin. 

### Other roles

Every other role can be setup to be able to change other roles, except admins. No matter what you do, other roles can never make themselves or others admin and they cannot change admin roles. 

Basic changeRole permissions follow the same procedure as always. You can set the general rule in the user blueprint in the permissions array. Changing roles is enabled by default. To disable it you can do this: 

```yaml
# users/editor.yml
permissions: 
  # other users
  users: 
    changeRole: false
  # own account
  user: 
     changeRole: false
```

Those global permission settings can then be overwritten individually with the option array. 

```yaml
# users/client.yml
options: 
  changeRole: 
    editor: true
```    

The editor role is now able to change the role of clients, but not of any other user. 










