### PR TITLE
Continue passing $inline parameter to Markdown component

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -924,7 +924,8 @@ class App
             (array)$options
         );
 
-        return ($this->component('markdown'))($this, $text, $options);
+        $inline = $options['inline'] ?? false;
+        return ($this->component('markdown'))($this, $text, $options, $inline);
     }
 
     /**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -924,6 +924,8 @@ class App
             (array)$options
         );
 
+        // TODO: deprecate passing the $inline parameter in 3.7.0
+        // TODO: remove passing the $inline parameter in 3.8.0
         $inline = $options['inline'] ?? false;
         return ($this->component('markdown'))($this, $text, $options, $inline);
     }

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -160,6 +160,43 @@ class AppComponentsTest extends TestCase
         $this->assertSame($expected, $this->kirby->component('markdown')($this->kirby, $text, ['breaks' => false]));
     }
 
+    public function testMarkdownPlugin()
+    {
+        $this->kirby = $this->kirby->clone([
+            'components' => [
+                'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false) {
+                    $result = Html::encode($text);
+
+                    if (!$inline) {
+                        $result = '<p>' . $result . '</p>';
+                    }
+
+                    return '<pre><code>' . $result . '</pre></code>';
+                }
+            ]
+        ]);
+
+        $text     = 'Test _case_';
+
+        $expected = '<pre><code><p>Test _case_</p></pre></code>';
+        $this->assertEquals($expected, $this->kirby->markdown($text));
+
+        // deprecated boolean second option
+        $this->assertEquals($expected, $this->kirby->markdown($text, false));
+
+        // deprecated fourth argument
+        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, [], false));
+        
+        $expected = '<pre><code>Test _case_</pre></code>';
+        $this->assertEquals($expected, $this->kirby->markdown($text, ['inline' => true]));
+
+        // deprecated boolean second option
+        $this->assertEquals($expected, $this->kirby->markdown($text, true));
+
+        // deprecated fourth argument
+        $this->assertEquals($expected, $this->kirby->component('markdown')($this->kirby, $text, [], true));
+    }
+
     public function testSmartypants()
     {
         $text     = '"Test"';


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
With Kirby 3.6.2, the $inline parameter for various Markdown methods was deprecated. This parameter was no longer being passed to Markdown component overrides, which is a breaking change. This PR continues to pass that until the parameter can be formally removed.


## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
- Continues passing `$inline` parameter to Markdown component plugins


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4126 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
