### PR TITLE
Fix pasting multiple lines to writer field with inline mode (Encloses all paragraphs)

### DIFF
--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -322,7 +322,14 @@ export default class Editor extends Emitter {
     div.appendChild(fragment);
 
     if (this.options.inline && div.querySelector("p")) {
-      return div.querySelector("p").innerHTML;
+      let paragraphs = [];
+
+      const elems = div.querySelectorAll("p");
+      [...elems].forEach((elem) => {
+        paragraphs.push(elem.innerHTML)
+      });
+
+      return paragraphs.join("<br>");
     }
 
     return div.innerHTML;


### PR DESCRIPTION
## This PR …

Encloses all paragraphs in a single paragraph. (The text is pasted as paragraphs, but saved with `<br>`, no instant conversion)

Please check other solution #4351 ⚠️Only one of them needs to be merged.

## Example

**String**
````
Lorem ipsum dolor sit amet, consectetur adipiscing elit. 

Donec lectus est, lacinia ultricies diam consectetur, consectetur ornare lorem. 

Etiam ipsum libero, fermentum nec blandit vitae, vehicula rhoncus nibh. Quisque at metus imperdiet, tristique risus vitae, pretium mi. 
````

**Output**
````html
<p>
  Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
  <br>
  Donec lectus est, lacinia ultricies diam consectetur, consectetur ornare lorem. 
  <br>
  Etiam ipsum libero, fermentum nec blandit vitae, vehicula rhoncus nibh. Quisque at metus imperdiet, tristique risus vitae, pretium mi. 
</p>
````

### Fixes
- Writer fields with `inline: true` only store first paragraph when multiple are pasted #4310

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
