### PR TITLE
No longer return `$this` on Collection `__set()` method

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -71,8 +71,9 @@ class Collection extends BaseCollection
 	 *
 	 * @param string $id
 	 * @param object $object
+	 * @return void
 	 */
-	public function __set(string $id, $object)
+	public function __set(string $id, $object): void
 	{
 		$this->data[$id] = $object;
 	}

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -40,9 +40,11 @@ class Structure extends Collection
 	 *
 	 * @param string $id
 	 * @param array|StructureObject $props
+	 * @return void
+	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public function __set(string $id, $props)
+	public function __set(string $id, $props): void
 	{
 		if (is_a($props, 'Kirby\Cms\StructureObject') === true) {
 			$object = $props;

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -59,6 +59,6 @@ class Structure extends Collection
 			]);
 		}
 
-		return parent::__set($object->id(), $object);
+		parent::__set($object->id(), $object);
 	}
 }

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -23,7 +23,6 @@ class Fields extends Collection
 	 *
 	 * @param string $name
 	 * @param object|array $field
-	 * @return $this
 	 */
 	public function __set(string $name, $field)
 	{
@@ -33,7 +32,7 @@ class Fields extends Collection
 			$field = Field::factory($field['type'], $field, $this);
 		}
 
-		return parent::__set($field->name(), $field);
+		parent::__set($field->name(), $field);
 	}
 
 	/**

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -23,8 +23,9 @@ class Fields extends Collection
 	 *
 	 * @param string $name
 	 * @param object|array $field
+	 * @return void
 	 */
-	public function __set(string $name, $field)
+	public function __set(string $name, $field): void
 	{
 		if (is_array($field) === true) {
 			// use the array key as name if the name is not set

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -167,8 +167,9 @@ class Uri
 	 *
 	 * @param string $property
 	 * @param mixed $value
+	 * @return void
 	 */
-	public function __set(string $property, $value)
+	public function __set(string $property, $value): void
 	{
 		if (method_exists($this, 'set' . $property) === true) {
 			$this->{'set' . $property}($value);

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -95,8 +95,9 @@ class Collection extends Iterator implements Countable
 	 *
 	 * @param string $key string or array
 	 * @param mixed $value
+	 * @return void
 	 */
-	public function __set(string $key, $value)
+	public function __set(string $key, $value): void
 	{
 		if ($this->caseSensitive === true) {
 			$this->data[$key] = $value;

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -95,7 +95,6 @@ class Collection extends Iterator implements Countable
 	 *
 	 * @param string $key string or array
 	 * @param mixed $value
-	 * @return $this
 	 */
 	public function __set(string $key, $value)
 	{
@@ -104,8 +103,6 @@ class Collection extends Iterator implements Countable
 		} else {
 			$this->data[strtolower($key)] = $value;
 		}
-
-		return $this;
 	}
 
 	/**


### PR DESCRIPTION
## Explanation
This PR changes the behavior of `__set()` methods to no longer return `$this`. Instead there is no return value.

A return type was never formalized in code, but was defined in the DocBlock for `Kirby\Toolkit\Collection`.

Although `Kirby\Toolkit\Collection` returns `$this`, the subclass `Kirby\Cms\Collection` **does not** return anything.

https://github.com/getkirby/kirby/blob/e15a4eacd7190e6088f2087507989892c9948519/src/Cms/Collection.php#L67-L78

The `Kirby\Cms\Pages` class extends `Kirby\Cms\Collection` and does not override `__set()` so it therefor also returns nothing.

`Kirby\Cms\Structure` also extends `Kirby\Cms\Collection`. It attempts to return a value in its reimplementation of `__set()`, but because it's returning `parent::__set()` and the `Kirby\Cms\Collection` implementation does not return anything, it's effectively returning void.

The [formal definition](https://www.php.net/manual/en/language.oop5.overloading.php#object.set) of the magic method `__set()` has a `void` return type.

```
public __set(string $name, mixed $value): void
```

Additionally, the PHP Docs also say that a return a type on `__set()` is always ignored. None of their examples return a value either.

> Note:
The return value of [__set()](https://www.php.net/manual/en/language.oop5.overloading.php#object.set) is ignored because of the way PHP processes the assignment operator. Similarly, [__get()](https://www.php.net/manual/en/language.oop5.overloading.php#object.get) is never called when chaining assignments together like this:
 $a = $obj->b = 8;

## This PR …

### Refactoring

- The `$collection->__set()` methods consistently no longer return the class instance to match PHP's definition for this method.

### Breaking changes
This is technically a breaking change: the return type is ignored, but only for usage such as `$collection->foo = $example;`. Usage by calling the function literally still would return a value `$collection->__set('foo', $example);`.

However, the impact of this breaking change should be minimal, considering that `Kirby\Cms\Collection` never returned a value anyways.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
