### PR TITLE
Add a static cache for resolved queries of blueprint fields with options

### DIFF
--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -141,13 +141,13 @@ class OptionsQuery
 
         preg_match('/(\bblock|file|page|user)\.+/i', $cacheKey, $matches);
         foreach($matches as $match) {
-            if ($model = A::get(strtolower($match[1]), $data)) {
+            if ($model = A::get($data, strtolower($match[1]))) {
                 $cacheKey .= '[' . $model->id() . ']';
             }
         }
 
         // if a cached collection exist return that
-        if ($cachedOptions = A::get($cacheKey, static::$cache)) {
+        if ($cachedOptions = A::get(static::$cache, $cacheKey)) {
             return $cachedOptions;
         }
         

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -134,9 +134,9 @@ class OptionsQuery
         // "{{ kirby.collection('customCollection') }}"
         // "{{ site.customMethod }}"
 
-        preg_match('/(?:\bblock|file|page|user)\.+/i', $cacheKey, $matches);
+        preg_match('/(\bblock|file|page|user)\.+/i', $cacheKey, $matches);
         foreach($matches as $match) {
-            if ($model = A::get($match[1], $data)) {
+            if ($model = A::get(strtolower($match[1]), $data)) {
                 $cacheKey .= '[' . $model->id() . ']';
             }
         }

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -122,6 +122,11 @@ class OptionsQuery
         $data    = $this->data();
         $cacheKey = $this->query();
 
+        // making sure the cache uses the current language
+        if ($language = kirby()->language()) {
+            $cacheKey .= '(' . $language->code() . ')';
+        }
+
         // If the query string contains any model with an id
         // then append that id to $cacheKey to make it unique.
         //

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -35,6 +35,11 @@ class OptionsQuery
     /**
      * @var array
      */
+    protected static $cache = [];
+
+    /**
+     * @var array
+     */
     protected $data;
 
     /**
@@ -114,6 +119,10 @@ class OptionsQuery
             return $this->options;
         }
 
+        if ($cachedOptions = A::get($this->query(), static::$cache)) {
+            return $cachedOptions;
+        }
+
         $data    = $this->data();
         $query   = new Query($this->query(), $data);
         $result  = $query->result();
@@ -129,6 +138,8 @@ class OptionsQuery
                 'value' => $this->template($alias, 'value', $data)
             ];
         }
+
+        static::$cache[$this->query()] = $options;
 
         return $this->options = $options;
     }


### PR DESCRIPTION
This does greatly improve performance when options are fetched. It's mainly needed inside the panel to speed up complex many-to-many relations of pages.

closes #3746

## Describe the PR
I added a simple static cache to keep resolved options in memory and prevent them from being resolved again.  

This does improve performance tested on a rather complex blueprint setup. Together with @waffl from the forum I have used xdebug to profile a 6000 pages setup with multiple and different many-to-many relations between pages, sometimes even in structures.

The cache is helpful since Kirby will resolve the query foreach loaded page with the same blueprint again and again. Once per field. This means once per row in a structure. We have seen between 400.000 and 2.000.000 requests to query->resolve on a base of 20 different fetch statements. A lot of these resolves are triggered by Kirby resolving the blueprints of pages related to the query, like siblings.

- The loading time of the a content in the panel with the static cache in place was improved from 14.000 millisec to 400 millisec.
- The loading time of the same content in frontend is around 120 millisec with and without the cache. That is because the blueprint does not need to be resolved here.


FORUM:
https://forum.getkirby.com/t/help-needed-troubleshooting-slow-panel-query-multiselect-field/23685/9

RELATED ISSUES:
https://github.com/getkirby/kirby/issues/3746

