### PR TITLE
Allow `rel="alternate stylesheet"` in css() helper

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -115,13 +115,13 @@ function css($url, $options = null): ?string
         }
     }
 
-	// only valid value for 'rel' is 'alternate stylesheet', if 'title' is given as well
+    // only valid value for 'rel' is 'alternate stylesheet', if 'title' is given as well
     if (
-		($options['rel'] ?? '') !== 'alternate stylesheet' ||
-		($options['title'] ?? '') === ''
-	) {
-		$options['rel'] = 'stylesheet';
-	}
+        ($options['rel'] ?? '') !== 'alternate stylesheet' ||
+        ($options['title'] ?? '') === ''
+    ) {
+        $options['rel'] = 'stylesheet';
+    }
 
     $url  = ($kirby->component('css'))($kirby, $url, $options);
     $url  = Url::to($url);

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -115,11 +115,18 @@ function css($url, $options = null): ?string
         }
     }
 
+	// only valid value for 'rel' is 'alternate stylesheet', if 'title' is given as well
+    if (
+		($options['rel'] ?? '') !== 'alternate stylesheet' ||
+		($options['title'] ?? '') === ''
+	) {
+		$options['rel'] = 'stylesheet';
+	}
+
     $url  = ($kirby->component('css'))($kirby, $url, $options);
     $url  = Url::to($url);
     $attr = array_merge((array)$options, [
-        'href' => $url,
-        'rel'  => 'stylesheet'
+        'href' => $url
     ]);
 
     return '<link ' . attr($attr) . '>';

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -143,6 +143,30 @@ class HelpersTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testCssHelperWithValidRelAttr()
+    {
+        $result   = css('assets/css/index.css', ['rel' => 'alternate stylesheet', 'title' => 'High contrast']);
+        $expected = '<link href="https://getkirby.com/assets/css/index.css" rel="alternate stylesheet" title="High contrast">';
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testCssHelperWithInvalidRelAttr()
+    {
+        $result   = css('assets/css/index.css', ['rel' => 'alternate', 'title' => 'High contrast']);
+        $expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet" title="High contrast">';
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testCssHelperWithRelAttrButNoTitle()
+    {
+        $result   = css('assets/css/index.css', ['rel' => 'alternate stylesheet']);
+        $expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet">';
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testCssHelperWithArray()
     {
         $result = css([


### PR DESCRIPTION
## Describe the PR
The `css()` helper currently does not allow setting the `rel` attribute to `alternate stylesheet`; always defaults to `stylesheet`.
- via https://forum.getkirby.com/t/alternate-stylesheet-with-css-helper-not-possible/24510/3
- MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets

This fix enables setting `rel="alternate stylesheet"`, but no other `rel` values, and only if the `title` attribute contains a valid string.

NB. This PR has a tiny loophole (actually might be a useful feature, even?) if the helper is used with an array of CSS paths; they would all receive the same `rel` and `title` attributes. Since that is still valid HTML (browsers simply ignore what does not make sense), I don't see a direct need to prevent that in the helper code?

## Release notes
### Fixes
`css()` helper now accepts `rel="alternate stylesheet"`

## Breaking changes
None

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

## When merging
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
