### PR TITLE
`Str::afterStart()` and `beforeEnd()`; used to make `Environment` code simpler

### DIFF
--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -789,10 +789,7 @@ class Environment
         $requestUri = str_replace('//', '/', $requestUri);
 
         // remove the script path only from the beginning of the URI
-        $scriptPath = $this->scriptPath();
-        if ($scriptPath && Str::position($requestUri, $scriptPath) === 0) {
-            $requestUri = Str::substr($requestUri, Str::length($scriptPath));
-        }
+        $requestUri = Str::afterStart($requestUri, $this->scriptPath());
 
         return trim($requestUri, '/');
     }

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -171,7 +171,7 @@ class Str
     }
 
     /**
-     * Returns the rest of the string after the given character
+     * Returns the rest of the string after the given substring or character
      *
      * @param string $string
      * @param string $needle
@@ -187,6 +187,27 @@ class Str
         }
 
         return static::substr($string, $position + static::length($needle));
+    }
+
+    /**
+     * Removes the given substring or character only from the start of the string
+     *
+     * @param string $string
+     * @param string $needle
+     * @param bool $caseInsensitive
+     * @return string
+     */
+    public static function afterStart(string $string, string $needle, bool $caseInsensitive = false): string
+    {
+        if ($needle === '') {
+            return $string;
+        }
+
+        if (static::startsWith($string, $needle, $caseInsensitive) === true) {
+            return static::substr($string, static::length($needle));
+        }
+
+        return $string;
     }
 
     /**
@@ -213,7 +234,7 @@ class Str
     }
 
     /**
-     * Returns the beginning of a string before the given character
+     * Returns the beginning of a string before the given substring or character
      *
      * @param string $string
      * @param string $needle
@@ -229,6 +250,27 @@ class Str
         }
 
         return static::substr($string, 0, $position);
+    }
+
+    /**
+     * Removes the given substring or character only from the end of the string
+     *
+     * @param string $string
+     * @param string $needle
+     * @param bool $caseInsensitive
+     * @return string
+     */
+    public static function beforeEnd(string $string, string $needle, bool $caseInsensitive = false): string
+    {
+        if ($needle === '') {
+            return $string;
+        }
+
+        if (static::endsWith($string, $needle, $caseInsensitive) === true) {
+            return static::substr($string, 0, -static::length($needle));
+        }
+
+        return $string;
     }
 
     /**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -52,7 +52,7 @@ class StrTest extends TestCase
         // case insensitive
         $this->assertSame(' Wörld', Str::after($string, 'ö', true));
         $this->assertSame(' Wörld', Str::after($string, 'Ö', true));
-        $this->assertSame('', Str::after($string, 'x'));
+        $this->assertSame('', Str::after($string, 'x', true));
 
         // non existing chars
         $this->assertSame('', Str::after('string', '.'), 'string with non-existing character should return false');
@@ -66,6 +66,28 @@ class StrTest extends TestCase
         $this->expectException('Kirby\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('The needle must not be empty');
         Str::after('test', '');
+    }
+
+    /**
+     * @covers ::afterStart
+     */
+    public function testAfterStart()
+    {
+        $string = 'Hellö Wörld';
+
+        // case sensitive
+        $this->assertSame(' Wörld', Str::afterStart($string, 'Hellö'));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, 'HELLÖ'));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, 'Wörld'));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, 'x'));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, ''));
+
+        // case insensitive
+        $this->assertSame(' Wörld', Str::afterStart($string, 'Hellö', true));
+        $this->assertSame(' Wörld', Str::afterStart($string, 'HELLÖ', true));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, 'Wörld', true));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, 'x', true));
+        $this->assertSame('Hellö Wörld', Str::afterStart($string, '', true));
     }
 
     /**
@@ -83,7 +105,7 @@ class StrTest extends TestCase
         // case insensitive
         $this->assertSame('Hell', Str::before($string, 'ö', true));
         $this->assertSame('Hell', Str::before($string, 'Ö', true));
-        $this->assertSame('', Str::before($string, 'x'));
+        $this->assertSame('', Str::before($string, 'x', true));
     }
 
     /**
@@ -94,6 +116,28 @@ class StrTest extends TestCase
         $this->expectException('Kirby\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('The needle must not be empty');
         Str::before('test', '');
+    }
+
+    /**
+     * @covers ::beforeEnd
+     */
+    public function testBeforeEnd()
+    {
+        $string = 'Hellö Wörld';
+
+        // case sensitive
+        $this->assertSame('Hellö ', Str::beforeEnd($string, 'Wörld'));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, 'WÖRLD'));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, 'Hellö'));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, 'x'));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, ''));
+
+        // case insensitive
+        $this->assertSame('Hellö ', Str::beforeEnd($string, 'Wörld', true));
+        $this->assertSame('Hellö ', Str::beforeEnd($string, 'WÖRLD', true));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, 'Hellö', true));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, 'x', true));
+        $this->assertSame('Hellö Wörld', Str::beforeEnd($string, '', true));
     }
 
     /**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `Str::afterStart()` and `Str::beforeEnd()` methods to remove a substring only from the start or end of a string

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
