### PR TITLE
Enable dropdown shortcut with closure

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -453,6 +453,15 @@ class Panel
         $routes    = [];
 
         foreach ($dropdowns as $name => $dropdown) {
+            // Handle shortcuts for dropdowns. The name is the pattern
+            // and options are defined in a Closure
+            if (is_a($dropdown, 'Closure') === true) {
+                $dropdown = [
+                    'pattern' => $name,
+                    'action'  => $dropdown
+                ];
+            }
+
             // create the full pattern with dropdowns prefix
             $pattern = 'dropdowns/' . trim(($dropdown['pattern'] ?? $name), '/');
 

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -526,6 +526,111 @@ class PanelTest extends TestCase
     }
 
     /**
+     * @covers ::routesForDropdowns
+     */
+    public function testRoutesForDropdowns(): void
+    {
+        $area = [
+            'dropdowns' => [
+                'test' => [
+                    'pattern' => 'test',
+                    'action'  => $action = function () {
+                        return [
+                            [
+                                'text' => 'Test',
+                                'link' => '/test'
+                            ]
+                        ];
+                    }
+                ]
+            ]
+        ];
+
+        $routes = Panel::routesForDropdowns('test', $area);
+
+        $expected = [
+            [
+                'pattern' => 'dropdowns/test',
+                'type'    => 'dropdown',
+                'area'    => 'test',
+                'method'  => 'GET|POST',
+                'action'  => $action,
+            ]
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /**
+     * @covers ::routesForDropdowns
+     */
+    public function testRoutesForDropdownsWithOptions(): void
+    {
+        $area = [
+            'dropdowns' => [
+                'test' => [
+                    'pattern' => 'test',
+                    'options' => $action = function () {
+                        return [
+                            [
+                                'text' => 'Test',
+                                'link' => '/test'
+                            ]
+                        ];
+                    }
+                ]
+            ]
+        ];
+
+        $routes = Panel::routesForDropdowns('test', $area);
+
+        $expected = [
+            [
+                'pattern' => 'dropdowns/test',
+                'type'    => 'dropdown',
+                'area'    => 'test',
+                'method'  => 'GET|POST',
+                'action'  => $action,
+            ]
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /**
+     * @covers ::routesForDropdowns
+     */
+    public function testRoutesForDropdownsWithShortcut(): void
+    {
+        $area = [
+            'dropdowns' => [
+                'test' => $action = function () {
+                    return [
+                        [
+                            'text' => 'Test',
+                            'link' => '/test'
+                        ]
+                    ];
+                }
+            ]
+        ];
+
+        $routes = Panel::routesForDropdowns('test', $area);
+
+        $expected = [
+            [
+                'pattern' => 'dropdowns/test',
+                'type'    => 'dropdown',
+                'area'    => 'test',
+                'method'  => 'GET|POST',
+                'action'  => $action,
+            ]
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    /**
      * @covers ::routesForViews
      */
     public function testRoutesForViews(): void


### PR DESCRIPTION
## Describe the PR

We've documented that dropdowns in areas can be created with a simple closure, but we never implemented it that way. 🙈
This PR implements what we've already documented and also adds unit tests for dropdown routes.


## Release notes

### Fix
- Area dropdowns can now be created with a simple closure instead of defining a full route: 
```php
'dropdowns' => [
    'example' => function () {
        return [ ... ]
    }
]
```

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3970 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
