### PR TITLE
Fix extending some top level props

### DIFF
--- a/src/Cms/PageBlueprint.php
+++ b/src/Cms/PageBlueprint.php
@@ -25,7 +25,7 @@ class PageBlueprint extends Blueprint
 
         // normalize all available page options
         $this->props['options'] = $this->normalizeOptions(
-            $props['options'] ?? true,
+            $this->props['options'] ?? true,
             // defaults
             [
                 'changeSlug'     => null,
@@ -50,10 +50,10 @@ class PageBlueprint extends Blueprint
         );
 
         // normalize the ordering number
-        $this->props['num'] = $this->normalizeNum($props['num'] ?? 'default');
+        $this->props['num'] = $this->normalizeNum($this->props['num'] ?? 'default');
 
         // normalize the available status array
-        $this->props['status'] = $this->normalizeStatus($props['status'] ?? null);
+        $this->props['status'] = $this->normalizeStatus($this->props['status'] ?? null);
     }
 
     /**

--- a/src/Cms/SiteBlueprint.php
+++ b/src/Cms/SiteBlueprint.php
@@ -26,7 +26,7 @@ class SiteBlueprint extends Blueprint
 
         // normalize all available page options
         $this->props['options'] = $this->normalizeOptions(
-            $props['options'] ?? true,
+            $this->props['options'] ?? true,
             // defaults
             [
                 'changeTitle' => null,

--- a/src/Cms/UserBlueprint.php
+++ b/src/Cms/UserBlueprint.php
@@ -30,7 +30,7 @@ class UserBlueprint extends Blueprint
 
         // normalize all available page options
         $this->props['options'] = $this->normalizeOptions(
-            $props['options'] ?? true,
+            $this->props['options'] ?? true,
             // defaults
             [
                 'create'         => null,

--- a/tests/Cms/Pages/PageBlueprintTest.php
+++ b/tests/Cms/Pages/PageBlueprintTest.php
@@ -333,4 +333,28 @@ class PageBlueprintTest extends TestCase
 
         $this->assertEquals($expected, $blueprint->status());
     }
+
+    /**
+     * @covers ::extend
+     */
+    public function testExtendNum()
+    {
+        new App([
+            'blueprints' => [
+                'pages/test' => [
+                    'title' => 'Extension Test',
+                    'num' => 'date'
+                ]
+            ]
+        ]);
+
+        $blueprint = new PageBlueprint([
+            'extends' => 'pages/test',
+            'title' => 'Extended',
+            'model'   => new Page(['slug' => 'test'])
+        ]);
+
+        $this->assertSame('Extended', $blueprint->title());
+        $this->assertSame('date', $blueprint->num());
+    }
 }


### PR DESCRIPTION
## This PR …

When parent class constructor run, all extended props assigned/set to `$this->props`, but we're still trying to access old `$props` variable after parent constructor called. So I've fixed with calling `$this->props` instead `$props` local variale, exactly what we do in [FileBlueprint::constructor()](https://github.com/getkirby/kirby/blob/3.6.3/src/Cms/FileBlueprint.php#L28-L48)

### Fixes
- Fixed top-level options not copied when extending a blueprint #4014

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
