### PR TITLE
More deprecated codes

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -4,7 +4,6 @@ use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\FileVersion;
-use Kirby\Cms\Helpers;
 use Kirby\Cms\Template;
 use Kirby\Data\Data;
 use Kirby\Email\PHPMailer as Emailer;
@@ -29,33 +28,6 @@ return [
 	 * @param string|array $options An array of attributes for the link tag or a media attribute string
 	 */
 	'css' => fn (App $kirby, string $url, $options = null): string => $url,
-
-
-	/**
-	 * Object and variable dumper
-	 * to help with debugging.
-	 *
-	 * @param \Kirby\Cms\App $kirby Kirby instance
-	 * @param mixed $variable
-	 * @param bool $echo
-	 * @return string
-	 *
-	 * @deprecated 3.7.0 Disable `dump()` via `KIRBY_HELPER_DUMP` instead and create your own function
-	 * @todo move to `Helpers::dump()`, remove component in 3.8.0
-	 */
-	'dump' => function (App $kirby, $variable, bool $echo = true) {
-		if ($kirby->environment()->cli() === true) {
-			$output = print_r($variable, true) . PHP_EOL;
-		} else {
-			$output = '<pre>' . print_r($variable, true) . '</pre>';
-		}
-
-		if ($echo === true) {
-			echo $output;
-		}
-
-		return $output;
-	},
 
 	/**
 	 * Add your own email provider
@@ -139,7 +111,6 @@ return [
 	 * @param \Kirby\Cms\App $kirby Kirby instance
 	 * @param string $text Text to parse
 	 * @param array $options Markdown options
-	 * @param bool $inline Whether to wrap the text in `<p>` tags
 	 * @return string
 	 */
 	'markdown' => function (

--- a/config/presets/files.php
+++ b/config/presets/files.php
@@ -5,7 +5,8 @@ use Kirby\Toolkit\I18n;
 return function (array $props) {
 	$props['sections'] = [
 		'files' => [
-			'headline' => $props['headline'] ?? I18n::translate('files'),
+			// TODO: Remove `headline` check in 3.9.0
+			'label'    => $props['headline'] ?? $props['label'] ?? I18n::translate('files'),
 			'type'     => 'files',
 			'layout'   => $props['layout'] ?? 'cards',
 			'template' => $props['template'] ?? null,
@@ -16,7 +17,9 @@ return function (array $props) {
 
 	// remove global options
 	unset(
+		// TODO: Remove in 3.9.0
 		$props['headline'],
+		$props['label'],
 		$props['layout'],
 		$props['template'],
 		$props['image']

--- a/config/presets/page.php
+++ b/config/presets/page.php
@@ -10,7 +10,7 @@ return function ($props) {
 
 		if (is_string($props) === true) {
 			$props = [
-				'headline' => $props
+				'label' => $props
 			];
 		}
 
@@ -27,18 +27,18 @@ return function ($props) {
 
 		if ($pages !== false) {
 			$sidebar['pages'] = $section([
-				'headline' => I18n::translate('pages'),
-				'type'     => 'pages',
-				'status'   => 'all',
-				'layout'   => 'list',
+				'label'  => I18n::translate('pages'),
+				'type'   => 'pages',
+				'status' => 'all',
+				'layout' => 'list',
 			], $pages);
 		}
 
 		if ($files !== false) {
 			$sidebar['files'] = $section([
-				'headline' => I18n::translate('files'),
-				'type'     => 'files',
-				'layout'   => 'list'
+				'label'  => I18n::translate('files'),
+				'type'   => 'files',
+				'layout' => 'list'
 			], $files);
 		}
 	}

--- a/config/presets/pages.php
+++ b/config/presets/pages.php
@@ -7,12 +7,12 @@ return function (array $props) {
 	// load the general templates setting for all sections
 	$templates = $props['templates'] ?? null;
 
-	$section = function ($headline, $status, $props) use ($templates) {
+	$section = function ($label, $status, $props) use ($templates) {
 		$defaults = [
-			'headline' => $headline,
-			'type'     => 'pages',
-			'layout'   => 'list',
-			'status'   => $status
+			'label'  => $label,
+			'type'   => 'pages',
+			'layout' => 'list',
+			'status' => $status
 		];
 
 		if ($props === true) {
@@ -21,7 +21,7 @@ return function (array $props) {
 
 		if (is_string($props) === true) {
 			$props = [
-				'headline' => $props
+				'label' => $props
 			];
 		}
 

--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -25,9 +25,9 @@ return [
 	],
 	'toArray' => function () {
 		return [
-			'headline' => $this->headline,
-			'text'     => $this->text,
-			'theme'    => $this->theme
+			'label' => $this->headline,
+			'text'  => $this->text,
+			'theme' => $this->theme
 		];
 	}
 ];

--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -7,13 +7,15 @@ return [
 	'props' => [
 		/**
 		 * The headline for the section. This can be a simple string or a template with additional info from the parent page.
+		 * @deprecated Will be removed in Kirby 3.9.0
 		 * @todo remove in 3.9.0
 		 */
 		'headline' => function ($headline = null) {
-			// TODO: add deprecation notive in 3.8.0
-			// if ($headline !== null) {
-			//     Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
-			// }
+			// @codeCoverageIgnoreStart
+			if ($headline !== null) {
+				Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
+			}
+			// @codeCoverageIgnoreEnd
 
 			return I18n::translate($headline, $headline);
 		},

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1548,7 +1548,9 @@ class App
 	 */
 	public function server()
 	{
+		// @codeCoverageIgnoreStart
 		Helpers::deprecated('$kirby->server() has been deprecated and will be removed in Kirby 3.9.0. Use $kirby->environment() instead.');
+		// @codeCoverageIgnoreEnd
 
 		return $this->environment();
 	}

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1542,12 +1542,14 @@ class App
 	 * @deprecated 3.7.0 Use `$kirby->environment()` instead
 	 *
 	 * @return \Kirby\Http\Environment
-	 * @todo Start throwing deprecation warnings in 3.8.0
+	 * @deprecated Will be removed in Kirby 3.9.0
 	 * @todo Remove in 3.9.0
 	 * @codeCoverageIgnore
 	 */
 	public function server()
 	{
+		Helpers::deprecated('$kirby->server() has been deprecated and will be removed in Kirby 3.9.0. Use $kirby->environment() instead.');
+
 		return $this->environment();
 	}
 

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -399,9 +399,9 @@ class Blueprint
 			if (empty($columnProps['sections']) === true) {
 				$columnProps['sections'] = [
 					$tabName . '-info-' . $columnKey => [
-						'headline' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
-						'type'     => 'info',
-						'text'     => 'No sections yet'
+						'label' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
+						'type'  => 'info',
+						'text'  => 'No sections yet'
 					]
 				];
 			}
@@ -623,17 +623,17 @@ class Blueprint
 
 			if (empty($type) === true || is_string($type) === false) {
 				$sections[$sectionName] = [
-					'name' => $sectionName,
-					'headline' => 'Invalid section type for section "' . $sectionName . '"',
-					'type' => 'info',
-					'text' => 'The following section types are available: ' . $this->helpList(array_keys(Section::$types))
+					'name'  => $sectionName,
+					'label' => 'Invalid section type for section "' . $sectionName . '"',
+					'type'  => 'info',
+					'text'  => 'The following section types are available: ' . $this->helpList(array_keys(Section::$types))
 				];
 			} elseif (isset(Section::$types[$type]) === false) {
 				$sections[$sectionName] = [
-					'name' => $sectionName,
-					'headline' => 'Invalid section type ("' . $type . '")',
-					'type' => 'info',
-					'text' => 'The following section types are available: ' . $this->helpList(array_keys(Section::$types))
+					'name'  => $sectionName,
+					'label' => 'Invalid section type ("' . $type . '")',
+					'type'  => 'info',
+					'text'  => 'The following section types are available: ' . $this->helpList(array_keys(Section::$types))
 				];
 			}
 

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -40,10 +40,21 @@ class Helpers
 	 * @param bool $echo
 	 * @return string
 	 */
-	public static function dump($variable, bool $echo = true): string
+	public static function dump(mixed $variable, bool $echo = true): string
 	{
 		$kirby = App::instance();
-		return ($kirby->component('dump'))($kirby, $variable, $echo);
+
+		if ($kirby->environment()->cli() === true) {
+			$output = print_r($variable, true) . PHP_EOL;
+		} else {
+			$output = '<pre>' . print_r($variable, true) . '</pre>';
+		}
+
+		if ($echo === true) {
+			echo $output;
+		}
+
+		return $output;
 	}
 
 	/**

--- a/src/Data/Yaml.php
+++ b/src/Data/Yaml.php
@@ -24,22 +24,8 @@ class Yaml extends Handler
 	 */
 	public static function encode($data): string
 	{
-		// TODO: The locale magic should no longer be
-		//       necessary when support for PHP 7.x is dropped
-
-		// fetch the current locale setting for numbers
-		$locale = setlocale(LC_NUMERIC, 0);
-
-		// change to english numerics to avoid issues with floats
-		setlocale(LC_NUMERIC, 'C');
-
 		// $data, $indent, $wordwrap, $no_opening_dashes
-		$yaml = Spyc::YAMLDump($data, false, false, true);
-
-		// restore the previous locale settings
-		setlocale(LC_NUMERIC, $locale);
-
-		return $yaml;
+		return Spyc::YAMLDump($data, false, false, true);
 	}
 
 	/**

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -50,19 +50,6 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, css('something.css'));
 	}
 
-	public function testDump()
-	{
-		$kirby = $this->kirby->clone([
-			'components' => [
-				'dump' => function ($kirby, $variable) {
-					return $variable;
-				}
-			]
-		]);
-
-		$this->assertSame('test', dump('test'));
-	}
-
 	public function testJsPlugin()
 	{
 		$this->kirby->clone([

--- a/tests/Cms/Blueprints/BlueprintPresetsTest.php
+++ b/tests/Cms/Blueprints/BlueprintPresetsTest.php
@@ -40,15 +40,15 @@ class BlueprintPresetsTest extends TestCase
 					'width' => '1/3',
 					'sections' => [
 						'pages' => [
-							'headline' => 'Pages',
-							'type'     => 'pages',
-							'status'   => 'all',
-							'layout'   => 'list'
+							'label'  => 'Pages',
+							'type'   => 'pages',
+							'status' => 'all',
+							'layout' => 'list'
 						],
 						'files' => [
-							'headline' => 'Files',
-							'type'     => 'files',
-							'layout'   => 'list'
+							'label' => 'Files',
+							'type'  => 'files',
+							'layout'=> 'list'
 						]
 					]
 				]
@@ -77,10 +77,10 @@ class BlueprintPresetsTest extends TestCase
 					'width' => '1/3',
 					'sections' => [
 						'pages' => [
-							'headline' => 'Pages',
-							'type'     => 'pages',
-							'status'   => 'all',
-							'layout'   => 'list'
+							'label'  => 'Pages',
+							'type'   => 'pages',
+							'status' => 'all',
+							'layout' => 'list'
 						]
 					]
 				]
@@ -109,9 +109,9 @@ class BlueprintPresetsTest extends TestCase
 					'width' => '1/3',
 					'sections' => [
 						'files' => [
-							'headline' => 'Files',
-							'type'     => 'files',
-							'layout'   => 'list'
+							'label'  => 'Files',
+							'type'   => 'files',
+							'layout' => 'list'
 						]
 					]
 				]
@@ -146,8 +146,8 @@ class BlueprintPresetsTest extends TestCase
 		$props = $preset([
 			'sidebar' => [
 				'test' => [
-					'headline' => 'Test',
-					'type'     => 'pages'
+					'label' => 'Test',
+					'type'  => 'pages'
 				]
 			]
 		]);
@@ -162,8 +162,8 @@ class BlueprintPresetsTest extends TestCase
 					'width' => '1/3',
 					'sections' => [
 						'test' => [
-							'headline' => 'Test',
-							'type'     => 'pages',
+							'label' => 'Test',
+							'type'  => 'pages',
 						]
 					]
 				]
@@ -186,16 +186,16 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'drafts' => [
-					'headline' => 'Drafts',
-					'type'     => 'pages',
-					'layout'   => 'list',
-					'status'   => 'drafts',
+					'label'  => 'Drafts',
+					'type'   => 'pages',
+					'layout' => 'list',
+					'status' => 'drafts',
 				],
 				'listed' => [
-					'headline' => 'Published',
-					'type'     => 'pages',
-					'layout'   => 'list',
-					'status'   => 'listed',
+					'label'  => 'Published',
+					'type'   => 'pages',
+					'layout' => 'list',
+					'status' => 'listed',
 				]
 			]
 		];
@@ -215,22 +215,22 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'drafts' => [
-					'headline' => 'Drafts',
-					'type'     => 'pages',
-					'layout'   => 'list',
-					'status'   => 'drafts',
+					'label'  => 'Drafts',
+					'type'   => 'pages',
+					'layout' => 'list',
+					'status' => 'drafts',
 				],
 				'unlisted' => [
-					'headline' => 'Unlisted',
-					'type'     => 'pages',
-					'layout'   => 'list',
-					'status'   => 'unlisted',
+					'label'  => 'Unlisted',
+					'type'   => 'pages',
+					'layout' => 'list',
+					'status' => 'unlisted',
 				],
 				'listed' => [
-					'headline' => 'Published',
-					'type'     => 'pages',
-					'layout'   => 'list',
-					'status'   => 'listed',
+					'label'  => 'Published',
+					'type'   => 'pages',
+					'layout' => 'list',
+					'status' => 'listed',
 				]
 			]
 		];
@@ -251,7 +251,7 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'files' => [
-					'headline' => 'Files',
+					'label'    => 'Files',
 					'type'     => 'files',
 					'layout'   => 'cards',
 					'info'     => '{{ file.dimensions }}',
@@ -264,19 +264,19 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertEquals($expected, $props);
 	}
 
-	public function testFilesPresetWithHeadline()
+	public function testFilesPresetWithLabel()
 	{
 		$preset = $this->load('files');
 
 		// default setup
 		$props = $preset([
-			'headline' => 'Images'
+			'label' => 'Images'
 		]);
 
 		$expected = [
 			'sections' => [
 				'files' => [
-					'headline' => 'Images',
+					'label'    => 'Images',
 					'type'     => 'files',
 					'layout'   => 'cards',
 					'info'     => '{{ file.dimensions }}',
@@ -301,7 +301,7 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'files' => [
-					'headline' => 'Files',
+					'label'    => 'Files',
 					'type'     => 'files',
 					'layout'   => 'list',
 					'info'     => '{{ file.dimensions }}',
@@ -326,7 +326,7 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'files' => [
-					'headline' => 'Files',
+					'label'    => 'Files',
 					'type'     => 'files',
 					'layout'   => 'cards',
 					'info'     => '{{ file.dimensions }}',
@@ -351,7 +351,7 @@ class BlueprintPresetsTest extends TestCase
 		$expected = [
 			'sections' => [
 				'files' => [
-					'headline' => 'Files',
+					'label'    => 'Files',
 					'type'     => 'files',
 					'layout'   => 'cards',
 					'info'     => '{{ file.dimensions }}',

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -71,10 +71,10 @@ class BlueprintTest extends TestCase
 						'width' => '1/3',
 						'sections' => [
 							'main-info-0' => [
-								'headline' => 'Column (1/3)',
-								'type'     => 'info',
-								'text'     => 'No sections yet',
-								'name'     => 'main-info-0'
+								'label' => 'Column (1/3)',
+								'type'  => 'info',
+								'text'  => 'No sections yet',
+								'name'  => 'main-info-0'
 							]
 						]
 					],
@@ -82,10 +82,10 @@ class BlueprintTest extends TestCase
 						'width' => '2/3',
 						'sections' => [
 							'main-info-1' => [
-								'headline' => 'Column (2/3)',
-								'type'     => 'info',
-								'text'     => 'No sections yet',
-								'name'     => 'main-info-1'
+								'label' => 'Column (2/3)',
+								'type'  => 'info',
+								'text'  => 'No sections yet',
+								'name'  => 'main-info-1'
 							]
 						]
 					]
@@ -470,8 +470,8 @@ class BlueprintTest extends TestCase
 		$this->assertEquals(true, is_array($sections));
 		$this->assertEquals(1, sizeof($sections));
 		$this->assertEquals(true, array_key_exists('main', $sections));
-		$this->assertEquals(true, array_key_exists('headline', $sections['main']));
-		$this->assertEquals('Invalid section type for section "main"', $sections['main']['headline']);
+		$this->assertEquals(true, array_key_exists('label', $sections['main']));
+		$this->assertEquals('Invalid section type for section "main"', $sections['main']['label']);
 	}
 
 	/**

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -104,7 +104,6 @@ class CoreTest extends TestCase
 		$components = $this->core->components();
 
 		$this->assertArrayHasKey('css', $components);
-		$this->assertArrayHasKey('dump', $components);
 		$this->assertArrayHasKey('file::url', $components);
 		$this->assertArrayHasKey('file::version', $components);
 		$this->assertArrayHasKey('js', $components);

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -44,18 +44,18 @@ class FilesSectionTest extends TestCase
 	{
 		// single headline
 		$section = new Section('files', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => 'Test'
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => 'Test'
 		]);
 
 		$this->assertEquals('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('files', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => [
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => [
 				'en' => 'Files',
 				'de' => 'Dateien'
 			]

--- a/tests/Cms/Sections/InfoSectionTest.php
+++ b/tests/Cms/Sections/InfoSectionTest.php
@@ -23,18 +23,18 @@ class InfoSectionTest extends TestCase
 	{
 		// single headline
 		$section = new Section('info', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => 'Test'
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => 'Test'
 		]);
 
 		$this->assertEquals('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('info', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => [
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => [
 				'en' => 'Information',
 				'de' => 'Informationen'
 			]
@@ -81,17 +81,17 @@ class InfoSectionTest extends TestCase
 	public function testToArray()
 	{
 		$section = new Section('info', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => 'Test Headline',
-			'text'     => 'Test Text',
-			'theme'    => 'notice'
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => 'Test Headline',
+			'text'  => 'Test Text',
+			'theme' => 'notice'
 		]);
 
 		$expected = [
-			'headline' => 'Test Headline',
-			'text'     => '<p>Test Text</p>',
-			'theme'    => 'notice'
+			'label' => 'Test Headline',
+			'text'  => '<p>Test Text</p>',
+			'theme' => 'notice'
 		];
 
 		$this->assertEquals($expected, $section->toArray());

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -25,18 +25,18 @@ class PagesSectionTest extends TestCase
 
 		// single headline
 		$section = new Section('pages', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => 'Test'
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => 'Test'
 		]);
 
 		$this->assertEquals('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('pages', [
-			'name'     => 'test',
-			'model'    => new Page(['slug' => 'test']),
-			'headline' => [
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+			'label' => [
 				'en' => 'Pages',
 				'de' => 'Seiten'
 			]

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -53,18 +53,18 @@ class StatsSectionTest extends TestCase
 	{
 		// single headline
 		$section = new Section('stats', [
-			'name'     => 'test',
-			'model'    => $this->model,
-			'headline' => 'Test'
+			'name'  => 'test',
+			'model' => $this->model,
+			'label' => 'Test'
 		]);
 
 		$this->assertEquals('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('stats', [
-			'name'     => 'test',
-			'model'    => $this->model,
-			'headline' => [
+			'name'  => 'test',
+			'model' => $this->model,
+			'label' => [
 				'en' => 'Stats',
 				'de' => 'Statistik'
 			]


### PR DESCRIPTION
## This PR …

### Deprecations

- Removed `dump` component
- Removed locale magic for `Yaml::encode()` method
- Deprecated sections `headline` prop
- Deprecated `$kirby->server()`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
