### PR TITLE
Fix sync bug

### DIFF
--- a/config/fields/slug.php
+++ b/config/fields/slug.php
@@ -38,14 +38,6 @@ return [
          */
         'sync'  => function (string $sync = null) {
             return $sync;
-        },
-
-        /**
-         * Set to object with keys `field` and `text` to add
-         * button to generate from another field
-         */
-        'wizard' => function ($wizard = false) {
-            return $wizard;
         }
     ],
     'validations' => [

--- a/panel/src/components/Forms/Field/SlugField.vue
+++ b/panel/src/components/Forms/Field/SlugField.vue
@@ -1,9 +1,5 @@
 <template>
   <k-field :input="_uid" v-bind="$props" :help="preview" class="k-slug-field">
-    <template v-if="wizard && wizard.text" #options>
-      <k-button :text="wizard.text" icon="wand" @click="onWizard" />
-    </template>
-
     <k-input
       :id="_uid"
       ref="input"
@@ -35,10 +31,6 @@ export default {
     path: {
       type: String
     },
-    wizard: {
-      type: [Boolean, Object],
-      default: false
-    }
   },
   data() {
     return {
@@ -67,11 +59,6 @@ export default {
     focus() {
       this.$refs.input.focus();
     },
-    onWizard() {
-      if (this.wizard?.field && this.formData[this.wizard.field]) {
-        this.slug = this.formData[this.wizard.field];
-      }
-    }
   }
 };
 </script>

--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -72,6 +72,11 @@ export default {
           return false;
         }
 
+        if (this.syncValue == null) {
+          this.syncValue = newValue[this.sync];
+          return false;
+        }
+
         this.syncValue = newValue[this.sync];
         this.onInput(this.sluggify(this.syncValue));
       },


### PR DESCRIPTION
## Describe the PR

#3940 Fix bug in slug field: Prevent from synching when Panel reopens.


## Release notes

Fixes:
- Slug sync each time reloading the Panel
- Remove wizard props (is obsolet now)



## Breaking changes

None



## Related issues/ideas

## Ready?

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass


## When merging

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
