### PR TITLE
Support YouTube’s `allowfullscreen` attribute #4212

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -500,11 +500,7 @@ class Html extends Xml
             ($attr['allowfullscreen'] ?? true) === true
         ) {
             $attr['allow'] = 'fullscreen';
-        }
-
-        // remove deprecated attribute
-        if (isset($attr['allowfullscreen']) === true) {
-            unset($attr['allowfullscreen']);
+            $attr['allowfullscreen'] = true;
         }
 
         return $attr;

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -873,7 +873,7 @@ class HelpersTest extends TestCase
     public function testVideo()
     {
         $video    = video('https://youtube.com/watch?v=xB3s_f7PzYk');
-        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -886,7 +886,7 @@ class HelpersTest extends TestCase
             ]
         ]);
 
-        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -899,7 +899,7 @@ class HelpersTest extends TestCase
             ]
         ]);
 
-        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -907,7 +907,7 @@ class HelpersTest extends TestCase
     public function testVimeo()
     {
         $video    = vimeo('https://vimeo.com/335292911');
-        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/335292911"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -915,7 +915,7 @@ class HelpersTest extends TestCase
     public function testVimeoWithOptions()
     {
         $video    = vimeo('https://vimeo.com/335292911', ['controls' => 0]);
-        $expected = '<iframe allow="fullscreen" src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -931,7 +931,7 @@ class HelpersTest extends TestCase
     public function testYoutube()
     {
         $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk');
-        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
 
         $this->assertSame($expected, $video);
     }
@@ -939,7 +939,7 @@ class HelpersTest extends TestCase
     public function testYoutubeWithOptions()
     {
         $video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
-        $expected = '<iframe allow="fullscreen" src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';
 
         $this->assertSame($expected, $video);
     }

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -604,7 +604,7 @@ class KirbyTagsTest extends TestCase
 
         $page  = $kirby->page('test');
 
-        $expected = '<figure class="video"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
+        $expected = '<figure class="video"><iframe allow="fullscreen" allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg?controls=0"></iframe></figure>';
         $this->assertSame($expected, $page->text()->kt()->value());
     }
 
@@ -653,7 +653,7 @@ class KirbyTagsTest extends TestCase
             ],
             [
                 '(video: https://www.youtube.com/watch?v=VhP7ZzZysQg)',
-                '<figure class="video-class"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>'
+                '<figure class="video-class"><iframe allow="fullscreen" allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>'
             ]
         ];
     }

--- a/tests/Text/fixtures/kirbytext/video-width-and-height/expected.html
+++ b/tests/Text/fixtures/kirbytext/video-width-and-height/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allow="fullscreen" height="200" src="https://player.vimeo.com/video/115805751" width="200"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" allowfullscreen height="200" src="https://player.vimeo.com/video/115805751" width="200"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/video-youtube/expected.html
+++ b/tests/Text/fixtures/kirbytext/video-youtube/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allow="fullscreen" src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" allowfullscreen src="https://www.youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/vimeo/expected.html
+++ b/tests/Text/fixtures/kirbytext/vimeo/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allow="fullscreen" src="https://player.vimeo.com/video/115805751"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/115805751"></iframe></figure>

--- a/tests/Text/fixtures/kirbytext/youtube/expected.html
+++ b/tests/Text/fixtures/kirbytext/youtube/expected.html
@@ -1,1 +1,1 @@
-<figure class="video"><iframe allow="fullscreen" src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>
+<figure class="video"><iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/VhP7ZzZysQg"></iframe></figure>

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -470,12 +470,12 @@ class HtmlTest extends TestCase
 
         // plain
         $html = Html::video($url);
-        $expected = '<iframe allow="fullscreen" src="' . $src . '"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
 
         // with attributes
         $html = Html::video($url, [], ['class' => 'video']);
-        $expected = '<iframe allow="fullscreen" class="video" src="' . $src . '"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen class="video" src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
 
         // with options
@@ -485,7 +485,7 @@ class HtmlTest extends TestCase
         ];
         $html = Html::video($url, $options);
         $char = Str::contains($src, '?') === true ? '&amp;' : '?';
-        $expected = '<iframe allow="fullscreen" src="' . $src . $char . 'foo=bar"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="' . $src . $char . 'foo=bar"></iframe>';
         $this->assertSame($expected, $html);
 
         // with attributes and options
@@ -494,7 +494,7 @@ class HtmlTest extends TestCase
             'youtube' => ['foo' => 'bar']
         ];
         $html = Html::video($url, $options, ['class' => 'video']);
-        $expected = '<iframe allow="fullscreen" class="video" src="' . $src . $char . 'foo=bar"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen class="video" src="' . $src . $char . 'foo=bar"></iframe>';
         $this->assertSame($expected, $html);
 
         // allow attribute
@@ -509,7 +509,7 @@ class HtmlTest extends TestCase
 
         // legacy allow fullscreen enabled
         $html = Html::video($url, [], ['allowfullscreen' => true]);
-        $expected = '<iframe allow="fullscreen" src="' . $src . '"></iframe>';
+        $expected = '<iframe allow="fullscreen" allowfullscreen src="' . $src . '"></iframe>';
         $this->assertSame($expected, $html);
 
         // legacy allow fullscreen disabled


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `Html::video()` supports the `allowfullscreen` attribute again, used by Youtube
https://github.com/getkirby/kirby/issues/4212

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
