### PR TITLE
Use headers from global response for `Response` objects

### DIFF
--- a/tests/Cms/App/AppIoTest.php
+++ b/tests/Cms/App/AppIoTest.php
@@ -79,12 +79,30 @@ class AppIoTest extends TestCase
     {
         $input = new Response([
             'code' => 200,
-            'body' => 'Test'
+            'body' => 'Test',
+            'type' => 'text/plain',
+            'headers' => [
+                'X-Foo'  => 'Foobar',
+                'X-Test' => 'Test'
+            ]
         ]);
 
-        $response = $this->app()->io($input);
+        $app = $this->app();
+        $app->response()->header('Cache-Control', 'no-cache');
+        $app->response()->header('X-Foo', 'Bar');
+        $response = $app->io($input);
 
-        $this->assertEquals($input, $response);
+        $this->assertSame([
+            'type' => 'text/plain',
+            'charset' => 'UTF-8',
+            'code' => 200,
+            'headers' => [
+                'Cache-Control' => 'no-cache',
+                'X-Foo'         => 'Foobar',
+                'X-Test'        => 'Test'
+            ],
+            'body' => 'Test',
+        ], $response->toArray());
     }
 
     public function testPage()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

API responses with an active session depend on the user who requested them. For better reliability and also security, intermediary caches must not cache API responses.

`$kirby->session()` already sets a `Cache-Control: no-store` header for dynamic responses, but that was so far not respected by the API (which returns its own custom `Response` object).

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->

### Bug fixes

- API responses now contain the `Cache-Control: no-store` header like other responses with an active session.
- The globally configured headers from `$kirby->response()` are now also respected when a route returns a full `Response` object.

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->

None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes https://forum.getkirby.com/t/owasp-criteria-auth-rest-api/24690.
- Fixes #4101.

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
- [x] Add changes to release notes draft in Notion
