### PR TITLE
`App::impersonate()`: don’t bind callback to `App`

### DIFF
--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -60,8 +60,7 @@ trait AppUsers
 		}
 
 		try {
-			// bind the App object to the callback
-			return $callback->call($this, $userAfter);
+			return $callback($userAfter);
 		} catch (Throwable $e) {
 			throw $e;
 		} finally {

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -60,7 +60,10 @@ trait AppUsers
 		}
 
 		try {
-			return $callback($userAfter);
+			// TODO: switch over in 3.9.0 to
+			// return $callback($userAfter);
+			$proxy = new AppUsersImpersonateProxy($this);
+			return $callback->call($proxy, $userAfter);
 		} catch (Throwable $e) {
 			throw $e;
 		} finally {

--- a/src/Cms/AppUsersImpersonateProxy.php
+++ b/src/Cms/AppUsersImpersonateProxy.php
@@ -19,17 +19,14 @@ namespace Kirby\Cms;
  */
 class AppUsersImpersonateProxy
 {
-
 	public function __construct(protected App $app)
-	{}
+	{
+	}
 
-    public function __call($name, $arguments)
+	public function __call($name, $arguments)
 	{
 		Helpers::deprecated('Calling $kirby->' . $name . '() as $this->' . $name . '() has been deprecated inside the $kirby->impersonate() callback function. Use a dedicated $kirby object for your call instead of $this. In Kirby 3.9.0 $this will no longer refer to the $kirby object, but the current context of the callback function.');
 
 		return $this->app->$name(...$arguments);
 	}
-
-
-
 }

--- a/src/Cms/AppUsersImpersonateProxy.php
+++ b/src/Cms/AppUsersImpersonateProxy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kirby\Cms;
+
+/**
+ * Temporary proxy class to ease transition
+ * of binding the callback for `$kirby->impersonate()`
+ *
+ * @package   Kirby Cms
+ * @author    Nico Hoffmann <nico@getkirby.com>,
+ * 			  Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ *
+ * @internal
+ * @deprecated Will be removed in Kirby 3.9.0
+ * @todo remove in 3.9.0
+ */
+class AppUsersImpersonateProxy
+{
+
+	public function __construct(protected App $app)
+	{}
+
+    public function __call($name, $arguments)
+	{
+		Helpers::deprecated('Calling $kirby->' . $name . '() as $this->' . $name . '() has been deprecated inside the $kirby->impersonate() callback function. Use a dedicated $kirby object for your call instead of $this. In Kirby 3.9.0 $this will no longer refer to the $kirby object, but the current context of the callback function.');
+
+		return $this->app->$name(...$arguments);
+	}
+
+
+
+}

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -73,11 +73,10 @@ class AppUsersTest extends TestCase
 		$this->assertNull($app->user(null, false));
 
 		// with callback
-		$result = $app->impersonate('homer@simpsons.com', function ($user) use ($app, $self) {
-			$self->assertSame($app, $this);
-			$self->assertSame($user, $this->user());
-			$self->assertSame('homer@simpsons.com', $user->email());
-			$self->assertNull($app->user(null, false));
+		$result = $app->impersonate('homer@simpsons.com', function ($user) use ($app) {
+			$this->assertSame($user, $app->user());
+			$this->assertSame('homer@simpsons.com', $user->email());
+			$this->assertNull($app->user(null, false));
 
 			return 'test1';
 		});
@@ -89,11 +88,10 @@ class AppUsersTest extends TestCase
 		$app->impersonate('kirby');
 		$caught = false;
 		try {
-			$app->impersonate('homer@simpsons.com', function ($user) use ($app, $self) {
-				$self->assertSame($app, $this);
-				$self->assertSame($user, $this->user());
-				$self->assertSame('homer@simpsons.com', $user->email());
-				$self->assertNull($app->user(null, false));
+			$app->impersonate('homer@simpsons.com', function ($user) use ($app) {
+				$this->assertSame($user, $app->user());
+				$this->assertSame('homer@simpsons.com', $user->email());
+				$this->assertNull($app->user(null, false));
 
 				throw new Exception('Something bad happened');
 			});


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

No idea why we so far have bound the callback to `App` - to me it makes a lot more sense to leave the callback in its actual `$this` context

### Deprecated
- `$kirby->impersonate($user, $callback)`: the `$callback` will not be bound anymore to the `$kirby` instance in Kirby 3.9.0, `$this` inside the callback will refer to the current context and not `$kirby` instead. Using `$this` as `$kirby` inside the callback will throw a deprecation warning in debug mode.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
