### PR TITLE
Added boolean type to available columnTypes for createColumn

### DIFF
--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -147,7 +147,7 @@ abstract class Sql
             'text'      => '{{ name }} TEXT {{ unique }}',
             'int'       => '{{ name }} INT(11) UNSIGNED {{ null }} {{ default }} {{ unique }}',
             'timestamp' => '{{ name }} TIMESTAMP {{ null }} {{ default }} {{ unique }}',
-            'boolean'   => '{{ name }} TINYINT(1) {{ null }} {{ default }} {{ unique }}'
+            'bool'   => '{{ name }} TINYINT(1) {{ null }} {{ default }} {{ unique }}'
         ];
     }
 

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -146,7 +146,8 @@ abstract class Sql
             'varchar'   => '{{ name }} varchar(255) {{ null }} {{ default }} {{ unique }}',
             'text'      => '{{ name }} TEXT {{ unique }}',
             'int'       => '{{ name }} INT(11) UNSIGNED {{ null }} {{ default }} {{ unique }}',
-            'timestamp' => '{{ name }} TIMESTAMP {{ null }} {{ default }} {{ unique }}'
+            'timestamp' => '{{ name }} TIMESTAMP {{ null }} {{ default }} {{ unique }}',
+            'boolean'   => '{{ name }} TINYINT(1) {{ null }} {{ default }} {{ unique }}'
         ];
     }
 

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -147,7 +147,7 @@ abstract class Sql
             'text'      => '{{ name }} TEXT {{ unique }}',
             'int'       => '{{ name }} INT(11) UNSIGNED {{ null }} {{ default }} {{ unique }}',
             'timestamp' => '{{ name }} TIMESTAMP {{ null }} {{ default }} {{ unique }}',
-            'bool'   => '{{ name }} TINYINT(1) {{ null }} {{ default }} {{ unique }}'
+            'bool'      => '{{ name }} TINYINT(1) {{ null }} {{ default }} {{ unique }}'
         ];
     }
 

--- a/src/Database/Sql/Sqlite.php
+++ b/src/Database/Sql/Sqlite.php
@@ -45,7 +45,7 @@ class Sqlite extends Sql
             'text'      => '{{ name }} TEXT {{ null }} {{ default }} {{ unique }}',
             'int'       => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
             'timestamp' => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
-            'boolean'   => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
+            'bool'   => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
         ];
     }
 

--- a/src/Database/Sql/Sqlite.php
+++ b/src/Database/Sql/Sqlite.php
@@ -44,7 +44,8 @@ class Sqlite extends Sql
             'varchar'   => '{{ name }} TEXT {{ null }} {{ default }} {{ unique }}',
             'text'      => '{{ name }} TEXT {{ null }} {{ default }} {{ unique }}',
             'int'       => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
-            'timestamp' => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
+            'timestamp' => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
+            'boolean'   => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
         ];
     }
 

--- a/src/Database/Sql/Sqlite.php
+++ b/src/Database/Sql/Sqlite.php
@@ -45,7 +45,7 @@ class Sqlite extends Sql
             'text'      => '{{ name }} TEXT {{ null }} {{ default }} {{ unique }}',
             'int'       => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
             'timestamp' => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}',
-            'bool'   => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
+            'bool'      => '{{ name }} INTEGER {{ null }} {{ default }} {{ unique }}'
         ];
     }
 


### PR DESCRIPTION
## This PR …

Adds an extra columnType for creating tables via the SQL and SQLite query builder classes. The reasons for this enhancement is to save up storage in MySQL tables.

* In the SQL query builder it will use the `TINYINT(1)` as boolean field instead of the `bool` alias for maximum compatibility.
* Also added in the SQLite query builder it will use the `INTEGER` as boolean field for columnType consistency with the SQL query builder.

### Features

- New `bool` column type for the `Database` classes

### Breaking changes

No.

### For review team

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
