### PR TITLE
Forward extension of accept property to browser

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -31,7 +31,7 @@ return [
                     'template' => $template
                 ]);
 
-                $uploads['accept'] = $file->blueprint()->acceptMime();
+                $uploads['accept'] = $file->blueprint()->acceptAttribute();
             } else {
                 $uploads['accept'] = '*';
             }

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -73,7 +73,7 @@ return [
                     'template' => $this->template
                 ]);
 
-                return $file->blueprint()->acceptMime();
+                return $file->blueprint()->acceptAttribute();
             }
 
             return null;

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -112,6 +112,27 @@ class FileBlueprint extends Blueprint
         // no restrictions, accept everything
         return '*';
     }
+    
+    /**
+     * Returns the list of all accepted file extensions and mime types in a comma separated string.
+     * Compatible with the `accept` attribute of HTML input elements.
+     *
+     * @return string
+     */
+    public function acceptAttribute(): string
+    {
+        $accept = $this->accept();
+
+        $extensionArray = A::wrap($accept['extension'] ?? []);
+        $mimeArray = A::wrap($accept['mime'] ?? []);
+
+        return A::join([
+            ...A::map($extensionArray, function ($extension) {
+                return '.' . $extension;
+            }),
+            ...$mimeArray
+        ]);
+    }
 
     /**
      * @param mixed $accept

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -117,6 +117,7 @@ class FileBlueprint extends Blueprint
     /**
      * Returns the list of all accepted file extensions and mime types in a comma separated string.
      * Compatible with the `accept` attribute of HTML input elements.
+     * When no restrictions are defined, the string `*` is returned.
      *
      * @return string
      */
@@ -130,7 +131,7 @@ class FileBlueprint extends Blueprint
         return A::join(array_merge(
             A::map($extensionArray, fn ($ext) => ".$ext"),
             $mimeArray
-        ));
+        )) ?: '*';
     }
 
     /**

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -127,12 +127,10 @@ class FileBlueprint extends Blueprint
         $extensionArray = A::wrap($accept['extension'] ?? []);
         $mimeArray = A::wrap($accept['mime'] ?? []);
 
-        return A::join([
-            ...A::map($extensionArray, function ($extension) {
-                return '.' . $extension;
-            }),
-            ...$mimeArray
-        ]);
+        return A::join(array_merge(
+            A::map($extensionArray, fn ($ext) => ".$ext"),
+            $mimeArray
+        ));
     }
 
     /**

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
 /**


### PR DESCRIPTION
Previously the `extension` part of the `accept` property in file blueprints was ignored when creating the [HTML `accept` attribute ](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept). 
For file types that are unknown to Kirby this resulted in a `accept="*"` attribute.

For context: https://forum.getkirby.com/t/new-file-blueprint-for-gpx-files/25618

## This PR …
... makes it so that a correct string, combining extensions and mime types in a comma separated list is used instead.
It does this by adding a new `acceptAttribute` method to the `FileBlueprint` class, and replaces the use of `acceptMime` in the files section and files field (currently `upload` mixin)  with that.

## Fixes
 - extension part of accept property is no longer ignored 

### Breaking changes
none

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
