### PR TITLE
Reverts plugin's fallback link to getkirby.com

### DIFF
--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -127,7 +127,7 @@ class Plugin extends Model
         $docs     = $info['support']['docs'] ?? null;
         $source   = $info['support']['source'] ?? null;
 
-        $link = $homepage ?? $docs ?? $source ?? 'https://getkirby.com/plugins/' . $this->id();
+        $link = $homepage ?? $docs ?? $source;
 
         return V::url($link) ? $link : null;
     }

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -209,7 +209,7 @@ class PluginTest extends TestCase
     public function testLinkWhenEmpty()
     {
         $plugin = new Plugin('getkirby/test-plugin');
-        $this->assertSame('https://getkirby.com/plugins/getkirby/test-plugin', $plugin->link());
+        $this->assertNull($plugin->link());
     }
 
     /**


### PR DESCRIPTION
### Fixes
-  Plugins with no homepage should not fallback to getkirby.com #4409

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
