### PR TITLE
Vitest optimizations and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,16 @@ jobs:
 
       - name: Run JavaScript unit tests
         if: always() && steps.finishPrepare.outcome == 'success'
-        run: npm run test:unit
+        run: npm run test:unit:coverage
         working-directory: panel
+      
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # for better reliability if the GitHub API is down
+          fail_ci_if_error: true
+          files: ${{ github.workspace }}/panel/coverage/lcov.info
+          flags: frontend
 
   frontend-e2e:
     name: "Frontend: E2E tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,15 @@ jobs:
         run: npm run test:unit:coverage
         working-directory: panel
       
-      - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # for better reliability if the GitHub API is down
-          fail_ci_if_error: true
-          files: ${{ github.workspace }}/panel/coverage/lcov.info
-          flags: frontend
+      # TODO: Disabled until Vitest coverage reporting is accurate and
+      #       Kirby's frontend tests are useful enough that we need this metric 
+      # - name: Upload coverage results to Codecov
+      #   uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }} # for better reliability if the GitHub API is down
+      #     fail_ci_if_error: true
+      #     files: ${{ github.workspace }}/panel/coverage/lcov.info
+      #     flags: frontend
 
   frontend-e2e:
     name: "Frontend: E2E tests"

--- a/panel/package.json
+++ b/panel/package.json
@@ -68,11 +68,5 @@
     "last 2 Opera versions",
     "last 2 OperaMobile versions",
     "last 2 UCAndroid versions"
-  ],
-  "c8": {
-    "skip-full": true,
-    "exclude": [
-      "vite.config.js"
-    ]
-  }
+  ]
 }

--- a/panel/src/components/Misc/Progress.test.js
+++ b/panel/src/components/Misc/Progress.test.js
@@ -1,7 +1,8 @@
+import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import Progress from "./Progress.vue";
 
