### PR TITLE
CI: Update tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           extensions: ${{ env.extensions }}
           ini-values: ${{ env.ini }}
           coverage: pcov
-          tools: phpunit:9.5.4, psalm:4.7.1
+          tools: phpunit:9.5.10, psalm:4.11.2
 
       - name: Setup problem matchers
         run: |
@@ -246,8 +246,8 @@ jobs:
           extensions: ${{ env.extensions }}
           coverage: none
           tools: |
-            composer:2.0.13, composer-normalize:2.13.3, composer-require-checker:3.2.0,
-            composer-unused:0.7.5, phpcpd:6.0.3, phpmd:2.10.0
+            composer:2.1.10, composer-normalize:2.15.0, composer-require-checker:3.3.0,
+            composer-unused:0.7.7, phpcpd:6.0.3, phpmd:2.10.2
 
       - name: Validate composer.json/composer.lock
         if: always() && steps.finishPrepare.outcome == 'success'
@@ -306,7 +306,7 @@ jobs:
         with:
           php-version: ${{ env.php }}
           coverage: none
-          tools: php-cs-fixer:3.0.0
+          tools: php-cs-fixer:3.2.1
 
       - name: Cache analysis data
         id: finishPrepare

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -165,16 +165,16 @@ class Collection extends BaseCollection
      * Checks if the given object or id
      * is in the collection
      *
-     * @param string|object $id
+     * @param string|object $key
      * @return bool
      */
-    public function has($id): bool
+    public function has($key): bool
     {
-        if (is_object($id) === true) {
-            $id = $id->id();
+        if (is_object($key) === true) {
+            $key = $key->id();
         }
 
-        return parent::has($id);
+        return parent::has($key);
     }
 
     /**
@@ -182,16 +182,16 @@ class Collection extends BaseCollection
      * The method will automatically detect objects
      * or ids and then search accordingly.
      *
-     * @param string|object $object
+     * @param string|object $needle
      * @return int
      */
-    public function indexOf($object): int
+    public function indexOf($needle): int
     {
-        if (is_string($object) === true) {
-            return array_search($object, $this->keys());
+        if (is_string($needle) === true) {
+            return array_search($needle, $this->keys());
         }
 
-        return array_search($object->id(), $this->keys());
+        return array_search($needle->id(), $this->keys());
     }
 
     /**
@@ -270,17 +270,17 @@ class Collection extends BaseCollection
      * offset, limit, search and paginate on the collection.
      * Any part of the query is optional.
      *
-     * @param array $query
+     * @param array $arguments
      * @return static
      */
-    public function query(array $query = [])
+    public function query(array $arguments = [])
     {
-        $paginate = $query['paginate'] ?? null;
-        $search   = $query['search'] ?? null;
+        $paginate = $arguments['paginate'] ?? null;
+        $search   = $arguments['search'] ?? null;
 
-        unset($query['paginate']);
+        unset($arguments['paginate']);
 
-        $result = parent::query($query);
+        $result = parent::query($arguments);
 
         if (empty($search) === false) {
             if (is_array($search) === true) {

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -18,6 +18,14 @@ abstract class Model
     use Properties;
 
     /**
+     * Each model must define a CLASS_ALIAS
+     * which will be used in template queries.
+     * The CLASS_ALIAS is a short human-readable
+     * version of the class name. I.e. page.
+     */
+    const CLASS_ALIAS = null;
+
+    /**
      * The parent Kirby instance
      *
      * @var \Kirby\Cms\App

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -21,14 +21,6 @@ use Throwable;
 abstract class ModelWithContent extends Model
 {
     /**
-     * Each model must define a CLASS_ALIAS
-     * which will be used in template queries.
-     * The CLASS_ALIAS is a short human-readable
-     * version of the class name. I.e. page.
-     */
-    const CLASS_ALIAS = null;
-
-    /**
      * The content
      *
      * @var \Kirby\Cms\Content


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

I've updated all CI tools to their latest version so that we can run CI with PHP 8.1 in a next step.

Psalm has some new features and improvements that catch more issues, so I fixed them in this PR as well.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

The changes to argument names are technically breaking changes as they will break PHP 8.0 named arguments. But I think the probability that anyone used named arguments for methods that have just one argument is pretty pretty low.

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->