### PR TITLE
`k-item`: fix z-index for dropdown #3944

### DIFF
--- a/panel/src/components/Layout/Item.vue
+++ b/panel/src/components/Layout/Item.vue
@@ -197,6 +197,9 @@ export default {
   z-index: 1;
 }
 .k-item-buttons > .k-dropdown {
+  z-index: var(--z-navigation);
+}
+.k-item-buttons > .k-dropdown-content {
   z-index: var(--z-dropdown);
 }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- Item dropdown icon doesn't overlap downdown itself anymore 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3944

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