-describe("Progress.vue", () => {
+describe.concurrent("Progress.vue", () => {
   it("mounts component", async () => {
     const wrapper = mount(Progress);
     expect(wrapper.element.value).toBe(0);

--- a/panel/src/components/Misc/Text.test.js
+++ b/panel/src/components/Misc/Text.test.js
@@ -1,7 +1,8 @@
+import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import Text from "./Text.vue";
 
-describe("Text.vue", () => {
+describe.concurrent("Text.vue", () => {
   it("has default slot", async () => {
     const wrapper = mount(Text, {
       slots: {

--- a/panel/src/components/Navigation/PrevNext.test.js
+++ b/panel/src/components/Navigation/PrevNext.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import PrevNext from "./PrevNext.vue";
 
@@ -5,7 +6,7 @@ const setup = {
   stubs: ["k-button-group"]
 };
 
-describe("PrevNext.vue", () => {
+describe.concurrent("PrevNext.vue", () => {
   it("has buttons", async () => {
     const wrapper = mount(PrevNext, {
       propsData: {

--- a/panel/src/components/Navigation/__snapshots__/PrevNext.test.js.snap
+++ b/panel/src/components/Navigation/__snapshots__/PrevNext.test.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`PrevNext.vue > has buttons 1`] = `
+exports[`PrevNext.vue > has CSS selector 1`] = `
 <k-button-group-stub
   buttons="[object Object],[object Object]"
   class="k-prev-next"

--- a/panel/src/fiber/dialog.test.js
+++ b/panel/src/fiber/dialog.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dialog from "./dialog.js";
 
 const Vue = () => {

--- a/panel/src/fiber/dropdown.test.js
+++ b/panel/src/fiber/dropdown.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dropdown from "./dropdown.js";
 
 describe.concurrent("$dropdown()", () => {

--- a/panel/src/fiber/index.test.js
+++ b/panel/src/fiber/index.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 
+import { describe, expect, it } from "vitest";
 import Fiber from "./index.js";
 
 describe.concurrent("$fiber", () => {

--- a/panel/src/fiber/search.test.js
+++ b/panel/src/fiber/search.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import search from "./search.js";
 
 describe.concurrent("$search()", () => {

--- a/panel/src/helpers/color.test.js
+++ b/panel/src/helpers/color.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import color from "./color.js";
 
 describe.concurrent("$helper.css.color()", () => {

--- a/panel/src/helpers/embed.test.js
+++ b/panel/src/helpers/embed.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import embed from "./embed.js";
 
 describe.concurrent("$helper.embed()", () => {

--- a/panel/src/helpers/object.clone.test.js
+++ b/panel/src/helpers/object.clone.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import { clone } from "./object.js";
 
 describe.concurrent("$helper.object.clone()", () => {

--- a/panel/src/helpers/object.merge.test.js
+++ b/panel/src/helpers/object.merge.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import { merge } from "./object.js";
 
 describe("$helper.object.merge", () => {

--- a/panel/src/helpers/ratio.test.js
+++ b/panel/src/helpers/ratio.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import ratio from "./ratio.js";
 
 describe.concurrent("$helper.ratio()", () => {

--- a/panel/src/helpers/sort.test.js
+++ b/panel/src/helpers/sort.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import sort from "./sort.js";
 
 describe.concurrent("$helper.sort()", () => {

--- a/panel/src/helpers/string.camelToKebab.test.js
+++ b/panel/src/helpers/string.camelToKebab.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.camelToKebab", () => {

--- a/panel/src/helpers/string.escapeHTML.test.js
+++ b/panel/src/helpers/string.escapeHTML.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.escapeHTML", () => {

--- a/panel/src/helpers/string.hasEmoji.test.js
+++ b/panel/src/helpers/string.hasEmoji.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.hasEmoji", () => {

--- a/panel/src/helpers/string.lcfirst.test.js
+++ b/panel/src/helpers/string.lcfirst.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.lcfirst", () => {

--- a/panel/src/helpers/string.pad.test.js
+++ b/panel/src/helpers/string.pad.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import { pad } from "./string.js";
 
 describe.concurrent("$helper.string.pad()", () => {

--- a/panel/src/helpers/string.random.test.js
+++ b/panel/src/helpers/string.random.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe("$helper.string.random", () => {

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import { slug } from "./string.js";
 
 describe.concurrent("$helper.string.slug()", () => {

--- a/panel/src/helpers/string.stripHTML.test.js
+++ b/panel/src/helpers/string.stripHTML.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe("$helper.string.stripHTML", () => {

--- a/panel/src/helpers/string.template.test.js
+++ b/panel/src/helpers/string.template.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.template", () => {

--- a/panel/src/helpers/string.ucfirst.test.js
+++ b/panel/src/helpers/string.ucfirst.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe.concurrent("$helper.string.ucfirst", () => {

--- a/panel/src/helpers/string.ucwords.test.js
+++ b/panel/src/helpers/string.ucwords.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe("$helper.string.ucwords", () => {

--- a/panel/src/helpers/string.uuid.test.js
+++ b/panel/src/helpers/string.uuid.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import string from "./string.js";
 
 describe("$helper.string.uuid", () => {

--- a/panel/src/libraries/dayjs-iso.test.js
+++ b/panel/src/libraries/dayjs-iso.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe("dayjs.iso()", () => {

--- a/panel/src/libraries/dayjs-merge.test.js
+++ b/panel/src/libraries/dayjs-merge.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe.concurrent("dayjs.merge()", () => {

--- a/panel/src/libraries/dayjs-pattern.test.js
+++ b/panel/src/libraries/dayjs-pattern.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe.concurrent("dayjs.pattern.at()", () => {

--- a/panel/src/libraries/dayjs-round.test.js
+++ b/panel/src/libraries/dayjs-round.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe.concurrent("dayjs.round()", () => {

--- a/panel/src/libraries/dayjs-units.test.js
+++ b/panel/src/libraries/dayjs-units.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 const data = {

--- a/panel/src/libraries/dayjs-validate.test.js
+++ b/panel/src/libraries/dayjs-validate.test.js
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, expect, it } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe.concurrent("dayjs.validate()", () => {

--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -105,7 +105,8 @@ export default defineConfig(({ command }) => {
         extension: ["js", "vue"],
         src: "src",
         reporter: ["text", "lcov"]
-      }
+      },
+      setupFiles: ["vitest.setup.js"]
     }
   };
 });

--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -99,7 +99,6 @@ export default defineConfig(({ command }) => {
     test: {
       environment: "jsdom",
       include: ["**/*.test.js"],
-      global: true
     }
   };
 });

--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -99,6 +99,13 @@ export default defineConfig(({ command }) => {
     test: {
       environment: "jsdom",
       include: ["**/*.test.js"],
+      coverage: {
+        all: true,
+        exclude: ["**/*.e2e.js", "**/*.test.js"],
+        extension: ["js", "vue"],
+        src: "src",
+        reporter: ["text", "lcov"]
+      }
     }
   };
 });

--- a/panel/vitest.setup.js
+++ b/panel/vitest.setup.js
@@ -1,0 +1,4 @@
+import Vue from "vue";
+
+Vue.config.productionTip = false;
+Vue.config.devtools = false;


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

- Vue development mode warnings are silenced during testing
- Test methods are imported explicitly according to the Vitest docs
- Coverage is now collected in CI, but not submitted to Codecov yet due to the following issues:
  - `.vue` files are for some reason not included in the coverage report even though they are added to the list in the config. Seems to be a bug in Vitest or `c8`. Peeky was able to collect coverage from Vue files.
  - The covered/uncovered lines are incorrect due to a bug in Vitest (vitest-dev/vitest#375).
  - Our frontend tests are not complete enough to make coverage a valuable metric yet.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

None (Vitest is already included in 3.6.2 release notes)

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None