### PR TITLE
Safe mode for markdown

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -138,6 +138,8 @@ return [
      * @param array $options Markdown options
      * @param bool $inline Whether to wrap the text in `<p>` tags (deprecated: set via $options['inline'] instead)
      * @return string
+     * @todo add deprecation warning for $inline parameter in 3.7.0
+     * @todo remove $inline parameter in in 3.8.0
      */
     'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
         static $markdown;

--- a/config/components.php
+++ b/config/components.php
@@ -153,7 +153,7 @@ return [
             $config   = $options;
         }
 
-        return $markdown->parse($text, $options['inline'] ?? false);
+        return $markdown->parse($text, $options['inline']);
     },
 
     /**

--- a/config/components.php
+++ b/config/components.php
@@ -136,12 +136,15 @@ return [
      * @param \Kirby\Cms\App $kirby Kirby instance
      * @param string $text Text to parse
      * @param array $options Markdown options
-     * @param bool $inline Whether to wrap the text in `<p>` tags
+     * @param bool $inline Whether to wrap the text in `<p>` tags (deprecated: set via $options['inline'] instead)
      * @return string
      */
     'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
         static $markdown;
         static $config;
+
+        // support for the deprecated fourth argument
+        $options['inline'] ??= $inline;
 
         // if the config options have changed or the component is called for the first time,
         // (re-)initialize the parser object
@@ -150,7 +153,7 @@ return [
             $config   = $options;
         }
 
-        return $markdown->parse($text, $inline);
+        return $markdown->parse($text, $options['inline'] ?? false);
     },
 
     /**

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -449,12 +449,12 @@ function kirbytags(?string $text = null, array $data = []): string
  * given string. Shortcut for `$kirby->kirbytext()`
  *
  * @param string|null $text
- * @param array $options
+ * @param array $data
  * @return string
  */
-function kirbytext(?string $text = null, array $options = []): string
+function kirbytext(?string $text = null, array $data = []): string
 {
-    return App::instance()->kirbytext($text, $options);
+    return App::instance()->kirbytext($text, $data);
 }
 
 /**
@@ -463,24 +463,24 @@ function kirbytext(?string $text = null, array $options = []): string
  * @since 3.1.0
  *
  * @param string|null $text
- * @param array $options
+ * @param array $data
  * @return string
  */
-function kirbytextinline(?string $text = null, array $options = []): string
+function kirbytextinline(?string $text = null, array $data = []): string
 {
-    return App::instance()->kirbytext($text, $options, true);
+    return App::instance()->kirbytext($text, $data, true);
 }
 
 /**
  * Shortcut for `kirbytext()` helper
  *
  * @param string|null $text
- * @param array $options
+ * @param array $data
  * @return string
  */
-function kt(?string $text = null, array $options = []): string
+function kt(?string $text = null, array $data = []): string
 {
-    return kirbytext($text, $options);
+    return kirbytext($text, $data);
 }
 
 /**
@@ -488,12 +488,12 @@ function kt(?string $text = null, array $options = []): string
  * @since 3.1.0
  *
  * @param string|null $text
- * @param array $options
+ * @param array $data
  * @return string
  */
-function kti(?string $text = null, array $options = []): string
+function kti(?string $text = null, array $data = []): string
 {
-    return kirbytextinline($text, $options);
+    return kirbytextinline($text, $data);
 }
 
 /**

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -528,11 +528,12 @@ function load(array $classmap, ?string $base = null)
  * `$kirby->markdown($text)`
  *
  * @param string|null $text
+ * @param array $options
  * @return string
  */
-function markdown(?string $text = null): string
+function markdown(?string $text = null, array $options = []): string
 {
-    return App::instance()->markdown($text);
+    return App::instance()->markdown($text, $options);
 }
 
 /**

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -449,12 +449,12 @@ function kirbytags(?string $text = null, array $data = []): string
  * given string. Shortcut for `$kirby->kirbytext()`
  *
  * @param string|null $text
- * @param array $data
+ * @param array $options
  * @return string
  */
