### PR TITLE
Fix back button in the login challenge view

### DIFF
--- a/config/areas/account/views.php
+++ b/config/areas/account/views.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\App;
 use Kirby\Cms\Find;
-use Kirby\Panel\Panel;
 
 return [
 	'account' => [
@@ -17,16 +16,6 @@ return [
 		'action'  => function (string $filename) {
 			return Find::file('account', $filename)->panel()->view();
 		}
-	],
-	'account.logout' => [
-		'pattern' => 'logout',
-		'auth'    => false,
-		'action'  => function () {
-			if ($user = App::instance()->user()) {
-				$user->logout();
-			}
-			Panel::go('login');
-		},
 	],
 	'account.password' => [
 		'pattern' => 'reset-password',

--- a/config/areas/logout.php
+++ b/config/areas/logout.php
@@ -1,0 +1,21 @@
+<?php
+
+use Kirby\Panel\Panel;
+use Kirby\Toolkit\I18n;
+
+return function ($kirby) {
+	return [
+		'icon'  => 'user',
+		'label' => I18n::translate('logout'),
+		'views' => [
+			'logout' => [
+				'pattern' => 'logout',
+				'auth'    => false,
+				'action'  => function () use ($kirby) {
+					$kirby->auth()->logout();
+					Panel::go('login');
+				},
+			]
+		]
+	];
+};

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -73,6 +73,7 @@ class Core
 			'installation' => $this->root . '/areas/installation.php',
 			'languages'    => $this->root . '/areas/languages.php',
 			'login'        => $this->root . '/areas/login.php',
+			'logout'       => $this->root . '/areas/logout.php',
 			'site'         => $this->root . '/areas/site.php',
 			'system'       => $this->root . '/areas/system.php',
 			'users'        => $this->root . '/areas/users.php',

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -73,7 +73,10 @@ class Panel
 		// not yet authenticated
 		if (!$user) {
 			return [
-				'login' => static::area('login', $areas['login']),
+				'logout' => static::area('logout', $areas['logout']),
+
+				// login area last because it defines a fallback route
+				'login'  => static::area('login', $areas['login']),
 			];
 		}
 

--- a/tests/Panel/Areas/AccountTest.php
+++ b/tests/Panel/Areas/AccountTest.php
@@ -61,21 +61,6 @@ class AccountTest extends AreaTestCase
 		$this->assertSame('The file "no-exist.jpg" cannot be found', $props['error']);
 	}
 
-	public function testLogout(): void
-	{
-		$this->install();
-		$this->login();
-
-		$this->assertRedirect('logout', 'login');
-	}
-
-	public function testLogoutGuestAccess(): void
-	{
-		$this->install();
-
-		$this->assertRedirect('logout', 'login');
-	}
-
 	public function testResetPassword(): void
 	{
 		$this->install();

--- a/tests/Panel/Areas/LogoutTest.php
+++ b/tests/Panel/Areas/LogoutTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Panel\Areas;
+
+class LogoutTest extends AreaTestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->install();
+	}
+
+	public function testLogoutGuest(): void
+	{
+		$this->assertRedirect('logout', 'login');
+	}
+
+	public function testLogoutUser(): void
+	{
+		$this->login('test@getkirby.com');
+		$this->assertSame('test@getkirby.com', $this->app->user()->email());
+
+		$this->assertRedirect('logout', 'login');
+
+		$this->assertNull($this->app->user());
+	}
+
+	public function testLogoutChallenge(): void
+	{
+		$this->app->session()->set('kirby.challenge.code', '123456');
+
+		$this->assertRedirect('logout', 'login');
+
+		$this->assertNull($this->app->session()->get('kirby.challenge.code'));
+	}
+}

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -98,7 +98,8 @@ class PanelTest extends TestCase
 		$areas = Panel::areas($this->app);
 
 		$this->assertArrayHasKey('login', $areas);
-		$this->assertCount(1, $areas);
+		$this->assertArrayHasKey('logout', $areas);
+		$this->assertCount(2, $areas);
 
 		// simulate a logged in user
 		$this->app->impersonate('test@getkirby.com');
@@ -110,7 +111,8 @@ class PanelTest extends TestCase
 		$this->assertArrayHasKey('system', $areas);
 		$this->assertArrayHasKey('users', $areas);
 		$this->assertArrayHasKey('account', $areas);
-		$this->assertCount(4, $areas);
+		$this->assertArrayHasKey('logout', $areas);
+		$this->assertCount(5, $areas);
 
 		// authenticated with plugins
 		$app = $this->app->clone([
@@ -126,7 +128,7 @@ class PanelTest extends TestCase
 		$areas = Panel::areas($app);
 
 		$this->assertArrayHasKey('todos', $areas);
-		$this->assertCount(5, $areas);
+		$this->assertCount(6, $areas);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- During logout, the session and Kirby's internal state is now more thoroughly cleaned

### Fixes

- The "Back" button during a password reset or two-step login works again #4397

### Breaking changes

- The Panel view `account.logout` of the `account` area was replaced by the `logout` view of the new `logout` area

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)