### PR TITLE
title alias for name property in fieldsets

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -54,7 +54,7 @@ class Fieldset extends Item
         $this->editable  = $params['editable'] ?? true;
         $this->icon      = $params['icon'] ?? null;
         $this->model     = $this->parent;
-        $this->name      = $this->createName($params['name'] ?? Str::ucfirst($this->type));
+        $this->name      = $this->createName($params['title'] ?? $params['name'] ?? Str::ucfirst($this->type));
         $this->label     = $this->createLabel($params['label'] ?? null);
         $this->preview   = $params['preview'] ?? null;
         $this->tabs      = $this->createTabs($params);

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -203,6 +203,51 @@ class FieldsetTest extends TestCase
     }
 
     /**
+     * @covers ::name
+     */
+    public function testNameTranslated()
+    {
+        $fieldset = new Fieldset([
+            'type'  => 'test',
+            'name'  => [
+                'en' => 'English name',
+                'de' => 'Deutscher Name',
+            ]
+        ]);
+
+        $this->assertSame('English name', $fieldset->name());
+    }
+
+    /**
+     * @covers ::name
+     */
+    public function testNameFromTitle()
+    {
+        $fieldset = new Fieldset([
+            'type'  => 'test',
+            'title' => 'Test Title'
+        ]);
+
+        $this->assertSame('Test Title', $fieldset->name());
+    }
+
+    /**
+     * @covers ::name
+     */
+    public function testNameFromTitleTranslated()
+    {
+        $fieldset = new Fieldset([
+            'type'  => 'test',
+            'title' => [
+                'en' => 'English name',
+                'de' => 'Deutscher Name',
+            ]
+        ]);
+
+        $this->assertSame('English name', $fieldset->name());
+    }
+
+    /**
      * @covers ::preview
      */
     public function testPreview()


### PR DESCRIPTION
## This PR …

In preparation to rename the `name` property of a Fieldset to `title`, this PR creates an alias to already support `title` in yaml files. This will also provide a fix for the linked issue. 

This PR replaces https://github.com/getkirby/kirby/pull/4192

### Enhancements

- More consistency for fieldset options by introducing `title` as alias for `name` #4177 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- ~[ ] In-code documentation (wherever needed)~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