-function kirbytext(?string $text = null, array $data = []): string
+function kirbytext(?string $text = null, array $options = []): string
 {
-    return App::instance()->kirbytext($text, $data);
+    return App::instance()->kirbytext($text, $options);
 }
 
 /**
@@ -463,24 +463,24 @@ function kirbytext(?string $text = null, array $data = []): string
  * @since 3.1.0
  *
  * @param string|null $text
- * @param array $data
+ * @param array $options
  * @return string
  */
-function kirbytextinline(?string $text = null, array $data = []): string
+function kirbytextinline(?string $text = null, array $options = []): string
 {
-    return App::instance()->kirbytext($text, $data, true);
+    return App::instance()->kirbytext($text, $options, true);
 }
 
 /**
  * Shortcut for `kirbytext()` helper
  *
  * @param string|null $text
- * @param array $data
+ * @param array $options
  * @return string
  */
-function kt(?string $text = null, array $data = []): string
+function kt(?string $text = null, array $options = []): string
 {
-    return kirbytext($text, $data);
+    return kirbytext($text, $options);
 }
 
 /**
@@ -488,12 +488,12 @@ function kt(?string $text = null, array $data = []): string
  * @since 3.1.0
  *
  * @param string|null $text
- * @param array $data
+ * @param array $options
  * @return string
  */
-function kti(?string $text = null, array $data = []): string
+function kti(?string $text = null, array $options = []): string
 {
-    return kirbytextinline($text, $data);
+    return kirbytextinline($text, $options);
 }
 
 /**

--- a/config/methods.php
+++ b/config/methods.php
@@ -451,10 +451,11 @@ return function (App $app) {
          * Converts markdown to valid HTML
          *
          * @param \Kirby\Cms\Field $field
+         * @param array $options
          * @return \Kirby\Cms\Field
          */
