### PR TITLE
Use `match` instead of `switch`

### DIFF
--- a/config/api/routes/roles.php
+++ b/config/api/routes/roles.php
@@ -10,14 +10,11 @@ return [
 		'action'  => function () {
 			$kirby = $this->kirby();
 
-			switch ($kirby->request()->get('canBe')) {
-				case 'changed':
-					return $kirby->roles()->canBeChanged();
-				case 'created':
-					return $kirby->roles()->canBeCreated();
-				default:
-					return $kirby->roles();
-			}
+			return match ($kirby->request()->get('canBe')) {
+				'changed' => $kirby->roles()->canBeChanged(),
+				'created' => $kirby->roles()->canBeCreated(),
+				default   => $kirby->roles()
+			};
 		}
 	],
 	[

--- a/config/methods.php
+++ b/config/methods.php
@@ -99,13 +99,10 @@ return function (App $app) {
 		 * @return array
 		 */
 		'toData' => function (Field $field, string $method = ',') {
-			switch ($method) {
-				case 'yaml':
-				case 'json':
-					return Data::decode($field->value, $method);
-				default:
-					return $field->split($method);
-			}
+			return match ($method) {
+				'yaml', 'json' => Data::decode($field->value, $method),
+				default        => $field->split($method)
+			};
 		},
 
 		/**

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -12,7 +12,7 @@ return [
 		}
 	],
 	'methods' => [
-		'searchterm' => function (): string|null  {
+		'searchterm' => function (): string|null {
 			return App::instance()->request()->get('searchterm');
 		}
 	]

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -62,22 +62,13 @@ return [
 			return $parent;
 		},
 		'pages' => function () {
-			switch ($this->status) {
-				case 'draft':
-					$pages = $this->parent->drafts();
-					break;
-				case 'listed':
-					$pages = $this->parent->children()->listed();
-					break;
-				case 'published':
-					$pages = $this->parent->children();
-					break;
-				case 'unlisted':
-					$pages = $this->parent->children()->unlisted();
-					break;
-				default:
-					$pages = $this->parent->childrenAndDrafts();
-			}
+			$pages = match ($this->status) {
+				'draft'     => $this->parent->drafts(),
+				'listed'    => $this->parent->children()->listed(),
+				'published' => $this->parent->children(),
+				'unlisted'  => $this->parent->children()->unlisted(),
+				default     => $this->parent->childrenAndDrafts()
+			};
 
 			// filters pages that are protected and not in the templates list
 			// internal `filter()` method used instead of foreach loop that previously included `unset()`

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -142,20 +142,14 @@ class Api extends BaseApi
 	{
 		$parent = $parentId === null ? $this->site() : $this->page($parentId);
 
-		switch ($status) {
-			case 'all':
-				return $parent->childrenAndDrafts();
-			case 'draft':
-			case 'drafts':
-				return $parent->drafts();
-			case 'listed':
-				return $parent->children()->listed();
-			case 'unlisted':
-				return $parent->children()->unlisted();
-			case 'published':
-			default:
-				return $parent->children();
-		}
+		return match ($status) {
+			'all'             => $parent->childrenAndDrafts(),
+			'draft', 'drafts' => $parent->drafts(),
+			'listed'          => $parent->children()->listed(),
+			'unlisted'        => $parent->children()->unlisted(),
+			'published'       => $parent->children(),
+			default           => $parent->children()
+		};
 	}
 
 	/**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -686,17 +686,11 @@ class App
 			$uri = null;
 		}
 
-		switch ($uri) {
-			case '/':
-				$parent = $this->site();
-				break;
-			case null:
-				$parent = $this->site()->page();
-				break;
-			default:
-				$parent = $this->site()->page($uri);
-				break;
-		}
+		$parent = match ($uri) {
+			'/'     => $this->site(),
+			null    => $this->site()->page(),
+			default => $this->site()->page($uri)
+		};
 
 		if ($parent) {
 			return $parent->image($filename);

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -308,28 +308,21 @@ class Auth
 		// clear the status cache
 		$this->status = null;
 
-		switch ($who) {
-			case null:
-				return $this->impersonate = null;
-			case 'kirby':
-				return $this->impersonate = new User([
-					'email' => 'kirby@getkirby.com',
-					'id'    => 'kirby',
-					'role'  => 'admin',
-				]);
-			case 'nobody':
-				return $this->impersonate = new User([
-					'email' => 'nobody@getkirby.com',
-					'id'    => 'nobody',
-					'role'  => 'nobody',
-				]);
-			default:
-				if ($user = $this->kirby->users()->find($who)) {
-					return $this->impersonate = $user;
-				}
-
-				throw new NotFoundException('The user "' . $who . '" cannot be found');
-		}
+		return match ($who) {
+			null     => $this->impersonate = null,
+			'kirby'  => $this->impersonate = new User([
+				'email' => 'kirby@getkirby.com',
+				'id'    => 'kirby',
+				'role'  => 'admin',
+			]),
+			'nobody' => $this->impersonate = new User([
+				'email' => 'nobody@getkirby.com',
+				'id'    => 'nobody',
+				'role'  => 'nobody',
+			]),
+			default  => $this->impersonate = $this->kirby->users()->find($who)
+				?? throw new NotFoundException('The user "' . $who . '" cannot be found')
+		};
 	}
 
 	/**

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -308,20 +308,19 @@ class Auth
 		// clear the status cache
 		$this->status = null;
 
-		return match ($who) {
-			null     => $this->impersonate = null,
-			'kirby'  => $this->impersonate = new User([
+		return $this->impersonate = match ($who) {
+			null     => null,
+			'kirby'  => new User([
 				'email' => 'kirby@getkirby.com',
 				'id'    => 'kirby',
 				'role'  => 'admin',
 			]),
-			'nobody' => $this->impersonate = new User([
+			'nobody' => new User([
 				'email' => 'nobody@getkirby.com',
 				'id'    => 'nobody',
 				'role'  => 'nobody',
 			]),
-			default  => $this->impersonate = $this->kirby->users()->find($who)
-				?? throw new NotFoundException('The user "' . $who . '" cannot be found')
+			default  => $this->kirby->users()->find($who) ?? throw new NotFoundException('The user "' . $who . '" cannot be found')
 		};
 	}
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -320,7 +320,7 @@ class Auth
 				'id'    => 'nobody',
 				'role'  => 'nobody',
 			]),
-			default  => $this->kirby->users()->find($who) ?? throw new NotFoundException('The user "' . $who . '" cannot be found')
+			default  => ($this->kirby->users()->find($who) ?? throw new NotFoundException('The user "' . $who . '" cannot be found'))
 		};
 	}
 

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -117,25 +117,14 @@ class Find
 
 		$kirby = App::instance();
 
-		switch ($modelName) {
-			case 'site':
-				$model = $kirby->site();
-				break;
-			case 'account':
-				$model = static::user();
-				break;
-			case 'page':
-				$model = static::page(basename($path));
-				break;
-			case 'file':
-				$model = static::file(...explode('/files/', $path));
-				break;
-			case 'user':
-				$model = $kirby->user(basename($path));
-				break;
-			default:
-				throw new InvalidArgumentException('Invalid model type: ' . $modelType);
-		}
+		$model = match ($modelName) {
+			'site'    => $kirby->site(),
+			'account' => static::user(),
+			'page'    => static::page(basename($path)),
+			'file'    => static::file(...explode('/files/', $path)),
+			'user'    => $kirby->user(basename($path)),
+			default   => throw new InvalidArgumentException('Invalid model type: ' . $modelType)
+		};
 
 		return $model ?? throw new NotFoundException([
 			'key' => $modelName . '.undefined'

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -184,16 +184,12 @@ trait PageActions
 	 */
 	public function changeStatus(string $status, int $position = null)
 	{
-		switch ($status) {
-			case 'draft':
-				return $this->changeStatusToDraft();
-			case 'listed':
-				return $this->changeStatusToListed($position);
-			case 'unlisted':
-				return $this->changeStatusToUnlisted();
-			default:
-				throw new InvalidArgumentException('Invalid status: ' . $status);
-		}
+		return match ($status) {
+			'draft'    => $this->changeStatusToDraft(),
+			'listed'   => $this->changeStatusToListed($position),
+			'unlisted' => $this->changeStatusToUnlisted(),
+			default    => throw new InvalidArgumentException('Invalid status: ' . $status)
+		};
 	}
 
 	/**

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -101,16 +101,12 @@ class PageRules
 			throw new InvalidArgumentException(['key' => 'page.status.invalid']);
 		}
 
-		switch ($status) {
-			case 'draft':
-				return static::changeStatusToDraft($page);
-			case 'listed':
-				return static::changeStatusToListed($page, $position);
-			case 'unlisted':
-				return static::changeStatusToUnlisted($page);
-			default:
-				throw new InvalidArgumentException(['key' => 'page.status.invalid']);
-		}
+		return match ($status) {
+			'draft'     => static::changeStatusToDraft($page),
+			'listed'    => static::changeStatusToListed($page, $position),
+			'unlisted'  => static::changeStatusToUnlisted($page),
+			default     => throw new InvalidArgumentException(['key' => 'page.status.invalid'])
+		};
 	}
 
 	/**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -551,7 +551,8 @@ class Query
 				'table'    => $this->table,
 				'where'    => $this->where,
 				'bindings' => $this->bindings
-			])
+			]),
+			default => null
 		};
 	}
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -522,41 +522,37 @@ class Query
 	{
 		$sql = $this->database->sql();
 
-		switch ($type) {
-			case 'select':
-				return $sql->select([
-					'table'    => $this->table,
-					'columns'  => $this->select,
-					'join'     => $this->join,
-					'distinct' => $this->distinct,
-					'where'    => $this->where,
-					'group'    => $this->group,
-					'having'   => $this->having,
-					'order'    => $this->order,
-					'offset'   => $this->offset,
-					'limit'    => $this->limit,
-					'bindings' => $this->bindings
-				]);
-			case 'update':
-				return $sql->update([
-					'table'    => $this->table,
-					'where'    => $this->where,
-					'values'   => $this->values,
-					'bindings' => $this->bindings
-				]);
-			case 'insert':
-				return $sql->insert([
-					'table'    => $this->table,
-					'values'   => $this->values,
-					'bindings' => $this->bindings
-				]);
-			case 'delete':
-				return $sql->delete([
-					'table'    => $this->table,
-					'where'    => $this->where,
-					'bindings' => $this->bindings
-				]);
-		}
+		return match ($type) {
+			'select' => $sql->select([
+				'table'    => $this->table,
+				'columns'  => $this->select,
+				'join'     => $this->join,
+				'distinct' => $this->distinct,
+				'where'    => $this->where,
+				'group'    => $this->group,
+				'having'   => $this->having,
+				'order'    => $this->order,
+				'offset'   => $this->offset,
+				'limit'    => $this->limit,
+				'bindings' => $this->bindings
+			]),
+			'update' => $sql->update([
+				'table'    => $this->table,
+				'where'    => $this->where,
+				'values'   => $this->values,
+				'bindings' => $this->bindings
+			]),
+			'insert' => $sql->insert([
+				'table'    => $this->table,
+				'values'   => $this->values,
+				'bindings' => $this->bindings
+			]),
+			'delete' => $sql->delete([
+				'table'    => $this->table,
+				'where'    => $this->where,
+				'bindings' => $this->bindings
+			])
+		};
 	}
 
 	/**

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -703,19 +703,19 @@ abstract class Sql
 		// split by dot, but only outside of quotes
 		$parts = preg_split('/(?:`[^`]*`|"[^"]*")(*SKIP)(*F)|\./', $identifier);
 
-		switch (count($parts)) {
+		return match (count($parts)) {
 			// non-qualified identifier
-			case 1:
-				return [$table, $this->unquoteIdentifier($parts[0])];
+			1 => [$table, $this->unquoteIdentifier($parts[0])],
 
 			// qualified identifier
-			case 2:
-				return [$this->unquoteIdentifier($parts[0]), $this->unquoteIdentifier($parts[1])];
+			2 => [
+				$this->unquoteIdentifier($parts[0]),
+				$this->unquoteIdentifier($parts[1])
+			],
 
 			// every other number is an error
-			default:
-				throw new InvalidArgumentException('Invalid identifier ' . $identifier);
-		}
+			default => throw new InvalidArgumentException('Invalid identifier ' . $identifier)
+		};
 	}
 
 	/**

--- a/src/Filesystem/Filename.php
+++ b/src/Filesystem/Filename.php
@@ -135,16 +135,11 @@ class Filename
 				$value = '';
 			}
 
-			switch ($key) {
-				case 'dimensions':
-					$result[] = $value;
-					break;
-				case 'crop':
-					$result[] = ($value === 'center') ? 'crop' : $key . '-' . $value;
-					break;
-				default:
-					$result[] = $key . $value;
-			}
+			$result[] = match ($key) {
+				'dimensions' => $value,
+				'crop'       => ($value === 'center') ? 'crop' : $key . '-' . $value,
+				default      => $key . $value
+			};
 		}
 
 		$result     = array_filter($result);

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -105,12 +105,10 @@ trait IsFile
 			'url'  => $this->url()
 		];
 
-		switch ($this->type()) {
-			case 'image':
-				return $this->asset = new Image($props);
-			default:
-				return $this->asset = new File($props);
-		}
+		return match ($this->type()) {
+			'image' => $this->asset = new Image($props),
+			default => $this->asset = new File($props)
+		};
 	}
 
 	/**

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -105,9 +105,9 @@ trait IsFile
 			'url'  => $this->url()
 		];
 
-		return match ($this->type()) {
-			'image' => $this->asset = new Image($props),
-			default => $this->asset = new File($props)
+		return $this->asset = match ($this->type()) {
+			'image' => new Image($props),
+			default => new File($props)
 		};
 	}
 

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -105,30 +105,23 @@ class Options
 	 */
 	public static function factory($options, array $props = [], $model = null): array
 	{
-		switch ($options) {
-			case 'api':
-				$options = static::api($props['api'], $model);
-				break;
-			case 'query':
-				$options = static::query($props['query'], $model);
-				break;
-			case 'children':
-			case 'grandChildren':
-			case 'siblings':
-			case 'index':
-			case 'files':
-			case 'images':
-			case 'documents':
-			case 'videos':
-			case 'audio':
-			case 'code':
-			case 'archives':
-				$options = static::query('page.' . $options, $model);
-				break;
-			case 'pages':
-				$options = static::query('site.index', $model);
-				break;
-		}
+		$options = match ($options) {
+			'api'      => static::api($props['api'], $model),
+			'query'    => static::query($props['query'], $model),
+			'pages'    => static::query('site.index', $model),
+			'children',
+			'grandChildren',
+			'siblings',
+			'index',
+			'files',
+			'images',
+			'documents',
+			'videos',
+			'audio',
+			'code',
+			'archives' => static::query('page.' . $options, $model),
+			default    => $options
+		};
 
 		if (is_array($options) === false) {
 			return [];

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -946,18 +946,17 @@ class Environment
 			return $key;
 		}
 
-		switch ($key) {
-			case 'SERVER_ADDR':
-			case 'SERVER_NAME':
-			case 'HTTP_HOST':
-			case 'HTTP_X_FORWARDED_HOST':
-				return static::sanitizeHost($value);
-			case 'SERVER_PORT':
-			case 'HTTP_X_FORWARDED_PORT':
-				return static::sanitizePort($value);
-			default:
-				return $value;
-		}
+		return match ($key) {
+			'SERVER_ADDR',
+			'SERVER_NAME',
+			'HTTP_HOST',
+			'HTTP_X_FORWARDED_HOST' => static::sanitizeHost($value),
+
+			'SERVER_PORT',
+			'HTTP_X_FORWARDED_PORT' => static::sanitizePort($value),
+
+			default => $value
+		};
 	}
 
 	/**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -147,18 +147,11 @@ abstract class Model
 			if ($image->isResizable() === true) {
 				$settings['src'] = static::imagePlaceholder();
 
-				switch ($layout) {
-					case 'cards':
-						$sizes = [352, 864, 1408];
-						break;
-					case 'cardlets':
-						$sizes = [96, 192];
-						break;
-					case 'list':
-					default:
-						$sizes = [38, 76];
-						break;
-				}
+				$sizes = match ($layout) {
+					'cards'    => [352, 864, 1408],
+					'cardlets' => [96, 192],
+					default    => [38, 76]
+				};
 
 				if (($settings['cover'] ?? false) === false || $layout === 'cards') {
 					$settings['srcset'] = $image->srcset($sizes);

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -275,16 +275,12 @@ class Panel
 		}
 
 		// handle different response types (view, dialog, ...)
-		switch ($options['type'] ?? null) {
-			case 'dialog':
-				return Dialog::response($result, $options);
-			case 'dropdown':
-				return Dropdown::response($result, $options);
-			case 'search':
-				return Search::response($result, $options);
-			default:
-				return View::response($result, $options);
-		}
+		return match ($options['type'] ?? null) {
+			'dialog'   => Dialog::response($result, $options),
+			'dropdown' => Dropdown::response($result, $options),
+			'search'   => Search::response($result, $options),
+			default    => View::response($result, $options)
+		};
 	}
 
 	/**

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -131,31 +131,26 @@ class Sessions
 	 * - In `manual` mode: Fails and throws an Exception
 	 *
 	 * @return \Kirby\Session\Session|null Either the current session or null in case there isn't one
+	 * @throws \Kirby\Exception\Exception
+	 * @throws \Kirby\Exception\LogicException
 	 */
 	public function current()
 	{
-		$token = null;
-		switch ($this->mode) {
-			case 'cookie':
-				$token = $this->tokenFromCookie();
-				break;
-			case 'header':
-				$token = $this->tokenFromHeader();
-				break;
-			case 'manual':
-				throw new LogicException([
-					'key'       => 'session.sessions.manualMode',
-					'fallback'  => 'Cannot automatically get current session in manual mode',
-					'translate' => false,
-					'httpCode'  => 500
-				]);
-			default:
-				// unexpected error that shouldn't occur
-				throw new Exception(['translate' => false]); // @codeCoverageIgnore
-		}
+		$token = match ($this->mode) {
+			'cookie' => $this->tokenFromCookie(),
+			'header' => $this->tokenFromHeader(),
+			'manual' => throw new LogicException([
+				'key'       => 'session.sessions.manualMode',
+				'fallback'  => 'Cannot automatically get current session in manual mode',
+				'translate' => false,
+				'httpCode'  => 500
+			]),
+			// unexpected error that shouldn't occur
+			default => throw new Exception(['translate' => false]) // @codeCoverageIgnore
+		};
 
 		// no token was found, no session
-		if (!is_string($token)) {
+		if (is_string($token) === false) {
 			return null;
 		}
 
@@ -253,11 +248,11 @@ class Sessions
 	{
 		$value = Cookie::get($this->cookieName());
 
-		if (is_string($value)) {
-			return $value;
-		} else {
+		if (is_string($value) === false) {
 			return null;
 		}
+
+		return $value;
 	}
 
 	/**
@@ -271,7 +266,7 @@ class Sessions
 		$headers = $request->headers();
 
 		// check if the header exists at all
-		if (!isset($headers['Authorization'])) {
+		if (isset($headers['Authorization']) === false) {
 			return null;
 		}
 

--- a/src/Toolkit/Date.php
+++ b/src/Toolkit/Date.php
@@ -502,19 +502,12 @@ class Date extends DateTime
 	 */
 	public function toString(string $mode = 'datetime', bool $timezone = true): string
 	{
-		switch ($mode) {
-			case 'date':
-				$format = 'Y-m-d';
-				break;
-			case 'time':
-				$format = 'H:i:s';
-				break;
-			case 'datetime':
-				$format = 'Y-m-d H:i:s';
-				break;
-			default:
-				throw new InvalidArgumentException('Invalid mode');
-		}
+		$format = match ($mode) {
+			'date'     => 'Y-m-d',
+			'time'     => 'H:i:s',
+			'datetime' => 'Y-m-d H:i:s',
+			default    => throw new InvalidArgumentException('Invalid mode')
+		};
 
 		if ($timezone === true) {
 			$format .= 'P';

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -527,17 +527,12 @@ class Html extends Xml
 		$uri   = new Uri($url);
 		$path  = $uri->path();
 		$query = $uri->query();
-		$id    = null;
 
-		switch ($uri->host()) {
-			case 'vimeo.com':
-			case 'www.vimeo.com':
-				$id = $path->last();
-				break;
-			case 'player.vimeo.com':
-				$id = $path->nth(1);
-				break;
-		}
+		$id = match ($uri->host()) {
+			'vimeo.com', 'www.vimeo.com' => $path->last(),
+			'player.vimeo.com'           => $path->nth(1),
+			default                      => null
+		};
 
 		if (empty($id) === true || preg_match('!^[0-9]*$!', $id) !== 1) {
 			return null;

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -613,23 +613,14 @@ class Str
 				$pool = array_merge($pool, static::pool($t));
 			}
 		} else {
-			switch (strtolower($type)) {
-				case 'alphalower':
-					$pool = range('a', 'z');
-					break;
-				case 'alphaupper':
-					$pool = range('A', 'Z');
-					break;
-				case 'alpha':
-					$pool = static::pool(['alphaLower', 'alphaUpper']);
-					break;
-				case 'num':
-					$pool = range(0, 9);
-					break;
-				case 'alphanum':
-					$pool = static::pool(['alpha', 'num']);
-					break;
-			}
+			$pool = match (strtolower($type)) {
+				'alphalower' => range('a', 'z'),
+				'alphaupper' => range('A', 'Z'),
+				'alpha'      => static::pool(['alphaLower', 'alphaUpper']),
+				'num'        => range(0, 9),
+				'alphanum'   => static::pool(['alpha', 'num']),
+				default      => $pool
+			};
 		}
 
 		return $array ? $pool : implode('', $pool);
@@ -1254,21 +1245,13 @@ class Str
 			$type = gettype($type);
 		}
 
-		switch ($type) {
-			case 'array':
-				return (array)$string;
-			case 'bool':
-			case 'boolean':
-				return filter_var($string, FILTER_VALIDATE_BOOLEAN);
-			case 'double':
-			case 'float':
-				return (float)$string;
-			case 'int':
-			case 'integer':
-				return (int)$string;
-		}
-
-		return (string)$string;
+		return match ($type) {
+			'array'           => (array)$string,
+			'bool', 'boolean' => filter_var($string, FILTER_VALIDATE_BOOLEAN),
+			'double', 'float' => (float)$string,
+			'int', 'integer'  => (int)$string,
+			default           => (string)$string
+		};
 	}
 
 	/**

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -338,22 +338,16 @@ V::$validators = [
 			return false;
 		}
 
-		switch ($operator) {
-			case '!=':
-				return $value !== $test;
-			case '<':
-				return $value < $test;
-			case '>':
-				return $value > $test;
-			case '<=':
-				return $value <= $test;
-			case '>=':
-				return $value >= $test;
-			case '==':
-				return $value === $test;
-		}
+		return match ($operator) {
+			'!=' => $value !== $test,
+			'<'  => $value < $test,
+			'>'  => $value > $test,
+			'<='  => $value <= $test,
+			'>='  => $value >= $test,
+			'=='  => $value === $test,
 
-		throw new InvalidArgumentException('Invalid date comparison operator: "' . $operator . '". Allowed operators: "==", "!=", "<", "<=", ">", ">="');
+			default => throw new InvalidArgumentException('Invalid date comparison operator: "' . $operator . '". Allowed operators: "==", "!=", "<", "<=", ">", ">="')
+		};
 	},
 
 	/**
@@ -601,18 +595,13 @@ V::$validators = [
 			throw new Exception('$value is of type without size');
 		}
 
-		switch ($operator) {
-			case '<':
-				return $count < $size;
-			case '>':
-				return $count > $size;
-			case '<=':
-				return $count <= $size;
-			case '>=':
-				return $count >= $size;
-			default:
-				return $count == $size;
-		}
+		return match ($operator) {
+			'<'     => $count < $size,
+			'>'     => $count > $size,
+			'<='    => $count <= $size,
+			'>='    => $count >= $size,
+			default => $count == $size
+		};
 	},
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

I'd argue that manual review can replace the failing `codecov/patch/backend` check here.

### Refactored
- Using PHP `match` statements instead of `switch` in various places


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
