### PR TITLE
`Pages`: Consistent find behavior for non-children

### DIFF
--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -107,26 +107,30 @@ class Files extends Collection
 
     /**
      * Tries to find a file by id/filename
+     * @deprecated 3.7.0 Use `$files->find()` instead
+     * @todo 3.8.0 Remove method
+     * @codeCoverageIgnore
      *
      * @param string $id
      * @return \Kirby\Cms\File|null
      */
     public function findById(string $id)
     {
-        return $this->get(ltrim($this->parent->id() . '/' . $id, '/'));
+        Helpers::deprecated('Cms\Files::findById() has been deprecated and will be removed in Kirby 3.8.0. Use $files->find() instead.');
+
+        return $this->findByKey($id);
     }
 
     /**
-     * Alias for FilesFinder::findById() which is
-     * used internally in the Files collection to
-     * map the get method correctly.
+     * Finds a file by its filename
+     * @internal Use `$files->find()` instead
      *
      * @param string $key
      * @return \Kirby\Cms\File|null
      */
     public function findByKey(string $key)
     {
-        return $this->findById($key);
+        return $this->get(ltrim($this->parent->id() . '/' . $key, '/'));
     }
 
     /**

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -201,62 +201,38 @@ class Pages extends Collection
      * Finds a page in the collection by id.
      * This works recursively for children and
      * children of children, etc.
+     * @deprecated 3.7.0 Use `$pages->get()` or `$pages->find()` instead
+     * @todo 3.8.0 Remove method
+     * @codeCoverageIgnore
      *
      * @param string|null $id
      * @return mixed
      */
     public function findById(string $id = null)
     {
-        if ($id === null) {
-            return null;
-        }
+        Helpers::deprecated('Cms\Pages::findById() has been deprecated and will be removed in Kirby 3.8.0. Use $pages->get() or $pages->find() instead.');
 
-        // remove trailing or leading slashes
-        $id = trim($id, '/');
-
-        // strip extensions from the id
-        if (strpos($id, '.') !== false) {
-            $info = pathinfo($id);
-
-            if ($info['dirname'] !== '.') {
-                $id = $info['dirname'] . '/' . $info['filename'];
-            } else {
-                $id = $info['filename'];
-            }
-        }
-
-        // try the obvious way
-        if ($page = $this->get($id)) {
-            return $page;
-        }
-
-        $start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
-        if ($page = $this->findByIdRecursive($id, $start, App::instance()->multilang())) {
-            return $page;
-        }
-
-        // for secondary languages, try the full translated URI
-        if (
-            App::instance()->multilang() === true &&
-            App::instance()->language()->isDefault() === false &&
-            $page = $this->findBy('uri', $id)
-        ) {
-            return $page;
-        }
-
-        return null;
+        return $this->findByKey($id);
     }
 
     /**
      * Finds a child or child of a child recursively.
+     * @deprecated 3.7.0 Use `$pages->find()` instead
+     * @todo 3.8.0 Integrate code into `findByKey()` and remove this method
      *
      * @param string $id
      * @param string|null $startAt
      * @param bool $multiLang
      * @return mixed
      */
-    public function findByIdRecursive(string $id, string $startAt = null, bool $multiLang = false)
+    public function findByIdRecursive(string $id, string $startAt = null, bool $multiLang = false, bool $silenceWarning = false)
     {
+        // @codeCoverageIgnoreStart
+        if ($silenceWarning !== true) {
+            Helpers::deprecated('Cms\Pages::findByIdRecursive() has been deprecated and will be removed in Kirby 3.8.0. Use $pages->find() instead.');
+        }
+        // @codeCoverageIgnoreEnd
+
         $path       = explode('/', $id);
         $item       = null;
         $query      = $startAt;
@@ -285,25 +261,70 @@ class Pages extends Collection
     }
 
     /**
-     * Uses the specialized find by id method
+     * Finds a page by its ID or URI
+     * @internal Use `$pages->find()` instead
      *
      * @param string|null $key
-     * @return mixed
+     * @return \Kirby\Cms\Page|null
      */
