### PR TITLE
Fix multilanguage inconsistency

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -900,7 +900,10 @@ class App
             return $this->multilang;
         }
 
-        return $this->multilang = $this->languages()->count() !== 0;
+        return $this->multilang = (
+            $this->option('languages') === true &&
+            $this->languages()->count() !== 0
+        );
     }
 
     /**

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -104,6 +104,9 @@ class ApiTest extends TestCase
         $this->assertSame('C', setlocale(LC_ALL, 0));
 
         $this->app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -132,6 +135,9 @@ class ApiTest extends TestCase
         $this->assertSame('C', setlocale(LC_ALL, 0));
 
         $this->app = $this->app->clone([
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -189,6 +195,7 @@ class ApiTest extends TestCase
                 ]
             ],
             'options' => [
+                'languages'      => true,
                 'panel.language' => 'de'
             ]
         ]);
@@ -204,6 +211,9 @@ class ApiTest extends TestCase
                 [
                     'email' => 'homer@simpsons.com'
                 ]
+            ],
+            'options' => [
+                'languages'   => true,
             ],
             'languages' => [
                 [
@@ -241,6 +251,7 @@ class ApiTest extends TestCase
                 ]
             ],
             'options' => [
+                'languages'      => true,
                 'panel.language' => 'de'
             ]
         ]);
@@ -251,6 +262,9 @@ class ApiTest extends TestCase
 
         // without logged in user without Panel language
         $app = $this->app->clone([
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'it-it',

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -9,6 +9,9 @@ class AppLanguagesTest extends TestCase
     public function testLanguages()
     {
         $app = new App([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -24,12 +27,15 @@ class AppLanguagesTest extends TestCase
 
         $this->assertTrue($app->multilang());
         $this->assertCount(2, $app->languages());
-        $this->assertEquals('en', $app->languageCode());
+        $this->assertSame('en', $app->languageCode());
     }
 
     public function testLanguageCode()
     {
         $app = new App([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -43,9 +49,9 @@ class AppLanguagesTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('de', $app->languageCode('de'));
-        $this->assertEquals('en', $app->languageCode('en'));
-        $this->assertEquals('en', $app->languageCode());
-        $this->assertEquals(null, $app->languageCode('fr'));
+        $this->assertSame('de', $app->languageCode('de'));
+        $this->assertSame('en', $app->languageCode('en'));
+        $this->assertSame('en', $app->languageCode());
+        $this->assertSame(null, $app->languageCode('fr'));
     }
 }

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -967,4 +967,125 @@ class AppTest extends TestCase
 
         $this->assertSame(['title' => 'Site'], $app->controller('none', [], 'json'));
     }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilang()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages'   => true
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($app->multilang());
+        $this->assertCount(2, $app->languages());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangDefault()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $this->assertFalse($app->multilang());
+        $this->assertCount(0, $app->languages());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangWithOption()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages'   => true
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($app->multilang());
+        $this->assertCount(2, $app->languages());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangEnabledOptionWithoutLanguages()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages' => true
+            ],
+            'languages' => []
+        ]);
+
+        $this->assertFalse($app->multilang());
+        $this->assertCount(0, $app->languages());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangDisabledOptionWithLanguages()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages'   => false
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                    'default' => true
+                ],
+                [
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ]
+        ]);
+
+        $this->assertFalse($app->multilang());
+        $this->assertCount(2, $app->languages());
+    }
 }

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -108,6 +108,9 @@ class AppTranslationsTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages'        => true
+            ],
             'languages' => [
                 [
                     'code'         => 'de',
@@ -162,6 +165,9 @@ class AppTranslationsTest extends TestCase
         $app = new App([
             'roots' => [
                 'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages' => true
             ],
             'languages' => [
                 [
@@ -462,6 +468,9 @@ class AppTranslationsTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'fr',
@@ -475,6 +484,9 @@ class AppTranslationsTest extends TestCase
         $app = new App([
             'roots' => [
                 'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages' => true
             ],
             'languages' => [
                 [
@@ -497,6 +509,7 @@ class AppTranslationsTest extends TestCase
                 ]
             ],
             'options' => [
+                'languages'      => true,
                 'panel.language' => 'it'
             ]
         ]);

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -34,6 +34,9 @@ class UrlTest extends TestCase
     public function testToWithLanguage()
     {
         $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 'en' => [
                     'code' => 'en'

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -250,6 +250,9 @@ class FileTest extends TestCase
                 'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
                 'content' => $index
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -123,6 +123,9 @@ class FindTest extends TestCase
     public function testLanguage()
     {
         $app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -16,6 +16,9 @@ class LanguageRouterTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code' => 'en'
@@ -180,6 +183,9 @@ class LanguageRouterTest extends TestCase
     public function testRouteWithPageScopeAndInvalidPage()
     {
         $app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'site' => [
                 'children' => [
                     ['slug' => 'notes']

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -16,6 +16,9 @@ class LanguageRoutesTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -243,6 +243,9 @@ class PageActionsTest extends TestCase
                     $calls++;
                 }
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code' => 'en',
@@ -284,7 +287,7 @@ class PageActionsTest extends TestCase
 
         $this->assertEquals('article', $modified->intendedTemplate());
         $this->assertSame(2, $calls);
-        
+
         $this->assertFileExists($modified->contentFile('en'));
         $this->assertFileExists($modified->contentFile('de'));
         $this->assertFileDoesNotExist($modified->contentFile('fr'));
@@ -431,6 +434,9 @@ class PageActionsTest extends TestCase
     public function testUpdateMergeMultilang()
     {
         $app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -559,6 +565,9 @@ class PageActionsTest extends TestCase
     public function testDuplicateMultiLang()
     {
         $app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code' => 'en',

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -336,6 +336,9 @@ class PageSortTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -385,6 +388,9 @@ class PageSortTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'site' => [
                 'children' => [
                     [
@@ -425,6 +431,9 @@ class PageSortTest extends TestCase
         $app = new App([
             'roots' => [
                 'index' => '/dev/null'
+            ],
+            'options' => [
+                'languages' => true
             ],
             'languages' => [
                 [

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -656,6 +656,9 @@ class PageTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code' => 'en'
@@ -737,6 +740,9 @@ class PageTest extends TestCase
                 'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
                 'content' => $index
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',
@@ -773,6 +779,9 @@ class PageTest extends TestCase
             'roots' => [
                 'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
                 'content' => $index
+            ],
+            'options' => [
+                'languages'   => true
             ],
             'languages' => [
                 [

--- a/tests/Cms/Pages/PageTranslationsTest.php
+++ b/tests/Cms/Pages/PageTranslationsTest.php
@@ -13,6 +13,9 @@ class PageTranslationsTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -327,6 +327,9 @@ class PagesTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code' => 'en',

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -671,6 +671,9 @@ class RouterTest extends TestCase
                     ]
                 ],
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 [
                     'code'    => 'fr',
@@ -728,6 +731,9 @@ class RouterTest extends TestCase
                         'template' => 'test'
                     ]
                 ],
+            ],
+            'options' => [
+                'languages' => true
             ],
             'languages' => [
                 [

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -132,6 +132,9 @@ class SiteTest extends TestCase
                 'index'   => $index = __DIR__ . '/fixtures/SitePropsTest/modified',
                 'content' => $index
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/Site/SiteTranslationsTest.php
+++ b/tests/Cms/Site/SiteTranslationsTest.php
@@ -12,6 +12,9 @@ class SiteTranslationsTest extends TestCase
             'roots' => [
                 'index' => '/dev/null'
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -155,6 +155,9 @@ class UserTest extends TestCase
                 'index'    => $index = __DIR__ . '/fixtures/UserPropsTest/modified',
                 'accounts' => $index
             ],
+            'options' => [
+                'languages'   => true
+            ],
             'languages' => [
                 [
                     'code'    => 'en',

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -379,6 +379,9 @@ class KirbyTagsTest extends TestCase
             'urls' => [
                 'index' => 'https://getkirby.com'
             ],
+            'options' => [
+                'languages' => true
+            ],
             'languages' => [
                 'en' => [
                     'code' => 'en'
@@ -406,6 +409,9 @@ class KirbyTagsTest extends TestCase
             ],
             'urls' => [
                 'index' => 'https://getkirby.com'
+            ],
+            'options' => [
+                'languages' => true
             ],
             'languages' => [
                 'en' => [


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Now the `Kirby::multilang()` method also checks the `languages` option. What do you think?

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements

- `Kirby::multilang()` method made more consistent

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
- Multi-language feature cannot be used by adding language manually without activating `languages` option.

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
