### PR TITLE
New V::empty and V::notEmpty validators

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -391,6 +391,23 @@ V::$validators = [
     },
 
     /**
+     * Checks for empty values
+     */
+    'empty' => function ($value = null): bool {
+        $empty = ['', null, []];
+
+        if (in_array($value, $empty, true) === true) {
+            return true;
+        }
+
+        if (is_countable($value) === true) {
+            return count($value) === 0;
+        }
+
+        return false;
+    },
+
+    /**
      * Checks if the given string ends with the given value
      */
     'endsWith' => function (string $value, string $end): bool {
@@ -500,6 +517,13 @@ V::$validators = [
     },
 
     /**
+     * Checks that the given value is not empty
+     */
+    'notEmpty' => function ($value): bool {
+        return V::empty($value) === false;
+    },
+
+    /**
      * Checks that the given value is not in the given list of values
      */
     'notIn' => function ($value, $notIn): bool {
@@ -514,11 +538,16 @@ V::$validators = [
     },
 
     /**
-     * Checks if the value is present in the given array
+     * Checks if the value is present
      */
-    'required' => function ($key, array $array): bool {
-        return isset($array[$key]) === true &&
-               V::notIn($array[$key], [null, '', []]) === true;
+    'required' => function ($value, $array = null): bool {
+        // with reference array
+        if (is_array($array) === true) {
+            return isset($array[$value]) === true && V::notEmpty($array[$value]) === true;
+        }
+
+        // without reference array
+        return V::notEmpty($value);
     },
 
     /**

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -209,6 +209,21 @@ class VTest extends TestCase
         $this->assertFalse(V::email('@getkirby.com'));
     }
 
+    public function testEmpty()
+    {
+        $this->assertTrue(V::empty(''));
+        $this->assertTrue(V::empty(null));
+        $this->assertTrue(V::empty([]));
+        $this->assertTrue(V::empty(new Collection()));
+
+        $this->assertFalse(V::empty(0));
+        $this->assertFalse(V::empty('0'));
+        $this->assertFalse(V::empty(false));
+        $this->assertFalse(V::empty(true));
+        $this->assertFalse(V::empty(['']));
+        $this->assertFalse(V::empty(new Collection(['a'])));
+    }
+
     public function testDateComparison()
     {
         $this->assertTrue(V::date('2345-01-01', '==', '01.01.2345'));
@@ -403,6 +418,12 @@ class VTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testNotEmpty()
+    {
+        $this->assertFalse(V::notEmpty(''));
+        $this->assertTrue(V::notEmpty(0));
+    }
+
     public function testNotIn()
     {
         $this->assertFalse(V::notIn('bastian', ['bastian', 'nico', 'sonja']));
@@ -503,6 +524,16 @@ class VTest extends TestCase
     }
 
     public function testRequired()
+    {
+        // required
+        $this->assertTrue(V::required(2));
+        $this->assertTrue(V::required(2));
+
+        $this->assertFalse(V::required(''));
+        $this->assertFalse(V::required(''));
+    }
+
+    public function testRequiredWithReferenceArray()
     {
         $this->assertTrue(V::required('a', ['a' => 2]));
         $this->assertTrue(V::required('a', ['a' => 'foo']));


### PR DESCRIPTION
## Features

### New `V::empty()` and `V::notEmpty()` validators

Checking for empty values in PHP is less easy than it sounds like. `empty()` is often giving wrong results. Especially if you pass 0 or '0'. The new validators help with this task. They also serve as underlying logic for a better `V::required()` validator. It can now be used in two ways. 

#### With a reference array

```php
V::required('myField', ['myField' => 'Some value']);
```

or just a value

```php
V::required('My value');
```

This makes the method more versatile and it can be used in `V::value()` 

```php
V::value('My value', [
  'required' => true,
  'minlength' => 5,
]);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
