### PR TITLE
Add new public static method `wrap` for `Str` class and new `json` validator or `V` class

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1444,15 +1444,15 @@ class Str
     }
 
     /**
-     * Wrap the string with the given strings
+     * Wraps the string with the given string(s)
      *
      * @param string $string String to wrap
-     * @param string $before String to wrap before
-     * @param string|null $after String to wrap after
+     * @param string $before String to prepend
+     * @param string|null $after String to append (if different from `$before`)
      * @return string
      */
     public static function wrap(string $string, string $before, string $after = null): string
     {
-        return $before . $string . ($after ??= $before);
+        return $before . $string . ($after ?? $before);
     }
 }

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1442,4 +1442,17 @@ class Str
             return '&nbsp;' . $matches[2];
         }, $string);
     }
+
+    /**
+     * Wrap the string with the given strings
+     *
+     * @param string $string String to wrap
+     * @param string $before String to wrap before
+     * @param string|null $after String to wrap after
+     * @return string
+     */
+    public static function wrap(string $string, string $before, string $after = null): string
+    {
+        return $before . $string . ($after ??= $before);
+    }
 }

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -447,6 +447,19 @@ V::$validators = [
     },
 
     /**
+     * Checks for valid json
+     */
+    'json' => function ($value): bool {
+        if (!is_string($value) || $value === '') {
+            return false;
+        }
+
+        json_decode($value);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    },
+
+    /**
      * Checks if the value is lower than the second value
      */
     'less' => function ($value, float $max): bool {

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1336,4 +1336,16 @@ EOT;
         $this->assertSame('Omelette du&nbsp;fromage&nbsp;?', Str::widont('Omelette du fromage ?'));
         $this->assertSame('', Str::widont());
     }
+
+    /**
+     * @covers ::wrap
+     */
+    public function testWrap()
+    {
+        $string = 'Pöst title';
+        $this->assertSame('# Pöst title {.title}', Str::wrap($string, '# ', ' {.title}'));
+
+        $string = 'Pöst title';
+        $this->assertSame('"Pöst title"', Str::wrap($string, '"'));
+    }
 }

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -458,6 +458,18 @@ class VTest extends TestCase
         $this->assertFalse(V::ip('192.168.255.24.23'));
     }
 
+    public function testJson()
+    {
+        $this->assertTrue(V::json('{"foo": "bar"}'));
+        $this->assertTrue(V::json("{}"));
+        $this->assertTrue(V::json("[]"));
+        $this->assertFalse(V::json("{foo: bar}"));
+        $this->assertFalse(V::json("foo"));
+        $this->assertFalse(V::json([]));
+        $this->assertFalse(V::json(false));
+        $this->assertFalse(V::json(42));
+    }
+
     public function testLess()
     {
         $this->assertTrue(V::less(1, 2));

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -468,6 +468,7 @@ class VTest extends TestCase
         $this->assertFalse(V::json([]));
         $this->assertFalse(V::json(false));
         $this->assertFalse(V::json(42));
+        $this->assertFalse(V::json(''));
     }
 
     public function testLess()

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -461,10 +461,10 @@ class VTest extends TestCase
     public function testJson()
     {
         $this->assertTrue(V::json('{"foo": "bar"}'));
-        $this->assertTrue(V::json("{}"));
-        $this->assertTrue(V::json("[]"));
-        $this->assertFalse(V::json("{foo: bar}"));
-        $this->assertFalse(V::json("foo"));
+        $this->assertTrue(V::json('{}'));
+        $this->assertTrue(V::json('[]'));
+        $this->assertFalse(V::json('{foo: bar}'));
+        $this->assertFalse(V::json('foo'));
         $this->assertFalse(V::json([]));
         $this->assertFalse(V::json(false));
         $this->assertFalse(V::json(42));


### PR DESCRIPTION
## This PR …

### Features
* New `Str::wrap()` method for wrapping the string with the given strings.
* New `V::json()` to check for valid json

```php
// Str::wrap()
echo Str::wrap($string, '# ', ' {.title}'); //=> # Pöst title {.title}
echo Str::wrap($string, '"'); //=> "Pöst title"

// V::json()
if (V::json('{"foo": "Foo"}')) {
  // do something...
}
```

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
