### PR TITLE
Feature: random in `Toolkit\A` and `Toolkit\Collection`

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -336,6 +336,29 @@ class A
     }
 
     /**
+     * Returns a number of random elements from an array,
+     * either in original or shuffled order
+     *
+     * @param array $array
+     * @param integer $count
+     * @param boolean $shuffle
+     * @return array
+     */
+    public static function random(array $array, int $count = 1, bool $shuffle = false): array
+    {
+        if ($shuffle) {
+            return array_slice(self::shuffle($array), 0, $count);
+        }
+
+        if ($count === 1) {
+            $key = array_rand($array);
+            return [$key => $array[$key]];
+        }
+
+        return self::get($array, array_rand($array, $count));
+    }
+
+    /**
      * Fills an array up with additional elements to certain amount.
      *
      * <code>

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -340,8 +340,8 @@ class A
      * either in original or shuffled order
      *
      * @param array $array
-     * @param integer $count
-     * @param boolean $shuffle
+     * @param int $count
+     * @param bool $shuffle
      * @return array
      */
     public static function random(array $array, int $count = 1, bool $shuffle = false): array

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -876,7 +876,7 @@ class Collection extends Iterator implements Countable
      *
      * @param int $count
      * @param bool $shuffle
-     * @return $this|static
+     * @return static
      */
     public function random(int $count = 1, bool $shuffle = false)
     {

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -870,6 +870,17 @@ class Collection extends Iterator implements Countable
         return $result;
     }
 
+    public function random(int $count = 1, bool $shuffle = false)
+    {
+        if ($shuffle) {
+            return $this->shuffle()->slice(0, $count);
+        }
+
+        $collection = clone $this;
+        $collection->data = A::random($collection->data, $count);
+        return $collection;
+    }
+
     /**
      * Removes an element from the array by key
      *

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -870,6 +870,14 @@ class Collection extends Iterator implements Countable
         return $result;
     }
 
+    /**
+     * Returns a new collection consisting of random elements,
+     * from the original collection, shuffled or ordered
+     *
+     * @param int $count
+     * @param bool $shuffle
+     * @return $this|static
+     */
     public function random(int $count = 1, bool $shuffle = false)
     {
         if ($shuffle) {

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -266,6 +266,34 @@ class ATest extends TestCase
     }
 
     /**
+     * @covers ::random
+     */
+    public function testRandom()
+    {
+        $array = $this->_array();
+        $arrayKeys = array_flip(array_keys($array));
+        $arrayValues = array_flip(array_values($array));
+
+        // Assert existence and correctness of keys
+        $random1 = A::random($array, 1);
+        $this->assertTrue(in_array(array_values($random1)[0], $array));
+        $this->assertTrue(in_array(array_key_first($random1), array_keys($array)));
+
+        // Assert order of keys in non-shuffled random
+        $random2 = A::random($array, 2);
+        $this->assertTrue($arrayKeys[array_key_first($random2)] < $arrayKeys[array_key_last($random2)]);
+
+        // Assert count in completely shuffled array
+        $random3 = A::random($array, 3, true);
+        $this->assertSame(count($array), count($random3));
+        foreach ($random3 as $key => $value) {
+            $this->assertContains($key, array_keys($array));
+            $this->assertContains($value, array_values($array));
+            $this->assertSame($arrayKeys[$key], $arrayValues[$value]);
+        }
+    }
+
+    /**
      * @covers ::fill
      */
     public function testFill()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -285,7 +285,7 @@ class ATest extends TestCase
 
         // Assert count in completely shuffled array
         $random3 = A::random($array, 3, true);
-        $this->assertSame(count($array), count($random3));
+        $this->assertCount(3, $random3);
         foreach ($random3 as $key => $value) {
             $this->assertContains($key, array_keys($array));
             $this->assertContains($value, array_values($array));

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -773,6 +773,36 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * @covers ::random
+     */
+    public function testRandom()
+    {
+        $collection = new Collection([
+            'one' => 'eins',
+            'two' => 'zwei',
+            'three' => 'drei',
+            'four' => 'vier'
+        ]);
+        $collectionKeys = array_flip($collection->keys());
+        $collectionValues = array_flip($collection->values());
+
+        // Assert existence and correctness of keys
+        $random1 = $collection->random();
+        $this->assertSame($collection->findByKey($random1->keys()[0]), $random1->first());
+
+        // Assert order of keys in non-shuffled random
+        $random2 = $collection->random(2);
+        $this->assertTrue($collectionKeys[$random2->keys()[0]] < $collectionKeys[$random2->keys()[1]]);
+
+        $random3 = $collection->random(3, true);
+        foreach ($random3 as $key => $value) {
+            $this->assertContains($key, $collection->keys());
+            $this->assertContains($value, $collection->values());
+            $this->assertSame($collectionKeys[$key], $collectionValues[$value]);
+        }
+    }
+
+    /**
      * @covers ::__unset
      */
     public function testRemoveMultiple()


### PR DESCRIPTION
## This PR …

### Features

New `A::random()` and `$collection->random()` methods to get one or multiple random items from arrays and collections, optionally shuffled. Unless shuffled, the overall order of the returned items is kept.

### Breaking changes

*None*

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
@distantnative said he doesn't hate me yet

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
