### PR TITLE
Refactor/fiber error handling

### DIFF
--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -7,6 +7,7 @@ export async function toJson(response) {
     data = JSON.parse(text);
   } catch (e) {
     window.panel.$vue.$api.onParserError(text);
+    return false;
   }
 
   return data;

--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -6,7 +6,7 @@ export async function toJson(response) {
   try {
     data = JSON.parse(text);
   } catch (e) {
-    window.panel.$vue.$api.onParserError(text);
+    window.panel.$vue.$api.onParserError({ html: text });
     return false;
   }
 

--- a/panel/src/components/Dialogs/FiberDialog.vue
+++ b/panel/src/components/Dialogs/FiberDialog.vue
@@ -21,24 +21,19 @@ export default {
     async onSubmit(value) {
 
       try {
-        const response = await this.$request(this.path, {
+        const dialog = await this.$request(this.path, {
           body: value,
           method: "POST",
+          type: "$dialog",
           headers: {
             "X-Fiber-Referrer": this.referrer
           }
         });
 
-        const dialog = response.$dialog;
-
-        // something's wrong with the response
-        if (!dialog) {
-          throw `The dialog could not be submitted`;
-        }
-
-        // there's an error message from the server
-        if (dialog.error) {
-          throw dialog.error;
+        // json parsing failed and
+        // the fatal dialog is taking over
+        if (dialog === false) {
+          return false;
         }
 
         // everything went fine. We can close the dialog
@@ -72,7 +67,6 @@ export default {
         }
 
       } catch (e) {
-        console.error(e);
         this.$refs.dialog.error(e);
       }
 

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -142,7 +142,7 @@ export default {
 
 <style>
 .k-block-selector.k-dialog {
-  background: #313740;
+  background: var(--color-dark);
   color: var(--color-white);
 }
 .k-block-selector .k-headline {

--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -18,7 +18,7 @@
     </template>
 
     <!-- Fatal iframe -->
-    <k-fatal v-if="$store.state.fatal" />
+    <k-fatal v-if="$store.state.fatal !== false" :html="$store.state.fatal" />
 
     <!-- Offline warning -->
     <div v-if="offline" class="k-offline-warning">

--- a/panel/src/components/Misc/Fatal.vue
+++ b/panel/src/components/Misc/Fatal.vue
@@ -4,7 +4,7 @@
       <k-bar>
         <template #left>
           <k-headline>
-            The JSON response could not be parsed:
+            The JSON response could not be parsed
           </k-headline>
         </template>
         <template #right>
@@ -25,25 +25,17 @@
  * @internal
  */
 export default {
-  computed: {
-    fatal() {
-      return this.$store.state.fatal;
-    }
+  props: {
+    html: String
   },
-  watch: {
-    fatal(html) {
-      if (html !== null) {
-        this.$nextTick(() => {
-          try {
-            let doc = this.$refs.iframe.contentWindow.document;
-            doc.open();
-            doc.write(html);
-            doc.close();
-          } catch (e) {
-            console.error(e);
-          }
-        })
-      }
+  mounted() {
+    try {
+      let doc = this.$refs.iframe.contentWindow.document;
+      doc.open();
+      doc.write(this.html);
+      doc.close();
+    } catch (e) {
+      console.error(e);
     }
   }
 }
@@ -55,7 +47,7 @@ export default {
   inset: 0;
   background: var(--color-backdrop);
   display: flex;
-  z-index: var(--z-dialog);
+  z-index: var(--z-fatal);
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
@@ -65,18 +57,23 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: var(--color-white);
-  padding: .75rem 1.5rem 1.5rem;
+  color: var(--color-black);
+  background: var(--color-red-400);
   box-shadow: var(--shadow-xl);
   border-radius: var(--rounded);
 }
-.k-fatal-box .k-bar {
-  margin-bottom: var(--spacing-3);
+.k-fatal-box .k-headline {
+  line-height: 1;
+  font-size: var(--text-sm);
+  padding: .75rem;
+}
+.k-fatal-box .k-button {
+  padding: .75rem;
 }
 .k-fatal-iframe {
   border: 0;
   width: 100%;
   flex-grow: 1;
-  border: 2px solid var(--color-border);
+  background: var(--color-white);
 }
 </style>

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -176,6 +176,10 @@ export default {
 
         const response = await this.$search(this.currentType.id, query);
 
+        if (response === false) {
+          throw `JSON parsing failed`;
+        }
+
         this.items = response.results;
 
       } catch (error) {

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -171,13 +171,13 @@ export default {
       try {
         // Skip API call if query empty
         if (query === null || query === "") {
-          throw new Error;
+          throw Error("Empty query");
         }
 
         const response = await this.$search(this.currentType.id, query);
 
         if (response === false) {
-          throw `JSON parsing failed`;
+          throw Error("JSON parsing failed");
         }
 
         this.items = response.results;

--- a/panel/src/config/api.js
+++ b/panel/src/config/api.js
@@ -28,9 +28,8 @@ export default {
             Vue.prototype.$go("/logout");
           }
         },
-        onParserError: (result) => {
-          store.dispatch("fatal", result);
-          throw new Error("The JSON response from the API could not be parsed");
+        onParserError: ({ html, silent }) => {
+          store.dispatch("fatal", { html, silent });
         },
         onPrepare: (options) => {
           // if language set, add to headers

--- a/panel/src/config/errors.js
+++ b/panel/src/config/errors.js
@@ -6,7 +6,8 @@ export default {
 
     // global rejected promise handler
     window.onunhandledrejection = (event) => {
-      store.dispatch("notification/error", event);
+      event.preventDefault();
+      store.dispatch("notification/error", event.reason);
     };
 
     // global deprecation handler

--- a/panel/src/config/errors.js
+++ b/panel/src/config/errors.js
@@ -2,30 +2,21 @@ import store from "@/store/store.js";
 
 export default {
   install(app) {
-    app.config.errorHandler = error => {
-      if (window.panel.$config.debug) {
-        window.console.error(error);
-      }
-
-      store.dispatch("notification/error", {
-        message: error.message || "An error occurred. Please reload the Panel."
-      });
-    };
-
     window.panel = window.panel || {};
-    window.panel.error = (notification, msg) => {
-      if (window.panel.$config.debug) {
-        window.console.error(notification + ": " + msg);
-      }
 
-      store.dispatch(
-        "notification/error",
-        notification + ". See the console for more information."
-      );
+    // global rejected promise handler
+    window.onunhandledrejection = (event) => {
+      store.dispatch("notification/error", event);
     };
 
-    window.panel.deprecated = (msg) => {
-      console.warn("Deprecated: " + msg);
-    }
+    // global deprecation handler
+    window.panel.deprecated = (message) => {
+      store.dispatch("notification/deprecated", message);
+    };
+
+    // global error handler
+    window.panel.error = app.config.errorHandler = (error) => {
+      store.dispatch("notification/error", error);
+    };
   }
 }

--- a/panel/src/fiber/dialog.js
+++ b/panel/src/fiber/dialog.js
@@ -15,7 +15,7 @@ export default async function (path, options = {}) {
 
   // check for an existing dialog component
   if (!dialog.component || this.$helper.isComponent(dialog.component) === false) {
-    throw `The dialog component does not exist`;
+    throw Error(`The dialog component does not exist`);
   }
 
   // make sure the dialog always receives a props object

--- a/panel/src/fiber/dialog.js
+++ b/panel/src/fiber/dialog.js
@@ -2,34 +2,28 @@
 import Fiber from "./index";
 
 export default async function (path, options = {}) {
-  try {
-    const data = await Fiber.request("dialogs/" + path, options);
+  const dialog = await Fiber.request("dialogs/" + path, {
+    ...options,
+    type: "$dialog"
+  });
 
-    // the GET request for the dialog is failing
-    if (!data.$dialog) {
-      throw `The dialog could not be loaded`;
-    }
-
-    // the dialog sends a backend error
-    if (data.$dialog.error) {
-      throw data.$dialog.error;
-    }
-
-    // check for an existing dialog component
-    if (!data.$dialog.component || this.$helper.isComponent(data.$dialog.component) === false) {
-      throw `The dialog component does not exist`;
-    }
-
-    // make sure the dialog always receives a props object
-    data.$dialog.props = data.$dialog.props || {};
-
-    // open the dialog and keep the dialog props in the store
-    this.$store.dispatch("dialog", data.$dialog);
-
-    // return the dialog object if needed
-    return data.$dialog;
-  } catch (e) {
-    console.error(e);
-    this.$store.dispatch("notification/error", e);
+  // the request could not be parsed
+  // the fatal view is taking over
+  if (dialog === false) {
+    return false;
   }
+
+  // check for an existing dialog component
+  if (!dialog.component || this.$helper.isComponent(dialog.component) === false) {
+    throw `The dialog component does not exist`;
+  }
+
+  // make sure the dialog always receives a props object
+  dialog.props = dialog.props || {};
+
+  // open the dialog and keep the dialog props in the store
+  this.$store.dispatch("dialog", dialog);
+
+  // return the dialog object if needed
+  return dialog;
 }

--- a/panel/src/fiber/dropdown.js
+++ b/panel/src/fiber/dropdown.js
@@ -16,7 +16,7 @@ export default function (path, options) {
     }
 
     if (Array.isArray(dropdown.options) === false || dropdown.options.length === 0) {
-      throw `The dropdown is empty`;
+      throw Error(`The dropdown is empty`);
     }
 
     dropdown.options.map(option => {

--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -26,7 +26,7 @@
 
 import clone from "../helpers/clone";
 import { merge } from "../helpers/object";
-import { toJson } from "../api/request";
+import store from "../store/store";
 
 export default {
   options: {},
@@ -96,8 +96,21 @@ export default {
    * @returns {object}
    */
   async go(url, options) {
-    const json = await this.request(url, options);
-    return this.setState(json, options);
+    try {
+      const response = await this.request(url, options);
+
+      // the request could not be parsed
+      // the fatal view is taking over
+      if (response === false) {
+        return false;
+      }
+
+      return this.setState(response, options);
+    } catch (e) {
+      if (options?.silent !== true) {
+        throw e;
+      }
+    }
   },
 
   /**
@@ -162,6 +175,7 @@ export default {
       only: [],
       query: {},
       silent: false,
+      type: "$view",
       ...options
     };
 
@@ -187,18 +201,48 @@ export default {
         }
       });
 
-      let json = await toJson(response);
+      const text = await response.text();
+      let json;
 
-      // add exisiting data to partial requests
-      if (only.length) {
-        json = merge(this.state, json);
+      try {
+        json = JSON.parse(text);
+      } catch (e) {
+        store.dispatch("fatal", {
+          html: text,
+          silent: options.silent
+        });
+        return false;
       }
 
-      return json;
+      // the return type does not match the expected type
+      if (!json[options.type]) {
+        throw `The ${options.type} could not be loaded`;
+      }
+
+      // request-specific data
+      const data = json[options.type];
+
+      // the response contains a custom error
+      if (data.error) {
+        throw data.error;
+      }
+
+      // views add the entire response object to the state
+      if (options.type === "$view") {
+        // add exisiting data to partial view requests
+        if (only.length) {
+          return merge(this.state, json);
+        }
+
+        return json;
+      }
+
+      // dialogs, searches and dropdowns only need what is
+      // contained in their request data (i.e. $dialog, $dropdown)
+      return data;
     } finally {
       this.options.onFinish(options);
     }
-
   },
 
   /**
@@ -208,6 +252,10 @@ export default {
    * @param {object} options
    */
   async setState(state, options = {}) {
+    if (typeof state !== "object") {
+      return false;
+    }
+
     // clone existing data
     this.state = clone(state);
 

--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -216,15 +216,15 @@ export default {
 
       // the return type does not match the expected type
       if (!json[options.type]) {
-        throw `The ${options.type} could not be loaded`;
+        throw Error(`The ${options.type} could not be loaded`);
       }
 
       // request-specific data
       const data = json[options.type];
 
-      // the response contains a custom error
+      // the response contains a custom error message
       if (data.error) {
-        throw data.error;
+        throw Error(data.error);
       }
 
       // views add the entire response object to the state

--- a/panel/src/fiber/search.js
+++ b/panel/src/fiber/search.js
@@ -2,28 +2,11 @@
 import Fiber from "./index";
 
 export default async function (type, query, options = {}) {
-  try {
-    const data = await Fiber.request("search/" + type, {
-      query: {
-        query: query
-      },
-      ...options
-    });
-
-    // the GET request for the search is failing
-    if (!data.$search) {
-      throw `The search could not be executed`;
-    }
-
-    // the search sends a backend error
-    if (data.$search.error) {
-      throw data.$search.error;
-    }
-
-    // return the search object if needed
-    return data.$search;
-  } catch (e) {
-    console.error(e);
-    this.$store.dispatch("notification/error", e);
-  }
+  return await Fiber.request("search/" + type, {
+    query: {
+      query: query
+    },
+    type: "$search",
+    ...options
+  });
 }

--- a/panel/src/store/modules/notification.js
+++ b/panel/src/store/modules/notification.js
@@ -26,6 +26,30 @@ export default {
       clearTimeout(this.timer);
       context.commit("UNSET");
     },
+    deprecated(context, message) {
+      console.warn("Deprecated: " + message);
+    },
+    error(context, error) {
+      if (error instanceof PromiseRejectionEvent) {
+        error.preventDefault();
+        error = error.reason;
+      }
+
+      if (typeof error === "string") {
+        error = { message: error };
+      }
+
+      if (window.panel.$config.debug) {
+        window.console.error(error);
+      }
+
+      context.dispatch("dialog", {
+        component: "k-error-dialog",
+        props: error,
+      }, {root: true});
+
+      context.dispatch("close");
+    },
     open(context, payload) {
       context.dispatch("close");
       context.commit("SET", payload);
@@ -46,19 +70,6 @@ export default {
         timeout: 4000,
         ...payload
       });
-    },
-    error(context, payload) {
-      if (typeof payload === "string") {
-        payload = { message: payload };
-      }
-
-      context.dispatch("dialog", {
-        component: "k-error-dialog",
-        props: payload,
-      }, {root: true});
-
-      context.dispatch("close");
-
     }
   }
 };

--- a/panel/src/store/modules/notification.js
+++ b/panel/src/store/modules/notification.js
@@ -30,24 +30,38 @@ export default {
       console.warn("Deprecated: " + message);
     },
     error(context, error) {
-      if (error instanceof PromiseRejectionEvent) {
-        error.preventDefault();
-        error = error.reason;
-      }
+      // props for the dialog
+      let props = error;
 
+      // handle when a simple string is thrown as error
+      // we should avoid that whenever possible
       if (typeof error === "string") {
-        error = { message: error };
+        props = {
+          message: error
+        };
       }
 
-      if (window.panel.$config.debug) {
-        window.console.error(error);
+      // handle proper Error instances
+      if (error instanceof Error) {
+        // convert error objects to props for the dialog
+        props = {
+          message: error.message
+        };
+
+        // only log errors to the console in debug mode
+        if (window.panel.$config.debug) {
+          window.console.error(error);
+        }
       }
 
+      // show the error dialog
       context.dispatch("dialog", {
         component: "k-error-dialog",
-        props: error,
+        props: props,
       }, {root: true});
 
+      // remove the notification from store
+      // to avoid showing it in the topbar
       context.dispatch("close");
     },
     open(context, payload) {

--- a/panel/src/store/store.js
+++ b/panel/src/store/store.js
@@ -14,7 +14,7 @@ export default new Vuex.Store({
   state: {
     dialog: null,
     drag: null,
-    fatal: null,
+    fatal: false,
     isLoading: false
   },
   mutations: {
@@ -38,8 +38,27 @@ export default new Vuex.Store({
     drag(context, drag) {
       context.commit("SET_DRAG", drag);
     },
-    fatal(context, html) {
-      context.commit("SET_FATAL", html);
+    fatal(context, options) {
+      // close the fatal window if false
+      // is passed as options
+      if (options === false) {
+        context.commit("SET_FATAL", false);
+        return;
+      }
+
+      console.error("The JSON response could not be parsed");
+
+      // show the full response in the console
+      // if debug mode is enabled
+      if (window.panel.$config.debug) {
+        console.info(options.html);
+      }
+
+      // only show the fatal dialog if the silent
+      // option is not set to true
+      if (!options.silent) {
+        context.commit("SET_FATAL", options.html);
+      }
     },
     isLoading(context, loading) {
       context.commit("SET_LOADING", loading === true);

--- a/panel/src/styles/variables.css
+++ b/panel/src/styles/variables.css
@@ -2,6 +2,7 @@
   /** Framework **/
   --color-backdrop: rgba(0, 0, 0, 0.6);
   --color-black: #000;
+  --color-dark: #313740;
   --color-light: var(--color-gray-200);
   --color-white: #fff;
 
@@ -134,6 +135,7 @@
   --color-text: var(--color-gray-900);
   --color-text-light: var(--color-gray-600);
 
+  --z-fatal: 1100;
   --z-loader: 1000;
   --z-notification: 900;
   --z-dialog: 800;

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -250,6 +250,7 @@ class View
         return [
             'code'      => $code,
             'component' => 'k-error-view',
+            'error'     => $message,
             'props'     => [
                 'error'  => $message,
                 'layout' => Panel::hasAccess(kirby()->user()) ? 'inside' : 'outside'

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -407,6 +407,7 @@ class ViewTest extends TestCase
         $expected = [
             'code' => 404,
             'component' => 'k-error-view',
+            'error' => 'Test',
             'props' => [
                 'error' => 'Test',
                 'layout' => 'outside'


### PR DESCRIPTION
## Describe the PR

Error handling was very chaotic across Fiber requests. There wasn't a unified way to deal with JSON parsing errors, particular errors in the request response and invalid response objects. I've cleaned it all up and also refactored our Fatal dialog. It's now a lot more usable and works especially well when you want to quickly debug something with dump() in Fiber PHP code. 

You can do 

```php
dump($something)
exit();
```

Pretty much anywhere now and the Panel will show the Fatal dialog with the output. This makes it even easier to work with those request. 

I tried to be very careful with the changes and split everything in logical commits, but we need to double-check all of it again. 

## Release notes

### Refactored
- Fiber handling and dialogs for Fiber

### Enhancements
- New CSS properties
  - `--color-dark: #313740;`
  - `--z-fatal`