### PR TITLE
Empty string body html and text when null for PHP 8.1

### DIFF
--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -20,12 +20,12 @@ class Body
     use Properties;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected $html;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected $text;
 
@@ -42,7 +42,7 @@ class Body
     /**
      * Returns the HTML content of the email body
      *
-     * @return string|null
+     * @return string
      */
     public function html()
     {
@@ -52,7 +52,7 @@ class Body
     /**
      * Returns the plain text content of the email body
      *
-     * @return string|null
+     * @return string
      */
     public function text()
     {
@@ -67,7 +67,7 @@ class Body
      */
     protected function setHtml(string $html = null)
     {
-        $this->html = $html;
+        $this->html = $html ?? '';
         return $this;
     }
 
@@ -79,7 +79,7 @@ class Body
      */
     protected function setText(string $text = null)
     {
-        $this->text = $text;
+        $this->text = $text ?? '';
         return $this;
     }
 }

--- a/tests/Email/BodyTest.php
+++ b/tests/Email/BodyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Kirby\Email;
+
+/**
+ * @coversDefaultClass \Kirby\Email\Body
+ */
+class BodyTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $body = new Body();
+
+        $this->assertSame('', $body->html());
+        $this->assertSame('', $body->text());
+    }
+
+    public function testConstructParams()
+    {
+        $data = [
+            'html' => '<strong>We will never reply</strong>',
+            'text' => 'We will never reply'
+        ];
+
+        $body = new Body($data);
+
+        $this->assertSame($data['html'], $body->html());
+        $this->assertSame($data['text'], $body->text());
+    }
+
+    public function testConstructNullParams()
+    {
+        $body = new Body([
+            'html' => null,
+            'text' => null
+        ]);
+
+        $this->assertSame('', $body->html());
+        $this->assertSame('', $body->text());
+    }
+}


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Thanks @anselmh for #4156  I offer a more comprehensive solution to the issue  in this PR.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Fixes

- Fixed Kirby and PHPMailer differ in their $text initialisation which fails in PHP8.1 #4155 


## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None

## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4155

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
