### PR TITLE
Fix pagination methods return type hints #4313

### DIFF
--- a/src/Cms/Pagination.php
+++ b/src/Cms/Pagination.php
@@ -96,9 +96,9 @@ class Pagination extends BasePagination
     /**
      * Returns the Url for the first page
      *
-     * @return string
+     * @return string|null
      */
-    public function firstPageUrl(): string
+    public function firstPageUrl(): ?string
     {
         return $this->pageUrl(1);
     }
@@ -106,9 +106,9 @@ class Pagination extends BasePagination
     /**
      * Returns the Url for the last page
      *
-     * @return string
+     * @return string|null
      */
-    public function lastPageUrl(): string
+    public function lastPageUrl(): ?string
     {
         return $this->pageUrl($this->lastPage());
     }

--- a/tests/Cms/Collections/PaginationTest.php
+++ b/tests/Cms/Collections/PaginationTest.php
@@ -34,7 +34,7 @@ class PaginationTest extends TestCase
             'total' => 120,
         ]);
 
-        $this->assertEquals('https://getkirby.com/page:2', $pagination->nextPageUrl());
+        $this->assertSame('https://getkirby.com/page:2', $pagination->nextPageUrl());
     }
 
     public function testSubfolderUrl()
@@ -64,7 +64,7 @@ class PaginationTest extends TestCase
             'total' => 120,
         ]);
 
-        $this->assertEquals('http://localhost/starterkit/page:2', $pagination->nextPageUrl());
+        $this->assertSame('http://localhost/starterkit/page:2', $pagination->nextPageUrl());
 
         $_SERVER = $server;
         Server::$cli = true;
@@ -77,7 +77,7 @@ class PaginationTest extends TestCase
             'page' => 2
         ]);
 
-        $this->assertEquals('https://getkirby.com/page:2', $pagination->pageUrl());
+        $this->assertSame('https://getkirby.com/page:2', $pagination->pageUrl());
     }
 
     public function testCurrentPageUrlWithFirstPage()
@@ -86,15 +86,15 @@ class PaginationTest extends TestCase
             'page' => 1
         ]);
 
-        $this->assertEquals('https://getkirby.com', $pagination->pageUrl());
+        $this->assertSame('https://getkirby.com', $pagination->pageUrl());
     }
 
     public function testPageUrl()
     {
         $pagination = $this->pagination();
 
-        $this->assertEquals('https://getkirby.com', $pagination->pageUrl(1));
-        $this->assertEquals('https://getkirby.com/page:12', $pagination->pageUrl(12));
+        $this->assertSame('https://getkirby.com', $pagination->pageUrl(1));
+        $this->assertSame('https://getkirby.com/page:12', $pagination->pageUrl(12));
 
         $this->assertNull($pagination->pageUrl(0));
         $this->assertNull($pagination->pageUrl(13));
@@ -103,13 +103,26 @@ class PaginationTest extends TestCase
     public function testFirstPageUrl()
     {
         $pagination = $this->pagination();
-        $this->assertEquals('https://getkirby.com', $pagination->firstPageUrl());
+        $this->assertSame('https://getkirby.com', $pagination->firstPageUrl());
     }
 
     public function testLastPageUrl()
     {
         $pagination = $this->pagination();
-        $this->assertEquals('https://getkirby.com/page:12', $pagination->lastPageUrl());
+        $this->assertSame('https://getkirby.com/page:12', $pagination->lastPageUrl());
+    }
+
+    public function testFirstLastPageUrlNull()
+    {
+        $pagination = new Pagination([
+            'page'  => 1,
+            'limit' => 10,
+            'total' => 0,
+            'url'   => new Uri('https://getkirby.com')
+        ]);
+
+        $this->assertSame(null, $pagination->firstPageUrl());
+        $this->assertSame(null, $pagination->lastPageUrl());
     }
 
     public function testNextPageUrl()
@@ -118,7 +131,7 @@ class PaginationTest extends TestCase
             'page' => 2
         ]);
 
-        $this->assertEquals('https://getkirby.com/page:3', $pagination->nextPageUrl());
+        $this->assertSame('https://getkirby.com/page:3', $pagination->nextPageUrl());
     }
 
     public function testNonExistingNextPage()
@@ -133,7 +146,7 @@ class PaginationTest extends TestCase
             'page' => 3
         ]);
 
-        $this->assertEquals('https://getkirby.com/page:2', $pagination->prevPageUrl());
+        $this->assertSame('https://getkirby.com/page:2', $pagination->prevPageUrl());
     }
 
     public function testNonExistingPrevPage()
@@ -148,7 +161,7 @@ class PaginationTest extends TestCase
             'page' => 2
         ]);
 
-        $this->assertEquals('https://getkirby.com', $pagination->prevPageUrl());
+        $this->assertSame('https://getkirby.com', $pagination->prevPageUrl());
     }
 
     public function testMethod()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fix return type hints to include `null` as possible return value for `Cms\Pagination::firstPageUrl()` and `Cms\Pagination::lastPageUrl()` 
#4313

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
