### PR TITLE
PHP 7.4 feature: `strip_tags` with array of tags

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -384,7 +384,7 @@ return function (App $app) {
             // Obsolete elements, script tags, image maps and form elements have
             // been excluded for safety reasons and as they are most likely not
             // needed in most cases.
-            $field->value = strip_tags($field->value, '<b><i><small><abbr><cite><code><dfn><em><kbd><strong><samp><var><a><bdo><br><img><q><span><sub><sup>');
+            $field->value = strip_tags($field->value, Html::$inlineList);
             return $field;
         },
 

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -25,6 +25,34 @@ class Html extends Xml
     public static $entities;
 
     /**
+     * List of HTML tags that can be used inline
+     *
+     * @var array
+     */
+    public static $inlineList = [
+        'b',
+        'i',
+        'small',
+        'abbr',
+        'cite',
+        'code',
+        'dfn',
+        'em',
+        'kbd',
+        'strong',
+        'samp',
+        'var',
+        'a',
+        'bdo',
+        'br',
+        'img',
+        'q',
+        'span',
+        'sub',
+        'sup'
+    ];
+
+    /**
      * Closing string for void tags;
      * can be used to switch to trailing slashes if required
      *


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- [x] Requires PHP 7.3 to be dropped

- Uses `strip_tags` with array of tags
- Adds `Toolkit\Html::$inlineList` with array of tags that are allowed in inline context

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] ~~Add changes to release notes draft in Notion~~
