### PR TITLE
Reverts info field height

### DIFF
--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -56,7 +56,7 @@ export default {
   background: var(--color-white);
   border-radius: var(--rounded);
   line-height: 1.25rem;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.75rem;
 }
 .k-box[data-theme="code"] {
   background: var(--color-gray-900);


### PR DESCRIPTION
## This PR …

- Reverts info field vertical padding to correct height
- Improved horizontal padding
- Keeps new borderless style (I think @bastianallgeier intended idea 🙂)

![screen-capture-1441-Test - Mægazine-localhost](https://user-images.githubusercontent.com/3393422/174885074-58780d84-031c-4242-8705-90158b58463d.png)


### Fixes

- Info field height taller than other fields #4408

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