-        'markdown' => function (Field $field) use ($app) {
-            $field->value = $app->markdown($field->value);
+        'markdown' => function (Field $field, array $options = []) use ($app) {
+            $field->value = $app->markdown($field->value, $options);
             return $field;
         },
 

--- a/config/methods.php
+++ b/config/methods.php
@@ -393,13 +393,14 @@ return function (App $app) {
          * Converts the field content from Markdown/Kirbytext to valid HTML
          *
          * @param \Kirby\Cms\Field $field
+         * @param array $options
          * @return \Kirby\Cms\Field
          */
-        'kirbytext' => function (Field $field) use ($app) {
-            $field->value = $app->kirbytext($field->value, [
+        'kirbytext' => function (Field $field, array $options = []) use ($app) {
+            $field->value = $app->kirbytext($field->value, A::merge($options, [
                 'parent' => $field->parent(),
                 'field'  => $field
-            ]);
+            ]));
 
             return $field;
         },
@@ -410,13 +411,17 @@ return function (App $app) {
          * @since 3.1.0
          *
          * @param \Kirby\Cms\Field $field
+         * @param array $options
          * @return \Kirby\Cms\Field
          */
-        'kirbytextinline' => function (Field $field) use ($app) {
-            $field->value = $app->kirbytext($field->value, [
-                'parent' => $field->parent(),
-                'field'  => $field
-            ], true);
+        'kirbytextinline' => function (Field $field, array $options = []) use ($app) {
+            $field->value = $app->kirbytext($field->value, A::merge($options, [
+                'parent'   => $field->parent(),
+                'field'    => $field,
+                'markdown' => [
+                    'inline' => true
+                ]
+            ]));
 
             return $field;
         },

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -788,6 +788,7 @@ class App
      * Parses KirbyTags first and Markdown afterwards
      *
      * @internal
+     * @todo deprecate $inline $option in 3.7.0 and remove in 3.8.0
      * @param string|null $text
      * @param array $options
      * @param bool $inline (deprecated: use $options['markdown']['inline'] instead)
@@ -896,6 +897,7 @@ class App
      * Parses Markdown
      *
      * @internal
+     * @todo deprecate boolean $options in 3.7.0 and remove in 3.8.0
      * @param string|null $text
      * @param bool|array $options
      * @return string

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -771,10 +771,11 @@ class App
      */
     public function kirbytags(string $text = null, array $data = []): string
     {
-        $data['kirby']  = $data['kirby']  ?? $this;
-        $data['site']   = $data['site']   ?? $data['kirby']->site();
-        $data['parent'] = $data['parent'] ?? $data['site']->page();
-        $options        = $this->options;
+        $data['kirby']  ??= $this;
+        $data['site']   ??= $data['kirby']->site();
+        $data['parent'] ??= $data['site']->page();
+
+        $options = $this->options;
 
         $text = $this->apply('kirbytags:before', compact('text', 'data', 'options'), 'text');
         $text = KirbyTags::parse($text, $data, $options);
@@ -788,15 +789,21 @@ class App
      *
      * @internal
      * @param string|null $text
-     * @param array $data
-     * @param bool $inline
+     * @param array $options
+     * @param bool $inline (deprecated: use $options['markdown']['inline'] instead)
      * @return string
      */
-    public function kirbytext(string $text = null, array $data = [], bool $inline = false): string
+    public function kirbytext(string $text = null, array $options = [], bool $inline = false): string
     {
+        $options = A::merge([
+            'markdown' => [
+                'inline' => $inline
+            ]
+        ], $options);
+
         $text = $this->apply('kirbytext:before', compact('text'), 'text');
-        $text = $this->kirbytags($text, $data);
-        $text = $this->markdown($text, $inline);
+        $text = $this->kirbytags($text, $options);
+        $text = $this->markdown($text, $options['markdown']);
 
         if ($this->option('smartypants', false) !== false) {
             $text = $this->smartypants($text);

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -890,12 +890,22 @@ class App
      *
      * @internal
      * @param string|null $text
-     * @param bool $inline
+     * @param bool|array $options
      * @return string
      */
-    public function markdown(string $text = null, bool $inline = false): string
+    public function markdown(string $text = null, $options = null): string
     {
-        return ($this->component('markdown'))($this, $text, $this->options['markdown'] ?? [], $inline);
+        // support for the old syntax to enable inline mode as second argument
+        if (is_bool($options) === true) {
+            $options = [
+                'inline' => $options
+            ];
+        }
+
+        // merge global options with local options
+        $options = array_merge($this->options['markdown'] ?? [], (array)$options);
+
+        return ($this->component('markdown'))($this, $text, $options);
     }
 
     /**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -788,19 +788,21 @@ class App
      * Parses KirbyTags first and Markdown afterwards
      *
      * @internal
-     * @todo deprecate $inline $option in 3.7.0 and remove in 3.8.0
      * @param string|null $text
-     * @param array $options
-     * @param bool $inline (deprecated: use $options['markdown']['inline'] instead)
+     * @param array $data
+     * @param bool $inline (deprecated: use $data['markdown']['inline'] instead)
      * @return string
+     * @todo add deprecation warning for $inline parameter in 3.7.0
+     * @todo rename $data parameter to $options in 3.7.0
+     * @todo remove $inline parameter in in 3.8.0
      */
-    public function kirbytext(string $text = null, array $options = [], bool $inline = false): string
+    public function kirbytext(string $text = null, array $data = [], bool $inline = false): string
     {
         $options = A::merge([
             'markdown' => [
                 'inline' => $inline
             ]
-        ], $options);
+        ], $data);
 
         $text = $this->apply('kirbytext:before', compact('text'), 'text');
         $text = $this->kirbytags($text, $options);
@@ -897,13 +899,18 @@ class App
      * Parses Markdown
      *
      * @internal
-     * @todo deprecate boolean $options in 3.7.0 and remove in 3.8.0
      * @param string|null $text
      * @param bool|array $options
      * @return string
+     * @todo rename $inline parameter to $options in 3.7.0
+     * @todo add deprecation warning for boolean $options in 3.7.0
+     * @todo remove boolean $options in in 3.8.0
      */
-    public function markdown(string $text = null, $options = null): string
+    public function markdown(string $text = null, $inline = null): string
     {
+        // TODO: remove after renaming parameter
+        $options = $inline;
+
         // support for the old syntax to enable inline mode as second argument
         if (is_bool($options) === true) {
             $options = [
@@ -912,7 +919,10 @@ class App
         }
 
         // merge global options with local options
-        $options = array_merge($this->options['markdown'] ?? [], (array)$options);
+        $options = array_merge(
+            $this->options['markdown'] ?? [],
+            (array)$options
+        );
 
         return ($this->component('markdown'))($this, $text, $options);
     }

--- a/src/Text/Markdown.php
+++ b/src/Text/Markdown.php
@@ -37,8 +37,9 @@ class Markdown
     public function defaults(): array
     {
         return [
+            'breaks' => true,
             'extra'  => false,
-            'breaks' => true
+            'safe'   => false
         ];
     }
 
@@ -69,6 +70,7 @@ class Markdown
         }
 
         $parser->setBreaksEnabled($this->options['breaks']);
+        $parser->setSafeMode($this->options['safe']);
 
         if ($inline === true) {
             return @$parser->line($text);

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -86,8 +86,8 @@ class AppComponentsTest extends TestCase
 
     public function testKirbytextWithSafeMode()
     {
-        $text     = '<h1>Test</h1>';
-        $expected = '&lt;h1&gt;Test&lt;/h1&gt;';
+        $text     = '<h1>**Test**</h1>';
+        $expected = '&lt;h1&gt;<strong>Test</strong>&lt;/h1&gt;';
 
         $this->assertEquals($expected, $this->kirby->kirbytext($text, [
             'markdown' => [

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -46,7 +46,7 @@ class AppComponentsTest extends TestCase
         ]);
 
         $expected = '<link href="/test.css" rel="stylesheet">';
-        $this->assertEquals($expected, css('something.css'));
+        $this->assertSame($expected, css('something.css'));
     }
 
     public function testDump()
@@ -59,7 +59,7 @@ class AppComponentsTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('test', dump('test'));
+        $this->assertSame('test', dump('test'));
     }
 
     public function testJsPlugin()
@@ -73,7 +73,7 @@ class AppComponentsTest extends TestCase
         ]);
 
         $expected = '<script src="/test.js"></script>';
-        $this->assertEquals($expected, js('something.js'));
+        $this->assertSame($expected, js('something.js'));
     }
 
     public function testKirbytext()
@@ -121,7 +121,7 @@ class AppComponentsTest extends TestCase
         $text     = 'Test';
         $expected = '<p>Test</p>';
 
-        $this->assertEquals($expected, $this->kirby->markdown($text));
+        $this->assertSame($expected, $this->kirby->markdown($text));
     }
 
     public function testMarkdownInline()
@@ -153,11 +153,11 @@ class AppComponentsTest extends TestCase
         $expected = '<p>1st line<br />
 2nd line</p>';
 
-        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, []));
+        $this->assertSame($expected, $this->kirby->component('markdown')($this->kirby, $text, []));
 
         $expected = '<p>1st line
 2nd line</p>';
-        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, ['breaks' => false]));
+        $this->assertSame($expected, $this->kirby->component('markdown')($this->kirby, $text, ['breaks' => false]));
     }
 
     public function testSmartypants()
