### PR TITLE
Revert fixed positioning for topbar and form buttons

### DIFF
--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -18,7 +18,7 @@
         <k-button icon="cancel" @click="notification = null" />
       </div>
 
-      <div class="k-dialog-body">
+      <div class="k-dialog-body scroll-y-auto">
         <slot />
       </div>
 
@@ -322,8 +322,6 @@ export default {
 
 .k-dialog-body {
   padding: 1.5rem;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .k-dialog-body .k-fieldset {

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -48,7 +48,7 @@
             />
           </nav>
         </header>
-        <div class="k-drawer-body">
+        <div class="k-drawer-body scroll-y-auto">
           <slot />
         </div>
       </div>
@@ -251,7 +251,6 @@ export default {
 .k-drawer-body {
   padding: 1.5rem;
   flex-grow: 1;
-  overflow-y: auto;
   background: var(--color-background);
 }
 

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -283,14 +283,8 @@ export default {
 </script>
 
 <style>
-.k-form-buttons {
-  position: fixed;
-  bottom: 0;
-  inset-inline: 0;
-  z-index: var(--z-navigation);
-}
 .k-form-buttons[data-theme] {
-    background: var(--theme-light);
+  background: var(--theme-light);
 }
 .k-form-buttons .k-view {
   display: flex;

--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -43,7 +43,7 @@
           >
         </k-dropdown-item>
 
-        <div class="k-multiselect-options">
+        <div class="k-multiselect-options scroll-y-auto">
           <k-dropdown-item
             v-for="option in visible"
             :key="option.value"
@@ -373,7 +373,6 @@ export default {
 .k-multiselect-options {
   position: relative;
   max-height: 275px;
-  overflow-y: auto;
   padding: .5rem 0;
 }
 

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -424,6 +424,7 @@ export default {
   line-height: 2em;
   overflow-x: auto;
   overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
   white-space: pre;
 }
 .k-writer-code code {

--- a/panel/src/components/Layout/Inside.vue
+++ b/panel/src/components/Layout/Inside.vue
@@ -8,9 +8,10 @@
         :view="$view"
       />
     </header>
-    <main class="k-panel-view">
+    <main class="k-panel-view scroll-y">
       <slot />
     </main>
+    <slot name="footer" />
   </k-panel>
 </template>
 
@@ -21,14 +22,21 @@ export default {
 </script>
 
 <style>
+.k-panel-inside {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+}
+.k-panel-inside:focus {
+  outline: 0;
+}
 .k-panel-header {
-  position: fixed;
-  top: 0;
-  inset-inline: 0;
   z-index: var(--z-navigation);
+  flex-shrink: 0;
 }
 .k-panel-view {
-  padding-top: 2.5rem;
+  flex-grow: 1;
   padding-bottom: 6rem;
 }
 </style>

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -62,9 +62,6 @@ export default {
       this.$emit("close");
       this.restoreScrollPosition();
 
-      // enable scrolling of background
-      document.documentElement.style.overflow = "visible";
-
       // unbind events
       this.$events.$off("keydown.esc", this.close);
     },
@@ -117,9 +114,6 @@ export default {
 
         // prevent that clicks on the overlay slot trigger close
         document.querySelector(".k-overlay > *").addEventListener("mousedown", e => e.stopPropagation());
-
-        // prevent scrolling of background
-        document.documentElement.style.overflow = "hidden";
 
         this.$emit("ready");
       }, 1)

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -15,7 +15,6 @@
           @edit="$dialog(id + '/changeName')"
         >
           {{ model.filename }}
-
           <template #left>
             <k-button-group>
               <k-button
@@ -43,7 +42,6 @@
               <k-languages-dropdown />
             </k-button-group>
           </template>
-
           <template #right>
             <k-prev-next
               :prev="prev"
@@ -51,7 +49,6 @@
             />
           </template>
         </k-header>
-
         <k-sections
           :blueprint="blueprint"
           :empty="$t('file.blueprint', { blueprint: $esc(blueprint) })"
@@ -59,14 +56,15 @@
           :parent="id"
           :tab="tab"
         />
-
         <k-upload
           ref="upload"
           @success="onUpload"
         />
       </k-view>
-      <k-form-buttons :lock="lock" />
     </div>
+    <template #footer>
+      <k-form-buttons :lock="lock" />
+    </template>
   </k-inside>
 </template>
 

--- a/panel/src/components/Views/PageView.vue
+++ b/panel/src/components/Views/PageView.vue
@@ -49,7 +49,6 @@
             <k-languages-dropdown />
           </k-button-group>
         </template>
-
         <template #right>
           <k-prev-next
             v-if="model.id"
@@ -58,7 +57,6 @@
           />
         </template>
       </k-header>
-
       <k-sections
         :blueprint="blueprint"
         :empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
@@ -67,7 +65,9 @@
         :tab="tab"
       />
     </k-view>
-    <k-form-buttons :lock="lock" />
+    <template #footer>
+      <k-form-buttons :lock="lock" />
+    </template>
   </k-inside>
 </template>
 

--- a/panel/src/components/Views/SiteView.vue
+++ b/panel/src/components/Views/SiteView.vue
@@ -37,7 +37,9 @@
         @submit="$emit('submit', $event)"
       />
     </k-view>
-    <k-form-buttons :lock="lock" />
+    <template #footer>
+      <k-form-buttons :lock="lock" />
+    </template>
   </k-inside>
 </template>
 

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -34,11 +34,9 @@
               :options="avatarOptions"
             />
           </k-dropdown>
-
           <k-button-group :buttons="buttons" />
         </k-view>
       </div>
-
       <k-view>
         <k-header
           :editable="permissions.changeName && !isLocked"
@@ -50,7 +48,6 @@
           <template v-else>
             {{ model.name }}
           </template>
-
           <template #left>
             <k-button-group>
               <k-dropdown class="k-user-view-options">
@@ -68,7 +65,6 @@
               <k-languages-dropdown />
             </k-button-group>
           </template>
-
           <template #right>
             <k-prev-next
               v-if="!model.account"
@@ -77,7 +73,6 @@
             />
           </template>
         </k-header>
-
         <k-sections
           :blueprint="blueprint"
           :empty="$t('user.blueprint', { blueprint: $esc(blueprint) })"
@@ -85,7 +80,6 @@
           :parent="id"
           :tab="tab"
         />
-
         <k-upload
           ref="upload"
           :url="uploadApi"
@@ -94,8 +88,10 @@
           @success="uploadedAvatar"
         />
       </k-view>
-      <k-form-buttons :lock="lock" />
     </div>
+    <template #footer>
+      <k-form-buttons :lock="lock" />
+    </template>
   </k-inside>
 </template>
 

--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -82,7 +82,6 @@ export default {
      * blocked overflow style
      */
     navigate() {
-      document.documentElement.style.overflow = "visible";
       this.$store.dispatch("navigate");
     },
 

--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -23,8 +23,8 @@ html {
 html,
 body {
   color: var(--color-gray-900);
-  min-height: 100vh;
-  overflow-y: scroll;
+  height: 100%;
+  overflow: hidden;
 }
 
 a {
@@ -41,9 +41,3 @@ b {
   font-weight: var(--font-bold);
 }
 
-.k-panel {
-  min-height: 100vh;
-}
-.k-panel:focus {
-  outline: 0;
-}

--- a/panel/src/styles/utilities.css
+++ b/panel/src/styles/utilities.css
@@ -48,3 +48,27 @@
   --theme-light: var(--color-focus-light);
   --theme-bg: var(--color-blue-200);
 }
+
+.scroll-x,
+.scroll-x-auto,
+.scroll-y,
+.scroll-y-auto {
+  -webkit-overflow-scrolling: touch;
+  transform: translate3d(0, 0, 0);
+}
+.scroll-x {
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+.scroll-x-auto {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.scroll-y {
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+.scroll-y-auto {
+  overflow-x: hidden;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Describe the PR

The fixed positioning of topbar and form buttons felt nice and seemed cleaner in total, but then introduced a couple issues with dialogs and drawers and especially scroll blocking for the panel view. 

This PR goes back to our old layout, but thanks to our refactored components it's all a lot cleaner now. It also shows that this "old" way of doing it actually takes a lot less hacks to make it work.   


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Fixed layout shift when opening overlays #3823
- Fixed dialog reset when dialogs are not closed properly #3923

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- #3823
- #3923 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
