### PR TITLE
`Http\Request`: Extensions for the auth types; more secure lookup

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -24,6 +24,7 @@ class Request
     public static $authTypes = [
         'basic'   => 'Kirby\Http\Request\Auth\BasicAuth',
         'bearer'  => 'Kirby\Http\Request\Auth\BearerAuth',
+        'session' => 'Kirby\Http\Request\Auth\SessionAuth',
     ];
 
     /**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Http;
 
-use Kirby\Http\Request\Auth\BasicAuth;
-use Kirby\Http\Request\Auth\BearerAuth;
 use Kirby\Http\Request\Body;
 use Kirby\Http\Request\Files;
 use Kirby\Http\Request\Query;
@@ -23,10 +21,15 @@ use Kirby\Toolkit\Str;
  */
 class Request
 {
+    public static $authTypes = [
+        'basic'   => 'Kirby\Http\Request\Auth\BasicAuth',
+        'bearer'  => 'Kirby\Http\Request\Auth\BearerAuth',
+    ];
+
     /**
      * The auth object if available
      *
-     * @var BearerAuth|BasicAuth|false|null
+     * @var \Kirby\Http\Request\Auth|false|null
      */
     protected $auth;
 
@@ -144,7 +147,7 @@ class Request
     /**
      * Returns the Auth object if authentication is set
      *
-     * @return \Kirby\Http\Request\Auth\BasicAuth|\Kirby\Http\Request\Auth\BearerAuth|null
+     * @return \Kirby\Http\Request\Auth|null
      */
     public function auth()
     {
@@ -153,15 +156,17 @@ class Request
         }
 
         if ($auth = $this->options['auth'] ?? $this->header('authorization')) {
-            $type  = Str::before($auth, ' ');
-            $token = Str::after($auth, ' ');
-            $class = 'Kirby\\Http\\Request\\Auth\\' . ucfirst($type) . 'Auth';
+            $type = Str::lower(Str::before($auth, ' '));
+            $data = Str::after($auth, ' ');
 
-            if (class_exists($class) === false) {
+            $class = static::$authTypes[$type] ?? null;
+            if (!$class || class_exists($class) === false) {
                 return $this->auth = false;
             }
 
-            return $this->auth = new $class($token);
+            $object = new $class($data);
+
+            return $this->auth = $object;
         }
 
         return $this->auth = false;

--- a/src/Http/Request/Auth.php
+++ b/src/Http/Request/Auth.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kirby\Http\Request;
+
+/**
+ * Base class for auth types
+ *
+ * @package   Kirby Http
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+abstract class Auth
+{
+    /**
+     * Raw authentication data after the first space
+     * in the `Authorization` header
+     *
+     * @var string
+     */
+    protected $data;
+
+    /**
+     * Constructor
+     *
+     * @param string $data
+     */
+    public function __construct(string $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Converts the object to a string
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return ucfirst($this->type()) . ' ' . $this->data();
+    }
+
+    /**
+     * Returns the raw authentication data after the
+     * first space in the `Authorization` header
+     *
+     * @return string
+     */
+    public function data(): string
+    {
+        return $this->data;
+    }
+
+    /**
+     * Returns the name of the auth type (lowercase)
+     *
+     * @return string
+     */
+    abstract public function type(): string;
+}

--- a/src/Http/Request/Auth/BasicAuth.php
+++ b/src/Http/Request/Auth/BasicAuth.php
@@ -2,12 +2,19 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
 use Kirby\Toolkit\Str;
 
 /**
- * Basic Authentication
+ * HTTP basic authentication data
+ *
+ * @package   Kirby Http
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
  */
-class BasicAuth extends BearerAuth
+class BasicAuth extends Auth
 {
     /**
      * @var string
@@ -27,11 +34,11 @@ class BasicAuth extends BearerAuth
     /**
      * @param string $token
      */
-    public function __construct(string $token)
+    public function __construct(string $data)
     {
-        parent::__construct($token);
+        parent::__construct($data);
 
-        $this->credentials = base64_decode($token);
+        $this->credentials = base64_decode($data);
         $this->username    = Str::before($this->credentials, ':');
         $this->password    = Str::after($this->credentials, ':');
     }

--- a/src/Http/Request/Auth/BearerAuth.php
+++ b/src/Http/Request/Auth/BearerAuth.php
@@ -2,36 +2,19 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
+
 /**
- * Bearer Auth
+ * Bearer token authentication data
+ *
+ * @package   Kirby Http
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
  */
-class BearerAuth
+class BearerAuth extends Auth
 {
-    /**
-     * @var string
-     */
-    protected $token;
-
-    /**
-     * Creates a new Bearer Auth object
-     *
-     * @param string $token
-     */
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * Converts the object to a string
-     *
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return ucfirst($this->type()) . ' ' . $this->token();
-    }
-
     /**
      * Returns the authentication token
      *
@@ -39,7 +22,7 @@ class BearerAuth
      */
     public function token(): string
     {
-        return $this->token;
+        return $this->data;
     }
 
     /**

--- a/src/Http/Request/Auth/SessionAuth.php
+++ b/src/Http/Request/Auth/SessionAuth.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Kirby\Http\Request\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Http\Request\Auth;
+
+/**
+ * Authentication data using Kirby's session
+ *
+ * @package   Kirby Http
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class SessionAuth extends Auth
+{
+    /**
+     * Tries to return the session object
+     *
+     * @return \Kirby\Session\Session
+     */
+    public function session()
+    {
+        return App::instance()->sessionHandler()->getManually($this->data);
+    }
+
+    /**
+     * Returns the session token
+     *
+     * @return string
+     */
+    public function token(): string
+    {
+        return $this->data;
+    }
+
+    /**
+     * Returns the authentication type
+     *
+     * @return string
+     */
+    public function type(): string
+    {
+        return 'session';
+    }
+}

--- a/tests/Http/Request/Auth/BasicAuthTest.php
+++ b/tests/Http/Request/Auth/BasicAuthTest.php
@@ -4,15 +4,21 @@ namespace Kirby\Http\Request\Auth;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Kirby\Http\Request\Auth
+ * @covers \Kirby\Http\Request\Auth\BasicAuth
+ */
 class BasicAuthTest extends TestCase
 {
     public function testInstance()
     {
-        $auth = new BasicAuth(base64_encode($credentials = 'testuser:testpass'));
+        $auth = new BasicAuth($data = base64_encode($credentials = 'testuser:testpass'));
 
-        $this->assertEquals($credentials, $auth->credentials());
-        $this->assertEquals('testpass', $auth->password());
-        $this->assertEquals('basic', $auth->type());
-        $this->assertEquals('testuser', $auth->username());
+        $this->assertSame('basic', $auth->type());
+        $this->assertSame($data, $auth->data());
+        $this->assertSame($credentials, $auth->credentials());
+        $this->assertSame('testpass', $auth->password());
+        $this->assertSame('testuser', $auth->username());
+        $this->assertSame('Basic ' . $data, (string)$auth);
     }
 }

--- a/tests/Http/Request/Auth/BearerAuthTest.php
+++ b/tests/Http/Request/Auth/BearerAuthTest.php
@@ -4,14 +4,19 @@ namespace Kirby\Http\Request\Auth;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Kirby\Http\Request\Auth
+ * @covers \Kirby\Http\Request\Auth\BearerAuth
+ */
 class BearerAuthTest extends TestCase
 {
     public function testInstance()
     {
         $auth = new BearerAuth('abcd');
 
-        $this->assertEquals('abcd', $auth->token());
-        $this->assertEquals('bearer', $auth->type());
-        $this->assertEquals('Bearer abcd', $auth->__toString());
+        $this->assertSame('bearer', $auth->type());
+        $this->assertSame('abcd', $auth->data());
+        $this->assertSame('abcd', $auth->token());
+        $this->assertSame('Bearer abcd', (string)$auth);
     }
 }

--- a/tests/Http/Request/Auth/SessionAuthTest.php
+++ b/tests/Http/Request/Auth/SessionAuthTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kirby\Http\Request\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Kirby\Http\Request\Auth
+ * @covers \Kirby\Http\Request\Auth\SessionAuth
+ */
+class SessionAuthTest extends TestCase
+{
+    protected $kirby;
+    protected $tmp;
+
+    public function setUp(): void
+    {
+        $this->tmp = dirname(__DIR__, 2) . '/tmp';
+        Dir::make($this->tmp . '/site/sessions');
+
+        $this->kirby = new App([
+            'roots' => [
+                'index' => $this->tmp
+            ]
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        $this->kirby->session()->destroy();
+        Dir::remove($this->tmp);
+    }
+
+    public function testInstance()
+    {
+        $session = $this->kirby->session();
+        $session->ensureToken();
+
+        $auth = new SessionAuth($session->token());
+
+        $this->assertSame('session', $auth->type());
+        $this->assertSame($session->token(), $auth->data());
+        $this->assertSame($session->token(), $auth->token());
+        $this->assertSame($session, $auth->session());
+        $this->assertSame('Session ' . $session->token(), (string)$auth);
+    }
+}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- `$request->auth()` now also handles Kirby's `Session` auth type automatically
- The auth types for `$request->auth()` can now be extended by plugins:

```php
Kirby\Http\Request::$authTypes['digest'] = 'Superwoman\Digest\Class';
```

### Breaking changes

- Custom auth type classes in the `Kirby\Http\Request\Auth\` namespace now need to be registered in the `Kirby\Http\Request::$authTypes` array. We also recommend to move the classes to your own namespace to avoid interference with core classes.

## Explanation

My main motivation was actually to get rid of the dynamic class lookup and replace it with the fixed list. This avoids weird edge cases where one could somehow instantiate arbitrary objects. Unlikely, but now this risk is gone.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
