### PR TITLE
Fix autofocus in picker dialogs search 

### DIFF
--- a/panel/src/mixins/picker/dialog.js
+++ b/panel/src/mixins/picker/dialog.js
@@ -136,7 +136,6 @@ export default {
       const isSelected = this.isSelected(item);
 
       return {
-        autofocus: true,
         icon: isSelected ? this.checkedIcon : "circle-outline",
         tooltip: isSelected ? this.$t("remove") : this.$t("select"),
         theme: isSelected ? "positive" : null


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Picker field dialog: focus doesn't get lost anymore when typing in search input
#3985

### Breaking changes
__None__


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [X] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
