### PR TITLE
The empty box no longer creates a button if the action is not allowed

### DIFF
--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -43,7 +43,7 @@
             :layout="options.layout"
             :data-invalid="isInvalid"
             icon="image"
-          v-on="{ click: add ? upload : undefined }"
+            v-on="{ click: add ? upload : undefined }"
           >
             {{ options.empty || $t('files.empty') }}
           </k-empty>

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -43,7 +43,7 @@
             :layout="options.layout"
             :data-invalid="isInvalid"
             icon="image"
-            @click="upload"
+          v-on="{ click: add ? upload : undefined }"
           >
             {{ options.empty || $t('files.empty') }}
           </k-empty>

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -45,7 +45,7 @@
           :layout="options.layout"
           :data-invalid="isInvalid"
           icon="page"
-          @click="create"
+          v-on="{ click: add ? create : undefined }"
         >
           {{ options.empty || $t('pages.empty') }}
         </k-empty>


### PR DESCRIPTION
## Describe the PR

The click event of the empty box in pages and files sections should not be defined if it's actually not possible to click it. This is a fix for a regression. 

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
- Fixed cursor on the empty box in pages and files sections https://github.com/getkirby/kirby/issues/3915

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- https://github.com/getkirby/kirby/issues/3915

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