@@ -165,7 +165,7 @@ class AppComponentsTest extends TestCase
         $text     = '"Test"';
         $expected = '&#8220;Test&#8221;';
 
-        $this->assertEquals($expected, $this->kirby->smartypants($text));
+        $this->assertSame($expected, $this->kirby->smartypants($text));
     }
 
     public function testSmartypantsDisabled()
@@ -273,10 +273,10 @@ class AppComponentsTest extends TestCase
         $text     = '"Test"';
         $expected = '&#8220;Test&#8221;';
 
-        $this->assertEquals($expected, $this->kirby->component('smartypants')($this->kirby, $text, []));
+        $this->assertSame($expected, $this->kirby->component('smartypants')($this->kirby, $text, []));
 
         $expected = 'TestTest&#8221;';
-        $this->assertEquals($expected, $this->kirby->component('smartypants')($this->kirby, $text, ['doublequote.open' => 'Test']));
+        $this->assertSame($expected, $this->kirby->component('smartypants')($this->kirby, $text, ['doublequote.open' => 'Test']));
     }
 
     public function testSnippet()
@@ -296,31 +296,31 @@ class AppComponentsTest extends TestCase
         F::write($fixtures . '/plugin.php', 'plugin');
 
         // simple string
-        $this->assertEquals('test', $app->snippet('test'));
+        $this->assertSame('test', $app->snippet('test'));
 
         // field
