### PR TITLE
Use translation as field name in user create dialog #4048

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -25,8 +25,8 @@ return [
                             'link'     => false,
                             'required' => true
                         ]),
-                        'password' => Field::password(),
-                        'language' => Field::translation([
+                        'password'     => Field::password(),
+                        'translation'  => Field::translation([
                             'required' => true
                         ]),
                         'role' => Field::role([
@@ -35,11 +35,11 @@ return [
                     ],
                     'submitButton' => t('create'),
                     'value' => [
-                        'name'     => '',
-                        'email'    => '',
-                        'password' => '',
-                        'language' => $kirby->panelLanguage(),
-                        'role'     => $kirby->user()->role()->name()
+                        'name'        => '',
+                        'email'       => '',
+                        'password'    => '',
+                        'translation' => $kirby->panelLanguage(),
+                        'role'        => $kirby->user()->role()->name()
                     ]
                 ]
             ];
@@ -49,7 +49,7 @@ return [
                 'name'     => get('name'),
                 'email'    => get('email'),
                 'password' => get('password'),
-                'language' => get('language'),
+                'language' => get('translation'),
                 'role'     => get('role')
             ]);
             return [

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -22,7 +22,7 @@ class UsersDialogsTest extends AreaTestCase
         $this->assertSame('Name', $props['fields']['name']['label']);
         $this->assertSame('Email', $props['fields']['email']['label']);
         $this->assertSame('Password', $props['fields']['password']['label']);
-        $this->assertSame('Language', $props['fields']['language']['label']);
+        $this->assertSame('Language', $props['fields']['translation']['label']);
         $this->assertSame('Role', $props['fields']['role']['label']);
 
         $this->assertSame('Create', $props['submitButton']);
@@ -31,7 +31,7 @@ class UsersDialogsTest extends AreaTestCase
         $this->assertSame('', $props['value']['name']);
         $this->assertSame('', $props['value']['email']);
         $this->assertSame('', $props['value']['password']);
-        $this->assertSame('en', $props['value']['language']);
+        $this->assertSame('en', $props['value']['translation']);
         $this->assertSame('admin', $props['value']['role']);
     }
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

I've fixed the issue with similiar solution with related issue https://github.com/getkirby/kirby/issues/3844

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Creating the user no longer collides with the content language in multi-language setups #4048 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4048 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
