### PR TITLE
Support for IntlDateFormatter

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -112,11 +112,11 @@ return function (App $app) {
          * Converts the field value to a timestamp or a formatted date
          *
          * @param \Kirby\Cms\Field $field
-         * @param string|null $format PHP date formatting string
+         * @param string|\IntlDateFormatter|null $format PHP date formatting string
          * @param string|null $fallback Fallback string for `strtotime` (since 3.2)
          * @return string|int
          */
-        'toDate' => function (Field $field, string $format = null, string $fallback = null) use ($app) {
+        'toDate' => function (Field $field, $format = null, string $fallback = null) use ($app) {
             if (empty($field->value) === true && $fallback === null) {
                 return null;
             }

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -353,12 +353,12 @@ class File extends ModelWithContent
     /**
      * Get the file's last modification time.
      *
-     * @param string|null $format
-     * @param string|null $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string|null $handler date, intl or strftime
      * @param string|null $languageCode
      * @return mixed
      */
-    public function modified(string $format = null, string $handler = null, string $languageCode = null)
+    public function modified($format = null, string $handler = null, string $languageCode = null)
     {
         $file     = $this->modifiedFile();
         $content  = $this->modifiedContent($languageCode);

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -463,11 +463,11 @@ class F
      * Get the file's last modification time.
      *
      * @param string $file
-     * @param string $format
-     * @param string $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string $handler date, intl or strftime
      * @return mixed
      */
-    public static function modified(string $file, string $format = null, string $handler = 'date')
+    public static function modified(string $file, $format = null, string $handler = 'date')
     {
         if (file_exists($file) !== true) {
             return false;

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -372,11 +372,11 @@ class File
     /**
      * Returns the file's last modification time
      *
-     * @param string $format
-     * @param string|null $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string|null $handler date, intl or strftime
      * @return mixed
      */
-    public function modified(?string $format = null, ?string $handler = null)
+    public function modified($format = null, ?string $handler = null)
     {
         $kirby = $this->kirby();
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Toolkit;
 
+use DateTime;
 use Exception;
+use IntlDateFormatter;
 use Kirby\Exception\InvalidArgumentException;
 
 /**
@@ -264,17 +266,33 @@ class Str
      * according to locale settings
      *
      * @param int|null $time
-     * @param string|null $format
-     * @param string $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string $handler date, intl or strftime
      * @return string|int
      */
-    public static function date(?int $time = null, ?string $format = null, string $handler = 'date')
+    public static function date(?int $time = null, $format = null, string $handler = 'date')
     {
         if (is_null($format) === true) {
             return $time;
         }
 
-        // separately handle strftime to be able
+        // $format is an IntlDateFormatter instance
+        if (is_a($format, 'IntlDateFormatter') === true) {
+            return $format->format($time ?? time());
+        }
+
+        // `intl` handler
+        if ($handler === 'intl') {
+            $datetime = new DateTime();
+
+            if ($time !== null) {
+                $datetime->setTimestamp($time);
+            }
+
+            return IntlDateFormatter::formatObject($datetime, $format);
+        }
+
+        // handle `strftime` to be able
         // to suppress deprecation warning
         // TODO: remove strftime support for PHP 9.0
         if ($handler === 'strftime') {

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use IntlDateFormatter;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -138,6 +139,12 @@ class StrTest extends TestCase
         // default `date` handler
         $this->assertSame($time, Str::date($time));
         $this->assertSame('29.01.2020', Str::date($time, 'd.m.Y'));
+
+        // `intl` handler
+        $formatter = new IntlDateFormatter(null, IntlDateFormatter::LONG, IntlDateFormatter::SHORT);
+        $this->assertSame($time, Str::date($time, null, 'intl'));
+        $this->assertSame('29/1/2020 01:01', Str::date($time, 'd/M/yyyy HH:mm', 'intl'));
+        $this->assertSame('January 29, 2020 at 1:01 AM', Str::date($time, $formatter));
 
         // `strftime` handler
         $this->assertSame($time, Str::date($time, null, 'strftime'));


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

PHP 8.1 deprecates `strftime` which will be dropped completely in PHP 9.
This PR adds support for `IntlDateFormatter` as future alternative. 

### Feature
- New `intl` date handler (e.g. for `date.handler` config option) using the [ICU date/time format syntax](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax)
```php
// different ways to use it
$page->myDateField()->toDate('M/d/yy', 'intl');

$formatter = new IntlDateFormatter(null, IntlDateFormatter::LONG, IntlDateFormatter::SHORT);
$page->myDateField()->toDate(formatter);
```

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