-        $this->assertEquals('test', $app->snippet(new Field(null, 'test', 'test')));
+        $this->assertSame('test', $app->snippet(new Field(null, 'test', 'test')));
 
         // fallback
-        $this->assertEquals('fallback', $app->snippet(['does-not-exist', 'fallback']));
+        $this->assertSame('fallback', $app->snippet(['does-not-exist', 'fallback']));
 
         // fallback from field
-        $this->assertEquals('fallback', $app->snippet(['does-not-exist', new Field(null, 'test', 'fallback')]));
+        $this->assertSame('fallback', $app->snippet(['does-not-exist', new Field(null, 'test', 'fallback')]));
 
         // from plugin
-        $this->assertEquals('plugin', $app->snippet('plugin'));
+        $this->assertSame('plugin', $app->snippet('plugin'));
 
         // from plugin with field
-        $this->assertEquals('plugin', $app->snippet(new Field(null, 'test', 'plugin')));
+        $this->assertSame('plugin', $app->snippet(new Field(null, 'test', 'plugin')));
 
         // fallback from plugin
-        $this->assertEquals('plugin', $app->snippet(['does-not-exist', 'plugin']));
+        $this->assertSame('plugin', $app->snippet(['does-not-exist', 'plugin']));
 
         // fallback from plugin with field
-        $this->assertEquals('plugin', $app->snippet(['does-not-exist', new Field(null, 'test', 'plugin') ]));
+        $this->assertSame('plugin', $app->snippet(['does-not-exist', new Field(null, 'test', 'plugin') ]));
 
         // inject data
-        $this->assertEquals('test', $app->snippet('variable', ['message' => 'test']));
+        $this->assertSame('test', $app->snippet('variable', ['message' => 'test']));
 
         Dir::remove($fixtures);
     }
@@ -340,7 +340,7 @@ class AppComponentsTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('test', url('anything'));
+        $this->assertSame('test', url('anything'));
     }
 
     public function testUrlPluginWithNativeComponent()
@@ -357,8 +357,8 @@ class AppComponentsTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('test-path', url('test'));
-        $this->assertEquals('/any/page', url('any/page'));
+        $this->assertSame('test-path', url('test'));
+        $this->assertSame('/any/page', url('any/page'));
     }
 
     public function testEmail()

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -84,6 +84,22 @@ class AppComponentsTest extends TestCase
         $this->assertEquals($expected, $this->kirby->markdown($text));
     }
 
+    public function testMarkdownInline()
+    {
+        $text     = 'Test';
+        $expected = 'Test';
+
+        $this->assertEquals($expected, $this->kirby->markdown($text, ['inline' => true]));
+    }
+
+    public function testMarkdownWithSafeMode()
+    {
+        $text     = '<div>Test</div>';
+        $expected = '<p>&lt;div&gt;Test&lt;/div&gt;</p>';
+
+        $this->assertEquals($expected, $this->kirby->markdown($text, ['safe' => true]));
+    }
+
     public function testMarkdownCachedInstance()
     {
         $text     = '1st line

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -76,6 +76,46 @@ class AppComponentsTest extends TestCase
         $this->assertEquals($expected, js('something.js'));
     }
 
