### PR TITLE
Fine-tuned cache handling based on request data

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1336,11 +1336,16 @@ class App
      */
     public function session(array $options = [])
     {
-        // never cache responses that depend on the session
-        $this->response()->cache(false);
-        $this->response()->header('Cache-Control', 'no-store', true);
+        $session = $this->sessionHandler()->get($options);
 
-        return $this->sessionHandler()->get($options);
+        // disable caching for sessions that use the `Authorization` header;
+        // cookie sessions are already covered by the `Cookie` class
+        if ($session->mode() === 'manual') {
+            $this->response()->cache(false);
+            $this->response()->header('Cache-Control', 'no-store, private', true);
+        }
+
+        return $session;
     }
 
     /**

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -43,7 +43,7 @@ class Responder
      * Flag that defines whether the current
      * response can be cached by Kirby's cache
      *
-     * @var string
+     * @var bool
      */
     protected $cache = true;
 
@@ -60,6 +60,23 @@ class Responder
      * @var string
      */
     protected $type = null;
+
+    /**
+     * Flag that defines whether the current
+     * response uses the HTTP `Authorization`
+     * request header
+     *
+     * @var bool
+     */
+    protected $usesAuth = false;
+
+    /**
+     * List of cookie names the response
+     * relies on
+     *
+     * @var array
+     */
+    protected $usesCookies = [];
 
     /**
      * Creates and sends the response
@@ -99,10 +116,68 @@ class Responder
     public function cache(?bool $cache = null)
     {
         if ($cache === null) {
+            // never ever cache private responses
+            if (static::isPrivate($this->usesAuth(), $this->usesCookies()) === true) {
+                return false;
+            }
+
             return $this->cache;
         }
 
         $this->cache = $cache;
+        return $this;
+    }
+
+    /**
+     * Setter and getter for the flag that defines
+     * whether the current response uses the HTTP
+     * `Authorization` request header
+     * @since 3.6.6
+     *
+     * @param bool|null $usesAuth
+     * @return bool|$this
+     */
+    public function usesAuth(?bool $usesAuth = null)
+    {
+        if ($usesAuth === null) {
+            return $this->usesAuth;
+        }
+
+        $this->usesAuth = $usesAuth;
+        return $this;
+    }
+
+    /**
+     * Setter for a cookie name that is
+     * used by the response
+     * @since 3.6.6
+     *
+     * @param string $name
+     * @return void
+     */
+    public function usesCookie(string $name): void
+    {
+        // only add unique names
+        if (in_array($name, $this->usesCookies) === false) {
+            $this->usesCookies[] = $name;
+        }
+    }
+
+    /**
+     * Setter and getter for the list of cookie
+     * names the response relies on
+     * @since 3.6.6
+     *
+     * @param array|null $usesCookies
+     * @return array|$this
+     */
+    public function usesCookies(?array $usesCookies = null)
+    {
+        if ($usesCookies === null) {
+            return $this->usesCookies;
+        }
+
+        $this->usesCookies = $usesCookies;
         return $this;
     }
 
@@ -179,10 +254,13 @@ class Responder
     public function fromArray(array $response): void
     {
         $this->body($response['body'] ?? null);
-        $this->expires($response['expires'] ?? null);
+        $this->cache($response['cache'] ?? null);
         $this->code($response['code'] ?? null);
+        $this->expires($response['expires'] ?? null);
         $this->headers($response['headers'] ?? null);
         $this->type($response['type'] ?? null);
+        $this->usesAuth($response['usesAuth'] ?? null);
+        $this->usesCookies($response['usesCookies'] ?? null);
     }
 
     /**
@@ -196,7 +274,7 @@ class Responder
     public function header(string $key, $value = null, bool $lazy = false)
     {
         if ($value === null) {
-            return $this->headers[$key] ?? null;
+            return $this->headers()[$key] ?? null;
         }
 
         if ($value === false) {
@@ -221,7 +299,31 @@ class Responder
     public function headers(array $headers = null)
     {
         if ($headers === null) {
-            return $this->headers;
+            $injectedHeaders = [];
+
+            if (static::isPrivate($this->usesAuth(), $this->usesCookies()) === true) {
+                // never ever cache private responses
+                $injectedHeaders['Cache-Control'] = 'no-store, private';
+            } else {
+                // the response is public, but it may
+                // vary based on request headers
+                $vary = [];
+
+                if ($this->usesAuth() === true) {
+                    $vary[] = 'Authorization';
+                }
+
+                if ($this->usesCookies() !== []) {
+                    $vary[] = 'Cookie';
+                }
+
+                if ($vary !== []) {
+                    $injectedHeaders['Vary'] = implode(', ', $vary);
+                }
+            }
+
+            // lazily inject (never override custom headers)
+            return array_merge($injectedHeaders, $this->headers);
         }
 
         $this->headers = $headers;
@@ -283,11 +385,14 @@ class Responder
      */
     public function toArray(): array
     {
+        // the `cache`, `expires`, `usesAuth` and `usesCookies`
+        // values are explicitly *not* serialized as they are
+        // volatile and not to be exported
         return [
-            'body'    => $this->body,
-            'code'    => $this->code,
-            'headers' => $this->headers,
-            'type'    => $this->type,
+            'body'    => $this->body(),
+            'code'    => $this->code(),
+            'headers' => $this->headers(),
+            'type'    => $this->type(),
         ];
     }
 
