### PR TITLE
Fix Panel image for `Asset` objects

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -84,9 +84,10 @@ return [
      * @param \Kirby\Cms\App $kirby Kirby instance
      * @param \Kirby\Cms\File|\Kirby\Filesystem\Asset $file The file object
      * @param array $options All thumb options (width, height, crop, blur, grayscale)
-     * @return \Kirby\Cms\File|\Kirby\Cms\FileVersion
+     * @return \Kirby\Cms\File|\Kirby\Cms\FileVersion|\Kirby\Filesystem\Asset
      */
     'file::version' => function (App $kirby, $file, array $options = []) {
+        // if file is not resizable, return
         if ($file->isResizable() === false) {
             return $file;
         }
@@ -96,14 +97,20 @@ return [
         $template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
         $thumbRoot = (new Filename($file->root(), $template, $options))->toString();
         $thumbName = basename($thumbRoot);
-        $job       = $mediaRoot . '/.jobs/' . $thumbName . '.json';
 
+        // check if the thumb already exists
         if (file_exists($thumbRoot) === false) {
+
+            // if not, create job file
+            $job = $mediaRoot . '/.jobs/' . $thumbName . '.json';
+
             try {
                 Data::write($job, array_merge($options, [
                     'filename' => $file->filename()
                 ]));
             } catch (Throwable $e) {
+                // if thumb doesn't exist yet and job file cannot
+                // be created, return
                 return $file;
             }
         }

--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -203,9 +203,10 @@ trait FileModifications
 
         if (
             is_a($result, 'Kirby\Cms\FileVersion') === false &&
-            is_a($result, 'Kirby\Cms\File') === false
+            is_a($result, 'Kirby\Cms\File') === false &&
+            is_a($result, 'Kirby\Filesystem\Asset') === false
         ) {
-            throw new InvalidArgumentException('The file::version component must return a File or FileVersion object');
+            throw new InvalidArgumentException('The file::version component must return a File, FileVersion or Asset object');
         }
 
         return $result;

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -141,8 +141,8 @@ abstract class Model
             // main url
             $settings['url'] = $image->url();
 
-            // only create srcsets for actual File objects
-            if (is_a($image, 'Kirby\Cms\File') === true) {
+            // only create srcsets for resizable files
+            if ($image->isResizable() === true) {
                 $settings['src'] = static::imagePlaceholder();
 
                 switch ($layout) {
@@ -174,6 +174,8 @@ abstract class Model
                         ]
                     ]);
                 }
+            } elseif ($image->isViewable() === true) {
+                $settings['src'] = $image->url();
             }
         }
 

--- a/tests/Cms/Files/FileModificationsTest.php
+++ b/tests/Cms/Files/FileModificationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\Asset;
 use PHPUnit\Framework\TestCase;
 
 class FileModificationsTest extends TestCase
@@ -40,6 +41,14 @@ class FileModificationsTest extends TestCase
 
         $file = $app->file('test.jpg');
         $file->thumb($input);
+    }
+
+    public function testThumbWithAssetObject()
+    {
+        $app = $this->app->clone();
+        $asset = new Asset('');
+        $result = $asset->thumb([]);
+        $this->assertInstanceOf(Asset::class, $result);
     }
 
     public function testThumbWithDefaultPreset()
@@ -106,7 +115,7 @@ class FileModificationsTest extends TestCase
         ]);
 
         $this->expectException('Kirby\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('The file::version component must return a File or FileVersion object');
+        $this->expectExceptionMessage('The file::version component must return a File, FileVersion or Asset object');
 
         $file = $app->file('test.jpg');
         $file->thumb(['width' => 100]);

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Site as ModelSite;
+use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
@@ -74,6 +75,11 @@ class ModelSiteWithImageMethod extends ModelSite
     public function panelBack()
     {
         return 'blue';
+    }
+
+    public function cover()
+    {
+        return new Asset('tmp/test.svg');
     }
 }
 
@@ -326,6 +332,18 @@ class ModelTest extends TestCase
         $this->assertSame($ratio, $image['ratio']);
         $this->assertStringContainsString('test-38x38-crop.jpg 1x', $image['srcset']);
         $this->assertStringContainsString('test-76x76-crop.jpg 2x', $image['srcset']);
+    }
+
+    /**
+     * @covers ::image
+     */
+    public function testImageWithNonResizableAsset()
+    {
+        $site  = new ModelSiteWithImageMethod([]);
+        $panel = new CustomPanelModel($site);
+        $image = $panel->image('site.cover');
+        $this->assertSame('//tmp/test.svg', $image['url']);
+        $this->assertSame('//tmp/test.svg', $image['src']);
     }
 
     /**


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

The PR makes the following changes
- `Panel\Model::image()` doesn't check for `File` object anymore to provide `src` and `srcset` but uses `->isResizable()` and `->isViewable()` instead
- `file::version` is allowed to return `Asset` object as well


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- `Asset` objects can be used as Panel preview images again

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes  #3933

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
