### PR TITLE
`Str` methods: handle empty `$needle`

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use Exception;
+use Kirby\Exception\InvalidArgumentException;
 
 /**
  * The String class provides a set
@@ -180,9 +181,9 @@ class Str
 
         if ($position === false) {
             return '';
-        } else {
-            return static::substr($string, $position + static::length($needle));
         }
+
+        return static::substr($string, $position + static::length($needle));
     }
 
     /**
@@ -222,9 +223,9 @@ class Str
 
         if ($position === false) {
             return '';
-        } else {
-            return static::substr($string, 0, $position);
         }
+
+        return static::substr($string, 0, $position);
     }
 
     /**
@@ -250,7 +251,12 @@ class Str
      */
     public static function contains(string $string = null, string $needle, bool $caseInsensitive = false): bool
     {
-        return call_user_func($caseInsensitive === true ? 'stripos' : 'strpos', $string, $needle) !== false;
+        if ($needle === '') {
+            return true;
+        }
+
+        $method = $caseInsensitive === true ? 'stripos' : 'strpos';
+        return call_user_func($method, $string, $needle) !== false;
     }
 
     /**
@@ -397,9 +403,9 @@ class Str
 
         if ($position === false) {
             return '';
-        } else {
-            return static::substr($string, $position);
         }
+
+        return static::substr($string, $position);
     }
 
     /**
@@ -512,6 +518,10 @@ class Str
      */
     public static function position(string $string = null, string $needle, bool $caseInsensitive = false)
     {
+        if ($needle === '') {
+            throw new InvalidArgumentException('The needle must not be empty');
+        }
+
         if ($caseInsensitive === true) {
             $string = static::lower($string);
             $needle = static::lower($needle);
@@ -1198,9 +1208,9 @@ class Str
 
         if ($position === false) {
             return '';
-        } else {
-            return static::substr($string, 0, $position + static::length($needle));
         }
+
+        return static::substr($string, 0, $position + static::length($needle));
     }
 
     /**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -58,6 +58,16 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::after
+     */
+    public function testAfterWithEmptyNeedle()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The needle must not be empty');
+        Str::after('test', '');
+    }
+
+    /**
      * @covers ::before
      */
     public function testBefore()
@@ -73,6 +83,16 @@ class StrTest extends TestCase
         $this->assertSame('Hell', Str::before($string, 'ö', true));
         $this->assertSame('Hell', Str::before($string, 'Ö', true));
         $this->assertSame('', Str::before($string, 'x'));
+    }
+
+    /**
+     * @covers ::before
+     */
+    public function testBeforeWithEmptyNeedle()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The needle must not be empty');
+        Str::before('test', '');
     }
 
     /**
@@ -103,6 +123,9 @@ class StrTest extends TestCase
         $this->assertTrue(Str::contains($string, 'Wörld', true));
         $this->assertTrue(Str::contains($string, 'hellö', true));
         $this->assertTrue(Str::contains($string, 'wörld', true));
+
+        // empty needle
+        $this->assertTrue(Str::contains($string, ''));
     }
 
     /**
@@ -305,6 +328,16 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::from
+     */
+    public function testFromWithEmptyNeedle()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The needle must not be empty');
+        Str::from('test', '');
+    }
+
+    /**
      * @covers ::kebab
      */
     public function testKebab()
@@ -404,6 +437,16 @@ class StrTest extends TestCase
         $this->assertTrue(Str::position($string, 'h', true) === 0);
         $this->assertTrue(Str::position($string, 'ö', true) === 4);
         $this->assertTrue(Str::position($string, 'Ö', true) === 4);
+    }
+
+    /**
+     * @covers ::position
+     */
+    public function testPositionWithEmptyNeedle()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The needle must not be empty');
+        Str::position('test', '');
     }
 
     /**
@@ -1103,6 +1146,16 @@ EOT;
         $this->assertSame('Hellö', Str::until($string, 'ö', true));
         $this->assertSame('Hellö', Str::until($string, 'Ö', true));
         $this->assertSame('', Str::until($string, 'x'));
+    }
+
+    /**
+     * @covers ::until
+     */
+    public function testUntilWithEmptyNeedle()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The needle must not be empty');
+        Str::until('test', '');
     }
 
     /**


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Aligns `Str` methods in their handling of an empty `$needle` string.



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixed
- `Str` methods handle an empty `$needle` string


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

Instead of PHP errors in PHP 7.4, most methods now throw a proper `Kirby\Exception\InvalidArgumentException`.
`Str::contains()` returns `true` when empty `$needle` is passed (instead PHP error).

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3459

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
