### PR TITLE
Fix invalid redirect url

### DIFF
--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -247,12 +247,12 @@ class Home
         // a redirect to login, logout or installation
         // views would lead to an infinite redirect loop
         if (in_array($path, ['', 'login', 'logout', 'installation'], true) === true) {
-            throw new InvalidArgumentException('Invalid redirect URL');
+            $path = 'site';
         }
 
         // Check if the user can access the URL
         if (static::hasAccess($user, $path) === true) {
-            return $url;
+            return Panel::url($path);
         }
 
         // Try to find an alternative

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -432,10 +432,7 @@ class HomeTest extends TestCase
         $this->app->impersonate('test@getkirby.com');
         $this->app->session()->set('panel.path', 'login');
 
-        $this->expectException('Kirby\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid redirect URL');
-
-        Home::url();
+        $this->assertSame('/panel/site', Home::url());
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

When an invalid redirect URL is stored in the session, the user is now redirected to site again. 