### PR TITLE
PHP 7.4 feature: null coalescing assignment operator

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -74,7 +74,7 @@ class Blueprint
         $props = $this->preset($props);
 
         // normalize the name
-        $props['name'] = $props['name'] ?? 'default';
+        $props['name'] ??= 'default';
 
         // normalize and translate the title
         $props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
@@ -337,7 +337,7 @@ class Blueprint
 
         $normalize = function ($props) use ($name) {
             // inject the filename as name if no name is set
-            $props['name'] = $props['name'] ?? $name;
+            $props['name'] ??= $name;
 
             // normalize the title
             $title = $props['title'] ?? ucfirst($props['name']);
@@ -577,7 +577,7 @@ class Blueprint
             $alias = $aliases[$key] ?? null;
 
             if ($alias !== null) {
-                $options[$alias] = $options[$alias] ?? $value;
+                $options[$alias] ??= $value;
                 unset($options[$key]);
             }
         }

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -208,7 +208,7 @@ class ContentLock
         }
 
         // add lock user to unlocked data
-        $this->data['unlock']   = $this->data['unlock'] ?? [];
+        $this->data['unlock'] ??= [];
         $this->data['unlock'][] = $this->data['lock']['user'];
 
         return $this->clearLock();

--- a/src/Cms/ContentTranslation.php
+++ b/src/Cms/ContentTranslation.php
@@ -208,7 +208,7 @@ class ContentTranslation
      */
     public function slug(): ?string
     {
-        return $this->slug = $this->slug ?? ($this->content()['slug'] ?? null);
+        return $this->slug ??= ($this->content()['slug'] ?? null);
     }
 
     /**

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -167,7 +167,7 @@ class Core
      */
     public function components(): array
     {
-        return $this->cache['components'] ?? $this->cache['components'] = include $this->root . '/components.php';
+        return $this->cache['components'] ??= include $this->root . '/components.php';
     }
 
     /**
@@ -203,7 +203,7 @@ class Core
      */
     public function fieldMethods(): array
     {
-        return $this->cache['fieldMethods'] ?? $this->cache['fieldMethods'] = (include $this->root . '/methods.php')($this->kirby);
+        return $this->cache['fieldMethods'] ??= (include $this->root . '/methods.php')($this->kirby);
     }
 
     /**
@@ -295,7 +295,7 @@ class Core
      */
     public function kirbyTags(): array
     {
-        return $this->cache['kirbytags'] ?? $this->cache['kirbytags'] = include $this->root . '/tags.php';
+        return $this->cache['kirbytags'] ??= include $this->root . '/tags.php';
     }
 
     /**
@@ -321,7 +321,7 @@ class Core
      */
     public function roots(): array
     {
-        return $this->cache['roots'] ?? $this->cache['roots'] = [
+        return $this->cache['roots'] ??= [
             // kirby
             'kirby' => function (array $roots) {
                 return dirname(__DIR__, 2);
@@ -428,7 +428,7 @@ class Core
      */
     public function routes(): array
     {
-        return $this->cache['routes'] ?? $this->cache['routes'] = (include $this->root . '/routes.php')($this->kirby);
+        return $this->cache['routes'] ??= (include $this->root . '/routes.php')($this->kirby);
     }
 
     /**
@@ -517,7 +517,7 @@ class Core
      */
     public function urls(): array
     {
-        return $this->cache['urls'] ?? $this->cache['urls'] = [
+        return $this->cache['urls'] ??= [
             'index' => function () {
                 return Url::index();
             },

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -43,7 +43,7 @@ class Fieldsets extends Items
             $fieldset = Blueprint::extend($fieldset);
 
             // make sure the type is always set
-            $fieldset['type'] = $fieldset['type'] ?? $type;
+            $fieldset['type'] ??= $type;
 
             // extract groups
             if ($fieldset['type'] === 'group') {
@@ -70,7 +70,7 @@ class Fieldsets extends Items
 
     public static function factory(array $items = null, array $params = [])
     {
-        $items = $items ?? option('blocks.fieldsets', [
+        $items ??= option('blocks.fieldsets', [
             'code'     => 'blocks/code',
             'gallery'  => 'blocks/gallery',
             'heading'  => 'blocks/heading',

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -367,7 +367,7 @@ class File extends ModelWithContent
             return $modified;
         }
 
-        $handler = $handler ?? $this->kirby()->option('date.handler', 'date');
+        $handler ??= $this->kirby()->option('date.handler', 'date');
 
         return $handler($format, $modified);
     }
@@ -422,7 +422,7 @@ class File extends ModelWithContent
      */
     public function parent()
     {
-        return $this->parent = $this->parent ?? $this->kirby()->site();
+        return $this->parent ??= $this->kirby()->site();
     }
 
     /**
@@ -472,7 +472,7 @@ class File extends ModelWithContent
      */
     public function root(): ?string
     {
-        return $this->root = $this->root ?? $this->parent()->root() . '/' . $this->filename();
+        return $this->root ??= $this->parent()->root() . '/' . $this->filename();
     }
 
     /**
@@ -598,7 +598,7 @@ class File extends ModelWithContent
      */
     public function template(): ?string
     {
-        return $this->template = $this->template ?? $this->content()->get('template')->value();
+        return $this->template ??= $this->content()->get('template')->value();
     }
 
     /**
@@ -631,7 +631,7 @@ class File extends ModelWithContent
      */
     public function url(): string
     {
-        return $this->url ?? $this->url = ($this->kirby()->component('file::url'))($this->kirby(), $this);
+        return $this->url ??= ($this->kirby()->component('file::url'))($this->kirby(), $this);
     }
 
 

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -88,8 +88,9 @@ class Languages extends Collection
             $props = F::load($file);
 
             if (is_array($props) === true) {
-                // inject the language code from the filename if it does not exist
-                $props['code'] = $props['code'] ?? F::name($file);
+                // inject the language code from the filename
+                // if it does not exist
+                $props['code'] ??= F::name($file);
 
                 $languages[] = new Language($props);
             }

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -67,7 +67,7 @@ abstract class Model
      */
     public function kirby()
     {
-        return static::$kirby = static::$kirby ?? App::instance();
+        return static::$kirby ??= App::instance();
     }
 
     /**
@@ -77,7 +77,7 @@ abstract class Model
      */
     public function site()
     {
-        return $this->site = $this->site ?? $this->kirby()->site();
+        return $this->site ??= $this->kirby()->site();
     }
 
     /**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -382,7 +382,7 @@ class Page extends ModelWithContent
      */
     public function depth(): int
     {
-        return $this->depth = $this->depth ?? (substr_count($this->id(), '/') + 1);
+        return $this->depth ??= (substr_count($this->id(), '/') + 1);
     }
 
     /**
@@ -1102,7 +1102,7 @@ class Page extends ModelWithContent
      */
     public function root(): string
     {
-        return $this->root = $this->root ?? $this->kirby()->root('content') . '/' . $this->diruri();
+        return $this->root ??= $this->kirby()->root('content') . '/' . $this->diruri();
     }
 
     /**

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -151,7 +151,7 @@ class Pages extends Collection
      */
     public static function factory(array $pages, Model $model = null, bool $draft = false)
     {
-        $model    = $model ?? App::instance()->site();
+        $model  ??= App::instance()->site();
         $children = new static([], $model);
         $kirby    = $model->kirby();
 

--- a/src/Cms/Pagination.php
+++ b/src/Cms/Pagination.php
@@ -69,9 +69,9 @@ class Pagination extends BasePagination
         $config  = $kirby->option('pagination', []);
         $request = $kirby->request();
 
-        $params['limit']    = $params['limit']    ?? $config['limit']    ?? 20;
-        $params['method']   = $params['method']   ?? $config['method']   ?? 'param';
-        $params['variable'] = $params['variable'] ?? $config['variable'] ?? 'page';
+        $params['limit']    ??= $config['limit']    ?? 20;
+        $params['method']   ??= $config['method']   ?? 'param';
+        $params['variable'] ??= $config['variable'] ?? 'page';
 
         if (empty($params['url']) === true) {
             $params['url'] = new Uri($kirby->url('current'), [
@@ -81,9 +81,9 @@ class Pagination extends BasePagination
         }
 
         if ($params['method'] === 'query') {
-            $params['page'] = $params['page'] ?? $params['url']->query()->get($params['variable']);
+            $params['page'] ??= $params['url']->query()->get($params['variable']);
         } elseif ($params['method'] === 'param') {
-            $params['page'] = $params['page'] ?? $params['url']->params()->get($params['variable']);
+            $params['page'] ??= $params['url']->params()->get($params['variable']);
         }
 
         parent::__construct($params);

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -210,7 +210,7 @@ class Role extends Model
      */
     public function title(): string
     {
-        return $this->title = $this->title ?? ucfirst($this->name());
+        return $this->title ??= ucfirst($this->name());
     }
 
     /**

--- a/src/Cms/Section.php
+++ b/src/Cms/Section.php
@@ -49,8 +49,8 @@ class Section extends Component
         }
 
         // use the type as fallback for the name
-        $attrs['name'] = $attrs['name'] ?? $type;
-        $attrs['type'] = $type;
+        $attrs['name'] ??= $type;
+        $attrs['type']   = $type;
 
         parent::__construct($type, $attrs);
     }

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -463,7 +463,7 @@ class Site extends ModelWithContent
      */
     public function root(): string
     {
-        return $this->root = $this->root ?? $this->kirby()->root('content');
+        return $this->root ??= $this->kirby()->root('content');
     }
 
     /**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -228,7 +228,7 @@ class User extends ModelWithContent
 
     protected function credentials(): array
     {
-        return $this->credentials = $this->credentials ?? $this->readCredentials();
+        return $this->credentials ??= $this->readCredentials();
     }
 
     /**
@@ -238,7 +238,7 @@ class User extends ModelWithContent
      */
     public function email(): ?string
     {
-        return $this->email = $this->email ?? $this->credentials()['email'] ?? null;
+        return $this->email ??= $this->credentials()['email'] ?? null;
     }
 
     /**
@@ -403,7 +403,7 @@ class User extends ModelWithContent
      */
     public function language(): string
     {
-        return $this->language ?? $this->language = $this->credentials()['language'] ?? $this->kirby()->panelLanguage();
+        return $this->language ??= $this->credentials()['language'] ?? $this->kirby()->panelLanguage();
     }
 
     /**
@@ -530,7 +530,7 @@ class User extends ModelWithContent
         $modifiedContent = F::modified($this->contentFile($languageCode));
         $modifiedIndex   = F::modified($this->root() . '/index.php');
         $modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
-        $handler         = $handler ?? $this->kirby()->option('date.handler', 'date');
+        $handler       ??= $this->kirby()->option('date.handler', 'date');
 
         return $handler($format, $modifiedTotal);
     }

--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -45,7 +45,7 @@ class Db
 
         // try to connect with the default
         // connection settings if no params are set
-        $defaults = [
+        $params ??= [
             'type'     => Config::get('db.type', 'mysql'),
             'host'     => Config::get('db.host', 'localhost'),
             'user'     => Config::get('db.user', 'root'),
@@ -54,7 +54,6 @@ class Db
             'prefix'   => Config::get('db.prefix', ''),
             'port'     => Config::get('db.port', '')
         ];
-        $params = $params ?? $defaults;
 
         return static::$connection = new Database($params);
     }

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -527,7 +527,7 @@ abstract class Sql
             ];
         }
 
-        $limit = $limit ?? '18446744073709551615';
+        $limit ??= '18446744073709551615';
 
         $offsetBinding = $this->bindingName('offset');
         $limitBinding  = $this->bindingName('limit');

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -504,8 +504,8 @@ class Dir
         }
 
         // create the ignore pattern
-        $ignore = $ignore ?? static::$ignore;
-        $ignore = array_merge($ignore, ['.', '..']);
+        $ignore ??= static::$ignore;
+        $ignore   = array_merge($ignore, ['.', '..']);
 
         // scan for all files and dirs
         $result = array_values((array)array_diff(scandir($dir), $ignore));

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -320,7 +320,7 @@ class Mime
         }
 
         // get the extension or extract it from the filename
-        $extension = $extension ?? F::extension($file);
+        $extension ??= F::extension($file);
 
         // try to guess the mime type at least
         if ($mime === false) {

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -71,8 +71,8 @@ class Field extends Component
         $this->formFields = $formFields;
 
         // use the type as fallback for the name
-        $attrs['name'] = $attrs['name'] ?? $type;
-        $attrs['type'] = $type;
+        $attrs['name'] ??= $type;
+        $attrs['type']   = $type;
 
         parent::__construct($type, $attrs);
     }

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -49,7 +49,7 @@ class BlocksField extends FieldClass
                 $type = $block['type'];
 
                 // get and cache fields at the same time
-                $fields[$type] = $fields[$type] ?? $this->fields($block['type']);
+                $fields[$type] ??= $this->fields($block['type']);
 
                 // overwrite the block content with form values
                 $block['content'] = $this->form($fields[$type], $block['content'])->$to();

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -29,7 +29,7 @@ class Fields extends Collection
     {
         if (is_array($field) === true) {
             // use the array key as name if the name is not set
-            $field['name'] = $field['name'] ?? $name;
+            $field['name'] ??= $name;
             $field = Field::factory($field['type'], $field, $this);
         }
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -268,9 +268,9 @@ class Form
         }
 
         // set a few defaults
-        $props['values'] = array_merge($original, $values);
-        $props['fields'] = $props['fields'] ?? [];
-        $props['model']  = $model;
+        $props['values']   = array_merge($original, $values);
+        $props['fields'] ??= [];
+        $props['model']    = $model;
 
         // search for the blueprint
         if (method_exists($model, 'blueprint') === true && $blueprint = $model->blueprint()) {

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -45,10 +45,10 @@ class Options
      */
     public static function api($api, $model = null): array
     {
-        $model = $model ?? App::instance()->site();
-        $fetch = null;
-        $text  = null;
-        $value = null;
+        $model ??= App::instance()->site();
+        $fetch   = null;
+        $text    = null;
+        $value   = null;
 
         if (is_array($api) === true) {
             $fetch = $api['fetch'] ?? null;
@@ -165,7 +165,7 @@ class Options
      */
     public static function query($query, $model = null): array
     {
-        $model = $model ?? App::instance()->site();
+        $model ??= App::instance()->site();
 
         // default text setup
         $text = [

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -174,7 +174,7 @@ class Request
      */
     public function body()
     {
-        return $this->body = $this->body ?? new Body();
+        return $this->body ??= new Body();
     }
 
     /**
@@ -269,7 +269,7 @@ class Request
      */
     public function files()
     {
-        return $this->files = $this->files ?? new Files();
+        return $this->files ??= new Files();
     }
 
     /**
@@ -379,7 +379,7 @@ class Request
      */
     public function query()
     {
-        return $this->query = $this->query ?? new Query();
+        return $this->query ??= new Query();
     }
 
     /**
@@ -407,6 +407,6 @@ class Request
             return $this->url()->clone($props);
         }
 
-        return $this->url = $this->url ?? Uri::current();
+        return $this->url ??= Uri::current();
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -160,10 +160,10 @@ class Response
             throw new Exception('The file could not be found');
         }
 
-        $filename = $filename ?? basename($file);
-        $modified = filemtime($file);
-        $body     = file_get_contents($file);
-        $size     = strlen($body);
+        $filename ??= basename($file);
+        $modified   = filemtime($file);
+        $body       = file_get_contents($file);
+        $size       = strlen($body);
 
         $props = array_replace_recursive([
             'body'    => $body,

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -92,7 +92,7 @@ class Router
      */
     public function call(string $path = null, string $method = 'GET', Closure $callback = null)
     {
-        $path   = $path ?? '';
+        $path ??= '';
         $ignore = [];
         $result = null;
         $loop   = true;

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -144,10 +144,10 @@ class Uri
 
         // parse the path and extract params
         if (empty($props['path']) === false) {
-            $extract         = Params::extract($props['path']);
-            $props['params'] = $props['params'] ?? $extract['params'];
-            $props['path']   = $extract['path'];
-            $props['slash']  = $props['slash'] ?? $extract['slash'];
+            $extract           = Params::extract($props['path']);
+            $props['params'] ??= $extract['params'];
+            $props['path']     = $extract['path'];
+            $props['slash']  ??= $extract['slash'];
         }
 
         $this->setProperties($this->props = $props);

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -145,8 +145,8 @@ class Url
         }
 
         // build the full url
-        $path = ltrim($path, '/');
-        $home = $home ?? static::home();
+        $path   = ltrim($path, '/');
+        $home ??= static::home();
 
         if (empty($path) === true) {
             return $home;

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -116,7 +116,7 @@ class Image extends File
      */
     public function exif()
     {
-        return $this->exif = $this->exif ?? new Exif($this);
+        return $this->exif ??= new Exif($this);
     }
 
     /**

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -316,7 +316,7 @@ class File extends Model
             $absolute = $parent !== $params['model'];
         }
 
-        $params['text'] = $params['text'] ?? '{{ file.filename }}';
+        $params['text'] ??= '{{ file.filename }}';
 
         return array_merge(parent::pickerData($params), [
             'filename' => $name,

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -68,7 +68,7 @@ abstract class Json
         }
 
         // always inject the response code
-        $data['code']     = $data['code']    ?? 200;
+        $data['code']   ??= 200;
         $data['path']     = $options['path'] ?? null;
         $data['referrer'] = Panel::referrer();
 

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -77,7 +77,7 @@ abstract class Model
      */
     public function dragTextType(string $type = null): string
     {
-        $type = $type ?? 'auto';
+        $type ??= 'auto';
 
         if ($type === 'auto') {
             $type = option('panel.kirbytext', true) ? 'kirbytext' : 'markdown';

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -231,7 +231,7 @@ class Page extends Model
      */
     public function pickerData(array $params = []): array
     {
-        $params['text'] = $params['text'] ?? '{{ page.title }}';
+        $params['text'] ??= '{{ page.title }}';
 
         return array_merge(parent::pickerData($params), [
             'dragText'    => $this->dragText(),

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -36,14 +36,14 @@ class Panel
      */
     public static function area(string $id, $area): array
     {
-        $area['id']              = $id;
-        $area['label']           = $area['label'] ?? $id;
-        $area['breadcrumb']      = $area['breadcrumb'] ?? [];
-        $area['breadcrumbLabel'] = $area['breadcrumbLabel'] ?? $area['label'];
-        $area['title']           = $area['label'];
-        $area['menu']            = $area['menu'] ?? false;
-        $area['link']            = $area['link'] ?? $id;
-        $area['search']          = $area['search'] ?? null;
+        $area['id']                = $id;
+        $area['label']           ??= $id;
+        $area['breadcrumb']      ??= [];
+        $area['breadcrumbLabel'] ??= $area['label'];
+        $area['title']             = $area['label'];
+        $area['menu']            ??= false;
+        $area['link']            ??= $id;
+        $area['search']          ??= null;
 
         return $area;
     }

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -172,7 +172,7 @@ class User extends Model
      */
     public function pickerData(array $params = null): array
     {
-        $params['text'] = $params['text'] ?? '{{ user.username }}';
+        $params['text'] ??= '{{ user.username }}';
 
         return array_merge(parent::pickerData($params), [
             'email'    => $this->model->email(),

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -138,7 +138,7 @@ class Dom
      */
     public function body()
     {
-        return $this->body = $this->body ?? $this->query('/html/body')[0] ?? null;
+        return $this->body ??= $this->query('/html/body')[0] ?? null;
     }
 
     /**

--- a/src/Toolkit/Escape.php
+++ b/src/Toolkit/Escape.php
@@ -81,7 +81,7 @@ class Escape
      */
     protected static function escaper()
     {
-        return static::$escaper = static::$escaper ?? new Escaper('utf-8');
+        return static::$escaper ??= new Escaper('utf-8');
     }
 
     /**

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -233,7 +233,7 @@ class Html extends Xml
      */
     public static function entities(): array
     {
-        return self::$entities = self::$entities ?? get_html_translation_table(HTML_ENTITIES);
+        return self::$entities ??= get_html_translation_table(HTML_ENTITIES);
     }
 
     /**

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -115,7 +115,7 @@ class I18n
      */
     public static function formatNumber($number, string $locale = null): string
     {
-        $locale = $locale ?? static::locale();
+        $locale ??= static::locale();
 
         $formatter = static::decimalNumberFormatter($locale);
         if ($formatter !== null) {
@@ -154,7 +154,7 @@ class I18n
      */
     public static function translate($key, $fallback = null, string $locale = null)
     {
-        $locale = $locale ?? static::locale();
+        $locale ??= static::locale();
 
         if (is_array($key) === true) {
             if (isset($key[$locale])) {
@@ -224,7 +224,7 @@ class I18n
      */
     public static function translation(string $locale = null): array
     {
-        $locale = $locale ?? static::locale();
+        $locale ??= static::locale();
 
         if (isset(static::$translations[$locale]) === true) {
             return static::$translations[$locale];
@@ -283,8 +283,7 @@ class I18n
      */
     public static function translateCount(string $key, int $count, string $locale = null, bool $formatNumber = true)
     {
-        $locale = $locale ?? static::locale();
-
+        $locale    ??= static::locale();
         $translation = static::translate($key, null, $locale);
 
         if ($translation === null) {

--- a/src/Toolkit/Properties.php
+++ b/src/Toolkit/Properties.php
@@ -115,7 +115,7 @@ trait Properties
         }
 
         // fetch the default value from the property
-        $value = $value ?? $this->$name ?? null;
+        $value ??= $this->$name ?? null;
 
         // store all original properties, to be able to clone them later
         $this->propertyData[$name] = $value;

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -899,8 +899,8 @@ class Str
      */
     public static function slug(string $string = null, string $separator = null, string $allowed = null, int $maxlength = 128): string
     {
-        $separator = $separator ?? static::$defaults['slug']['separator'];
-        $allowed   = $allowed   ?? static::$defaults['slug']['allowed'];
+        $separator ??= static::$defaults['slug']['separator'];
+        $allowed   ??= static::$defaults['slug']['allowed'];
 
         $string = trim($string);
         $string = static::lower($string);


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- [x] Requires dropped PHP 7.3 support

```php
$a = $a ?? 'default';
```

becomes

```php
$a ??= 'default';
```

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] ~~Add changes to release notes draft in Notion~~
