### PR TITLE
Fix vite rollupOptions input path

### DIFF
--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -55,7 +55,7 @@ export default defineConfig(({ command }) => {
       minify: "terser",
       cssCodeSplit: false,
       rollupOptions: {
-        input: "/src/index.js",
+        input: "./src/index.js",
         output: {
           entryFileNames: "js/[name].js",
           chunkFileNames: "js/[name].js",


### PR DESCRIPTION
Vite rollupOptions input path fixed based on the document: https://rollupjs.org/guide/en/#input

Fixed the related error:

````
vite v2.7.1 building for production...
✓ 0 modules transformed.
Could not resolve entry module (......\src\index.js).
error during build:
Error: Could not resolve entry module (......\src\index.js).
````