### PR TITLE
Add A::where, A::only, A::except

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -729,7 +729,7 @@ class A
 
     /**
      * Filter the array using the given callback
-     * using both keys and values
+     * using both value and key
      *
      * @param array $array
      * @param callable $callback
@@ -741,7 +741,7 @@ class A
     }
 
     /**
-     * Filter the array using the given key or array of keys
+     * Filter the array, using only the given key or array of keys
      *
      * @param array $array
      * @param int|string|array $keys
@@ -759,7 +759,7 @@ class A
     }
 
     /**
-     * Filter the array using the given key or array of keys
+     * Filter the array for ever key except the given key or array of keys
      *
      * @param array $array
      * @param int|string|array $keys

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -726,4 +726,53 @@ class A
             return $array;
         }
     }
+
+    /**
+     * Filter the array using the given callback
+     * using both keys and values
+     *
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function where(array $array, callable $callback): array
+    {
+        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Filter the array using the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function only(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return A::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true);
+        });
+    }
+
+    /**
+     * Filter the array using the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function except(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return A::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true) === false;
+        });
+    }
 }

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -753,7 +753,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return A::where($array, function ($value, $key) use ($keys) {
+        return static::where($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true);
         });
     }
@@ -771,7 +771,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return A::where($array, function ($value, $key) use ($keys) {
+        return static::where($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true) === false;
         });
     }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -698,4 +698,73 @@ class ATest extends TestCase
         $result = A::wrap(null);
         $this->assertSame([], $result);
     }
+
+     /**
+     * @covers ::where
+     */
+    public function testWhere()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        ray($associativeArray);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($key, ['cat', 'dog']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($value, ['miao', 'tweet']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return $key === 'cat' || $value === 'tweet';
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($array, function($value, $key){
+            return $key > 0;
+        });
+        $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
+    }
+
+     /**
+     * @covers ::only
+     */
+    public function testOnly()
+    {
+        $associativeArray = $this->_array();
+        // cat, dog, bird, cat, dog, bird
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['cat' => 'miao'], A::only($associativeArray, 'cat'));
+        $this->assertSame(['cat' => 'miao', 'bird' => 'tweet'], A::only($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::only($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat'], A::only($array, range(1, 3)));
+        $this->assertSame(['cat'], A::only($array, 0));
+        $this->assertSame([], A::only($array, -1));
+    }
+
+     /**
+     * @covers ::except
+     */
+    public function testExcept()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::except($associativeArray, 'cat'));
+        $this->assertSame(['dog' => 'wuff'], A::except($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::except($associativeArray, ['cat', 'dog', 'bird']));
+        $this->assertSame($associativeArray, A::except($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::except($array, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::except($array, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::except($array, -1));
+    }
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -707,8 +707,6 @@ class ATest extends TestCase
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);
 
-        ray($associativeArray);
-
         $result = A::where($associativeArray, function($value, $key){
             return in_array($key, ['cat', 'dog']);
         });


### PR DESCRIPTION
I often (twice or more every project) need a simple way to filter an array for (or except) given keys, and every time I'm sad there isn't one included in the `A` Toolkit class, so I added them. Both call another added method for simpler filtering of associative (an indexed too) arrays, without needing to remember `ARRAY_FILTER_USE_BOTH` every time!

## This PR …

Adds a `::where` (filtering using both value and key), `::only` (filtering for only given keys), `::except` (everything except given keys) methods to `Kirby\Toolkit\A`

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
