### PR TITLE
Support label instead of headline for sections

### DIFF
--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -6,15 +6,26 @@ return [
     'props' => [
         /**
          * The headline for the section. This can be a simple string or a template with additional info from the parent page.
+         * @todo deprecate in 3.8
          */
         'headline' => function ($headline = null) {
             return I18n::translate($headline, $headline);
+        },
+        /**
+         * label is the new official replacement for headline
+         */
+        'label' => function ($label = null) {
+            return I18n::translate($label, $label);
         }
     ],
     'computed' => [
         'headline' => function () {
             if ($this->headline) {
                 return $this->model()->toString($this->headline);
+            }
+
+            if ($this->label) {
+                return $this->model()->toString($this->label);
             }
 
             return ucfirst($this->name);

--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -6,7 +6,7 @@ return [
     'props' => [
         /**
          * The headline for the section. This can be a simple string or a template with additional info from the parent page.
-         * @todo deprecate in 3.8
+         * @todo deprecate in 3.7
          */
         'headline' => function ($headline = null) {
             return I18n::translate($headline, $headline);

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -45,6 +45,30 @@ class PagesSectionTest extends TestCase
         $this->assertEquals('Pages', $section->headline());
     }
 
+    public function testHeadlineFromLabel()
+    {
+        // single label
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'label' => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->headline());
+
+        // translated label
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => new Page(['slug' => 'test']),
+            'label' => [
+                'en' => 'Pages',
+                'de' => 'Seiten'
+            ]
+        ]);
+
+        $this->assertEquals('Pages', $section->headline());
+    }
+
     public function testParent()
     {
         $this->app->impersonate('kirby');


### PR DESCRIPTION
## Enhancements

- Support `label` as new, better alternative to `headline` for sections https://github.com/getkirby/kirby/issues/4194

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