+    public function testKirbytext()
+    {
+        $text     = 'Test';
+        $expected = '<p>Test</p>';
+
+        $this->assertEquals($expected, $this->kirby->kirbytext($text));
+    }
+
+    public function testKirbytextWithSafeMode()
+    {
+        $text     = '<h1>Test</h1>';
+        $expected = '&lt;h1&gt;Test&lt;/h1&gt;';
+
+        $this->assertEquals($expected, $this->kirby->kirbytext($text, [
+            'markdown' => [
+                'safe' => true
+            ]
+        ], true));
+    }
+
+    public function testKirbytextInline()
+    {
+        $text     = 'Test';
+        $expected = 'Test';
+
+        $this->assertEquals($expected, $this->kirby->kirbytext($text, [
+            'markdown' => [
+                'inline' => true
+            ]
+        ], true));
+    }
+
+    public function testKirbytextInlineDeprecated()
+    {
+        $text     = 'Test';
+        $expected = 'Test';
+
+        $this->assertEquals($expected, $this->kirby->kirbytext($text, [], true));
+    }
+
     public function testMarkdown()
     {
         $text     = 'Test';
@@ -90,6 +130,12 @@ class AppComponentsTest extends TestCase
         $expected = 'Test';
 
         $this->assertEquals($expected, $this->kirby->markdown($text, ['inline' => true]));
+
+        // deprecated boolean second option
+        $this->assertEquals($expected, $this->kirby->markdown($text, true));
+
+        // deprecated fourth argument
+        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, [], true));
     }
 
     public function testMarkdownWithSafeMode()

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -520,6 +520,14 @@ class FieldMethodsTest extends TestCase
         $this->assertSame($expected, $this->field($kirbytext)->kt()->value());
     }
 
+    public function testKirbytextWithSafeMode()
+    {
+        $kirbytext = '<h1>Test</h1>';
+        $expected  = '<p>&lt;h1&gt;Test&lt;/h1&gt;</p>';
+
+        $this->assertSame($expected, $this->field($kirbytext)->kirbytext(['markdown' => ['safe' => true]])->value());
+    }
+
     public function testKirbytextInline()
     {
         $kirbytext = '(link: # text: Test)';
@@ -527,6 +535,14 @@ class FieldMethodsTest extends TestCase
 
         $this->assertSame($expected, $this->field($kirbytext)->kirbytextinline()->value());
         $this->assertSame($expected, $this->field($kirbytext)->kti()->value());
+    }
+
+    public function testKirbytextInlineWithSafeMode()
+    {
+        $kirbytext = '<b>Test</b>';
+        $expected  = '&lt;b&gt;Test&lt;/b&gt;';
+
+        $this->assertSame($expected, $this->field($kirbytext)->kirbytextInline(['markdown' => ['safe' => true]])->value());
     }
 
     public function testKirbytags()
@@ -548,6 +564,14 @@ class FieldMethodsTest extends TestCase
         $expected = '<p><strong>Test</strong></p>';
 
         $this->assertSame($expected, $this->field($markdown)->markdown()->value());
+    }
+
+    public function testMarkdownWithSafeMode()
+    {
+        $markdown = '<h1>Test</h1>';
+        $expected = '<p>&lt;h1&gt;Test&lt;/h1&gt;</p>';
+
+        $this->assertSame($expected, $this->field($markdown)->markdown(['safe' => true])->value());
     }
 
     public function testOr()

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -451,14 +451,11 @@ class HelpersTest extends TestCase
 
     public function testKirbyTextHelper()
     {
-        $text   = 'This is **just** a text.';
-        $normal = '<p>This is <strong>just</strong> a text.</p>';
-        $inline = 'This is <strong>just</strong> a text.';
+        $text     = 'This is **just** a text.';
+        $expected = '<p>This is <strong>just</strong> a text.</p>';
 
-        $this->assertSame($normal, kirbytext($text));
-        $this->assertSame($normal, kt($text));
-        $this->assertSame($inline, kirbytextinline($text));
-        $this->assertSame($inline, kti($text));
+        $this->assertSame($expected, kirbytext($text));
+        $this->assertSame($expected, kt($text));
     }
 
     public function testKirbyTextHelperWithSafeMode()