@@ -309,5 +414,33 @@ class Responder
 
         $this->type = $type;
         return $this;
+    }
+
+    /**
+     * Checks whether the response needs to be exempted from
+     * all caches due to using dynamic data based on auth
+     * and/or cookies; the request data only matters if it
+     * is actually used/relied on by the response
+     * @internal
+     *
+     * @param bool $usesAuth
+     * @param array $usesCookies
+     * @return bool
+     */
+    public static function isPrivate(bool $usesAuth, array $usesCookies): bool
+    {
+        $kirby = App::instance();
+
+        if ($usesAuth === true && $kirby->request()->hasAuth() === true) {
+            return true;
+        }
+
+        foreach ($usesCookies as $cookie) {
+            if (isset($_COOKIE[$cookie]) === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -132,7 +132,7 @@ class Responder
      * Setter and getter for the flag that defines
      * whether the current response uses the HTTP
      * `Authorization` request header
-     * @since 3.6.6
+     * @since 3.7.0
      *
      * @param bool|null $usesAuth
      * @return bool|$this
@@ -150,7 +150,7 @@ class Responder
     /**
      * Setter for a cookie name that is
      * used by the response
-     * @since 3.6.6
+     * @since 3.7.0
      *
      * @param string $name
      * @return void
@@ -166,7 +166,7 @@ class Responder
     /**
      * Setter and getter for the list of cookie
      * names the response relies on
-     * @since 3.6.6
+     * @since 3.7.0
      *
      * @param array|null $usesCookies
      * @return array|$this
@@ -421,6 +421,7 @@ class Responder
      * all caches due to using dynamic data based on auth
      * and/or cookies; the request data only matters if it
      * is actually used/relied on by the response
+     * @since 3.7.0
      * @internal
      *
      * @param bool $usesAuth

--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use Kirby\Toolkit\Str;
 
 /**
@@ -41,6 +42,9 @@ class Cookie
      */
     public static function set(string $key, string $value, array $options = []): bool
     {
+        // modify CMS caching behavior
+        static::trackUsage($key);
+
         // extract options
         $expires  = static::lifetime($options['lifetime'] ?? 0);
         $path     = $options['path']     ?? '/';
@@ -123,6 +127,10 @@ class Cookie
         if ($key === null) {
             return $_COOKIE;
         }
+
+        // modify CMS caching behavior
+        static::trackUsage($key);
+
         $value = $_COOKIE[$key] ?? null;
         return empty($value) ? $default : static::parse($value);
     }
@@ -205,5 +213,22 @@ class Cookie
         }
 
         return false;
+    }
+
+    /**
+     * Tells the CMS responder that a cookie was used
+     * to modify the caching behavior
+     *
+     * @param string $key
+     * @return void
+     */
+    protected static function trackUsage(string $key): void
+    {
+        // lazily request the instance for non-CMS use cases
+        $kirby = App::instance(null, true);
+
+        if ($kirby) {
+            $kirby->response()->usesCookie($key);
+        }
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -302,7 +302,7 @@ class Request
     /**
      * Returns whether the request contains
      * the `Authorization` header
-     * @since 3.6.6
+     * @since 3.7.0
      *
      * @return bool
      */

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use Kirby\Http\Request\Body;
 use Kirby\Http\Request\Files;
 use Kirby\Http\Request\Query;
@@ -156,6 +157,13 @@ class Request
             return $this->auth;
         }
 
+        // modify CMS caching behavior:
+        // lazily request the instance for non-CMS use cases
+        $kirby = App::instance(null, true);
+        if ($kirby) {
+            $kirby->response()->usesAuth(true);
+        }
+
         if ($auth = $this->options['auth'] ?? $this->header('authorization')) {
             $type = Str::lower(Str::before($auth, ' '));
             $data = Str::after($auth, ' ');
@@ -289,6 +297,20 @@ class Request
     public function get($key = null, $fallback = null)
     {
         return A::get($this->data(), $key, $fallback);
+    }
+
+    /**
+     * Returns whether the request contains
+     * the `Authorization` header
+     * @since 3.6.6
+     *
+     * @return bool
+     */
+    public function hasAuth(): bool
+    {
+        $header = $this->options['auth'] ?? $this->header('authorization');
+
+        return $header !== null;
     }
 
     /**

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -210,7 +210,7 @@ class Panel
     {
         return Response::json($data, $code, get('_pretty'), [
             'X-Fiber' => 'true',
-            'Cache-Control' => 'no-store'
+            'Cache-Control' => 'no-store, private'
         ]);
     }
 

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -468,14 +468,20 @@ class AppTest extends TestCase
 
         $this->assertInstanceOf(Session::class, $app->session());
 
+        $this->assertTrue($app->response()->cache());
+        $this->assertSame(['Vary' => 'Cookie'], $app->response()->headers());
+
+        // manual session that blocks caching
+        $app->response()->headers([]);
+        $this->assertInstanceOf(Session::class, $app->session(['createMode' => 'manual']));
         $this->assertFalse($app->response()->cache());
-        $this->assertSame(['Cache-Control' => 'no-store'], $app->response()->headers());
+        $this->assertSame(['Vary' => 'Cookie', 'Cache-Control' => 'no-store, private'], $app->response()->headers());
 
         // test lazy header setter
-        $app->response()->header('Cache-Control', 'custom');
-        $this->assertInstanceOf(Session::class, $app->session());
+        $app->response()->headers(['Cache-Control' => 'custom']);
+        $this->assertInstanceOf(Session::class, $app->session(['createMode' => 'manual']));
         $this->assertFalse($app->response()->cache());
-        $this->assertSame(['Cache-Control' => 'custom'], $app->response()->headers());
+        $this->assertSame(['Vary' => 'Cookie', 'Cache-Control' => 'custom'], $app->response()->headers());
     }
 
     public function testInstance()

--- a/tests/Cms/Pages/PageCacheTest.php
+++ b/tests/Cms/Pages/PageCacheTest.php
@@ -3,32 +3,48 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
-use Kirby\Filesystem\F;
 use PHPUnit\Framework\TestCase;
 
 class PageCacheTest extends TestCase
 {
     protected $app;
-    protected $fixtures;
+    protected $tmp;
 
     public function setUp(): void
     {
         $this->app = new App([
             'roots' => [
-                'index' => $this->fixtures = __DIR__ . '/fixtures/PageCacheTest'
+                'index'     => $this->tmp = __DIR__ . '/tmp',
+                'templates' => __DIR__ . '/fixtures/PageCacheTest'
             ],
             'site' => [
                 'children' => [
                     [
-                        'slug' => 'a'
+                        'slug' => 'default'
                     ],
                     [
-                        'slug'     => 'b',
+                        'slug'     => 'expiry',
                         'template' => 'expiry'
                     ],
                     [
-                        'slug'     => 'c',
+                        'slug'     => 'disabled',
                         'template' => 'disabled'
+                    ],
+                    [
+                        'slug'     => 'dynamic-auth',
+                        'template' => 'dynamic'
+                    ],
+                    [
+                        'slug'     => 'dynamic-cookie',
+                        'template' => 'dynamic'
+                    ],
+                    [
+                        'slug'     => 'dynamic-session',
+                        'template' => 'dynamic'
+                    ],
+                    [
+                        'slug'     => 'dynamic-auth-session',
+                        'template' => 'dynamic'
                     ]
                 ]
             ],
@@ -37,24 +53,18 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        Dir::make($this->fixtures);
-        F::write(
-            $this->fixtures . '/site/templates/default.php',
-            'This is a test: <?= uniqid() ?>'
-        );
-        F::write(
-            $this->fixtures . '/site/templates/disabled.php',
-            'This is a test: <?= uniqid() ?><?php $kirby->response()->cache(false); ?>'
-        );
-        F::write(
-            $this->fixtures . '/site/templates/expiry.php',
-            '<?php $time = random_int(1000000000, 2000000000); $kirby->response()->expires($time); echo $time;'
-        );
+        Dir::make($this->tmp);
     }
 
     public function tearDown(): void
     {
-        Dir::remove($this->fixtures);
+        Dir::remove($this->tmp);
+
+        unset(
+            $_COOKIE['foo'],
+            $_COOKIE['kirby_session'],
+            $_SERVER['HTTP_AUTHORIZATION']
+        );
     }
 
     public function requestMethodProvider()
@@ -80,7 +90,7 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals($expected, $app->page('a')->isCacheable());
+        $this->assertEquals($expected, $app->page('default')->isCacheable());
     }
 
     /**
@@ -95,7 +105,7 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        $this->assertFalse($app->page('a')->isCacheable());
+        $this->assertFalse($app->page('default')->isCacheable());
     }
 
     public function testRequestParams()
@@ -106,7 +116,7 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        $this->assertFalse($app->page('a')->isCacheable());
+        $this->assertFalse($app->page('default')->isCacheable());
     }
 
     public function testIgnoreId()
@@ -115,14 +125,14 @@ class PageCacheTest extends TestCase
             'options' => [
                 'cache.pages' => [
                     'ignore' => [
-                        'b'
+                        'expiry'
                     ]
                 ]
             ]
         ]);
 
-        $this->assertTrue($app->page('a')->isCacheable());
-        $this->assertFalse($app->page('b')->isCacheable());
+        $this->assertTrue($app->page('default')->isCacheable());
+        $this->assertFalse($app->page('expiry')->isCacheable());
     }
 
     public function testIgnoreCallback()
@@ -131,14 +141,14 @@ class PageCacheTest extends TestCase
             'options' => [
                 'cache.pages' => [
                     'ignore' => function ($page) {
-                        return $page->id() === 'a';
+                        return $page->id() === 'default';
                     }
                 ]
             ]
         ]);
 
-        $this->assertFalse($app->page('a')->isCacheable());
-        $this->assertTrue($app->page('b')->isCacheable());
+        $this->assertFalse($app->page('default')->isCacheable());
+        $this->assertTrue($app->page('expiry')->isCacheable());
     }
 
     public function testDisabledCache()
@@ -150,7 +160,7 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        $this->assertFalse($app->page('a')->isCacheable());
+        $this->assertFalse($app->page('default')->isCacheable());
 
         // deactivate in array
         $app = $this->app->clone([
@@ -161,20 +171,20 @@ class PageCacheTest extends TestCase
             ]
         ]);
 
-        $this->assertFalse($app->page('a')->isCacheable());
+        $this->assertFalse($app->page('default')->isCacheable());
     }
 
     public function testRenderCache()
     {
         $cache = $this->app->cache('pages');
-        $page  = $this->app->page('a');
+        $page  = $this->app->page('default');
 
-        $this->assertNull($cache->retrieve('a.html'));
+        $this->assertNull($cache->retrieve('default.html'));
 
         $html1 = $page->render();
         $this->assertStringStartsWith('This is a test:', $html1);
 
-        $value = $cache->retrieve('a.html');
+        $value = $cache->retrieve('default.html');
         $this->assertInstanceOf('Kirby\Cache\Value', $value);
         $this->assertSame($html1, $value->value()['html']);
         $this->assertNull($value->expires());
@@ -186,13 +196,13 @@ class PageCacheTest extends TestCase
     public function testRenderCacheCustomExpiry()
     {
         $cache = $this->app->cache('pages');
-        $page  = $this->app->page('b');
+        $page  = $this->app->page('expiry');
 
-        $this->assertNull($cache->retrieve('b.html'));
+        $this->assertNull($cache->retrieve('expiry.html'));
 
         $time = $page->render();
 
-        $value = $cache->retrieve('b.html');
+        $value = $cache->retrieve('expiry.html');
         $this->assertInstanceOf('Kirby\Cache\Value', $value);
         $this->assertSame($time, $value->value()['html']);
         $this->assertSame((int)$time, $value->expires());
@@ -201,15 +211,113 @@ class PageCacheTest extends TestCase
     public function testRenderCacheDisabled()
     {
         $cache = $this->app->cache('pages');
-        $page  = $this->app->page('c');
+        $page  = $this->app->page('disabled');
 
-        $this->assertNull($cache->retrieve('c.html'));
+        $this->assertNull($cache->retrieve('disabled.html'));
 
         $html1 = $page->render();
         $this->assertStringStartsWith('This is a test:', $html1);
 
-        $this->assertNull($cache->retrieve('c.html'));
+        $this->assertNull($cache->retrieve('disabled.html'));
 
+        $html2 = $page->render();
+        $this->assertNotSame($html1, $html2);
+    }
+
+    public function dynamicProvider(): array
+    {
+        return [
+            ['dynamic-auth', ['auth']],
+            ['dynamic-cookie', ['cookie']],
+            ['dynamic-session', ['session']],
+            ['dynamic-auth-session', ['auth', 'session']],
+        ];
+    }
+
+    /**
+     * @dataProvider dynamicProvider
+     */
+    public function testRenderCacheDynamicNonActive(string $slug, array $dynamicElements)
+    {
+        $cache = $this->app->cache('pages');
+        $page  = $this->app->page($slug);
+
+        $this->assertNull($cache->retrieve($slug . '.html'));
+
+        $html1 = $page->render();
+        $this->assertStringStartsWith('This is a test:', $html1);
+
+        $cacheValue = $cache->retrieve($slug . '.html');
+        $this->assertNotNull($cacheValue);
+        $this->assertSame(in_array('auth', $dynamicElements), $cacheValue->value()['usesAuth']);
+        if (in_array('cookie', $dynamicElements)) {
+            $this->assertSame(['foo'], $cacheValue->value()['usesCookies']);
+        } elseif (in_array('session', $dynamicElements)) {
+            $this->assertSame(['kirby_session'], $cacheValue->value()['usesCookies']);
+        } else {
+            $this->assertSame([], $cacheValue->value()['usesCookies']);
+        }
+
+        // reset the Kirby Responder object
+        $this->setUp();
+        $html2 = $page->render();
+        $this->assertSame($html1, $html2);
+    }
+
+    /**
+     * @dataProvider dynamicProvider
+     */
+    public function testRenderCacheDynamicActiveOnFirstRender(string $slug, array $dynamicElements)
+    {
+        $_COOKIE['foo'] = $_COOKIE['kirby_session'] = 'bar';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer brown-bearer';
+
+        $cache = $this->app->cache('pages');
+        $page  = $this->app->page($slug);
+
+        $this->assertNull($cache->retrieve($slug . '.html'));
+
+        $html1 = $page->render();
+        $this->assertStringStartsWith('This is a test:', $html1);
+
+        $cacheValue = $cache->retrieve($slug . '.html');
+        $this->assertNull($cacheValue);
+
+        // reset the Kirby Responder object
+        $this->setUp();
+        $html2 = $page->render();
+        $this->assertNotSame($html1, $html2);
+    }
+
+    /**
+     * @dataProvider dynamicProvider
+     */
+    public function testRenderCacheDynamicActiveOnSecondRender(string $slug, array $dynamicElements)
+    {
+        $cache = $this->app->cache('pages');
+        $page  = $this->app->page($slug);
+
+        $this->assertNull($cache->retrieve($slug . '.html'));
+
+        $html1 = $page->render();
+        $this->assertStringStartsWith('This is a test:', $html1);
+
+        $cacheValue = $cache->retrieve($slug . '.html');
+        $this->assertNotNull($cacheValue);
+        $this->assertSame(in_array('auth', $dynamicElements), $cacheValue->value()['usesAuth']);
+        if (in_array('cookie', $dynamicElements)) {
+            $this->assertSame(['foo'], $cacheValue->value()['usesCookies']);
+        } elseif (in_array('session', $dynamicElements)) {
+            $this->assertSame(['kirby_session'], $cacheValue->value()['usesCookies']);
+        } else {
+            $this->assertSame([], $cacheValue->value()['usesCookies']);
+        }
+
+        $_COOKIE['foo'] = $_COOKIE['kirby_session'] = 'bar';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer brown-bearer';
+
+        // reset the Kirby Responder object
+        $this->setUp();
         $html2 = $page->render();
         $this->assertNotSame($html1, $html2);
     }

--- a/tests/Cms/Pages/fixtures/PageCacheTest/default.php
+++ b/tests/Cms/Pages/fixtures/PageCacheTest/default.php
@@ -1,0 +1,1 @@
+This is a test: <?= uniqid() ?>

--- a/tests/Cms/Pages/fixtures/PageCacheTest/disabled.php
+++ b/tests/Cms/Pages/fixtures/PageCacheTest/disabled.php
@@ -1,0 +1,3 @@
+This is a test: <?= uniqid() ?>
+
+<?php $kirby->response()->cache(false); ?>

--- a/tests/Cms/Pages/fixtures/PageCacheTest/dynamic.php
+++ b/tests/Cms/Pages/fixtures/PageCacheTest/dynamic.php
@@ -1,0 +1,15 @@
+This is a test: <?= uniqid() ?>
+
+<?php
+
+if (Str::contains($page->slug(), '-auth')) {
+    $kirby->request()->auth();
+}
+
+if (Str::contains($page->slug(), '-cookie')) {
+    Cookie::get('foo');
+}
+
+if (Str::contains($page->slug(), '-session')) {
+    $kirby->session();
+}

--- a/tests/Cms/Pages/fixtures/PageCacheTest/expiry.php
+++ b/tests/Cms/Pages/fixtures/PageCacheTest/expiry.php
@@ -1,0 +1,6 @@
+<?php
+
+$time = random_int(1000000000, 2000000000);
+
+$kirby->response()->expires($time);
+echo $time;

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -18,6 +18,11 @@ class ResponderTest extends TestCase
         ]);
     }
 
