### PR TITLE
Fix blocks stuck as selected in blocks within layout field 

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -465,7 +465,17 @@ export default {
     onOutsideFocus(event) {
       const overlay = document.querySelector(".k-overlay:last-of-type");
       if (this.$el.contains(event.target) === false && (!overlay || overlay.contains(event.target) === false)) {
-        this.select(null);
+        return this.select(null);
+      }
+
+      // since we are still working in the same block when overlay is open
+      // we cannot detect the transition between the layout columns
+      // following codes detect if the target is in the same column
+      if (overlay) {
+        const layoutColumn = this.$el.closest(".k-layout-column");
+        if (layoutColumn && layoutColumn.contains(event.target) === false) {
+          return this.select(null);
+        }
       }
     },
     onPaste(e) {


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Since we are still working in the same block when overlay is open, we cannot detect the transition between the layout columns. This PR codes detect if the target is in the same column. 

I'm not sure as it looks a bit hacky 🤷‍♂️ 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Fix blocks stuck as selected in blocks within layout field #3856

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3856

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
