### PR TITLE
Fix phpmailer message body empty exception 

### DIFF
--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -46,7 +46,7 @@ class Body
      */
     public function html()
     {
-        return $this->html;
+        return $this->html ?? '';
     }
 
     /**
@@ -56,7 +56,7 @@ class Body
      */
     public function text()
     {
-        return $this->text;
+        return $this->text ?? '';
     }
 
     /**
@@ -67,7 +67,7 @@ class Body
      */
     protected function setHtml(string $html = null)
     {
-        $this->html = $html ?? '';
+        $this->html = $html;
         return $this;
     }
 
@@ -79,7 +79,7 @@ class Body
      */
     protected function setText(string $text = null)
     {
-        $this->text = $text ?? '';
+        $this->text = $text;
         return $this;
     }
 }

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -211,7 +211,7 @@ class Email
      */
     public function isHtml()
     {
-        return $this->body()->html() !== null;
+        return empty($this->body()->html()) === false;
     }
 
     /**

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -33,20 +33,21 @@ class EmailTest extends TestCase
             'sales@supercompany.com'     => 'Super Company Sales'
         ];
 
-        $this->assertEquals($from, $email->from());
-        $this->assertEquals($fromName, $email->fromName());
-        $this->assertEquals([$to => null], $email->to());
-        $this->assertEquals($replyTo, $email->replyTo());
-        $this->assertEquals($replyToName, $email->replyToName());
-        $this->assertEquals($subject, $email->subject());
-        $this->assertEquals($expectedCc, $email->cc());
-        $this->assertEquals($expectedCc, $email->bcc());
+        $this->assertSame($from, $email->from());
+        $this->assertSame($fromName, $email->fromName());
+        $this->assertSame([$to => null], $email->to());
+        $this->assertSame($replyTo, $email->replyTo());
+        $this->assertSame($replyToName, $email->replyToName());
+        $this->assertSame($subject, $email->subject());
+        $this->assertSame($expectedCc, $email->cc());
+        $this->assertSame($expectedCc, $email->bcc());
 
         $this->assertInstanceOf(Body::class, $email->body());
-        $this->assertEquals($body, $email->body()->text());
-        $this->assertEquals(null, $email->body()->html());
+        $this->assertSame($body, $email->body()->text());
+        $this->assertSame('', $email->body()->html());
+        $this->assertFalse($email->isHtml());
 
-        $this->assertEquals(['type' => 'mail'], $email->transport());
+        $this->assertSame(['type' => 'mail'], $email->transport());
     }
 
     public function testRequiredProperty()
@@ -67,9 +68,9 @@ class EmailTest extends TestCase
             'bcc' => null,
         ]);
 
-        $this->assertEquals('', $email->replyTo());
-        $this->assertEquals([], $email->cc());
-        $this->assertEquals([], $email->bcc());
+        $this->assertSame('', $email->replyTo());
+        $this->assertSame([], $email->cc());
+        $this->assertSame([], $email->bcc());
     }
 
     public function testInvalidAddress()
@@ -103,8 +104,8 @@ class EmailTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Body::class, $email->body());
-        $this->assertEquals($body['text'], $email->body()->text());
-        $this->assertEquals($body['html'], $email->body()->html());
+        $this->assertSame($body['text'], $email->body()->text());
+        $this->assertSame($body['html'], $email->body()->html());
 
         $this->assertTrue($email->isHtml());
     }
@@ -118,8 +119,8 @@ class EmailTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Body::class, $email->body());
-        $this->assertEquals(null, $email->body()->text());
-        $this->assertEquals($body['html'], $email->body()->html());
+        $this->assertSame('', $email->body()->text());
+        $this->assertSame($body['html'], $email->body()->html());
 
         $this->assertTrue($email->isHtml());
     }
@@ -133,7 +134,7 @@ class EmailTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals($attachments, $email->attachments());
+        $this->assertSame($attachments, $email->attachments());
     }
 
     public function testBeforeSend()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

If the body parameter is an array and there is no `html` or `text` index, the property will still return `null` because the setter will not run. So I moved the null coalescing operator to getter.

Also switched `null` check to empty check in `Email::isHtml()` method to fix #4183 issue.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
None

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4183 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [x] Add changes to release notes draft in Notion
