### PR TITLE
Catch exceptions: remove unused variables

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -109,7 +109,7 @@ return [
 				Data::write($job, array_merge($options, [
 					'filename' => $file->filename()
 				]));
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				// if thumb doesn't exist yet and job file cannot
 				// be created, return
 				return $file;

--- a/config/methods.php
+++ b/config/methods.php
@@ -68,7 +68,7 @@ return function (App $app) {
 				]);
 
 				return $blocks->filter('isHidden', false);
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				if ($field->parent() === null) {
 					$message = 'Invalid blocks data for "' . $field->key() . '" field';
 				} else {
@@ -252,7 +252,7 @@ return function (App $app) {
 		'toStructure' => function (Field $field) {
 			try {
 				return new Structure(Data::decode($field->value, 'yaml'), $field->parent());
-			} catch (Exception $e) {
+			} catch (Exception) {
 				if ($field->parent() === null) {
 					$message = 'Invalid structure data for "' . $field->key() . '" field';
 				} else {

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -228,7 +228,7 @@ return [
 						'name'  => basename($props['name']),
 						'title' => $props['title'],
 					];
-				} catch (Throwable $e) {
+				} catch (Throwable) {
 					$blueprints[] = [
 						'name'  => basename($template),
 						'title' => ucfirst($template),

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -212,7 +212,7 @@ class FileCache extends Cache
 					break;
 				}
 			}
-		} catch (Exception $e) { // @codeCoverageIgnore
+		} catch (Exception) { // @codeCoverageIgnore
 			// silently stops the process
 		}
 	}

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -111,7 +111,7 @@ class Value
 			} else {
 				return null;
 			}
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return null;
 		}
 	}

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1322,7 +1322,7 @@ class App
 				}
 
 				return $response->body($output);
-			} catch (NotFoundException $e) {
+			} catch (NotFoundException) {
 				return null;
 			}
 		}
@@ -1768,7 +1768,7 @@ class App
 	{
 		try {
 			return static::$version = static::$version ?? Data::read(dirname(__DIR__, 2) . '/composer.json')['version'] ?? null;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			throw new LogicException('The Kirby version cannot be detected. The composer.json is probably missing or not readable.');
 		}
 	}

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -121,7 +121,7 @@ trait AppUsers
 		} else {
 			try {
 				return $this->auth()->user(null, $allowImpersonation);
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				return null;
 			}
 		}

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -590,7 +590,7 @@ class Auth
 		try {
 			$log  = Data::read($this->logfile(), 'json');
 			$read = true;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			$log  = [];
 			$read = false;
 		}

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -114,7 +114,7 @@ class Blocks extends Items
 		if (empty($input) === false && is_array($input) === false) {
 			try {
 				$input = Json::decode((string)$input);
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				$parser = new Parsley((string)$input, new BlockSchema());
 				$input  = $parser->blocks();
 			}

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -208,7 +208,7 @@ class Blueprint
 				$mixin = static::find($extend);
 				$mixin = static::extend($mixin);
 				$props = A::merge($mixin, $props, A::MERGE_REPLACE);
-			} catch (Exception $e) {
+			} catch (Exception) {
 				// keep the props unextended if the snippet wasn't found
 			}
 		}
@@ -231,7 +231,7 @@ class Blueprint
 	{
 		try {
 			$props = static::load($name);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			$props = $fallback !== null ? static::load($fallback) : null;
 		}
 

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -101,7 +101,7 @@ class Collections
 		try {
 			$this->load($name);
 			return true;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			return false;
 		}
 	}

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -350,7 +350,7 @@ class Language extends Model
 
 		try {
 			return Data::read($file);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return [];
 		}
 	}
@@ -456,7 +456,7 @@ class Language extends Model
 	{
 		try {
 			$existingData = Data::read($this->root());
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			$existingData = [];
 		}
 

--- a/src/Cms/LanguageRouter.php
+++ b/src/Cms/LanguageRouter.php
@@ -129,7 +129,7 @@ class LanguageRouter
 					return $route->action()->call($route, $language, ...$route->arguments());
 				}
 			});
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return $kirby->resolve($path, $language->code());
 		}
 	}

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -65,7 +65,7 @@ class Layouts extends Items
 		if (empty($input) === false && is_array($input) === false) {
 			try {
 				$input = Data::decode($input, 'json');
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				return [];
 			}
 		}

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -128,11 +128,11 @@ class Media
 				$kirby->thumb($source, $thumb, $options);
 				F::remove($job);
 				return Response::file($thumb);
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				F::remove($thumb);
 				return Response::file($source);
 			}
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -352,7 +352,7 @@ abstract class ModelWithContent extends Model
 				'model'             => $this,
 				static::CLASS_ALIAS => $this
 			]);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return null;
 		}
 
