### PR TITLE
Support single string as `panel.favicon` value #4092

### DIFF
--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
@@ -174,7 +175,8 @@ class Document
      */
     public static function favicon(string $url = ''): array
     {
-        $icons = kirby()->option('panel.favicon', [
+        $kirby = kirby();
+        $icons = $kirby->option('panel.favicon', [
             'apple-touch-icon' => [
                 'type' => 'image/png',
                 'url'  => $url . '/apple-touch-icon.png',
@@ -189,17 +191,21 @@ class Document
             ]
         ]);
 
+        if (is_array($icons) === true) {
+            return $icons;
+        }
+
         // make sure to convert favicon string to array
         if (is_string($icons) === true) {
-            $icons = [
+            return [
                 'shortcut icon' => [
-                    'type' => 'image/svg+xml',
+                    'type' => F::mime($icons),
                     'url'  => $icons,
                 ]
             ];
         }
 
-        return $icons;
+        throw new InvalidArgumentException('Invalid panel.favicon option');
     }
 
     /**

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -136,8 +136,8 @@ class Document
      */
     public static function customAsset(string $option): ?string
     {
-        if ($css = kirby()->option($option)) {
-            $asset = asset($css);
+        if ($path = kirby()->option($option)) {
+            $asset = asset($path);
 
             if ($asset->exists() === true) {
                 return $asset->url() . '?' . $asset->modified();

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -65,22 +65,9 @@ class Document
             'css' => [
                 'index'   => $url . '/css/style.css',
                 'plugins' => $plugins->url('css'),
-                'custom'  => static::customCss(),
+                'custom'  => static::customAsset('panel.css'),
             ],
-            'icons' => $kirby->option('panel.favicon', [
-                'apple-touch-icon' => [
-                    'type' => 'image/png',
-                    'url'  => $url . '/apple-touch-icon.png',
-                ],
-                'shortcut icon' => [
-                    'type' => 'image/svg+xml',
-                    'url'  => $url . '/favicon.svg',
-                ],
-                'alternate icon' => [
-                    'type' => 'image/png',
-                    'url'  => $url . '/favicon.png',
-                ]
-            ]),
+            'icons' => static::favicon($url),
             'js' => [
                 'vendor'       => [
                     'nonce' => $nonce,
@@ -99,7 +86,7 @@ class Document
                 ],
                 'custom'       => [
                     'nonce' => $nonce,
-                    'src'   => static::customJs(),
+                    'src'   => static::customAsset('panel.js'),
                     'type'  => 'module'
                 ],
                 'index'        => [
@@ -139,14 +126,16 @@ class Document
     }
 
     /**
-     * Check for a custom css file from the
-     * config (panel.css)
+     * Check for a custom asset file from the
+     * config (e.g. panel.css or panel.js)
+     * @since 3.6.2
      *
+     * @param string $option asset option name
      * @return string|null
      */
-    public static function customCss(): ?string
+    public static function customAsset(string $option): ?string
     {
-        if ($css = kirby()->option('panel.css')) {
+        if ($css = kirby()->option($option)) {
             $asset = asset($css);
 
             if ($asset->exists() === true) {
@@ -158,22 +147,59 @@ class Document
     }
 
     /**
-     * Check for a custom js file from the
-     * config (panel.js)
-     *
-     * @return string|null
+     * @deprecated 3.7.0 Use `Document::customAsset('panel.css)` instead
+     * @todo add deprecation warning in 3.7.0, remove in 3.8.0
+     */
+    public static function customCss(): ?string
+    {
+        return static::customAsset('panel.css');
+    }
+
+    /**
+     * @deprecated 3.7.0 Use `Document::customAsset('panel.js)` instead
+     * @todo add deprecation warning in 3.7.0, remove in 3.8.0
      */
     public static function customJs(): ?string
     {
-        if ($js = kirby()->option('panel.js')) {
-            $asset = asset($js);
+        return static::customAsset('panel.js');
+    }
 
-            if ($asset->exists() === true) {
-                return $asset->url() . '?' . $asset->modified();
-            }
+    /**
+     * Returns array of favion icons
+     * based on config option
+     * @since 3.6.2
+     *
+     * @param string $url URL prefix for default icons
+     * @return array
+     */
+    public static function favicon(string $url = ''): array
+    {
+        $icons = kirby()->option('panel.favicon', [
+            'apple-touch-icon' => [
+                'type' => 'image/png',
+                'url'  => $url . '/apple-touch-icon.png',
+            ],
+            'shortcut icon' => [
+                'type' => 'image/svg+xml',
+                'url'  => $url . '/favicon.svg',
+            ],
+            'alternate icon' => [
+                'type' => 'image/png',
+                'url'  => $url . '/favicon.png',
+            ]
+        ]);
+
+        // make sure to convert favicon string to array
+        if (is_string($icons) === true) {
+            $icons = [
+                'shortcut icon' => [
+                    'type' => 'image/svg+xml',
+                    'url'  => $icons,
+                ]
+            ];
         }
 
-        return null;
+        return $icons;
     }
 
     /**

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -44,7 +44,7 @@ class DocumentTest extends TestCase
     /**
      * @covers ::assets
      */
-    public function testAssets(): void
+    public function testAssetsDefaults(): void
     {
         // default asset setup
         $assets  = Document::assets();
@@ -72,10 +72,15 @@ class DocumentTest extends TestCase
 
         $this->assertSame($base . '/js/index.js', $assets['js']['index']['src']);
         $this->assertSame('module', $assets['js']['index']['type']);
+    }
 
-
+    /**
+     * @covers ::assets
+     */
+    public function testAssetsDev(): void
+    {
         // dev mode
-        $this->app = $this->app->clone([
+        $app = $this->app->clone([
             'request' => [
                 'url' => 'http://sandbox.test'
             ],
@@ -87,9 +92,9 @@ class DocumentTest extends TestCase
         ]);
 
         // add vite file
-        F::write($viteFile = $this->app->roots()->panel() . '/.vite-running', '');
+        F::write($app->roots()->panel() . '/.vite-running', '');
 
-        $assets = Document::assets($this->app);
+        $assets = Document::assets($app);
         $base   = 'http://sandbox.test:3000';
 
         // css
@@ -107,10 +112,15 @@ class DocumentTest extends TestCase
             'index' => $base . '/src/index.js',
             'vite' => $base . '/@vite/client'
         ], array_map(fn ($js) => $js['src'], $assets['js']));
+    }
 
-
+    /**
+     * @covers ::assets
+     */
+    public function testAssetsCustomUrl(): void
+    {
         // dev mode with custom url
-        $this->app = $this->app->clone([
+        $app = $this->app->clone([
             'request' => [
                 'url' => 'http://sandbox.test'
             ],
@@ -121,7 +131,7 @@ class DocumentTest extends TestCase
             ]
         ]);
 
-        $assets = Document::assets($this->app);
+        $assets = Document::assets($app);
         $base   = 'http://localhost:3000';
 
         // css
@@ -139,10 +149,15 @@ class DocumentTest extends TestCase
             'index' => $base . '/src/index.js',
             'vite' => $base . '/@vite/client'
         ], array_map(fn ($js) => $js['src'], $assets['js']));
+    }
 
-
+    /**
+     * @covers ::assets
+     */
+    public function testAssetsCustomCssJs(): void
+    {
         // custom panel css and js
-        $this->app = $this->app->clone([
+        $app = $this->app->clone([
             'options' => [
                 'panel' => [
                     'css' => '/assets/panel.css',
@@ -155,17 +170,17 @@ class DocumentTest extends TestCase
         F::write($this->tmp . '/assets/panel.css', 'test');
         F::write($this->tmp . '/assets/panel.js', 'test');
 
-        $assets = Document::assets($this->app);
+        $assets = Document::assets($app);
 
         $this->assertTrue(Str::contains($assets['css']['custom'], 'assets/panel.css'));
         $this->assertTrue(Str::contains($assets['js']['custom']['src'], 'assets/panel.js'));
 
         // clean up vite file
-        F::remove($viteFile);
+        F::remove($app->roots()->panel() . '/.vite-running');
     }
 
     /**
-     * @covers ::customCss
+     * @covers ::customAsset
      */
     public function testCustomCss(): void
     {
@@ -178,7 +193,7 @@ class DocumentTest extends TestCase
             ]
         ]);
 
-        $this->assertNull(Document::customCss());
+        $this->assertNull(Document::customAsset('panel.css'));
 
         // valid
         F::write($this->tmp . '/panel.css', '');
@@ -191,11 +206,14 @@ class DocumentTest extends TestCase
             ]
         ]);
 
-        $this->assertTrue(Str::contains(Document::customCss(), '/panel.css'));
+        $this->assertStringContainsString(
+            '/panel.css',
+            Document::customAsset('panel.css')
+        );
     }
 
     /**
-     * @covers ::customJs
+     * @covers ::customAsset
      */
     public function testCustomJs(): void
     {
@@ -208,7 +226,7 @@ class DocumentTest extends TestCase
             ]
         ]);
 
-        $this->assertNull(Document::customJs());
+        $this->assertNull(Document::customAsset('panel.js'));
 
         // valid
         F::write($this->tmp . '/panel.js', '');
@@ -221,7 +239,56 @@ class DocumentTest extends TestCase
             ]
         ]);
 
-        $this->assertTrue(Str::contains(Document::customJs(), '/panel.js'));
+        $this->assertStringContainsString(
+            '/panel.js',
+            Document::customAsset('panel.js')
+        );
+    }
+
+    /**
+     * @covers ::favicon
+     */
+    public function testFaviconString(): void
+    {
+        // single string
+        $app = $this->app->clone([
+            'options' => [
+                'panel' => [
+                    'favicon' => 'assets/favicon.ico'
+                ]
+            ]
+        ]);
+
+        $icons = Document::favicon();
+        $this->assertSame('assets/favicon.ico', $icons['shortcut icon']['url']);
+    }
+
+    /**
+     * @covers ::favicon
+     */
+    public function testFaviconArray(): void
+    {
+        // array
+        $app = $this->app->clone([
+            'options' => [
+                'panel' => [
+                    'favicon' => [
+                        'shortcut icon' => [
+                            'type' => 'image/svg+xml',
+                            'url'  => 'assets/my-favicon.svg',
+                        ],
+                        'alternate icon' => [
+                            'type' => 'image/png',
+                            'url'  => 'assets/my-favicon.png',
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $icons = Document::favicon();
+        $this->assertSame('assets/my-favicon.svg', $icons['shortcut icon']['url']);
+        $this->assertSame('assets/my-favicon.png', $icons['alternate icon']['url']);
     }
 
     /**

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -248,24 +248,6 @@ class DocumentTest extends TestCase
     /**
      * @covers ::favicon
      */
-    public function testFaviconString(): void
-    {
-        // single string
-        $app = $this->app->clone([
-            'options' => [
-                'panel' => [
-                    'favicon' => 'assets/favicon.ico'
-                ]
-            ]
-        ]);
-
-        $icons = Document::favicon();
-        $this->assertSame('assets/favicon.ico', $icons['shortcut icon']['url']);
-    }
-
-    /**
-     * @covers ::favicon
-     */
     public function testFaviconArray(): void
     {
         // array
@@ -289,6 +271,44 @@ class DocumentTest extends TestCase
         $icons = Document::favicon();
         $this->assertSame('assets/my-favicon.svg', $icons['shortcut icon']['url']);
         $this->assertSame('assets/my-favicon.png', $icons['alternate icon']['url']);
+    }
+
+    /**
+     * @covers ::favicon
+     */
+    public function testFaviconString(): void
+    {
+        // single string
+        $app = $this->app->clone([
+            'options' => [
+                'panel' => [
+                    'favicon' => 'assets/favicon.ico'
+                ]
+            ]
+        ]);
+
+        $icons = Document::favicon();
+        $this->assertSame('image/x-icon', $icons['shortcut icon']['type']);
+        $this->assertSame('assets/favicon.ico', $icons['shortcut icon']['url']);
+    }
+
+    /**
+     * @covers ::favicon
+     */
+    public function testFaviconInvalid(): void
+    {
+        // single string
+        $app = $this->app->clone([
+            'options' => [
+                'panel' => [
+                    'favicon' => 5
+                ]
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid panel.favicon option');
+        $icons = Document::favicon();
     }
 
     /**


### PR DESCRIPTION
## Fixes 
- `panel.favicon` option now supports single string as value

```php
return [
  'panel' => [
    'favicon' => 'assets/favicon.ico'
  ]
];
```

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

_None_


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4092

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
- [x] Add changes to release notes draft in Notion
