### PR TITLE
Fix overwritable site title #3901

### DIFF
--- a/config/areas/site.php
+++ b/config/areas/site.php
@@ -7,7 +7,7 @@ return function ($kirby) {
             return $kirby->site()->title()->or(t('view.site'))->toString();
         },
         'icon'      => 'home',
-        'label'     => t('view.site'),
+        'label'     => $kirby->site()->blueprint()->title() ?? t('view.site'),
         'menu'      => true,
         'dialogs'   => require __DIR__ . '/site/dialogs.php',
         'dropdowns' => require __DIR__ . '/site/dropdowns.php',

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -177,4 +177,54 @@ class SiteTest extends AreaTestCase
         $this->assertNull($props['next']);
         $this->assertNull($props['prev']);
     }
+
+    public function testSiteTitle(): void
+    {
+        $this->app([
+            'blueprints' => [
+                'site' => [
+                    'title' => 'My Blog',
+                ]
+            ]
+        ]);
+
+        $this->login();
+
+        $view  = $this->view('site');
+
+        $this->assertSame('site', $view['id']);
+        $this->assertSame('My Blog', $view['title']);
+    }
+
+    public function testSiteTitleMultilang(): void
+    {
+        $this->app([
+            'blueprints' => [
+                'site' => [
+                    'title' => [
+                        'de' => 'Mein Blog',
+                        'en' => 'My Blog',
+                    ],
+                ]
+            ],
+            'languages' => [
+                [
+                    'code'    => 'en',
+                    'name'    => 'English',
+                ],
+                [
+                    'default' => true,
+                    'code'    => 'de',
+                    'name'    => 'Deutsch'
+                ]
+            ],
+        ]);
+
+        $this->login();
+
+        $view  = $this->view('site');
+
+        $this->assertSame('site', $view['id']);
+        $this->assertSame('Mein Blog', $view['title']);
+    }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
Now the menu name can be changed again with the custom site title from the site blueprint.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixed regressions from 3.6.0-rc.3

- Fixed overwritable custom site title #3901


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3901 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
