### PR TITLE
Use standard "application/javascript" MIME type

### DIFF
--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -48,7 +48,7 @@ class Mime
         'html'  => 'text/html',
         'ico'   => 'image/x-icon',
         'ics'   => 'text/calendar',
-        'js'    => 'application/javascript',
+        'js'    => ['application/javascript', 'application/x-javascript'],
         'json'  => ['application/json', 'text/json'],
         'j2k'   => ['image/jp2'],
         'jp2'   => ['image/jp2'],

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -48,7 +48,7 @@ class Mime
         'html'  => 'text/html',
         'ico'   => 'image/x-icon',
         'ics'   => 'text/calendar',
-        'js'    => 'application/x-javascript',
+        'js'    => 'application/javascript',
         'json'  => ['application/json', 'text/json'],
         'j2k'   => ['image/jp2'],
         'jp2'   => ['image/jp2'],


### PR DESCRIPTION
## Describe the PR
Replace the non-standard `application/x-javascript` MIME type with `application/javascript`.

## Release notes
### Fixes
Assign MIME type `application/javascript` to JS files

## Breaking changes
None

## Related issues/ideas
- Fixes #4174 

## Ready?
- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] CI checks pass

## When merging
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion