### PR TITLE
Fix pasting multiple lines to writer field with inline mode (no `<p>` output)

### DIFF
--- a/panel/src/components/Forms/Writer/Nodes/Doc.js
+++ b/panel/src/components/Forms/Writer/Nodes/Doc.js
@@ -13,7 +13,7 @@ export default class Doc extends Node {
 
 	get schema() {
 		return {
-			content: this.options.inline ? "paragraph+" : "block+"
+			content: this.options.inline ? "inline*" : "block+"
 		};
 	}
 }


### PR DESCRIPTION
## This PR …

Use `inline*` option instead  `paragraph+` option that accepting multiple paragraphs when `inline` mode enabled. But there is a breaking change that this option has no `<p>` output. Would this be intended or unexpected behavior?

Please check other solution #4350 ⚠️Only one of them needs to be merged.

## Example

**String**
````
Lorem ipsum dolor sit amet, consectetur adipiscing elit. 

Donec lectus est, lacinia ultricies diam consectetur, consectetur ornare lorem. 

Etiam ipsum libero, fermentum nec blandit vitae, vehicula rhoncus nibh. Quisque at metus imperdiet, tristique risus vitae, pretium mi. 
````

**Output**
````html
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lectus est, lacinia ultricies diam consectetur, consectetur ornare lorem. Etiam ipsum libero, fermentum nec blandit vitae, vehicula rhoncus nibh. Quisque at metus imperdiet, tristique risus vitae, pretium mi. 
````

### Fixes
- Writer fields with `inline: true` only store first paragraph when multiple are pasted #4310

### Breaking changes
- No paragraph (`<p>`) output when inline mode

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
