### PR TITLE
New stats section

### DIFF
--- a/config/sections/stats.php
+++ b/config/sections/stats.php
@@ -1,0 +1,56 @@
+<?php
+
+use Kirby\Toolkit\I18n;
+
+return [
+    'mixins' => [
+        'headline',
+    ],
+    'props' => [
+        'reports' => function ($reports = null) {
+            if ($reports === null) {
+                return [];
+            }
+
+            if (is_string($reports) === true) {
+                $reports = $this->model()->query($reports);
+            }
+
+            if (is_array($reports) === false) {
+                return [];
+            }
+
+            return $reports;
+        }
+    ],
+    'computed' => [
+        'reports' => function () {
+            $reports = [];
+            $model   = $this->model();
+
+            $value = function ($value) use ($model) {
+                return $value === null ? null : $model->toString($value);
+            };
+
+            foreach ($this->reports as $report) {
+                if (is_string($report) === true) {
+                    $report = $model->query($report);
+                }
+
+                if (is_array($report) === false) {
+                    continue;
+                }
+
+                $reports[] = [
+                    'label' => I18n::translate($report['label'], $report['label']),
+                    'value' => $value($report['value'] ?? null),
+                    'info'  => $value($report['info'] ?? null),
+                    'link'  => $value($report['link'] ?? null),
+                    'theme' => $value($report['theme'] ?? null)
+                ];
+            }
+
+            return $reports;
+        }
+    ]
+];

