### PR TITLE
Fix CSS for the date field to wrap more reliably

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -3,7 +3,6 @@
     <div
       ref="body"
       :data-invalid="!novalidate && isInvalid"
-      :data-time-length="timeLength"
       class="k-date-field-body"
       data-theme="field"
     >
@@ -155,23 +154,6 @@ export default {
       }
 
       return this.iso.date === null;
-    },
-    /**
-     * Size class for time input
-     * @returns {string}
-     */
-    timeLength() {
-      const length = String(this.time.display).length;
-
-      if (length <= 5) {
-        return "sm";
-      }
-
-      if (length <= 8) {
-        return "md";
-      }
-
-      return "lg";
     }
   },
   watch: {
@@ -310,21 +292,20 @@ export default {
   border: 0 !important;
   box-shadow: none !important;
 }
-.k-date-field-body[data-time-length="sm"] {
-  --time-width: 6.5rem;
+
+/* https://heydonworks.com/article/the-flexbox-holy-albatross/ */
+.k-date-field-body {
+  --multiplier: calc(25rem - 100%);
 }
-.k-date-field-body[data-time-length="md"] {
-  --time-width: 7.5rem;
-}
-.k-date-field-body[data-time-length="lg"] {
-  --time-width: 9rem;
+.k-date-field-body > * {
+  flex-grow: 1;
+  flex-basis: calc(var(--multiplier) * 999);
+  max-width: 100%;
 }
 .k-date-field-body .k-input[data-type="date"] {
-  flex-grow: 1;
-  flex-basis: calc(100% - var(--time-width) - 1rem);
+  min-width: 60%;
 }
 .k-date-field-body .k-input[data-type="time"] {
-  flex-grow: 1;
-  flex-basis: var(--time-width);
+  min-width: 30%;
 }
 </style>


### PR DESCRIPTION
## Describe the PR

The date field with the activated time option did not wrap properly in narrow spaces. This PR fixes this. Unfortunately I did not find any useful way to keep the time field as narrow as possible. The best way seemed @Heydon's Holy Albatross technique: https://heydonworks.com/article/the-flexbox-holy-albatross/ But I only managed to get it working with percentages. 

## Fixes

- Fixes date field wrapping in narrow columns

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
