### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Update dependencies"
+      prefix: "composer"
     labels:
       - "type: refactoring ♻️"
     open-pull-requests-limit: 10
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Update dependencies"
+      prefix: "npm"
     labels:
       - "type: refactoring ♻️"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
-    vendor: true
     target-branch: "develop"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
- Fixed commit-message prefix: Support up to 15 characters
Document: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message

- Removed `vendor` setting for a while until related issue to be fixed: https://github.com/dependabot/dependabot-core/issues/386
Document: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#vendor