--- a/config/sections/stats.php
+++ b/config/sections/stats.php
@@ -27,10 +27,7 @@ return [
         'reports' => function () {
             $reports = [];
             $model   = $this->model();
-
-            $value = function ($value) use ($model) {
-                return $value === null ? null : $model->toString($value);
-            };
+            $value   = fn ($value) => $value === null ? null : $model->toString($value);
 
             foreach ($this->reports as $report) {
                 if (is_string($report) === true) {

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -470,18 +470,18 @@
   "section.required": "The section is required",
 
   "select": "Select",
+  "server": "Server",
   "settings": "Settings",
   "show": "Show",
+  "site.blueprint": "The site has no blueprint yet. You can define the setup in <strong>/site/blueprints/site.yml</strong>",
   "size": "Size",
   "slug": "URL appendix",
   "sort": "Sort",
+  "stats.empty": "No reports",
+
   "title": "Title",
   "template": "Template",
   "today": "Today",
-
-  "server": "Server",
-
-  "site.blueprint": "The site has no blueprint yet. You can define the setup in <strong>/site/blueprints/site.yml</strong>",
 
   "toolbar.button.code": "Code",
   "toolbar.button.bold": "Bold",

--- a/panel/src/components/Layout/Stats.vue
+++ b/panel/src/components/Layout/Stats.vue
@@ -1,0 +1,63 @@
+<template>
+  <dl class="k-stats">
+    <component
+      v-for="(report, id) in reports"
+      :is="report.link ? 'k-link' : 'div'"
+      :data-theme="report.theme"
+      :key="id"
+      :to="report.link"
+      class="k-stat"
+    >
+      <dt class="k-stat-label">{{ report.label }}</dt>
+      <dd class="k-stat-value">{{ report.value }}</dd>
+      <dd class="k-stat-info">{{ report.info }}</dd>
+    </component>
+  </dl>
+</template>
+
+<script>
+export default {
+  props: {
+    reports: Array
+  }
+};
+</script>
+
+<style>
+.k-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  grid-gap: 1px;
+}
+.k-stat {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-white);
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
+  padding: var(--spacing-3) var(--spacing-6);
+  line-height: var(--leading-normal);
+}
+.k-stat.k-link:hover {
+  background: var(--color-gray-100);
+}
+.k-stat dt,
+.k-stat dd {
+  display: block;
+}
+.k-stat-value {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--spacing-1);
+  order: 1;
+}
+.k-stat-label,
+.k-stat-info {
+  font-size: var(--text-xs);
+}
+.k-stat-label {
+  order: 2;
+}
+.k-stat-info {
+  order: 3;
+  color: var(--theme, var(--color-gray-500));
+}
+</style>

--- a/panel/src/components/Sections/StatsSection.vue
+++ b/panel/src/components/Sections/StatsSection.vue
@@ -1,0 +1,33 @@
+<template>
+  <section v-if="isLoading === false" class="k-stats-section">
+    <header class="k-section-header">
+      <k-headline>
+        {{ headline }}
+      </k-headline>
+    </header>
+    <k-stats v-if="reports.length > 0" :reports="reports" />
+    <k-empty v-else icon="chart"> {{ empty || $t("stats.empty") }}</k-empty>
+  </section>
+</template>
+
+<script>
+import SectionMixin from "@/mixins/section/section.js";
+
+export default {
+  mixins: [SectionMixin],
+  data() {
+    return {
+      isLoading: true,
+      headline: null,
+      reports: null
+    };
+  },
+  async created() {
+    const section = await this.load();
+    this.isLoading = false;
+    this.headline = section.headline;
+    this.reports = section.reports;
+  },
+  methods: {}
+};
+</script>

--- a/panel/src/components/Sections/index.js
+++ b/panel/src/components/Sections/index.js
@@ -1,0 +1,17 @@
+import Vue from "vue";
+import Sections from "@/components/Sections/Sections.vue";
+
+Vue.component("k-sections", Sections);
+
+/* Section Types */
+import FieldsSection from "@/components/Sections/FieldsSection.vue";
+import FilesSection from "@/components/Sections/FilesSection.vue";
+import InfoSection from "@/components/Sections/InfoSection.vue";
+import PagesSection from "@/components/Sections/PagesSection.vue";
+import StatsSection from "@/components/Sections/StatsSection.vue";
+
+Vue.component("k-fields-section", FieldsSection);
+Vue.component("k-files-section", FilesSection);
+Vue.component("k-info-section", InfoSection);
+Vue.component("k-pages-section", PagesSection);
+Vue.component("k-stats-section", StatsSection);

--- a/panel/src/config/components.js
+++ b/panel/src/config/components.js
@@ -224,6 +224,7 @@ import ItemImage from "@/components/Layout/ItemImage.vue";
 import Items from "@/components/Layout/Items.vue";
 import Overlay from "@/components/Layout/Overlay.vue";
 import Panel from "@/components/Layout/Panel.vue";
+import Stats from "@/components/Layout/Stats.vue";
 import Table from "@/components/Layout/Table.vue";
 import TableCell from "@/components/Layout/TableCell.vue";
 import Tabs from "@/components/Layout/Tabs.vue";
@@ -245,6 +246,7 @@ Vue.component("k-item-image", ItemImage);
 Vue.component("k-items", Items);
 Vue.component("k-overlay", Overlay);
 Vue.component("k-panel", Panel);
+Vue.component("k-stats", Stats);
 Vue.component("k-table", Table);
 Vue.component("k-table-cell", TableCell);
 Vue.component("k-tabs", Tabs);
@@ -321,17 +323,7 @@ Vue.component("k-tag", Tag);
 Vue.component("k-topbar", Topbar);
 
 /* Sections */
-import Sections from "@/components/Sections/Sections.vue";
-import InfoSection from "@/components/Sections/InfoSection.vue";
-import PagesSection from "@/components/Sections/PagesSection.vue";
-import FilesSection from "@/components/Sections/FilesSection.vue";
-import FieldsSection from "@/components/Sections/FieldsSection.vue";
-
-Vue.component("k-sections", Sections);
-Vue.component("k-info-section", InfoSection);
-Vue.component("k-pages-section", PagesSection);
-Vue.component("k-files-section", FilesSection);
-Vue.component("k-fields-section", FieldsSection);
+import "@/components/Sections/index.js";
 
 /* Views */
 import AccountView from "@/components/Views/AccountView.vue";

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -424,6 +424,7 @@ class Core
             'files'  => $this->root . '/sections/files.php',
             'info'   => $this->root . '/sections/info.php',
             'pages'  => $this->root . '/sections/pages.php',
+            'stats'  => $this->root . '/sections/stats.php',
         ];
     }
 

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class MockPageForStatsSection extends Page
+{
+    public function report()
+    {
+        return $this->reports()[0];
+    }
+
+    public function reports()
+    {
+        return [
+            [
+                'label' => 'A',
+                'value' => 'Value A',
+                'info'  => 'Info A',
+                'link'  => 'https://getkirby.com',
+                'theme' => null,
+            ],
+            [
+                'label' => 'B',
+                'value' => 'Value B',
+                'info'  => null,
+                'link'  => null,
+                'theme' => null,
+            ]
+        ];
+    }
+}
+
+class StatsSectionTest extends TestCase
+{
+    protected $app;
+
+    public function setUp(): void
+    {
+        App::destroy();
+
+        $this->app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ]
+        ]);
+
+        $this->model = new MockPageForStatsSection(['slug' => 'test']);
+    }
+
+    public function testHeadline()
+    {
+        // single headline
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'headline' => 'Test'
+        ]);
+
+        $this->assertEquals('Test', $section->headline());
+
+        // translated headline
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'headline' => [
+                'en' => 'Stats',
+                'de' => 'Statistik'
+            ]
+        ]);
+
+        $this->assertEquals('Stats', $section->headline());
+    }
+
+    public function testReports()
+    {
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'reports'  => $reports = $this->model->reports()
+        ]);
+
+        $this->assertSame($reports, $section->reports());
+    }
+
+    public function testReportsFromQuery()
+    {
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'reports'  => 'page.reports'
+        ]);
+
+        $this->assertSame($this->model->reports(), $section->reports());
+    }
+
+    public function testReportsWithQueries()
+    {
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'reports'  => [
+                'page.report'
+            ]
+        ]);
+
+        $this->assertSame([$this->model->report()], $section->reports());
+    }
+}

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -95,6 +95,18 @@ class StatsSectionTest extends TestCase
         $this->assertSame($this->model->reports(), $section->reports());
     }
 
