### PR TITLE
Detect server port also via HTTP_HOST

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -119,13 +119,21 @@ class Server
      */
     public static function port(bool $forwarded = false): int
     {
-        $port = $forwarded === true ? static::get('HTTP_X_FORWARDED_PORT') : null;
-
-        if (empty($port) === true) {
-            $port = static::get('SERVER_PORT');
+        // based on forwarded port
+        if ($forwarded === true) {
+            if ($port = static::get('HTTP_X_FORWARDED_PORT')) {
+                return $port;
+            }
         }
 
-        return $port;
+        // based on HTTP host
+        $host = static::get('HTTP_HOST');
+        if ($pos = strpos($host, ':')) {
+            return (int)substr($host, $pos + 1);
+        }
+
+        // based on server port
+        return static::get('SERVER_PORT');
     }
 
     /**

--- a/tests/Http/ServerTest.php
+++ b/tests/Http/ServerTest.php
@@ -32,6 +32,10 @@ class ServerTest extends TestCase
         // SERVER_PORT
         $_SERVER['SERVER_PORT'] = 777;
         $this->assertEquals(777, Server::port());
+
+        // HTTP_HOST
+        $_SERVER['HTTP_HOST'] = 'localhost:776';
+        $this->assertEquals(776, Server::port());
     }
 
     public function testForwardedPort()


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- Support port detection via HTTP_HOST for non-standard http port


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3645

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
