### PR TITLE
Conditionally define `DS` constant

### DIFF
--- a/config/setup.php
+++ b/config/setup.php
@@ -3,7 +3,9 @@
 /**
  * Constants
  */
-define('DS', '/');
+if (!defined('DS')) {
+	define('DS', '/');
+}
 
 /**
  * Class aliases


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->
This change conditionally defines the `DS` constant only if it hasn't already been defined.

I'm not sure _why_ this constant is still being defined—it seems completely unused. Should this definition just be removed altogether?

If its still important to keep, this change would help me avoid a constant redeclaration error that's coming from a separate library.

### Breaking changes
None.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
