### PR TITLE
Areas menu divider

### DIFF
--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -354,6 +354,11 @@ class View
                 continue;
             }
 
+            // available options for before divider: `before`, `both`, `true`
+            if (in_array($area['divider'] ?? false, ['before', 'both', true], true) === true) {
+                $menu[] = '-';
+            }
+
             $menu[] = [
                 'current'  => $areaId === $current,
                 'disabled' => $menuSetting === 'disabled',
@@ -362,6 +367,11 @@ class View
                 'link'     => $area['link'],
                 'text'     => $area['label'],
             ];
+
+            // available options for after divider: `after`, `both`
+            if (in_array($area['divider'] ?? false, ['after', 'both'], true) === true) {
+                $menu[] = '-';
+            }
         }
 
         $menu[] = '-';

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -589,6 +589,58 @@ class ViewTest extends TestCase
     /**
      * @covers ::menu
      */
+    public function testMenuAreasDivider()
+    {
+        $menu = View::menu(
+            [
+                'products' => [
+                    'icon'    => 'tag',
+                    'label'   => 'Products',
+                    'link'    => 'products',
+                    'menu'    => true,
+                    'divider' => true
+                ],
+                'orders' => [
+                    'icon'    => 'cart',
+                    'label'   => 'Orders',
+                    'link'    => 'orders',
+                    'menu'    => true,
+                    'divider' => 'both'
+                ],
+                'report' => [
+                    'icon'    => 'chart',
+                    'label'   => 'Report',
+                    'link'    => 'report',
+                    'menu'    => true,
+                    'divider' => 'after'
+                ],
+                'settings' => [
+                    'icon'    => 'settings',
+                    'label'   => 'Settings',
+                    'link'    => 'settings',
+                    'menu'    => true
+                ],
+            ],
+        );
+
+        $this->assertCount(12, $menu);
+        $this->assertSame('-', $menu[0]);
+        $this->assertSame('products', $menu[1]['id']);
+        $this->assertSame('-', $menu[2]);
+        $this->assertSame('orders', $menu[3]['id']);
+        $this->assertSame('-', $menu[4]);
+        $this->assertSame('report', $menu[5]['id']);
+        $this->assertSame('-', $menu[6]);
+        $this->assertSame('settings', $menu[7]['id']);
+        $this->assertSame('-', $menu[8]);
+        $this->assertSame('account', $menu[9]['id']);
+        $this->assertSame('-', $menu[10]);
+        $this->assertSame('logout', $menu[11]['id']);
+    }
+
+    /**
+     * @covers ::menu
+     */
     public function testMenuAccess()
     {
         $menu = View::menu(


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Now a divider can be added between the menus. 

Available options:
- `true`: adds before
- `before`: adds before
- `after`: adds after
- `both`: adds before and after \*

\* We can give a more understandable name for `both`, or we can use the true option as `both`, just `true`, `before`, `after`

### Sample usage

```php
return [
    'products' => [
        'icon'    => 'tag',
        'label'   => 'Products',
        'link'    => 'products',
        'menu'    => true,
        'divider' => true
    ],
    'orders' => [
        'icon'    => 'cart',
        'label'   => 'Orders',
        'link'    => 'orders',
        'menu'    => true,
        'divider' => 'both'
    ],
    'report' => [
        'icon'    => 'chart',
        'label'   => 'Report',
        'link'    => 'report',
        'menu'    => true,
        'divider' => 'after'
    ],
    'settings' => [
        'icon'    => 'settings',
        'label'   => 'Settings',
        'link'    => 'settings',
        'menu'    => true
    ],
];
````

### Output of sample
````
---
Products
---
Orders
---
Report
---
Settings
````

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements

- Areas menu divider


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
