### PR TITLE
Make `@todo` changes for 3.7.0

### DIFF
--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kirby\Cms\File;
-use Kirby\Cms\Helpers;
 use Kirby\Form\Form;
 
 /**

--- a/config/api/models/File.php
+++ b/config/api/models/File.php
@@ -30,13 +30,6 @@ return [
         },
         'niceSize'   => fn (File $file) => $file->niceSize(),
         'options'    => fn (File $file) => $file->panel()->options(),
-        'panelIcon'  => function (File $file) {
-            // TODO: remove in 3.7.0
-            // @codeCoverageIgnoreStart
-            Helpers::deprecated('The API field file.panelIcon has been deprecated and will be removed in 3.7.0. Use file.panelImage instead');
-            return $file->panel()->image();
-        // @codeCoverageIgnoreEnd
-        },
         'panelImage' => fn (File $file) => $file->panel()->image(),
         'panelUrl'   => fn (File $file) => $file->panel()->url(true),
         'prev'       => fn (File $file) => $file->prev(),

--- a/config/api/models/Page.php
+++ b/config/api/models/Page.php
@@ -23,11 +23,12 @@ return [
         'isSortable'  => fn (Page $page) => $page->isSortable(),
         /**
          * @deprecated 3.6.0
-         * @todo Throw deprecated warning in 3.7.0
          * @todo Remove in 3.8.0
          * @codeCoverageIgnore
          */
         'next' => function (Page $page) {
+            Helpers::deprecated('The API field page.next has been deprecated and will be removed in 3.8.0.');
+
             return $page
                 ->nextAll()
                 ->filter('intendedTemplate', $page->intendedTemplate())
@@ -37,24 +38,17 @@ return [
         },
         'num'     => fn (Page $page) => $page->num(),
         'options' => fn (Page $page) => $page->panel()->options(['preview']),
-        /**
-         * @todo Remove in 3.7.0
-         * @codeCoverageIgnore
-         */
-        'panelIcon' => function (Page $page) {
-            Helpers::deprecated('The API field page.panelIcon has been deprecated and will be removed in 3.7.0. Use page.panelImage instead');
-            return $page->panel()->image();
-        },
         'panelImage' => fn (Page $page) => $page->panel()->image(),
         'parent'     => fn (Page $page) => $page->parent(),
         'parents'    => fn (Page $page) => $page->parents()->flip(),
         /**
          * @deprecated 3.6.0
-         * @todo Throw deprecated warning in 3.7.0
          * @todo Remove in 3.8.0
          * @codeCoverageIgnore
          */
         'prev' => function (Page $page) {
+            Helpers::deprecated('The API field page.prev has been deprecated and will be removed in 3.8.0.');
+
             return $page
                 ->prevAll()
                 ->filter('intendedTemplate', $page->intendedTemplate())

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kirby\Cms\Helpers;
 
 /**
  * Content Lock Routes

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -8,29 +8,6 @@ use Kirby\Cms\Helpers;
 return [
     [
         'pattern' => '(:all)/lock',
-        'method'  => 'GET',
-        /**
-         * @deprecated 3.6.0
-         * @todo Remove in 3.7.0
-         */
-        'action'  => function (string $path) {
-            Helpers::deprecated('The `GET (:all)/lock` API endpoint has been deprecated and will be removed in 3.7.0');
-
-            if ($lock = $this->parent($path)->lock()) {
-                return [
-                    'supported' => true,
-                    'locked'    => $lock->get()
-                ];
-            }
-
-            return [
-                'supported' => false,
-                'locked'    => null
-            ];
-        }
-    ],
-    [
-        'pattern' => '(:all)/lock',
         'method'  => 'PATCH',
         'action'  => function (string $path) {
             if ($lock = $this->parent($path)->lock()) {
@@ -45,30 +22,6 @@ return [
             if ($lock = $this->parent($path)->lock()) {
                 return $lock->remove();
             }
-        }
-    ],
-    [
-        'pattern' => '(:all)/unlock',
-        'method'  => 'GET',
-        /**
-         * @deprecated 3.6.0
-         * @todo Remove in 3.7.0
-         */
-        'action'  => function (string $path) {
-            Helpers::deprecated('The `GET (:all)/unlock` API endpoint has been deprecated and will be removed in 3.7.0');
-
-
-            if ($lock = $this->parent($path)->lock()) {
-                return [
-                    'supported' => true,
-                    'unlocked'  => $lock->isUnlocked()
-                ];
-            }
-
-            return [
-                'supported' => false,
-                'unlocked'  => null
-            ];
         }
     ],
     [

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -36,21 +36,9 @@ return [
         }
     ],
     [
-        'pattern' => [
-            'pages/(:any)/blueprints',
-            /**
-             * @deprecated
-             * @todo remove in 3.7.0
-             */
-            'pages/(:any)/children/blueprints',
-        ],
+        'pattern' => 'pages/(:any)/blueprints',
         'method'  => 'GET',
         'action'  => function (string $id) {
-            // @codeCoverageIgnoreStart
-            if ($this->route->pattern() === 'pages/([a-zA-Z0-9\.\-_%= \+\@\(\)]+)/children/blueprints') {
-                Helpers::deprecated('`GET pages/(:any)/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET pages/(:any)/blueprints` instead');
-            }
-            // @codeCoverageIgnoreEnd
             return $this->page($id)->blueprints($this->requestQuery('section'));
         }
     ],

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kirby\Cms\Helpers;
 
 /**
  * Page Routes

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kirby\Cms\Helpers;
 
 /**
  * Site Routes

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -49,21 +49,9 @@ return [
         }
     ],
     [
-        'pattern' => [
-            'site/blueprints',
-            /**
-             * @deprecated
-             * @todo remove in 3.7.0
-             */
-            'site/children/blueprints',
-        ],
+        'pattern' => 'site/blueprints',
         'method'  => 'GET',
         'action'  => function () {
-            // @codeCoverageIgnoreStart
-            if ($this->route->pattern() === 'site/children/blueprints') {
-                Helpers::deprecated('`GET site/children/blueprints` API endpoint has been deprecated and will be removed in 3.7.0. Use `GET site/blueprints` instead.');
-            }
-            // @codeCoverageIgnoreEnd
             return $this->site()->blueprints($this->requestQuery('section'));
         }
     ],

--- a/config/components.php
+++ b/config/components.php
@@ -150,7 +150,7 @@ return [
         // warning for deprecated fourth parameter
         if ($inline === null) {
             $inline = false;
-        } else {
+        } elseif (isset($options['inline']) === false) {
             Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
         }
 

--- a/config/components.php
+++ b/config/components.php
@@ -4,6 +4,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\FileVersion;
+use Kirby\Cms\Helpers;
 use Kirby\Cms\Template;
 use Kirby\Data\Data;
 use Kirby\Email\PHPMailer as Emailer;
@@ -140,12 +141,18 @@ return [
      * @param array $options Markdown options
      * @param bool $inline Whether to wrap the text in `<p>` tags (deprecated: set via $options['inline'] instead)
      * @return string
-     * @todo add deprecation warning for $inline parameter in 3.7.0
      * @todo remove $inline parameter in in 3.8.0
      */
-    'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
+    'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = null): string {
         static $markdown;
         static $config;
+
+        // warning for deprecated fourth parameter
+        if ($inline === null) {
+            $inline = false;
+        } else {
+            Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
+        }
 
         // support for the deprecated fourth argument
         $options['inline'] ??= $inline;

--- a/config/components.php
+++ b/config/components.php
@@ -151,7 +151,9 @@ return [
         if ($inline === null) {
             $inline = false;
         } elseif (isset($options['inline']) === false) {
+            // @codeCoverageIgnoreStart
             Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
+            // @codeCoverageIgnoreEnd
         }
 
         // support for the deprecated fourth argument

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -3,7 +3,6 @@
 use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Html;
-use Kirby\Cms\Pages;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\F;

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -420,7 +420,7 @@ if (Helpers::hasOverride('page') === false) { // @codeCoverageIgnore
      * @param string|null $id
      * @return \Kirby\Cms\Page|null
      */
-    function page($id = null)
+    function page(?string $id = null)
     {
         if (empty($id) === true) {
             return App::instance()->site()->page();

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -3,6 +3,7 @@
 use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Html;
+use Kirby\Cms\Pages;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\F;
@@ -416,23 +417,16 @@ if (Helpers::hasOverride('page') === false) { // @codeCoverageIgnore
      * Fetches a single page or multiple pages by
      * id or the current page when no id is specified
      *
-     * @param string|array ...$id
-     * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
-     * @todo reduce to one parameter in 3.7.0 (also change return and return type)
+     * @param string $id
+     * @return \Kirby\Cms\Page|null
      */
-    function page(...$id)
+    function page($id)
     {
         if (empty($id) === true) {
             return App::instance()->site()->page();
         }
 
-        if (count($id) > 1) {
-            // @codeCoverageIgnoreStart
-            Helpers::deprecated('Passing multiple parameters to the `page()` helper has been deprecated. Please use the `pages()` helper instead.');
-            // @codeCoverageIgnoreEnd
-        }
-
-        return App::instance()->site()->find(...$id);
+        return App::instance()->site()->find($id);
     }
 }
 
@@ -441,18 +435,17 @@ if (Helpers::hasOverride('pages') === false) { // @codeCoverageIgnore
      * Helper to build page collections
      *
      * @param string|array ...$id
-     * @return \Kirby\Cms\Page|\Kirby\Cms\Pages|null
-     * @todo return only Pages|null in 3.7.0, wrap in Pages for single passed id
+     * @return \Kirby\Cms\Pages|null
      */
     function pages(...$id)
     {
-        if (count($id) === 1 && is_array($id[0]) === false) {
-            // @codeCoverageIgnoreStart
-            Helpers::deprecated('Passing a single id to the `pages()` helper will return a Kirby\Cms\Pages collection with a single element instead of the single Kirby\Cms\Page object itself - starting in 3.7.0.');
-            // @codeCoverageIgnoreEnd
+        $pages = App::instance()->site()->find(...$id);
+
+        if (is_a($pages, 'Kirby\Cms\Page') === false) {
+            $pages = new Pages([$pages]);
         }
 
-        return App::instance()->site()->find(...$id);
+        return $pages;
     }
 }
 

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -414,13 +414,13 @@ if (Helpers::hasOverride('option') === false) { // @codeCoverageIgnore
 
 if (Helpers::hasOverride('page') === false) { // @codeCoverageIgnore
     /**
-     * Fetches a single page or multiple pages by
-     * id or the current page when no id is specified
+     * Fetches a single page by id or
+     * the current page when no id is specified
      *
-     * @param string $id
+     * @param string|null $id
      * @return \Kirby\Cms\Page|null
      */
-    function page($id)
+    function page($id = null)
     {
         if (empty($id) === true) {
             return App::instance()->site()->page();
@@ -432,7 +432,7 @@ if (Helpers::hasOverride('page') === false) { // @codeCoverageIgnore
 
 if (Helpers::hasOverride('pages') === false) { // @codeCoverageIgnore
     /**
-     * Helper to build page collections
+     * Helper to build pages collection
      *
      * @param string|array ...$id
      * @return \Kirby\Cms\Pages|null

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -439,13 +439,15 @@ if (Helpers::hasOverride('pages') === false) { // @codeCoverageIgnore
      */
     function pages(...$id)
     {
-        $pages = App::instance()->site()->find(...$id);
-
-        if (is_a($pages, 'Kirby\Cms\Page') === false) {
-            $pages = new Pages([$pages]);
+        // ensure that a list of string arguments and an array
+        // as the first argument are treated the same
+        if (count($id) === 1 && is_array($id[0]) === true) {
+            $id = $id[0];
         }
 
-        return $pages;
+        // always passes $id an array; ensures we get a
+        // collection even if only one ID is passed
+        return App::instance()->site()->find($id);
     }
 }
 

--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -10,9 +10,10 @@ return [
          * @todo remove in 3.9.0
          */
         'headline' => function ($headline = null) {
-            if ($headline !== null) {
-                Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
-            }
+            // TODO: add deprecation notive in 3.8.0
+            // if ($headline !== null) {
+            //     Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
+            // }
 
             return I18n::translate($headline, $headline);
         },

--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -1,18 +1,25 @@
 <?php
 
+use Kirby\Cms\Helpers;
 use Kirby\Toolkit\I18n;
 
 return [
     'props' => [
         /**
          * The headline for the section. This can be a simple string or a template with additional info from the parent page.
-         * @todo deprecate in 3.7
+         * @todo remove in 3.9.0
          */
         'headline' => function ($headline = null) {
+            if ($headline !== null) {
+                Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
+            }
+
             return I18n::translate($headline, $headline);
         },
         /**
-         * label is the new official replacement for headline
+         * The label for the section. This can be a simple string or
+         * a template with additional info from the parent page.
+         * Replaces the `headline` prop.
          */
         'label' => function ($label = null) {
             return I18n::translate($label, $label);

--- a/panel/src/api/index.js
+++ b/panel/src/api/index.js
@@ -47,17 +47,5 @@ export default (extensions = {}) => {
   api.translations = translations(api);
   api.users = users(api);
 
-  /**
-   * @deprecated 3.5.0
-   * @todo remove in 3.7.0
-   */
-  api.files.rename = api.files.changeName;
-  api.pages.slug = api.pages.changeSlug;
-  api.pages.status = api.pages.changeStatus;
-  api.pages.template = api.pages.changeTemplate;
-  api.pages.title = api.pages.changeTitle;
-  api.site.title = api.site.changeTitle;
-  api.system.info = api.system.get;
-
   return api;
 };

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -900,11 +900,13 @@ class App
     public function kirbytext(string $text = null, array $options = [], bool $inline = null): string
     {
         // warning for deprecated fourth parameter
+        // @codeCoverageIgnoreStart
         if ($inline === null) {
             $inline = false;
         } else {
             Helpers::deprecated('Cms\App::kribytext(): the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
         }
+        // @codeCoverageIgnoreEnd
 
         $options['markdown']['inline'] ??= $inline;
 
@@ -1011,6 +1013,7 @@ class App
     public function markdown(string $text = null, $options = null): string
     {
         // support for the old syntax to enable inline mode as second argument
+        // @codeCoverageIgnoreStart
         if (is_bool($options) === true) {
             Helpers::deprecated('Cms\App::markdown(): Passing a boolean as second parameter has been deprecated and won\'t be supported anymore in Kirby 3.8.0. Instead pass array with the key "inline" set to true or false.');
 
@@ -1018,6 +1021,7 @@ class App
                 'inline' => $options
             ];
         }
+        // @codeCoverageIgnoreEnd
 
         // merge global options with local options
         $options = array_merge(

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -892,20 +892,21 @@ class App
      *
      * @internal
      * @param string|null $text
-     * @param array $data
-     * @param bool $inline (deprecated: use $data['markdown']['inline'] instead)
+     * @param array $options
+     * @param bool $inline (deprecated: use $options['markdown']['inline'] instead)
      * @return string
-     * @todo add deprecation warning for $inline parameter in 3.7.0
-     * @todo rename $data parameter to $options in 3.7.0
      * @todo remove $inline parameter in in 3.8.0
      */
-    public function kirbytext(string $text = null, array $data = [], bool $inline = false): string
+    public function kirbytext(string $text = null, array $options = [], bool $inline = null): string
     {
-        $options = A::merge([
-            'markdown' => [
-                'inline' => $inline
-            ]
-        ], $data);
+        // warning for deprecated fourth parameter
+        if ($inline === null) {
+            $inline = false;
+        } else {
+            Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
+        }
+
+        $options['markdown']['inline'] ??= $inline;
 
         $text = $this->apply('kirbytext:before', compact('text'), 'text');
         $text = $this->kirbytags($text, $options);
@@ -1005,17 +1006,14 @@ class App
      * @param string|null $text
      * @param bool|array $options
      * @return string
-     * @todo rename $inline parameter to $options in 3.7.0
-     * @todo add deprecation warning for boolean $options in 3.7.0
      * @todo remove boolean $options in in 3.8.0
      */
-    public function markdown(string $text = null, $inline = null): string
+    public function markdown(string $text = null, $options = null): string
     {
-        // TODO: remove after renaming parameter
-        $options = $inline;
-
         // support for the old syntax to enable inline mode as second argument
         if (is_bool($options) === true) {
+            Helpers::deprecated('Cms\App::markdown(): Passing a boolean as second parameter has been deprecated and won\'t be supported anymore in Kirby 3.8.0. Instead pass array with the key "inline" set to true or false.');
+
             $options = [
                 'inline' => $options
             ];
@@ -1027,7 +1025,6 @@ class App
             (array)$options
         );
 
-        // TODO: deprecate passing the $inline parameter in 3.7.0
         // TODO: remove passing the $inline parameter in 3.8.0
         $inline = $options['inline'] ?? false;
         return ($this->component('markdown'))($this, $text, $options, $inline);

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -903,7 +903,7 @@ class App
         if ($inline === null) {
             $inline = false;
         } else {
-            Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
+            Helpers::deprecated('Cms\App::kribytext(): the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
         }
 
         $options['markdown']['inline'] ??= $inline;

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -904,7 +904,7 @@ class App
         if ($inline === null) {
             $inline = false;
         } else {
-            Helpers::deprecated('Cms\App::kribytext(): the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
+            Helpers::deprecated('Cms\App::kirbytext(): the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'markdown\'][\'inline\'] instead.');
         }
         // @codeCoverageIgnoreEnd
 

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -156,22 +156,6 @@ trait AppTranslations
     }
 
     /**
-     * Set locale settings
-     *
-     * @deprecated 3.5.0 Use `\Kirby\Toolkit\Locale::set()` instead
-     * @todo Remove in 3.7.0
-     *
-     * @param string|array $locale
-     */
-    public function setLocale($locale): void
-    {
-        // @codeCoverageIgnoreStart
-        Helpers::deprecated('`Kirby\Cms\App::setLocale()` has been deprecated and will be removed in 3.7.0. Use `Kirby\Toolkit\Locale::set()` instead');
-        Locale::set($locale);
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
      * Load a specific translation by locale
      *
      * @param string|null $locale Locale name or `null` for the current locale

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -96,34 +96,6 @@ class Block extends Item
     }
 
     /**
-     * Deprecated method to return the block type
-     *
-     * @deprecated 3.5.0 Use `\Kirby\Cms\Block::type()` instead
-     * @todo Remove in 3.7.0
-     *
-     * @return string
-     */
-    public function _key(): string
-    {
-        Helpers::deprecated('Block::_key() has been deprecated. Use Block::type() instead.');
-        return $this->type();
-    }
-
-    /**
-     * Deprecated method to return the block id
-     *
-     * @deprecated 3.5.0 Use `\Kirby\Cms\Block::id()` instead
-     * @todo Remove in 3.7.0
-     *
-     * @return string
-     */
-    public function _uid(): string
-    {
-        Helpers::deprecated('Block::_uid() has been deprecated. Use Block::id() instead.');
-        return $this->id();
-    }
-
-    /**
      * Returns the content object
      *
      * @return \Kirby\Cms\Content

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -425,16 +425,11 @@ class File extends ModelWithContent
      * Returns the parent id if a parent exists
      *
      * @internal
-     * @todo 3.7.0 When setParent() is changed, the if check is not needed anymore
-     * @return string|null
+     * @return string
      */
-    public function parentId(): ?string
+    public function parentId(): string
     {
-        if ($parent = $this->parent()) {
-            return $parent->id();
-        }
-
-        return null;
+        return $this->parent()->id();
     }
 
     /**
@@ -511,22 +506,13 @@ class File extends ModelWithContent
     }
 
     /**
-     * Sets the parent model object;
-     * this property is required for `File::create()` and
-     * will be generally required starting with Kirby 3.7.0
+     * Sets the parent model object
      *
      * @param \Kirby\Cms\Model|null $parent
      * @return $this
-     * @todo make property required in 3.7.0
      */
-    protected function setParent(Model $parent = null)
+    protected function setParent(Model $parent)
     {
-        // @codeCoverageIgnoreStart
-        if ($parent === null) {
-            Helpers::deprecated('You are creating a `Kirby\Cms\File` object without passing the `parent` property. While unsupported, this hasn\'t caused any direct errors so far. To fix inconsistencies, the `parent` property will be required when creating a `Kirby\Cms\File` object in Kirby 3.7.0 and higher. Not passing this property will start throwing a breaking error.');
-        }
-        // @codeCoverageIgnoreEnd
-
         $this->parent = $parent;
         return $this;
     }
@@ -641,7 +627,6 @@ class File extends ModelWithContent
      * used in the panel, when the file
      * gets dragged onto a textarea
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -652,6 +637,7 @@ class File extends ModelWithContent
      */
     public function dragText(string $type = null, bool $absolute = false): string
     {
+        Helpers::deprecated('Cms\File::dragText() has been deprecated and will be removed in Kirby 3.8.0. Use $file->panel()->dragText() instead.');
         return $this->panel()->dragText($type, $absolute);
     }
 
@@ -659,7 +645,6 @@ class File extends ModelWithContent
      * Returns an array of all actions
      * that can be performed in the Panel
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @since 3.3.0 This also checks for the lock status
@@ -671,13 +656,13 @@ class File extends ModelWithContent
      */
     public function panelOptions(array $unlock = []): array
     {
+        Helpers::deprecated('Cms\File::panelOptions() has been deprecated and will be removed in Kirby 3.8.0. Use $file->panel()->options() instead.');
         return $this->panel()->options($unlock);
     }
 
     /**
      * Returns the full path without leading slash
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -686,6 +671,7 @@ class File extends ModelWithContent
      */
     public function panelPath(): string
     {
+        Helpers::deprecated('Cms\File::panelPath() has been deprecated and will be removed in Kirby 3.8.0. Use $file->panel()->path() instead.');
         return $this->panel()->path();
     }
 
@@ -693,7 +679,6 @@ class File extends ModelWithContent
      * Prepares the response data for file pickers
      * and file fields
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @param array|null $params
@@ -702,6 +687,7 @@ class File extends ModelWithContent
      */
     public function panelPickerData(array $params = []): array
     {
+        Helpers::deprecated('Cms\File::panelPickerData() has been deprecated and will be removed in Kirby 3.8.0. Use $file->panel()->pickerData() instead.');
         return $this->panel()->pickerData($params);
     }
 
@@ -709,7 +695,6 @@ class File extends ModelWithContent
      * Returns the url to the editing view
      * in the panel
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -719,6 +704,7 @@ class File extends ModelWithContent
      */
     public function panelUrl(bool $relative = false): string
     {
+        Helpers::deprecated('Cms\File::panelUrl() has been deprecated and will be removed in Kirby 3.8.0. Use $file->panel()->url() instead.');
         return $this->panel()->url($relative);
     }
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -508,7 +508,7 @@ class File extends ModelWithContent
     /**
      * Sets the parent model object
      *
-     * @param \Kirby\Cms\Model|null $parent
+     * @param \Kirby\Cms\Model $parent
      * @return $this
      */
     protected function setParent(Model $parent)

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -654,7 +654,6 @@ abstract class ModelWithContent extends Model
      * Returns the panel icon definition
      *
      * @deprecated 3.6.0 Use `->panel()->image()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -664,12 +663,12 @@ abstract class ModelWithContent extends Model
      */
     public function panelIcon(array $params = null): ?array
     {
+        Helpers::deprecated('Cms\ModelWithContent::panelIcon() has been deprecated and will be removed in Kirby 3.8.0. Use $model->panel()->image() instead.');
         return $this->panel()->image($params);
     }
 
     /**
      * @deprecated 3.6.0 Use `->panel()->image()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -679,6 +678,7 @@ abstract class ModelWithContent extends Model
      */
     public function panelImage($settings = null): ?array
     {
+        Helpers::deprecated('Cms\ModelWithContent::panelImage() has been deprecated and will be removed in Kirby 3.8.0. Use $model->panel()->image() instead.');
         return $this->panel()->image($settings);
     }
 
@@ -688,7 +688,6 @@ abstract class ModelWithContent extends Model
      * This also checks for the lock status
      *
      * @deprecated 3.6.0 Use `->panel()->options()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @param array $unlock An array of options that will be force-unlocked
@@ -697,6 +696,7 @@ abstract class ModelWithContent extends Model
      */
     public function panelOptions(array $unlock = []): array
     {
+        Helpers::deprecated('Cms\ModelWithContent::panelOptions() has been deprecated and will be removed in Kirby 3.8.0. Use $model->panel()->options() instead.');
         return $this->panel()->options($unlock);
     }
 }

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1472,7 +1472,6 @@ class Page extends ModelWithContent
      * gets dragged onto a textarea
      *
      * @deprecated 3.6.0 Use `->panel()->dragText()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -1482,6 +1481,7 @@ class Page extends ModelWithContent
      */
     public function dragText(string $type = null): string
     {
+        Helpers::deprecated('Cms\Page::dragText() has been deprecated and will be removed in Kirby 3.8.0. Use $page->panel()->dragText() instead.');
         return $this->panel()->dragText($type);
     }
 
@@ -1490,7 +1490,6 @@ class Page extends ModelWithContent
      * used in the panel to make routing work properly
      *
      * @deprecated 3.6.0 Use `->panel()->id()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -1499,6 +1498,7 @@ class Page extends ModelWithContent
      */
     public function panelId(): string
     {
+        Helpers::deprecated('Cms\Page::panelId() has been deprecated and will be removed in Kirby 3.8.0. Use $page->panel()->id() instead.');
         return $this->panel()->id();
     }
 
@@ -1506,7 +1506,6 @@ class Page extends ModelWithContent
      * Returns the full path without leading slash
      *
      * @deprecated 3.6.0 Use `->panel()->path()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -1515,6 +1514,7 @@ class Page extends ModelWithContent
      */
     public function panelPath(): string
     {
+        Helpers::deprecated('Cms\Page::panelPath() has been deprecated and will be removed in Kirby 3.8.0. Use $page->panel()->path() instead.');
         return $this->panel()->path();
     }
 
@@ -1523,7 +1523,6 @@ class Page extends ModelWithContent
      * and page fields
      *
      * @deprecated 3.6.0 Use `->panel()->pickerData()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @param array|null $params
@@ -1532,6 +1531,7 @@ class Page extends ModelWithContent
      */
     public function panelPickerData(array $params = []): array
     {
+        Helpers::deprecated('Cms\Page::panelPickerData() has been deprecated and will be removed in Kirby 3.8.0. Use $page->panel()->pickerData() instead.');
         return $this->panel()->pickerData($params);
     }
 
@@ -1540,7 +1540,6 @@ class Page extends ModelWithContent
      * in the panel
      *
      * @deprecated 3.6.0 Use `->panel()->url()` instead
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -1550,6 +1549,7 @@ class Page extends ModelWithContent
      */
     public function panelUrl(bool $relative = false): string
     {
+        Helpers::deprecated('Cms\Page::panelUrl() has been deprecated and will be removed in Kirby 3.8.0. Use $page->panel()->url() instead.');
         return $this->panel()->url($relative);
     }
 }

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -160,7 +160,7 @@ class Permissions
     protected function setAction(string $category, string $action, $setting)
     {
         // deprecated fallback for the settings/system view
-        // TODO: remove in 3.7
+        // TODO: remove in 3.8.0
         if ($category === 'access' && $action === 'settings') {
             $action = 'system';
         }

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -668,7 +668,6 @@ class Site extends ModelWithContent
     /**
      * Returns the full path without leading slash
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -677,6 +676,7 @@ class Site extends ModelWithContent
      */
     public function panelPath(): string
     {
+        Helpers::deprecated('Cms\Site::panelPath() has been deprecated and will be removed in Kirby 3.8.0. Use $site->panel()->path() instead.');
         return $this->panel()->path();
     }
 
@@ -684,7 +684,6 @@ class Site extends ModelWithContent
      * Returns the url to the editing view
      * in the panel
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -694,6 +693,7 @@ class Site extends ModelWithContent
      */
     public function panelUrl(bool $relative = false): string
     {
+        Helpers::deprecated('Cms\Site::panelUrl() has been deprecated and will be removed in Kirby 3.8.0. Use $site->panel()->url() instead.');
         return $this->panel()->url($relative);
     }
 }

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -888,7 +888,6 @@ class User extends ModelWithContent
     /**
      * Returns the full path without leading slash
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -897,13 +896,13 @@ class User extends ModelWithContent
      */
     public function panelPath(): string
     {
+        Helpers::deprecated('Cms\User::panelPath() has been deprecated and will be removed in Kirby 3.8.0. Use $user->panel()->path() instead.');
         return $this->panel()->path();
     }
 
     /**
      * Returns prepared data for the panel user picker
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @param array|null $params
@@ -912,6 +911,7 @@ class User extends ModelWithContent
      */
     public function panelPickerData(array $params = null): array
     {
+        Helpers::deprecated('Cms\User::panelPickerData() has been deprecated and will be removed in Kirby 3.8.0. Use $user->panel()->pickerData() instead.');
         return $this->panel()->pickerData($params);
     }
 
@@ -919,7 +919,6 @@ class User extends ModelWithContent
      * Returns the url to the editing view
      * in the panel
      *
-     * @todo Add `deprecated()` helper warning in 3.7.0
      * @todo Remove in 3.8.0
      *
      * @internal
@@ -929,6 +928,7 @@ class User extends ModelWithContent
      */
     public function panelUrl(bool $relative = false): string
     {
+        Helpers::deprecated('Cms\User::panelUrl() has been deprecated and will be removed in Kirby 3.8.0. Use $user->panel()->url() instead.');
         return $this->panel()->url($relative);
     }
 }

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -176,6 +176,7 @@ class Environment
 
         // keep Server flags compatible for now
         // TODO: remove in 3.8.0
+        // @codeCoverageIgnoreStart
         if (is_int($options['allowed']) === true) {
             Helpers::deprecated('
                 Using `Server::` constants for the `url` option has been deprecated and support will be removed in 3.8.0. Use one of the following instead: a single fixed URL, an array of allowed URLs to match dynamically, `*` wildcard to match dynamically even from insecure headers, or `true` to match automtically from safe server variables.
@@ -183,6 +184,7 @@ class Environment
 
             $options['allowed'] = $this->detectAllowedFromFlag($options['allowed']);
         }
+        // @codeCoverageIgnoreEnd
 
         // insecure auto-detection
         if ($options['allowed'] === '*' || $options['allowed'] === ['*']) {

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -330,7 +330,7 @@ class Uri
      * or any other executed script.
      *
      * @param array $props
-     * @return string|static
+     * @return static
      */
     public static function index(array $props = [])
     {

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -330,7 +330,7 @@ class Uri
      * or any other executed script.
      *
      * @param array $props
-     * @return string
+     * @return string|static
      */
     public static function index(array $props = [])
     {

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -100,10 +100,9 @@ class Url
      * Returns the url to the executed script
      *
      * @param array $props
-     * @param bool $forwarded Deprecated! Todo: remove in 3.7.0
      * @return string
      */
-    public static function index(array $props = [], bool $forwarded = false): string
+    public static function index(array $props = []): string
     {
         return Uri::index($props)->toString();
     }

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Helpers;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Asset;
@@ -151,19 +152,21 @@ class Document
 
     /**
      * @deprecated 3.7.0 Use `Document::customAsset('panel.css)` instead
-     * @todo add deprecation warning in 3.7.0, remove in 3.8.0
+     * @todo remove in 3.8.0
      */
     public static function customCss(): ?string
     {
+        Helpers::deprecated('Panel\Document::customCss() has been deprecated and will be removed in Kirby 3.8.0. Use Panel\Document::customAsset(\'panel.css\') instead.');
         return static::customAsset('panel.css');
     }
 
     /**
      * @deprecated 3.7.0 Use `Document::customAsset('panel.js)` instead
-     * @todo add deprecation warning in 3.7.0, remove in 3.8.0
+     * @todo remove in 3.8.0
      */
     public static function customJs(): ?string
     {
+        Helpers::deprecated('Panel\Document::customJs() has been deprecated and will be removed in Kirby 3.8.0. Use Panel\Document::customAsset(\'panel.js\') instead.');
         return static::customAsset('panel.js');
     }
 

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -153,6 +153,7 @@ class Document
     /**
      * @deprecated 3.7.0 Use `Document::customAsset('panel.css)` instead
      * @todo remove in 3.8.0
+     * @codeCoverageIgnore
      */
     public static function customCss(): ?string
     {
@@ -163,6 +164,7 @@ class Document
     /**
      * @deprecated 3.7.0 Use `Document::customAsset('panel.js)` instead
      * @todo remove in 3.8.0
+     * @codeCoverageIgnore
      */
     public static function customJs(): ?string
     {

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -3,7 +3,6 @@
 namespace Kirby\Toolkit;
 
 use Closure;
-use Kirby\Cms\Helpers;
 use NumberFormatter;
 
 /**

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -54,22 +54,6 @@ class I18n
     protected static $decimalsFormatters = [];
 
     /**
-     * Returns the first fallback locale
-     *
-     * @deprecated 3.5.1 Use `\Kirby\Toolkit\I18n::fallbacks()` instead
-     * @todo Remove in 3.7.0
-     *
-     * @return string
-     */
-    public static function fallback(): string
-    {
-        // @codeCoverageIgnoreStart
-        Helpers::deprecated('I18n::fallback() has been deprecated. Use I18n::fallbacks() instead.');
-        return static::fallbacks()[0];
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
      * Returns the list of fallback locales
      *
      * @return array

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1181,10 +1181,10 @@ class Str
      *                    keys and replacements as values.
      *                    Supports query syntax.
      * @param string|array|null $options An options array that contains:
-     *                                    - fallback: if a token does not have any matches
-     *                                    - callback: to be able to handle each matching result
-     *                                    - start: start placeholder
-     *                                    - end: end placeholder
+     *                                   - fallback: if a token does not have any matches
+     *                                   - callback: to be able to handle each matching result
+     *                                   - start: start placeholder
+     *                                   - end: end placeholder
      * @return string The filled-in string
      */
     public static function template(string $string = null, array $data = [], array $options = null): string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1180,11 +1180,11 @@ class Str
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values.
      *                    Supports query syntax.
-     * @param string|array|null $options An options array that contains:
-     *                                   - fallback: if a token does not have any matches
-     *                                   - callback: to be able to handle each matching result
-     *                                   - start: start placeholder
-     *                                   - end: end placeholder
+     * @param array $options An options array that contains:
+     *                       - fallback: if a token does not have any matches
+     *                       - callback: to be able to handle each matching result
+     *                       - start: start placeholder
+     *                       - end: end placeholder
      * @return string The filled-in string
      */
     public static function template(string $string = null, array $data = [], array $options = []): string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1187,9 +1187,9 @@ class Str
      *                                   - end: end placeholder
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], array $options = null): string
+    public static function template(string $string = null, array $data = [], array $options = []): string
     {
-        $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
+        $fallback = $options['fallback'] ?? null;
         $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
         $start    = (string)($options['start'] ?? '{{');
         $end      = (string)($options['end'] ?? '}}');

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -555,12 +555,12 @@ class Str
      * @param string|null $string
      * @return bool
      * @deprecated 3.6.0 use `Kirby\Toolkit\V::url()` instead
-     * @todo Throw deprecation warning in 3.7.0
      * @todo Remove in 3.8.0
      * @codeCoverageIgnore
      */
     public static function isURL(?string $string = null): bool
     {
+        Helpers::deprecated('Toolkit\Str::isUrl() has been deprecated and will be removed in Kirby 3.8.0. Use Toolkit\V::url() instead.');
         return filter_var($string, FILTER_VALIDATE_URL) !== false;
     }
 
@@ -1180,36 +1180,19 @@ class Str
      * @param array $data Associative array with placeholders as
      *                    keys and replacements as values.
      *                    Supports query syntax.
-     * @param string|array|null $fallback An options array that contains:
+     * @param string|array|null $options An options array that contains:
      *                                    - fallback: if a token does not have any matches
      *                                    - callback: to be able to handle each matching result
      *                                    - start: start placeholder
      *                                    - end: end placeholder
-     *                                    A simple fallback string is supported for compatibility (but deprecated).
-     * @param string $start Placeholder start characters (deprecated)
-     * @param string $end Placeholder end characters (deprecated)
-     *
-     * @todo Remove `$start` and `$end` parameters, rename `$fallback` to `$options` and only support `array` type for `$options` in 3.7.0
-     *
      * @return string The filled-in string
      */
-    public static function template(string $string = null, array $data = [], $fallback = null, string $start = '{{', string $end = '}}'): string
+    public static function template(string $string = null, array $data = [], array $options = null): string
     {
-        // @codeCoverageIgnoreStart
-        if (
-            is_string($fallback) === true ||
-            $start !== '{{' ||
-            $end !== '}}'
-        ) {
-            Helpers::deprecated('Str::template(): The $fallback, $start and $end parameters have been deprecated. Please pass an array to the $options parameter instead with `fallback`, `start` or `end` keys: Str::template($string, $data, $options)');
-        }
-        // @codeCoverageIgnoreEnd
-
-        $options  = $fallback;
         $fallback = is_string($options) === true ? $options : ($options['fallback'] ?? null);
         $callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
-        $start    = (string)($options['start'] ?? $start);
-        $end      = (string)($options['end'] ?? $end);
+        $start    = (string)($options['start'] ?? '{{');
+        $end      = (string)($options['end'] ?? '}}');
 
         // make sure $string is string
         $string ??= '';
@@ -1247,15 +1230,11 @@ class Str
      * Converts a filesize string with shortcuts
      * like M, G or K to an integer value
      *
-     * @param mixed $size
+     * @param string $size
      * @return int
      */
-    public static function toBytes($size): int
+    public static function toBytes(string $size): int
     {
-        // TODO: remove in 3.7.0
-        // in favor of strict parameter type hint
-        $size ??= '';
-
         $size = trim($size);
         $last = strtolower($size[strlen($size)-1] ?? '');
         $size = (int)$size;

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -421,8 +421,7 @@ class Xml
             return $value;
         }
 
-        // TODO: in 3.7.0 use ENT_NOQUOTES | ENT_XML1 instead
-        $encoded = htmlentities($value, ENT_COMPAT);
+        $encoded = htmlentities($value, ENT_NOQUOTES | ENT_XML1);
         if ($encoded === $value) {
             // no CDATA block needed
             return $value;

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -421,7 +421,7 @@ class Xml
             return $value;
         }
 
-        $encoded = htmlentities($value, ENT_QUOTES | ENT_SUBSTITUTE);
+        $encoded = htmlentities($value, ENT_NOQUOTES | ENT_XML1);
         if ($encoded === $value) {
             // no CDATA block needed
             return $value;

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -421,7 +421,7 @@ class Xml
             return $value;
         }
 
-        $encoded = htmlentities($value, ENT_NOQUOTES | ENT_XML1);
+        $encoded = htmlentities($value, ENT_QUOTES | ENT_SUBSTITUTE);
         if ($encoded === $value) {
             // no CDATA block needed
             return $value;

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -45,7 +45,8 @@ class FileRulesTest extends TestCase
 
     public function testChangeNameWithEmptyInput()
     {
-        $file = new File(['filename' => 'test.jpg']);
+        $parent = new Page(['slug' => 'test']);
+        $file = new File(['filename' => 'test.jpg', 'parent' => $parent]);
 
         $this->expectException('Kirby\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('The name must not be empty');

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -131,18 +131,4 @@ class PermissionsTest extends TestCase
 
         new Permissions();
     }
-
-    /**
-     * @todo Remove in 3.7
-     */
-    public function testSettingsFallback()
-    {
-        $permissions = new Permissions([
-            'access' => [
-                'settings' => false
-            ]
-        ]);
-
-        $this->assertFalse($permissions->for('access.system'));
-    }
 }

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1187,10 +1187,7 @@ EOT;
      */
     public function testToBytes()
     {
-        $this->assertSame(0, Str::toBytes(0));
         $this->assertSame(0, Str::toBytes(''));
-        $this->assertSame(0, Str::toBytes(null));
-        $this->assertSame(0, Str::toBytes(false));
         $this->assertSame(0, Str::toBytes('x'));
         $this->assertSame(0, Str::toBytes('K'));
         $this->assertSame(0, Str::toBytes('M'));

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -183,8 +183,8 @@ class XmlTest extends TestCase
         $tag = Xml::tag('name', null, ['foo' => 'bar']);
         $this->assertSame('<name foo="bar" />', $tag);
 
-        $tag = Xml::tag('name', 'Süper Önencœded ßtring', ['foo' => 'bar']);
-        $this->assertSame('<name foo="bar"><![CDATA[Süper Önencœded ßtring]]></name>', $tag);
+        $tag = Xml::tag('name', 'String with <not> a tag & some text', ['foo' => 'bar']);
+        $this->assertSame('<name foo="bar"><![CDATA[String with <not> a tag & some text]]></name>', $tag);
 
         $tag = Xml::tag('name', 'content', ['foo' => 'bar'], '  ', 1);
         $this->assertSame('  <name foo="bar">content</name>', $tag);
@@ -214,9 +214,9 @@ class XmlTest extends TestCase
             [null, null],
             ['', null],
             ['<![CDATA[test]]>', '<![CDATA[test]]>'],
-            ['<![CDATA[töst]]>', '<![CDATA[töst]]>'],
+            ['<![CDATA[String with <not> a tag & some text]]>', '<![CDATA[String with <not> a tag & some text]]>'],
             ['test', 'test'],
-            ['töst', '<![CDATA[töst]]>'],
+            ['String with <not> a tag & some text', '<![CDATA[String with <not> a tag & some text]]>'],
             ['This is a <![CDATA[test]]> with CDATA', '<![CDATA[This is a <![CDATA[test]]]]><![CDATA[> with CDATA]]>'],
             ['te]]>st', '<![CDATA[te]]]]><![CDATA[>st]]>'],
             ['tö]]>st', '<![CDATA[tö]]]]><![CDATA[>st]]>']


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Deprecation warnings
- API field `page.next` now throws deprecation warning and will be removed in v3.8.0.
- API field `page.prev` now throws deprecation warning and will be removed in v3.8.0.
- `markdown` component: using the deprecated `$inline` parameter will now throw a warning and will be removed in v3.8.0. Use `$options['inline']` instead.
- `Cms\App::kirbytext()`: using the deprecated `$inline` parameter will now throw a warning and will be removed in v3.8.0. Use `$options['markdown']['inline']` instead.
- `Cms\App::markdown()`: using the deprecated `$inline` parameter will now throw a warning and will be removed in v3.8.0. Use `$options['inline']` instead.
- `Cms\File::dragText()` now throws a deprecation warning and will be removed in v3.8.0. Use `$file->panel()->dragText()` instead.
- `Cms\File::panelOptions()` now throws a deprecation warning and will be removed in v3.8.0. Use `$file->panel()->options()` instead.
- `Cms\File::panelPath()` now throws a deprecation warning and will be removed in v3.8.0. Use `$file->panel()->path()` instead.
- `Cms\File::panelPickerData()` now throws a deprecation warning and will be removed in v3.8.0. Use `$file->panel()->pickerData()` instead.
- `Cms\File::panelUrl()` now throws a deprecation warning and will be removed in v3.8.0. Use `$file->panel()->url()` instead.
- `Cms\ModelWithContent::panelIcon()` now throws a deprecation warning and will be removed in v3.8.0. Use `$model->panel()->image()` instead.
- `Cms\ModelWithContent::panelImage()` now throws a deprecation warning and will be removed in v3.8.0. Use `$model->panel()->image()` instead.
- `Cms\ModelWithContent::panelOptions()` now throws a deprecation warning and will be removed in v3.8.0. Use `$model->panel()->options()` instead.
- `Cms\Page::dragText()` now throws a deprecation warning and will be removed in v3.8.0. Use `$page->panel()->dragText()` instead.
- `Cms\Page::panelId()` now throws a deprecation warning and will be removed in v3.8.0. Use `$page->panel()->id()` instead.
- `Cms\Page::panelPath()` now throws a deprecation warning and will be removed in v3.8.0. Use `$page->panel()->path()` instead.
- `Cms\Page::panelPickerData()` now throws a deprecation warning and will be removed in v3.8.0. Use `$page->panel()->pickerData()` instead.
- `Cms\Page::panelUrl()` now throws a deprecation warning and will be removed in v3.8.0. Use `$page->panel()->url()` instead.
- `Cms\Site::panelPath()` now throws a deprecation warning and will be removed in v3.8.0. Use `$site->panel()->path()` instead.
- `Cms\Site:panelUrl()` now throws a deprecation warning and will be removed in v3.8.0. Use `$site->panel()->url()` instead.
- `Cms\User::panelPath()` now throws a deprecation warning and will be removed in v3.8.0. Use `$user->panel()->path()` instead.
- `Cms\User::panelPickerData()` now throws a deprecation warning and will be removed in v3.8.0. Use `$user->panel()->pickerData()` instead.
- `Cms\User:panelUrl()` now throws a deprecation warning and will be removed in v3.8.0. Use `$user->panel()->url()` instead.
- Deprecated `Panel\Document::customCss()` now throws a warning and will be removed in v3.8.0. Use `Panel\Document::customAsset('panel.css')` instead.
- Deprecated `Panel\Document::customJs()` now throws a warning and will be removed in v3.8.0. Use `Panel\Document::customAsset('panel.js')` instead.

### Removed deprecated code

- Deprecated API field `page.panelIcon` has been removed. Use `page.panelImage` instead.
- Deprecated API field `file.panelIcon` has been removed. Use `file.panelImage` instead.
- Deprecated `GET (:all)/lock` API endpoint has been removed.
- Deprecated `GET (:all)/unlock` API endpoint has been removed.
- Deprecated `GET pages/(:any)/children/blueprints` API endpoint has been removed. Use `GET pages/(:any)/blueprints` instead.
- Deprecated `GET site/children/blueprints` API endpoint has been removed. Use `GET site/blueprints` instead.
- `page` helper now always only returns a `Kirby\Cms\Page` object or `null`, never a pages collection. Only allows passing a single id as parameter.
- `pages` helper now always only returns a `Kirby\Cms\Pages` collection or `null`, never single page object.
- Deprecated JS API method `files.rename()` has been removed. Use `files.changeName()` instead.
- Deprecated JS API method `pages.slug()` has been removed. Use `pages.changeSlug()` instead.
- Deprecated JS API method `pages.status()` has been removed. Use `pages.changeStatus()` instead.
- Deprecated JS API method `pages.template()` has been removed. Use `pages.changeTemplate()` instead.
- Deprecated JS API method `pages.title()` has been removed. Use `pages.changeTitle()` instead.
- Deprecated JS API method `site.title()` has been removed. Use `site.changeTitle()` instead.
- Deprecated JS API method `system.info()` has been removed. Use `system.get()` instead.
- Deprecated `Cms\App::setLocale()` has been removed. Use `Toolkit\Locale::set()` instead.
- Deprecated `Cms\Block::_key()` has been removed. Use `Block::type()` instead.
- Deprecated `Cms\Block:: _uid()` has been removed. Use `Block::id()` instead.
- `Http\Server::host()`: removed deprecated `$forwarded` parameter.
- `Http\Server::port()`: removed deprecated `$forwarded` parameter.
- `Http\Uri::current()`: removed deprecated `$forwarded` parameter.
- `Http\Uri::index()`: removed deprecated `$forwarded` parameter.
- `Http\Url::index()`: removed deprecated `$forwarded` parameter.
- Deprecated `Toolkit\I18n::fallback()` has been removed. Use `I18n::fallbacks()` instead.
- `Toolkit\Str::template()`: The `$fallback`, `$start` and `$end` parameters have been removed. Please pass an array to the `$options` parameter instead with `fallback`, `start` or `end` keys.

### Breaking changes
- Creating a `Kirby\Cms\File` object requires the `parent` property now.
- `Toolkit\Str::toBytes()` strictly only accepts a string as parameter now.

### Enhancements

- `Toolkit\Xml::value()` now uses better logic to determine whether a `CDATA` block is needed.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
