### PR TITLE
Fix loading blueprint with i18n’ed name #4177

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -76,8 +76,7 @@ class Blueprint
         // normalize the name
         $props['name'] ??= 'default';
 
-        // normalize and translate the name and title
-        $props['name']  = $this->i18n($props['name']);
+        // normalize and translate the title
         $props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
 
         // convert all shortcuts

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -76,7 +76,8 @@ class Blueprint
         // normalize the name
         $props['name'] ??= 'default';
 
-        // normalize and translate the title
+        // normalize and translate the name and title
+        $props['name']  = $this->i18n($props['name']);
         $props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
 
         // convert all shortcuts
@@ -290,9 +291,13 @@ class Blueprint
         // now ensure that we always return the data array
         if (is_string($file) === true && F::exists($file) === true) {
             return static::$loaded[$name] = Data::read($file);
-        } elseif (is_array($file) === true) {
+        }
+
+        if (is_array($file) === true) {
             return static::$loaded[$name] = $file;
-        } elseif (is_callable($file) === true) {
+        }
+
+        if (is_callable($file) === true) {
             return static::$loaded[$name] = $file($kirby);
         }
 
@@ -335,20 +340,10 @@ class Blueprint
     {
         $props = static::find($name);
 
-        $normalize = function ($props) use ($name) {
-            // inject the filename as name if no name is set
-            $props['name'] ??= $name;
+        // inject the filename as name if no name is set
+        $props['name'] ??= $name;
 
-            // normalize the title
-            $title = $props['title'] ?? ucfirst($props['name']);
-
-            // translate the title
-            $props['title'] = I18n::translate($title, $title);
-
-            return $props;
-        };
-
-        return $normalize($props);
+        return $props;
     }
 
     /**

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -54,7 +54,7 @@ class Fieldset extends Item
         $this->editable  = $params['editable'] ?? true;
         $this->icon      = $params['icon'] ?? null;
         $this->model     = $this->parent;
-        $this->name      = $this->createName($params['name'] ?? Str::ucfirst($this->type));
+        $this->name      = $this->createName($params['title'] ?? $params['name'] ?? Str::ucfirst($this->type));
         $this->label     = $this->createLabel($params['label'] ?? null);
         $this->preview   = $params['preview'] ?? null;
         $this->tabs      = $this->createTabs($params);

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -326,6 +326,27 @@ class BlueprintTest extends TestCase
     }
 
     /**
+     * @covers ::load
+     */
+    public function testLoadWithI18nName()
+    {
+        Blueprint::$loaded = [];
+
+        $this->app = $this->app->clone([
+            'blueprints' => [
+                'pages/test' => function () {
+                    return ['name' => ['en' => 'foo', 'de' => 'fuh']];
+                }
+            ]
+        ]);
+
+        $blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+
+        $this->assertSame('Foo', $blueprint->title());
+        $this->assertSame('foo', $blueprint->name());
+    }
+
+    /**
      * @covers ::fields
      * @covers ::field
      */


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Blueprints with different translations for `name` key now can be loaded
#4177 

### Breaking changes
_None_


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
-  ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
