### PR TITLE
Fix path ending with params separator

### DIFF
--- a/src/Http/Params.php
+++ b/src/Http/Params.php
@@ -69,10 +69,13 @@ class Params extends Query
                 }
 
                 $paramParts = Str::split($p, $separator);
-                $paramKey   = $paramParts[0];
+                $paramKey   = $paramParts[0] ?? null;
                 $paramValue = $paramParts[1] ?? null;
 
-                $params[$paramKey] = $paramValue;
+                if ($paramKey !== null) {
+                    $params[$paramKey] = $paramValue;
+                }
+
                 unset($path[$index]);
             }
 

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -33,12 +33,36 @@ class ParamsTest extends TestCase
         $this->assertEquals(null, $params->b);
     }
 
+    public function testExtractFromNull()
+    {
+        $params   = Params::extract();
+        $expected = [
+            'path'   => null,
+            'params' => null,
+            'slash'  => false
+        ];
+
+        $this->assertEquals($expected, $params);
+    }
+
     public function testExtractFromEmptyString()
     {
         $params   = Params::extract('');
         $expected = [
             'path'   => null,
             'params' => null,
+            'slash'  => false
+        ];
+
+        $this->assertEquals($expected, $params);
+    }
+
+    public function testExtractFromSeparator()
+    {
+        $params   = Params::extract(Params::separator());
+        $expected = [
+            'path'   => [],
+            'params' => [],
             'slash'  => false
         ];
 


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->
The problem arises when the parameter separator (`:` for unix or `;` for windows) is by itself. Fixed by adding `null` control.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed path ending with params separator #4138


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4138 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
