### PR TITLE
Fix deprecation warning for `$app->markdown()`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -143,14 +143,12 @@ return [
      * @return string
      * @todo remove $inline parameter in in 3.8.0
      */
-    'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = null): string {
+    'markdown' => function (App $kirby, string $text = null, array $options = [], bool $inline = false): string {
         static $markdown;
         static $config;
 
         // warning for deprecated fourth parameter
-        if ($inline === null) {
-            $inline = false;
-        } elseif (isset($options['inline']) === false) {
+        if (func_num_args() === 4 && isset($options['inline']) === false) {
             // @codeCoverageIgnoreStart
             Helpers::deprecated('markdown component: the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'inline\'] instead.');
             // @codeCoverageIgnoreEnd
@@ -166,7 +164,7 @@ return [
             $config   = $options;
         }
 
-        return $markdown->parse($text, $options['inline']);
+        return $markdown->parse($text, $options['inline'] ?? false);
     },
 
     /**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -897,13 +897,11 @@ class App
      * @return string
      * @todo remove $inline parameter in in 3.8.0
      */
-    public function kirbytext(string $text = null, array $options = [], bool $inline = null): string
+    public function kirbytext(string $text = null, array $options = [], bool $inline = false): string
     {
         // warning for deprecated fourth parameter
         // @codeCoverageIgnoreStart
-        if ($inline === null) {
-            $inline = false;
-        } else {
+        if (func_num_args() === 3) {
             Helpers::deprecated('Cms\App::kirbytext(): the $inline parameter is deprecated and will be removed in Kirby 3.8.0. Use $options[\'markdown\'][\'inline\'] instead.');
         }
         // @codeCoverageIgnoreEnd
@@ -1006,7 +1004,7 @@ class App
      *
      * @internal
      * @param string|null $text
-     * @param bool|array $options
+     * @param bool|array $options Boolean inline value is deprecated, use `['inline' => true]` instead
      * @return string
      * @todo remove boolean $options in in 3.8.0
      */
@@ -1030,7 +1028,9 @@ class App
         );
 
         // TODO: remove passing the $inline parameter in 3.8.0
-        $inline = $options['inline'] ?? false;
+        // $options['inline'] is set to `false` to avoid the deprecation
+        // warning in the component; this can also be removed in 3.8.0
+        $inline = $options['inline'] ??= false;
         return ($this->component('markdown'))($this, $text, $options, $inline);
     }
 


### PR DESCRIPTION
## Release notes for RC2 only
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Calling `$kirby->markdown()` or `$field->markdown()` no longer triggers a deprecation warning
- Custom `markdown` components no longer break because of `null` being passed to `$inline`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] ~In-code documentation (wherever needed)~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
