### PR TITLE
Use null-safe operator from PHP 8.0

### DIFF
--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -32,28 +32,23 @@ return [
 		'slugs'        => fn () => Str::$language,
 		'title'        => fn () => $this->site()->title()->value(),
 		'translation' => function () {
-			if ($user = $this->user()) {
-				$translationCode = $user->language();
-			} else {
-				$translationCode = $this->kirby()->panelLanguage();
+			$code   = $this->user()?->language();
+			$code ??= $this->kirby()->panelLanguage();
+
+			if ($translation = $this->kirby()->translation($code)) {
+				return $translation;
 			}
 
-			if ($translation = $this->kirby()->translation($translationCode)) {
-				return $translation;
-			} else {
-				return $this->kirby()->translation('en');
-			}
+			return $this->kirby()->translation('en');
 		},
 		'kirbytext' => fn () => $this->kirby()->option('panel.kirbytext') ?? true,
 		'user' => fn () => $this->user(),
 		'version' => function () {
-			$user = $this->user();
-
-			if ($user && $user->role()->permissions()->for('access', 'system') === true) {
+			if ($this->user()?->role()->permissions()->for('access', 'system') === true) {
 				return $this->kirby()->version();
-			} else {
-				return null;
 			}
+
+			return null;
 		}
 	],
 	'type'   => 'Kirby\Cms\System',

--- a/config/api/models/System.php
+++ b/config/api/models/System.php
@@ -32,8 +32,8 @@ return [
 		'slugs'        => fn () => Str::$language,
 		'title'        => fn () => $this->site()->title()->value(),
 		'translation' => function () {
-			$code   = $this->user()?->language();
-			$code ??= $this->kirby()->panelLanguage();
+			$code = $this->user()?->language() ??
+					$this->kirby()->panelLanguage();
 
 			if ($translation = $this->kirby()->translation($code)) {
 				return $translation;

--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -12,9 +12,7 @@ return [
 		'pattern' => $pattern . '/files/(:any)/sections/(:any)',
 		'method'  => 'GET',
 		'action'  => function (string $path, string $filename, string $sectionName) {
-			if ($section = $this->file($path, $filename)->blueprint()->section($sectionName)) {
-				return $section->toResponse();
-			}
+			return $this->file($path, $filename)->blueprint()->section($sectionName)?->toResponse();
 		}
 	],
 	[

--- a/config/api/routes/languages.php
+++ b/config/api/routes/languages.php
@@ -29,18 +29,14 @@ return [
 		'pattern' => 'languages/(:any)',
 		'method'  => 'PATCH',
 		'action'  => function (string $code) {
-			if ($language = $this->kirby()->languages()->find($code)) {
-				return $language->update($this->requestBody());
-			}
+			return $this->kirby()->languages()->find($code)?->update($this->requestBody());
 		}
 	],
 	[
 		'pattern' => 'languages/(:any)',
 		'method'  => 'DELETE',
 		'action'  => function (string $code) {
-			if ($language = $this->kirby()->languages()->find($code)) {
-				return $language->delete();
-			}
+			return $this->kirby()->languages()->find($code)?->delete();
 		}
 	]
 ];

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -9,36 +9,28 @@ return [
 		'pattern' => '(:all)/lock',
 		'method'  => 'PATCH',
 		'action'  => function (string $path) {
-			if ($lock = $this->parent($path)->lock()) {
-				return $lock->create();
-			}
+			return $this->parent($path)->lock()?->create();
 		}
 	],
 	[
 		'pattern' => '(:all)/lock',
 		'method'  => 'DELETE',
 		'action'  => function (string $path) {
-			if ($lock = $this->parent($path)->lock()) {
-				return $lock->remove();
-			}
+			return $this->parent($path)->lock()?->remove();
 		}
 	],
 	[
 		'pattern' => '(:all)/unlock',
 		'method'  => 'PATCH',
 		'action'  => function (string $path) {
-			if ($lock = $this->parent($path)->lock()) {
-				return $lock->unlock();
-			}
+			return  $this->parent($path)->lock()?->unlock();
 		}
 	],
 	[
 		'pattern' => '(:all)/unlock',
 		'method'  => 'DELETE',
 		'action'  => function (string $path) {
-			if ($lock = $this->parent($path)->lock()) {
-				return $lock->resolve();
-			}
+			return  $this->parent($path)->lock()?->resolve();
 		}
 	],
 ];

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -104,9 +104,7 @@ return [
 		'pattern' => 'pages/(:any)/sections/(:any)',
 		'method'  => 'GET',
 		'action'  => function (string $id, string $sectionName) {
-			if ($section = $this->page($id)->blueprint()->section($sectionName)) {
-				return $section->toResponse();
-			}
+			return $this->page($id)->blueprint()->section($sectionName)?->toResponse();
 		}
 	],
 	[

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -79,18 +79,16 @@ return [
 
 			if ($this->requestMethod() === 'GET') {
 				return $pages->search($this->requestQuery('q'));
-			} else {
-				return $pages->query($this->requestBody());
 			}
+
+			return $pages->query($this->requestBody());
 		}
 	],
 	[
 		'pattern' => 'site/sections/(:any)',
 		'method'  => 'GET',
 		'action'  => function (string $sectionName) {
-			if ($section = $this->site()->blueprint()->section($sectionName)) {
-				return $section->toResponse();
-			}
+			return $this->site()->blueprint()->section($sectionName)?->toResponse();
 		}
 	],
 	[

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -12,7 +12,7 @@ return [
 		}
 	],
 	'methods' => [
-		'searchterm' => function (): string|null  {
+		'searchterm' => function (): string|null {
 			return App::instance()->request()->get('searchterm');
 		}
 	]

--- a/config/tags.php
+++ b/config/tags.php
@@ -117,11 +117,8 @@ return [
 					return $img;
 				}
 
-				if ($link = $tag->file($tag->link)) {
-					$link = $link->url();
-				} else {
-					$link = $tag->link === 'self' ? $tag->src : $tag->link;
-				}
+				$link   = $tag->file($tag->link)?->url();
+				$link ??= $tag->link === 'self' ? $tag->src : $tag->link;
 
 				return Html::a($link, [$img], [
 					'rel'    => $tag->rel,

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -133,11 +133,7 @@ class Api
 	 */
 	public function authenticate()
 	{
-		if ($auth = $this->authentication()) {
-			return $auth->call($this);
-		}
-
-		return true;
+		return $this->authentication()?->call($this) ?? true;
 	}
 
 	/**

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -39,11 +39,9 @@ class Api extends BaseApi
 		$this->kirby->setCurrentLanguage($this->language());
 
 		$allowImpersonation = $this->kirby()->option('api.allowImpersonation', false);
-		if ($user = $this->kirby->user(null, $allowImpersonation)) {
-			$translation = $user->language();
-		} else {
-			$translation = $this->kirby->panelLanguage();
-		}
+
+		$translation   = $this->kirby->user(null, $allowImpersonation)?->language();
+		$translation ??= $this->kirby->panelLanguage();
 		$this->kirby->setCurrentTranslation($translation);
 
 		return parent::call($path, $method, $requestData);

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -698,11 +698,7 @@ class App
 				break;
 		}
 
-		if ($parent) {
-			return $parent->image($filename);
-		}
-
-		return null;
+		return $parent?->image($filename);
 	}
 
 	/**
@@ -938,11 +934,7 @@ class App
 	 */
 	public function languageCode(string $languageCode = null): string|null
 	{
-		if ($language = $this->language($languageCode)) {
-			return $language->code();
-		}
-
-		return null;
+		return $this->language($languageCode)?->code();
 	}
 
 	/**

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -27,11 +27,7 @@ trait AppTranslations
 	protected function i18n(): void
 	{
 		I18n::$load = function ($locale): array {
-			$data = [];
-
-			if ($translation = $this->translation($locale)) {
-				$data = $translation->data();
-			}
+			$data = $this->translation($locale)?->data() ?? [];
 
 			// inject translations from the current language
 			if (

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -636,9 +636,7 @@ class Auth
 		$this->impersonate = null;
 
 		// logout the current user if it exists
-		if ($user = $this->user()) {
-			$user->logout();
-		}
+		$this->user()?->logout();
 
 		// clear the pending challenge
 		$session = $this->kirby->session();

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -123,7 +123,7 @@ class Email
 					$this->props['body']['text'] = $text->render($data);
 				}
 
-			// fallback to single email text template
+				// fallback to single email text template
 			} elseif ($text->exists()) {
 				$this->props['body'] = $text->render($data);
 			} else {

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -123,7 +123,7 @@ class Email
 					$this->props['body']['text'] = $text->render($data);
 				}
 
-				// fallback to single email text template
+			// fallback to single email text template
 			} elseif ($text->exists()) {
 				$this->props['body'] = $text->render($data);
 			} else {

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -235,9 +235,7 @@ trait FileActions
 			$file->unpublish();
 
 			// remove the lock of the old file
-			if ($lock = $file->lock()) {
-				$lock->remove();
-			}
+			$file->lock()?->remove();
 
 			if ($file->kirby()->multilang() === true) {
 				foreach ($file->translations() as $translation) {

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -33,7 +33,7 @@ class Find
 		$filename = urldecode($filename);
 		$file     = static::parent($path)->file($filename);
 
-		if ($file && $file->isReadable() === true) {
+		if ($file?->isReadable() === true) {
 			return $file;
 		}
 
@@ -78,7 +78,7 @@ class Find
 		$id   = str_replace(['+', ' '], '/', $id);
 		$page = App::instance()->page($id);
 
-		if ($page && $page->isReadable() === true) {
+		if ($page?->isReadable() === true) {
 			return $page;
 		}
 

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -23,10 +23,7 @@ trait HasSiblings
 	 */
 	public function indexOf($collection = null): int
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->indexOf($this);
 	}
 
@@ -39,10 +36,7 @@ trait HasSiblings
 	 */
 	public function next($collection = null)
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->nth($this->indexOf($collection) + 1);
 	}
 
@@ -55,10 +49,7 @@ trait HasSiblings
 	 */
 	public function nextAll($collection = null)
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->slice($this->indexOf($collection) + 1);
 	}
 
@@ -71,10 +62,7 @@ trait HasSiblings
 	 */
 	public function prev($collection = null)
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->nth($this->indexOf($collection) - 1);
 	}
 
@@ -87,10 +75,7 @@ trait HasSiblings
 	 */
 	public function prevAll($collection = null)
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->slice(0, $this->indexOf($collection));
 	}
 
@@ -144,10 +129,7 @@ trait HasSiblings
 	 */
 	public function isFirst($collection = null): bool
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->first()->is($this);
 	}
 
@@ -160,10 +142,7 @@ trait HasSiblings
 	 */
 	public function isLast($collection = null): bool
 	{
-		if ($collection === null) {
-			$collection = $this->siblingsCollection();
-		}
-
+		$collection ??= $this->siblingsCollection();
 		return $collection->last()->is($this);
 	}
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -662,9 +662,7 @@ class Language extends Model
 
 		// convert the current default to a non-default language
 		if ($updated->isDefault() === true) {
-			if ($oldDefault = $kirby->defaultLanguage()) {
-				$oldDefault->clone(['default' => false])->save();
-			}
+			$kirby->defaultLanguage()?->clone(['default' => false])->save();
 
 			$code = $this->code();
 			$site = $kirby->site();

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -567,10 +567,8 @@ class Page extends ModelWithContent
 	 */
 	public function isActive(): bool
 	{
-		if ($page = $this->site()->page()) {
-			if ($page->is($this) === true) {
-				return true;
-			}
+		if ($this->site()->page()?->is($this) === true) {
+			return true;
 		}
 
 		return false;
@@ -649,11 +647,7 @@ class Page extends ModelWithContent
 	 */
 	public function isChildOf($parent): bool
 	{
-		if ($parentObj = $this->parent()) {
-			return $parentObj->is($parent);
-		}
-
-		return false;
+		return $this->parent()?->is($parent) ?? false;
 	}
 
 	/**
@@ -754,10 +748,8 @@ class Page extends ModelWithContent
 			return true;
 		}
 
-		if ($page = $this->site()->page()) {
-			if ($page->parents()->has($this->id()) === true) {
-				return true;
-			}
+		if ($this->site()->page()?->parents()->has($this->id()) === true) {
+			return true;
 		}
 
 		return false;
@@ -933,11 +925,7 @@ class Page extends ModelWithContent
 	 */
 	public function parentId(): string|null
 	{
-		if ($parent = $this->parent()) {
-			return $parent->id();
-		}
-
-		return null;
+		return $this->parent()?->id();
 	}
 
 	/**

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -91,10 +91,8 @@ trait PageActions
 		// in multi-language installations the slug for the non-default
 		// languages is stored in the text file. The changeSlugForLanguage
 		// method takes care of that.
-		if ($language = $this->kirby()->language($languageCode)) {
-			if ($language->isDefault() === false) {
-				return $this->changeSlugForLanguage($slug, $languageCode);
-			}
+		if ($this->kirby()->language($languageCode)?->isDefault() === false) {
+			return $this->changeSlugForLanguage($slug, $languageCode);
 		}
 
 		// if the slug stays exactly the same,
@@ -113,9 +111,7 @@ trait PageActions
 
 			if ($oldPage->exists() === true) {
 				// remove the lock of the old page
-				if ($lock = $oldPage->lock()) {
-					$lock->remove();
-				}
+				$oldPage->lock()?->remove();
 
 				// actually move stuff on disk
 				if (Dir::move($oldPage->root(), $newPage->root()) !== true) {

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -86,11 +86,7 @@ class PagePicker extends Picker
 			return $this->parent();
 		}
 
-		if ($items = $this->items()) {
-			return $items->parent();
-		}
-
-		return null;
+		return $this->items()?->parent();
 	}
 
 	/**
@@ -238,11 +234,7 @@ class PagePicker extends Picker
 	public function start()
 	{
 		if (empty($this->options['query']) === false) {
-			if ($items = $this->itemsForQuery()) {
-				return $items->parent();
-			}
-
-			return $this->site;
+			return $this->itemsForQuery()?->parent() ?? $this->site;
 		}
 
 		return $this->site;

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -61,26 +61,22 @@ class PageRules
 		$siblings = $page->parentModel()->children();
 		$drafts   = $page->parentModel()->drafts();
 
-		if ($duplicate = $siblings->find($slug)) {
-			if ($duplicate->is($page) === false) {
-				throw new DuplicateException([
-					'key'  => 'page.duplicate',
-					'data' => [
-						'slug' => $slug
-					]
-				]);
-			}
+		if ($siblings->find($slug)?->is($page) === false) {
+			throw new DuplicateException([
+				'key'  => 'page.duplicate',
+				'data' => [
+					'slug' => $slug
+				]
+			]);
 		}
 
-		if ($duplicate = $drafts->find($slug)) {
-			if ($duplicate->is($page) === false) {
-				throw new DuplicateException([
-					'key'  => 'page.draft.duplicate',
-					'data' => [
-						'slug' => $slug
-					]
-				]);
-			}
+		if ($drafts->find($slug)?->is($page) === false) {
+			throw new DuplicateException([
+				'key'  => 'page.draft.duplicate',
+				'data' => [
+					'slug' => $slug
+				]
+			]);
 		}
 
 		return true;

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -179,14 +179,14 @@ class UserRules
 		$currentUser = $user->kirby()->user();
 
 		// admins are allowed everything
-		if ($currentUser && $currentUser->isAdmin() === true) {
+		if ($currentUser?->isAdmin() === true) {
 			return true;
 		}
 
 		// only admins are allowed to add admins
 		$role = $props['role'] ?? null;
 
-		if ($role === 'admin' && $currentUser && $currentUser->isAdmin() === false) {
+		if ($role === 'admin' && $currentUser?->isAdmin() === false) {
 			throw new PermissionException([
 				'key' => 'user.create.permission'
 			]);

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -1178,11 +1178,7 @@ class Collection extends Iterator implements Countable
 			return $callback->call($this, $condition);
 		}
 
-		if ($fallback !== null) {
-			return $fallback->call($this, $condition);
-		}
-
-		return $this;
+		return $fallback?->call($this, $condition) ?? $this;
 	}
 
 	/**

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -99,13 +99,9 @@ class I18n
 	 */
 	public static function formatNumber($number, string $locale = null): string
 	{
-		$locale ??= static::locale();
-
-		$formatter = static::decimalNumberFormatter($locale);
-		if ($formatter !== null) {
-			$number = $formatter->format($number);
-		}
-
+		$locale    ??= static::locale();
+		$formatter   = static::decimalNumberFormatter($locale);
+		$number      = $formatter?->format($number) ?? $number;
 		return (string)$number;
 	}
 


### PR DESCRIPTION
Making use of the null safe operator from PHP 8.0.

I'd argue that manual review can replace the failing `codecov/patch/backend` check here.

### Refactored
- Using PHP's new null safe operator 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~