### PR TITLE
`Toolkit\Obj`: support `array` as the `$property` argument for getting multiple properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,10 +17,16 @@ tests/ export-ignore
 
 # panel
 panel/.env.example export-ignore
+panel/.eslintrc.js export-ignore
+panel/.prettierrc.json export-ignore
 panel/cypress.json export-ignore
 panel/package-lock.json export-ignore
 panel/package.json export-ignore
 panel/public export-ignore
 panel/README.md export-ignore
 panel/src export-ignore
-panel/vue.config.js export-ignore
+panel/vite.config.js export-ignore
+panel/vitest.setup.js export-ignore
+
+# other
+.vscode/ export-ignore

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please post all bug reports in our [issue tracker](https://github.com/getkirby/k
 If you have ideas for a feature or enhancement for Kirby, please use our [feedback platform](https://feedback.getkirby.com).
 
 **Translations, bug fixes, code contributions ...**  
-Read about how to contribute to the development in our [contributing guide](/.github/CONTRIBUTING.md).
+Read about how to contribute to the development in our [contributing guide](/CONTRIBUTING.md).
 
 
 

--- a/config/methods.php
+++ b/config/methods.php
@@ -112,11 +112,11 @@ return function (App $app) {
          * Converts the field value to a timestamp or a formatted date
          *
          * @param \Kirby\Cms\Field $field
-         * @param string|null $format PHP date formatting string
+         * @param string|\IntlDateFormatter|null $format PHP date formatting string
          * @param string|null $fallback Fallback string for `strtotime` (since 3.2)
          * @return string|int
          */
-        'toDate' => function (Field $field, string $format = null, string $fallback = null) use ($app) {
+        'toDate' => function (Field $field, $format = null, string $fallback = null) use ($app) {
             if (empty($field->value) === true && $fallback === null) {
                 return null;
             }

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -401,7 +401,7 @@ export default {
 }
 .k-writer .ProseMirror ul,
 .k-writer .ProseMirror ol {
-  padding-inline-start: 1rem;
+  padding-inline-start: 1.75rem;
 }
 .k-writer .ProseMirror ul > li {
   list-style: disc;

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -353,12 +353,12 @@ class File extends ModelWithContent
     /**
      * Get the file's last modification time.
      *
-     * @param string|null $format
-     * @param string|null $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string|null $handler date, intl or strftime
      * @param string|null $languageCode
      * @return mixed
      */
-    public function modified(string $format = null, string $handler = null, string $languageCode = null)
+    public function modified($format = null, string $handler = null, string $languageCode = null)
     {
         $file     = $this->modifiedFile();
         $content  = $this->modifiedContent($languageCode);

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -80,28 +80,30 @@ class FileRules
      */
     public static function create(File $file, BaseFile $upload): bool
     {
-        // first we want to ensure that we are not trying to
-        // create a duplicate file. So if a file
-        // with the same name already exists
+        // We want to ensure that we are not creating duplicate files.
+        // If a file with the same name already exists
         if ($file->exists() === true) {
             // $file will be based on the props of the new file,
-            // so we need to get the props of the existing file
-            $existing = kirby()->file($file->id());
+            // to compare templates, we need to get the props of
+            // the already existing file from meta content file
+            $existing = $file->parent()->file($file->filename());
 
             // if the new upload is the exact same file
-            // and uses the same template, we can continue,
-            // otherwise throw an eroror for duplicate file
+            // and uses the same template, we can continue
             if (
-                $file->sha1() !== $upload->sha1() ||
-                $file->template() !== $existing->template()
+                $file->sha1() === $upload->sha1() &&
+                $file->template() === $existing->template()
             ) {
-                throw new DuplicateException([
-                    'key'  => 'file.duplicate',
-                    'data' => [
-                        'filename' => $file->filename()
-                    ]
-                ]);
+                return true;
             }
+
+            // otherwise throw an error for duplicate file
+            throw new DuplicateException([
+                'key'  => 'file.duplicate',
+                'data' => [
+                    'filename' => $file->filename()
+                ]
+            ]);
         }
 
         if ($file->permissions()->create() !== true) {

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -80,8 +80,21 @@ class FileRules
      */
     public static function create(File $file, BaseFile $upload): bool
     {
+        // first we want to ensure that we are not trying to
+        // create a duplicate file. So if a file
+        // with the same name already exists
         if ($file->exists() === true) {
-            if ($file->sha1() !== $upload->sha1()) {
+            // $file will be based on the props of the new file,
+            // so we need to get the props of the existing file
+            $existing = kirby()->file($file->id());
+
+            // if the new upload is the exact same file
+            // and uses the same template, we can continue,
+            // otherwise throw an eroror for duplicate file
+            if (
+                $file->sha1() !== $upload->sha1() ||
+                $file->template() !== $existing->template()
+            ) {
                 throw new DuplicateException([
                     'key'  => 'file.duplicate',
                     'data' => [

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -775,7 +775,11 @@ class Query
 
         // apply it to the dataset and retrieve all rows. make sure to use Collection as the iterator to be able to attach the pagination object
         $iterator   = $this->iterator;
-        $collection = $this->offset($pagination->offset())->limit($pagination->limit())->iterator('Collection')->all();
+        $collection = $this
+            ->offset($pagination->offset())
+            ->limit($pagination->limit())
+            ->iterator('Kirby\Toolkit\Collection')
+            ->all();
 
         $this->iterator($iterator);
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -972,6 +972,11 @@ class Query
                     $this->bindings($sql['bindings']);
                 } elseif (is_callable($args[0]) === true) {
                     $query = clone $this;
+
+                    // since the callback uses its own where condition
+                    // it is necessary to clear/reset the cloned where condition
+                    $query->where = null;
+
                     call_user_func($args[0], $query);
 
                     // copy over the bindings from the nested query

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -853,8 +853,14 @@ abstract class Sql
         $query    = [];
         $bindings = [];
 
-        foreach ($values as $key => $value) {
-            $fields[] = $this->columnName($table, $key, $enforceQualified);
+        foreach ($values as $column => $value) {
+            $key = $this->columnName($table, $column, $enforceQualified);
+
+            if ($key === null) {
+                continue;
+            }
+
+            $fields[] = $key;
 
             if (in_array($value, static::$literals, true) === true) {
                 $query[] = $value ?: 'null';
@@ -895,6 +901,10 @@ abstract class Sql
 
         foreach ($values as $column => $value) {
             $key = $this->columnName($table, $column, $enforceQualified);
+
+            if ($key === null) {
+                continue;
+            }
 
             if (in_array($value, static::$literals, true) === true) {
                 $query[] = $key . ' = ' . ($value ?: 'null');

--- a/src/Database/Sql/Sqlite.php
+++ b/src/Database/Sql/Sqlite.php
@@ -137,7 +137,7 @@ class Sqlite extends Sql
     public function tables(): array
     {
         return [
-            'query'    => 'SELECT name FROM sqlite_master WHERE type = "table"',
+            'query'    => 'SELECT name FROM sqlite_master WHERE type = "table" OR type = "view"',
             'bindings' => []
         ];
     }

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -463,11 +463,11 @@ class F
      * Get the file's last modification time.
      *
      * @param string $file
-     * @param string $format
-     * @param string $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string $handler date, intl or strftime
      * @return mixed
      */
-    public static function modified(string $file, string $format = null, string $handler = 'date')
+    public static function modified(string $file, $format = null, string $handler = 'date')
     {
         if (file_exists($file) !== true) {
             return false;

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -372,11 +372,11 @@ class File
     /**
      * Returns the file's last modification time
      *
-     * @param string $format
-     * @param string|null $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string|null $handler date, intl or strftime
      * @return mixed
      */
-    public function modified(?string $format = null, ?string $handler = null)
+    public function modified($format = null, ?string $handler = null)
     {
         $kirby = $this->kirby();
 

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -17,6 +17,11 @@ use Throwable;
 class File extends Model
 {
     /**
+     * @var \Kirby\Cms\File
+     */
+    protected $model;
+
+    /**
      * Breadcrumb array
      *
      * @return array
@@ -423,11 +428,11 @@ class File extends Model
         return [
             'next' => function () use ($file, $siblings): ?array {
                 $next = $siblings->nth($siblings->indexOf($file) + 1);
-                return $next ? $next->panel()->toLink('filename') : null;
+                return $this->toPrevNextLink($next, 'filename');
             },
             'prev' => function () use ($file, $siblings): ?array {
                 $prev = $siblings->nth($siblings->indexOf($file) - 1);
-                return $prev ? $prev->panel()->toLink('filename') : null;
+                return $this->toPrevNextLink($prev, 'filename');
             }
         ];
     }

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Form\Form;
+use Kirby\Http\Uri;
 use Kirby\Toolkit\A;
 
 /**
@@ -407,7 +408,11 @@ abstract class Model
         $data = $model->panel()->toLink($tooltip);
 
         if ($tab = get('tab')) {
-            $data['link'] .= '?tab=' . $tab;
+            $uri = new Uri($data['link'], [
+                'query' => ['tab' => $tab]
+            ]);
+
+            $data['link'] = $uri->toString();
         }
 
         return $data;

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -388,6 +388,32 @@ abstract class Model
     }
 
     /**
+     * Returns link url and tooltip
+     * for optional sibling model and
+     * preserves tab selection
+     *
+     * @internal
+     *
+     * @param \Kirby\Cms\ModelWithContent|null $model
+     * @param string $tooltip
+     * @return array
+     */
+    protected function toPrevNextLink($model = null, string $tooltip = 'title'): ?array
+    {
+        if ($model === null) {
+            return null;
+        }
+
+        $data = $model->panel()->toLink($tooltip);
+
+        if ($tab = get('tab')) {
+            $data['link'] .= '?tab=' . $tab;
+        }
+
+        return $data;
+    }
+
+    /**
      * Returns the url to the editing view
      * in the Panel
      *

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -15,6 +15,11 @@ namespace Kirby\Panel;
 class Page extends Model
 {
     /**
+     * @var \Kirby\Cms\Page
+     */
+    protected $model;
+
+    /**
      * Breadcrumb array
      *
      * @return array
@@ -309,14 +314,8 @@ class Page extends Model
         };
 
         return [
-            'next' => function () use ($siblings) {
-                $next = $siblings('next')->first();
-                return $next ? $next->panel()->toLink('title') : null;
-            },
-            'prev'   => function () use ($siblings) {
-                $prev = $siblings('prev')->last();
-                return $prev ? $prev->panel()->toLink('title') : null;
-            }
+            'next' => fn () => $this->toPrevNextLink($siblings('next')->first()),
+            'prev' => fn () => $this->toPrevNextLink($siblings('prev')->last())
         ];
     }
 

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -15,6 +15,11 @@ namespace Kirby\Panel;
 class Site extends Model
 {
     /**
+     * @var \Kirby\Cms\Site
+     */
+    protected $model;
+
+    /**
      * Returns the setup for a dropdown option
      * which is used in the changes dropdown
      * for example.

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -15,6 +15,11 @@ namespace Kirby\Panel;
 class User extends Model
 {
     /**
+     * @var \Kirby\Cms\User
+     */
+    protected $model;
+
+    /**
      * Breadcrumb array
      *
      * @return array
@@ -193,14 +198,8 @@ class User extends Model
         $user = $this->model;
 
         return [
-            'next' => function () use ($user) {
-                $next = $user->next();
-                return $next ? $next->panel()->toLink('username') : null;
-            },
-            'prev' => function () use ($user) {
-                $prev = $user->prev();
-                return $prev ? $prev->panel()->toLink('username') : null;
-            }
+            'next' => fn () => $this->toPrevNextLink($user->next(), 'username'),
+            'prev' => fn () => $this->toPrevNextLink($user->prev(), 'username')
         ];
     }
 

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -741,31 +741,13 @@ class A
     }
 
     /**
-     * Filter the array, using only the given key or array of keys
+     * Remove key(s) from an array
      *
      * @param array $array
      * @param int|string|array $keys
      * @return array
      */
-    public static function only(array $array, $keys): array
-    {
-        if (is_int($keys) || is_string($keys)) {
-            $keys = static::wrap($keys);
-        }
-
-        return static::filter($array, function ($value, $key) use ($keys) {
-            return in_array($key, $keys, true);
-        });
-    }
-
-    /**
-     * Filter the array for ever key except the given key or array of keys
-     *
-     * @param array $array
-     * @param int|string|array $keys
-     * @return array
-     */
-    public static function except(array $array, $keys): array
+    public static function without(array $array, $keys): array
     {
         if (is_int($keys) || is_string($keys)) {
             $keys = static::wrap($keys);

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -726,4 +726,53 @@ class A
             return $array;
         }
     }
+
+    /**
+     * Filter the array using the given callback
+     * using both value and key
+     *
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function where(array $array, callable $callback): array
+    {
+        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Filter the array, using only the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function only(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return static::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true);
+        });
+    }
+
+    /**
+     * Filter the array for ever key except the given key or array of keys
+     *
+     * @param array $array
+     * @param int|string|array $keys
+     * @return array
+     */
+    public static function except(array $array, $keys): array
+    {
+        if (is_int($keys) || is_string($keys)) {
+            $keys = static::wrap($keys);
+        }
+
+        return static::where($array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys, true) === false;
+        });
+    }
 }

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -730,6 +730,7 @@ class A
     /**
      * Filter the array using the given callback
      * using both value and key
+     * @since 3.6.5
      *
      * @param array $array
      * @param callable $callback
@@ -742,6 +743,7 @@ class A
 
     /**
      * Remove key(s) from an array
+     * @since 3.6.5
      *
      * @param array $array
      * @param int|string|array $keys

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -735,7 +735,7 @@ class A
      * @param callable $callback
      * @return array
      */
-    public static function where(array $array, callable $callback): array
+    public static function filter(array $array, callable $callback): array
     {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
@@ -753,7 +753,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return static::where($array, function ($value, $key) use ($keys) {
+        return static::filter($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true);
         });
     }
@@ -771,7 +771,7 @@ class A
             $keys = static::wrap($keys);
         }
 
-        return static::where($array, function ($value, $key) use ($keys) {
+        return static::filter($array, function ($value, $key) use ($keys) {
             return in_array($key, $keys, true) === false;
         });
     }

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -742,7 +742,14 @@ class Collection extends Iterator implements Countable
      */
     public function paginate(...$arguments)
     {
-        $this->pagination = Pagination::for($this, ...$arguments);
+        // set pagination property if passed first argument
+        // already a pagination object, otherwise create new
+        // pagination instance with passed arguments
+        if (is_a($arguments[0], 'Kirby\Toolkit\Pagination') === true) {
+            $this->pagination = $arguments[0]->clone();
+        } else {
+            $this->pagination = Pagination::for($this, ...$arguments);
+        }
 
         // slice and clone the collection according to the pagination
         return $this->slice($this->pagination->offset(), $this->pagination->limit());

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -742,14 +742,7 @@ class Collection extends Iterator implements Countable
      */
     public function paginate(...$arguments)
     {
-        // set pagination property if passed first argument
-        // already a pagination object, otherwise create new
-        // pagination instance with passed arguments
-        if (is_a($arguments[0], 'Kirby\Toolkit\Pagination') === true) {
-            $this->pagination = $arguments[0]->clone();
-        } else {
-            $this->pagination = Pagination::for($this, ...$arguments);
-        }
+        $this->pagination = Pagination::for($this, ...$arguments);
 
         // slice and clone the collection according to the pagination
         return $this->slice($this->pagination->offset(), $this->pagination->limit());

--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -64,12 +64,17 @@ class Obj extends stdClass
     /**
      * Property Getter
      *
-     * @param string $property
+     * @param string|array $property
      * @param mixed $fallback
      * @return mixed
      */
-    public function get(string $property, $fallback = null)
+    public function get(string|array $property, $fallback = null)
     {
+        if (is_array($property)) {
+            $filtered = A::get($this->toArray(), $property);
+            return ! empty($filtered) ? $filtered : $fallback;
+        }
+
         return $this->$property ?? $fallback;
     }
 

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -75,7 +75,12 @@ class Pagination
 
         $params = [];
 
-        if (is_array($a) === true) {
+        if (is_a($a, static::class) === true) {
+            /**
+             * First argument is a pagination/self object
+             */
+            return $a;
+        } elseif (is_array($a) === true) {
 
             /**
              * First argument is an option array

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Toolkit;
 
+use DateTime;
 use Exception;
+use IntlDateFormatter;
 use Kirby\Exception\InvalidArgumentException;
 
 /**
@@ -264,17 +266,33 @@ class Str
      * according to locale settings
      *
      * @param int|null $time
-     * @param string|null $format
-     * @param string $handler date or strftime
+     * @param string|\IntlDateFormatter|null $format
+     * @param string $handler date, intl or strftime
      * @return string|int
      */
-    public static function date(?int $time = null, ?string $format = null, string $handler = 'date')
+    public static function date(?int $time = null, $format = null, string $handler = 'date')
     {
         if (is_null($format) === true) {
             return $time;
         }
 
-        // separately handle strftime to be able
+        // $format is an IntlDateFormatter instance
+        if (is_a($format, 'IntlDateFormatter') === true) {
+            return $format->format($time ?? time());
+        }
+
+        // `intl` handler
+        if ($handler === 'intl') {
+            $datetime = new DateTime();
+
+            if ($time !== null) {
+                $datetime->setTimestamp($time);
+            }
+
+            return IntlDateFormatter::formatObject($datetime, $format);
+        }
+
+        // handle `strftime` to be able
         // to suppress deprecation warning
         // TODO: remove strftime support for PHP 9.0
         if ($handler === 'strftime') {

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -102,6 +102,8 @@ class FileRulesTest extends TestCase
         $file = $this->createMock(File::class);
         $file->method('filename')->willReturn('test.jpg');
         $file->method('exists')->willReturn(true);
+        $page = $this->createMock(Page::class);
+        $file->method('parent')->willReturn($page);
 
         $this->expectException('Kirby\Exception\DuplicateException');
         $this->expectExceptionMessage('A file with the name "test.jpg" already exists');

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -2,21 +2,30 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
 
 class FileRulesTest extends TestCase
 {
     protected $app;
+    protected $fixtures;
 
     public function setUp(): void
     {
         $this->app = new App([
             'roots' => [
-                'index' => '/dev/null'
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest'
             ]
         ]);
 
         $this->app->impersonate('kirby');
+        Dir::make($this->fixtures);
+    }
+
+    public function tearDown(): void
+    {
+        Dir::remove($this->fixtures);
     }
 
     public function testChangeName()
@@ -111,6 +120,129 @@ class FileRulesTest extends TestCase
         $upload = $this->createMock(BaseFile::class);
 
         FileRules::create($file, $upload);
+    }
+
+    public function testCreateSameFile()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createSameFile',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        // create new file
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'test'
+            ]
+        ]);
+
+        $upload = new BaseFile($testImage);
+        $create = FileRules::create($newFile, $upload);
+
+        $this->assertTrue($create);
+    }
+
+    public function testCreateSameFileWithDifferentTemplate()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createSameFileWithDifferentTemplate',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'cover'
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\DuplicateException');
+        $this->expectExceptionMessage('A file with the name "test.jpg" already exists');
+
+        $upload = new BaseFile($testImage);
+        FileRules::create($newFile, $upload);
+    }
+
+    public function testCreateDifferentFileWithSameFilename()
+    {
+        $testImage =  __DIR__ . '/fixtures/files/test.jpg';
+
+        $app = new App([
+            'roots' => [
+                'index' => $this->fixtures = __DIR__ . '/fixtures/FileRulesTest/createDifferentFileWithSameFilename',
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug' => 'test',
+                        'files' => [
+                            ['filename' => 'test.jpg', 'content' => ['template' => 'test']],
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $page = $app->page('test');
+
+        // create real file with content and move into page root
+        F::copy($testImage, $page->root() . '/test.jpg');
+        F::write($page->root() . '/test.jpg.txt', 'Template: test');
+
+        $newFile = new File([
+            'filename' => 'test.jpg',
+            'parent' => $page,
+            'content' => [
+                'template' => 'test'
+            ]
+        ]);
+
+        $this->expectException('Kirby\Exception\DuplicateException');
+        $this->expectExceptionMessage('A file with the name "test.jpg" already exists');
+
+        $upload = new BaseFile(__DIR__ . '/fixtures/files/cat.jpg');
+        FileRules::create($newFile, $upload);
     }
 
     public function testCreateHarmfulContents()

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -403,7 +403,12 @@ class QueryTest extends TestCase
 
         $this->assertCount(4, $results);
         $this->assertSame('John', $results->first()->fname());
-        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+        $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(4, $pagination->total());
+        $this->assertSame(1, $pagination->page());
+        $this->assertSame(1, $pagination->start());
+        $this->assertSame(4, $pagination->end());
+        $this->assertSame(10, $pagination->limit());
 
         // example two
         $results = $query->page(3, 1);
@@ -411,14 +416,24 @@ class QueryTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertSame('George', $results->first()->fname());
-        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+        $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(4, $pagination->total());
+        $this->assertSame(3, $pagination->page());
+        $this->assertSame(3, $pagination->start());
+        $this->assertSame(3, $pagination->end());
+        $this->assertSame(1, $pagination->limit());
 
-        // example  three
+        // example three
         $results = $query->page(2, 3);
         $pagination = $results->pagination();
 
         $this->assertCount(1, $results);
         $this->assertSame('Mark', $results->first()->fname());
-        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+        $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(4, $pagination->total());
+        $this->assertSame(2, $pagination->page());
+        $this->assertSame(4, $pagination->start());
+        $this->assertSame(4, $pagination->end());
+        $this->assertSame(3, $pagination->limit());
     }
 }

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -404,6 +404,7 @@ class QueryTest extends TestCase
         $this->assertCount(4, $results);
         $this->assertSame('John', $results->first()->fname());
         $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(1, $pagination->pages());
         $this->assertSame(4, $pagination->total());
         $this->assertSame(1, $pagination->page());
         $this->assertSame(1, $pagination->start());
@@ -417,6 +418,7 @@ class QueryTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('George', $results->first()->fname());
         $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(4, $pagination->pages());
         $this->assertSame(4, $pagination->total());
         $this->assertSame(3, $pagination->page());
         $this->assertSame(3, $pagination->start());
@@ -430,6 +432,7 @@ class QueryTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame('Mark', $results->first()->fname());
         $this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+        $this->assertSame(2, $pagination->pages());
         $this->assertSame(4, $pagination->total());
         $this->assertSame(2, $pagination->page());
         $this->assertSame(4, $pagination->start());

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -393,6 +393,17 @@ class QueryTest extends TestCase
         $this->assertSame(3, $count);
     }
 
+    public function testWhereCallback()
+    {
+        $count = $this->database
+            ->table('users')
+            ->where('balance', '>', 75)
+            ->where(fn ($q) => $q->where('role_id', '=', 3))
+            ->count();
+
+        $this->assertSame(1, $count);
+    }
+
     public function testPage()
     {
         $query = $this->database->table('users');

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -392,4 +392,33 @@ class QueryTest extends TestCase
 
         $this->assertSame(3, $count);
     }
+
+    public function testPage()
+    {
+        $query = $this->database->table('users');
+
+        // example one
+        $results = $query->page(1, 10);
+        $pagination = $results->pagination();
+
+        $this->assertCount(4, $results);
+        $this->assertSame('John', $results->first()->fname());
+        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+
+        // example two
+        $results = $query->page(3, 1);
+        $pagination = $results->pagination();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('George', $results->first()->fname());
+        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+
+        // example  three
+        $results = $query->page(2, 3);
+        $pagination = $results->pagination();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Mark', $results->first()->fname());
+        $this->assertInstanceOf('\Kirby\Toolkit\Pagination', $pagination);
+    }
 }

--- a/tests/Database/Sql/MysqlTest.php
+++ b/tests/Database/Sql/MysqlTest.php
@@ -20,6 +20,8 @@ class MysqlTest extends TestCase
             'type'     => 'sqlite',
             'database' => ':memory:'
         ]);
+        $this->database->execute('CREATE TABLE test (id INTEGER)');
+        $this->database->execute('CREATE VIEW view_test AS SELECT * FROM test');
 
         $this->sql = new Mysql($this->database);
     }
@@ -42,5 +44,15 @@ class MysqlTest extends TestCase
         $result = $this->sql->tables();
         $this->assertStringStartsWith('SELECT TABLE_NAME AS name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ', $result['query']);
         $this->assertSame(':memory:', A::first($result['bindings']));
+    }
+
+    /**
+     * @covers ::tables
+     */
+    public function testValidateTable()
+    {
+        $this->assertTrue($this->database->validateTable('test'));
+        $this->assertTrue($this->database->validateTable('view_test'));
+        $this->assertFalse($this->database->validateTable('not_exist'));
     }
 }

--- a/tests/Database/Sql/SqliteTest.php
+++ b/tests/Database/Sql/SqliteTest.php
@@ -22,6 +22,7 @@ class SqliteTest extends TestCase
             'database' => ':memory:'
         ]);
         $this->database->execute('CREATE TABLE test (id INTEGER)');
+        $this->database->execute('CREATE VIEW view_test AS SELECT * FROM test');
 
         $this->sql = new Sqlite($this->database);
     }
@@ -159,7 +160,17 @@ class SqliteTest extends TestCase
     public function testTables()
     {
         $result = $this->sql->tables();
-        $this->assertSame('SELECT name FROM sqlite_master WHERE type = "table"', $result['query']);
+        $this->assertSame('SELECT name FROM sqlite_master WHERE type = "table" OR type = "view"', $result['query']);
         $this->assertSame([], $result['bindings']);
+    }
+
+    /**
+     * @covers ::tables
+     */
+    public function testValidateTable()
+    {
+        $this->assertTrue($this->database->validateTable('test'));
+        $this->assertTrue($this->database->validateTable('view_test'));
+        $this->assertFalse($this->database->validateTable('not_exist'));
     }
 }

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -459,4 +459,38 @@ class SqlTest extends TestCase
             'bindings' => []
         ], $this->sql->having('test < :value'));
     }
+
+    public function testValueSet()
+    {
+        $this->database->createTable('users', [
+            'name' => ['type' => 'varchar']
+        ]);
+
+        $values = $this->sql->values('users', [
+            'name' => 'John Doe',
+            'nonexisting' => 'test',
+        ], ', ', true);
+
+        $this->assertArrayHasKey('query', $values);
+        $this->assertArrayHasKey('bindings', $values);
+        $this->assertCount(1, $values['bindings']);
+        $this->assertSame('John Doe', current($values['bindings']));
+    }
+
+    public function testValueList()
+    {
+        $this->database->createTable('users', [
+            'name' => ['type' => 'varchar']
+        ]);
+
+        $values = $this->sql->values('users', [
+            'name' => 'John Doe',
+            'nonexisting' => 'test',
+        ], ', ', false);
+
+        $this->assertArrayHasKey('query', $values);
+        $this->assertArrayHasKey('bindings', $values);
+        $this->assertCount(1, $values['bindings']);
+        $this->assertSame('John Doe', current($values['bindings']));
+    }
 }

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -19,7 +19,7 @@ class ModelFileTestForceLocked extends ModelFile
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\File
+ * @coversDefaultClass \Kirby\Panel\File|\Kirby\Panel\Model
  */
 class FileTest extends TestCase
 {
@@ -698,6 +698,7 @@ class FileTest extends TestCase
 
     /**
      * @covers ::props
+     * @covers ::prevNext
      */
     public function testPropsPrevNext()
     {
@@ -725,6 +726,7 @@ class FileTest extends TestCase
 
     /**
      * @covers ::props
+     * @covers ::prevNext
      */
     public function testPropsPrevNextWithSort()
     {
@@ -748,6 +750,30 @@ class FileTest extends TestCase
         $props = (new File($page->file('c.jpg')))->props();
         $this->assertSame('/pages/test/files/a.jpg', $props['prev']()['link']);
         $this->assertNull($props['next']());
+    }
+
+    /**
+     * @covers ::prevNext
+     * @covers ::toPrevNextLink
+     */
+    public function testPropsPrevNextWithTab()
+    {
+        $page = new ModelPage([
+            'slug'  => 'test',
+            'files' => [
+                ['filename' => 'a.jpg'],
+                ['filename' => 'b.jpg'],
+                ['filename' => 'c.jpg']
+            ]
+        ]);
+
+        $_GET['tab'] = 'test';
+
+        $prevNext = (new File($page->file('b.jpg')))->prevNext();
+        $this->assertSame('/pages/test/files/a.jpg?tab=test', $prevNext['prev']()['link']);
+        $this->assertSame('/pages/test/files/c.jpg?tab=test', $prevNext['next']()['link']);
+
+        $_GET = [];
     }
 
     /**

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -18,7 +18,7 @@ class ModelPageTestForceLocked extends ModelPage
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\Page
+ * @coversDefaultClass \Kirby\Panel\Page|\Kirby\Panel\Model
  */
 class PageTest extends TestCase
 {
@@ -601,6 +601,32 @@ class PageTest extends TestCase
 
         $props = (new Page($app->page('baz')))->props();
         $this->assertSame('/pages/foo', $props['prev']()['link']);
+    }
+
+    /**
+     * @covers ::prevNext
+     * @covers ::toPrevNextLink
+     */
+    public function testPropsPrevNextWithTab()
+    {
+        $app = $this->app->clone([
+            'site' => [
+                'children' => [
+                    ['slug' => 'foo'],
+                    ['slug' => 'bar'],
+                    ['slug' => 'baz']
+                ]
+            ],
+        ]);
+        $app->impersonate('kirby');
+
+        $_GET['tab'] = 'test';
+
+        $prevNext = (new Page($app->page('bar')))->prevNext();
+        $this->assertSame('/pages/foo?tab=test', $prevNext['prev']()['link']);
+        $this->assertSame('/pages/baz?tab=test', $prevNext['next']()['link']);
+
+        $_GET = [];
     }
 
     /**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -18,7 +18,7 @@ class ModelUserTestForceLocked extends ModelUser
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\User
+ * @coversDefaultClass \Kirby\Panel\User|\Kirby\Panel\Model
  */
 class UserTest extends TestCase
 {
@@ -434,6 +434,29 @@ class UserTest extends TestCase
         $prevNext = (new User($app->user('c@getkirby.com')))->prevNext();
         $this->assertSame('b@getkirby.com', $prevNext['prev']()['tooltip']);
         $this->assertNull($prevNext['next']());
+    }
+
+    /**
+     * @covers ::prevNext
+     * @covers ::toPrevNextLink
+     */
+    public function testPrevNextWithTab()
+    {
+        $app = $this->app->clone([
+            'users' => [
+                ['id' => 'a', 'email' => 'a@getkirby.com'],
+                ['id' => 'b', 'email' => 'b@getkirby.com'],
+                ['id' => 'c', 'email' => 'c@getkirby.com']
+            ]
+        ]);
+
+        $_GET['tab'] = 'test';
+
+        $prevNext = (new User($app->user('b@getkirby.com')))->prevNext();
+        $this->assertSame('/users/a?tab=test', $prevNext['prev']()['link']);
+        $this->assertSame('/users/c?tab=test', $prevNext['next']()['link']);
+
+        $_GET = [];
     }
 
     /**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -708,22 +708,22 @@ class ATest extends TestCase
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return in_array($key, ['cat', 'dog']);
         });
         $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return in_array($value, ['miao', 'tweet']);
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::where($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function($value, $key){
             return $key === 'cat' || $value === 'tweet';
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::where($array, function($value, $key){
+        $result = A::filter($array, function($value, $key){
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -730,40 +730,22 @@ class ATest extends TestCase
     }
 
      /**
-     * @covers ::only
+     * @covers ::without
      */
-    public function testOnly()
-    {
-        $associativeArray = $this->_array();
-        // cat, dog, bird, cat, dog, bird
-        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
-
-        $this->assertSame(['cat' => 'miao'], A::only($associativeArray, 'cat'));
-        $this->assertSame(['cat' => 'miao', 'bird' => 'tweet'], A::only($associativeArray, ['cat', 'bird']));
-        $this->assertSame([], A::only($associativeArray, ['this', 'doesnt', 'exist']));
-
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat'], A::only($array, range(1, 3)));
-        $this->assertSame(['cat'], A::only($array, 0));
-        $this->assertSame([], A::only($array, -1));
-    }
-
-     /**
-     * @covers ::except
-     */
-    public function testExcept()
+    public function testWithout()
     {
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);
 
         $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
 
-        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::except($associativeArray, 'cat'));
-        $this->assertSame(['dog' => 'wuff'], A::except($associativeArray, ['cat', 'bird']));
-        $this->assertSame([], A::except($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame($associativeArray, A::except($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
+        $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
+        $this->assertSame($associativeArray, A::without($associativeArray, ['this', 'doesnt', 'exist']));
 
-        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::except($array, range(1, 3)));
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::except($array, 0));
-        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::except($array, -1));
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($array, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($array, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($array, -1));
     }
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -706,7 +706,7 @@ class ATest extends TestCase
     public function testFilter()
     {
         $associativeArray = $this->_array();
-        $array = array_keys($associativeArray);
+        $indexedArray = array_keys($associativeArray);
 
         $result = A::filter($associativeArray, function($value, $key){
             return in_array($key, ['cat', 'dog']);
@@ -723,7 +723,7 @@ class ATest extends TestCase
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($array, function($value, $key){
+        $result = A::filter($indexedArray, function($value, $key){
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
@@ -735,17 +735,15 @@ class ATest extends TestCase
     public function testWithout()
     {
         $associativeArray = $this->_array();
-        $array = array_keys($associativeArray);
-
-        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+        $indexedArray = [...array_keys($associativeArray), ...array_keys($associativeArray)];
 
         $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
         $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
         $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame($associativeArray, A::without($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'doesnt', 'exist']));
 
-        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($array, range(1, 3)));
-        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($array, 0));
-        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($array, -1));
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($indexedArray, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($indexedArray, -1));
     }
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -740,7 +740,7 @@ class ATest extends TestCase
         $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, 'cat'));
         $this->assertSame(['dog' => 'wuff'], A::without($associativeArray, ['cat', 'bird']));
         $this->assertSame([], A::without($associativeArray, ['cat', 'dog', 'bird']));
-        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'doesnt', 'exist']));
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'cat', 'doesnt', 'exist']));
 
         $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, range(1, 3)));
         $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($indexedArray, 0));

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -701,9 +701,9 @@ class ATest extends TestCase
 
 
      /**
-     * @covers ::where
+     * @covers ::filter
      */
-    public function testWhere()
+    public function testFilter()
     {
         $associativeArray = $this->_array();
         $array = array_keys($associativeArray);

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -700,7 +700,7 @@ class ATest extends TestCase
     }
 
 
-     /**
+    /**
      * @covers ::filter
      */
     public function testFilter()
@@ -708,28 +708,28 @@ class ATest extends TestCase
         $associativeArray = $this->_array();
         $indexedArray = array_keys($associativeArray);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return in_array($key, ['cat', 'dog']);
         });
         $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return in_array($value, ['miao', 'tweet']);
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($associativeArray, function($value, $key){
+        $result = A::filter($associativeArray, function ($value, $key) {
             return $key === 'cat' || $value === 'tweet';
         });
         $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
 
-        $result = A::filter($indexedArray, function($value, $key){
+        $result = A::filter($indexedArray, function ($value, $key) {
             return $key > 0;
         });
         $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
     }
 
-     /**
+    /**
      * @covers ::without
      */
     public function testWithout()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -698,4 +698,72 @@ class ATest extends TestCase
         $result = A::wrap(null);
         $this->assertSame([], $result);
     }
+
+
+     /**
+     * @covers ::where
+     */
+    public function testWhere()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($key, ['cat', 'dog']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'dog'  => 'wuff'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return in_array($value, ['miao', 'tweet']);
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($associativeArray, function($value, $key){
+            return $key === 'cat' || $value === 'tweet';
+        });
+        $this->assertSame(['cat'  => 'miao', 'bird' => 'tweet'], $result);
+
+        $result = A::where($array, function($value, $key){
+            return $key > 0;
+        });
+        $this->assertSame([1 => 'dog', 2 => 'bird'], $result);
+    }
+
+     /**
+     * @covers ::only
+     */
+    public function testOnly()
+    {
+        $associativeArray = $this->_array();
+        // cat, dog, bird, cat, dog, bird
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['cat' => 'miao'], A::only($associativeArray, 'cat'));
+        $this->assertSame(['cat' => 'miao', 'bird' => 'tweet'], A::only($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::only($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat'], A::only($array, range(1, 3)));
+        $this->assertSame(['cat'], A::only($array, 0));
+        $this->assertSame([], A::only($array, -1));
+    }
+
+     /**
+     * @covers ::except
+     */
+    public function testExcept()
+    {
+        $associativeArray = $this->_array();
+        $array = array_keys($associativeArray);
+
+        $array = [...array_keys($associativeArray), ...array_keys($associativeArray)];
+
+        $this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::except($associativeArray, 'cat'));
+        $this->assertSame(['dog' => 'wuff'], A::except($associativeArray, ['cat', 'bird']));
+        $this->assertSame([], A::except($associativeArray, ['cat', 'dog', 'bird']));
+        $this->assertSame($associativeArray, A::except($associativeArray, ['this', 'doesnt', 'exist']));
+
+        $this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::except($array, range(1, 3)));
+        $this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::except($array, 0));
+        $this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::except($array, -1));
+    }
 }

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -19,6 +19,20 @@ class ObjTest extends TestCase
         $this->assertNull($obj->foo);
     }
 
