### PR TITLE
trim does not except null anymore.

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -205,6 +205,10 @@ class Pages extends Collection
      */
     public function findById(string $id = null)
     {
+        if ($id === null) {
+            return null;
+        }
+
         // remove trailing or leading slashes
         $id = trim($id, '/');
 

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -319,6 +319,7 @@ class PagesTest extends TestCase
         $this->assertNull($pages->findById('mother'));
         $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
         $this->assertNull($pages->findById('child'));
+        $this->assertNull($pages->findById(null));
     }
 
     public function testFindByIdAndUriTranslated()


### PR DESCRIPTION
## Describe the PR
`trim` does not accept `null` in newer versions of PHP:

```
❯ php -v && php -r "trim(null);"
PHP 8.1.2 (cli) (built: Jan 21 2022 04:47:26) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with Xdebug v3.1.2, Copyright (c) 2002-2021, by Derick Rethans
    with Zend OPcache v8.1.2, Copyright (c), by Zend Technologies
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in Command line code on line 1
```

## Release notes
### Fixes
- Fixed calling `Pages->findById()` throws deprecation warning with PHP 8.1


## Breaking changes
None

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