+    public function tearDown(): void
+    {
+        unset($_COOKIE['foo'], $_SERVER['HTTP_AUTHORIZATION']);
+    }
+
     /**
      * @covers ::cache
      */
@@ -26,10 +31,38 @@ class ResponderTest extends TestCase
         $responder = new Responder();
         $this->assertTrue($responder->cache());
 
+        $this->assertSame($responder, $responder->cache(false));
+        $this->assertFalse($responder->cache());
+
         $this->assertSame($responder, $responder->cache(true));
         $this->assertTrue($responder->cache());
+    }
 
-        $this->assertSame($responder, $responder->cache(false));
+    /**
+     * @covers ::cache
+     */
+    public function testCacheUsesCookies()
+    {
+        $_COOKIE['foo'] = 'bar';
+
+        $responder = new Responder();
+        $this->assertTrue($responder->cache());
+
+        $responder->usesCookie('foo');
+        $this->assertFalse($responder->cache());
+    }
+
+    /**
+     * @covers ::cache
+     */
+    public function testCacheUsesAuth()
+    {
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer brown-bearer';
+
+        $responder = new Responder();
+        $this->assertTrue($responder->cache());
+
+        $responder->usesAuth(true);
         $this->assertFalse($responder->cache());
     }
 
@@ -100,18 +133,27 @@ class ResponderTest extends TestCase
     {
         $responder = new Responder();
         $responder->fromArray([
-            'body'    => 'Lorem ipsum',
-            'expires' => 1234567890,
-            'code'    => 301,
-            'headers' => ['Location' => 'https://example.com'],
-            'type'    => 'text/plain'
+            'body'        => 'Lorem ipsum',
+            'cache'       => false,
+            'code'        => 301,
+            'expires'     => 1234567890,
+            'headers'     => ['Location' => 'https://example.com'],
+            'type'        => 'text/plain',
+            'usesAuth'    => true,
+            'usesCookies' => ['foo'],
         ]);
 
         $this->assertSame('Lorem ipsum', $responder->body());
-        $this->assertSame(1234567890, $responder->expires());
         $this->assertSame(301, $responder->code());
-        $this->assertSame(['Location' => 'https://example.com'], $responder->headers());
+        $this->assertFalse($responder->cache());
+        $this->assertSame(1234567890, $responder->expires());
+        $this->assertSame([
+            'Vary' => 'Authorization, Cookie',
+            'Location' => 'https://example.com'
+        ], $responder->headers());
         $this->assertSame('text/plain', $responder->type());
+        $this->assertTrue($responder->usesAuth());
+        $this->assertSame(['foo'], $responder->usesCookies());
     }
 
     /**
@@ -141,5 +183,176 @@ class ResponderTest extends TestCase
         $this->assertSame('private', $responder->header('Cache-Control'));
         $this->assertSame($responder, $responder->header('Cache-Control', 'no-cache', true));
         $this->assertSame('private', $responder->header('Cache-Control'));
+
+        // modified caching behavior (not active)
+        $responder->headers([]);
+        $responder->usesAuth(true);
+        $responder->usesCookie('foo');
+        $this->assertNull($responder->header('Cache-Control'));
+        $this->assertSame('Authorization, Cookie', $responder->header('Vary'));
+
+        // modified caching behavior (active)
+        $_COOKIE['foo'] = 'bar';
+        $this->assertSame('no-store, private', $responder->header('Cache-Control'));
+        $this->assertNull($responder->header('Vary'));
+
+        // never override custom header value
+        $responder->header('Cache-Control', 'private');
+        $this->assertSame('private', $responder->header('Cache-Control'));
+    }
+
+    /**
+     * @covers ::headers
+     */
+    public function testHeaders()
+    {
+        $responder = new Responder();
+        $this->assertSame([], $responder->headers());
+
+        $this->assertSame($responder, $responder->headers($headers = ['Foo' => 'foo', 'Bar' => 'bar']));
+        $this->assertSame($headers, $responder->headers());
+
+        $this->assertSame($responder, $responder->headers($headers = ['Foo' => 'bar']));
+        $this->assertSame($headers, $responder->headers());
+    }
+
+    /**
+     * @covers ::headers
+     */
+    public function testHeadersCacheBehavior()
+    {
+        $responder = new Responder();
+        $this->assertSame([], $responder->headers());
+
+        // non-active (auth)
+        $responder->usesAuth(true);
+        $responder->usesCookies([]);
+        $this->assertSame(['Vary' => 'Authorization'], $responder->headers());
+
+        // non-active (cookies)
+        $responder->usesAuth(false);
+        $responder->usesCookies(['foo']);
+        $this->assertSame(['Vary' => 'Cookie'], $responder->headers());
+
+        // non-active (both)
+        $responder->usesAuth(true);
+        $responder->usesCookies(['foo']);
+        $this->assertSame(['Vary' => 'Authorization, Cookie'], $responder->headers());
+
+        // active
+        $_COOKIE['foo'] = 'bar';
+        $this->assertSame(['Cache-Control' => 'no-store, private'], $responder->headers());
+
+        // never override custom header value
+        $responder->header('Cache-Control', 'private');
+        $this->assertSame(['Cache-Control' => 'private'], $responder->headers());
+    }
+
+    /**
+     * @covers ::isPrivate
+     */
+    public function testIsPrivate()
+    {
+        $responder = new Responder();
+
+        // no dynamic data in environment
+        $this->assertFalse($responder->isPrivate(true, []));
+        $this->assertFalse($responder->isPrivate(true, ['foo']));
+        $this->assertFalse($responder->isPrivate(true, ['bar']));
+        $this->assertFalse($responder->isPrivate(true, ['foo', 'bar']));
+        $this->assertFalse($responder->isPrivate(false, ['foo']));
+        $this->assertFalse($responder->isPrivate(false, ['foo', 'bar']));
+        $this->assertFalse($responder->isPrivate(false, ['bar']));
+        $this->assertFalse($responder->isPrivate(false, []));
+
+        // with dynamic data in environment
+        $_COOKIE['foo'] = 'bar';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer brown-bearer';
+
+        $this->assertTrue($responder->isPrivate(true, []));
+        $this->assertTrue($responder->isPrivate(true, ['foo']));
+        $this->assertTrue($responder->isPrivate(true, ['bar']));
+        $this->assertTrue($responder->isPrivate(true, ['foo', 'bar']));
+        $this->assertTrue($responder->isPrivate(false, ['foo']));
+        $this->assertTrue($responder->isPrivate(false, ['foo', 'bar']));
+        $this->assertFalse($responder->isPrivate(false, ['bar']));
+        $this->assertFalse($responder->isPrivate(false, []));
+    }
+
+    /**
+     * @covers ::toArray
+     */
+    public function testToArray()
+    {
+        $responder = new Responder();
+        $responder->fromArray([
+            'body'        => 'Lorem ipsum',
+            'cache'       => false,
+            'code'        => 301,
+            'expires'     => 1234567890,
+            'headers'     => ['Location' => 'https://example.com'],
+            'type'        => 'text/plain',
+            'usesAuth'    => true,
+            'usesCookies' => ['foo'],
+        ]);
+
+        $this->assertSame([
+            'body'    => 'Lorem ipsum',
+            'code'    => 301,
+            'headers' => [
+                'Vary'     => 'Authorization, Cookie',
+                'Location' => 'https://example.com'
+            ],
+            'type'    => 'text/plain'
+        ], $responder->toArray());
+    }
+
+    /**
+     * @covers ::usesAuth
+     */
+    public function testUsesAuth()
+    {
+        $responder = new Responder();
+        $this->assertFalse($responder->usesAuth());
+
+        $this->assertSame($responder, $responder->usesAuth(true));
+        $this->assertTrue($responder->usesAuth());
+
+        $this->assertSame($responder, $responder->usesAuth(false));
+        $this->assertFalse($responder->usesAuth());
+    }
+
+    /**
+     * @covers ::usesCookie
+     */
+    public function testUsesCookie()
+    {
+        $responder = new Responder();
+        $this->assertSame([], $responder->usesCookies());
+
+        $responder->usesCookie('foo');
+        $this->assertSame(['foo'], $responder->usesCookies());
+
+        $responder->usesCookie('bar');
+        $this->assertSame(['foo', 'bar'], $responder->usesCookies());
+
+        // deduplication
+        $responder->usesCookie('bar');
+        $this->assertSame(['foo', 'bar'], $responder->usesCookies());
+    }
+
+    /**
+     * @covers ::usesCookies
+     */
+    public function testUsesCookies()
+    {
+        $responder = new Responder();
+        $this->assertSame([], $responder->usesCookies());
+
+        $this->assertSame($responder, $responder->usesCookies($cookies = ['foo', 'bar']));
+        $this->assertSame($cookies, $responder->usesCookies());
+
+        $this->assertSame($responder, $responder->usesCookies($cookies = ['bar']));
+        $this->assertSame($cookies, $responder->usesCookies());
     }
 }

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use PHPUnit\Framework\TestCase;
 
 class CookieTest extends TestCase
