### PR TITLE
PHP 8.1: don't pass `null`

### DIFF
--- a/config/fields/list.php
+++ b/config/fields/list.php
@@ -11,7 +11,7 @@ return [
     ],
     'computed' => [
         'value' => function () {
-            return trim($this->value);
+            return trim($this->value ?? '');
         }
     ]
 ];

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -27,7 +27,7 @@ return [
          * Sets the default text when a new page/file/user is created
          */
         'default' => function (string $default = null) {
-            return trim($default);
+            return trim($default ?? '');
         },
 
         /**
@@ -81,7 +81,7 @@ return [
         },
 
         'value' => function (string $value = null) {
-            return trim($value);
+            return trim($value ?? '');
         }
     ],
     'api' => function () {

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -29,7 +29,8 @@ return [
     ],
     'computed' => [
         'value' => function () {
-            return Sane::sanitize(trim($this->value), 'html');
+            $value = trim($this->value ?? '');
+            return Sane::sanitize($value, 'html');
         }
     ],
 ];

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -162,7 +162,7 @@ class Api
      */
     public function call(string $path = null, string $method = 'GET', array $requestData = [])
     {
-        $path = rtrim($path, '/');
+        $path = rtrim($path ?? '', '/');
 
         $this->setRequestMethod($method);
         $this->setRequestData($requestData);

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -128,7 +128,7 @@ trait AppErrors
                     'code'      => $code,
                     'message'   => $exception->getMessage(),
                     'details'   => $details,
-                    'file'      => ltrim($exception->getFile(), $_SERVER['DOCUMENT_ROOT'] ?? null),
+                    'file'      => ltrim($exception->getFile(), $_SERVER['DOCUMENT_ROOT'] ?? ''),
                     'line'      => $exception->getLine(),
                 ], $httpCode);
             } else {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -508,7 +508,7 @@ class System
             ];
         }
 
-        $software = $_SERVER['SERVER_SOFTWARE'] ?? null;
+        $software = $_SERVER['SERVER_SOFTWARE'] ?? '';
 
         preg_match('!(' . implode('|', $servers) . ')!i', $software, $matches);
 

