### PR TITLE
Compare JSON docs to avoid unsaved changes loop

### DIFF
--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -376,8 +376,6 @@ export default class Editor extends Emitter {
 
     // give extensions access to our view
     this.extensions.view = this.view;
-
-    this.setContent(this.options.content, true);
   }
 
   isEditable() {

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -130,6 +130,7 @@ export default {
   data() {
     return {
       editor: null,
+      json: {},
       html: this.value,
       isEmpty: true,
       toolbar: false
@@ -173,7 +174,16 @@ export default {
           }
         },
         update: (payload) => {
-          this.html    = payload.editor.getHTML();
+          // compare documents to avoid minor HTML differences
+          // to cause unwanted updates
+          const jsonNew = JSON.stringify(this.editor.getJSON());
+          const jsonOld = JSON.stringify(this.json);
+
+          if (jsonNew === jsonOld) {
+            return;
+          }
+
+          this.json    = jsonNew;
           this.isEmpty = payload.editor.isEmpty();
 
           // when a new list item or heading is created, textContent length returns 0
@@ -188,6 +198,9 @@ export default {
           ) {
             this.html = "";
           }
+
+          // create the final HTML to send to the server
+          this.html = payload.editor.getHTML();
 
           this.$emit("input", this.html);
         }
@@ -206,6 +219,8 @@ export default {
     });
 
     this.isEmpty = this.editor.isEmpty();
+    this.json    = this.editor.getJSON();
+
   },
   beforeDestroy() {
     this.editor.destroy();


### PR DESCRIPTION
## Describe the PR

By comparing the ProseMirror JSON docs, subtle differences in the HTML output are no longer relevant. This could really be the needed fix for the problem. 

## Fixes

https://github.com/getkirby/kirby/issues/3798