### PR TITLE
Support i18n keys for form options

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -137,7 +137,10 @@ class Options
         $result = [];
 
         foreach ($options as $key => $option) {
-            if (is_array($option) === false || isset($option['value']) === false) {
+            if (
+                is_array($option) === false ||
+                isset($option['value']) === false
+            ) {
                 $option = [
                     'value' => is_int($key) ? $option : $key,
                     'text'  => $option
@@ -145,9 +148,7 @@ class Options
             }
 
             // translate the option text
-            if (is_array($option['text']) === true) {
-                $option['text'] = I18n::translate($option['text'], $option['text']);
-            }
+            $option['text'] = I18n::translate($option['text'], $option['text']);
 
             // add the option to the list
             $result[] = $option;

--- a/tests/Form/OptionsTest.php
+++ b/tests/Form/OptionsTest.php
@@ -86,20 +86,20 @@ class OptionsTest extends TestCase
 
         $expected = [
             [
-                'value' => 'apple',
-                'text'  => 'Apple'
+                'text'  => 'Apple',
+                'value' => 'apple'
             ],
             [
-                'value' => 'intel',
-                'text'  => 'Intel'
+                'text'  => 'Intel',
+                'value' => 'intel'
             ],
             [
-                'value' => 'microsoft',
-                'text'  => 'Microsoft'
+                'text'  => 'Microsoft',
+                'value' => 'microsoft'
             ],
         ];
 
-        $this->assertEquals($expected, $options);
+        $this->assertSame($expected, $options);
     }
 
     public function testBlocks()
@@ -257,7 +257,7 @@ class OptionsTest extends TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testTranslated()
@@ -269,8 +269,8 @@ class OptionsTest extends TestCase
             'b' => ['en' => 'B (en)', 'de' => 'B (de)']
         ]);
 
-        $this->assertEquals('A (en)', $options[0]['text']);
-        $this->assertEquals('B (en)', $options[1]['text']);
+        $this->assertSame('A (en)', $options[0]['text']);
+        $this->assertSame('B (en)', $options[1]['text']);
 
         I18n::$locale = 'de';
 
@@ -279,25 +279,61 @@ class OptionsTest extends TestCase
             'b' => ['en' => 'B (en)', 'de' => 'B (de)']
         ]);
 
-        $this->assertEquals('A (de)', $options[0]['text']);
-        $this->assertEquals('B (de)', $options[1]['text']);
+        $this->assertSame('A (de)', $options[0]['text']);
+        $this->assertSame('B (de)', $options[1]['text']);
+    }
+
+    public function testTranslatedWithI18nKey()
+    {
+        $app = $this->app->clone([
+            'languages' => [
+                [
+                    'code'    => 'de',
+                    'default' => true
+                ],
+                [
+                    'code'=> 'en'
+                ]
+            ],
+            'translations' => [
+                'de' => [
+                    'test.a' => 'A (de)',
+                    'test.b' => 'B (de)'
+                ],
+                'en' => [
+                    'test.a' => 'A (en)',
+                    'test.b' => 'B (en)'
+                ]
+            ]
+        ]);
+
+        I18n::$locale = 'en';
+
+        $options = Options::factory([
+            'test.a',
+            'test.b'
+        ]);
+
+        $this->assertSame('A (en)', $options[0]['text']);
+        $this->assertSame('B (en)', $options[1]['text']);
+
+        I18n::$locale = 'de';
+
+        $options = Options::factory([
+            'test.a',
+            'test.b'
+        ]);
+
+        $this->assertSame('A (de)', $options[0]['text']);
+        $this->assertSame('B (de)', $options[1]['text']);
     }
 
     public function testUntranslated()
     {
-        I18n::$translations = [
-            'en' => [
-                'language' => 'Language'
-            ],
-            'de' => [
-                'language' => 'Sprache'
-            ]
-        ];
-
         $options = Options::factory([
-            'language' => 'language',
+            'test.c'
         ]);
 
-        $this->assertEquals('language', $options[0]['text']);
+        $this->assertSame('test.c', $options[0]['text']);
     }
 }


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Allows to use i18n keys as options

```yaml
mySelectField:
  label: myfield.label
  type: select
  options:
    option1: myfield.option1
    option2: myfield.option2

```


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- Support for translation keys as option text


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

⚠️ Option text that is the same as an existing i18n key now gets replaced by the translation string.



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3955

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
