### PR TITLE
`Str::date()` for DRY code

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -121,13 +121,14 @@ return function (App $app) {
                 return null;
             }
 
-            $time = empty($field->value) === true ? strtotime($fallback) : $field->toTimestamp();
-
-            if ($format === null) {
-                return $time;
+            if (empty($field->value) === false) {
+                $time = $field->toTimestamp();
+            } else {
+                $time = strtotime($fallback);
             }
 
-            return ($app->option('date.handler', 'date'))($format, $time);
+            $handler = $app->option('date.handler', 'date');
+            return Str::date($time, $format, $handler);
         },
 
         /**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -6,6 +6,7 @@ use Kirby\Filesystem\F;
 use Kirby\Filesystem\IsFile;
 use Kirby\Panel\File as Panel;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\Str;
 
 /**
  * The `$file` object provides a set
@@ -362,14 +363,9 @@ class File extends ModelWithContent
         $file     = $this->modifiedFile();
         $content  = $this->modifiedContent($languageCode);
         $modified = max($file, $content);
-
-        if (is_null($format) === true) {
-            return $modified;
-        }
-
         $handler ??= $this->kirby()->option('date.handler', 'date');
 
-        return $handler($format, $modified);
+        return Str::date($modified, $format, $handler);
     }
 
     /**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -532,7 +532,7 @@ class User extends ModelWithContent
         $modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
         $handler       ??= $this->kirby()->option('date.handler', 'date');
 
-        return $handler($format, $modifiedTotal);
+        return Str::date($modifiedTotal, $format, $handler);
     }
 
     /**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -5,6 +5,7 @@ namespace Kirby\Filesystem;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
@@ -450,7 +451,7 @@ class Dir
             $modified = ($newModified > $modified) ? $newModified : $modified;
         }
 
-        return $format !== null ? $handler($format, $modified) : $modified;
+        return Str::date($modified, $format, $handler);
     }
 
     /**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -475,11 +475,7 @@ class F
 
         $modified = filemtime($file);
 
-        if (is_null($format) === true) {
-            return $modified;
-        }
-
-        return $handler($format, $modified);
+        return Str::date($modified, $format, $handler);
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -260,6 +260,24 @@ class Str
     }
 
     /**
+     * Convert timestamp to date string
+     * according to locale settings
+     *
+     * @param int|null $time
+     * @param string|null $format
+     * @param string $handler
+     * @return string|int
+     */
+    public static function date(?int $time = null, ?string $format = null, string $handler = 'date')
+    {
+        if (is_null($format) === true) {
+            return $time;
+        }
+
+        return $handler($format, $time);
+    }
+
+    /**
      * Converts a string to a different encoding
      *
      * @param string $string

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -129,6 +129,22 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::date
+     */
+    public function testDate()
+    {
+        $time = mktime(1, 1, 1, 1, 29, 2020);
+
+        // default `date` handler
+        $this->assertSame($time, Str::date($time));
+        $this->assertSame('29.01.2020', Str::date($time, 'd.m.Y'));
+
+        // `strftime` handler
+        $this->assertSame($time, Str::date($time, null, 'strftime'));
+        $this->assertSame('29.01.2020', Str::date($time, '%d.%m.%Y', 'strftime'));
+    }
+
+    /**
      * @covers ::convert
      */
     public function testConvert()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

In preparation of handling `strftime` separately in PHP 8.1 (for suppressing deprecation warnings).


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Enhancements
- New `Str::date($time, $format, $handler)` method to format a timestamp as date string


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
