### PR TITLE
Fix parsing of multiple nested spans

### DIFF
--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -167,6 +167,10 @@ class Parsley
      */
     public function endInlineBlock()
     {
+        if (empty($this->inline) === true) {
+            return;
+        }
+
         $html = [];
 
         foreach ($this->inline as $inline) {
@@ -228,6 +232,11 @@ class Parsley
         }
 
         if (is_a($element, 'DOMElement') === true) {
+            // all spans will be treated as inline elements
+            if ($element->tagName === 'span') {
+                return true;
+            }
+
             if ($this->containsBlock($element) === true) {
                 return false;
             }

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -113,7 +113,7 @@ class ParsleyTest extends TestCase
         return [
             ['<p>Test</p>', '/html/body/p/text()', true],
             ['<p>Test</p>', '/html/body/p', false],
-            ['<span>Test</span>', '/html/body/span', false],
+            ['<span>Test</span>', '/html/body/span', true],
             ['<i><h1>Test</h1></i>', '/html/body/i', false],
         ];
     }

--- a/tests/Parsley/fixtures/span-with-marks.html
+++ b/tests/Parsley/fixtures/span-with-marks.html
@@ -1,0 +1,1 @@
+<span><span>Text</span> <b>Bold</b> <span><i>Italic</i></span></span>

--- a/tests/Parsley/fixtures/span-with-marks.php
+++ b/tests/Parsley/fixtures/span-with-marks.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    [
+        'content' => [
+            'text' => '<p>Text <b>Bold</b> <i>Italic</i></p>',
+        ],
+        'type' => 'text',
+    ],
+];


### PR DESCRIPTION
## Describe the PR

Nested spans created unwanted paragraph blocks. 

## Release notes

### Fixed regression from 3.6.0-rc.3

- Fixed unwanted blocks when parsing HTML https://github.com/getkirby/kirby/issues/3813

## Breaking changes
None

## Related issues/ideas

- Fixes https://github.com/getkirby/kirby/issues/3813

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
