### PR TITLE
New option to keep cells/columns on mobile

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -106,6 +106,7 @@ return [
         },
         'columns' => function () {
             $columns = [];
+            $mobile  = 0;
 
             if (empty($this->columns)) {
                 foreach ($this->fields as $field) {
@@ -133,11 +134,21 @@ return [
                         continue;
                     }
 
+                    if (($columnProps['mobile'] ?? false) === true) {
+                        $mobile++;
+                    }
+
                     $columns[$columnName] = array_merge($columnProps, [
                         'type'  => $field['type'],
                         'label' => $field['label'] ?? $field['name']
                     ]);
                 }
+            }
+
+            // make the first column visible on mobile
+            // if no other mobile columns are defined
+            if ($mobile === 0) {
+                $columns[array_key_first($columns)]['mobile'] = true;
             }
 
             return $columns;

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -36,8 +36,8 @@ return [
             if ($this->image !== false) {
                 $columns['image'] = [
                     'label'  => ' ',
-                    'type'   => 'image',
                     'mobile' => true,
+                    'type'   => 'image',
                     'width'  => 'var(--table-row-height)'
                 ];
             }
@@ -45,8 +45,8 @@ return [
             if ($this->text) {
                 $columns['title'] = [
                     'label'  => I18n::translate('title'),
+                    'mobile' => true,
                     'type'   => 'url',
-                    'mobile' => true
                 ];
             }
 
@@ -65,9 +65,9 @@ return [
             if ($this->type === 'pages') {
                 $columns['flag'] = [
                     'label'  => ' ',
+                    'mobile' => true,
                     'type'   => 'flag',
                     'width'  => 'var(--table-row-height)',
-                    'mobile' => true,
                 ];
             }
 

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -35,16 +35,18 @@ return [
 
             if ($this->image !== false) {
                 $columns['image'] = [
-                    'label' => ' ',
-                    'type'  => 'image',
-                    'width' => 'var(--table-row-height)'
+                    'label'  => ' ',
+                    'type'   => 'image',
+                    'mobile' => true,
+                    'width'  => 'var(--table-row-height)'
                 ];
             }
 
             if ($this->text) {
                 $columns['title'] = [
-                    'label' => I18n::translate('title'),
-                    'type'  => 'url'
+                    'label'  => I18n::translate('title'),
+                    'type'   => 'url',
+                    'mobile' => true
                 ];
             }
 
@@ -62,9 +64,10 @@ return [
 
             if ($this->type === 'pages') {
                 $columns['flag'] = [
-                    'label' => ' ',
-                    'type'  => 'flag',
-                    'width' => 'var(--table-row-height)'
+                    'label'  => ' ',
+                    'type'   => 'flag',
+                    'width'  => 'var(--table-row-height)',
+                    'mobile' => true,
                 ];
             }
 

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -7,34 +7,36 @@
     <!-- Header row -->
     <thead>
       <tr>
-        <th v-if="hasIndexColumn" class="k-table-index-column">#</th>
+        <th v-if="hasIndexColumn" data-mobile class="k-table-index-column">
+          #
+        </th>
 
-        <template v-for="(column, columnIndex) in columns">
-          <th
-            :key="columnIndex + '-header'"
-            :style="'width:' + width(column.width)"
-            class="k-table-column"
-            @click="
-              onHeader({
-                column,
-                columnIndex
-              })
-            "
+        <th
+          v-for="(column, columnIndex) in columns"
+          :key="columnIndex + '-header'"
+          :data-mobile="column.mobile"
+          :style="'width:' + width(column.width)"
+          class="k-table-column"
+          @click="
+            onHeader({
+              column,
+              columnIndex
+            })
+          "
+        >
+          <slot
+            name="header"
+            v-bind="{
+              column,
+              columnIndex,
+              label: label(column, columnIndex)
+            }"
           >
-            <slot
-              name="header"
-              v-bind="{
-                column,
-                columnIndex,
-                label: label(column, columnIndex)
-              }"
-            >
-              {{ label(column, columnIndex) }}
-            </slot>
-          </th>
-        </template>
+            {{ label(column, columnIndex) }}
+          </slot>
+        </th>
 
-        <th v-if="hasOptions" class="k-table-options-column"></th>
+        <th v-if="hasOptions" data-mobile class="k-table-options-column"></th>
       </tr>
     </thead>
 
@@ -59,6 +61,7 @@
         <td
           v-if="hasIndexColumn"
           :data-sortable="sortable && row.sortable !== false"
+          data-mobile
           class="k-table-index-column"
         >
           <slot
@@ -84,6 +87,7 @@
           :column="column"
           :field="fields[columnIndex]"
           :row="row"
+          :mobile="column.mobile"
           :value="row[columnIndex]"
           :style="'width:' + width(column.width)"
           class="k-table-column"
@@ -105,7 +109,7 @@
         />
 
         <!-- Options -->
-        <td v-if="hasOptions" class="k-table-options-column">
+        <td v-if="hasOptions" data-mobile class="k-table-options-column">
           <slot name="options" v-bind="{ row, rowIndex, options }">
             <k-options-dropdown
               :options="row.options || options"
@@ -402,16 +406,15 @@ export default {
   left: 0;
   right: 0;
   height: 0.5rem;
-  background: -webkit-linear-gradient(top, rgba(#000, 0.05), rgba(#000, 0));
+  background: linear-gradient(to bottom, rgba(#000, 0.05), rgba(#000, 0));
   z-index: 2;
 }
 
 .k-table-index,
 .k-table .k-sort-handle {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: var(--table-row-height);
+  display: grid;
+  place-items: center;
+  width: 100%;
   height: var(--table-row-height);
 }
 
@@ -421,7 +424,7 @@ export default {
   display: none;
 }
 .k-table tr:hover .k-sort-handle {
-  display: flex !important;
+  display: grid !important;
 }
 
 .k-table-row-ghost {
@@ -475,23 +478,9 @@ td.k-table-options-column {
 
 /** Mobile */
 @media screen and (max-width: 65em) {
-  .k-table td,
-  .k-table th {
+  .k-table td:not([data-mobile]),
+  .k-table th:not([data-mobile]) {
     display: none;
-  }
-
-  .k-table th:first-child,
-  .k-table[data-indexed="true"] th:nth-child(2),
-  .k-table th:last-child,
-  .k-table td:first-child,
-  .k-table[data-indexed="true"] td:nth-child(2),
-  .k-table td:last-child {
-    display: table-cell;
-  }
-
-  .k-table th.k-table-column:nth-child(2),
-  .k-table td.k-table-column:nth-child(2) {
-    width: auto !important;
   }
 }
 </style>

--- a/panel/src/components/Layout/TableCell.vue
+++ b/panel/src/components/Layout/TableCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <td :data-align="column.align">
+  <td :data-align="column.align" :data-mobile="mobile">
     <template v-if="$helper.object.isEmpty(value) === false">
       <!-- Table cell type component -->
       <component
@@ -26,6 +26,13 @@ export default {
      * Optional corresponding field options
      */
     field: Object,
+    /**
+     * Keep cell on mobile
+     */
+    mobile: {
+      type: Boolean,
+      default: false
+    },
     /**
      * Current row
      */

--- a/panel/src/components/Views/SystemView.vue
+++ b/panel/src/components/Views/SystemView.vue
@@ -31,7 +31,8 @@
           :columns="{
             name: {
               label: $t('name'),
-              type: 'url'
+              type: 'url',
+              mobile: true
             },
             author: {
               label: $t('author')
@@ -41,7 +42,8 @@
             },
             version: {
               label: $t('version'),
-              width: '8rem'
+              width: '8rem',
+              mobile: true
             }
           }"
           :rows="plugins"

--- a/tests/Cms/Sections/mixins/LayoutMixinTest.php
+++ b/tests/Cms/Sections/mixins/LayoutMixinTest.php
@@ -50,9 +50,10 @@ class LayoutMixinTest extends TestCase
 
         $expected = [
             'image' => [
-                'label' => ' ',
-                'type'  => 'image',
-                'width' => 'var(--table-row-height)'
+                'label'  => ' ',
+                'mobile' => true,
+                'type'   => 'image',
+                'width'  => 'var(--table-row-height)'
             ]
         ];
 
@@ -69,13 +70,15 @@ class LayoutMixinTest extends TestCase
 
         $expected = [
             'image' => [
-                'label' => ' ',
-                'type'  => 'image',
-                'width' => 'var(--table-row-height)'
+                'label'  => ' ',
+                'mobile' => true,
+                'type'   => 'image',
+                'width'  => 'var(--table-row-height)'
             ],
             'title' => [
-                'label' => 'Title',
-                'type'  => 'url'
+                'label'  => 'Title',
+                'mobile' => true,
+                'type'   => 'url'
             ]
         ];
 
@@ -93,17 +96,19 @@ class LayoutMixinTest extends TestCase
 
         $expected = [
             'image' => [
-                'label' => ' ',
-                'type'  => 'image',
-                'width' => 'var(--table-row-height)',
+                'label'  => ' ',
+                'mobile' => true,
+                'type'   => 'image',
+                'width'  => 'var(--table-row-height)',
             ],
             'title' => [
-                'label' => 'Title',
-                'type'  => 'url'
+                'label'  => 'Title',
+                'mobile' => true,
+                'type'   => 'url'
             ],
             'info' => [
-                'label' => 'Info',
-                'type'  => 'text'
+                'label'  => 'Info',
+                'type'   => 'text'
             ]
         ];
 
@@ -119,14 +124,16 @@ class LayoutMixinTest extends TestCase
 
         $expected = [
             'image' => [
-                'label' => ' ',
-                'type'  => 'image',
-                'width' => 'var(--table-row-height)',
+                'label'  => ' ',
+                'mobile' => true,
+                'type'   => 'image',
+                'width'  => 'var(--table-row-height)',
             ],
             'flag' => [
-                'label' => ' ',
-                'type'  => 'flag',
-                'width' => 'var(--table-row-height)'
+                'label'  => ' ',
+                'mobile' => true,
+                'type'   => 'flag',
+                'width'  => 'var(--table-row-height)'
             ]
         ];
 
@@ -149,6 +156,7 @@ class LayoutMixinTest extends TestCase
         $expected = [
             'image' => [
                 'label' => ' ',
+                'mobile' => true,
                 'type'  => 'image',
                 'width' => 'var(--table-row-height)',
             ],

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -63,6 +63,63 @@ class StructureFieldTest extends TestCase
         $this->assertEquals($expected, $field->data());
     }
 
+    public function testColumnsFromFields()
+    {
+        $field = $this->field('structure', [
+            'fields' => [
+                'a' => [
+                    'type' => 'text'
+                ],
+                'b' => [
+                    'type' => 'text'
+                ]
+            ],
+        ]);
+
+        $expected = [
+            'a' => [
+                'type' => 'text',
+                'label' => 'a',
+                'mobile' => true // the first column should be automatically kept on mobile
+            ],
+            'b' => [
+                'type' => 'text',
+                'label' => 'b',
+            ],
+        ];
+
+        $this->assertSame($expected, $field->columns());
+    }
+
+    public function testColumnsWithCustomMobileSetup()
+    {
+        $field = $this->field('structure', [
+            'columns' => [
+                'b' => [
+                    'mobile' => true
+                ]
+            ],
+            'fields' => [
+                'a' => [
+                    'type' => 'text'
+                ],
+                'b' => [
+                    'type' => 'text'
+                ]
+            ],
+        ]);
+
+        $expected = [
+            'b' => [
+                'mobile' => true,
+                'type' => 'text',
+                'label' => 'b',
+            ],
+        ];
+
+        $this->assertSame($expected, $field->columns());
+    }
+
     public function testLowerCaseColumnsNames()
     {
         $field = $this->field('structure', [


### PR DESCRIPTION
## This PR …

## Enhancements

- Columns for the new `k–table` component can now use the new `mobile: true` option to make sure they are still visible in the mobile view. This gives a lot more control over the responsiveness of tables. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
