### PR TITLE
Fix DB where callback with reset props 

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -972,6 +972,11 @@ class Query
                     $this->bindings($sql['bindings']);
                 } elseif (is_callable($args[0]) === true) {
                     $query = clone $this;
+
+                    // since the callback uses its own where condition
+                    // it is necessary to clear/reset the cloned where condition
+                    $query->where = null;
+
                     call_user_func($args[0], $query);
 
                     // copy over the bindings from the nested query

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -393,6 +393,17 @@ class QueryTest extends TestCase
         $this->assertSame(3, $count);
     }
 
+    public function testWhereCallback()
+    {
+        $count = $this->database
+            ->table('users')
+            ->where('balance', '>', 75)
+            ->where(fn ($q) => $q->where('role_id', '=', 3))
+            ->count();
+
+        $this->assertSame(1, $count);
+    }
+
     public function testPage()
     {
         $query = $this->database->table('users');


### PR DESCRIPTION
## This PR …

I'm not sure about solution but since we only need `where` prop in callback, I've fixed the issue with reset `where` prop ~via new `clone` method~. Need your review and feel free to close the PR if not acceptable.

Btw I couldn't write unit test due to can't get query string. But I've tested and query string is correct as expected.

### Fixes

- Fixed DB where callback #2831

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
