### PR TITLE
Fix monospace option in textarea

### DIFF
--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -338,7 +338,7 @@ export default {
   box-shadow: none;
   outline: 0;
 }
-.k-textarea-input[data-font="monospace"] {
+.k-textarea-input-native[data-font="monospace"] {
   font-family: var(--font-mono);
 }
 


### PR DESCRIPTION
## Fixed regressions from 3.6.0-rc.3

- Fixed monospace option in textarea fields https://github.com/getkirby/kirby/issues/3902