### PR TITLE
Replace `$_SERVER` with new `Environment` class in the core

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -680,6 +680,12 @@ class Api
      */
     public function responseForException(Throwable $e): array
     {
+        if (isset($this->kirby) === true) {
+            $docRoot = $this->kirby->environment()->get('DOCUMENT_ROOT');
+        } else {
+            $docRoot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+        }
+
         // prepare the result array for all exception types
         $result = [
             'status'    => 'error',
@@ -687,7 +693,7 @@ class Api
             'code'      => empty($e->getCode()) === true ? 500 : $e->getCode(),
             'exception' => get_class($e),
             'key'       => null,
-            'file'      => F::relativepath($e->getFile(), $_SERVER['DOCUMENT_ROOT'] ?? null),
+            'file'      => F::relativepath($e->getFile(), $docRoot),
             'line'      => $e->getLine(),
             'details'   => [],
             'route'     => $this->route ? $this->route->pattern() : null

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\F;
 use Kirby\Http\Response;
 use Kirby\Toolkit\I18n;
 use Whoops\Handler\CallbackHandler;
@@ -129,7 +130,7 @@ trait AppErrors
                     'code'      => $code,
                     'message'   => $exception->getMessage(),
                     'details'   => $details,
-                    'file'      => ltrim($exception->getFile(), $this->environment()->get('DOCUMENT_ROOT', '')),
+                    'file'      => F::relativepath($exception->getFile(), $this->environment()->get('DOCUMENT_ROOT', '')),
                     'line'      => $exception->getLine(),
                 ], $httpCode);
             } else {

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -129,7 +129,7 @@ trait AppErrors
                     'code'      => $code,
                     'message'   => $exception->getMessage(),
                     'details'   => $details,
-                    'file'      => ltrim($exception->getFile(), $_SERVER['DOCUMENT_ROOT'] ?? ''),
+                    'file'      => ltrim($exception->getFile(), $this->environment()->get('DOCUMENT_ROOT', '')),
                     'line'      => $exception->getLine(),
                 ], $httpCode);
             } else {

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Exception;
 
+use Kirby\Http\Environment;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -143,10 +144,11 @@ class Exception extends \Exception
      */
     final public function getFileRelative(): string
     {
-        $file = $this->getFile();
+        $file    = $this->getFile();
+        $docRoot = Environment::getGlobally('DOCUMENT_ROOT');
 
-        if (empty($_SERVER['DOCUMENT_ROOT']) === false) {
-            $file = ltrim(Str::after($file, $_SERVER['DOCUMENT_ROOT']), '/');
+        if (empty($docRoot) === false) {
+            $file = ltrim(Str::after($file, $docRoot), '/');
         }
 
         return $file;

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
@@ -628,6 +629,36 @@ class Environment
         }
 
         return $this->info[$key] ?? static::sanitize($key, $default);
+    }
+
+    /**
+     * Gets a value from the global server environment array
+     * of the current app instance; falls back to `$_SERVER` if
+     * no app instance is running
+     *
+     * @param string|false|null $key The key to look for. Pass `false` or `null`
+     *                               to return the entire server array.
+     * @param mixed $default Optional default value, which should be
+     *                       returned if no element has been found
+     * @return mixed
+     */
+    public static function getGlobally($key = null, $default = null)
+    {
+        // first try the global `Environment` object if the CMS is running
+        $app = App::instance(null, true);
+        if ($app) {
+            return $app->environment()->get($key, $default);
+        }
+
+        if (is_string($key) === false) {
+            return static::sanitize($_SERVER);
+        }
+
+        if (isset($_SERVER[$key]) === false) {
+            $key = strtoupper($key);
+        }
+
+        return static::sanitize($key, $_SERVER[$key] ?? $default);
     }
 
     /**

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -163,7 +163,7 @@ class Environment
             'allowed' => null
         ], $options ?? []);
 
-        $this->info          = $this->sanitize($info);
+        $this->info          = static::sanitize($info);
         $this->cli           = $this->detectCli($options['cli']);
         $this->ip            = $this->detectIp();
         $this->host          = null;
@@ -541,7 +541,7 @@ class Environment
 
         return [
             'host' => $parts[0] ?? null,
-            'port' => $this->sanitizePort($parts[1] ?? null),
+            'port' => static::sanitizePort($parts[1] ?? null),
         ];
     }
 
@@ -627,7 +627,7 @@ class Environment
             $key = strtoupper($key);
         }
 
-        return $this->info[$key] ?? $this->sanitize($key, $default);
+        return $this->info[$key] ?? static::sanitize($key, $default);
     }
 
     /**
@@ -829,11 +829,11 @@ class Environment
      * @param mixed $value
      * @return mixed
      */
-    public function sanitize($key, $value = null)
+    public static function sanitize($key, $value = null)
     {
         if (is_array($key) === true) {
             foreach ($key as $k => $v) {
-                $key[$k] = $this->sanitize($k, $v);
+                $key[$k] = static::sanitize($k, $v);
             }
 
             return $key;
@@ -844,10 +844,10 @@ class Environment
             case 'SERVER_NAME':
             case 'HTTP_HOST':
             case 'HTTP_X_FORWARDED_HOST':
-                return $this->sanitizeHost($value);
+                return static::sanitizeHost($value);
             case 'SERVER_PORT':
             case 'HTTP_X_FORWARDED_PORT':
-                return $this->sanitizePort($value);
+                return static::sanitizePort($value);
             default:
                 return $value;
         }
@@ -859,7 +859,7 @@ class Environment
      * @param string|null $host
      * @return string|null
      */
-    protected function sanitizeHost(?string $host = null): ?string
+    protected static function sanitizeHost(?string $host = null): ?string
     {
         if (empty($host) === true) {
             return null;
@@ -887,7 +887,7 @@ class Environment
      * @param string|int|null $port
      * @return int|null
      */
-    protected function sanitizePort($port = null): ?int
+    protected static function sanitizePort($port = null): ?int
     {
         // already fine
         if (is_int($port) === true) {

--- a/src/Http/Header.php
+++ b/src/Http/Header.php
@@ -130,7 +130,7 @@ class Header
     public static function status($code = null, bool $send = true)
     {
         $codes    = static::$codes;
-        $protocol = $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
+        $protocol = Environment::getGlobally('SERVER_PROTOCOL', 'HTTP/1.1');
 
         // allow full control over code and message
         if (is_string($code) === true && preg_match('/^\d{3} \w.+$/', $code) === 1) {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -226,14 +226,14 @@ class Request
         $methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'];
 
         // the request method can be overwritten with a header
-        $methodOverride = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? '');
+        $methodOverride = strtoupper(Environment::getGlobally('HTTP_X_HTTP_METHOD_OVERRIDE', ''));
 
         if ($method === null && in_array($methodOverride, $methods) === true) {
             $method = $methodOverride;
         }
 
         // final chain of options to detect the method
-        $method = $method ?? $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $method = $method ?? Environment::getGlobally('REQUEST_METHOD', 'GET');
 
         // uppercase the shit out of it
         $method = strtoupper($method);
@@ -314,7 +314,7 @@ class Request
     {
         $headers = [];
 
-        foreach ($_SERVER as $key => $value) {
+        foreach (Environment::getGlobally() as $key => $value) {
             if (substr($key, 0, 5) !== 'HTTP_' && substr($key, 0, 14) !== 'REDIRECT_HTTP_') {
                 continue;
             }

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -185,7 +185,7 @@ class Url
      */
     public static function last(): string
     {
-        return $_SERVER['HTTP_REFERER'] ?? '';
+        return Environment::getGlobally('HTTP_REFERER', '');
     }
 
     /**

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -55,10 +55,10 @@ class Visitor
      */
     public function __construct(array $arguments = [])
     {
-        $this->ip($arguments['ip'] ?? $_SERVER['REMOTE_ADDR'] ?? '');
-        $this->userAgent($arguments['userAgent'] ?? $_SERVER['HTTP_USER_AGENT'] ?? '');
-        $this->acceptedLanguage($arguments['acceptedLanguage'] ?? $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '');
-        $this->acceptedMimeType($arguments['acceptedMimeType'] ?? $_SERVER['HTTP_ACCEPT'] ?? '');
+        $this->ip($arguments['ip'] ?? Environment::getGlobally('REMOTE_ADDR', ''));
+        $this->userAgent($arguments['userAgent'] ?? Environment::getGlobally('HTTP_USER_AGENT', ''));
+        $this->acceptedLanguage($arguments['acceptedLanguage'] ?? Environment::getGlobally('HTTP_ACCEPT_LANGUAGE', ''));
+        $this->acceptedMimeType($arguments['acceptedMimeType'] ?? Environment::getGlobally('HTTP_ACCEPT', ''));
     }
 
     /**

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -80,7 +80,7 @@ class AppErrorsTest extends TestCase
      * @covers ::handleErrors
      * @covers ::getExceptionHookWhoopsHandler
      */
-    public function testHandleErrors()
+    public function testHandleErrors1()
     {
         $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
         $whoopsMethod->setAccessible(true);
@@ -99,6 +99,19 @@ class AppErrorsTest extends TestCase
         $this->assertCount(2, $handlers);
         $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
+    }
+
+    /**
+     * @covers ::handleErrors
+     * @covers ::getExceptionHookWhoopsHandler
+     */
+    public function testHandleErrors2()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+
+        $testMethod = new ReflectionMethod(App::class, 'handleErrors');
+        $testMethod->setAccessible(true);
 
         $app = $this->app->clone([
             'cli' => false,
@@ -107,13 +120,28 @@ class AppErrorsTest extends TestCase
             ]
         ]);
 
+        $whoops = $whoopsMethod->invoke($app);
+
         $testMethod->invoke($app);
         $handlers = $whoops->getHandlers();
         $this->assertCount(2, $handlers);
-        $this->assertInstanceOf('Whoops\Handler\PlainTextHandler', $handlers[0]);
+        $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
+    }
 
-        $app = new App([
+    /**
+     * @covers ::handleErrors
+     * @covers ::getExceptionHookWhoopsHandler
+     */
+    public function testHandleErrors3()
+    {
+        $whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+        $whoopsMethod->setAccessible(true);
+
+        $testMethod = new ReflectionMethod(App::class, 'handleErrors');
+        $testMethod->setAccessible(true);
+
+        $app = $this->app->clone([
             'cli' => false,
             'server' => [
                 'HTTP_ACCEPT' => 'text/html'
@@ -290,7 +318,7 @@ class AppErrorsTest extends TestCase
             'details' => [
                 'Some error message'
             ],
-            'file' => __FILE__,
+            'file' => basename(__FILE__),
             'line' => $exception->getLine()
         ]), $this->_getBufferedContent($handlers[0]));
         $this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -49,7 +49,7 @@ class AuthTest extends TestCase
     {
         $this->app->session()->destroy();
         Dir::remove($this->fixtures);
-        unset($_SERVER['HTTP_AUTHORIZATION']);
+        App::destroy();
     }
 
     /**
@@ -195,7 +195,11 @@ class AuthTest extends TestCase
      */
     public function testUserBasicAuth()
     {
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:springfield123');
+        $this->app->clone([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('homer@simpsons.com:springfield123')
+            ]
+        ]);
 
         $user = $this->auth->user();
         $this->assertSame('homer@simpsons.com', $user->email());
@@ -215,7 +219,11 @@ class AuthTest extends TestCase
         $this->expectException('Kirby\Exception\PermissionException');
         $this->expectExceptionMessage('Invalid login');
 
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:invalid');
+        $this->app->clone([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('homer@simpsons.com:invalid')
+            ]
+        ]);
 
         $this->auth->user();
     }
@@ -228,7 +236,11 @@ class AuthTest extends TestCase
         $this->expectException('Kirby\Exception\PermissionException');
         $this->expectExceptionMessage('Invalid login');
 
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode('homer@simpsons.com:invalid');
+        $this->app->clone([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('homer@simpsons.com:invalid')
+            ]
+        ]);
 
         try {
             $this->auth->user();

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Exception;
 
+use Kirby\Cms\App;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +24,7 @@ class ExceptionTest extends TestCase
 {
     public function tearDown(): void
     {
-        unset($_SERVER['DOCUMENT_ROOT']);
+        App::destroy();
     }
 
     /**
@@ -185,10 +186,20 @@ class ExceptionTest extends TestCase
         $exception = new Exception();
         $this->assertSame(__FILE__, $exception->getFileRelative());
 
-        $_SERVER['DOCUMENT_ROOT'] = __DIR__;
+        new App([
+            'server' => [
+                'DOCUMENT_ROOT' => __DIR__
+            ]
+        ]);
+
         $this->assertSame(F::filename(__FILE__), $exception->getFileRelative());
 
-        $_SERVER['DOCUMENT_ROOT'] = __DIR__ . '/';
+        new App([
+            'server' => [
+                'DOCUMENT_ROOT' => __DIR__ . '/'
+            ]
+        ]);
+
         $this->assertSame(F::filename(__FILE__), $exception->getFileRelative());
     }
 
@@ -209,7 +220,12 @@ class ExceptionTest extends TestCase
         ];
         $this->assertSame($expected, $exception->toArray());
 
-        $_SERVER['DOCUMENT_ROOT'] = __DIR__;
+        new App([
+            'server' => [
+                'DOCUMENT_ROOT' => __DIR__ . '/'
+            ]
+        ]);
+
         $exception = new Exception();
         $expected['file'] = F::filename(__FILE__);
         $expected['line'] = $exception->getLine();

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -1168,8 +1168,7 @@ class EnvironmentTest extends TestCase
      */
     public function testSanitize($key, $value, $expected)
     {
-        $env = new Environment();
-        $this->assertSame($expected, $env->sanitize($key, $value));
+        $this->assertSame($expected, Environment::sanitize($key, $value));
     }
 
     /**
@@ -1185,8 +1184,7 @@ class EnvironmentTest extends TestCase
             $expected[$row[0]] = $row[2];
         }
 
-        $env = new Environment();
-        $this->assertSame($expected, $env->sanitize($input));
+        $this->assertSame($expected, Environment::sanitize($input));
     }
 
     public function providerForScriptPaths()

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Http;
 
+use Kirby\Cms\App;
 use Kirby\Http\Request\Auth\BasicAuth;
 use Kirby\Http\Request\Auth\BearerAuth;
 use Kirby\Http\Request\Body;
@@ -11,6 +12,11 @@ use PHPUnit\Framework\TestCase;
 
 class RequestTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        App::destroy();
+    }
+
     public function testCustomProps()
     {
         $file = [
@@ -66,27 +72,31 @@ class RequestTest extends TestCase
 
     public function testBasicAuth()
     {
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode($credentials = 'testuser:testpass');
+        new App([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode($credentials = 'testuser:testpass')
+            ]
+        ]);
 
         $request = new Request();
 
         $this->assertInstanceOf(BasicAuth::class, $request->auth());
         $this->assertEquals('testuser', $request->auth()->username());
         $this->assertEquals('testpass', $request->auth()->password());
-
-        unset($_SERVER['HTTP_AUTHORIZATION']);
     }
 
     public function testBearerAuth()
     {
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer abcd';
+        new App([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Bearer abcd'
+            ]
+        ]);
 
         $request = new Request();
 
         $this->assertInstanceOf(BearerAuth::class, $request->auth());
         $this->assertEquals('abcd', $request->auth()->token());
-
-        unset($_SERVER['HTTP_AUTHORIZATION']);
     }
 
     public function testCli()
@@ -104,13 +114,15 @@ class RequestTest extends TestCase
 
     public function testUnknownAuth()
     {
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Unknown abcd';
+        new App([
+            'server' => [
+                'HTTP_AUTHORIZATION' => 'Unknown abcd'
+            ]
+        ]);
 
         $request = new Request();
 
         $this->assertFalse($request->auth());
-
-        unset($_SERVER['HTTP_AUTHORIZATION']);
     }
 
     public function testMethod()

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Session;
 
+use Kirby\Cms\App;
 use Kirby\Http\Cookie;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -25,6 +26,7 @@ class AutoSessionTest extends TestCase
     public function tearDown(): void
     {
         unset($this->store);
+        App::destroy();
     }
 
     /**
@@ -72,7 +74,7 @@ class AutoSessionTest extends TestCase
     public function testGet()
     {
         Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
-        $_SERVER['HTTP_AUTHORIZATION'] = 'Session 9999999999.valid2.' . $this->store->validKey;
+        $this->setAuthorization('Session 9999999999.valid2.' . $this->store->validKey);
         $autoSession = new AutoSession($this->store);
 
         // default: no detection
@@ -85,7 +87,7 @@ class AutoSessionTest extends TestCase
 
         // newly created session
         Cookie::remove('kirby_session');
-        unset($_SERVER['HTTP_AUTHORIZATION']);
+        $this->setAuthorization('');
         $session = $autoSession->get();
         $this->assertNull($session->token());
         $this->assertSame('cookie', $session->mode());
@@ -263,5 +265,14 @@ class AutoSessionTest extends TestCase
 
         $autoSession->collectGarbage();
         $this->assertTrue($this->store->collectedGarbage);
+    }
+
+    protected function setAuthorization(string $value): void
+    {
+        new App([
+            'server' => [
+                'HTTP_AUTHORIZATION' => $value
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/getkirby/kirby/pull/4285#discussion_r889576280.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- Methods in Kirby's core now use the global environment object instead of `$_SERVER` wherever possible
- JSON errors in debug mode now contain the file path relative to the document root for consistency with the API that already handles it like this

## Changes to 3.7 code (not for release notes)

- `Environment::sanitize()` now is a static method (already doesn't depend on the instance)
- New `Environment::getGlobally()` method to access info from the global app object with a fallback to `$_SERVER`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
