### PR TITLE
Fixes for table columns

### DIFF
--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 return [
     'props' => [
@@ -66,7 +67,8 @@ return [
                     continue;
                 }
 
-                $column['id'] = $columnName;
+                $column['label'] ??= Str::ucfirst($columnName);
+                $column['id']      = $columnName;
                 $columns[$columnName . 'Cell'] = $column;
             }
 

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -53,7 +53,7 @@ return [
 
             if ($this->info) {
                 $columns['info'] = [
-                    'label' => 'Info',
+                    'label' => I18n::translate('info'),
                     'type'  => 'text',
                 ];
             }

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -58,6 +58,14 @@ return [
             }
 
             foreach ($this->columns as $columnName => $column) {
+                if ($column === true) {
+                    $column = [];
+                }
+
+                if ($column === false) {
+                    continue;
+                }
+
                 $column['id'] = $columnName;
                 $columns[$columnName . 'Cell'] = $column;
             }

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -67,8 +67,17 @@ return [
                     continue;
                 }
 
+                // fallback for labels
                 $column['label'] ??= Str::ucfirst($columnName);
-                $column['id']      = $columnName;
+
+                // make sure to translate labels
+                $column['label'] = I18n::translate($column['label'], $column['label']);
+
+                // keep the original column name as id
+                $column['id'] = $columnName;
+
+                // add the custom column to the array with a key that won't
+                // override the system columns
                 $columns[$columnName . 'Cell'] = $column;
             }
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -297,6 +297,7 @@
   "hide": "Hide",
   "hour": "Hour",
   "import": "Import",
+  "info": "Info",
   "insert": "Insert",
   "insert.after": "Insert after",
   "insert.before": "Insert before",

--- a/tests/Cms/Sections/mixins/LayoutMixinTest.php
+++ b/tests/Cms/Sections/mixins/LayoutMixinTest.php
@@ -149,6 +149,14 @@ class LayoutMixinTest extends TestCase
                 'date' => [
                     'label' => 'Date',
                     'type'  => 'date'
+                ],
+                'simple' => true,
+                'removed' => false,
+                'translated' => [
+                    'label' => [
+                        'en' => 'Translated',
+                        'de' => 'Übersetzt'
+                    ]
                 ]
             ]
         ]);
@@ -164,6 +172,14 @@ class LayoutMixinTest extends TestCase
                 'label' => 'Date',
                 'type'  => 'date',
                 'id'    => 'date'
+            ],
+            'simpleCell' => [
+                'label' => 'Simple',
+                'id'    => 'simple'
+            ],
+            'translatedCell' => [
+                'label' => 'Translated',
+                'id'    => 'translated'
             ]
         ];
 
@@ -199,7 +215,8 @@ class LayoutMixinTest extends TestCase
                 'safeHtml' => [
                     'label' => 'Safe HTML',
                     'value' => '{{ page.html }}'
-                ]
+                ],
+                'removed' => false
             ]
         ]);
 


### PR DESCRIPTION
## Fixes

- Support boolean column definitions to set simple columns or unset columns when extending sections. This was already supported in structure fields and adds more consistency. 
- Fix automatic column labels. Labels are now formed by the column name if a label is not set.
- Fix translatable column labels. 
- The Info column label was not yet translated. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
