### PR TITLE
Fixed Fiber requests to non-origin urls 

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -16,8 +16,7 @@ return [
     'page.changeSort' => [
         'pattern' => 'pages/(:any)/changeSort',
         'load' => function (string $id) {
-            $page     = Find::page($id);
-            $position = null;
+            $page = Find::page($id);
 
             if ($page->blueprint()->num() !== 'default') {
                 throw new PermissionException([

--- a/panel/src/fiber/index.js
+++ b/panel/src/fiber/index.js
@@ -220,6 +220,14 @@ export default class Fiber {
 
     try {
       const url = this.url(path, options.query);
+
+      // don't even try to request a cross-origin url
+      // redirect instead.
+      if (new URL(url).origin !== location.origin) {
+        this.redirect(url);
+        return false;
+      }
+
       const response = await this.fetch(url, {
         method: options.method,
         body: this.body(options.body),


### PR DESCRIPTION
## Fixes

- Redirects to non-origin URLs caused a network exception. They now trigger a full redirect instead of sending the Fiber request. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
