### PR TITLE
fix passing `null` to `trim()`

### DIFF
--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -37,7 +37,7 @@ class Inline
 	public function __construct(DOMNode $node, array $marks = [])
 	{
 		$this->createMarkRules($marks);
-		$this->html = trim(static::parseNode($node, $this->marks));
+		$this->html = trim(static::parseNode($node, $this->marks) ?? '');
 	}
 
 	/**


### PR DESCRIPTION
In php 8.1 passing `null` to a parameter `string` is no longer allowed.

## This PR …
- Fixes an exception happening in PHP 8.1 when pasting text with empty paragraphs into a blocks field. 

## Additional details:
The encountered exception is: `"trim(): Passing null to parameter #1 ($string) of type string is deprecated"`

`Kirby\Parsley\Inline::parseNode()` returns `?string`. PHPs `trim()` function expects `string`. 
An alternative to this PR would be changing `Kirby\Parsley\Inline::parseNode()` so that it returns always `string`, but that'd be a breaking change, I guess. 

### Breaking changes
none


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
