### PR TITLE
Add JPEG size hint to ImageMagick command

### DIFF
--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -129,16 +129,18 @@ class Darkroom
         $options = $this->options($options);
         $image   = new Image($file);
 
+        $dimensions      = $image->dimensions();
+        $thumbDimensions = $dimensions->thumb($options);
+
         $sourceWidth  = $image->width();
         $sourceHeight = $image->height();
 
-        $dimensions = $image->dimensions()->thumb($options);
+        $options['width']  = $thumbDimensions->width();
+        $options['height'] = $thumbDimensions->height();
 
-        $options['width']  = $dimensions->width();
-        $options['height'] = $dimensions->height();
-
-        $options['scaleWidth']  = $options['width'] / $sourceWidth;
-        $options['scaleHeight'] = $options['height'] / $sourceHeight;
+        // scale ratio compared to the source dimensions
+        $options['scaleWidth']  = $sourceWidth ? $options['width'] / $sourceWidth : null;
+        $options['scaleHeight'] = $sourceHeight ? $options['height'] / $sourceHeight : null;
 
         return $options;
     }

--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -63,14 +63,16 @@ class Darkroom
     protected function defaults(): array
     {
         return [
-            'autoOrient' => true,
-            'blur'       => false,
-            'crop'       => false,
-            'format'     => null,
-            'grayscale'  => false,
-            'height'     => null,
-            'quality'    => 90,
-            'width'      => null,
+            'autoOrient'  => true,
+            'blur'        => false,
+            'crop'        => false,
+            'format'      => null,
+            'grayscale'   => false,
+            'height'      => null,
+            'quality'     => 90,
+            'scaleHeight' => null,
+            'scaleWidth'  => null,
+            'width'       => null,
         ];
     }
 
@@ -124,12 +126,19 @@ class Darkroom
      */
     public function preprocess(string $file, array $options = [])
     {
-        $options    = $this->options($options);
-        $image      = new Image($file);
+        $options = $this->options($options);
+        $image   = new Image($file);
+
+        $sourceWidth  = $image->width();
+        $sourceHeight = $image->height();
+
         $dimensions = $image->dimensions()->thumb($options);
 
         $options['width']  = $dimensions->width();
         $options['height'] = $dimensions->height();
+
+        $options['scaleWidth']  = $options['width'] / $sourceWidth;
+        $options['scaleHeight'] = $options['height'] / $sourceHeight;
 
         return $options;
     }

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -5,6 +5,7 @@ namespace Kirby\Image\Darkroom;
 use Exception;
 use Kirby\Filesystem\F;
 use Kirby\Image\Darkroom;
+use Kirby\Image\Image;
 
 /**
  * ImageMagick
@@ -73,6 +74,16 @@ class ImageMagick extends Darkroom
 
         // limit to single-threading to keep CPU usage sane
         $command .= ' -limit thread 1';
+
+        // add JPEG size hint to optimize CPU and memory usage
+        if (F::mime($file) === 'image/jpeg') {
+            $image = new Image($file);
+
+            // add hint only when downscaling
+            if ($options['width'] < $image->width() && $options['height'] < $image->height()) {
+                $command .= sprintf(' -define jpeg:size=%dx%d', $options['width'], $options['height']);
+            }
+        }
 
         // append input file
         return $command . ' ' . escapeshellarg($file);

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -5,7 +5,6 @@ namespace Kirby\Image\Darkroom;
 use Exception;
 use Kirby\Filesystem\F;
 use Kirby\Image\Darkroom;
-use Kirby\Image\Image;
 
 /**
  * ImageMagick
@@ -77,10 +76,8 @@ class ImageMagick extends Darkroom
 
         // add JPEG size hint to optimize CPU and memory usage
         if (F::mime($file) === 'image/jpeg') {
-            $image = new Image($file);
-
             // add hint only when downscaling
-            if ($options['width'] < $image->width() && $options['height'] < $image->height()) {
+            if ($options['scaleWidth'] < 1 && $options['scaleHeight'] < 1) {
                 $command .= ' -define ' . escapeshellarg(sprintf('jpeg:size=%dx%d', $options['width'], $options['height']));
             }
         }

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -81,7 +81,7 @@ class ImageMagick extends Darkroom
 
             // add hint only when downscaling
             if ($options['width'] < $image->width() && $options['height'] < $image->height()) {
-                $command .= sprintf(' -define jpeg:size=%dx%d', $options['width'], $options['height']);
+                $command .= ' -define ' . escapeshellarg(sprintf('jpeg:size=%dx%d', $options['width'], $options['height']));
             }
         }
 

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -40,6 +40,8 @@ class GdLibTest extends TestCase
             'grayscale' => false,
             'height' => 500,
             'quality' => 90,
+            'scaleHeight' => 1,
+            'scaleWidth' => 1,
             'width' => 500,
         ], $gd->process($file));
     }

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -41,6 +41,8 @@ class ImageMagickTest extends TestCase
             'grayscale' => false,
             'height' => 500,
             'quality' => 90,
+            'scaleHeight' => 1,
+            'scaleWidth' => 1,
             'width' => 500,
             'bin' => 'convert',
             'interlace' => false


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
One step in enhancing Kirby’s thumbnail creation, especially with large images in resource-restricted server environments. It adds a “size hint” (see [ImageMagick docs](https://imagemagick.org/script/defines.php)) when calling ImageMagick with a JPEG file which can reduce the CPU and memory usage drastically—most notably when the output file is a lot smaller than the original.



## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements
* JPEG size hint added to the ImageMagick thumb driver to increase performance with large source images



## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None



## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Partly fixes #3023 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] ~Unit tests for fixed bug/feature~ (hard if not impossible to test because it's an internal working of IM)
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] Add changes to release notes draft in Notion
