### PR TITLE
Explicit CSS data attr selectors for styling

### DIFF
--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -243,7 +243,7 @@ export default {
 }
 
 /* Nested drawers */
-.k-drawer[data-nested] {
+.k-drawer[data-nested="true"] {
   background: none;
 }
 </style>

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -240,11 +240,11 @@ export default {
   outline: 0;
 }
 
-.k-block-container[data-batched] {
+.k-block-container[data-batched="true"] {
   z-index: 2;
   border-bottom-color: transparent;
 }
-.k-block-container[data-batched]::after {
+.k-block-container[data-batched="true"]::after {
   position: absolute;
   inset: 0;
   content: "";
@@ -253,7 +253,7 @@ export default {
   border: 1px solid var(--color-focus);
 }
 
-.k-block-container[data-selected] {
+.k-block-container[data-selected="true"] {
   z-index: 2;
   box-shadow: var(--color-focus) 0 0 0 1px, var(--color-focus-outline) 0 0 0 3px;
   border-bottom-color: transparent;
@@ -265,18 +265,18 @@ export default {
   inset-inline-end: 0.75rem;
   margin-top: calc(-1.75rem + 2px);
 }
-.k-block-container[data-last-in-batch] > .k-block-options,
-.k-block-container[data-selected] > .k-block-options {
+.k-block-container[data-last-in-batch="true"] > .k-block-options,
+.k-block-container[data-selected="true"] > .k-block-options {
   display: flex;
 }
-.k-block-container[data-hidden] .k-block {
+.k-block-container[data-hidden="true"] .k-block {
   opacity: 0.25;
 }
-.k-drawer-options .k-button[data-disabled] {
+.k-drawer-options .k-button[data-disabled="true"] {
   vertical-align: middle;
   display: inline-grid;
 }
-[data-disabled] .k-block-container {
+[data-disabled="true"] .k-block-container {
   background: var(--color-background);
 }
 </style>

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -642,13 +642,13 @@ export default {
   background: var(--color-white);
   box-shadow: var(--shadow);
 }
-[data-disabled] .k-blocks {
+[data-disabled="true"] .k-blocks {
   background: var(--color-background);
 }
-.k-blocks[data-multi-select-key] .k-block-container > * {
+.k-blocks[data-multi-select-key="true"] .k-block-container > * {
   pointer-events: none;
 }
-.k-blocks[data-empty] {
+.k-blocks[data-empty="true"] {
   padding: 0;
   background: none;
   box-shadow: none;

--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -385,7 +385,7 @@ export default {
 .k-calendar-table .k-button:hover {
   color: var(--color-white);
 }
-.k-calendar-day:hover .k-button:not([data-disabled]) {
+.k-calendar-day:hover .k-button:not([data-disabled="true"]) {
   border-color: rgba(255, 255, 255, 0.25);
 }
 .k-calendar-day[aria-current="date"] .k-button {
@@ -396,14 +396,14 @@ export default {
   border-color: var(--color-focus-light);
   color: var(--color-focus-light);
 }
-.k-calendar-day[data-between] {
+.k-calendar-day[data-between="true"] {
   background: #333;
 }
-.k-calendar-day[data-first] {
+.k-calendar-day[data-first="true"] {
   border-start-start-radius: 100%;
   border-end-start-radius: 100%;
 }
-.k-calendar-day[data-last] {
+.k-calendar-day[data-last="true"] {
   border-start-end-radius: 100%;
   border-end-end-radius: 100%;
 }

--- a/panel/src/components/Forms/Counter.vue
+++ b/panel/src/components/Forms/Counter.vue
@@ -53,7 +53,7 @@ export default {
   color: var(--color-gray-900);
   font-weight: var(--font-bold);
 }
-.k-counter[data-invalid] {
+.k-counter[data-invalid="true"] {
   box-shadow: none;
   border: 0;
   color: var(--color-negative);

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -93,13 +93,13 @@ export default {
   padding: 0.75rem;
   display: flex;
 }
-.k-field[data-disabled] {
+.k-field[data-disabled="true"] {
   cursor: not-allowed;
 }
-.k-field[data-disabled] * {
+.k-field[data-disabled="true"] * {
   pointer-events: none;
 }
-.k-field[data-disabled] .k-text[data-theme="help"] * {
+.k-field[data-disabled="true"] .k-text[data-theme="help"] * {
   pointer-events: initial;
 }
 .k-field-counter {

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -148,7 +148,7 @@ export default {
 </script>
 
 <style>
-.k-files-field[data-disabled] * {
+.k-files-field[data-disabled="true"] * {
   pointer-events: all !important;
 }
 </style>

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -53,7 +53,7 @@ export default {
 </script>
 
 <style>
-.k-pages-field[data-disabled] * {
+.k-pages-field[data-disabled="true"] * {
   pointer-events: all !important;
 }
 </style>

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -663,10 +663,12 @@ export default {
 }
 
 .k-structure-table .k-sort-handle,
-.k-structure-table[data-sortable] tr:hover .k-structure-table-index-number {
+.k-structure-table[data-sortable="true"]
+  tr:hover
+  .k-structure-table-index-number {
   display: none;
 }
-.k-structure-table[data-sortable] tr:hover .k-sort-handle {
+.k-structure-table[data-sortable="true"] tr:hover .k-sort-handle {
   display: flex !important;
 }
 
@@ -692,16 +694,16 @@ export default {
   cursor: -webkit-grabbing;
 }
 
-[data-disabled] .k-structure-table {
+[data-disabled="true"] .k-structure-table {
   background: var(--color-background);
 }
-[data-disabled] .k-structure-table th,
-[data-disabled] .k-structure-table td {
+[data-disabled="true"] .k-structure-table th,
+[data-disabled="true"] .k-structure-table td {
   background: var(--color-background);
   border-bottom: 1px solid var(--color-border);
   border-inline-end: 1px solid var(--color-border);
 }
-[data-disabled] .k-structure-table td:last-child {
+[data-disabled="true"] .k-structure-table td:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -47,7 +47,7 @@ export default {
 </script>
 
 <style>
-.k-users-field[data-disabled] * {
+.k-users-field[data-disabled="true"] * {
   pointer-events: all !important;
 }
 </style>

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -135,11 +135,11 @@ export default {
 }
 
 /* Disabled state */
-.k-input[data-disabled] {
+.k-input[data-disabled="true"] {
   pointer-events: none;
 }
 
-[data-disabled] .k-input-icon {
+[data-disabled="true"] .k-input-icon {
   color: var(--color-gray-600);
 }
 
@@ -153,7 +153,7 @@ export default {
   box-shadow: var(--color-focus-outline) 0 0 0 2px;
 }
 
-.k-input[data-theme="field"][data-disabled] {
+.k-input[data-theme="field"][data-disabled="true"] {
   background: var(--color-background);
 }
 

--- a/panel/src/components/Forms/Input/CheckboxInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxInput.vue
@@ -125,7 +125,9 @@ export default {
   border-color: var(--color-gray-900);
   background: var(--color-gray-900);
 }
-[data-disabled] .k-checkbox-input-native:checked + .k-checkbox-input-icon {
+[data-disabled="true"]
+  .k-checkbox-input-native:checked
+  + .k-checkbox-input-icon {
   border-color: var(--color-gray-600);
   background: var(--color-gray-600);
 }

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -109,7 +109,7 @@ export default {
   border-color: var(--color-gray-900);
   background: var(--color-gray-900);
 }
-[data-disabled] .k-radio-input input:checked + label::before {
+[data-disabled="true"] .k-radio-input input:checked + label::before {
   border-color: var(--color-gray-600);
   background: var(--color-gray-600);
 }

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -338,35 +338,35 @@ export default {
   padding: 4px;
 }
 
-[data-disabled] .k-range-input-native::-webkit-slider-runnable-track {
+[data-disabled="true"] .k-range-input-native::-webkit-slider-runnable-track {
   background: linear-gradient(
       var(--range-track-color-disabled),
       var(--range-track-color-disabled)
     )
     0 / var(--position) 100% no-repeat var(--range-track-background);
 }
-[data-disabled] .k-range-input-native::-moz-range-progress {
+[data-disabled="true"] .k-range-input-native::-moz-range-progress {
   height: var(--range-track-height);
   background: var(--range-track-color-disabled);
 }
-[data-disabled] .k-range-input-native::-ms-fill-lower {
+[data-disabled="true"] .k-range-input-native::-ms-fill-lower {
   height: var(--range-track-height);
   background: var(--range-track-color-disabled);
 }
-[data-disabled] .k-range-input-native::-webkit-slider-thumb {
+[data-disabled="true"] .k-range-input-native::-webkit-slider-thumb {
   border: var(--range-thumb-border-disabled);
 }
-[data-disabled] .k-range-input-native::-moz-range-thumb {
+[data-disabled="true"] .k-range-input-native::-moz-range-thumb {
   border: var(--range-thumb-border-disabled);
 }
-[data-disabled] .k-range-input-native::-ms-thumb {
+[data-disabled="true"] .k-range-input-native::-ms-thumb {
   border: var(--range-thumb-border-disabled);
 }
 
-[data-disabled] .k-range-input-tooltip {
+[data-disabled="true"] .k-range-input-tooltip {
   background: var(--color-gray-600);
 }
-[data-disabled] .k-range-input-tooltip::after {
+[data-disabled="true"] .k-range-input-tooltip::after {
   border-inline-end: 5px solid var(--color-gray-600);
 }
 </style>

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -434,7 +434,7 @@ export default {
   font-family: var(--font-mono);
 }
 
-.k-writer[data-placeholder][data-empty]::before {
+.k-writer[data-placeholder][data-empty="true"]::before {
   grid-area: content;
   content: attr(data-placeholder);
   line-height: inherit;

--- a/panel/src/components/Layout/AspectRatio.vue
+++ b/panel/src/components/Layout/AspectRatio.vue
@@ -57,7 +57,7 @@ export default {
   width: 100%;
   object-fit: contain;
 }
-.k-aspect-ratio[data-cover] > * {
+.k-aspect-ratio[data-cover="true"] > * {
   object-fit: cover;
 }
 </style>

--- a/panel/src/components/Layout/Column.vue
+++ b/panel/src/components/Layout/Column.vue
@@ -29,7 +29,7 @@ export default {
   grid-column-start: span 12;
 }
 
-.k-column[data-sticky] > div {
+.k-column[data-sticky="true"] > div {
   position: sticky;
   top: 4vh;
   z-index: 2;
@@ -90,14 +90,14 @@ export default {
   }
 }
 
-.k-column[data-disabled] {
+.k-column[data-disabled="true"] {
   cursor: not-allowed;
   opacity: 0.4;
 }
-.k-column[data-disabled] * {
+.k-column[data-disabled="true"] * {
   pointer-events: none;
 }
-.k-column[data-disabled] .k-text[data-theme="help"] * {
+.k-column[data-disabled="true"] .k-text[data-theme="help"] * {
   pointer-events: initial;
 }
 </style>

--- a/panel/src/components/Layout/Dropzone.vue
+++ b/panel/src/components/Layout/Dropzone.vue
@@ -93,7 +93,7 @@ export default {
   pointer-events: none;
   z-index: 1;
 }
-.k-dropzone[data-over]::after {
+.k-dropzone[data-over="true"]::after {
   display: block;
   outline: 1px solid var(--color-focus);
   box-shadow: var(--color-focus-outline) 0 0 0 3px;

--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -69,7 +69,7 @@ export default {
   padding: min(4vw, 3rem);
   outline: 0;
 }
-.k-file-preview-image-link[data-tabbed] {
+.k-file-preview-image-link[data-tabbed="true"] {
   box-shadow: none;
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;

--- a/panel/src/components/Layout/Item.vue
+++ b/panel/src/components/Layout/Item.vue
@@ -156,7 +156,7 @@ export default {
   grid-area: info;
   color: var(--color-gray-500);
 }
-.k-item-title-link.k-link[data-tabbed] {
+.k-item-title-link.k-link[data-="true"] {
   box-shadow: none;
 }
 .k-item-title-link::after {
@@ -268,7 +268,7 @@ export default {
     "content"
     "footer";
 }
-.k-cardlets-item[data-has-figure] {
+.k-cardlets-item[data-has-figure="true"] {
   grid-template-columns: 6rem auto;
   grid-template-areas:
     "figure content"
@@ -324,11 +324,11 @@ export default {
 .k-cards-item {
   --item-content-wrapper: 0;
 }
-.k-cards-item[data-has-flag],
-.k-cards-item[data-has-options] {
+.k-cards-item[data-has-flag="true"],
+.k-cards-item[data-has-options="true"] {
   --item-content-wrapper: 38px;
 }
-.k-cards-item[data-has-flag][data-has-options] {
+.k-cards-item[data-has-flag="true"][data-has-options="true"] {
   --item-content-wrapper: 76px;
 }
 
@@ -337,7 +337,7 @@ export default {
  * as the info is visible. Otherwise it could create
  * a gap between title and info
  */
-.k-cards-item[data-has-info] .k-item-title::after {
+.k-cards-item[data-has-info="true"] .k-item-title::after {
   display: none;
 }
 

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -143,12 +143,12 @@ export default {
   z-index: var(--z-dialog);
   transform: translate3d(0, 0, 0);
 }
-.k-overlay[data-centered] {
+.k-overlay[data-centered="true"] {
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.k-overlay[data-dimmed] {
+.k-overlay[data-dimmed="true"] {
   background: var(--color-backdrop);
 }
 .k-overlay-loader {

--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -63,11 +63,11 @@ export default {
 </script>
 
 <style>
-.k-panel[data-loading] {
+.k-panel[data-loading="true"] {
   animation: LoadingCursor 0.5s;
 }
-.k-panel[data-loading]::after,
-.k-panel[data-dragging] {
+.k-panel[data-loading="true"]::after,
+.k-panel[data-dragging="true"] {
   user-select: none;
 }
 </style>

--- a/panel/src/components/Layouter/Layout.vue
+++ b/panel/src/components/Layouter/Layout.vue
@@ -137,7 +137,7 @@ export default {
   background: #fff;
   box-shadow: var(--shadow);
 }
-[data-disabled] .k-layout {
+[data-disabled="true"] .k-layout {
   padding-inline-end: 0;
 }
 .k-layout:not(:last-of-type) {

--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -98,7 +98,7 @@ export default {
 .k-icon[data-back="pattern"] {
   color: var(--color-white);
 }
-[data-disabled] .k-icon[data-back="pattern"] svg {
+[data-disabled="true"] .k-icon[data-back="pattern"] svg {
   opacity: 1;
 }
 

--- a/panel/src/components/Misc/Image.vue
+++ b/panel/src/components/Misc/Image.vue
@@ -147,7 +147,7 @@ export default {
 .k-image-error svg * {
   fill: rgba(255, 255, 255, 0.3);
 }
-.k-image[data-cover] img {
+.k-image[data-cover="true"] img {
   object-fit: cover;
 }
 .k-image[data-back="black"] span {

--- a/panel/src/components/Misc/StatusIcon.vue
+++ b/panel/src/components/Misc/StatusIcon.vue
@@ -80,10 +80,10 @@ export default {
 .k-status-icon .k-button-text {
   color: var(--color-black);
 }
-.k-status-icon[data-disabled] {
+.k-status-icon[data-disabled="true"] {
   opacity: 1 !important;
 }
-.k-status-icon[data-disabled] .k-icon {
+.k-status-icon[data-disabled="true"] .k-icon {
   color: var(--color-gray-400);
   opacity: 0.5;
 }

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -131,11 +131,11 @@ button::-moz-focus-inner {
 }
 
 /* hide button text on small screens */
-.k-button[data-responsive] .k-button-text {
+.k-button[data-responsive="true"] .k-button-text {
   display: none;
 }
 @media screen and (min-width: 30em) {
-  .k-button[data-responsive] .k-button-text {
+  .k-button[data-responsive="true"] .k-button-text {
     display: inline;
   }
 }

--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -26,12 +26,12 @@ export default {
 </script>
 
 <style>
-.k-button[data-disabled] {
+.k-button[data-disabled="true"] {
   opacity: 0.5;
   pointer-events: none;
   cursor: default;
 }
-.k-card-options > .k-button[data-disabled] {
+.k-card-options > .k-button[data-disabled="true"] {
   display: inline-flex;
 }
 </style>

--- a/panel/src/components/Navigation/DropdownContent.vue
+++ b/panel/src/components/Navigation/DropdownContent.vue
@@ -277,7 +277,7 @@ export default {
   margin-bottom: 0.5rem;
 }
 
-.k-dropdown-content[data-dropup] {
+.k-dropdown-content[data-dropup="true"] {
   top: auto;
   bottom: 100%;
   margin-bottom: 0.5rem;

--- a/panel/src/components/Navigation/Search.vue
+++ b/panel/src/components/Navigation/Search.vue
@@ -253,7 +253,7 @@ export default {
 .k-search .k-item:not(:last-child) {
   margin-bottom: 0.25rem;
 }
-.k-search .k-item[data-selected] {
+.k-search .k-item[data-selected="true"] {
   outline: 2px solid var(--color-focus);
 }
 .k-search .k-item-info {

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -75,10 +75,10 @@ export default {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
 }
-[data-disabled] .k-tag {
+[data-disabled="true"] .k-tag {
   background-color: var(--color-gray-600);
 }
-[data-disabled] .k-tag .k-tag-toggle {
+[data-disabled="true"] .k-tag .k-tag-toggle {
   display: none;
 }
 </style>

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -83,7 +83,7 @@ export default {
   display: none;
 }
 
-[data-locked] .k-fields-section {
+[data-locked="true"] .k-fields-section {
   opacity: 0.2;
   pointer-events: none;
 }

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -181,7 +181,7 @@ export default {
 </script>
 
 <style>
-.k-files-section[data-processing] {
+.k-files-section[data-processing="true"] {
   pointer-events: none;
 }
 </style>

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -172,7 +172,7 @@ export default {
 </script>
 
 <style>
-.k-pages-section[data-processing] {
+.k-pages-section[data-processing="true"] {
   pointer-events: none;
 }
 </style>

--- a/panel/src/components/Views/UserView.vue
+++ b/panel/src/components/Views/UserView.vue
@@ -184,7 +184,7 @@ export default {
   height: 5rem;
   line-height: 0;
 }
-.k-user-view-image[data-disabled] {
+.k-user-view-image[data-disabled="true"] {
   opacity: 1;
 }
 .k-user-view-image .k-image {
@@ -198,7 +198,7 @@ export default {
   color: var(--color-gray-500);
   transition: color 0.3s;
 }
-.k-header[data-editable] .k-user-name-placeholder:hover {
+.k-header[data-editable="true"] .k-user-name-placeholder:hover {
   color: var(--color-gray-900);
 }
 </style>

--- a/panel/src/styles/utilities.css
+++ b/panel/src/styles/utilities.css
@@ -10,17 +10,17 @@
 }
 
 /* Invalid */
-[data-invalid] {
+[data-invalid="true"] {
   border: 1px solid var(--color-negative-outline);
   box-shadow: var(--color-negative-outline) 0 0 3px 2px;
 }
-[data-invalid]:focus-within {
+[data-invalid="true"]:focus-within {
   border: var(--field-input-invalid-focus-border) !important;
   box-shadow: var(--color-negative-outline) 0 0 0 2px !important;
 }
 
 /* Tabbed */
-[data-tabbed] {
+[data-tabbed="true"] {
   box-shadow: var(--shadow-outline);
 }
 


### PR DESCRIPTION

## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Since Vue 3 will render `:data-disabled='false'` as `data-attribute="false"`  instead of omitting the attribute, we can prepare a future migration to Vue 3 (still quite a way to go) by using explicit CSS selectors for when the data attribute is rendered by `true` as value.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Refactoring
- Panel uses more specific CSS selectors for data attributes with a boolean value


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://github.com/getkirby/backlog/issues/2

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [ ] Add changes to release notes draft in Notion
