### PR TITLE
Fix date JS unit tests

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -40,7 +40,7 @@
         "vite": "^2.6.14",
         "vite-plugin-rewrite-all": "^0.1.2",
         "vite-plugin-vue2": "^1.9.0",
-        "vitest": "^0.1.12",
+        "vitest": "^0.2.7",
         "vue-docgen-api": "^4.43.0",
         "vue-template-compiler": "^2.6.14"
       }
@@ -2302,15 +2302,16 @@
       "dev": true
     },
     "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
@@ -5059,6 +5060,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.2.tgz",
+      "integrity": "sha512-QgVamnvj0jX1LMPlCAq0MK6hATORFtGqHoUKXTkwNe13BqlN6aePQCKnnTcFvdDYEEITcJ+gBl4mTW7YJtJbyQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6521,9 +6531,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.2.8.tgz",
-      "integrity": "sha512-4VXqQzzh9gC5uOLk77cLr9R3wqJq07xJlgM9IUdCNJCet139r+046ETKbU1x7mGs7B0k7eopyH5U6yflbBXNyA==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.2.10.tgz",
+      "integrity": "sha512-Qij6rGWCDjWIejxCXXVi6bNgvrYBp3PbqC4cBP/0fD6WHDOHCw09Zd13CsxrDqSR5PFq01WeqDws8t5lz5sH0A==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -6759,9 +6769,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.10.tgz",
-      "integrity": "sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==",
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+      "integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.13.12",
@@ -6863,18 +6873,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.1.12.tgz",
-      "integrity": "sha512-uiGDO1aKX2rUWtkR7iNedbtN3ij/qr4l1DwAbX5cIADUD7VBuFimaUrL8KyFw3eSxdA56xJyl8JpvSAsvvpN7w==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.2.7.tgz",
+      "integrity": "sha512-rKbmtADi6jsxYrwBrw4+sdYPLm3eiTmx7ojoZXQshScxnGWbHP18hWNa2NUEOYgowatkIiWPDVIyFB1kPnhokw==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.0",
         "@types/chai-subset": "^1.3.3",
-        "chai": "^4.3.4",
+        "chai": "^4.3.6",
         "local-pkg": "^0.4.1",
         "tinypool": "^0.1.1",
-        "tinyspy": "^0.2.8",
-        "vite": ">=2.7.10"
+        "tinyspy": "^0.2.10",
+        "vite": ">=2.7.13"
       },
       "bin": {
         "vitest": "vitest.mjs"
@@ -9181,15 +9191,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
@@ -11264,6 +11275,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loupe": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.2.tgz",
+      "integrity": "sha512-QgVamnvj0jX1LMPlCAq0MK6hATORFtGqHoUKXTkwNe13BqlN6aePQCKnnTcFvdDYEEITcJ+gBl4mTW7YJtJbyQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -12448,9 +12468,9 @@
       "dev": true
     },
     "tinyspy": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.2.8.tgz",
-      "integrity": "sha512-4VXqQzzh9gC5uOLk77cLr9R3wqJq07xJlgM9IUdCNJCet139r+046ETKbU1x7mGs7B0k7eopyH5U6yflbBXNyA==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.2.10.tgz",
+      "integrity": "sha512-Qij6rGWCDjWIejxCXXVi6bNgvrYBp3PbqC4cBP/0fD6WHDOHCw09Zd13CsxrDqSR5PFq01WeqDws8t5lz5sH0A==",
       "dev": true
     },
     "tmp": {
@@ -12642,9 +12662,9 @@
       }
     },
     "vite": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.10.tgz",
-      "integrity": "sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==",
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+      "integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.13.12",
@@ -12707,18 +12727,18 @@
       }
     },
     "vitest": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.1.12.tgz",
-      "integrity": "sha512-uiGDO1aKX2rUWtkR7iNedbtN3ij/qr4l1DwAbX5cIADUD7VBuFimaUrL8KyFw3eSxdA56xJyl8JpvSAsvvpN7w==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.2.7.tgz",
+      "integrity": "sha512-rKbmtADi6jsxYrwBrw4+sdYPLm3eiTmx7ojoZXQshScxnGWbHP18hWNa2NUEOYgowatkIiWPDVIyFB1kPnhokw==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.0",
         "@types/chai-subset": "^1.3.3",
-        "chai": "^4.3.4",
+        "chai": "^4.3.6",
         "local-pkg": "^0.4.1",
         "tinypool": "^0.1.1",
-        "tinyspy": "^0.2.8",
-        "vite": ">=2.7.10"
+        "tinyspy": "^0.2.10",
+        "vite": ">=2.7.13"
       }
     },
     "void-elements": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -50,7 +50,7 @@
     "vite": "^2.6.14",
     "vite-plugin-rewrite-all": "^0.1.2",
     "vite-plugin-vue2": "^1.9.0",
-    "vitest": "^0.1.12",
+    "vitest": "^0.2.7",
     "vue-docgen-api": "^4.43.0",
     "vue-template-compiler": "^2.6.14"
   },

--- a/panel/src/libraries/dayjs-interpret.test.js
+++ b/panel/src/libraries/dayjs-interpret.test.js
@@ -2,9 +2,20 @@
  * @vitest-environment node
  */
 
+import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import dayjs from "./dayjs.js";
 
 describe("dayjs.interpret(input, 'date')", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    const date = new Date(2022, 0, 15);
+    vi.setSystemTime(date);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   const expected = {
     "2021-03-05": "2021-03-05",
     "2021-03-5": "2021-03-05",


### PR DESCRIPTION
- Upgrades `vitest`
- Uses a pinned date (15 Jan 2022) for date interpret tests (as otherwise tests would fail every new month)