### PR TITLE
Set router callbacks on initialisation 

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -329,26 +329,9 @@ class App
      */
     public function call(string $path = null, string $method = null)
     {
-        $router = $this->router();
-
-        /**
-         * @todo Closures should not defined statically but
-         * for each instance to avoid this constant setting and unsetting
-         */
-        $router::$beforeEach = function ($route, $path, $method) {
-            $this->trigger('route:before', compact('route', 'path', 'method'));
-        };
-
-        $router::$afterEach = function ($route, $path, $method, $result, $final) {
-            return $this->apply('route:after', compact('route', 'path', 'method', 'result', 'final'), 'result');
-        };
-
-        $result = $router->call($path ?? $this->path(), $method ?? $this->request()->method());
-
-        $router::$beforeEach = null;
-        $router::$afterEach  = null;
-
-        return $result;
+        $path   ??= $this->path();
+        $method ??= $this->request()->method();
+        return $this->router()->call($path, $method);
     }
 
     /**
@@ -1302,7 +1285,15 @@ class App
             }
         }
 
-        return $this->router = $this->router ?? new Router($routes);
+        return $this->router ??= new Router(
+            $routes,
+            function ($route, $path, $method) {
+                $this->trigger('route:before', compact('route', 'path', 'method'));
+            },
+            function ($route, $path, $method, $result, $final) {
+                return $this->apply('route:after', compact('route', 'path', 'method', 'result', 'final'), 'result');
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

We added as a quick fix that `App::call()` keeps setting and unsetting the router hooks.
This PR removes the callbacks as static properties and rather as specific properties of the Router instance that get passed on initialisation.

### Refactoring
- Improved internal usage of router callbacks

### Breaking changes
- `Http\Router::$beforeEach` and `Http\Router::$afterEach` aren't static anymore. Pass them as 2nd and 3rd parameter to the constructor instead.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
