### PR TITLE
Fix block `->prev()`, `->next()` and `->siblings()`

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -206,6 +206,16 @@ class Block extends Item
 	}
 
 	/**
+	 * Returns the sibling collection that filtered by block status
+	 *
+	 * @return \Kirby\Cms\Collection
+	 */
+	protected function siblingsCollection()
+	{
+		return $this->siblings->filter('isHidden', $this->isHidden());
+	}
+
+	/**
 	 * Returns the block type
 	 *
 	 * @return string

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -260,4 +260,94 @@ class BlockTest extends TestCase
 		$this->assertSame('Lorem ipsum dolor …', $block->excerpt(20));
 		$this->assertSame($expected, (string)$block);
 	}
+
+	public function samplePrevNextBlocks()
+	{
+		return Blocks::factory([
+			[
+				'type' => 'code',
+				'isHidden' => true
+			],
+			[
+				'type' => 'gallery',
+				'isHidden' => true
+			],
+			[
+				'type' => 'heading',
+				'isHidden' => false
+			],
+			[
+				'type' => 'image',
+				'isHidden' => false
+			],
+			[
+				'type' => 'line',
+				'isHidden' => false
+			],
+			[
+				'type' => 'list',
+				'isHidden' => true
+			],
+			[
+				'type' => 'markdown',
+				'isHidden' => false
+			],
+			[
+				'type' => 'quote',
+				'isHidden' => true
+			],
+			[
+				'type' => 'table',
+				'isHidden' => false
+			],
+			[
+				'type' => 'text',
+				'isHidden' => true
+			],
+			[
+				'type' => 'video',
+				'isHidden' => false
+			],
+		]);
+	}
+
+	public function testHiddenSiblings()
+	{
+		$blocks = $this->samplePrevNextBlocks();
+		$block = $blocks->first();
+
+		$this->assertCount(5, $block->siblings());
+		$this->assertNull($block->prev());
+	}
+
+	public function testVisibleSiblings()
+	{
+		$blocks = $this->samplePrevNextBlocks();
+		$block = $blocks->last();
+
+		$this->assertCount(6, $block->siblings());
+		$this->assertNull($block->next());
+	}
+
+	public function testPrevNextVisible()
+	{
+		$blocks = $this->samplePrevNextBlocks();
+		$block = $blocks->nth(4);
+
+		$this->assertSame('line', $block->type());
+		$this->assertFalse($block->isHidden());
+		$this->assertSame('image', $block->prev()->type());
+		$this->assertSame('markdown', $block->next()->type());
+	}
+
+	public function testPrevNextHidden()
+	{
+		$blocks = $this->samplePrevNextBlocks();
+		$block = $blocks->nth(5);
+
+		$this->assertSame('list', $block->type());
+		$this->assertTrue($block->isHidden());
+		$this->assertSame('gallery', $block->prev()->type());
+		$this->assertSame('quote', $block->next()->type());
+	}
 }


### PR DESCRIPTION
## This PR …

Now the previous and next item of the block returns according to own status (visible/hidden). If the block is hidden, the prev() and next() methods return the hidden block. If the block is visible, the prev() and next() methods return the visible blocks.

### Fixes

- `$block->prev()` & `$block->next()` no longer return hidden blocks from a visible block #4480

### Breaking changes

None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
