### PR TITLE
Panel redirects from hooks

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Panel\Field;
 use Kirby\Panel\Panel;
+use Kirby\Panel\Redirect;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -354,15 +355,21 @@ return [
 				]);
 			}
 
-			$page = Find::parent($request->get('parent', 'site'))->createChild([
-				'content'  => ['title' => $title],
-				'slug'     => $request->get('slug'),
-				'template' => $request->get('template'),
-			]);
+			try {
+				$page = Find::parent($request->get('parent', 'site'))->createChild([
+					'content'  => ['title' => $title],
+					'slug'     => $request->get('slug'),
+					'template' => $request->get('template'),
+				]);
+
+				$redirect = $page->panel()->url(true);
+			} catch (Redirect $exception) {
+				$redirect = $exception->location();
+			}
 
 			return [
 				'event'    => 'page.create',
-				'redirect' => $page->panel()->url(true)
+				'redirect' => $redirect
 			];
 		}
 	],


### PR DESCRIPTION
## This PR …

This is WIP and POC pull request. Just implemented for `page.create:after` hook for test. Need your reviews..
Not sure, may be we can catch the redirect exception for all hooks from single/common/global/final point/place.

### Sample codes and use case on implementing custom slug
````php
<?php

use Kirby\Cms\Page;
use Kirby\Panel\Panel;
use Kirby\Toolkit\Str;

return [
    'debug' => true,
     'hooks' => [
        'page.create:after' => function (Page $page) {
            $page = $page->changeSlug(Str::uuid());

            Panel::go($page->panel()->url(true));
        }
    ]
];
````

### Features
- Enable Panel redirects from backend hooks: https://kirby.nolt.io/298


### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
