### PR TITLE
Redirects to non-fiber resources

### DIFF
--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -202,7 +202,7 @@ export default {
       // redirect to non-fiber resources
       if (response.headers.has("X-Fiber") === false) {
         window.location.href = response.url;
-        return new Promise(() => {});
+        return false;
       }
 
       const text = await response.text();

--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -199,6 +199,12 @@ export default {
         }
       });
 
+      // redirect to non-fiber resources
+      if (response.headers.has("X-Fiber") === false) {
+        window.location.href = response.url;
+        return new Promise(() => {});
+      }
+
       const text = await response.text();
       let json;
 

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -397,10 +397,6 @@ class View
      */
     public static function response($data, array $options = [])
     {
-        $kirby = kirby();
-        $area  = $options['area']  ?? [];
-        $areas = $options['areas'] ?? [];
-
         // handle redirects
         if (is_a($data, 'Kirby\Panel\Redirect') === true) {
             return Response::redirect($data->location(), $data->code());


### PR DESCRIPTION
## Describe the PR

When firing a redirect to a non-fiber page in routes, the redirect would lead to non-parseable output and the request would fail. This PR fixes this issue.  

## Release notes

### Fixes

- Fixed redirects in fetch requests to non-fiber resources: https://github.com/getkirby/kirby/issues/4084

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
