### PR TITLE
Make sure that block content is always an array

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -79,11 +79,11 @@ class Block extends Item
 
         // make sure the content is always defined as array to keep
         // at least a bit of backward compatibility with older fields
-        if (is_array($params['content'] ?? []) === false) {
+        if (is_array($params['content'] ?? null) === false) {
             $params['content'] = [];
         }
 
-        $this->content  = $params['content']  ?? [];
+        $this->content  = $params['content'];
         $this->isHidden = $params['isHidden'] ?? false;
         $this->type     = $params['type'];
 

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -77,6 +77,12 @@ class Block extends Item
             throw new InvalidArgumentException('The block type is missing');
         }
 
+        // make sure the content is always defined as array to keep
+        // at least a bit of backward compatibility with older fields
+        if (is_array($params['content'] ?? []) === false) {
+            $params['content'] = [];
+        }
+
         $this->content  = $params['content']  ?? [];
         $this->isHidden = $params['isHidden'] ?? false;
         $this->type     = $params['type'];

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -54,6 +54,16 @@ class BlockTest extends TestCase
         $this->assertSame($content, $block->content()->toArray());
     }
 
+    public function testContentWhenNotArray()
+    {
+        $block = new Block([
+            'type'    => 'heading',
+            'content' => 'this is invalid now'
+        ]);
+
+        $this->assertSame([], $block->content()->toArray());
+    }
+
     public function testController()
     {
         $block = new Block([


### PR DESCRIPTION
## This PR …

We radically removed all old converters for the editor or builder fields to make them compatible with blocks. But those converters at least made sure that $params['content'] is always an array in the Block constructor. This PR checks for valid content arrays in the constructor now and returns an empty array if content is the wrong type. This adds at least a little more compatibility by making the blocks editable again in the Panel. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
