### PR TITLE
Fix `query` to `searchterm` for sortable

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -55,8 +55,8 @@ return [
 			$files = $files->filter('isReadable', true);
 
 			// search
-			if ($this->search === true && empty($this->searchterm) === false) {
-				$files = $files->search($this->searchterm);
+			if ($this->search === true && empty($this->searchterm()) === false) {
+				$files = $files->search($this->searchterm());
 			}
 
 			// sort

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -11,7 +11,7 @@ return [
 			return $search;
 		}
 	],
-	'computed' => [
+	'methods' => [
 		'searchterm' => function (): ?string {
 			return App::instance()->request()->get('searchterm');
 		}

--- a/config/sections/mixins/sort.php
+++ b/config/sections/mixins/sort.php
@@ -35,7 +35,7 @@ return [
 			}
 
 			// don't allow sorting while search filter is active
-			if (empty($this->searchterm) === false) {
+			if (empty($this->searchterm()) === false) {
 				return false;
 			}
 

--- a/config/sections/mixins/sort.php
+++ b/config/sections/mixins/sort.php
@@ -35,7 +35,7 @@ return [
 			}
 
 			// don't allow sorting while search filter is active
-			if (empty($this->query) === false) {
+			if (empty($this->searchterm) === false) {
 				return false;
 			}
 

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -99,8 +99,8 @@ return [
 			});
 
 			// search
-			if ($this->search === true && empty($this->searchterm) === false) {
-				$pages = $pages->search($this->searchterm);
+			if ($this->search === true && empty($this->searchterm()) === false) {
+				$pages = $pages->search($this->searchterm());
 			}
 
 			// sort

--- a/tests/Cms/Sections/mixins/SortMixinTest.php
+++ b/tests/Cms/Sections/mixins/SortMixinTest.php
@@ -86,8 +86,8 @@ class SortMixinTest extends TestCase
 	public function testSortableWhileSearching()
 	{
 		$section = new Section('test', [
-			'model' => $this->page,
-			'query' => 'searching …'
+			'model'      => $this->page,
+			'searchterm' => 'searching …'
 		]);
 
 		$this->assertFalse($section->sortable());


### PR DESCRIPTION
## This PR …

I've fixed the old `query` name to `searchterm` about sortable of sections. 

~But there is still a bug that `$this->searchterm` returns `null` from `sort` mixin. When I try to `App::instance()->request()->get('searchterm')`, value return but `$this->searchterm` not.  The mixins seem to have a problem accessing each other's props/computed values. @distantnative need your help.~

### Fixes
- Fixed sortable issue when search active for sections.

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
