### PR TITLE
Refactor plugin loading JS

### DIFF
--- a/panel/public/js/plugins.js
+++ b/panel/public/js/plugins.js
@@ -1,4 +1,3 @@
-
 window.panel = window.panel || {};
 window.panel.plugins = {
   components: {},
@@ -17,7 +16,7 @@ window.panel.plugin = function (plugin, parts) {
       options = { template: options };
     }
 
-    window.panel.plugins["components"][`k-block-type-${name}`] = {
+    window.panel.plugins.components[`k-block-type-${name}`] = {
       extends: "k-block-type",
       ...options
     };
@@ -25,35 +24,35 @@ window.panel.plugin = function (plugin, parts) {
 
   // Components
   resolve(parts, "components", function (name, options) {
-    window.panel.plugins["components"][name] = options;
+    window.panel.plugins.components[name] = options;
   });
 
   // Fields
   resolve(parts, "fields", function (name, options) {
-    window.panel.plugins["components"][`k-${name}-field`] = options;
+    window.panel.plugins.components[`k-${name}-field`] = options;
   });
 
   // Icons
   resolve(parts, "icons", function (name, options) {
-    window.panel.plugins["icons"][name] = options;
+    window.panel.plugins.icons[name] = options;
   });
 
   // Sections
   resolve(parts, "sections", function (name, options) {
-    window.panel.plugins["components"][`k-${name}-section`] = {
+    window.panel.plugins.components[`k-${name}-section`] = {
       ...options,
-      mixins: ["section"].concat(options.mixins || [])
+      mixins: ["section", ...(options.mixins || [])]
     };
   });
 
-  // Vue.use
+  // `Vue.use`
   resolve(parts, "use", function (name, options) {
-    window.panel.plugins["use"].push(options);
+    window.panel.plugins.use.push(options);
   });
 
-  // created callback
+  // Vue `created` callback
   if (parts["created"]) {
-    window.panel.plugins["created"].push(parts["created"]);
+    window.panel.plugins.created.push(parts["created"]);
   }
 
   // Login
@@ -62,20 +61,15 @@ window.panel.plugin = function (plugin, parts) {
   }
 
   // Third-party plugins
-  resolve(parts, "thirdParty", function(name, options) {
-    window.panel.plugins["thirdParty"][name] = options;
+  resolve(parts, "thirdParty", function (name, options) {
+    window.panel.plugins.thirdParty[name] = options;
   });
-
 };
 
 function resolve(object, type, callback) {
   if (object[type]) {
-
-    if (Object.entries) {
-      Object.entries(object[type]).forEach(function ([name, options]) {
-        callback(name, options);
-      });
+    for (const [name, options] of Object.entries(object[type])) {
+      callback(name, options);
     }
-
   }
 }

--- a/panel/src/config/plugins.js
+++ b/panel/src/config/plugins.js
@@ -3,28 +3,23 @@ import section from "../mixins/section/section.js";
 
 export default {
   install(app) {
-    let components = {};
+    const components = { ...app.options.components };
 
-    for (var key in app.options.components) {
-      components[key] = app.options.components[key];
-    }
-
-    let mixins = {
+    const mixins = {
       section: section
     };
 
     /**
      * Components
      */
-    Object.entries(window.panel.plugins.components).forEach(([name, options]) => {
-
+    for (const [name, options] of Object.entries(window.panel.plugins.components)) {
       // make sure component has something to show
       if (!options.template && !options.render && !options.extends) {
         store.dispatch(
           "notification/error",
           `Neither template or render method provided nor extending a component when loading plugin component "${name}". The component has not been registered.`
         );
-        return;
+        continue;
       }
 
       // resolve extending via component name
@@ -60,14 +55,13 @@ export default {
 
       app.component(name, options);
       components[name] = app.options.components[name];
-    });
+    }
 
     /**
-     * app.use
+     * `Vue.use`
      */
-    window.panel.plugins.use.forEach(plugin => {
+    for (const plugin of window.panel.plugins.use) {
       app.use(plugin);
-    });
-
+    }
   }
 }


### PR DESCRIPTION
## Describe the PR

Originally from @johannschopplich 

This PR refactors two Panel parts responsible for plugin loading and formats them coherently.
- No need to check for `Object.entries` support anymore.
- Removed `var` leftover and simplified `component` object cloning.

I prefer `for..of` loops over `forEach` calls, since the last bracket can be omitted. Subjective, of course.

## Release notes

None.

## Breaking changes

None.

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

None.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] ~~Add changes to release notes draft in Notion~~
