### PR TITLE
Fix droppable files files when disabled

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -6,7 +6,7 @@
       </k-button-group>
     </template>
 
-    <k-dropzone :disabled="more === false" @drop="drop">
+    <k-dropzone :disabled="!moreUpload" @drop="drop">
       <template v-if="selected.length">
         <k-items
           :items="selected"
@@ -56,7 +56,7 @@ export default {
   },
   computed: {
     moreUpload() {
-      return this.more && this.uploads;
+      return !this.disabled && this.more && this.uploads;
     },
     options() {
       if (this.uploads) {


### PR DESCRIPTION
## This PR …

If the files field is disabled, the file should not be uploaded. So computed `moreUpload` prop improved with adding disabled control and disabled attribute of `dropzone` component binded to `moreUpload` value.

### Fixes
- Fixed droppable files files when disabled #4231

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
