### PR TITLE
Fix missing title field issue #4140

### DIFF
--- a/panel/src/store/modules/content.js
+++ b/panel/src/store/modules/content.js
@@ -249,11 +249,6 @@ export default {
       // attach the language to the id
       model.id = context.getters.id(model.id);
 
-      // remove title from model content
-      if (model.id.startsWith("/pages/") || model.id.startsWith("/site")) {
-        delete model.content.title;
-      }
-
       const data = {
         api: model.api,
         originals: clone(model.content),

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -37,7 +37,19 @@ abstract class Model
      */
     public function content(): array
     {
-        return Form::for($this->model)->values();
+        $content = Form::for($this->model)->values();
+
+        // For Page and Site models, the title is a reserved field
+        // that's handled separately and should not be available in
+        // the regular content array for the Panel
+        if (
+            is_a($this->model, 'Kirby\Cms\Page') === true ||
+            is_a($this->model, 'Kirby\Cms\Site') === true
+        ) {
+            unset($content['title']);
+        }
+
+        return $content;
     }
 
     /**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -3,7 +3,10 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
+use Kirby\Cms\File as ModelFile;
+use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
+use Kirby\Cms\User as ModelUser;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
@@ -125,6 +128,67 @@ class ModelTest extends TestCase
             ]
         ]);
         $this->assertSame($content, $panel->content());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::content
+     */
+    public function testContentWithTitle()
+    {
+        // panel model for file
+        $model = new CustomPanelModel(
+            new ModelFile([
+                'filename' => 'test.jpg',
+                'content' => [
+                    'title' => 'Test'
+                ]
+            ])
+        );
+
+        $this->assertArrayHasKey('title', $model->content());
+
+        // panel model for user
+        $model = new CustomPanelModel(
+            new ModelUser([
+                'id' => 'test@getkirby.com',
+                'content' => [
+                    'title' => 'Test'
+                ]
+            ])
+        );
+
+        $this->assertArrayHasKey('title', $model->content());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::content
+     */
+    public function testContentWithoutTitle()
+    {
+        // panel model for site
+        $model = new CustomPanelModel(
+            new ModelSite([
+                'content' => [
+                    'title' => 'Test'
+                ]
+            ])
+        );
+
+        $this->assertArrayNotHasKey('title', $model->content());
+
+        // panel model for page
+        $model = new CustomPanelModel(
+            new ModelPage([
+                'slug' => 'test',
+                'content' => [
+                    'title' => 'Test'
+                ]
+            ])
+        );
+
+        $this->assertArrayNotHasKey('title', $model->content());
     }
 
     /**


### PR DESCRIPTION
## Release notes

### Fixes

- Fixed regression that removed the title field from content for files and users #4140

## Ready?
<!--
If you feel like you can help to check off the following tasks,
that'd be great. If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] CI checks pass

<!--
CI runs automatically when the PR is created. You can also run `composer ci` locally.
Running locally requires PHPUnit, PHP-CS-Fixer, Psalm, PHPCPD and PHPMD.
-->

## When merging
<!-- We will take care of the following TODOs when reviewing and merging the PR. -->

- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
- [ ] Add changes to release notes draft in Notion
