### PR TITLE
Remove non-standard MIME content type from Response::download()

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -167,7 +167,7 @@ class Response
 
         $props = array_replace_recursive([
             'body'    => $body,
-            'type'    => 'application/force-download',
+            'type'    => F::mime($file),
             'headers' => [
                 'Pragma'                    => 'public',
                 'Cache-Control'             => 'no-cache, no-store, must-revalidate',


### PR DESCRIPTION
## Describe the PR
Response::download() triggers a response that includes the HTTP header Content-Type: application/force-download. While this works fine in most browsers, it may cause issues (e.g. occured on at least two iOS devices) as that is not a valid MIME type.

## Related issues/ideas
- Fixes #3956 

## Ready?

The "Content-Type" part of the `download()`-method's response is not currently covered by tests; not sure does this fix require an addition to the tests as it now dynamically loads the file's MIME type?

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

## When merging
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
