### PR TITLE
fix focus handling of block option buttons

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -14,7 +14,7 @@
     @keydown.ctrl.shift.down.prevent="$emit('sortDown')"
     @keydown.ctrl.shift.up.prevent="$emit('sortUp')"
     @focus="$emit('focus')"
-    @focusin="$emit('focus')"
+    @focusin="onFocusIn"
   >
     <div :class="className" class="k-block">
       <component
@@ -201,6 +201,14 @@ export default {
           this.$refs.container.focus();
         }
       }
+    },
+    onFocusIn(event) {
+      // skip focus if the event is coming from the options buttons
+      if (this.$refs.options?.$el?.contains(event.target)) {
+        return;
+      }
+
+      this.$emit("focus", event);
     },
     goTo(block) {
       if (block) {

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -204,6 +204,8 @@ export default {
     },
     onFocusIn(event) {
       // skip focus if the event is coming from the options buttons
+      // to preserve the current focus (since options buttons directly
+      // trigger events and don't need any focus themselves)
       if (this.$refs.options?.$el?.contains(event.target)) {
         return;
       }

--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -5,13 +5,13 @@
         :tooltip="$t('copy')"
         class="k-block-options-button"
         icon="template"
-        @mousedown.native.prevent="$emit('copy')"
+        @click.prevent="$emit('copy')"
       />
       <k-button
         :tooltip="$t('remove')"
         class="k-block-options-button"
         icon="trash"
-        @mousedown.native.prevent="$emit('confirmToRemoveSelected')"
+        @click.prevent="$emit('confirmToRemoveSelected')"
       />
     </template>
     <template v-else>

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -472,6 +472,11 @@ export default {
       this.isMultiSelectKey = event.metaKey || event.ctrlKey || event.altKey;
     },
     onOutsideFocus(event) {
+      //ignore focus in dialogs
+      if (event.target.closest(".k-dialog")) {
+        return;
+      }
+
       const overlay = document.querySelector(".k-overlay:last-of-type");
       if (
         this.$el.contains(event.target) === false &&
@@ -479,6 +484,7 @@ export default {
       ) {
         return this.select(null);
       }
+
 
       // since we are still working in the same block when overlay is open
       // we cannot detect the transition between the layout columns

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -485,7 +485,6 @@ export default {
         return this.select(null);
       }
 
-
       // since we are still working in the same block when overlay is open
       // we cannot detect the transition between the layout columns
       // following codes detect if the target is in the same column

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -472,7 +472,7 @@ export default {
       this.isMultiSelectKey = event.metaKey || event.ctrlKey || event.altKey;
     },
     onOutsideFocus(event) {
-      //ignore focus in dialogs
+      // ignore focus in dialogs to not alter current selection
       if (event.target.closest(".k-dialog")) {
         return;
       }


### PR DESCRIPTION
## Describe the PR
BlockOptions now use a Click handler, but don't send a focus event to Blocks.vue.  This allows them to be clicked without losing the blocks selection.
Focus events in dialogs also no longer cause the selection to be lost.

## Release notes
 - Fixes delete and copy blocks buttons not working as expected in Chrome

## Breaking changes
None

## Related issues/ideas
- Fixes https://github.com/getkirby/kirby/issues/4129
- Fixes https://github.com/getkirby/kirby/issues/4131
- Fixes https://github.com/getkirby/kirby/issues/3941

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
