### PR TITLE
Add new public static method `charAt` for `Str` class

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -298,6 +298,18 @@ class Str
     }
 
     /**
+     * Returns the character at index.
+     *
+     * @param string $string String to extract the character from
+     * @param int $index Position of the character
+     * @return string
+     */
+    public static function charAt(string $string = null, int $index): string
+    {
+        return static::substr($string, $index, 1);
+    }
+    
+    /**
      * Checks if a str contains another string
      *
      * @param string $string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -298,7 +298,7 @@ class Str
     }
 
     /**
-     * Returns the character at index.
+     * Returns the character at index
      *
      * @param string $string String to extract the character from
      * @param int $index Position of the character

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -308,6 +308,7 @@ class Str
     {
         return static::substr($string, $index, 1);
     }
+
     /**
      * Checks if a str contains another string
      *

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -308,7 +308,6 @@ class Str
     {
         return static::substr($string, $index, 1);
     }
-    
     /**
      * Checks if a str contains another string
      *

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -217,6 +217,19 @@ class StrTest extends TestCase
     }
 
     /**
+     * @covers ::charAt
+     */
+    public function testcharAt()
+    {
+        $string = 'Hellö Wörld';
+        $this->assertSame('H', Str::charAt($string, 0));
+        $this->assertSame('ö', Str::charAt($string, 4));
+        $this->assertSame('d', Str::charAt($string, 10));
+        $this->assertSame('', Str::charAt($string, 11));
+        $this->assertSame('', Str::charAt($string, 12));
+    }
+
+    /**
      * @covers ::convert
      */
     public function testConvert()


### PR DESCRIPTION
## This PR …

### Features
* New `Str::charAt()` method to get the character at specific index.

```php
$string = "Hellö Wörld";
echo Str::charAt($string, 0); //=> H
echo Str::charAt($string, 10); //=> d
```

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