@@ -374,7 +374,7 @@ abstract class ModelWithContent extends Model
 	{
 		try {
 			return Data::read($this->contentFile($languageCode));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return [];
 		}
 	}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -272,7 +272,7 @@ class Page extends ModelWithContent
 					'name'  => basename($props['name']),
 					'title' => $props['title'],
 				];
-			} catch (Exception $e) {
+			} catch (Exception) {
 				// skip invalid blueprints
 			}
 		}

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -107,7 +107,7 @@ class Plugin extends Model
 
 		try {
 			$info = Data::read($this->manifest());
-		} catch (Exception $e) {
+		} catch (Exception) {
 			// there is no manifest file or it is invalid
 			$info = [];
 		}

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -55,7 +55,7 @@ class Role extends Model
 	{
 		try {
 			return static::load('admin');
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return static::factory(static::defaults()['admin'], $inject);
 		}
 	}
@@ -152,7 +152,7 @@ class Role extends Model
 	{
 		try {
 			return static::load('nobody');
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return static::factory(static::defaults()['nobody'], $inject);
 		}
 	}

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -398,7 +398,7 @@ class Site extends ModelWithContent
 
 		try {
 			return $this->page = $this->homePage();
-		} catch (LogicException $e) {
+		} catch (LogicException) {
 			return $this->page = null;
 		}
 	}

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -196,28 +196,28 @@ class System
 		// init /site/accounts
 		try {
 			Dir::make($this->app->root('accounts'));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			throw new PermissionException('The accounts directory could not be created');
 		}
 
 		// init /site/sessions
 		try {
 			Dir::make($this->app->root('sessions'));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			throw new PermissionException('The sessions directory could not be created');
 		}
 
 		// init /content
 		try {
 			Dir::make($this->app->root('content'));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			throw new PermissionException('The content directory could not be created');
 		}
 
 		// init /media
 		try {
 			Dir::make($this->app->root('media'));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			throw new PermissionException('The media directory could not be created');
 		}
 	}
@@ -277,7 +277,7 @@ class System
 	{
 		try {
 			$license = Json::read($this->app->root('license'));
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 

--- a/src/Cms/Template.php
+++ b/src/Cms/Template.php
@@ -128,7 +128,7 @@ class Template
 			try {
 				// Try the default template in the default template directory.
 				return F::realpath($this->root() . '/' . $this->name() . '.' . $this->extension(), $this->root());
-			} catch (Exception $e) {
+			} catch (Exception) {
 				// ignore errors, continue searching
 			}
 
@@ -145,7 +145,7 @@ class Template
 		try {
 			// Try the template with type extension in the default template directory.
 			return F::realpath($this->root() . '/' . $name . '.' . $this->extension(), $this->root());
-		} catch (Exception $e) {
+		} catch (Exception) {
 			// Look for the template with type extension provided by an extension.
 			// This might be null if the template does not exist.
 			return App::instance()->extension($this->store(), $name);

--- a/src/Cms/Translation.php
+++ b/src/Cms/Translation.php
@@ -145,7 +145,7 @@ class Translation
 	{
 		try {
 			$data = array_merge(Data::read($root), $inject);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			$data = [];
 		}
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -184,7 +184,7 @@ class User extends ModelWithContent
 
 		try {
 			return $this->blueprint = UserBlueprint::factory('users/' . $this->role(), 'users/default', $this);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return $this->blueprint = new UserBlueprint([
 				'model' => $this,
 				'name'  => 'default',

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -263,7 +263,7 @@ trait UserActions
 
 				// we can't really test for a random match
 				// @codeCoverageIgnoreStart
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				$length++;
 			}
 		} while (true);

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -385,7 +385,7 @@ class Dir
 
 		try {
 			return symlink($source, $link) === true;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -192,7 +192,7 @@ class F
 		try {
 			static::realpath($file, $in);
 			return true;
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return false;
 		}
 	}
@@ -361,7 +361,7 @@ class F
 
 		try {
 			return $method($source, $link) === true;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}
@@ -793,7 +793,7 @@ class F
 
 		try {
 			return filesize($file);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return 0;
 		}
 	}

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -57,7 +57,7 @@ class BlocksField extends FieldClass
 				$block['content'] = $this->form($fields[$type], $block['content'])->$to();
 
 				$result[] = $block;
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				$result[] = $block;
 
 				// skip invalid blocks
@@ -254,7 +254,7 @@ class BlocksField extends FieldClass
 
 					try {
 						$blockFields = $fields[$blockType] ?? $this->fields($blockType) ?? [];
-					} catch (Throwable $e) {
+					} catch (Throwable) {
 						// skip invalid blocks
 						continue;
 					}

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -201,7 +201,7 @@ class LayoutField extends BlocksField
 
 							try {
 								$blockFields = $fields[$blockType] ?? $this->fields($blockType) ?? [];
-							} catch (Throwable $e) {
+							} catch (Throwable) {
 								// skip invalid blocks
 								continue;
 							}

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -816,7 +816,7 @@ abstract class FieldClass
 	{
 		try {
 			return Data::decode($value, 'json');
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return [];
 		}
 	}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -110,7 +110,7 @@ class Response
 	{
 		try {
 			return $this->send();
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return '';
 		}
 	}

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -132,7 +132,7 @@ class Router
 				}
 
 				$loop = false;
-			} catch (Exceptions\NextRouteException $e) {
+			} catch (Exceptions\NextRouteException) {
 				$ignore[] = $route;
 			}
 

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -184,7 +184,7 @@ class Uri
 	{
 		try {
 			return $this->toString();
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return '';
 		}
 	}

--- a/src/Panel/Dropdown.php
+++ b/src/Panel/Dropdown.php
@@ -54,7 +54,7 @@ class Dropdown extends Json
 				}
 
 				$options[] = $option;
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				continue;
 			}
 		}

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -282,7 +282,7 @@ class File extends Model
 			// check if the file type is allowed at all,
 			// otherwise it cannot be replaced
 			$this->model->match($this->model->blueprint()->accept());
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			$options['replace'] = false;
 		}
 