+    public function test__getMultiple()
+    {
+        $obj = new Obj([
+            'one' => 'first',
+            'two' => 'second',
+            'three' => 'third'
+        ]);
+
+        $this->assertEquals('first', $obj->get('one'));
+        $this->assertEquals(['one' => 'first', 'three' => 'third'], $obj->get(['one', 'three']));
+        $this->assertEquals(['one' => 'first', 'three' => 'third', 'eight' => null], $obj->get(['one', 'three', 'eight']));
+        $this->assertEquals($obj->toArray(), $obj->get(['one', 'two', 'three']));
+    }
+
     public function testToArray()
     {
         $obj = new Obj($expected = [

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use IntlDateFormatter;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -138,6 +139,12 @@ class StrTest extends TestCase
         // default `date` handler
         $this->assertSame($time, Str::date($time));
         $this->assertSame('29.01.2020', Str::date($time, 'd.m.Y'));
+
+        // `intl` handler
+        $formatter = new IntlDateFormatter(null, IntlDateFormatter::LONG, IntlDateFormatter::SHORT);
+        $this->assertSame($time, Str::date($time, null, 'intl'));
+        $this->assertSame('29/1/2020 01:01', Str::date($time, 'd/M/yyyy HH:mm', 'intl'));
+        $this->assertSame('January 29, 2020 at 1:01 AM', Str::date($time, $formatter));
 
         // `strftime` handler
         $this->assertSame($time, Str::date($time, null, 'strftime'));


### PR DESCRIPTION
## This PR …
Adds support for getting multiple properties from `Toolkit\Obj` objects and derived objects, like so:

```php
$thing = new Obj(['one' => '👋', 'two' => 'Kirby']);
$properties = $thing->get(['one', 'two'], 'or-not');
```

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

Because it uses `A::get()` internally, getting non-existent properties in the array returns `['no' => null]`, which I'm not quite sure how to handle - it makes sense from a consistency POV, but might not be expected. I didn't want to pollute the PR with more robust edge case handling.

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
