### PR TITLE
Call `route` hooks only for core router

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -328,17 +328,9 @@ class App
      */
     public function call(string $path = null, string $method = null)
     {
-        $router = $this->router();
-
-        $router::$beforeEach = function ($route, $path, $method) {
-            $this->trigger('route:before', compact('route', 'path', 'method'));
-        };
-
-        $router::$afterEach = function ($route, $path, $method, $result, $final) {
-            return $this->apply('route:after', compact('route', 'path', 'method', 'result', 'final'), 'result');
-        };
-
-        return $router->call($path ?? $this->path(), $method ?? $this->request()->method());
+        $path   ??= $this->path();
+        $method ??= $this->request()->method();
+        return $this->router()->call($path, $method);
     }
 
     /**
@@ -1234,7 +1226,15 @@ class App
             }
         }
 
-        return $this->router = $this->router ?? new Router($routes);
+        return $this->router ??= new Router(
+            $routes,
+            function ($route, $path, $method) {
+                $this->trigger('route:before', compact('route', 'path', 'method'));
+            },
+            function ($route, $path, $method, $result, $final) {
+                return $this->apply('route:after', compact('route', 'path', 'method', 'result', 'final'), 'result');
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

In 3.6.0 we introduced a new `router()` helper and use a separate `Router` instance for our Panel routes. However, the `route:before` and `route:after` hooks get called for any call of any `Router` object - instead of only our core Kirby router, which I think is the expected behaviour.



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- `route:before` and `route:after` hooks only get called for core routing calls

## Related

- Fixes https://github.com/getkirby/kirby/issues/3951

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

Previous static `Http\Router::$beforeEach` and `Http\Router::$afterEach` closures cannot be set statically anymore but need to be passed to `Router::__construct()` as 2nd and 3rd parameters.



## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
