### PR TITLE
Don't throw deprecation notice for `kirbytextinline()` and `kti()` helpers

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -330,12 +330,13 @@ if (Helpers::hasOverride('kirbytextinline') === false) { // @codeCoverageIgnore
      * @since 3.1.0
      *
      * @param string|null $text
-     * @param array $data
+     * @param array $options
      * @return string
      */
-    function kirbytextinline(?string $text = null, array $data = []): string
+    function kirbytextinline(?string $text = null, array $options = []): string
     {
-        return App::instance()->kirbytext($text, $data, true);
+        $options['markdown']['inline'] = true;
+        return App::instance()->kirbytext($text, $options);
     }
 }
 
@@ -359,12 +360,13 @@ if (Helpers::hasOverride('kti') === false) { // @codeCoverageIgnore
      * @since 3.1.0
      *
      * @param string|null $text
-     * @param array $data
+     * @param array $options
      * @return string
      */
-    function kti(?string $text = null, array $data = []): string
+    function kti(?string $text = null, array $options = []): string
     {
-        return App::instance()->kirbytext($text, $data, true);
+        $options['markdown']['inline'] = true;
+        return App::instance()->kirbytext($text, $options);
     }
 }
 


### PR DESCRIPTION
## This PR …

Don't throw deprecation notice for `kirbytextinline()` and `kti()` helpers.

### Fixes
- #4366

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
