### PR TITLE
Don't throw pages() behavior deprecation warning if single item is an array

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -584,7 +584,7 @@ function page(...$id)
  */
 function pages(...$id)
 {
-    if (count($id) === 1) {
+    if (count($id) === 1 && is_array($id[0]) === false) {
         // @codeCoverageIgnoreStart
         deprecated('Passing a single id to the `pages()` helper will return a Kirby\Cms\Pages collection with a single element instead of the single Kirby\Cms\Page object itself - starting in 3.7.0.');
         // @codeCoverageIgnoreEnd


### PR DESCRIPTION
## Describe the PR
This changes the deprecation warning to not be thrown if the single item passed to the `pages()` is an array.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- `pages()` helper does not throw deprecation warning for arrays as single parameter


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3938 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