@@ -467,6 +464,25 @@ class HelpersTest extends TestCase
         $expected = '<p>&lt;h1&gt;Kirby&lt;/h1&gt;</p>';
 
         $this->assertSame($expected, kirbytext($text, ['markdown' => ['safe' => true]]));
+        $this->assertSame($expected, kt($text, ['markdown' => ['safe' => true]]));
+    }
+
+    public function testKirbyTextInlineHelper()
+    {
+        $text     = 'This is **just** a text.';
+        $expected = 'This is <strong>just</strong> a text.';
+
+        $this->assertSame($expected, kirbytextinline($text));
+        $this->assertSame($expected, kti($text));
+    }
+
+    public function testKirbyTextInlineHelperWithSafeMode()
+    {
+        $text     = 'This is <b>just</b> a text.';
+        $expected = 'This is &lt;b&gt;just&lt;/b&gt; a text.';
+
+        $this->assertSame($expected, kirbytextinline($text, ['markdown' => ['safe' => true]]));
+        $this->assertSame($expected, kti($text, ['markdown' => ['safe' => true]]));
     }
 
     public function testLoad()

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -461,6 +461,14 @@ class HelpersTest extends TestCase
         $this->assertSame($inline, kti($text));
     }
 
+    public function testKirbyTextHelperWithSafeMode()
+    {
+        $text     = '<h1>Kirby</h1>';
+        $expected = '<p>&lt;h1&gt;Kirby&lt;/h1&gt;</p>';
+
+        $this->assertSame($expected, kirbytext($text, ['markdown' => ['safe' => true]]));
+    }
+
     public function testLoad()
     {
         load([
@@ -476,6 +484,14 @@ class HelpersTest extends TestCase
     {
         $tag = markdown('# Kirby');
         $expected = '<h1>Kirby</h1>';
+
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testMarkdownHelperWithSafeMode()
+    {
+        $tag = markdown('<h1>Kirby</h1>', ['safe' => true]);
+        $expected = '<p>&lt;h1&gt;Kirby&lt;/h1&gt;</p>';
 
         $this->assertSame($expected, $tag);
     }

--- a/tests/Text/MarkdownTest.php
+++ b/tests/Text/MarkdownTest.php
@@ -13,8 +13,9 @@ class MarkdownTest extends TestCase
         $markdown = new Markdown();
 
         $this->assertSame([
+            'breaks' => true,
             'extra'  => false,
-            'breaks' => true
+            'safe'   => false,
         ], $markdown->defaults());
     }
 
@@ -26,6 +27,24 @@ class MarkdownTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Markdown::class, $markdown);
+    }
+
+    public function testSafeModeDisabled()
+    {
+        $markdown = new Markdown([
+            'safe' => false
+        ]);
+
+        $this->assertSame('<div>Custom HTML</div>', $markdown->parse('<div>Custom HTML</div>'));
+    }
+
+    public function testSafeModeEnabled()
+    {
+        $markdown = new Markdown([
+            'safe' => true
+        ]);
+
+        $this->assertSame('<p>&lt;div&gt;Custom HTML&lt;/div&gt;</p>', $markdown->parse('<div>Custom HTML</div>'));
     }
 
     public function testParse()


### PR DESCRIPTION
## Describe the PR

This PR adds access to the Parsedown safeMode option and cleans up the method calls for markdown and kirbytext methods. 

Safe mode can now be enabled like this: 

```php 
// helpers
kirbytext($text, [
  'markdown' => [
    'safe' => true
  ]
]);

kirbytextInline($text, [
  'markdown' => [
    'safe' => true
  ]
]);

markdown($text, [
   'safe' => true
]);

// field methods
$page->text()->kirbytext([
  'markdown' => [
    'safe' => true
  ]
]);

$page->text()->kirbytextInline([
  'markdown' => [
    'safe' => true
  ]
]);

$page->text()->markdown([
   'safe' => true
]);


```

The safe mode is now also available as global markdown setting: 

```php
<?php 

// config.php
return [
  'markdown' => [
    'safe' => true
  ]
];
```

## Breaking changes
None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
