### PR TITLE
Fix and support callback option to programmable page and user blueprints

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -289,13 +289,16 @@ class Blueprint
             $file = $kirby->extension('blueprints', $name);
         }
 
+        // callback option can be return array or blueprint file path
+        if (is_callable($file) === true) {
+            $file = $file($kirby);
+        }
+
         // now ensure that we always return the data array
         if (is_string($file) === true && F::exists($file) === true) {
             return static::$loaded[$name] = Data::read($file);
         } elseif (is_array($file) === true) {
             return static::$loaded[$name] = $file;
-        } elseif (is_callable($file) === true) {
-            return static::$loaded[$name] = $file($kirby);
         }
 
         // neither a valid file nor array data

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -106,12 +106,12 @@ class Roles extends Collection
                 continue;
             }
 
-            if (is_array($blueprint) === true) {
-                $role = Role::factory($blueprint, $inject);
-            } elseif (is_callable($blueprint) === true) {
+            // callback option can be return array or blueprint file path
+            if (is_callable($blueprint) === true) {
                 $blueprint = $blueprint($kirby);
-                $blueprint['name'] ??= $blueprintName;
+            }
 
+            if (is_array($blueprint) === true) {
                 $role = Role::factory($blueprint, $inject);
             } else {
                 $role = Role::load($blueprint, $inject);

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -97,15 +97,21 @@ class Roles extends Collection
      */
     public static function load(string $root = null, array $inject = [])
     {
+        $kirby = App::instance();
         $roles = new static();
 
         // load roles from plugins
-        foreach (App::instance()->extensions('blueprints') as $blueprintName => $blueprint) {
+        foreach ($kirby->extensions('blueprints') as $blueprintName => $blueprint) {
             if (substr($blueprintName, 0, 6) !== 'users/') {
                 continue;
             }
 
             if (is_array($blueprint) === true) {
+                $role = Role::factory($blueprint, $inject);
+            } elseif (is_callable($blueprint) === true) {
+                $blueprint = $blueprint($kirby);
+                $blueprint['name'] ??= $blueprintName;
+
                 $role = Role::factory($blueprint, $inject);
             } else {
                 $role = Role::load($blueprint, $inject);

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Data\Data;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -341,7 +342,7 @@ class BlueprintTest extends TestCase
      * @covers ::factory
      * @covers ::find
      */
-    public function testFactoryWithCallback()
+    public function testFactoryWithCallbackArray()
     {
         Blueprint::$loaded = [];
 
@@ -352,6 +353,34 @@ class BlueprintTest extends TestCase
                 }
             ]
         ]);
+
+        $blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+
+        $this->assertSame('Test', $blueprint->title());
+        $this->assertSame('pages/test', $blueprint->name());
+    }
+
+    /**
+     * @covers ::factory
+     * @covers ::find
+     */
+    public function testFactoryWithCallbackString()
+    {
+        Blueprint::$loaded = [];
+
+        $this->app = $this->app->clone([
+            'roots' => [
+                'index' => '/dev/null',
+                'blueprints' => $fixtures = __DIR__ . '/fixtures/BlueprintTest/factoryWithCallbackString',
+            ],
+            'blueprints' => [
+                'pages/test' => function () use ($fixtures) {
+                    return $fixtures . '/custom/test.yml';
+                }
+            ]
+        ]);
+
+        Data::write($fixtures . '/custom/test.yml', ['title' => 'Test']);
 
         $blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
 

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -55,6 +55,32 @@ class RolesTest extends TestCase
         $this->assertEquals('editor', $roles->last()->name());
     }
 
+    public function testLoadFromPluginsCallable()
+    {
+        new App([
+            'blueprints' => [
+                'users/admin' => function () {
+                    return [
+                        'name' => 'admin',
+                        'title' => 'Admin'
+                    ];
+                },
+                'users/editor' => function () {
+                    return [
+                        'name' => 'editor',
+                        'title' => 'Editor'
+                    ];
+                }
+            ]
+        ]);
+
+        $roles = Roles::load();
+
+        $this->assertCount(2, $roles);
+        $this->assertSame('admin', $roles->first()->name());
+        $this->assertSame('editor', $roles->last()->name());
+    }
+
     public function testCanBeChanged()
     {
         new App([

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Data\Data;
+use Kirby\Filesystem\Dir;
+
 class RolesTest extends TestCase
 {
     public function testFactory()
@@ -55,7 +58,43 @@ class RolesTest extends TestCase
         $this->assertEquals('editor', $roles->last()->name());
     }
 
-    public function testLoadFromPluginsCallable()
+    public function testLoadFromPluginsCallbackString()
+    {
+        new App([
+            'roots' => [
+                'index' => '/dev/null',
+                'blueprints' => $fixtures = __DIR__ . '/fixtures/RolesTest/loadFromPluginsCallbackString',
+            ],
+            'blueprints' => [
+                'users/admin' => function () use ($fixtures) {
+                    return $fixtures . '/custom/admin.yml';
+                },
+                'users/editor' => function () use ($fixtures) {
+                    return $fixtures . '/custom/editor.yml';
+                }
+            ]
+        ]);
+
+        Data::write($fixtures . '/custom/admin.yml', [
+            'name' => 'admin',
+            'title' => 'Admin'
+        ]);
+
+        Data::write($fixtures . '/custom/editor.yml', [
+            'name' => 'editor',
+            'title' => 'Editor'
+        ]);
+
+        $roles = Roles::load();
+
+        $this->assertCount(2, $roles);
+        $this->assertSame('admin', $roles->first()->name());
+        $this->assertSame('editor', $roles->last()->name());
+
+        Dir::remove($fixtures);
+    }
+
+    public function testLoadFromPluginsCallbackArray()
     {
         new App([
             'blueprints' => [


### PR DESCRIPTION
## This PR …

Added missing callback support for loading user roles via plugins.

### Enhancements

- Support returning blueprint file path in callback for programmable blueprints

### Fixes

- Fixed callback option for user blueprints load

### Breaking changes

None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