@@ -51,6 +52,22 @@ class CookieTest extends TestCase
         $this->assertSame('bar', Cookie::get('foo'));
         $this->assertSame('some amazing default', Cookie::get('does_not_exist', 'some amazing default'));
         $this->assertSame($_COOKIE, Cookie::get());
+    }
+
+    public function testGetSetTrack()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $this->assertSame([], $app->response()->usesCookies());
+
+        Cookie::set('foo', 'fooo');
+        Cookie::get('bar');
+
+        $this->assertSame(['foo', 'bar'], $app->response()->usesCookies());
     }
 
     public function testParse()

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use Kirby\Http\Request\Auth\BasicAuth;
 use Kirby\Http\Request\Auth\BearerAuth;
 use Kirby\Http\Request\Body;
@@ -98,6 +99,22 @@ class RequestTest extends TestCase
         $this->assertFalse($request->auth());
 
         unset($_SERVER['HTTP_AUTHORIZATION']);
+    }
+
+    public function testAuthTrack()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $this->assertFalse($app->response()->usesAuth());
+
+        $request = new Request();
+        $request->auth();
+
+        $this->assertTrue($app->response()->usesAuth());
     }
 
     public function testMethod()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `$kirby->response()->usesAuth()` and `->usesCookie()` method to tell Kirby's automatic caching system about used `Authorization` headers and cookies. These methods are called automatically when the Kirby `Request` and `Cookie` classes are used. #4277
