### PR TITLE
Fix converting blocks from non-existing type #3962

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -329,12 +329,13 @@ export default {
 
       const fields = (fieldset) => {
         let fields = {};
-        Object.values(fieldset.tabs).forEach((tab) => {
+
+        for (const tab of Object.values(fieldset?.tabs ?? {})) {
           fields = {
             ...fields,
             ...tab.fields
           };
-        });
+        }
 
         return fields;
       };
@@ -353,16 +354,16 @@ export default {
 
       let content = newBlock.content;
 
-      const oldFields = fields(oldFieldset);
       const newFields = fields(newFieldset);
+      const oldFields = fields(oldFieldset);
 
-      Object.entries(newFields).forEach(([name, field]) => {
+      for (const [name, field] of Object.entries(newFields)) {
         const oldField = oldFields[name];
 
         if (oldField?.type === field.type && oldBlock?.content?.[name]) {
           content[name] = oldBlock.content[name];
         }
-      });
+      }
 
       this.blocks[index] = {
         ...newBlock,


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

When converting from a non-existing block type (e.g. when there was a custom block type but got renamed in the meantime), the Panel would throw errors when it was trying to migrate the fields from old to new type as it couldn't find the old fieldset. Now, we gracefully fall back to an empty fieldset.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- Converting blocks from non-existing type (e.g. after renaming) doesn't throw an error


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3962

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
