### PR TITLE
Use internal `->filter()` method instead loop that unsetting the original data

### DIFF
--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -115,21 +115,24 @@ return [
                     $pages = $this->parent->childrenAndDrafts();
             }
 
-            // loop for the best performance
-            foreach ($pages->data as $id => $page) {
-
+            // filters pages that are protected and not in the templates list
+            // internal `filter()` method used instead of foreach loop that previously included `unset()`
+            // because `unset()` is updating the original data, `filter()` is just filtering
+            // also it has been tested that there is no performance difference
+            // even in 0.1 seconds on 100k virtual pages
+            $pages = $pages->filter(function ($page) {
                 // remove all protected pages
                 if ($page->isReadable() === false) {
-                    unset($pages->data[$id]);
-                    continue;
+                    return false;
                 }
 
                 // filter by all set templates
                 if ($this->templates && in_array($page->intendedTemplate()->name(), $this->templates) === false) {
-                    unset($pages->data[$id]);
-                    continue;
+                    return false;
                 }
-            }
+
+                return true;
+            });
 
             // sort
             if ($this->sortBy) {

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -539,4 +539,31 @@ class PagesSectionTest extends TestCase
         $this->assertSame('en: A', $section->data()[1]['text']);
         $this->assertSame('en: B', $section->data()[2]['text']);
     }
+
+    public function testUnreadable()
+    {
+        $this->app->clone([
+            'blueprints' => [
+                'pages/unreadable' => [
+                    'options' => ['read' => false]
+                ]
+            ]
+        ]);
+
+        $page = new Page([
+            'slug' => 'test',
+            'children' => [
+                ['slug' => 'subpage-a'],
+                ['slug' => 'subpage-b', 'template' => 'unreadable'],
+                ['slug' => 'subpage-c']
+            ]
+        ]);
+
+        $section = new Section('pages', [
+            'name'  => 'test',
+            'model' => $page
+        ]);
+
+        $this->assertCount(2, $section->data());
+    }
 }


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

The issue was that the `unset()` function used during the loop was updating the original data/collection. With @lukasbestle suggestion, we solved the problem by filtering without updating the original data/collection using the internal `->filter()` method.

We also considered the performance issue and we did not see any problem as there was not even a 0.1 second difference in 100k virtual pages.

I haven't added unit testing for now. I can write unit tests if you OK with the PR.

### Fixes

- Preview image from other page was not shown when the page is a child of site and status `published` was queried #4297

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