--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -124,7 +124,7 @@ class Home
 				// check the firewall
 				return Panel::hasAccess($user, $areaId);
 			});
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -179,7 +179,7 @@ class Panel
 		try {
 			static::firewall($user, $area);
 			return true;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -162,7 +162,7 @@ class Sessions
 		// token was found, try to get the session
 		try {
 			return $this->get($token);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return null;
 		}
 	}
@@ -192,7 +192,7 @@ class Sessions
 		try {
 			$mode = (is_string($tokenFromHeader)) ? 'header' : 'cookie';
 			return $this->get($token, $mode);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return null;
 		}
 	}

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -183,13 +183,13 @@ class Component
 				if (isset($this->attrs[$propName]) === true) {
 					try {
 						$this->$propName = $this->props[$propName] = $propFunction->call($this, $this->attrs[$propName]);
-					} catch (TypeError $e) {
+					} catch (TypeError) {
 						throw new TypeError('Invalid value for "' . $propName . '"');
 					}
 				} else {
 					try {
 						$this->$propName = $this->props[$propName] = $propFunction->call($this);
-					} catch (ArgumentCountError $e) {
+					} catch (ArgumentCountError) {
 						throw new ArgumentCountError('Please provide a value for "' . $propName . '"');
 					}
 				}

--- a/src/Toolkit/Date.php
+++ b/src/Toolkit/Date.php
@@ -313,7 +313,7 @@ class Date extends DateTime
 
 		try {
 			return new static($datetime, $timezone);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return null;
 		}
 	}

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1208,7 +1208,7 @@ class Str
 			if (strpos($query, '.') !== false) {
 				try {
 					$result = (new Query($match[1], $data))->result();
-				} catch (Exception $e) {
+				} catch (Exception) {
 					$result = null;
 				}
 			} else {

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -146,7 +146,7 @@ class V
 						}
 					}
 					$value = implode(', ', $value);
-				} catch (Throwable $e) {
+				} catch (Throwable) {
 					$value = '-';
 				}
 			}
@@ -380,7 +380,7 @@ V::$validators = [
 		if (filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
 			try {
 				$email = Idn::encodeEmail($value);
-			} catch (Throwable $e) {
+			} catch (Throwable) {
 				return false;
 			}
 

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -244,7 +244,7 @@ class AuthTest extends TestCase
 
 		try {
 			$this->auth->user();
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			// tested above, this check is for the second call
 		}
 


### PR DESCRIPTION
PHP 8.0 allows to remove the variabel from `catch` statements if they aren't used.

I'd argue that manual review can replace the failing `codecov/patch/backend` check here.

### Refactored
- Removed unused variables from PHP `catch` statements

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~