### PR TITLE
Fix double slashes in asset URLs with base URL `/`

### DIFF
--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -38,7 +38,7 @@ class Asset
 		$this->setProperties([
 			'path' => dirname($path),
 			'root' => $this->kirby()->root('index') . '/' . $path,
-			'url'  => $this->kirby()->url('index') . '/' . $path
+			'url'  => $this->kirby()->url('base') . '/' . $path
 		]);
 	}
 

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -276,7 +276,7 @@ class Document
 		try {
 			if (static::link() === true) {
 				usleep(1);
-				Response::go($kirby->url('index') . '/' . $kirby->path());
+				Response::go($kirby->url('base') . '/' . $kirby->path());
 			}
 		} catch (Throwable $e) {
 			die('The Panel assets cannot be installed properly. ' . $e->getMessage());

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -44,6 +44,19 @@ class AssetTest extends TestCase
 		$this->assertSame('/dev/null/' . $file, $asset->id());
 		$this->assertSame('https://getkirby.com/' . $file, $asset->url());
 		$this->assertSame('images', $asset->path());
+
+		$this->app->clone([
+			'urls' => [
+				'index' => '/'
+			]
+		]);
+
+		$asset = $this->_asset($file = 'images/logo.svg');
+
+		$this->assertSame('/dev/null/' . $file, $asset->root());
+		$this->assertSame('/dev/null/' . $file, $asset->id());
+		$this->assertSame('/' . $file, $asset->url());
+		$this->assertSame('images', $asset->path());
 	}
 
 	/**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -342,8 +342,8 @@ class ModelTest extends TestCase
 		$site  = new ModelSiteWithImageMethod([]);
 		$panel = new CustomPanelModel($site);
 		$image = $panel->image('site.cover');
-		$this->assertSame('//tmp/test.svg', $image['url']);
-		$this->assertSame('//tmp/test.svg', $image['src']);
+		$this->assertSame('/tmp/test.svg', $image['url']);
+		$this->assertSame('/tmp/test.svg', $image['src']);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Asset URLs no longer start with two slashes if the site's base URL was configured as `/` #4508

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
