### PR TITLE
Fix `File::previewUrl` on custom `file::url` component 

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -791,6 +791,18 @@ trait AppPlugins
     }
 
     /**
+     * Checks if a native component was extended
+     * @since 3.7.0
+     *
+     * @param string $component
+     * @return bool
+     */
+    public function isNativeComponent(string $component): bool
+    {
+        return $this->component($component) === $this->nativeComponent($component);
+    }
+
+    /**
      * Returns the native implementation
      * of a core component
      *

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -752,6 +752,11 @@ class File extends ModelWithContent
                     return $this->url();
                 }
 
+                // checks `file::url` component is extended
+                if ($this->kirby()->isNativeComponent('file::url') === false) {
+                    return $this->url();
+                }
+
                 return $url;
             case 'user':
                 return $this->url();

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -375,6 +375,34 @@ class FileTest extends TestCase
         $this->assertSame($file->url(), $file->previewUrl());
     }
 
+    public function testPreviewUrlForExtendedComponent()
+    {
+        $app = new App([
+            'roots' => [
+                'index' => '/dev/null'
+            ],
+            'components' => [
+                'file::url' => function ($kirby, $file, array $options = []) {
+                    return 'https://getkirby.com/' . $file->filename();
+                }
+            ],
+            'site' => [
+                'children' => [
+                    [
+                        'slug'     => 'test',
+                        'template' => 'test',
+                        'files'    => [
+                            ['filename' => 'test.pdf']
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $file = $app->file('test/test.pdf');
+        $this->assertSame('https://getkirby.com/test.pdf', $file->previewUrl());
+    }
+
     public function testQuery()
     {
         $file = $this->file();


### PR DESCRIPTION
## This PR …

WIP and POC of @distantnative comment: https://github.com/getkirby/kirby/issues/4143#issuecomment-1075001280 @lukasbestle not agreed about solution but I just created the PR to force fixing the issue soon. Feel free to close any time.

### Fixes
 - `file::url` component doesn't work as expected in 3.6.x on File Panel Pages #4143

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
