### PR TITLE
Fix tabs resize for mobile

### DIFF
--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -68,10 +68,13 @@ export default {
     }
   },
   watch: {
-    tabs(tabs) {
-      this.visibleTabs = tabs;
-      this.invisibleTabs = [];
-      this.resize(true);
+    tabs: {
+      handler(tabs) {
+        this.visibleTabs = tabs;
+        this.invisibleTabs = [];
+        this.resize(true);
+      },
+      immediate: true
     }
   },
   created() {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

`resize()` method wasn't called when component was mounted, but only first time `tabs` prop was refreshed

### Fixes
- Tabs now immediately get hidden behind "More" button on mobile 
#4230


### Breaking changes
_None_


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
