### PR TITLE
Correct `sort` data when multiple files upload

### DIFF
--- a/panel/src/components/Forms/Upload.vue
+++ b/panel/src/components/Forms/Upload.vue
@@ -176,6 +176,11 @@ export default {
             this.complete(file, response.data);
           }
         });
+
+        // if there is sort data, increment in the loop for next file
+        if (this.options?.attributes?.sort !== undefined) {
+          this.options.attributes.sort++;
+        }
       });
     },
     complete(file, data) {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

In multi-file upload, I fixed the `sort` data on Vue side, because a single request is made on PHP side and uploading files looped on Vue side. I'm not sure it's the right solution.

### Fixes

- Sorting files messed up when uploading multiple files #4303

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
