### PR TITLE
exclude "vitest" from vite pre-bundling

### DIFF
--- a/panel/vite.config.js
+++ b/panel/vite.config.js
@@ -64,7 +64,10 @@ export default defineConfig(({ command }) => {
       }
     },
     optimizeDeps: {
-      entries: "src/**/*.{js,vue}"
+      entries: "src/**/*.{js,vue}",
+      exclude: [
+        "vitest"
+      ]
     },
     css: {
       postcss: {


### PR DESCRIPTION
## Describe the PR
Running `vite` (or `npm run dev`) from the panel folder does not work in fresh clones of this repo. This PR fixes that.

## Release notes
- Skip prebundling of "vitest"

## Breaking changes
None

## Details
Pre-bundling "vitest" doesn't work because it requires "node only" functionality. Trying to do so results in errors like:
```
 > node_modules/local-pkg/dist/shared.mjs:54:9: error: No matching export in "browser-external:fs" for import "existsSync"
    54 │ import { existsSync, promises as fs3 } from "fs";
 > node_modules/local-pkg/dist/shared.mjs:54:21: error: No matching export in "browser-external:fs" for import "promises"
    54 │ import { existsSync, promises as fs3 } from "fs";
...more...
 > node_modules/local-pkg/index.mjs:1:15: error: No matching export in "browser-external:path" for import "dirname"
    1 │ import { join, dirname } from 'path'
...more...
```

The dependency to `vitest` gets picked up by the bundler because of the test files that also match the `"src/**/*.{js,vue}"` glob in the `optimizeDeps.entries` option. 

Writing a glob that includes `*.js`, but does not include `.test.js`, seems to be impossible (I've tried). Therefore the [`exclude`](https://vitejs.dev/config/#optimizedeps-exclude) property seems to be the easiest route. 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
