### PR TITLE
Update "quote" block preview to allow paragraphs

### DIFF
--- a/panel/src/components/Forms/Blocks/Types/Quote.vue
+++ b/panel/src/components/Forms/Blocks/Types/Quote.vue
@@ -2,7 +2,7 @@
 	<div class="k-block-type-quote-editor">
 		<k-writer
 			ref="text"
-			:inline="true"
+			:inline="textField.inline ?? false"
 			:marks="textField.marks"
 			:placeholder="textField.placeholder"
 			:value="content.text"
@@ -11,7 +11,7 @@
 		/>
 		<k-writer
 			ref="citation"
-			:inline="true"
+			:inline="citationField.inline ?? true"
 			:marks="citationField.marks"
 			:placeholder="citationField.placeholder"
 			:value="content.citation"


### PR DESCRIPTION
## This PR …
Adds the option to set `inline: false` in a custom `quote` block blueprint and have this reflected in the block preview. 

### Fixes
The quote block preview matches the writer field in the drawer better.

### Breaking changes
none

The default block blueprint stays the same with its `inline: true`. This PR affects only people that overwrote their `blocks/quote.yml` blueprint to either not have an `inline` property, or they explicitly set it to `false`, the preview now matches the writer field in the drawer. Therefore I'd consider this a fix and not a breaking change. 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
