### PR TITLE
Fix textarea caption using inline markdown

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -144,7 +144,7 @@ return [
 
             // render KirbyText in caption
             if ($tag->caption) {
-                $options = ['markdown'=> ['inline' => true]];
+                $options = ['markdown' => ['inline' => true]];
                 $caption = $tag->kirby()->kirbytext($tag->caption, $options);
                 $tag->caption = [$caption];
             }

--- a/config/tags.php
+++ b/config/tags.php
@@ -144,7 +144,9 @@ return [
 
             // render KirbyText in caption
             if ($tag->caption) {
-                $tag->caption = [$tag->kirby()->kirbytext($tag->caption, [], true)];
+                $options = ['markdown'=> ['inline' => true]];
+                $caption = $tag->kirby()->kirbytext($tag->caption, $options);
+                $tag->caption = [$caption];
             }
 
             return Html::figure([ $link($image) ], $tag->caption, [


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Image KirbyTag with caption doesn't trigger deprecation warning anymore
#4435


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
