### PR TITLE
Fixes more possible deprecated warnings when `null` passing for PHP 8.1

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -343,7 +343,7 @@ return [
      * Modify all URLs
      *
      * @param \Kirby\Cms\App $kirby Kirby instance
-     * @param string $path URL path
+     * @param string|null $path URL path
      * @param array|string|null $options Array of options for the Uri class
      * @return string
      */
@@ -376,7 +376,10 @@ return [
         }
 
         // keep relative urls
-        if (substr($path, 0, 2) === './' || substr($path, 0, 3) === '../') {
+        if (
+            $path !== null &&
+            (substr($path, 0, 2) === './' || substr($path, 0, 3) === '../')
+        ) {
             return $path;
         }
 

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -77,13 +77,13 @@ class Url
     /**
      * Tries to fix a broken url without protocol
      *
-     * @param string $url
+     * @param string|null $url
      * @return string
      */
     public static function fix(string $url = null): string
     {
         // make sure to not touch absolute urls
-        return (!preg_match('!^(https|http|ftp)\:\/\/!i', $url)) ? 'http://' . $url : $url;
+        return (!preg_match('!^(https|http|ftp)\:\/\/!i', $url ?? '')) ? 'http://' . $url : $url;
     }
 
     /**
@@ -111,7 +111,7 @@ class Url
     /**
      * Checks if an URL is absolute
      *
-     * @param string $url
+     * @param string|null $url
      * @return bool
      */
     public static function isAbsolute(string $url = null): bool
@@ -120,14 +120,14 @@ class Url
         //  //example.com/uri
         //  http://example.com/uri, https://example.com/uri, ftp://example.com/uri
         //  mailto:example@example.com, geo:49.0158,8.3239?z=11
-        return preg_match('!^(//|[a-z0-9+-.]+://|mailto:|tel:|geo:)!i', $url) === 1;
+        return $url !== null && preg_match('!^(//|[a-z0-9+-.]+://|mailto:|tel:|geo:)!i', $url) === 1;
     }
 
     /**
      * Convert a relative path into an absolute URL
      *
-     * @param string $path
-     * @param string $home
+     * @param string|null $path
+     * @param string|null $home
      * @return string
      */
     public static function makeAbsolute(string $path = null, string $home = null): string

--- a/src/Text/SmartyPants.php
+++ b/src/Text/SmartyPants.php
@@ -121,7 +121,7 @@ class SmartyPants
     public function parse(string $text = null): string
     {
         // prepare the text
-        $text = str_replace('&quot;', '"', $text);
+        $text = str_replace('&quot;', '"', $text ?? '');
 
         // parse the text
         return $this->parser->transform($text);

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -28,7 +28,10 @@ class UrlTest extends TestCase
 
     public function testTo()
     {
-        $this->assertEquals('https://getkirby.com/projects', Url::to('projects'));
+        $this->assertSame('https://getkirby.com', Url::to());
+        $this->assertSame('https://getkirby.com', Url::to(''));
+        $this->assertSame('https://getkirby.com', Url::to('/'));
+        $this->assertSame('https://getkirby.com/projects', Url::to('projects'));
     }
 
     public function testToWithLanguage()

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -101,8 +101,10 @@ class UrlTest extends TestCase
 
     public function testFix()
     {
-        $this->assertEquals('http://getkirby.com', Url::fix('getkirby.com'));
-        $this->assertEquals('ftp://getkirby.com', Url::fix('ftp://getkirby.com'));
+        $this->assertSame('http://', Url::fix());
+        $this->assertSame('http://', Url::fix(''));
+        $this->assertSame('http://getkirby.com', Url::fix('getkirby.com'));
+        $this->assertSame('ftp://getkirby.com', Url::fix('ftp://getkirby.com'));
     }
 
     public function testBase()

--- a/tests/Text/SmartyPantsTest.php
+++ b/tests/Text/SmartyPantsTest.php
@@ -15,6 +15,14 @@ class SmartyPantsTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testParseEmpty()
+    {
+        $parser = new SmartyPants();
+
+        $this->assertSame('', $parser->parse());
+        $this->assertSame('', $parser->parse(''));
+    }
+
     public function testDefaults()
     {
         $expected = [


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Fixed more possible deprecated warnings when `null` passing for PHP 8.1.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Fixes

- Fixed calling `url()` helper throws deprecation warning with PHP 8.1 #4047 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4047 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
