### PR TITLE
Fix breaking change for the multilang dropdown

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -76,7 +76,9 @@ class Panel
 
         unset($areas['installation'], $areas['login']);
 
-        // disable the language area for single-language installations
+        // Disable the language area for single-language installations
+        // This does not check for installed languages. Otherwise you'd
+        // not be able to add the first language through the view
         if (!$kirby->option('languages')) {
             unset($areas['languages']);
         }
@@ -210,6 +212,18 @@ class Panel
             'X-Fiber' => 'true',
             'Cache-Control' => 'no-store'
         ]);
+    }
+
+    /**
+     * Checks for a multilanguage installation
+     *
+     * @return bool
+     */
+    public static function multilang(): bool
+    {
+        // multilang setup check
+        $kirby = kirby();
+        return $kirby->option('languages') || $kirby->multilang();
     }
 
     /**
@@ -516,7 +530,7 @@ class Panel
         $kirby = kirby();
 
         // language switcher
-        if ($kirby->option('languages')) {
+        if (static::multilang()) {
             $fallback = 'en';
 
             if ($defaultLanguage = $kirby->defaultLanguage()) {

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -142,7 +142,7 @@ class View
         $kirby = kirby();
 
         // multilang setup check
-        $multilang = $kirby->option('languages') || $kirby->multilang();
+        $multilang = Panel::multilang();
 
         // get the authenticated user
         $user = $kirby->user();

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -142,7 +142,7 @@ class View
         $kirby = kirby();
 
         // multilang setup check
-        $multilang = $kirby->multilang();
+        $multilang = $kirby->option('languages') || $kirby->multilang();
 
         // get the authenticated user
         $user = $kirby->user();

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -142,7 +142,7 @@ class View
         $kirby = kirby();
 
         // multilang setup check
-        $multilang = $kirby->option('languages', false) !== false;
+        $multilang = $kirby->multilang();
 
         // get the authenticated user
         $user = $kirby->user();

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -66,7 +66,7 @@ abstract class AreaTestCase extends TestCase
         $this->app([
             'options' => [
                 'languages' => true
-            ]
+            ],
         ]);
     }
 

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -336,6 +336,48 @@ class PanelTest extends TestCase
     }
 
     /**
+     * @covers ::multilang
+     */
+    public function testMultilang()
+    {
+        $this->app = $this->app->clone([
+            'options' => [
+                'languages' => true
+            ]
+        ]);
+
+        $this->assertTrue(Panel::multilang());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangWithImplicitLanguageInstallation()
+    {
+        $this->app = $this->app->clone([
+            'languages' => [
+                [
+                    'code' => 'en',
+                    'default' => true
+                ],
+                [
+                    'code' => 'de',
+                ]
+            ]
+        ]);
+
+        $this->assertTrue(Panel::multilang());
+    }
+
+    /**
+     * @covers ::multilang
+     */
+    public function testMultilangDisabled()
+    {
+        $this->assertFalse(Panel::multilang());
+    }
+
+    /**
      * @covers ::response
      */
     public function testResponse()


### PR DESCRIPTION
## Describe the PR

With this change, the language dropdown will appear again even if the "languages" option is disabled. This makes it possible to add languages manually on the filesystem, but keep language management disabled in the Panel.


## Release notes

### Fixed regressions from 3.6.0-rc.3

- Language dropdown is no longer missing when adding languages manually https://github.com/getkirby/kirby/issues/3888

## Breaking changes
None

## Related issues/ideas
- Fixes https://github.com/getkirby/kirby/issues/3888

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
