### PR TITLE
`Toolkit\Obj`: support `array` as the `$property` argument for getting multiple properties

### DIFF
--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -73,6 +73,10 @@ class Obj extends stdClass
     public function get($property, $fallback = null)
     {
         if (is_array($property)) {
+            if ($fallback === null) {
+                $fallback = [];
+            }
+
             if (!is_array($fallback)) {
                 throw new InvalidArgumentException('The fallback value must be an array when getting multiple properties');
             }

--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -64,12 +64,17 @@ class Obj extends stdClass
     /**
      * Property Getter
      *
-     * @param string $property
+     * @param string|array $property
      * @param mixed $fallback
      * @return mixed
      */
-    public function get(string $property, $fallback = null)
+    public function get(string|array $property, $fallback = null)
     {
+        if (is_array($property)) {
+            $filtered = A::get($this->toArray(), $property);
+            return ! empty($filtered) ? $filtered : $fallback;
+        }
+
         return $this->$property ?? $fallback;
     }
 

--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Kirby\Exception\InvalidArgumentException;
 use stdClass;
 
 /**
@@ -71,8 +72,15 @@ class Obj extends stdClass
     public function get(string|array $property, $fallback = null)
     {
         if (is_array($property)) {
-            $filtered = A::get($this->toArray(), $property);
-            return ! empty($filtered) ? $filtered : $fallback;
+            if (!is_array($fallback)) {
+                throw new InvalidArgumentException('The fallback value must be an array when getting multiple properties');
+            }
+
+            $result = [];
+            foreach($property as $key) {
+                $result[$key] = $this->$key ?? $fallback[$key] ?? null;
+            }
+            return $result;
         }
 
         return $this->$property ?? $fallback;

--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -63,13 +63,14 @@ class Obj extends stdClass
     }
 
     /**
-     * Property Getter
+     * Gets one or multiple properties of the object
      *
      * @param string|array $property
-     * @param mixed $fallback
+     * @param mixed $fallback If multiple properties are requested:
+     *                        Associative array of fallback values per key
      * @return mixed
      */
-    public function get(string|array $property, $fallback = null)
+    public function get($property, $fallback = null)
     {
         if (is_array($property)) {
             if (!is_array($fallback)) {
@@ -77,7 +78,7 @@ class Obj extends stdClass
             }
 
             $result = [];
-            foreach($property as $key) {
+            foreach ($property as $key) {
                 $result[$key] = $this->$key ?? $fallback[$key] ?? null;
             }
             return $result;

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -19,6 +19,20 @@ class ObjTest extends TestCase
         $this->assertNull($obj->foo);
     }
 
+    public function test__getMultiple()
+    {
+        $obj = new Obj([
+            'one' => 'first',
+            'two' => 'second',
+            'three' => 'third'
+        ]);
+
+        $this->assertEquals('first', $obj->get('one'));
+        $this->assertEquals(['one' => 'first', 'three' => 'third'], $obj->get(['one', 'three']));
+        $this->assertEquals(['one' => 'first', 'three' => 'third', 'eight' => null], $obj->get(['one', 'three', 'eight']));
+        $this->assertEquals($obj->toArray(), $obj->get(['one', 'two', 'three']));
+    }
+
     public function testToArray()
     {
         $obj = new Obj($expected = [

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -29,8 +29,22 @@ class ObjTest extends TestCase
 
         $this->assertEquals('first', $obj->get('one'));
         $this->assertEquals(['one' => 'first', 'three' => 'third'], $obj->get(['one', 'three']));
-        $this->assertEquals(['one' => 'first', 'three' => 'third', 'eight' => null], $obj->get(['one', 'three', 'eight']));
+        $this->assertEquals([
+            'one' => 'first',
+            'three' => 'third',
+            'four' => 'fallback',
+            'eight' => null
+        ], $obj->get(['one', 'three', 'four', 'eight'], ['four' => 'fallback']));
         $this->assertEquals($obj->toArray(), $obj->get(['one', 'two', 'three']));
+    }
+
+    public function test__getMultipleInvalidFallback()
+    {
+        $this->expectException('Kirby\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('fallback value must be an array');
+
+        $obj = new Obj(['one' => 'first']);
+        $obj->get(['two'], 'invalid fallback');
     }
 
     public function testToArray()

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -19,7 +19,7 @@ class ObjTest extends TestCase
         $this->assertNull($obj->foo);
     }
 
-    public function test__getMultiple()
+    public function testGetMultiple()
     {
         $obj = new Obj([
             'one' => 'first',
@@ -38,7 +38,7 @@ class ObjTest extends TestCase
         $this->assertEquals($obj->toArray(), $obj->get(['one', 'two', 'three']));
     }
 
-    public function test__getMultipleInvalidFallback()
+    public function testGetMultipleInvalidFallback()
     {
         $this->expectException('Kirby\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('fallback value must be an array');


### PR DESCRIPTION
## This PR …

### Features

Added support for getting multiple properties from `Toolkit\Obj` objects and derived objects, like so:

```php
$thing = new Obj(['one' => '👋', 'two' => 'Kirby']);

$properties = $thing->get(['one', 'three'], ['three' => 'fallback']);
// results in ['one' => '👋', 'three' => 'fallback']
```

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

~Because it uses `A::get()` internally, getting non-existent properties in the array returns `['no' => null]`, which I'm not quite sure how to handle - it makes sense from a consistency POV, but might not be expected. I didn't want to pollute the PR with more robust edge case handling.~

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
