### PR TITLE
Add A::filter, A::without

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -741,31 +741,13 @@ class A
     }
 
     /**
-     * Filter the array, using only the given key or array of keys
+     * Remove key(s) from an array
      *
      * @param array $array
      * @param int|string|array $keys
      * @return array
      */
-    public static function only(array $array, $keys): array
-    {
-        if (is_int($keys) || is_string($keys)) {
-            $keys = static::wrap($keys);
-        }
-
-        return static::filter($array, function ($value, $key) use ($keys) {
-            return in_array($key, $keys, true);
-        });
-    }
-
-    /**
-     * Filter the array for ever key except the given key or array of keys
-     *
-     * @param array $array
-     * @param int|string|array $keys
-     * @return array
-     */
-    public static function except(array $array, $keys): array
+    public static function without(array $array, $keys): array
     {
         if (is_int($keys) || is_string($keys)) {
             $keys = static::wrap($keys);

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -726,4 +726,53 @@ class A
             return $array;
         }
     }
+
+    /**
+     * Filter the array using the given callback
+     * using both value and key
+     *
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function where(array $array, callable $callback): array
+    {
+        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Filter the array, using only the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function only(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return static::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true);
+        });
+    }
+
+    /**
+     * Filter the array for ever key except the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function except(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return static::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true) === false;
+        });
+    }
 }

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -735,7 +735,7 @@ class A
      * @param callable $callback
      * @return array
      */
-    public static function where(array $array, callable $callback): array
+    public static function filter(array $array, callable $callback): array
     {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
@@ -753,7 +753,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return static::where($array, function ($value, $key) use ($keys) {
+        return static::filter($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true);
         });
     }
@@ -771,7 +771,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return static::where($array, function ($value, $key) use ($keys) {
+        return static::filter($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true) === false;
         });
     }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -708,22 +708,22 @@ class ATest extends TestCase
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return in_array($key, ['cat', 'dog']);
         });
         $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return in_array($value, ['miao', 'tweet']);
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return $key === 'cat' || $value === 'tweet';
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::where($array, function($value, $key){
+        $result = A::filter($array, function($value, $key){
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -730,40 +730,22 @@ class ATest extends TestCase
     }
 
      /**
-     * @covers ::only
+     * @covers ::without
      */
-    public function testOnly()
-    {
-        $associativeArray = $this->_array();
-        // cat, dog, bird, cat, dog, bird
-        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
-
-        $this->assertSame(['cat' => 'miao'], A::only($associativeArray, 'cat'));
-        $this->assertSame(['cat' => 'miao', 'bird' => 'tweet'], A::only($associativeArray, ['cat', 'bird']));
-        $this->assertSame([], A::only($associativeArray, ['this', 'doesnt', 'exist']));
-
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat'], A::only($array, range(1, 3)));
-        $this->assertSame(['cat'], A::only($array, 0));
-        $this->assertSame([], A::only($array, -1));
-    }
-
-     /**
-     * @covers ::except
-     */
-    public function testExcept()
+    public function testWithout()
     {
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);
 
         $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
 
-        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::except($associativeArray, 'cat'));
-        $this->assertSame(['dog' => 'wuff'], A::except($associativeArray, ['cat', 'bird']));
-        $this->assertSame([], A::except($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame($associativeArray, A::except($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
+        $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
+        $this->assertSame($associativeArray, A::without($associativeArray, ['this', 'doesnt', 'exist']));
 
-        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::except($array, range(1, 3)));
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::except($array, 0));
-        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::except($array, -1));
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($array, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($array, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($array, -1));
     }
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -706,7 +706,7 @@ class ATest extends TestCase
     public function testFilter()
     {
         $associativeArray = $this->_array();
-        $array = array_keys($associativeArray);
+        $indexedArray = array_keys($associativeArray);
 
         $result = A::filter($associativeArray, function($value, $key){
             return in_array($key, ['cat', 'dog']);
@@ -723,7 +723,7 @@ class ATest extends TestCase
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($array, function($value, $key){
+        $result = A::filter($indexedArray, function($value, $key){
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
@@ -735,17 +735,15 @@ class ATest extends TestCase
     public function testWithout()
     {
         $associativeArray = $this->_array();
-        $array = array_keys($associativeArray);
-
-        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+        $indexedArray = [...array_keys($associativeArray), ...array_keys($associativeArray)];
 
         $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
         $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
         $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame($associativeArray, A::without($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'doesnt', 'exist']));
 
-        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($array, range(1, 3)));
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($array, 0));
-        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($array, -1));
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($indexedArray, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($indexedArray, -1));
     }
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -740,7 +740,7 @@ class ATest extends TestCase
         $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
         $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
         $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'cat', 'doesnt', 'exist']));
 
         $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, range(1, 3)));
         $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($indexedArray, 0));

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -701,9 +701,9 @@ class ATest extends TestCase
 
 
      /**
-     * @covers ::where
+     * @covers ::filter
      */
