### PR TITLE
Make the JSON unexpected error message translatable

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -157,6 +157,8 @@
 
   "error.template.default.notFound": "The default template does not exist",
 
+  "error.unexpected": "An unexpected error occurred! Enable debug mode for more info: https://getkirby.com/docs/reference/system/options/debug",
+
   "error.user.changeEmail.permission": "You are not allowed to change the email for the user \"{name}\"",
   "error.user.changeLanguage.permission": "You are not allowed to change the language for the user \"{name}\"",
   "error.user.changeName.permission": "You are not allowed to change the name for the user \"{name}\"",

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Http\Response;
+use Kirby\Toolkit\I18n;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\Handler;
 use Whoops\Handler\PlainTextHandler;
@@ -136,7 +137,7 @@ trait AppErrors
                     'status'  => 'error',
                     'code'    => $code,
                     'details' => $details,
-                    'message' => 'An unexpected error occurred! Enable debug mode for more info: https://getkirby.com/docs/reference/system/options/debug',
+                    'message' => I18n::translate('error.unexpected'),
                 ], $httpCode);
             }
 


### PR DESCRIPTION
## Describe the PR

This PR makes the JSON unexpected error message translatable. From the [Kirby Feedback](https://kirby.nolt.io/386) site:

> When debug mode is off, the message that is included with JSON error responses is a hard-coded message in English. Would it be possible to make that string translatable?
> 
> As well as supporting other languages, you could then potentially override that message to display something a little more appropriate for non-developers (e.g. “An unexpected error occurred. An administrator has been notified.”).

A couple of notes:

- I haven't written any tests yet as I'm a little unsure on how to go about testing this change.
- I've added the English translation string to `i18n/translations/en.json` manually. I'm aware that translations are managed with Transifex, so if required I can sign up and make sure the translation is added there.

## Release notes

Enhancement: Make the JSON unexpected error message translatable


## Breaking changes

None


## Related issues/ideas

- Implements https://kirby.nolt.io/386

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
