### PR TITLE
Add new public static method `increment` for `Str` class

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -540,7 +540,7 @@ class Str
     {
         preg_match('/(.+)' . $separator . '([0-9]+)$/', $string, $match);
 
-        return isset($match[2]) ? $match[1] . $separator . ((int) $match[2] + 1) : $string . $separator . $first;
+        return isset($match[2]) ? $match[1] . $separator . ((int)$match[2] + 1) : $string . $separator . $first;
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -538,7 +538,7 @@ class Str
      */
     public static function increment(string $string, int $first = 1, string $separator = '_'): string
     {
-        preg_match('/(.+)' . $separator . '([0-9]+)$/', $string, $match);
+        preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $string, $match);
 
         return isset($match[2]) ? $match[1] . $separator . ((int)$match[2] + 1) : $string . $separator . $first;
     }

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -529,7 +529,7 @@ class Str
     }
 
     /**
-     * Add's _1 to a string or increment the ending number to allow _2, _3, etc
+     * Adds `-1` to a string or increments the ending number to allow `-2`, `-3`, etc.
      *
      * @param string $string The string to increment
      * @param string $separator
@@ -538,13 +538,14 @@ class Str
      */
     public static function increment(string $string, string $separator = '-', int $first = 1): string
     {
-        preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $string, $match);
+        preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $string, $matches);
 
-        if (isset($match[2]) === true) {
+        if (isset($matches[2]) === true) {
             // increment the existing ending number
-            return $match[1] . $separator . ((int)$match[2] + 1);
+            return $matches[1] . $separator . ((int)$matches[2] + 1);
         }
 
+        // append a new ending number
         return $string . $separator . $first;
     }
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -540,7 +540,12 @@ class Str
     {
         preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $string, $match);
 
-        return isset($match[2]) ? $match[1] . $separator . ((int)$match[2] + 1) : $string . $separator . $first;
+        if (isset($match[2]) === true) {
+            // increment the existing ending number
+            return $match[1] . $separator . ((int)$match[2] + 1);
+        }
+
+        return $string . $separator . $first;
     }
 
     /**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -531,9 +531,9 @@ class Str
     /**
      * Add's _1 to a string or increment the ending number to allow _2, _3, etc
      *
-     * @param  string  $string    The string to increment
-     * @param  int     $first     Start with
-     * @param  string  $separator Separator
+     * @param string $string The string to increment
+     * @param int $first Start with
+     * @param string $separator Separator
      * @return string
      */
     public static function increment(string $string, int $first = 1, string $separator = '_'): string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -529,6 +529,21 @@ class Str
     }
 
     /**
+     * Add's _1 to a string or increment the ending number to allow _2, _3, etc
+     *
+     * @param  string  $string    The string to increment
+     * @param  int     $first     Start with
+     * @param  string  $separator Separator
+     * @return string
+     */
+    public static function increment(string $string, int $first = 1, string $separator = '_'): string
+    {
+        preg_match('/(.+)' . $separator . '([0-9]+)$/', $string, $match);
+
+        return isset($match[2]) ? $match[1] . $separator . ((int) $match[2] + 1) : $string . $separator . $first;
+    }
+
+    /**
      * Checks if the given string is a URL
      *
      * @param string|null $string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -532,11 +532,11 @@ class Str
      * Add's _1 to a string or increment the ending number to allow _2, _3, etc
      *
      * @param string $string The string to increment
-     * @param int $first Start with
-     * @param string $separator Separator
+     * @param string $separator
+     * @param int $first Starting number
      * @return string
      */
-    public static function increment(string $string, int $first = 1, string $separator = '_'): string
+    public static function increment(string $string, string $separator = '-', int $first = 1): string
     {
         preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $string, $match);
 

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -426,6 +426,39 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::increment
+     */
+    public function testIncrement()
+    {
+        $string = 'Pöst';
+        $this->assertSame('Pöst_1', Str::increment($string));
+
+        $string = 'Pöst_1';
+        $this->assertSame('Pöst_2', Str::increment($string));
+
+        $string = 'Pöst_2';
+        $this->assertSame('Pöst_3', Str::increment($string));
+
+        $string = 'Pöst';
+        $this->assertSame('Pöst-1', Str::increment($string, 1, '-'));
+
+        $string = 'Pöst';
+        $this->assertSame('Pöst-10', Str::increment($string, 10, '-'));
+
+        $string = 'Pöst-10';
+        $this->assertSame('Pöst-11', Str::increment($string, 1, '-'));
+
+        $string = 'Pöst-10';
+        $this->assertSame('Pöst-11', Str::increment($string, 10, '-'));
+
+        $string = 'Pöst';
+        $this->assertSame('Pöst 1', Str::increment($string, 1, ' '));
+
+        $string = 'Pöst post 1';
+        $this->assertSame('Pöst post 2', Str::increment($string, 1, ' '));
+    }
+
+    /**
      * @covers ::kebab
      */
     public function testKebab()

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -449,7 +449,7 @@ class StrTest extends TestCase
         $this->assertSame('Pöst-11', Str::increment($string, '-', 1));
 
         $string = 'Pöst-10';
