### PR TITLE
New plugin static methods: `::register()` and `::get()`

### DIFF
--- a/config/aliases.php
+++ b/config/aliases.php
@@ -13,6 +13,7 @@ return [
 	'page'       => 'Kirby\Cms\Page',
 	'pages'      => 'Kirby\Cms\Pages',
 	'pagination' => 'Kirby\Cms\Pagination',
+	'plugin'     => 'Kirby\Cms\Plugin',
 	'r'          => 'Kirby\Cms\R',
 	'response'   => 'Kirby\Cms\Response',
 	's'          => 'Kirby\Cms\S',

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -87,6 +87,17 @@ class Plugin extends Model
 	}
 
 	/**
+	 * Kirby plugin getter
+	 *
+	 * @param string $name
+	 * @return \Kirby\Cms\Plugin|null
+	 */
+	public static function get(string $name)
+	{
+		return App::plugin($name);
+	}
+
+	/**
 	 * Returns the unique id for the plugin
 	 *
 	 * @return string
@@ -171,6 +182,18 @@ class Plugin extends Model
 	public function option(string $key)
 	{
 		return $this->kirby()->option($this->prefix() . '.' . $key);
+	}
+
+	/**
+	 * Registers a plugin in the CMS
+	 *
+	 * @param string $name
+	 * @param array $extends
+	 * @return \Kirby\Cms\Plugin
+	 */
+	public static function register(string $name, array $extends = [])
+	{
+		return App::plugin($name, $extends);
 	}
 
 	/**

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -3,7 +3,7 @@
 namespace Kirby\Cms;
 
 /**
- * @coversDefaultClass Kirby\Cms\Plugin
+ * @coversDefaultClass \Kirby\Cms\Plugin
  */
 class PluginTest extends TestCase
 {
@@ -77,6 +77,17 @@ class PluginTest extends TestCase
 		]);
 
 		$this->assertSame($extends, $plugin->extends());
+	}
+
+	/**
+	 * @covers ::get
+	 */
+	public function testGet()
+	{
+		$plugin = Plugin::register('getkirby/test-plugin', []);
+
+		$this->assertSame($plugin, Plugin::get('getkirby/test-plugin'));
+		$this->assertSame(Plugin::get('getkirby/test-plugin'), App::instance()->plugin('getkirby/test-plugin'));
 	}
 
 	/**
@@ -307,6 +318,16 @@ class PluginTest extends TestCase
 		$plugin = new Plugin('getkirby/test-plugin', []);
 
 		$this->assertSame('getkirby.test-plugin', $plugin->prefix());
+	}
+
+	/**
+	 * @covers ::register
+	 */
+	public function testRegister()
+	{
+		$plugin = Plugin::register('getkirby/test-plugin', []);
+
+		$this->assertSame($plugin, App::instance()->plugin('getkirby/test-plugin'));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

- New `Plugin` class alias added
- New `Plugin` static methods (alias of `App::instance()->plugin()`) added: `::get()` and `::register()`

````php
Plugin::get('plugin/test'); // plugin getter
Plugin::register('plugin/test'); // plugin setter without extends
Plugin::register('plugin/test', ['options' => []]); // plugin setter with extends
````

### Fixes
- Initializing plugins which don't require PHP #4419

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