-    public function testWhere()
+    public function testFilter()
     {
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -700,7 +700,7 @@ class ATest extends TestCase
     }
 
 
-     /**
+    /**
      * @covers ::filter
      */
     public function testFilter()
@@ -708,28 +708,28 @@ class ATest extends TestCase
         $associativeArray = $this->_array();
         $indexedArray = array_keys($associativeArray);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return in_array($key, ['cat', 'dog']);
         });
         $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return in_array($value, ['miao', 'tweet']);
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return $key === 'cat' || $value === 'tweet';
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($indexedArray, function($value, $key){
+        $result = A::filter($indexedArray, function ($value, $key) {
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
     }
 
-     /**
+    /**
      * @covers ::without
      */
     public function testWithout()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -698,4 +698,72 @@ class ATest extends TestCase
         $result = A::wrap(null);
         $this->assertSame([], $result);
     }
+
+
+     /**
+     * @covers ::where
+     */
+    public function testWhere()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($key, ['cat', 'dog']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($value, ['miao', 'tweet']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return $key === 'cat' || $value === 'tweet';
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($array, function($value, $key){
+            return $key > 0;
+        });
+        $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
+    }
+
+     /**
+     * @covers ::only
+     */
+    public function testOnly()
+    {
+        $associativeArray = $this->_array();
+        // cat, dog, bird, cat, dog, bird
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['cat' => 'miao'], A::only($associativeArray, 'cat'));
+        $this->assertSame(['cat' => 'miao', 'bird' => 'tweet'], A::only($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::only($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat'], A::only($array, range(1, 3)));
+        $this->assertSame(['cat'], A::only($array, 0));
+        $this->assertSame([], A::only($array, -1));
+    }
+
+     /**
+     * @covers ::except
+     */
+    public function testExcept()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::except($associativeArray, 'cat'));
+        $this->assertSame(['dog' => 'wuff'], A::except($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::except($associativeArray, ['cat', 'dog', 'bird']));
+        $this->assertSame($associativeArray, A::except($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::except($array, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::except($array, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::except($array, -1));
+    }
 }


### PR DESCRIPTION
I often (twice or more every project) need a simple way to filter an array for (or except) given keys, and every time I'm sad there isn't one included in the `A` Toolkit class, so I added them. Both call another added method for simpler filtering of associative (an indexed too) arrays, without needing to remember `ARRAY_FILTER_USE_BOTH` every time!

This time into the proper branch and based on proper branch…

## This PR …

Adds a `::filter()` (filtering using both value and key), `::without()` (everything except given keys) methods to `Kirby\Toolkit\A`

Edit 2: after review 2 `A::except` was renamed to `A::without` to be in line with collections.
Edit 1: after review, `A::where` was renamed to `A::filter`
Original:
Adds a `::where` (filtering using both value and key), `::only` (filtering for only given keys), `::except` (everything except given keys) methods to `Kirby\Toolkit\A`


## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

I think the in-code documentation is sufficient, but am not sure what is the treshold for "Needs code example"

### For review team

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)