### PR TITLE
Fix showing hidden blocks in layout field

### DIFF
--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -65,10 +65,15 @@ class LayoutColumn extends Item
     /**
      * Returns the blocks collection
      *
+     * @param bool $includeHidden Sets whether to include hidden blocks
      * @return \Kirby\Cms\Blocks
      */
-    public function blocks()
+    public function blocks(bool $includeHidden = false)
     {
+        if ($includeHidden === false) {
+            return $this->blocks->filter('isHidden', false);
+        }
+
         return $this->blocks;
     }
 
@@ -121,7 +126,7 @@ class LayoutColumn extends Item
     public function toArray(): array
     {
         return [
-            'blocks' => $this->blocks()->toArray(),
+            'blocks' => $this->blocks(true)->toArray(),
             'id'     => $this->id(),
             'width'  => $this->width(),
         ];

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -78,16 +78,17 @@ class Layouts extends Items
     /**
      * Converts layouts to blocks
      *
+     * @param bool $includeHidden Sets whether to include hidden blocks
      * @return \Kirby\Cms\Blocks
      */
-    public function toBlocks()
+    public function toBlocks(bool $includeHidden = false)
     {
         $blocks = [];
 
         if ($this->isNotEmpty() === true) {
             foreach ($this->data() as $layout) {
                 foreach ($layout->columns() as $column) {
-                    foreach ($column->blocks() as $block) {
+                    foreach ($column->blocks($includeHidden) as $block) {
                         $blocks[] = $block->toArray();
                     }
                 }

--- a/tests/Cms/Layouts/LayoutColumnTest.php
+++ b/tests/Cms/Layouts/LayoutColumnTest.php
@@ -27,6 +27,21 @@ class LayoutColumnTest extends TestCase
         $this->assertSame('text', $column->blocks()->last()->type());
     }
 
+    public function testHiddenBlocks()
+    {
+        $column = new LayoutColumn([
+            'blocks' => [
+                ['type' => 'heading'],
+                ['type' => 'text', 'isHidden' => true],
+            ]
+        ]);
+
+        $this->assertFalse($column->isEmpty());
+        $this->assertTrue($column->isNotEmpty());
+        $this->assertCount(1, $column->blocks());
+        $this->assertCount(2, $column->blocks(true));
+    }
+
     public function testSpan()
     {
         $column = new LayoutColumn([

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -137,4 +137,24 @@ class LayoutsTest extends TestCase
         $this->assertCount(2, $blocks);
         $this->assertInstanceOf('Kirby\Cms\Blocks', $blocks);
     }
+
+    public function testHiddenBlocks()
+    {
+        $data = [
+            [
+                'type'     => 'heading',
+                'content'  => ['text' => 'Heading'],
+            ],
+            [
+                'type'     => 'text',
+                'content'  => ['text' => 'Text'],
+                'isHidden' => true,
+            ]
+        ];
+
+        $layouts = Layouts::factory($data);
+
+        $this->assertCount(1, $layouts->toBlocks());
+        $this->assertCount(2, $layouts->toBlocks(true));
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

New usage

````php
$layouts->toBlocks(); // do not include hidden blocks
$layouts->toBlocks(true); // include hidden blocks

$column->blocks(); // do not include hidden blocks
$column->blocks(true); // include hidden blocks
````

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes
- Fixed showing hidden blocks in layout field #3857 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

- Hidden blocks in the layout field will no longer be visible as expected

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3857 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
