### PR TITLE
Passing empty string for `is_file()` when param `null` 

### DIFF
--- a/src/Toolkit/Tpl.php
+++ b/src/Toolkit/Tpl.php
@@ -19,13 +19,14 @@ class Tpl
     /**
      * Renders the template
      *
-     * @param string $file
+     * @param string|null $file
      * @param array $data
      * @return string
+     * @throws Throwable
      */
-    public static function load(string $file = null, array $data = []): string
+    public static function load(?string $file = null, array $data = []): string
     {
-        if (is_file($file) === false) {
+        if ($file === null || is_file($file) === false) {
             return '';
         }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
All `is_file()` functions checked. There was only one that accept `null` parameter and it fixed.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed passing `null` to parameter to `is_file()` function in `Tpl::load()` method on PHP 8.1 #4032


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4032

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
