### PR TITLE
Undo breaking change in FieldClass::store

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -187,7 +187,7 @@ class BlocksField extends FieldClass
         ];
     }
 
-    public function store($value = null)
+    public function store($value)
     {
         $blocks = $this->blocksToValues((array)$value, 'content');
 

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -142,7 +142,7 @@ class LayoutField extends BlocksField
         return $this->settings;
     }
 
-    public function store($value = null)
+    public function store($value)
     {
         $value = Layouts::factory($value, ['parent' => $this->model])->toArray();
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -699,7 +699,7 @@ abstract class FieldClass
      * @param mixed $value
      * @return mixed
      */
-    public function store($value = null)
+    public function store($value)
     {
         return $value;
     }

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -511,9 +511,6 @@ class FieldClassTest extends TestCase
     public function testStore()
     {
         $field = new TestField();
-        $this->assertNull($field->store());
-
-        $field = new TestField();
         $this->assertSame('test', $field->store('test'));
     }
 


### PR DESCRIPTION
## Describe the PR

The `FieldClass::store` method introduced an unnecessary breaking change. This PR reverts that change. 

