### PR TITLE
Only show error output when in debug mode

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -255,7 +255,11 @@ class Block extends Item
 			$kirby = $this->parent()->kirby();
 			return (string)$kirby->snippet('blocks/' . $this->type(), $this->controller(), true);
 		} catch (Throwable $e) {
-			return '<p>Block error: "' . $e->getMessage() . '" in block type: "' . $this->type() . '"</p>';
+			if ($kirby->option('debug') === true) {
+				return '<p>Block error: "' . $e->getMessage() . '" in block type: "' . $this->type() . '"</p>';
+			}
+
+			return '';
 		}
 	}
 }

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -181,6 +181,48 @@ class BlockTest extends TestCase
 		$this->assertSame($expected, (string)$block);
 	}
 
+	public function testToHtmlInvalid()
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null',
+				'snippets' => __DIR__ . '/fixtures/snippets'
+			]
+		]);
+
+		$block = new Block([
+			'content' => [
+				'text' => 'Test'
+			],
+			'type' => 'debug'
+		]);
+
+		$this->assertSame('', $block->toHtml());
+	}
+
+	public function testToHtmlInvalidWithDebugMode()
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null',
+				'snippets' => __DIR__ . '/fixtures/snippets'
+			],
+			'options' => [
+				'debug' => true
+			]
+		]);
+
+		$block = new Block([
+			'content' => [
+				'text' => 'Test'
+			],
+			'type' => 'debug'
+		]);
+
+		$expected = '<p>Block error: "Call to undefined function shouldThrowException()" in block type: "debug"</p>';
+		$this->assertSame($expected, $block->toHtml());
+	}
+
 	public function testToHtmlWithCustomSnippets()
 	{
 		$this->app = new App([

--- a/tests/Cms/Blocks/fixtures/snippets/blocks/debug.php
+++ b/tests/Cms/Blocks/fixtures/snippets/blocks/debug.php
@@ -1,0 +1,1 @@
+<?= shouldThrowException();


### PR DESCRIPTION
## This PR …
<!--

-->
Output error message only in debug mode, return empty string if not.


### Fixes
Blocks no longer output error messages unless `debug` mode is active #4448

### Breaking changes

n/a

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
