### PR TITLE
Query images for image and gallery blocks

### DIFF
--- a/config/blocks/gallery/gallery.yml
+++ b/config/blocks/gallery/gallery.yml
@@ -5,7 +5,7 @@ fields:
   images:
     label: field.blocks.gallery.images.label
     type: files
-    query: page.images
+    query: model.images
     multiple: true
     layout: cards
     size: tiny

--- a/config/blocks/gallery/gallery.yml
+++ b/config/blocks/gallery/gallery.yml
@@ -5,6 +5,7 @@ fields:
   images:
     label: field.blocks.gallery.images.label
     type: files
+    query: page.images
     multiple: true
     layout: cards
     size: tiny

--- a/config/blocks/image/image.yml
+++ b/config/blocks/image/image.yml
@@ -13,6 +13,7 @@ fields:
   image:
     label: field.blocks.image.name
     type: files
+    query: page.images
     multiple: false
     image:
       back: black

--- a/config/blocks/image/image.yml
+++ b/config/blocks/image/image.yml
@@ -13,7 +13,7 @@ fields:
   image:
     label: field.blocks.image.name
     type: files
-    query: page.images
+    query: model.images
     multiple: false
     image:
       back: black

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -347,6 +347,7 @@ abstract class ModelWithContent extends Model
             $result = Str::query($query, [
                 'kirby'             => $this->kirby(),
                 'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
+                'model'             => $this,
                 static::CLASS_ALIAS => $this
             ]);
         } catch (Throwable $e) {

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -375,6 +375,14 @@ class FileTest extends TestCase
         $this->assertSame($file->url(), $file->previewUrl());
     }
 
+    public function testQuery()
+    {
+        $file = $this->file();
+
+        $this->assertSame('cover.jpg', $file->query('file.filename'));
+        $this->assertSame('cover.jpg', $file->query('model.filename'));
+    }
+
     public function testApiUrl()
     {
         $app = new App([

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -933,6 +933,16 @@ class PageTest extends TestCase
         $page->controller();
     }
 
+    public function testQuery()
+    {
+        $page = new Page([
+            'slug' => 'test'
+        ]);
+
+        $this->assertSame('test', $page->query('page.slug'));
+        $this->assertSame('test', $page->query('model.slug'));
+    }
+
     public function testToArray()
     {
         $page = new Page([

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -263,6 +263,18 @@ class SiteTest extends TestCase
         $this->assertInstanceOf('Kirby\Panel\Site', $site->panel());
     }
 
+    public function testQuery()
+    {
+        $site = new Site([
+            'content' => [
+                'title' => 'Mægazine',
+            ]
+        ]);
+
+        $this->assertSame('Mægazine', $site->query('site.title')->value());
+        $this->assertSame('Mægazine', $site->query('model.title')->value());
+    }
+
     public function testApiUrl()
     {
         $site = new Site();

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -305,8 +305,12 @@ class UserTest extends TestCase
             'name'  => 'Test User'
         ]);
 
-        $this->assertEquals('Test User', $user->query('user.name'));
-        $this->assertEquals('test@getkirby.com', $user->query('user.email'));
+        $this->assertSame('Test User', $user->query('user.name')->value());
+        $this->assertSame('test@getkirby.com', $user->query('user.email'));
+
+        // also test with `model` key
+        $this->assertSame('Test User', $user->query('model.name')->value());
+        $this->assertSame('test@getkirby.com', $user->query('model.email'));
     }
 
     public function testUserMethods()


### PR DESCRIPTION
## Describe the PR
<!--
A clear and concise description of the bug the PR fixes or the feature the PR introduces.
Use this section for review hints and explanations for easier code understanding if necessary.
-->

Use `query: model.images` for image and gallery blocks to ensure only images selectable.

## Release notes
<!--
A concise list of changes to be used in the version release notes.
Please use sub-headings for "Features", "Enhancements", "Fixes"...
-->
### Enhancements
- Supports `model.` entry for model queries (as placeholder alias for `page.`, `file.`, `user.` or `site.`), which allows a query syntax that can be shared between different model types.
- Image and gallery blocks picker only shows images for selection

## Breaking changes
<!--
If PR creates known breaking changes, please list them.
If there are no breaking changes, please write "None".
-->
None


## Related issues/ideas
<!--
PR relates to issues in the `kirby` repo or ideas on `feedback.getkirby.com`:
-->

- Fixes #4189 

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