-        $this->assertSame('Pöst-11', Str::increment($string, '-',  10));
+        $this->assertSame('Pöst-11', Str::increment($string, '-', 10));
 
         $string = 'Pöst';
         $this->assertSame('Pöst 1', Str::increment($string, ' ', 1));

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -440,16 +440,16 @@ class StrTest extends TestCase
         $this->assertSame('Pöst-3', Str::increment($string));
 
         $string = 'Pöst';
-        $this->assertSame('Pöst-1', Str::increment($string, '-'));
+        $this->assertSame('Pöst_1', Str::increment($string, '_'));
 
         $string = 'Pöst';
-        $this->assertSame('Pöst-10', Str::increment($string, '-', 10));
+        $this->assertSame('Pöst_10', Str::increment($string, '_', 10));
 
-        $string = 'Pöst-10';
-        $this->assertSame('Pöst-11', Str::increment($string, '-', 1));
+        $string = 'Pöst_10';
+        $this->assertSame('Pöst_11', Str::increment($string, '_', 1));
 
-        $string = 'Pöst-10';
-        $this->assertSame('Pöst-11', Str::increment($string, '-', 10));
+        $string = 'Pöst_10';
+        $this->assertSame('Pöst_11', Str::increment($string, '_', 10));
 
         $string = 'Pöst';
         $this->assertSame('Pöst 1', Str::increment($string, ' ', 1));
@@ -459,6 +459,9 @@ class StrTest extends TestCase
 
         $string = 'Pöst_10';
         $this->assertSame('Pöst_10-1', Str::increment($string, '-'));
+
+        $string = 'Pöst-10';
+        $this->assertSame('Pöst-10_1', Str::increment($string, '_'));
 
         $string = 'Pöst-5';
         $this->assertSame('Pöst-6', Str::increment($string, '-', 10));

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -431,31 +431,40 @@ class StrTest extends TestCase
     public function testIncrement()
     {
         $string = 'Pöst';
-        $this->assertSame('Pöst_1', Str::increment($string));
+        $this->assertSame('Pöst-1', Str::increment($string));
 
-        $string = 'Pöst_1';
-        $this->assertSame('Pöst_2', Str::increment($string));
+        $string = 'Pöst-1';
+        $this->assertSame('Pöst-2', Str::increment($string));
 
-        $string = 'Pöst_2';
-        $this->assertSame('Pöst_3', Str::increment($string));
-
-        $string = 'Pöst';
-        $this->assertSame('Pöst-1', Str::increment($string, 1, '-'));
+        $string = 'Pöst-2';
+        $this->assertSame('Pöst-3', Str::increment($string));
 
         $string = 'Pöst';
-        $this->assertSame('Pöst-10', Str::increment($string, 10, '-'));
+        $this->assertSame('Pöst-1', Str::increment($string, '-'));
+
+        $string = 'Pöst';
+        $this->assertSame('Pöst-10', Str::increment($string, '-', 10));
 
         $string = 'Pöst-10';
-        $this->assertSame('Pöst-11', Str::increment($string, 1, '-'));
+        $this->assertSame('Pöst-11', Str::increment($string, '-', 1));
 
         $string = 'Pöst-10';
-        $this->assertSame('Pöst-11', Str::increment($string, 10, '-'));
+        $this->assertSame('Pöst-11', Str::increment($string, '-',  10));
 
         $string = 'Pöst';
-        $this->assertSame('Pöst 1', Str::increment($string, 1, ' '));
+        $this->assertSame('Pöst 1', Str::increment($string, ' ', 1));
 
         $string = 'Pöst post 1';
-        $this->assertSame('Pöst post 2', Str::increment($string, 1, ' '));
+        $this->assertSame('Pöst post 2', Str::increment($string, ' ', 1));
+
+        $string = 'Pöst_10';
+        $this->assertSame('Pöst_10-1', Str::increment($string, '-'));
+
+        $string = 'Pöst-5';
+        $this->assertSame('Pöst-6', Str::increment($string, '-', 10));
+
+        $string = 'Pöst-15';
+        $this->assertSame('Pöst-16', Str::increment($string, '-', 10));
     }
 
     /**


### PR DESCRIPTION
## This PR …

### Features
* New `Str::increment()` method for appending a number `-1` to a string or incrementing the ending number to allow `-2`, `-3`, etc.

```php
echo Str::increment('Page-1'); //=> Page-2
echo Str::increment('Page', '_'); //=> Page_1
```

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
