### PR TITLE
Move changes dropdown to the backend to fix broken links and other is…

### DIFF
--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -1,10 +1,16 @@
 <?php
 
-use Kirby\Cms\Find;
+use Kirby\Panel\Dropdown;
 
 $files = require __DIR__ . '/../files/dropdowns.php';
 
 return [
+    'changes' => [
+        'pattern' => 'changes',
+        'options' => function () {
+            return Dropdown::changes();
+        }
+    ],
     'page' => [
         'pattern' => 'pages/(:any)',
         'options' => function (string $path) {

--- a/panel/src/components/Forms/FormIndicator.vue
+++ b/panel/src/components/Forms/FormIndicator.vue
@@ -39,12 +39,9 @@ export default {
     },
     ids() {
       return Object
-        .entries(this.store)
-        .filter(([, model]) => {
-          return Object.keys(model.changes).length > 0;
-        })
-        .map(([id]) => {
-          return id;
+        .keys(this.store)
+        .filter(id => {
+          return Object.keys(this.store[id].changes).length > 0;
         });
     },
     store() {

--- a/panel/src/components/Forms/FormIndicator.vue
+++ b/panel/src/components/Forms/FormIndicator.vue
@@ -40,10 +40,10 @@ export default {
     ids() {
       return Object
         .entries(this.store)
-        .filter(([id, model]) => {
+        .filter(([, model]) => {
           return Object.keys(model.changes).length > 0;
         })
-        .map(([id, model]) => {
+        .map(([id]) => {
           return id;
         });
     },

--- a/panel/src/fiber/dropdown.js
+++ b/panel/src/fiber/dropdown.js
@@ -3,40 +3,38 @@ import Fiber from "./index";
 
 export default function (path, options) {
   return async ready => {
+    options = {
+      method: "POST",
+      ...options
+    };
 
-    try {
-      const data = await Fiber.request("dropdowns/" + path, options);
+    const data = await Fiber.request("dropdowns/" + path, options);
 
-      // the GET request for the dialog is failing
-      if (!data.$dropdown) {
-        throw "The dropdown could not be loaded";
-      }
-
-      // the dropdown sends a backend error
-      if (data.$dropdown.error) {
-        throw data.$dropdown.error;
-      }
-
-      if (Array.isArray(data.$dropdown.options) === false || data.$dropdown.options.length === 0) {
-        throw "The dropdown is empty";
-      }
-
-      data.$dropdown.options.map(option => {
-        if (option.dialog) {
-          option.click = function () {
-            const url     = typeof option.dialog === "string" ? option.dialog : option.dialog.url;
-            const options = typeof option.dialog === "object" ? option.dialog : {};
-            this.$dialog(url, options);
-          };
-        }
-        return option;
-      });
-
-      ready(data.$dropdown.options);
-
-    } catch (e) {
-      console.error(e);
-      this.$store.dispatch("notification/error", e);
+    // the request for the dialog is failing
+    if (!data.$dropdown) {
+      throw "The dropdown could not be loaded";
     }
+
+    // the dropdown sends a backend error
+    if (data.$dropdown.error) {
+      throw data.$dropdown.error;
+    }
+
+    if (Array.isArray(data.$dropdown.options) === false || data.$dropdown.options.length === 0) {
+      throw "The dropdown is empty";
+    }
+
+    data.$dropdown.options.map(option => {
+      if (option.dialog) {
+        option.click = function () {
+          const url     = typeof option.dialog === "string" ? option.dialog : option.dialog.url;
+          const options = typeof option.dialog === "object" ? option.dialog : {};
+          this.$dialog(url, options);
+        };
+      }
+      return option;
+    });
+
+    ready(data.$dropdown.options);
   }
 }

--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -187,6 +187,10 @@ export default {
         }
       });
 
+      if (response.ok === false) {
+        throw response;
+      }
+
       let json = await toJson(response);
 
       // add exisiting data to partial requests

--- a/panel/src/store/modules/content.js
+++ b/panel/src/store/modules/content.js
@@ -19,7 +19,7 @@ export default {
 
     /**
      * Object of models:
-     *  Key   => type/slug/language, e.g. pages/blog+a-blog-post/de
+     *  Key   => type/slug/?language=languageCode, e.g. pages/blog+a-blog-post/?language=de
      *  Value => Object of
      *            - api: API endpoint
      *            - originals: values as they are in the content file
@@ -66,7 +66,7 @@ export default {
       id = id || state.current;
 
       if (window.panel.$language) {
-        return id + "/" + window.panel.$language.code;
+        return id + "?language=" + window.panel.$language.code;
       }
 
       return id;
@@ -251,7 +251,7 @@ export default {
       model.id = context.getters.id(model.id);
 
       // remove title from model content
-      if (model.id.startsWith("pages/") || model.id.startsWith("site")) {
+      if (model.id.startsWith("/pages/") || model.id.startsWith("/site")) {
         delete model.content.title;
       }
 

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -75,7 +75,7 @@ class Find
      */
     public static function page(string $id)
     {
-        $id   = str_replace('+', '/', $id);
+        $id   = str_replace(['+', ' '], '/', $id);
         $page = App::instance()->page($id);
 
         if ($page && $page->isReadable() === true) {
@@ -100,6 +100,7 @@ class Find
      */
     public static function parent(string $path)
     {
+        $path       = trim($path, '/');
         $modelType  = in_array($path, ['site', 'account']) ? $path : trim(dirname($path), '/');
         $modelTypes = [
             'site'    => 'site',

--- a/src/Panel/Dropdown.php
+++ b/src/Panel/Dropdown.php
@@ -2,6 +2,12 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Cms\Find;
+use Kirby\Exception\LogicException;
+use Kirby\Http\Uri;
+use Kirby\Toolkit\Str;
+use Throwable;
+
 /**
  * The Dropdown response class handles Fiber
  * requests to render the JSON object for
@@ -16,6 +22,51 @@ namespace Kirby\Panel;
 class Dropdown extends Json
 {
     protected static $key = '$dropdown';
+
+    /**
+     * Returns the options for the changes dropdown
+     *
+     * @return array
+     */
+    public static function changes(): array
+    {
+        $kirby     = kirby();
+        $multilang = $kirby->multilang();
+        $ids       = Str::split(get('ids'));
+        $options   = [];
+
+        foreach ($ids as $id) {
+            try {
+                // parse the given ID to extract
+                // the path and an optional query
+                $uri    = new Uri($id);
+                $path   = $uri->path()->toString();
+                $query  = $uri->query();
+                $option = Find::parent($path)->panel()->dropdownOption();
+
+                // add the language to each option, if it is included in the query
+                // of the given ID and the language actually exists
+                if ($multilang && $query->language && $language = $kirby->language($query->language)) {
+                    $option['text'] .= ' (' . $language->code() . ')';
+                    $option['link']  .= '?language=' . $language->code();
+                }
+
+                $options[] = $option;
+            } catch (Throwable $e) {
+                continue;
+            }
+        }
+
+        // the given set of ids does not match any
+        // real models. This means that the stored ids
+        // in local storage are not correct and the changes
+        // store needs to be cleared
+        if (empty($options) === true) {
+            throw new LogicException('No changes for given models');
+        }
+
+        return $options;
+    }
 
     /**
      * Renders dropdowns

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -160,6 +160,21 @@ class File extends Model
     }
 
     /**
+     * Returns the setup for a dropdown option
+     * which is used in the changes dropdown
+     * for example.
+     *
+     * @return array
+     */
+    public function dropdownOption(): array
+    {
+        return [
+            'icon' => 'image',
+            'text' => $this->model->filename(),
+        ] + parent::dropdownOption();
+    }
+
+    /**
      * Returns the Panel icon color
      *
      * @return string

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -87,6 +87,22 @@ abstract class Model
     }
 
     /**
+     * Returns the setup for a dropdown option
+     * which is used in the changes dropdown
+     * for example.
+     *
+     * @return array
+     */
+    public function dropdownOption(): array
+    {
+        return [
+            'icon' => 'page',
+            'link' => $this->url(),
+            'text' => $this->model->id(),
+        ];
+    }
+
+    /**
      * Returns the Panel image definition
      *
      * @internal

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -154,6 +154,19 @@ class Page extends Model
         return $result;
     }
 
+    /**
+     * Returns the setup for a dropdown option
+     * which is used in the changes dropdown
+     * for example.
+     *
+     * @return array
+     */
+    public function dropdownOption(): array
+    {
+        return [
+            'text' => $this->model->title()->value(),
+        ] + parent::dropdownOption();
+    }
 
     /**
      * Returns the escaped Id, which is

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -443,6 +443,7 @@ class Panel
                 'pattern' => $pattern,
                 'type'    => 'dropdown',
                 'area'    => $areaId,
+                'method'  => 'GET|POST',
                 'action'  => $dropdown['options'] ?? $dropdown['action']
             ];
         }

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -15,6 +15,21 @@ namespace Kirby\Panel;
 class Site extends Model
 {
     /**
+     * Returns the setup for a dropdown option
+     * which is used in the changes dropdown
+     * for example.
+     *
+     * @return array
+     */
+    public function dropdownOption(): array
+    {
+        return [
+            'icon' => 'home',
+            'text' => $this->model->title()->value(),
+        ] + parent::dropdownOption();
+    }
+
+    /**
      * Returns the image file object based on provided query
      *
      * @internal

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -88,6 +88,21 @@ class User extends Model
     }
 
     /**
+     * Returns the setup for a dropdown option
+     * which is used in the changes dropdown
+     * for example.
+     *
+     * @return array
+     */
+    public function dropdownOption(): array
+    {
+        return [
+            'icon' => 'user',
+            'text' => $this->model->username(),
+        ] + parent::dropdownOption();
+    }
+
+    /**
      * @return string|null
      */
     public function home(): ?string

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -271,7 +271,9 @@ class FindTest extends TestCase
         $this->assertInstanceOf(User::class, Find::parent('account'));
         $this->assertInstanceOf(User::class, Find::parent('users/test@getkirby.com'));
         $this->assertInstanceOf(Site::class, Find::parent('site'));
+        $this->assertInstanceOf(Site::class, Find::parent('/site'));
         $this->assertInstanceOf(Page::class, Find::parent('pages/a+aa'));
+        $this->assertInstanceOf(Page::class, Find::parent('pages/a aa'));
         $this->assertInstanceOf(File::class, Find::parent('site/files/sitefile.jpg'));
         $this->assertInstanceOf(File::class, Find::parent('pages/a/files/a-regular-file.jpg'));
         $this->assertInstanceOf(File::class, Find::parent('users/test@getkirby.com/files/userfile.jpg'));

--- a/tests/Panel/Areas/SiteDropdownsTest.php
+++ b/tests/Panel/Areas/SiteDropdownsTest.php
@@ -2,13 +2,53 @@
 
 namespace Kirby\Panel\Areas;
 
-class PageDropdownsTest extends AreaTestCase
+class SiteDropdownsTest extends AreaTestCase
 {
     public function setUp(): void
     {
         parent::setUp();
         $this->install();
         $this->login();
+    }
+
+    public function testChangesDropdown(): void
+    {
+        $this->app([
+            'request' => [
+                'body' => [
+                    'ids' => [
+                        'site',
+                        'pages/test'
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    ['slug' => 'test']
+                ],
+                'content' => [
+                    'title' => 'Test site'
+                ]
+            ]
+        ]);
+
+        $this->login();
+
+        $options = $this->dropdown('changes')['options'];
+        $expected = [
+            [
+                'icon' => 'home',
+                'text' => 'Test site',
+                'link' => '/panel/site'
+            ],
+            [
+                'icon' => 'page',
+                'text' => 'test',
+                'link' => '/panel/pages/test'
+            ]
+        ];
+
+        $this->assertEquals($expected, $options);
     }
 
     public function testPageDropdown(): void

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -111,6 +111,41 @@ class DropdownTest extends TestCase
     /**
      * @covers ::changes
      */
+    public function testChangesWithInvalidId()
+    {
+        $this->app = $this->app->clone([
+            'request' => [
+                'body' => [
+                    'ids' => [
+                        'site',
+                        'pages/does-not-exist'
+                    ]
+                ]
+            ],
+            'site' => [
+                'content' => [
+                    'title' => 'Test site'
+                ]
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+
+        $options = Dropdown::changes();
+        $expected = [
+            [
+                'icon' => 'home',
+                'text' => 'Test site',
+                'link' => '/panel/site'
+            ]
+        ];
+
+        $this->assertEquals($expected, $options);
+    }
+
+    /**
+     * @covers ::changes
+     */
     public function testChangesWithLanguages()
     {
         $this->app = $this->app->clone([

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -41,6 +41,125 @@ class DropdownTest extends TestCase
     }
 
     /**
+     * @covers ::changes
+     */
+    public function testChanges()
+    {
+        $this->app = $this->app->clone([
+            'request' => [
+                'body' => [
+                    'ids' => [
+                        'site',
+                        'pages/test',
+                        'pages/test/files/test.jpg',
+                        'users/test'
+                    ]
+                ]
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'content' => [
+                            'title' => 'Test page'
+                        ],
+                        'files' => [
+                            [
+                                'filename' => 'test.jpg',
+                            ]
+                        ]
+                    ]
+                ],
+                'content' => [
+                    'title' => 'Test site'
+                ]
+            ],
+            'users' => [
+                ['email' => 'test@getkirby.com', 'id' => 'test']
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+
+        $options = Dropdown::changes();
+        $expected = [
+            [
+                'icon' => 'home',
+                'text' => 'Test site',
+                'link' => '/panel/site'
+            ],
+            [
+                'icon' => 'page',
+                'text' => 'Test page',
+                'link' => '/panel/pages/test'
+            ],
+            [
+                'icon' => 'image',
+                'text' => 'test.jpg',
+                'link' => '/panel/pages/test/files/test.jpg'
+            ],
+            [
+                'icon' => 'user',
+                'text' => 'test@getkirby.com',
+                'link' => '/panel/users/test'
+            ]
+        ];
+
+        $this->assertEquals($expected, $options);
+    }
+
+    /**
+     * @covers ::changes
+     */
+    public function testChangesWithLanguages()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'languages' => true,
+            ],
+            'request' => [
+                'body' => [
+                    'ids' => [
+                        'site?language=en',
+                    ]
+                ]
+            ],
+            'site' => [
+                'content' => [
+                    'title' => 'Test site'
+                ]
+            ],
+            'languages' => [
+                ['code' => 'en', 'name' => 'English']
+            ]
+        ]);
+
+        $this->app->impersonate('kirby');
+
+        $options = Dropdown::changes();
+        $expected = [
+            [
+                'icon' => 'home',
+                'text' => 'Test site (en)',
+                'link' => '/panel/site?language=en'
+            ],
+        ];
+
+        $this->assertEquals($expected, $options);
+    }
+
+    /**
+     * @covers ::changes
+     */
+    public function testChangesWithoutOptions()
+    {
+        $this->expectException('Kirby\Exception\LogicException');
+        $this->expectExceptionMessage('No changes for given models');
+
+        Dropdown::changes();
+    }
+
+    /**
      * @covers ::error
      */
     public function testError(): void

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -259,6 +259,26 @@ class FileTest extends TestCase
     }
 
     /**
+     * @covers ::dropdownOption
+     */
+    public function testDropdownOption()
+    {
+        $page = new ModelPage([
+            'slug' => 'test',
+            'files' => [
+                ['filename' => 'test.jpg'],
+            ]
+        ]);
+
+        $panel  = new File($page->file());
+        $option = $panel->dropdownOption();
+
+        $this->assertSame('image', $option['icon']);
+        $this->assertSame('test.jpg', $option['text']);
+        $this->assertSame('/panel/pages/test/files/test.jpg', $option['link']);
+    }
+
+    /**
      * @covers ::imageDefaults
      * @covers ::imageColor
      * @covers ::imageIcon

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -231,6 +231,19 @@ class ModelTest extends TestCase
         new App();
     }
 
+    public function testDropdown()
+    {
+        $model  = new CustomPanelModel(new ModelSite());
+        $option = $model->dropdownOption();
+        $expected = [
+            'icon' => 'page',
+            'link' => '/panel/custom',
+            'text' => null
+        ];
+
+        $this->assertSame($expected, $option);
+    }
+
     /**
      * @covers ::image
      * @covers ::imageDefaults

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -88,6 +88,26 @@ class PageTest extends TestCase
     }
 
     /**
+     * @covers ::dropdownOption
+     */
+    public function testDropdownOption()
+    {
+        $page = new ModelPage([
+            'slug'    => 'test',
+            'content' => [
+                'title' => 'Test page'
+            ]
+        ]);
+
+        $panel  = new Page($page);
+        $option = $panel->dropdownOption();
+
+        $this->assertSame('page', $option['icon']);
+        $this->assertSame('Test page', $option['text']);
+        $this->assertSame('/panel/pages/test', $option['link']);
+    }
+
+    /**
      * @covers ::dragText
      */
     public function testDragText()

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -39,11 +39,21 @@ class SiteTest extends TestCase
     }
 
     /**
-     * @covers ::path
+     * @covers ::dropdownOption
      */
-    public function testPath()
+    public function testDropdownOption(): void
     {
-        $this->assertSame('site', $this->panel()->path());
+        $model = $this->panel([
+            'content' => [
+                'title' => 'Test site'
+            ]
+        ]);
+
+        $option = $model->dropdownOption();
+
+        $this->assertSame('home', $option['icon']);
+        $this->assertSame('Test site', $option['text']);
+        $this->assertSame('/panel/site', $option['link']);
     }
 
     /**
@@ -106,6 +116,14 @@ class SiteTest extends TestCase
             'src' => Model::imagePlaceholder(),
             'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
         ], $panel->image(['cover' => true]));
+    }
+
+    /**
+     * @covers ::path
+     */
+    public function testPath()
+    {
+        $this->assertSame('site', $this->panel()->path());
     }
 
     /**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -58,6 +58,22 @@ class UserTest extends TestCase
     }
 
     /**
+     * @covers ::dropdownOption
+     */
+    public function testDropdownOption(): void
+    {
+        $model = new ModelUser([
+            'id' => 'test',
+            'email' => 'test@getkirby.com',
+        ]);
+
+        $option = (new User($model))->dropdownOption();
+        $this->assertSame('user', $option['icon']);
+        $this->assertSame('test@getkirby.com', $option['text']);
+        $this->assertSame('/panel/users/test', $option['link']);
+    }
+
+    /**
      * @covers ::home
      */
     public function testHome()


### PR DESCRIPTION
## Describe the PR

The changes dropdown was always a bit hacky. We had to send a single request for every model in the changes store and then build the options in JS. After the move to Fiber the links and labels were broken. I decided to not fix it in JS, but move to a Fiber dropdown instead. This works better than expected but also requires a couple changes throughout multiple classes. It's all tested and should not be a big deal, but it would be good if @distantnative and @afbora could have a closer look. 

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3854

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