-    public function findByKey(string $key = null)
+    public function findByKey(?string $key = null)
     {
-        return $this->findById($key);
+        if ($key === null) {
+            return null;
+        }
+
+        // remove trailing or leading slashes
+        $key = trim($key, '/');
+
+        // strip extensions from the id
+        if (strpos($key, '.') !== false) {
+            $info = pathinfo($key);
+
+            if ($info['dirname'] !== '.') {
+                $key = $info['dirname'] . '/' . $info['filename'];
+            } else {
+                $key = $info['filename'];
+            }
+        }
+
+        // try the obvious way
+        if ($page = $this->get($key)) {
+            return $page;
+        }
+
+        // try to find the page by its (translated) URI by stepping through the page tree
+        $start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
+        if ($page = $this->findByIdRecursive($key, $start, App::instance()->multilang(), true)) {
+            return $page;
+        }
+
+        // for secondary languages, try the full translated URI
+        // (for collections without parent that won't have a result above)
+        if (
+            App::instance()->multilang() === true &&
+            App::instance()->language()->isDefault() === false &&
+            $page = $this->findBy('uri', $key)
+        ) {
+            return $page;
+        }
+
+        return null;
     }
 
     /**
-     * Alias for Pages::findById
+     * Alias for `$pages->find()`
+     * @deprecated 3.7.0 Use `$pages->find()` instead
+     * @todo 3.8.0 Remove method
+     * @codeCoverageIgnore
      *
      * @param string $id
      * @return \Kirby\Cms\Page|null
      */
     public function findByUri(string $id)
     {
-        return $this->findById($id);
+        Helpers::deprecated('Cms\Pages::findByUri() has been deprecated and will be removed in Kirby 3.8.0. Use $pages->find() instead.');
+
+        return $this->findByKey($id);
     }
 
     /**

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -230,6 +230,11 @@ class Pages extends Collection
             return $page;
         }
 
+        $start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
+        if ($page = $this->findByIdRecursive($id, $start, App::instance()->multilang())) {
+            return $page;
+        }
+
         // for secondary languages, try the full translated URI
         if (
             App::instance()->multilang() === true &&
@@ -239,10 +244,7 @@ class Pages extends Collection
             return $page;
         }
 
-        $start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
-        $page  = $this->findByIdRecursive($id, $start, App::instance()->multilang());
-
-        return $page;
+        return null;
     }
 
     /**

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -94,7 +94,7 @@ class Pages extends Collection
      */
     public function children()
     {
-        $children = new Pages([], $this->parent);
+        $children = new Pages([]);
 
         foreach ($this->data as $page) {
             foreach ($page->children() as $childKey => $child) {
@@ -132,7 +132,7 @@ class Pages extends Collection
      */
     public function drafts()
     {
-        $drafts = new Pages([], $this->parent);
+        $drafts = new Pages([]);
 
         foreach ($this->data as $page) {
             foreach ($page->drafts() as $draftKey => $draft) {
@@ -227,6 +227,15 @@ class Pages extends Collection
 
         // try the obvious way
         if ($page = $this->get($id)) {
+            return $page;
+        }
+
+        // for secondary languages, try the full translated URI
+        if (
+            App::instance()->multilang() === true &&
+            App::instance()->language()->isDefault() === false &&
+            $page = $this->findBy('uri', $id)
+        ) {
             return $page;
         }
 
@@ -352,7 +361,7 @@ class Pages extends Collection
             return $index;
         }
 
-        $index = new Pages([], $this->parent);
+        $index = new Pages([]);
 
         foreach ($this->data as $pageKey => $page) {
             $index->data[$pageKey] = $page;

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -86,7 +86,8 @@ class Users extends Collection
     }
 
     /**
-     * Finds a user in the collection by id or email address
+     * Finds a user in the collection by ID or email address
+     * @internal Use `$users->find()` instead
      *
      * @param string $key
      * @return \Kirby\Cms\User|null

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -313,6 +313,20 @@ class PagesTest extends TestCase
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findByUri('child'));
 
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
+
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
@@ -415,6 +429,20 @@ class PagesTest extends TestCase
         $this->assertNull($site->children()->findById('child'));
         $this->assertNull($site->children()->findByUri('child'));
 
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
+
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');
         $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
@@ -473,6 +501,35 @@ class PagesTest extends TestCase
         $this->assertNull($site->children()->findById('oma/mutter/child'));
         $this->assertNull($site->children()->findById('grandmother/mutter/child'));
         $this->assertNull($site->children()->findById('grandmother/mutter/kind'));
+
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mutter/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mutter/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('oma/mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('oma/mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mutter/kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mutter/kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
         $this->assertIsPage($pages->findById('grandma'), 'grandma');

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -269,7 +269,7 @@ class PagesTest extends TestCase
         $this->assertIsPage($this->pages()->find('b.json'), 'b');
     }
 
-    public function testFindByIdAndUri()
+    public function testFindChildren()
     {
         $site = new Site([
             'children' => [
@@ -289,54 +289,40 @@ class PagesTest extends TestCase
             ]
         ]);
 
-        $this->assertIsPage($site->children()->findById('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findById('grandma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma.json'), 'grandma');
-        $this->assertIsPage($site->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mother/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertNull($site->children()->findById('mother'));
-        $this->assertNull($site->children()->findByUri('mother'));
-        $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertNull($site->children()->findById('child'));
-        $this->assertNull($site->children()->findByUri('child'));
+        $this->assertIsPage($site->children()->find('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma/'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma.json'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mother/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mother.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertNull($site->children()->find('mother'));
+        $this->assertIsPage($site->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother')->children()->find('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother')->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertNull($site->children()->find('child'));
 
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->find('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
-        $this->assertIsPage($pages->findById('grandma'), 'grandma');
-        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-        $this->assertNull($pages->findById('mother'));
-        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertNull($pages->findById('child'));
-        $this->assertNull($pages->findById(null));
+        $this->assertIsPage($pages->find('grandma'), 'grandma');
+        $this->assertIsPage($pages->find('grandma/mother'), 'grandma/mother');
+        $this->assertNull($pages->find('mother'));
+        $this->assertIsPage($pages->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertNull($pages->find('child'));
+        $this->assertNull($pages->find(null));
     }
 
-    public function testFindByIdAndUriTranslated()
+    public function testFindChildrenTranslated()
     {
         $app = new App([
             'roots' => [
@@ -399,156 +385,103 @@ class PagesTest extends TestCase
 
         $site = $app->site();
 
-        $this->assertIsPage($site->children()->findById('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findById('grandma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma.json'), 'grandma');
-        $this->assertIsPage($site->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mother/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mother.json'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('grandma/mother'), 'grandma/mother');
-        $this->assertNull($site->children()->findById('mother'));
-        $this->assertNull($site->children()->findByUri('mother'));
-        $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother')->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
-        $this->assertNull($site->children()->findById('child'));
-        $this->assertNull($site->children()->findByUri('child'));
+        $this->assertIsPage($site->children()->find('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma/'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma.json'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mother/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mother.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertNull($site->children()->find('mother'));
+        $this->assertIsPage($site->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother')->children()->find('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother')->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('mother')->children()->find('child'), 'grandma/mother/child');
+        $this->assertNull($site->children()->find('child'));
 
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->find('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
-        $this->assertIsPage($pages->findById('grandma'), 'grandma');
-        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-        $this->assertNull($pages->findById('mother'));
-        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertNull($pages->findById('child'));
+        $this->assertIsPage($pages->find('grandma'), 'grandma');
+        $this->assertIsPage($pages->find('grandma/mother'), 'grandma/mother');
+        $this->assertNull($pages->find('mother'));
+        $this->assertIsPage($pages->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertNull($pages->find('child'));
 
         $app->setCurrentLanguage('de');
 
-        $this->assertIsPage($site->children()->findById('oma'), 'grandma');
-        $this->assertIsPage($site->children()->findById('oma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('oma'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('oma/'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('oma.json'), 'grandma');
-        $this->assertIsPage($site->children()->findById('oma/mutter/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter/'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('oma/mutter.json'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mutter'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('oma')->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mutter'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('oma/mutter/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('oma/mutter/kind/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind/'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter/kind.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('oma/mutter')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma/mutter')->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mutter'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma/mother/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma'), 'grandma');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mutter'), 'grandma/mother');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma/mother/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('grandma')->children()->findById('mother')->children()->findById('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('grandma')->children()->findByUri('mother')->children()->findByUri('child'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findById('oma')->children()->findById('mutter')->children()->findById('kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->children()->findByUri('oma')->children()->findByUri('mutter')->children()->findByUri('kind'), 'grandma/mother/child');
-        $this->assertNull($site->children()->findById('child'));
-        $this->assertNull($site->children()->findById('kind'));
-        $this->assertNull($site->children()->findByUri('child'));
-        $this->assertNull($site->children()->findByUri('kind'));
-        $this->assertNull($site->children()->findById('oma/mother'));
-        $this->assertNull($site->children()->findById('oma/mother/kind'));
-        $this->assertNull($site->children()->findById('oma/mutter/child'));
-        $this->assertNull($site->children()->findById('grandmother/mutter/child'));
-        $this->assertNull($site->children()->findById('grandmother/mutter/kind'));
+        $this->assertIsPage($site->children()->find('oma'), 'grandma');
+        $this->assertIsPage($site->children()->find('oma/'), 'grandma');
+        $this->assertIsPage($site->children()->find('oma.json'), 'grandma');
+        $this->assertIsPage($site->children()->find('oma/mutter/'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('oma/mutter.json'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('oma')->children()->find('mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('oma')->children()->find('mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('oma')->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma/mutter/kind.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma/mutter')->children()->find('kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma/mutter')->children()->find('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma/mutter')->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mutter'), 'grandma/mother');
+        $this->assertIsPage($site->children()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('grandma'), 'grandma');
+        $this->assertIsPage($site->children()->find('grandma')->children()->find('mother')->children()->find('child'), 'grandma/mother/child');
+        $this->assertIsPage($site->children()->find('oma')->children()->find('mutter')->children()->find('kind'), 'grandma/mother/child');
+        $this->assertNull($site->children()->find('child'));
+        $this->assertNull($site->children()->find('kind'));
+        $this->assertNull($site->children()->find('oma/mother'));
+        $this->assertNull($site->children()->find('oma/mother/kind'));
+        $this->assertNull($site->children()->find('oma/mutter/child'));
+        $this->assertNull($site->children()->find('grandmother/mutter/child'));
+        $this->assertNull($site->children()->find('grandmother/mutter/kind'));
 
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('oma/mutter/kind.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind/'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('oma/mutter/kind.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findById('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($site->find('grandma')->grandChildren()->findByUri('grandma/mother/child.json'), 'grandma/mother/child');
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mutter/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mutter/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('oma/mutter'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('oma/mutter'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('grandma/mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mutter'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mutter'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mutter/kind'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mutter/kind'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('mother/child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('kind'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findById('child'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('kind'));
-        $this->assertNull($site->find('grandma')->grandChildren()->findByUri('child'));
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('oma/mutter/kind/'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('oma/mutter/kind.json'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($site->find('grandma')->grandChildren()->find('grandma/mother/child.json'), 'grandma/mother/child');
+        $this->assertNull($site->find('grandma')->grandChildren()->find('grandma/mutter/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('oma/mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('grandma/mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mutter'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mutter/kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('mother/child'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('kind'));
+        $this->assertNull($site->find('grandma')->grandChildren()->find('child'));
 
         $pages = new Pages($site->children()->find('grandma', 'grandma/mother', 'grandma/mother/child'));
-        $this->assertIsPage($pages->findById('grandma'), 'grandma');
-        $this->assertIsPage($pages->findById('oma'), 'grandma');
-        $this->assertIsPage($pages->findById('grandma/mother'), 'grandma/mother');
-        $this->assertIsPage($pages->findById('grandma/mutter'), 'grandma/mother');
-        $this->assertIsPage($pages->findById('oma/mutter'), 'grandma/mother');
-        $this->assertNull($pages->findById('mother'));
-        $this->assertNull($pages->findById('mutter'));
-        $this->assertIsPage($pages->findById('grandma/mother/child'), 'grandma/mother/child');
-        $this->assertIsPage($pages->findById('grandma/mother/kind'), 'grandma/mother/child');
-        $this->assertIsPage($pages->findById('grandma/mutter/kind'), 'grandma/mother/child');
-        $this->assertIsPage($pages->findById('oma/mutter/kind'), 'grandma/mother/child');
-        $this->assertNull($pages->findById('oma/mother/kind'));
-        $this->assertNull($pages->findById('child'));
-        $this->assertNull($pages->findById('kind'));
+        $this->assertIsPage($pages->find('grandma'), 'grandma');
+        $this->assertIsPage($pages->find('oma'), 'grandma');
+        $this->assertIsPage($pages->find('grandma/mother'), 'grandma/mother');
+        $this->assertIsPage($pages->find('grandma/mutter'), 'grandma/mother');
+        $this->assertIsPage($pages->find('oma/mutter'), 'grandma/mother');
+        $this->assertNull($pages->find('mother'));
+        $this->assertNull($pages->find('mutter'));
+        $this->assertIsPage($pages->find('grandma/mother/child'), 'grandma/mother/child');
+        $this->assertIsPage($pages->find('grandma/mother/kind'), 'grandma/mother/child');
+        $this->assertIsPage($pages->find('grandma/mutter/kind'), 'grandma/mother/child');
+        $this->assertIsPage($pages->find('oma/mutter/kind'), 'grandma/mother/child');
+        $this->assertNull($pages->find('oma/mother/kind'));
+        $this->assertNull($pages->find('child'));
+        $this->assertNull($pages->find('kind'));
     }
 
-    public function testFindByIdWithSwappedSlugsTranslated()
+    public function testFindChildrenWithSwappedSlugsTranslated()
     {
         $app = new App([
             'roots' => [
@@ -623,45 +556,45 @@ class PagesTest extends TestCase
 
         $site = $app->site();
 
-        $this->assertIsPage($site->children()->findById('aaa'), 'aaa');
-        $this->assertIsPage($site->children()->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'aaa/bbb');
-        $this->assertIsPage($site->children()->findById('zzz'), 'zzz');
-        $this->assertIsPage($site->children()->findById('zzz/yyy'), 'zzz/yyy');
-        $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->find('aaa'), 'aaa');
+        $this->assertIsPage($site->children()->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->find('aaa')->children()->find('bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->find('zzz'), 'zzz');
+        $this->assertIsPage($site->children()->find('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->find('zzz')->children()->find('yyy'), 'zzz/yyy');
 
         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
-        $this->assertIsPage($pages->findById('aaa'), 'aaa');
-        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($pages->findById('zzz'), 'zzz');
-        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($pages->find('aaa'), 'aaa');
+        $this->assertIsPage($pages->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->find('zzz'), 'zzz');
+        $this->assertIsPage($pages->find('zzz/yyy'), 'zzz/yyy');
 
         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz'));
-        $this->assertIsPage($pages->findById('aaa'), 'aaa');
-        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($pages->findById('zzz'), 'zzz');
-        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($pages->find('aaa'), 'aaa');
+        $this->assertIsPage($pages->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->find('zzz'), 'zzz');
+        $this->assertIsPage($pages->find('zzz/yyy'), 'zzz/yyy');
 
         $app->setCurrentLanguage('de');
 
-        $this->assertIsPage($site->children()->findById('aaa'), 'aaa');
-        $this->assertIsPage($site->children()->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($site->children()->findById('aaa')->children()->findById('bbb'), 'aaa/bbb');
-        $this->assertIsPage($site->children()->findById('zzz'), 'zzz');
-        $this->assertIsPage($site->children()->findById('zzz/yyy'), 'zzz/yyy');
-        $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->find('aaa'), 'aaa');
+        $this->assertIsPage($site->children()->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->find('aaa')->children()->find('bbb'), 'aaa/bbb');
+        $this->assertIsPage($site->children()->find('zzz'), 'zzz');
+        $this->assertIsPage($site->children()->find('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($site->children()->find('zzz')->children()->find('yyy'), 'zzz/yyy');
 
         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
-        $this->assertIsPage($pages->findById('aaa'), 'aaa');
-        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($pages->findById('zzz'), 'zzz');
-        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($pages->find('aaa'), 'aaa');
+        $this->assertIsPage($pages->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->find('zzz'), 'zzz');
+        $this->assertIsPage($pages->find('zzz/yyy'), 'zzz/yyy');
 
         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz'));
-        $this->assertIsPage($pages->findById('aaa'), 'aaa');
-        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
-        $this->assertIsPage($pages->findById('zzz'), 'zzz');
-        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+        $this->assertIsPage($pages->find('aaa'), 'aaa');
+        $this->assertIsPage($pages->find('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->find('zzz'), 'zzz');
+        $this->assertIsPage($pages->find('zzz/yyy'), 'zzz/yyy');
     }
 
     public function testFindMultiple()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -636,6 +636,12 @@ class PagesTest extends TestCase
         $this->assertIsPage($pages->findById('zzz'), 'zzz');
         $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
 
+        $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz'));
+        $this->assertIsPage($pages->findById('aaa'), 'aaa');
+        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->findById('zzz'), 'zzz');
+        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+
         $app->setCurrentLanguage('de');
 
         $this->assertIsPage($site->children()->findById('aaa'), 'aaa');
@@ -646,6 +652,12 @@ class PagesTest extends TestCase
         $this->assertIsPage($site->children()->findById('zzz')->children()->findById('yyy'), 'zzz/yyy');
 
         $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz', 'zzz/yyy'));
+        $this->assertIsPage($pages->findById('aaa'), 'aaa');
+        $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
+        $this->assertIsPage($pages->findById('zzz'), 'zzz');
+        $this->assertIsPage($pages->findById('zzz/yyy'), 'zzz/yyy');
+
+        $pages = new Pages($site->children()->find('aaa', 'aaa/bbb', 'zzz'));
         $this->assertIsPage($pages->findById('aaa'), 'aaa');
         $this->assertIsPage($pages->findById('aaa/bbb'), 'aaa/bbb');
         $this->assertIsPage($pages->findById('zzz'), 'zzz');


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- The behavior of the `$pages->find()`, `$pages->findById()` and `$pages->findByUri()` methods in non-direct-child collections (e.g. `$page->grandChildren()`) is now consistent between single-lang and multi-lang installations #4105

### Enhancements

- `$pages->find()` can now find pages by their translated URI in secondary languages of multi-lang setups, even in collections without a parent (like `$page->grandChildren()`)

### Deprecations

- The `$pages->findById()` and `$pages->findByUri()` methods have been deprecated and will be removed in v3.8.0. If you want to directly get a page by ID, use `$pages->get()`. If you want the previous fuzzy behavior that queries both by ID and URI, use `$pages->find()`.
- The `$pages->findByIdRecursive()` method has been deprecated and will be removed in v3.8.0. Please use `$pages->find()` instead.
- The `$files->findById()` method has been deprecated and will be removed in v3.8.0. Please use `$files->find()` instead.
- The `$pages->findByKey()`, `$files->findByKey()` and `$users->findByKey()` methods have been marked as internal. Please use the `find()` methods instead.

### Breaking changes

- The `$pages->children()`, `$pages->drafts()` and `$pages->index()` methods no longer set the `$pages->parent()` object as the collection items can have multiple different parents. This can change the behavior when finding collection items in secondary languages and when merging collections. #4105

## Open question

What doesn't work is a mixed-language query in the secondary language, something like this:

```php
$site->find('grandma')->grandChildren()->findById('grandma/mother/kind');
```

This hasn't worked before either, only in "root" collections like `$site->children()`. And I don't think we can make it work without a lot of added complexity. I might be wrong though.

For the more common case of the full translated URI I added another case.

@neildaniels Do you think it makes sense? Or do you see a better solution that covers such queries with (partially or fully) translated URIs in the secondary language better?

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~

### For Lukas when this PR is merged; see https://github.com/getkirby/kirby/issues/4105#issuecomment-1021543529

- [x] Add the breaking change to 3.6 release notes for future reference for those updating their existing sites to 3.6.
- [x] Document the expected usage of the `find()` and `findBy('slug', ...)` methods in collections better.