- New `$kirby->request()->hasAuth()` method to check the existence of the `Authorization` header #4277

### Enhancements

- Kirby's response handling now automatically controls page and HTTP caching based on cookies, session and the `Authorization` request header being used by the response. If any of these are used and also contained in the request, the response is considered private. If they are used but not contained in the request, the page is only cached for visitors without these cookies/session/auth. Manual sessions are always considered private. #3976

### Fixes

- Fixed a regression that prevented page and HTTP caching when the session was accessed, even when the session was not active #3976
- The Panel and API now send the `Cache-Control: no-store, private` response header instead of just `Cache-Control: no-store` for better compatibility with caches like CloudFlare #4299

### Breaking changes

*None*

## Explanation

This PR implements the behavior I wrote down in https://github.com/getkirby/kirby/issues/3976#issuecomment-1094297863.

I have done manual tests in the frontend and Panel to confirm the behavior and also added detailed unit tests to avoid regressions in the future.

**But the big question is if the behavior is correct at all.** So I'm happy for your help with real-world testing in actual projects. Does this PR behave like you expect? A few notes and recommendations for testing:

- Make sure that the page cache is enabled. Also ensure the cache is cleared when you start testing.
- Relevant are four cases:
  - Pages that *don't* use the session or cookies.
  - Pages that use the session and/or cookies in various ways with the visitor having the cookie(s) already set when first visiting the page with empty page cache.
  - The same, but after the page was already cached by another visitor that didn't have the cookie(s) set.
  - The same, but with repeated requests by a visitor that doesn't have the cookie(s) set.
- Please note that responses that set cookies or store data in the session are treated like a visitor that already requests with those cookies or session.
- The changes have both an effect on response headers for caching (`Vary` and `Cache-Control`) and also on the page cache (prevention of caching in the first place or prevention of cache retrieval).

Pinging @sebastiangreger @bvdputte @gearsdigital @adamkiss @christophknoth as you were involved in the original issue discussion.

If everything is fine, we plan to release this change in Kirby 3.6.6 (RC on Tuesday 26th).

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
