### PR TITLE
Add frame option to ImageMagick Darkroom Driver

### DIFF
--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -82,8 +82,14 @@ class ImageMagick extends Darkroom
             }
         }
 
+        // frame option to allow selecting layers for multi-layer or frames for animated images
+        $fileOptions = '';
+        if ($options['frame'] !== null) {
+            $fileOptions = '[' . escapeshellarg($options['frame']) . ']';
+        }
+
         // append input file
-        return $command . ' ' . escapeshellarg($file);
+        return $command . ' ' . escapeshellarg($file) . $fileOptions;
     }
 
     /**
@@ -96,6 +102,7 @@ class ImageMagick extends Darkroom
         return parent::defaults() + [
             'bin'       => 'convert',
             'interlace' => false,
+            'frame'     => null,
         ];
     }
 


### PR DESCRIPTION
## This PR …
Adds a frame option to the ImageMagick Thumb/Darkroom Driver, that allows one to select a single frame from an animated or multi-layered image. This should be useful when e.g. generating inline thumbs that shouldn't be animated, with e.g. [kirby-blurry-placeholder](https://github.com/johannschopplich/kirby-blurry-placeholder/blob/main/classes/KirbyExtended/BlurryPlaceholder.php) - [see also](https://github.com/johannschopplich/kirby-blurry-placeholder/issues/18).

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
