### PR TITLE
Prevent upload same file with different template

### DIFF
--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -80,28 +80,30 @@ class FileRules
      */
     public static function create(File $file, BaseFile $upload): bool
     {
-        // first we want to ensure that we are not trying to
-        // create a duplicate file. So if a file
-        // with the same name already exists
+        // We want to ensure that we are not creating duplicate files.
+        // If a file with the same name already exists
         if ($file->exists() === true) {
             // $file will be based on the props of the new file,
-            // so we need to get the props of the existing file
-            $existing = kirby()->file($file->id());
+            // to compare templates, we need to get the props of
+            // the already existing file from meta content file
+            $existing = $file->parent()->file($file->filename());
 
             // if the new upload is the exact same file
-            // and uses the same template, we can continue,
-            // otherwise throw an eroror for duplicate file
+            // and uses the same template, we can continue
             if (
-                $file->sha1() !== $upload->sha1() ||
-                $file->template() !== $existing->template()
+                $file->sha1() === $upload->sha1() &&
+                $file->template() === $existing->template()
             ) {
-                throw new DuplicateException([
-                    'key'  => 'file.duplicate',
-                    'data' => [
-                        'filename' => $file->filename()
-                    ]
-                ]);
+                return true;
             }
+
+            // otherwise throw an error for duplicate file
+            throw new DuplicateException([
+                'key'  => 'file.duplicate',
+                'data' => [
+                    'filename' => $file->filename()
+                ]
+            ]);
         }
 
         if ($file->permissions()->create() !== true) {

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -80,8 +80,21 @@ class FileRules
      */
     public static function create(File $file, BaseFile $upload): bool
     {
+        // first we want to ensure that we are not trying to
+        // create a duplicate file. So if a file
+        // with the same name already exists
         if ($file->exists() === true) {
-            if ($file->sha1() !== $upload->sha1()) {
+            // $file will be based on the props of the new file,
+            // so we need to get the props of the existing file
+            $existing = kirby()->file($file->id());
+
+            // if the new upload is the exact same file
+            // and uses the same template, we can continue,
+            // otherwise throw an eroror for duplicate file
+            if (
+                $file->sha1() !== $upload->sha1() ||
+                $file->template() !== $existing->template()
+            ) {
                 throw new DuplicateException([
                     'key'  => 'file.duplicate',
                     'data' => [

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -102,6 +102,8 @@ class FileRulesTest extends TestCase
         $file = $this->createMock(File::class);
         $file->method('filename')->willReturn('test.jpg');
         $file->method('exists')->willReturn(true);
+        $page = $this->createMock(Page::class);
+        $file->method('parent')->willReturn($page);
 
         $this->expectException('Kirby\Exception\DuplicateException');
         $this->expectExceptionMessage('A file with the name "test.jpg" already exists');

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -2,21 +2,30 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
 
 class FileRulesTest extends TestCase
 {
     protected $app;
+    protected $fixtures;
 
     public function setUp(): void
     {
         $this->app = new App([
             'roots' => [
-                'index' => '/dev/null'
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest'
             ]
         ]);
 
         $this->app->impersonate('kirby');
+        Dir::make($this->fixtures);
+    }
+
+    public function tearDown(): void
+    {
+        Dir::remove($this->fixtures);
     }
 
     public function testChangeName()
@@ -111,6 +120,129 @@ class FileRulesTest extends TestCase
         $upload = $this->createMock(BaseFile::class);
 
         FileRules::create($file, $upload);
+    }
+
+    public function testCreateSameFile()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createSameFile',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        // create new file
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'test'
+            ]
+        ]);
+
+        $upload = new BaseFile($testImage);
+        $create = FileRules::create($newFile, $upload);
+
+        $this->assertTrue($create);
+    }
+
+    public function testCreateSameFileWithDifferentTemplate()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createSameFileWithDifferentTemplate',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'cover'
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\DuplicateException');
+        $this->expectExceptionMessage('A file with the name "test.jpg" already exists');
+
+        $upload = new BaseFile($testImage);
+        FileRules::create($newFile, $upload);
+    }
+
+    public function testCreateDifferentFileWithSameFilename()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createDifferentFileWithSameFilename',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'test'
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\DuplicateException');
+        $this->expectExceptionMessage('A file with the name "test.jpg" already exists');
+
+        $upload = new BaseFile(__DIR__ . '/fixtures/files/cat.jpg');
+        FileRules::create($newFile, $upload);
     }
 
     public function testCreateHarmfulContents()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- When uploading the same file again (same filename, same content) an error is thrown when the assigned template doesn't match with the existing file
https://github.com/getkirby/kirby/issues/4076


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
