### PR TITLE
Minimal fix for `route` hooks only on core routing

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -330,6 +330,10 @@ class App
     {
         $router = $this->router();
 
+        /**
+         * @todo Closures should not defined statically but
+         * for each instance to avoid this constant setting and unsetting
+         */
         $router::$beforeEach = function ($route, $path, $method) {
             $this->trigger('route:before', compact('route', 'path', 'method'));
         };
@@ -338,7 +342,12 @@ class App
             return $this->apply('route:after', compact('route', 'path', 'method', 'result', 'final'), 'result');
         };
 
-        return $router->call($path ?? $this->path(), $method ?? $this->request()->method());
+        $result = $router->call($path ?? $this->path(), $method ?? $this->request()->method());
+
+        $router::$beforeEach = null;
+        $router::$afterEach  = null;
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
**## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

In 3.6.0 we introduced a new `router()` helper and use a separate `Router` instance for our Panel routes. However, the `route:before` and `route:after` hooks get called for any call of any `Router` object - instead of only our core Kirby router, which I think is the expected behaviour.



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes
- `route:before` and `route:after` hooks only get called for core routing calls

## Related

- Fixes https://github.com/getkirby/kirby/issues/3951

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None.



## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
**
