### PR TITLE
Load language rules in fiber

### DIFF
--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -168,9 +168,11 @@ class View
             '$language' => function () use ($kirby, $multilang, $language) {
                 if ($multilang === true && $language) {
                     return [
-                        'code'    => $language->code(),
-                        'default' => $language->isDefault(),
-                        'name'    => $language->name(),
+                        'code'      => $language->code(),
+                        'default'   => $language->isDefault(),
+                        'direction' => $language->direction(),
+                        'name'      => $language->name(),
+                        'rules'     => $language->rules(),
                     ];
                 }
             },
@@ -178,9 +180,11 @@ class View
                 if ($multilang === true) {
                     return $kirby->languages()->values(function ($language) {
                         return [
-                            'code'    => $language->code(),
-                            'default' => $language->isDefault(),
-                            'name'    => $language->name(),
+                            'code'      => $language->code(),
+                            'default'   => $language->isDefault(),
+                            'direction' => $language->direction(),
+                            'name'      => $language->name(),
+                            'rules'     => $language->rules(),
                         ];
                     });
                 }

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\Toolkit\A;
@@ -316,14 +317,18 @@ class ViewTest extends TestCase
 
         $expected = [
             [
-                'code'    => 'en',
-                'default' => true,
-                'name'    => 'English'
+                'code'      => 'en',
+                'default'   => true,
+                'direction' => 'ltr',
+                'name'      => 'English',
+                'rules'     => Language::loadRules('en')
             ],
             [
-                'code'    => 'de',
-                'default' => false,
-                'name'    => 'Deutsch'
+                'code'      => 'de',
+                'default'   => false,
+                'direction' => 'ltr',
+                'name'      => 'Deutsch',
+                'rules'     => Language::loadRules('de')
             ]
         ];
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
Added missing `rules` prop to fiber response. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixed regressions from 3.6.0-rc.3

- Fixed converting slugs incorrectly in multilanguge websites #3900

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3900

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
