### PR TITLE
Better error message when the parent model of a pages section is invalid

### DIFF
--- a/config/sections/mixins/parent.php
+++ b/config/sections/mixins/parent.php
@@ -34,7 +34,7 @@ return [
             }
 
             if ($parent === null) {
-                $parent = $this->model;
+                return $this->model;
             }
 
             return $parent;

--- a/config/sections/mixins/parent.php
+++ b/config/sections/mixins/parent.php
@@ -34,7 +34,7 @@ return [
             }
 
             if ($parent === null) {
-                return $this->model;
+                $parent = $this->model;
             }
 
             return $parent;

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\Blueprint;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 
@@ -88,7 +89,13 @@ return [
     ],
     'computed' => [
         'parent' => function () {
-            return $this->parentModel();
+            $parent = $this->parentModel();
+
+            if (is_a($parent, 'Kirby\Cms\Site') === false && is_a($parent, 'Kirby\Cms\Page') === false) {
+                throw new InvalidArgumentException('The parent is invalid. You must choose the site or a page as parent.');
+            }
+
+            return $parent;
         },
         'pages' => function () {
             switch ($this->status) {

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -74,6 +74,27 @@ class PagesSectionTest extends TestCase
         $this->assertEquals('test/a', $section->parent()->id());
     }
 
+    public function testParentWithInvalidOption()
+    {
+        $this->app->impersonate('kirby');
+
+        $parent = new Page([
+            'slug' => 'test',
+            'children' => [
+                ['slug' => 'a']
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The parent is invalid. You must choose the site or a page as parent.');
+
+        new Section('pages', [
+            'name'  => 'test',
+            'model' => $parent,
+            'parent' => 'kirby.user'
+        ]);
+    }
+
     public function statusProvider()
     {
         return [


### PR DESCRIPTION
## Describe the PR

When the pages section is setup with an invalid parent (i.e. user) the error message was super cryptic so far. It's now showing: 

```
The section "pages" could not be loaded: The parent is invalid. You must choose the site or a page as parent.
```

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements

- Better error message for invalid parent in pages section https://github.com/getkirby/kirby/issues/3916

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- https://github.com/getkirby/kirby/issues/3916

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
