### PR TITLE
Add console info message when system health checks ended

### DIFF
--- a/panel/src/components/Views/SystemView.vue
+++ b/panel/src/components/Views/SystemView.vue
@@ -146,14 +146,15 @@ export default {
       );
     }
   },
-  created() {
+  async created() {
     console.info(
       "Running system health checks for the Panel system view; failed requests in the following console output are expected behavior."
     );
-    this.check("content");
-    this.check("git");
-    this.check("kirby");
-    this.check("site");
+    await this.check("content");
+    await this.check("git");
+    await this.check("kirby");
+    await this.check("site");
+    console.info("System health checks ended.");
   },
   methods: {
     async check(key) {


### PR DESCRIPTION
I needed to use `async` and `await` to get the message to be printed after all the checks are complete.