### PR TITLE
Blur activeElement before trying copy

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -5,7 +5,7 @@
         :tooltip="$t('copy')"
         class="k-block-options-button"
         icon="template"
-        @mousedown.native.prevent="$emit('copy')"
+        @mousedown.native.prevent="copy()"
       />
       <k-button
         :tooltip="$t('remove')"
@@ -114,6 +114,16 @@ export default {
   methods: {
     open() {
       this.$refs.options.open();
+    },
+    blurActiveElement() {
+      const activeElement = document.activeElement;
+      if (activeElement && typeof activeElement.blur === "function") {
+        activeElement.blur();
+      }
+    },
+    copy() {
+      this.blurActiveElement();
+      this.$emit("copy");
     }
   }
 };


### PR DESCRIPTION
## Describe the PR
Makes it so that blocks can be copied via the dedicated Copy button, even when an input element has a focus. It achieves this by removing the focus from the activeElement before emitting the "copy" event, just like normal button presses would do, but before. 

## Breaking changes
None

## Related issues/ideas
- Fixes https://github.com/getkirby/kirby/issues/4129

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
