### PR TITLE
Implement system.exception hook

### DIFF
--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -158,7 +158,21 @@ trait AppErrors
         $whoops = $this->whoops();
         $whoops->clearHandlers();
         $whoops->pushHandler($handler);
+        $whoops->pushHandler($this->getExceptionHookWhoopsHandler());
         $whoops->register(); // will only do something if not already registered
+    }
+
+    /**
+     * Initializes a callback handler for triggering the `system.exception` hook
+     *
+     * @return \Whoops\Handler\CallbackHandler
+     */
+    protected function getExceptionHookWhoopsHandler(): CallbackHandler
+    {
+        return new CallbackHandler(function ($exception, $inspector, $run) {
+            $this->trigger('system.exception', compact('exception'));
+            return Handler::DONE;
+        });
     }
 
     /**

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -40,8 +40,9 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
     }
 
     /**
@@ -66,8 +67,9 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // JSON
         Server::$cli = false;
@@ -75,8 +77,9 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // HTML
         Server::$cli = false;
@@ -93,8 +96,9 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // reset global state
         Server::$cli            = $oldCli;
@@ -121,9 +125,10 @@ class AppErrorsTest extends TestCase
         // without options
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
         $this->assertSame($this->_getBufferedContent($app->root('kirby') . '/views/fatal.php'), $this->_getBufferedContent($handlers[0]));
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // without fatal closure
         $optionsMethod->invoke($app, ['fatal' => function () {
@@ -132,39 +137,44 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
         $this->assertSame('Fatal Error Test!', $this->_getBufferedContent($handlers[0]));
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // disabling Whoops without debugging doesn't matter
         $optionsMethod->invoke($app, ['debug' => false, 'whoops' => false]);
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // with debugging enabled
         $optionsMethod->invoke($app, ['debug' => true, 'whoops' => true]);
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
         $this->assertSame('Kirby CMS Debugger', $handlers[0]->getPageTitle());
         $this->assertSame(dirname(__DIR__, 3) . '/assets', $handlers[0]->getResourcePaths()[0]);
         $this->assertFalse($handlers[0]->getEditorHref('test', 1));
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // with debugging enabled and editor
         $optionsMethod->invoke($app, ['debug' => true, 'whoops' => true, 'editor' => 'vscode']);
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
+
         $this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
         $this->assertSame('Kirby CMS Debugger', $handlers[0]->getPageTitle());
         $this->assertSame(dirname(__DIR__, 3) . '/assets', $handlers[0]->getResourcePaths()[0]);
         $this->assertSame('vscode://file/test:1', $handlers[0]->getEditorHref('test', 1));
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // with debugging enabled, but without Whoops
         $optionsMethod->invoke($app, ['debug' => true, 'whoops' => false]);
@@ -193,8 +203,9 @@ class AppErrorsTest extends TestCase
 
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         // test CallbackHandler with default
         $this->assertSame(json_encode([
@@ -237,7 +248,7 @@ class AppErrorsTest extends TestCase
         $optionsMethod->invoke($app, ['debug' => true, 'whoops' => true]);
 
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
 
         $this->assertSame(json_encode([
@@ -251,6 +262,7 @@ class AppErrorsTest extends TestCase
             'file' => __FILE__,
             'line' => $exception->getLine()
         ]), $this->_getBufferedContent($handlers[0]));
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
     }
 
     /**
@@ -273,15 +285,17 @@ class AppErrorsTest extends TestCase
 
         $setMethod->invoke($app, new PlainTextHandler());
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PlaintextHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         $setMethod->invoke($app, function () {
             // empty callback
         });
         $handlers = $whoops->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 
         $unsetMethod->invoke($app);
         $handlers = $whoops->getHandlers();

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -25,6 +25,37 @@ class AppErrorsTest extends TestCase
     }
 
     /**
+     * @covers ::getExceptionHookWhoopsHandler
+     */
+    public function testExceptionHook()
+    {
+        $result = null;
+
+        $app = $this->app->clone([
+            'hooks' => [
+                'system.exception' => function ($exception) use (&$result) {
+                    $result = $exception->getMessage();
+                }
+            ]
+        ]);
+
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+
+        $whoops  = $whoopsMethod->invoke($app);
+        $handler = $whoops->getHandlers()[1];
+
+        // test CallbackHandler with \Exception class
+        $exception = new \Exception('Some error message');
+        $handler->setException($exception);
+
+        // handle the exception
+        $this->_getBufferedContent($handler);
+
+        $this->assertSame('Some error message', $result);
+    }
+
+    /**
      * @covers ::handleCliErrors
      * @covers ::getExceptionHookWhoopsHandler
      */

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -26,6 +26,7 @@ class AppErrorsTest extends TestCase
 
     /**
      * @covers ::handleCliErrors
+     * @covers ::getExceptionHookWhoopsHandler
      */
     public function testHandleCliErrors()
     {
@@ -47,6 +48,7 @@ class AppErrorsTest extends TestCase
 
     /**
      * @covers ::handleErrors
+     * @covers ::getExceptionHookWhoopsHandler
      */
     public function testHandleErrors()
     {
@@ -107,6 +109,7 @@ class AppErrorsTest extends TestCase
 
     /**
      * @covers ::handleHtmlErrors
+     * @covers ::getExceptionHookWhoopsHandler
      */
     public function testHandleHtmlErrors()
     {
@@ -186,6 +189,7 @@ class AppErrorsTest extends TestCase
 
     /**
      * @covers ::handleJsonErrors
+     * @covers ::getExceptionHookWhoopsHandler
      */
     public function testHandleJsonErrors()
     {
@@ -268,6 +272,7 @@ class AppErrorsTest extends TestCase
     /**
      * @covers ::setWhoopsHandler
      * @covers ::unsetWhoopsHandler
+     * @covers ::getExceptionHookWhoopsHandler
      */
     public function testSetUnsetWhoopsHandler()
     {


### PR DESCRIPTION
## Describe the PR
This is an idea how to implement a new hook for `system.exception`. It will register an additional Whoops callback handler to trigger the hook which makes it possible to implement plugins for custom error monitoring (eg. Sentry).

_Original by @thathoff - moved to branch in our repo to rebase._

## Related

https://kirby.nolt.io/371

## Release notes

### Feature

- New `system.exception` hook

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

## When merging
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
