### PR TITLE
Enhance `Uri::current()` method for reverse proxy

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -254,10 +254,17 @@ class Uri
         );
         $uri = parse_url('http://getkirby.com' . $uri);
 
+        // returns default ports if reverse proxy exists
+        if ($forwarded === false && isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true) {
+            $port = Server::https() === true ? 443 : 80;
+        } else {
+            $port = Server::port($forwarded);
+        }
+
         $url = new static(array_merge([
             'scheme' => Server::https() === true ? 'https' : 'http',
             'host'   => Server::host($forwarded),
-            'port'   => Server::port($forwarded),
+            'port'   => $port,
             'path'   => $uri['path'] ?? null,
             'query'  => $uri['query'] ?? null,
         ], $props));

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -96,6 +96,34 @@ class UriTest extends TestCase
         $this->assertEquals('a/b/ktest.loc', $uri->path());
     }
 
+    public function testCurrentWithReverseProxyDefault()
+    {
+        $_SERVER['HTTP_HOST'] = 'ktest.loc:8080';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.1.123.234';
+
+        $uri = Uri::current();
+        $this->assertSame(80, $uri->port());
+    }
+
+    public function testCurrentWithReverseProxyCustomPort()
+    {
+        $_SERVER['HTTP_HOST'] = 'ktest.loc:8080';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.1.123.234';
+
+        $uri = Uri::current(['port' => 8888]);
+        $this->assertSame(8888, $uri->port());
+    }
+
+    public function testCurrentWithReverseProxyForwarded()
+    {
+        $_SERVER['HTTP_HOST'] = 'ktest.loc:8080';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.1.123.234';
+        $_SERVER['HTTP_X_FORWARDED_PORT'] = '8888';
+
+        $uri = Uri::current([], true);
+        $this->assertSame(8888, $uri->port());
+    }
+
     public function testValidScheme()
     {
         $url = new Uri();


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

First of all I would like to thank @samzzi for setting up an environment that I can test 🙌 

As a result of my tests, I reached Sam's conclusion on the forum:
https://forum.getkirby.com/t/reverse-proxy-shenanigans/24722

When `Uri::current()` doesn't return the correct url in reverse proxy, the whole system is broken. As a solution, I preferred to use the default ports (80-non ssl and 443-ssl) if there is a reverse proxy. Of course, it can still be overwritten with `forwarded` and `port` parameters.

It works successfully in local, remote server, subfolder, nginx reverse proxy environment and cloudflare. But frankly I am not sure if this change is 100% correct and includes any breaking changes.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed the panel not working behind reverse proxy setups #3947 

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #3947 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
