### PR TITLE
Extending multiple blueprint at once

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -203,12 +203,14 @@ class Blueprint
             return $props;
         }
 
-        try {
-            $mixin = static::find($extends);
-            $mixin = static::extend($mixin);
-            $props = A::merge($mixin, $props, A::MERGE_REPLACE);
-        } catch (Exception $e) {
-            // keep the props unextended if the snippet wasn't found
+        foreach (A::wrap($extends) as $extend) {
+            try {
+                $mixin = static::find($extend);
+                $mixin = static::extend($mixin);
+                $props = A::merge($mixin, $props, A::MERGE_REPLACE);
+            } catch (Exception $e) {
+                // keep the props unextended if the snippet wasn't found
+            }
         }
 
         // remove the extends flag

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -275,6 +275,49 @@ class BlueprintTest extends TestCase
     }
 
     /**
+     * @covers ::extend
+     */
+    public function testExtendMultiple()
+    {
+        new App([
+            'blueprints' => [
+                'props/after' => ['after' => 'foo'],
+                'props/before' => ['before' => 'bar'],
+                'props/required' => ['required' => true],
+                'props/text' => ['type' => 'text'],
+                'props/translatable' => ['translatable' => false],
+                'props/width' => ['width' => '1/3']
+            ]
+        ]);
+
+        $blueprint = new Blueprint([
+            'model' => new Page(['slug' => 'test']),
+            'fields' => [
+                'test' => [
+                    'label' => 'Test',
+                    'extends'  => [
+                        'props/after',
+                        'props/before',
+                        'props/required',
+                        'props/text',
+                        'props/translatable',
+                        'props/width',
+                    ]
+                ]
+            ]
+        ]);
+
+        $field = $blueprint->field('test');
+
+        $this->assertSame('foo', $field['after']);
+        $this->assertSame('bar', $field['before']);
+        $this->assertSame(true, $field['required']);
+        $this->assertSame('text', $field['type']);
+        $this->assertSame(false, $field['translatable']);
+        $this->assertSame('1/3', $field['width']);
+    }
+
+    /**
      * @covers ::factory
      * @covers ::find
      */


### PR DESCRIPTION
## This PR

Implements https://kirby.nolt.io/378

Sample usage:

````yaml
fields:
  layout:
    type: layout
    label: Layout
    extends:
      - layout/layouts
      - layout/fieldsets
      - layout/settings
````

### Features
 - Extending multiple blueprint at once

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
