### PR TITLE
Fix multi selecting blocks without click

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -174,15 +174,7 @@ export default {
 		}
 	},
 	created() {
-		// resets multi selecting on tab change
-		// keep only if there are already multiple selections
-		// triggers `blur` event when tab changed
-		window.addEventListener("blur", () => {
-			if (this.batch.length === 0) {
-				this.isMultiSelectKey = false;
-			}
-		});
-
+		this.$events.$on("blur", this.onBlur);
 		this.$events.$on("copy", this.copy);
 		this.$events.$on("focus", this.onOutsideFocus);
 		this.$events.$on("keydown", this.onKey);
@@ -190,6 +182,7 @@ export default {
 		this.$events.$on("paste", this.onPaste);
 	},
 	destroyed() {
+		this.$events.$off("blur", this.onBlur);
 		this.$events.$off("copy", this.copy);
 		this.$events.$off("focus", this.onOutsideFocus);
 		this.$events.$off("keydown", this.onKey);
@@ -476,6 +469,14 @@ export default {
 			}
 
 			return true;
+		},
+		onBlur() {
+			// resets multi selecting on tab change
+			// keep only if there are already multiple selections
+			// triggers `blur` event when tab changed
+			if (this.batch.length === 0) {
+				this.isMultiSelectKey = false;
+			}
 		},
 		onKey(event) {
 			this.isMultiSelectKey = event.metaKey || event.ctrlKey || event.altKey;

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -174,6 +174,15 @@ export default {
 		}
 	},
 	created() {
+		// resets multi selecting on tab change
+		// keep only if there are already multiple selections
+		// triggers `blur` event when tab changed
+		window.addEventListener("blur", () => {
+			if (this.batch.length === 0) {
+				this.isMultiSelectKey = false;
+			}
+		});
+
 		this.$events.$on("copy", this.copy);
 		this.$events.$on("focus", this.onOutsideFocus);
 		this.$events.$on("keydown", this.onKey);

--- a/panel/src/config/events.js
+++ b/panel/src/config/events.js
@@ -8,6 +8,9 @@ export default {
 			$on: emitter.on,
 			$off: emitter.off,
 			$emit: emitter.emit,
+			blur(e) {
+				bus.$emit("blur", e);
+			},
 			click(e) {
 				bus.$emit("click", e);
 			},
@@ -90,19 +93,21 @@ export default {
 			}
 		};
 
-		window.addEventListener("online", bus.online);
-		window.addEventListener("offline", bus.offline);
-		window.addEventListener("dragenter", bus.dragenter, false);
-		window.addEventListener("dragover", bus.prevent, false);
-		window.addEventListener("dragexit", bus.prevent, false);
-		window.addEventListener("dragleave", bus.dragleave, false);
-		window.addEventListener("drop", bus.drop, false);
-		window.addEventListener("keydown", bus.keydown, false);
-		window.addEventListener("keyup", bus.keyup, false);
 		document.addEventListener("click", bus.click, false);
 		document.addEventListener("copy", bus.copy, true);
 		document.addEventListener("focus", bus.focus, true);
 		document.addEventListener("paste", bus.paste, true);
+
+		window.addEventListener("blur", bus.blur, false);
+		window.addEventListener("dragenter", bus.dragenter, false);
+		window.addEventListener("dragexit", bus.prevent, false);
+		window.addEventListener("dragleave", bus.dragleave, false);
+		window.addEventListener("drop", bus.drop, false);
+		window.addEventListener("dragover", bus.prevent, false);
+		window.addEventListener("keydown", bus.keydown, false);
+		window.addEventListener("keyup", bus.keyup, false);
+		window.addEventListener("offline", bus.offline);
+		window.addEventListener("online", bus.online);
 
 		app.prototype.$events = bus;
 	}


### PR DESCRIPTION
## This PR …

The issue fixed with listening `window.addEventListener('blur')` event and reset the multi select mode.

### Fixes
- Multi select mode in blocks field is triggered without click #4319

### Breaking changes

none

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- ~[ ] Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- ~[ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
