### PR TITLE
Fix PHPUnit `@covers` warnings

### DIFF
--- a/tests/Cms/Pages/PageBlueprintTest.php
+++ b/tests/Cms/Pages/PageBlueprintTest.php
@@ -4,6 +4,9 @@ namespace Kirby\Cms;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\PageBlueprint
+ */
 class PageBlueprintTest extends TestCase
 {
     public function testOptions()

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -19,7 +19,7 @@ class ModelFileTestForceLocked extends ModelFile
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\File|\Kirby\Panel\Model
+ * @coversDefaultClass \Kirby\Panel\File
  */
 class FileTest extends TestCase
 {

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -18,7 +18,7 @@ class ModelPageTestForceLocked extends ModelPage
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\Page|\Kirby\Panel\Model
+ * @coversDefaultClass \Kirby\Panel\Page
  */
 class PageTest extends TestCase
 {

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -18,7 +18,7 @@ class ModelUserTestForceLocked extends ModelUser
 }
 
 /**
- * @coversDefaultClass \Kirby\Panel\User|\Kirby\Panel\Model
+ * @coversDefaultClass \Kirby\Panel\User
  */
 class UserTest extends TestCase
 {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

See for example https://github.com/getkirby/kirby/runs/6194858507?check_suite_focus=true#step:12:101

*No release notes necessary (internal refactoring)*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Tests and checks all pass