### PR TITLE
`ArrayIterator` return type hint

### DIFF
--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -40,7 +40,7 @@ class Iterator implements IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->data);
     }


### PR DESCRIPTION
PHP 8.1 demands the return type to match the `IteratorAggregate` protocol