### PR TITLE
Bring back autoprefixer for CSS

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -23,6 +23,7 @@
         "vuex": "^3.6.2"
       },
       "devDependencies": {
+        "autoprefixer": "^10.4.0",
         "cypress": "^8.5.0",
         "eslint": "^7.32.0",
         "eslint-plugin-cypress": "^2.12.1",
@@ -1310,6 +1311,33 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
+      "integrity": "sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.17.5",
+        "caniuse-lite": "^1.0.30001272",
+        "fraction.js": "^4.1.1",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/autosize": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-5.0.1.tgz",
@@ -2062,16 +2090,16 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.2.tgz",
-      "integrity": "sha512-jSDZyqJmkKMEMi7SZAgX5UltFdR5NAO43vY0AwTpu4X3sGH7GLLQ83KiUomgrnvZRCeW0yPPnKqnxPqQOER9zQ==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
+      "integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001261",
-        "electron-to-chromium": "^1.3.854",
+        "caniuse-lite": "^1.0.30001271",
+        "electron-to-chromium": "^1.3.878",
         "escalade": "^3.1.1",
-        "nanocolors": "^0.2.12",
-        "node-releases": "^1.1.76"
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2134,9 +2162,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001263",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001263.tgz",
-      "integrity": "sha512-doiV5dft6yzWO1WwU19kt8Qz8R0/8DgEziz6/9n2FxUasteZNwNNYSmJO3GLBH8lCVE73AB1RPDPAeYbcO5Cvw==",
+      "version": "1.0.30001272",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
+      "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2576,9 +2604,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.857",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz",
-      "integrity": "sha512-a5kIr2lajm4bJ5E4D3fp8Y/BRB0Dx2VOcCRE5Gtb679mXIME/OFhWler8Gy2ksrf8gFX+EFCSIGA33FB3gqYpg==",
+      "version": "1.3.885",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.885.tgz",
+      "integrity": "sha512-JXKFJcVWrdHa09n4CNZYfYaK6EW5aAew7/wr3L1OnsD1L+JHL+RCtd7QgIsxUbFPeTwPlvnpqNNTOLkoefmtXg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3317,6 +3345,19 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
       }
     },
     "node_modules/fs-extra": {
@@ -4273,10 +4314,19 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "1.1.77",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
-      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -4414,6 +4464,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4507,6 +4563,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6876,6 +6938,20 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
+    "autoprefixer": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
+      "integrity": "sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.17.5",
+        "caniuse-lite": "^1.0.30001272",
+        "fraction.js": "^4.1.1",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
     "autosize": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-5.0.1.tgz",
@@ -7597,16 +7673,16 @@
       }
     },
     "browserslist": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.2.tgz",
-      "integrity": "sha512-jSDZyqJmkKMEMi7SZAgX5UltFdR5NAO43vY0AwTpu4X3sGH7GLLQ83KiUomgrnvZRCeW0yPPnKqnxPqQOER9zQ==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
+      "integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001261",
-        "electron-to-chromium": "^1.3.854",
+        "caniuse-lite": "^1.0.30001271",
+        "electron-to-chromium": "^1.3.878",
         "escalade": "^3.1.1",
-        "nanocolors": "^0.2.12",
-        "node-releases": "^1.1.76"
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -7644,9 +7720,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001263",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001263.tgz",
-      "integrity": "sha512-doiV5dft6yzWO1WwU19kt8Qz8R0/8DgEziz6/9n2FxUasteZNwNNYSmJO3GLBH8lCVE73AB1RPDPAeYbcO5Cvw==",
+      "version": "1.0.30001272",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
+      "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
       "dev": true
     },
     "caseless": {
@@ -7995,9 +8071,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.857",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz",
-      "integrity": "sha512-a5kIr2lajm4bJ5E4D3fp8Y/BRB0Dx2VOcCRE5Gtb679mXIME/OFhWler8Gy2ksrf8gFX+EFCSIGA33FB3gqYpg==",
+      "version": "1.3.885",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.885.tgz",
+      "integrity": "sha512-JXKFJcVWrdHa09n4CNZYfYaK6EW5aAew7/wr3L1OnsD1L+JHL+RCtd7QgIsxUbFPeTwPlvnpqNNTOLkoefmtXg==",
       "dev": true
     },
     "emoji-regex": {
@@ -8514,6 +8590,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "fraction.js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "dev": true
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -9249,9 +9331,15 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.77",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
-      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "dev": true
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "npm-run-path": {
@@ -9360,6 +9448,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -9417,6 +9511,12 @@
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/panel/package.json
+++ b/panel/package.json
@@ -28,6 +28,7 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
+    "autoprefixer": "^10.4.0",
     "cypress": "^8.5.0",
     "eslint": "^7.32.0",
     "eslint-plugin-cypress": "^2.12.1",
@@ -41,5 +42,20 @@
     "vue-docgen-api": "^4.41.2",
     "vue-template-compiler": "^2.6.14",
     "wait-on": "^6.0.0"
-  }
+  },
+  "browserslist": [
+    "last 2 Android versions",
+    "last 2 Chrome versions",
+    "last 2 ChromeAndroid versions",
+    "last 2 Edge versions",
+    "last 2 Firefox versions",
+    "last 2 FirefoxAndroid versions",
+    "last 2 iOS versions",
+    "last 2 KaiOS versions",
+    "last 2 Safari versions",
+    "last 2 Samsung versions",
+    "last 2 Opera versions",
+    "last 2 OperaMobile versions",
+    "last 2 UCAndroid versions"
+  ]
 }

--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -2,10 +2,11 @@ import fs from "fs";
 import path from "path";
 import { defineConfig } from "vite";
 import { createVuePlugin } from "vite-plugin-vue2";
-import pluginRewriteAll from "vite-plugin-rewrite-all";
+import postcssAutoprefixer from "autoprefixer";
 import postcssCsso from "postcss-csso";
-import postcssLogical from "postcss-logical";
 import postcssDirPseudoClass from "postcss-dir-pseudo-class";
+import postcssLogical from "postcss-logical";
+import pluginRewriteAll from "vite-plugin-rewrite-all";
 
 let custom;
 try {
@@ -69,7 +70,8 @@ export default defineConfig(({ command }) => {
         plugins: [
           postcssLogical(),
           postcssDirPseudoClass(),
-          postcssCsso()
+          postcssCsso(),
+          postcssAutoprefixer()
         ]
       }
     },


### PR DESCRIPTION
## Describe the PR

When switching to `vite`, I missed adding `autoprefixer`.
Increases CSS size a little but solves regressions.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed regressions
- CSS gets auto prefixed again (e.g. solves issue with toggle field in Safari)


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3865

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
