### PR TITLE
`I18n`: support fallback to language code

### DIFF
--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -145,7 +145,7 @@ class I18n
 			if (isset($key[$locale])) {
 				return $key[$locale];
 			}
-			// try to use lagnuage code, e.g. `es` when locale is `es_ES`
+			// try to use language code, e.g. `es` when locale is `es_ES`
 			$lang = Str::before($locale, '_');
 			if (isset($key[$lang])) {
 				return $key[$lang];
@@ -225,7 +225,7 @@ class I18n
 			return static::$translations[$locale] = (static::$load)($locale);
 		}
 
-		// try to use lagnuage code, e.g. `es` when locale is `es_ES`
+		// try to use language code, e.g. `es` when locale is `es_ES`
 		$lang = Str::before($locale, '_');
 		if (isset(static::$translations[$lang]) === true) {
 			return static::$translations[$lang];

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -141,9 +141,16 @@ class I18n
 		$locale ??= static::locale();
 
 		if (is_array($key) === true) {
+			// try to use actual locale
 			if (isset($key[$locale])) {
 				return $key[$locale];
 			}
+			// try to use lagnuage code, e.g. `es` when locale is `es_ES`
+			$lang = Str::before($locale, '_');
+			if (isset($key[$lang])) {
+				return $key[$lang];
+			}
+			// use fallback
 			if (is_array($fallback)) {
 				return $fallback[$locale] ?? $fallback['en'] ?? reset($fallback);
 			}
@@ -216,6 +223,12 @@ class I18n
 
 		if (is_a(static::$load, 'Closure') === true) {
 			return static::$translations[$locale] = (static::$load)($locale);
+		}
+
+		// try to use lagnuage code, e.g. `es` when locale is `es_ES`
+		$lang = Str::before($locale, '_');
+		if (isset(static::$translations[$lang]) === true) {
+			return static::$translations[$lang];
 		}
 
 		return static::$translations[$locale] = [];

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -161,6 +161,16 @@ class I18nTest extends TestCase
 	/**
 	 * @covers ::translate
 	 */
+	public function testTranslateWithLanguageCode()
+	{
+		I18n::$locale = 'es_ES';
+
+		$this->assertSame('vamos', I18n::translate(['es' => 'vamos']));
+	}
+
+	/**
+	 * @covers ::translate
+	 */
 	public function testTranslateWithFallback()
 	{
 		I18n::$translations = [
@@ -364,6 +374,9 @@ class I18nTest extends TestCase
 			],
 			'de' => [
 				'test' => 'juhu'
+			],
+			'es' => [
+				'test' => 'vamos'
 			]
 		];
 
@@ -372,6 +385,9 @@ class I18nTest extends TestCase
 
 		I18n::$locale = 'de';
 		$this->assertSame('juhu', I18n::translate('test'));
+
+		I18n::$locale = 'es_ES';
+		$this->assertSame('vamos', I18n::translate('test'));
 
 		I18n::$locale = 'fr';
 		I18n::$fallback = 'fr';


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- Translations now also check for simple language codes when using complex locales (e.g. `es` for `es_ES`)
#4412

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
