### PR TITLE
Fix email sending via PHPMailer in PHP8.1

### DIFF
--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -25,9 +25,9 @@ class Body
     protected $html;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $text;
+    protected $text = '';
 
     /**
      * Email body constructor


### PR DESCRIPTION
## Describe the PR

This fixes #4155 where a different initialization of $text in the email body in Kirby compared to PHPMailer causes emails not to be sent. It simply adjusts the initialization and since there are no unit tests affected, I didn’t need to change any. This change results in the emails being sent again.

_If there’s more missing, please either request changes or go ahead and change/commit anything you need in addition or even drop this PR if it’s not worth keeping it._

## Release notes

This fixes #4155 where a different initialization of $text in the email body in Kirby compared to PHPMailer causes emails not to be sent.

## Breaking changes

None

## Related issues/ideas

- Fixes #4155 

## Ready?

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

## When merging

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
