### PR TITLE
Minor `FileRules` refactoring to ensure that `.phtml` uploads are never allowed

### DIFF
--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -189,7 +189,11 @@ class FileRules
             ]);
         }
 
-        if (Str::contains($extension, 'php') || Str::contains($extension, 'phar')) {
+        if (
+            Str::contains($extension, 'php') ||
+            Str::contains($extension, 'phar') ||
+            Str::contains($extension, 'phtml')
+        ) {
             throw new InvalidArgumentException([
                 'key'  => 'file.type.forbidden',
                 'data' => ['type' => 'PHP']

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -182,7 +182,7 @@ class FileRules
         // make it easier to compare the extension
         $extension = strtolower($extension);
 
-        if (empty($extension)) {
+        if (empty($extension) === true) {
             throw new InvalidArgumentException([
                 'key'  => 'file.extension.missing',
                 'data' => ['filename' => $file->filename()]
@@ -190,9 +190,9 @@ class FileRules
         }
 
         if (
-            Str::contains($extension, 'php') ||
-            Str::contains($extension, 'phar') ||
-            Str::contains($extension, 'phtml')
+            Str::contains($extension, 'php') !== false ||
+            Str::contains($extension, 'phar') !== false ||
+            Str::contains($extension, 'phtml') !== false
         ) {
             throw new InvalidArgumentException([
                 'key'  => 'file.type.forbidden',
@@ -200,14 +200,14 @@ class FileRules
             ]);
         }
 
-        if (Str::contains($extension, 'htm')) {
+        if (Str::contains($extension, 'htm') !== false) {
             throw new InvalidArgumentException([
                 'key'  => 'file.type.forbidden',
                 'data' => ['type' => 'HTML']
             ]);
         }
 
-        if (V::in($extension, ['exe', App::instance()->contentExtension()])) {
+        if (V::in($extension, ['exe', App::instance()->contentExtension()]) !== false) {
             throw new InvalidArgumentException([
                 'key'  => 'file.extension.forbidden',
                 'data' => ['extension' => $extension]

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -189,13 +189,6 @@ class FileRules
             ]);
         }
 
-        if (V::in($extension, ['php', 'phar', 'html', 'htm', 'exe', App::instance()->contentExtension()])) {
-            throw new InvalidArgumentException([
-                'key'  => 'file.extension.forbidden',
-                'data' => ['extension' => $extension]
-            ]);
-        }
-
         if (Str::contains($extension, 'php') || Str::contains($extension, 'phar')) {
             throw new InvalidArgumentException([
                 'key'  => 'file.type.forbidden',
@@ -207,6 +200,13 @@ class FileRules
             throw new InvalidArgumentException([
                 'key'  => 'file.type.forbidden',
                 'data' => ['type' => 'HTML']
+            ]);
+        }
+
+        if (V::in($extension, ['exe', App::instance()->contentExtension()])) {
+            throw new InvalidArgumentException([
+                'key'  => 'file.extension.forbidden',
+                'data' => ['extension' => $extension]
             ]);
         }
 

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -253,14 +253,17 @@ class FileRulesTest extends TestCase
             ['jpg', true],
             ['png', true],
             ['', false, 'The extensions for "test" is missing'],
-            ['htm', false, 'The extension "htm" is not allowed'],
-            ['html', false, 'The extension "html" is not allowed'],
-            ['php', false, 'The extension "php" is not allowed'],
-            ['phar', false, 'The extension "phar" is not allowed'],
-            ['exe', false, 'The extension "exe" is not allowed'],
+            ['php', false, 'You are not allowed to upload PHP files'],
+            ['phar', false, 'You are not allowed to upload PHP files'],
+            ['phtml', false, 'You are not allowed to upload PHP files'],
             ['php4', false, 'You are not allowed to upload PHP files'],
-            ['dhtml', false, 'You are not allowed to upload HTML files'],
             ['1phar2', false, 'You are not allowed to upload PHP files'],
+            ['phtml5', false, 'You are not allowed to upload PHP files'],
+            ['htm', false, 'You are not allowed to upload HTML files'],
+            ['html', false, 'You are not allowed to upload HTML files'],
+            ['dhtml', false, 'You are not allowed to upload HTML files'],
+            ['exe', false, 'The extension "exe" is not allowed'],
+            ['txt', false, 'The extension "txt" is not allowed'],
         ];
     }
 
@@ -291,12 +294,15 @@ class FileRulesTest extends TestCase
 
             // extension
             ['test', '', 'text/plain', false, 'The extensions for "test" is missing'],
-            ['test.htm', 'htm', 'text/plain', false, 'The extension "htm" is not allowed'],
-            ['test.html', 'html', 'text/plain', false, 'The extension "html" is not allowed'],
-            ['test.php', 'php', 'text/plain', false, 'The extension "php" is not allowed'],
-            ['test.phar', 'phar', 'text/plain', false, 'The extension "phar" is not allowed'],
+            ['test.htm', 'htm', 'text/plain', false, 'You are not allowed to upload HTML files'],
+            ['test.html', 'html', 'text/plain', false, 'You are not allowed to upload HTML files'],
+            ['test.php', 'php', 'text/plain', false, 'You are not allowed to upload PHP files'],
+            ['test.phtml', 'phtml', 'text/plain', false, 'You are not allowed to upload PHP files'],
+            ['test.phar', 'phar', 'text/plain', false, 'You are not allowed to upload PHP files'],
             ['test.exe', 'exe', 'text/plain', false, 'The extension "exe" is not allowed'],
+            ['test.txt', 'txt', 'text/plain', false, 'The extension "txt" is not allowed'],
             ['test.php4', 'php4', 'text/plain', false, 'You are not allowed to upload PHP files'],
+            ['test.phtml5', 'phtml5', 'text/plain', false, 'You are not allowed to upload PHP files'],
             ['test.1phar2', '1phar2', 'text/plain', false, 'You are not allowed to upload PHP files'],
 
             // mime
@@ -313,7 +319,7 @@ class FileRulesTest extends TestCase
 
             // rule order
             ['.test.jpg', 'jpg', 'application/php', false, 'You are not allowed to upload PHP files'],
-            ['.test.htm', 'htm', 'text/plain', false, 'The extension "htm" is not allowed'],
+            ['.test.htm', 'htm', 'text/plain', false, 'You are not allowed to upload HTML files'],
             ['.test.jpg', 'jpg', 'text/plain', false, 'You are not allowed to upload invisible files'],
         ];
     }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

This does not change the behavior besides the different order of error messages. The error message `you are not allowed to upload PHP files` is now preferred over `the extension "php" is not allowed` as the first message is more specific.

Besides that the change ensures that we never have a regression that allows the upload of malicious `.phtml` files.

**Note:** You may want to review each commit separately as the overall diff is quite messy.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] ~Add changes to release notes draft in Notion~
