### PR TITLE
Cache: Handle `set()` in the core and add `getObject()` method

### DIFF
--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -57,6 +57,7 @@ class ApcuCache extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */
@@ -66,21 +67,16 @@ class ApcuCache extends Cache
     }
 
     /**
-     * Writes an item to the cache for a given number of minutes and
+     * Internal method to store the raw cache value;
      * returns whether the operation was successful
      *
-     * <code>
-     *   // put an item in the cache for 15 minutes
-     *   $cache->set('value', 'my value', 15);
-     * </code>
-     *
+     * @internal
      * @param string $key
-     * @param mixed $value
-     * @param int $minutes
+     * @param \Kirby\Cache\Value $value
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function store(string $key, Value $value): bool
     {
-        return apcu_store($this->key($key), (new Value($value, $minutes))->toJson(), $this->expiration($minutes));
+        return apcu_store($this->key($key), $value->toJson(), $value->expires() ?? 0);
     }
 }

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -100,7 +100,7 @@ abstract class Cache
     abstract public function retrieve(string $key);
 
     /**
-     * Gets an item from the cache
+     * Gets an item from the cache unless it is expired
      *
      * <code>
      *   // get an item from the cache driver
@@ -116,22 +116,45 @@ abstract class Cache
      */
     public function get(string $key, $default = null)
     {
+        $value = $this->getObject($key);
+
+        // return the pure value
+        return $value ? $value->value() : $default;
+    }
+
+    /**
+     * Gets an item object from the cache unless it is expired
+     *
+     * <code>
+     *   // get an item from the cache driver
+     *   $value = $cache->getObject('value');
+     *
+     *   // access the cached (meta)data
+     *   $value->value();
+     *   $value->created();
+     *   $value->expires();
+     * </code>
+     *
+     * @param string $key
+     * @return \Kirby\Cache\Value|null
+     */
+    public function getObject(string $key)
+    {
         // get the Value
         $value = $this->retrieve($key);
 
         // check for a valid cache value
         if (!is_a($value, 'Kirby\Cache\Value')) {
-            return $default;
+            return null;
         }
 
         // remove the item if it is expired
         if ($value->expires() > 0 && time() >= $value->expires()) {
             $this->remove($key);
-            return $default;
+            return null;
         }
 
-        // return the pure value
-        return $value->value();
+        return $value;
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cache;
 
+use Kirby\Exception\Exception;
+
 /**
  * Cache foundation
  * This abstract class is used as
@@ -34,8 +36,7 @@ abstract class Cache
 
     /**
      * Writes an item to the cache for a given number of minutes and
-     * returns whether the operation was successful;
-     * this needs to be defined by the driver
+     * returns whether the operation was successful
      *
      * <code>
      *   // put an item in the cache for 15 minutes
@@ -47,7 +48,30 @@ abstract class Cache
      * @param int $minutes
      * @return bool
      */
-    abstract public function set(string $key, $value, int $minutes = 0): bool;
+    public function set(string $key, $value, int $minutes = 0): bool
+    {
+        $value = Value::fromArray(compact('value', 'minutes'));
+
+        return $this->store($key, $value);
+    }
+
+    /**
+     * Internal method to store the raw cache value;
+     * needs to return whether the operation was successful;
+     * this needs to be defined by the driver
+     *
+     * @todo 3.8 Make this method `abstract` to require drivers to implement it
+     * @codeCoverageIgnore
+     *
+     * @internal
+     * @param string $key
+     * @param \Kirby\Cache\Value $value
+     * @return bool
+     */
+    public function store(string $key, Value $value): bool
+    {
+        throw new Exception('The ' . static::class . ' cache driver implements neither the set() nor the store() methods.');
+    }
 
     /**
      * Adds the prefix to the key if given
@@ -69,6 +93,7 @@ abstract class Cache
      * needs to return a Value object or null if not found;
      * this needs to be defined by the driver
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -114,30 +114,26 @@ class FileCache extends Cache
     }
 
     /**
-     * Writes an item to the cache for a given number of minutes and
+     * Internal method to store the raw cache value;
      * returns whether the operation was successful
      *
-     * <code>
-     *   // put an item in the cache for 15 minutes
-     *   $cache->set('value', 'my value', 15);
-     * </code>
-     *
+     * @internal
      * @param string $key
-     * @param mixed $value
-     * @param int $minutes
+     * @param \Kirby\Cache\Value $value
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function store(string $key, Value $value): bool
     {
         $file = $this->file($key);
 
-        return F::write($file, (new Value($value, $minutes))->toJson());
+        return F::write($file, $value->toJson());
     }
 
     /**
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -43,28 +43,24 @@ class MemCached extends Cache
     }
 
     /**
-     * Writes an item to the cache for a given number of minutes and
+     * Internal method to store the raw cache value;
      * returns whether the operation was successful
      *
-     * <code>
-     *   // put an item in the cache for 15 minutes
-     *   $cache->set('value', 'my value', 15);
-     * </code>
-     *
+     * @internal
      * @param string $key
-     * @param mixed $value
-     * @param int $minutes
+     * @param \Kirby\Cache\Value $value
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function store(string $key, Value $value): bool
     {
-        return $this->connection->set($this->key($key), (new Value($value, $minutes))->toJson(), $this->expiration($minutes));
+        return $this->connection->set($this->key($key), $value->toJson(), $value->expires() ?? 0);
     }
 
     /**
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -20,22 +20,17 @@ class MemoryCache extends Cache
     protected $store = [];
 
     /**
-     * Writes an item to the cache for a given number of minutes and
+     * Internal method to store the raw cache value;
      * returns whether the operation was successful
      *
-     * <code>
-     *   // put an item in the cache for 15 minutes
-     *   $cache->set('value', 'my value', 15);
-     * </code>
-     *
+     * @internal
      * @param string $key
-     * @param mixed $value
-     * @param int $minutes
+     * @param \Kirby\Cache\Value $value
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function store(string $key, Value $value): bool
     {
-        $this->store[$key] = new Value($value, $minutes);
+        $this->store[$key] = $value;
         return true;
     }
 
@@ -43,6 +38,7 @@ class MemoryCache extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -14,20 +14,15 @@ namespace Kirby\Cache;
 class NullCache extends Cache
 {
     /**
-     * Writes an item to the cache for a given number of minutes and
+     * Internal method to store the raw cache value;
      * returns whether the operation was successful
      *
-     * <code>
-     *   // put an item in the cache for 15 minutes
-     *   $cache->set('value', 'my value', 15);
-     * </code>
-     *
+     * @internal
      * @param string $key
-     * @param mixed $value
-     * @param int $minutes
+     * @param \Kirby\Cache\Value $value
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function store(string $key, Value $value): bool
     {
         return true;
     }
@@ -36,6 +31,7 @@ class NullCache extends Cache
      * Internal method to retrieve the raw cache value;
      * needs to return a Value object or null if not found
      *
+     * @internal
      * @param string $key
      * @return \Kirby\Cache\Value|null
      */

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -19,20 +19,22 @@ class Value
 {
     /**
      * Cached value
+     *
      * @var mixed
      */
     protected $value;
 
     /**
-     * the number of minutes until the value expires
-     * @todo Rename this property to $expiry to reflect
-     *       both minutes and absolute timestamps
+     * The number of minutes until the value expires
+     * or the absolute UNIX expiry timestamp
+     *
      * @var int
      */
     protected $minutes;
 
     /**
      * Creation timestamp
+     *
      * @var int
      */
     protected $created;
@@ -41,9 +43,9 @@ class Value
      * Constructor
      *
      * @param mixed $value
-     * @param int $minutes the number of minutes until the value expires
-     *                     or an absolute UNIX timestamp
-     * @param int $created the UNIX timestamp when the value has been created
+     * @param int $minutes The number of minutes until the value expires
+     *                     or an absolute UNIX expiry timestamp
+     * @param int $created The UNIX timestamp when the value has been created
      */
     public function __construct($value, int $minutes = 0, int $created = null)
     {
@@ -91,7 +93,11 @@ class Value
      */
     public static function fromArray(array $array)
     {
-        return new static($array['value'] ?? null, $array['minutes'] ?? 0, $array['created'] ?? null);
+        return new static(
+            $array['value'] ?? null,
+            $array['minutes'] ?? 0,
+            $array['created'] ?? null,
+        );
     }
 
     /**

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -23,7 +23,7 @@ class ApcuCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::exists
      * @covers ::retrieve
      * @covers ::remove
@@ -48,7 +48,7 @@ class ApcuCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::exists
      * @covers ::retrieve
      * @covers ::remove

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -41,8 +41,9 @@ class CacheTest extends TestCase
 
     /**
      * @covers ::get
+     * @covers ::set
      */
-    public function testGet()
+    public function testGetSet()
     {
         $cache = new TestCache();
 
@@ -60,10 +61,11 @@ class CacheTest extends TestCase
 
         $this->assertSame('default', $cache->get('doesnotexist', 'default'));
 
-        $cache->set('notyetexpired', 'foo', 10, time());
+        $cache->set('notyetexpired', 'foo', 10);
         $this->assertSame('foo', $cache->get('notyetexpired'));
+        $this->assertSame(time() + 600, $cache->expires('notyetexpired'));
 
-        $cache->set('expired', 'foo', 10, 0);
+        $cache->setWithCreated('expired', 'foo', 10, 0);
         $this->assertTrue(isset($cache->store['expired']));
         $this->assertSame('default', $cache->get('expired', 'default'));
         $this->assertFalse(isset($cache->store['expired']));
@@ -109,7 +111,7 @@ class CacheTest extends TestCase
         $cache->set('foo', 'foo');
         $this->assertFalse($cache->expired('foo'));
 
-        $cache->set('foo', 'foo', 10, 0);
+        $cache->setWithCreated('foo', 'foo', 10, 0);
         $this->assertTrue($cache->expired('foo'));
 
         $cache->set('foo', 'foo', 10);
@@ -126,7 +128,7 @@ class CacheTest extends TestCase
     {
         $cache = new TestCache();
 
-        $cache->set('foo', 'foo', 10, 1234);
+        $cache->setWithCreated('foo', 'foo', 10, 1234);
         $this->assertSame(1234, $cache->created('foo'));
         $this->assertSame(1234, $cache->modified('foo'));
 
@@ -144,7 +146,7 @@ class CacheTest extends TestCase
         $cache->set('foo', 'foo');
         $this->assertTrue($cache->exists('foo'));
 
-        $cache->set('foo', 'foo', 10, 0);
+        $cache->setWithCreated('foo', 'foo', 10, 0);
         $this->assertFalse($cache->exists('foo'));
 
         $this->assertFalse($cache->exists('doesnotexist'));

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -183,7 +183,7 @@ class FileCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::created
      * @covers ::retrieve
      * @covers ::remove
@@ -218,7 +218,7 @@ class FileCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::created
      * @covers ::retrieve
      * @covers ::remove
@@ -252,7 +252,7 @@ class FileCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::created
      * @covers ::retrieve
      * @covers ::remove

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -33,7 +33,7 @@ class MemCachedTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::retrieve
      * @covers ::remove
      */
@@ -57,7 +57,7 @@ class MemCachedTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::retrieve
      * @covers ::remove
      */

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/mocks.php';
 class MemoryCacheTest extends TestCase
 {
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::retrieve
      * @covers ::remove
      */
@@ -36,7 +36,7 @@ class MemoryCacheTest extends TestCase
     }
 
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::retrieve
      * @covers ::remove
      */

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class NullCacheTest extends TestCase
 {
     /**
-     * @covers ::set
+     * @covers ::store
      * @covers ::retrieve
      * @covers ::remove
      */

--- a/tests/Cache/mocks.php
+++ b/tests/Cache/mocks.php
@@ -15,16 +15,32 @@ function time(): int
         throw new Exception('Mock time() function was loaded outside of the test environment. This should never happen.');
     }
 
-    return 1337;
+    return MockTime::$time;
+}
+
+class MockTime
+{
+    public static $time = 1337;
 }
 
 class TestCache extends Cache
 {
     public $store = [];
 
-    public function set(string $key, $value, int $minutes = 0, int $created = null): bool
+    public function setWithCreated(string $key, $value, int $minutes = 0, int $created = 0): bool
     {
-        $value = new Value($value, $minutes, $created);
+        $originalMockTime = MockTime::$time;
+        MockTime::$time = $created;
+
+        $result = parent::set($key, $value, $minutes);
+
+        MockTime::$time = $originalMockTime;
+
+        return $result;
+    }
+
+    public function store(string $key, $value): bool
+    {
         $this->store[$key] = $value;
         return true;
     }


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `$cache->getObject()` method to get a full `Value` object from the cache, not just the pure value
- New `$cache->store()` method to store a `Value` object (needs to be implemented by cache drivers)

### Deprecated

- Cache drivers should no longer implement the `set()` method starting with Kirby 3.8. Instead, they should implement the new `store()` method that receives the `Value` object instead of the pure cache value and minutes. For compatibility with older Kirby versions, you can still implement `set()` for the time being:

```php
/**
 * Compatibility layer for older Kirby versions before 3.7
 * @todo Remove this method for Kirby 3.8 support
 */
public function set(string $key, $value, int $minutes = 0): bool
{
    $value = \Kirby\Cache\Value::fromArray(compact('value', 'minutes'));

    return $this->store($key, $value);
}
```

## Explanation

I had planned to add support for a `metadata()` array to the `Cache\Value` class to fix #3976. This is now no longer necessary, but I was thinking if we should make the cache drivers independent from the `Cache\Value` implementation anyway. They would just always deal with the `Value` object and its `toJson()` and `fromJson()` methods. But currently the `set()` method doesn't accept the `Value` object, so this PR changes that to make the behavior consistent.

I've also decided to remove the `TODO` comment for the `Value::$minutes` attribute. I feel like the name is totally fine as just `$expiry` would be unclear (is it a timestamp? Or minutes? Or seconds?). The combination of the timestamp and minutes is not super optimal, but any change would bring more breaking changes. So I think we should just keep it named `$minutes`.

## Alternatives

- We can leave it like it is if we decide that we don't need the `Value` flexibility and rather want to avoid the breaking change.
- I've found out about the [PSR-16 caching standard](https://www.php-fig.org/psr/psr-16/). This standard defines a rather simple interface for caching libraries. By switching to this interface, we can make it much easier for users to plug in third party caching libraries without having to implement our own `Cache` class structure.

Before working on this further, I think we need to decide which route we want to go. I currently feel like we should go for either of these alternatives. So either we don't do anything at all or we use the opportunity to switch to PSR-16 rather than making changes to our own class structure.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
