### PR TITLE
Fix multiselect border-radius

### DIFF
--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -330,6 +330,9 @@ export default {
 .k-multiselect-input .k-sortable-ghost {
   background: var(--color-focus);
 }
+.k-multiselect-input .k-tag {
+  border-radius: var(--rounded-sm);
+}
 
 .k-multiselect-input .k-dropdown-content {
   width: 100%;


### PR DESCRIPTION
You changed the border-radius for `tags` (and it's so much better) but the `multiselect` field still had the old, bigger one.

<img alt="CleanShot 2022-07-06 at 20 00 41@2x" src="https://user-images.githubusercontent.com/7975568/177614352-1c0e0c7a-8f53-41bc-8aa2-fd85ed0ba144.png">

