### PR TITLE
Changed "Login" to "Log in"

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -360,7 +360,7 @@
   "lock.unlock": "Unlock",
   "lock.isUnlocked": "Your unsaved changes have been overwritten by another user. You can download your changes to merge them manually.",
 
-  "login": "Login",
+  "login": "Log in",
   "login.code.label.login": "Login code",
   "login.code.label.password-reset": "Password reset code",
   "login.code.placeholder.email": "000 000",

--- a/tests/Cms/Loader/LoaderTest.php
+++ b/tests/Cms/Loader/LoaderTest.php
@@ -96,7 +96,7 @@ class LoaderTest extends TestCase
 
 		$this->assertSame('Your account', $areas['account']['label']);
 		$this->assertSame('Installation', $areas['installation']['label']);
-		$this->assertSame('Login', $areas['login']['label']);
+		$this->assertSame('Log in', $areas['login']['label']);
 		$this->assertSame('System', $areas['system']['label']);
 		$this->assertSame('Site', $areas['site']['label']);
 		$this->assertSame('Users', $areas['users']['label']);

--- a/tests/Panel/Areas/LoginTest.php
+++ b/tests/Panel/Areas/LoginTest.php
@@ -32,7 +32,7 @@ class LoginTest extends AreaTestCase
 		$props = $view['props'];
 
 		$this->assertSame('login', $view['id']);
-		$this->assertSame('Login', $view['title']);
+		$this->assertSame('Log in', $view['title']);
 		$this->assertSame('k-login-view', $view['component']);
 		$this->assertSame(['password'], $props['methods']);
 		$this->assertNull($props['pending']['email']);


### PR DESCRIPTION
“Login” is a noun, not a verb, so the button text on the login form (which is where this text is used) should really be “Log in”. 😊 http://loginisnotaverb.com

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
https://kirby.nolt.io/444

### Breaking changes
None I can see.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] ~In-code documentation (wherever needed)~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
