### PR TITLE
Fix collection `prevUnlisted()` method 

### DIFF
--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -110,7 +110,7 @@ trait PageSiblings
      */
     public function prevUnlisted($collection = null)
     {
-        return $this->prevAll($collection)->unlisted()->first();
+        return $this->prevAll($collection)->unlisted()->last();
     }
 
     /**

--- a/tests/Cms/Pages/PageSiblingsTest.php
+++ b/tests/Cms/Pages/PageSiblingsTest.php
@@ -63,8 +63,10 @@ class PageSiblingsTest extends TestCase
     public function testHasNextListed()
     {
         $site = $this->site([
-            ['slug' => 'unlisted'],
-            ['slug' => 'listed', 'num' => 1],
+            ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-b'],
+            ['slug' => 'listed-b', 'num' => 2],
         ]);
 
         $collection = $site->children();
@@ -76,8 +78,10 @@ class PageSiblingsTest extends TestCase
     public function testHasNextUnlisted()
     {
         $site = $this->site([
-            ['slug' => 'listed', 'num' => 1],
-            ['slug' => 'unlisted'],
+            ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-b', 'num' => 2],
+            ['slug' => 'unlisted-b'],
         ]);
 
         $collection = $site->children();
@@ -106,8 +110,10 @@ class PageSiblingsTest extends TestCase
     public function testHasPrevListed()
     {
         $site = $this->site([
-            ['slug' => 'listed', 'num' => 1],
-            ['slug' => 'unlisted'],
+            ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-b', 'num' => 2],
+            ['slug' => 'unlisted-b'],
         ]);
 
         $collection = $site->children();
@@ -119,8 +125,10 @@ class PageSiblingsTest extends TestCase
     public function testHasPrevUnlisted()
     {
         $site = $this->site([
-            ['slug' => 'unlisted'],
-            ['slug' => 'listed', 'num' => 1]
+            ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-b'],
+            ['slug' => 'listed-b', 'num' => 2],
         ]);
 
         $collection = $site->children();
@@ -194,22 +202,24 @@ class PageSiblingsTest extends TestCase
     {
         $collection = $this->site([
             ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-a', 'num' => 1],
             ['slug' => 'unlisted-b'],
-            ['slug' => 'listed', 'num' => 1],
+            ['slug' => 'listed-b', 'num' => 2],
         ])->children();
 
-        $this->assertEquals('listed', $collection->first()->nextListed()->slug());
+        $this->assertSame('listed-a', $collection->first()->nextListed()->slug());
     }
 
     public function testNextUnlisted()
     {
         $collection = $this->site([
             ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-a'],
             ['slug' => 'listed-b', 'num' => 2],
-            ['slug' => 'unlisted'],
+            ['slug' => 'unlisted-b'],
         ])->children();
 
-        $this->assertEquals('unlisted', $collection->first()->nextUnlisted()->slug());
+        $this->assertSame('unlisted-a', $collection->first()->nextUnlisted()->slug());
     }
 
     public function testPrev()
@@ -233,23 +243,25 @@ class PageSiblingsTest extends TestCase
     public function testPrevListed()
     {
         $collection = $this->site([
-            ['slug' => 'listed', 'num' => 1],
+            ['slug' => 'listed-a', 'num' => 1],
             ['slug' => 'unlisted-a'],
+            ['slug' => 'listed-b', 'num' => 1],
             ['slug' => 'unlisted-b'],
         ])->children();
 
-        $this->assertEquals('listed', $collection->last()->prevListed()->slug());
+        $this->assertSame('listed-b', $collection->last()->prevListed()->slug());
     }
 
     public function testPrevUnlisted()
     {
         $collection = $this->site([
-            ['slug' => 'unlisted'],
+            ['slug' => 'unlisted-a'],
             ['slug' => 'listed-a', 'num' => 1],
+            ['slug' => 'unlisted-b'],
             ['slug' => 'listed-b', 'num' => 2],
         ])->children();
 
-        $this->assertEquals('unlisted', $collection->last()->prevUnlisted()->slug());
+        $this->assertSame('unlisted-b', $collection->last()->prevUnlisted()->slug());
     }
 
     public function testSiblings()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Fixed the issue replacing `->first()` with `->last()`.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed `$page->prevUnlisted()` returns wrong collection item #4086 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4086

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
