### PR TITLE
Rename `minutes` property with `expiry`

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -45,12 +45,12 @@ abstract class Cache
      *
      * @param string $key
      * @param mixed $value
-     * @param int $minutes
+     * @param int $expiry
      * @return bool
      */
-    public function set(string $key, $value, int $minutes = 0): bool
+    public function set(string $key, $value, int $expiry = 0): bool
     {
-        $value = Value::fromArray(compact('value', 'minutes'));
+        $value = Value::fromArray(compact('value', 'expiry'));
 
         return $this->store($key, $value);
     }

--- a/tests/Cache/ValueTest.php
+++ b/tests/Cache/ValueTest.php
@@ -56,7 +56,7 @@ class ValueTest extends TestCase
     {
         $data = [
             'created' => 10000,
-            'minutes' => 0,
+            'expiry'  => 0,
             'value'   => 'foo'
         ];
         $value = Value::fromArray($data);
@@ -67,7 +67,7 @@ class ValueTest extends TestCase
 
         $data = [
             'created' => 10000,
-            'minutes' => 1234567890,
+            'expiry'  => 1234567890,
             'value'   => 'foo'
         ];
         $value = Value::fromArray($data);
@@ -79,7 +79,7 @@ class ValueTest extends TestCase
         $time = time();
         $data = [
             'created' => null,
-            'minutes' => 1000,
+            'expiry'  => 1000,
             'value'   => ['this is' => 'an array']
         ];
         $value = Value::fromArray($data);
@@ -88,13 +88,13 @@ class ValueTest extends TestCase
         $this->assertSame(['this is' => 'an array'], $value->value());
         $this->assertSame([
             'created' => $time,
-            'minutes' => 1000,
+            'expiry'  => 1000,
             'value'   => ['this is' => 'an array']
         ], $value->toArray());
 
         $data = [
             'created' => 10000,
-            'minutes' => null,
+            'expiry'  => null,
             'value'   => 'foo'
         ];
         $value = Value::fromArray($data);
@@ -103,7 +103,7 @@ class ValueTest extends TestCase
         $this->assertSame('foo', $value->value());
         $this->assertSame([
             'created' => 10000,
-            'minutes' => 0,
+            'expiry'  => 0,
             'value'   => 'foo'
         ], $value->toArray());
     }
@@ -117,7 +117,7 @@ class ValueTest extends TestCase
 
         $data = [
             'created' => 'invalid',
-            'minutes' => 'invalid',
+            'expiry'  => 'invalid',
             'value'   => 'foo'
         ];
         $value = Value::fromArray($data);
@@ -131,7 +131,7 @@ class ValueTest extends TestCase
     {
         $data = json_encode([
             'created' => 10000,
-            'minutes' => 0,
+            'expiry'  => 0,
             'value'   => 'foo'
         ]);
         $value = Value::fromJson($data);
@@ -143,7 +143,7 @@ class ValueTest extends TestCase
         $time = time();
         $data = json_encode([
             'created' => null,
-            'minutes' => 1000,
+            'expiry'  => 1000,
             'value'   => ['this is' => 'an array']
         ]);
         $value = Value::fromJson($data);
@@ -152,13 +152,13 @@ class ValueTest extends TestCase
         $this->assertSame(['this is' => 'an array'], $value->value());
         $this->assertSame(json_encode([
             'created' => $time,
-            'minutes' => 1000,
+            'expiry'  => 1000,
             'value'   => ['this is' => 'an array']
         ]), $value->toJson());
 
         $data = json_encode([
             'created' => 10000,
-            'minutes' => null,
+            'expiry'  => null,
             'value'   => 'foo'
         ]);
         $value = Value::fromJson($data);
@@ -167,7 +167,7 @@ class ValueTest extends TestCase
         $this->assertSame('foo', $value->value());
         $this->assertSame(json_encode([
             'created' => 10000,
-            'minutes' => 0,
+            'expiry'  => 0,
             'value'   => 'foo'
         ]), $value->toJson());
 
@@ -175,7 +175,7 @@ class ValueTest extends TestCase
 
         $data = json_encode([
             'created' => 'invalid',
-            'minutes' => 'invalid',
+            'expiry'  => 'invalid',
             'value'   => 'foo'
         ]);
         $this->assertNull(Value::fromJson($data));


### PR DESCRIPTION
### This PR

Based on https://github.com/getkirby/kirby/pull/4263

@lukasbestle Feel free to close the PR if not acceptable (Maybe you don't want to remove the `minutes` option from array.). 

⚠️ Btw note that the branch needs to be rebase for the `Helpers::deprecated()` method to work.

### Related issue

- https://github.com/getkirby/backlog/issues/24