### PR TITLE
Fix inline docs for `cardlets` layout option

### DIFF
--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -5,9 +5,10 @@ use Kirby\Toolkit\A;
 
 return [
     'mixins' => [
-        'picker',
         'filepicker',
+        'layout',
         'min',
+        'picker',
         'upload'
     ],
     'props' => [
@@ -25,20 +26,6 @@ return [
          */
         'default' => function ($default = null) {
             return $default;
-        },
-
-        /**
-         * Changes the layout of the selected files. Available layouts: `list`, `cards`
-         */
-        'layout' => function (string $layout = 'list') {
-            return $layout;
-        },
-
-        /**
-         * Layout size for cards: `tiny`, `small`, `medium`, `large` or `huge`
-         */
-        'size' => function (string $size = 'auto') {
-            return $size;
         },
 
         'value' => function ($value = null) {

--- a/config/fields/mixins/layout.php
+++ b/config/fields/mixins/layout.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    'props' => [
+        /**
+         * Changes the layout of the selected entries.
+         * Available layouts: `list`, `cardlets`, `cards`
+         */
+        'layout' => function (string $layout = 'list') {
+            $layouts = ['list', 'cardlets', 'cards'];
+            return in_array($layout, $layouts) ? $layout : 'list';
+        },
+
+        /**
+         * Layout size for cards: `tiny`, `small`, `medium`, `large` or `huge`
+         */
+        'size' => function (string $size = 'auto') {
+            return $size;
+        },
+    ]
+];

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -4,7 +4,12 @@ use Kirby\Data\Data;
 use Kirby\Toolkit\A;
 
 return [
-    'mixins' => ['min', 'pagepicker', 'picker'],
+    'mixins' => [
+        'layout',
+        'min',
+        'pagepicker',
+        'picker',
+    ],
     'props' => [
         /**
          * Unset inherited props
@@ -23,24 +28,10 @@ return [
         },
 
         /**
-         * Changes the layout of the selected files. Available layouts: `list`, `cards`
-         */
-        'layout' => function (string $layout = 'list') {
-            return $layout;
-        },
-
-        /**
          * Optional query to select a specific set of pages
          */
         'query' => function (string $query = null) {
             return $query;
-        },
-
-        /**
-         * Layout size for cards: `tiny`, `small`, `medium`, `large` or `huge`
-         */
-        'size' => function (string $size = 'auto') {
-            return $size;
         },
 
         /**

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -4,7 +4,12 @@ use Kirby\Data\Data;
 use Kirby\Toolkit\A;
 
 return [
-    'mixins' => ['min', 'picker', 'userpicker'],
+    'mixins' => [
+        'layout',
+        'min',
+        'picker',
+        'userpicker'
+    ],
     'props' => [
         /**
          * Unset inherited props

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -28,7 +28,7 @@ return [
             return $image ?? [];
         },
         /**
-         * Optional info text setup. Info text is shown on the right (lists) or below (cards) the filename.
+         * Optional info text setup. Info text is shown on the right (lists, cardlets) or below (cards) the filename.
          */
         'info' => function ($info = null) {
             return I18n::translate($info, $info);

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -3,7 +3,8 @@
 return [
     'props' => [
         /**
-         * Section layout. Available layout methods: `list`, `cardlets`, `cards`.
+         * Section layout.
+         * Available layout methods: `list`, `cardlets`, `cards`.
          */
         'layout' => function (string $layout = 'list') {
             $layouts = ['list', 'cardlets', 'cards'];

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -218,6 +218,7 @@ class Core
         return [
             'datetime'   => $this->root . '/fields/mixins/datetime.php',
             'filepicker' => $this->root . '/fields/mixins/filepicker.php',
+            'layout'     => $this->root . '/fields/mixins/layout.php',
             'min'        => $this->root . '/fields/mixins/min.php',
             'options'    => $this->root . '/fields/mixins/options.php',
             'pagepicker' => $this->root . '/fields/mixins/pagepicker.php',

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -203,6 +203,7 @@ class CoreTest extends TestCase
         $this->assertArrayHasKey('datetime', $mixins);
         $this->assertArrayHasKey('filepicker', $mixins);
         $this->assertArrayHasKey('min', $mixins);
+        $this->assertArrayHasKey('layout', $mixins);
         $this->assertArrayHasKey('options', $mixins);
         $this->assertArrayHasKey('pagepicker', $mixins);
         $this->assertArrayHasKey('picker', $mixins);


### PR DESCRIPTION
## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed regression
- Fixed inline docs for `cardlets` layout option


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3881

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