--- a/src/Cms/Template.php
+++ b/src/Cms/Template.php
@@ -78,7 +78,11 @@ class Template
      */
     public function exists(): bool
     {
-        return file_exists($this->file());
+        if ($file = $this->file()) {
+            return file_exists($file);
+        }
+
+        return false;
     }
 
     /**

--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -65,7 +65,7 @@ class Data
                    static::$handlers[static::$aliases[$type] ?? null] ??
                    null;
 
-        if (class_exists($handler)) {
+        if ($handler !== null && class_exists($handler)) {
             return new $handler();
         }
 

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -128,7 +128,7 @@ class Exception extends \Exception
             ]);
 
             // handover to Exception parent class constructor
-            parent::__construct($message, null, $args['previous'] ?? null);
+            parent::__construct($message, 0, $args['previous'] ?? null);
         }
 
         // set the Exception code to the key

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -220,7 +220,7 @@ class Request
         $methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'];
 
         // the request method can be overwritten with a header
-        $methodOverride = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? null);
+        $methodOverride = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? '');
 
         if ($method === null && in_array($methodOverride, $methods) === true) {
             $method = $methodOverride;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -234,7 +234,7 @@ class Response
     public static function json($body = '', ?int $code = null, ?bool $pretty = null, array $headers = [])
     {
         if (is_array($body) === true) {
-            $body = json_encode($body, $pretty === true ? JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES : null);
+            $body = json_encode($body, $pretty === true ? JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES : 0);
         }
 
         return new static([

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -92,6 +92,9 @@ class Server
      */
     public static function sanitize(string $key, $value)
     {
+        // make sure $value is not null
+        $value ??= '';
+
         switch ($key) {
             case 'SERVER_ADDR':
             case 'SERVER_NAME':

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -246,8 +246,12 @@ class Uri
             return static::$current;
         }
 
-        $uri = Server::get('REQUEST_URI');
-        $uri = preg_replace('!^(http|https)\:\/\/' . Server::get('HTTP_HOST') . '!', '', $uri);
+        $uri = Server::get('REQUEST_URI') ?? '';
+        $uri = preg_replace(
+            '!^(http|https)\:\/\/' . Server::get('HTTP_HOST') . '!',
+            '',
+            $uri
+        );
         $uri = parse_url('http://getkirby.com' . $uri);
 
         $url = new static(array_merge([

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -260,6 +260,9 @@ class Url
      */
     public static function to(string $path = null, $options = null): string
     {
+        // make sure $path is string
+        $path ??= '';
+
         // keep relative urls
         if (substr($path, 0, 2) === './' || substr($path, 0, 3) === '../') {
             return $path;

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -229,11 +229,14 @@ class Panel
     /**
      * Returns the referrer path if present
      *
-     * @return string|null
+     * @return string
      */
-    public static function referrer(): ?string
+    public static function referrer(): string
     {
-        $referrer = kirby()->request()->header('X-Fiber-Referrer') ?? get('_referrer');
+        $referrer = kirby()->request()->header('X-Fiber-Referrer')
+                 ?? get('_referrer')
+                 ?? '';
+
         return '/' . trim($referrer, '/');
     }
 

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -145,6 +145,10 @@ class Html extends Xml
         // all other cases can share the XML variant
         $attr = parent::attr($name, $value);
 
+        if ($attr === null) {
+            return null;
+        }
+
         // HTML supports named entities
         $entities = parent::entities();
         $html = array_keys($entities);
@@ -353,7 +357,7 @@ class Html extends Xml
      */
     public static function rel(?string $rel = null, ?string $target = null): ?string
     {
-        $rel = trim($rel);
+        $rel = trim($rel ?? '');
 
         if ($target === '_blank') {
             if (empty($rel) === false) {

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -379,6 +379,9 @@ class Str
      */
     public static function float($value): string
     {
+        // make sure $value is not null
+        $value ??= '';
+
         // Convert exponential to decimal, 1e-8 as 0.00000001
         if (strpos(strtolower($value), 'e') !== false) {
             $value = rtrim(sprintf('%.16f', (float)$value), '0');
@@ -442,7 +445,7 @@ class Str
      */
     public static function length(string $string = null): int
     {
-        return mb_strlen($string, 'UTF-8');
+        return mb_strlen($string ?? '', 'UTF-8');
     }
 
     /**
@@ -912,7 +915,7 @@ class Str
         $separator ??= static::$defaults['slug']['separator'];
         $allowed   ??= static::$defaults['slug']['allowed'];
 
-        $string = trim($string);
+        $string = trim($string ?? '');
         $string = static::lower($string);
         $string = static::ascii($string);
 
@@ -968,8 +971,11 @@ class Str
             return $string;
         }
 
-        $parts  = explode($separator, $string);
-        $out    = [];
+        // make sure $string is string
+        $string ??= '';
+
+        $parts = explode($separator, $string);
+        $out   = [];
 
         foreach ($parts as $p) {
             $p = trim($p);
@@ -1056,6 +1062,9 @@ class Str
         $start    = (string)($options['start'] ?? $start);
         $end      = (string)($options['end'] ?? $end);
 
+        // make sure $string is string
+        $string ??= '';
+
         return preg_replace_callback('!' . $start . '(.*?)' . $end . '!', function ($match) use ($data, $fallback, $callback) {
             $query = trim($match[1]);
 
@@ -1094,8 +1103,12 @@ class Str
      */
     public static function toBytes($size): int
     {
+        // TODO: remove in 3.7.0
+        // in favor of strict parameter type hint
+        $size ??= '';
+
         $size = trim($size);
-        $last = strtolower($size[strlen($size)-1] ?? null);
+        $last = strtolower($size[strlen($size)-1] ?? '');
         $size = (int)$size;
 
         switch ($last) {
@@ -1234,6 +1247,9 @@ class Str
      */
     public static function widont(string $string = null): string
     {
+        // make sure $string is string
+        $string ??= '';
+
         // Replace space between last word and punctuation
         $string = preg_replace_callback('|(\S)\s(\S?)$|u', function ($matches) {
             return $matches[1] . '&nbsp;' . $matches[2];

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -249,6 +249,9 @@ V::$validators = [
      * third argument to compare them.
      */
     'date' => function (?string $value, string $operator = null, string $test = null): bool {
+        // make sure $value is a string
+        $value ??= '';
+
         $args = func_get_args();
 
         // simple date validation
@@ -522,6 +525,6 @@ V::$validators = [
         // In search for the perfect regular expression: https://mathiasbynens.be/demo/url-regex
         // Added localhost support and removed 127.*.*.* ip restriction
         $regex = '_^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:localhost)|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$_iu';
-        return preg_match($regex, $value) !== 0;
+        return preg_match($regex, $value ?? '') !== 0;
     }
 ];


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Don't pass `null` to native functions that actually don't accept `null` but a specific type (string, int...).


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