+    public function testReportsFromInvalidValue()
+    {
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'reports'  => new \stdClass()
+        ]);
+
+        $this->assertSame([], $section->reports());
+    }
+
+
     public function testReportsWithQueries()
     {
         $section = new Section('stats', [
@@ -106,5 +118,18 @@ class StatsSectionTest extends TestCase
         ]);
 
         $this->assertSame([$this->model->report()], $section->reports());
+    }
+
+    public function testReportsWithInvalidQueries()
+    {
+        $section = new Section('stats', [
+            'name'     => 'test',
+            'model'    => $this->model,
+            'reports'  => [
+                'page.somethingSomething'
+            ]
+        ]);
+
+        $this->assertSame([], $section->reports());
     }
 }


### PR DESCRIPTION
## Features

The brand new statistics section, can be used to show beautiful stats for your site or shop. Revenue, transactions, Twitter likes, page impressions … it's totally up to you. You can add as many reports to a stats section as needed. Reports can be customized with our query syntax and integrated easily into page models or site methods. 

```yaml
stats:
  type: stats
  reports:
    - label: Revenue
      value: €29,682
      info: +112.5%
      link: https://getkirby.com/shop
      theme: positive
    - label: Transactions
      value: 265
      info: +82.8%
      theme: positive
    - label: Avg. Transaction
      value: €112.01
      info: +16.3%
      theme: positive
    - label: Refunds
      value: €91.75
      info: +49.5%
      theme: positive
```

… with template strings and queries …

```yaml
stats:
  type: stats
  reports:
    - page.revenue
    - label: 
        de: Transactions
        en: Transaktionen
      value: "{{ page.transactions }}"
      info: "{{ page.transactionsIncrease }}"
```

… a custom array of reports coming from a query

```yaml
stats:
  type: stats
  reports: page.reports
```

![Screenshot 2022-04-30 at 15 45 45](https://user-images.githubusercontent.com/24532/166108086-0f3be58d-2231-42cb-ae44-5ecb2dcbdc09.png)


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
