### PR TITLE
Use `Email` package without `Properties` trait

### DIFF
--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -19,20 +19,11 @@ class Body
 {
 	use Properties;
 
-	/**
-	 * @var string
-	 */
-	protected $html;
-
-	/**
-	 * @var string
-	 */
-	protected $text;
+	protected string|null $html = null;
+	protected string|null $text = null;
 
 	/**
 	 * Email body constructor
-	 *
-	 * @param array $props
 	 */
 	public function __construct(array $props = [])
 	{
@@ -41,20 +32,16 @@ class Body
 
 	/**
 	 * Returns the HTML content of the email body
-	 *
-	 * @return string
 	 */
-	public function html()
+	public function html(): string
 	{
 		return $this->html ?? '';
 	}
 
 	/**
 	 * Returns the plain text content of the email body
-	 *
-	 * @return string
 	 */
-	public function text()
+	public function text(): string
 	{
 		return $this->text ?? '';
 	}
@@ -62,10 +49,9 @@ class Body
 	/**
 	 * Sets the HTML content for the email body
 	 *
-	 * @param string|null $html
 	 * @return $this
 	 */
-	protected function setHtml(string $html = null)
+	protected function setHtml(string|null $html = null): static
 	{
 		$this->html = $html;
 		return $this;
@@ -74,10 +60,9 @@ class Body
 	/**
 	 * Sets the plain text content for the email body
 	 *
-	 * @param string|null $text
 	 * @return $this
 	 */
-	protected function setText(string $text = null)
+	protected function setText(string|null $text = null): static
 	{
 		$this->text = $text;
 		return $this;

--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Email;
 
-use Kirby\Toolkit\Properties;
-
 /**
  * Representation of a an Email body
  * with a text and optional html version
@@ -17,17 +15,25 @@ use Kirby\Toolkit\Properties;
  */
 class Body
 {
-	use Properties;
-
-	protected string|null $html = null;
-	protected string|null $text = null;
+	protected string $html;
+	protected string $text;
 
 	/**
 	 * Email body constructor
 	 */
-	public function __construct(array $props = [])
-	{
-		$this->setProperties($props);
+	public function __construct(
+		string|array|null $html = null,
+		string|null $text = null
+	) {
+		// support deprecated passign props as array
+		// TODO: add deprecation warning at some point
+		if (is_array($html) === true) {
+			$text ??= $html['text'] ?? null;
+			$html   = $html['html'] ?? null;
+		}
+
+		$this->html = $html ?? '';
+		$this->text = $text ?? '';
 	}
 
 	/**
@@ -35,7 +41,7 @@ class Body
 	 */
 	public function html(): string
 	{
-		return $this->html ?? '';
+		return $this->html;
 	}
 
 	/**
@@ -43,28 +49,6 @@ class Body
 	 */
 	public function text(): string
 	{
-		return $this->text ?? '';
-	}
-
-	/**
-	 * Sets the HTML content for the email body
-	 *
-	 * @return $this
-	 */
-	protected function setHtml(string|null $html = null): static
-	{
-		$this->html = $html;
-		return $this;
-	}
-
-	/**
-	 * Sets the plain text content for the email body
-	 *
-	 * @return $this
-	 */
-	protected function setText(string|null $text = null): static
-	{
-		$this->text = $text;
-		return $this;
+		return $this->text;
 	}
 }

--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -51,4 +51,15 @@ class Body
 	{
 		return $this->text;
 	}
+
+	/**
+	 * Returns array of plain text and html
+	 */
+	public function toArray()
+	{
+		return [
+			'text' => $this->text(),
+			'html' => $this->html()
+		];
+	}
 }

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -24,89 +24,31 @@ class Email
 	/**
 	 * If set to `true`, the debug mode is enabled
 	 * for all emails
-	 *
-	 * @var bool
 	 */
-	public static $debug = false;
+	public static bool $debug = false;
 
 	/**
 	 * Store for sent emails when `Email::$debug`
 	 * is set to `true`
-	 *
-	 * @var array
 	 */
-	public static $emails = [];
+	public static array $emails = [];
 
-	/**
-	 * @var array|null
-	 */
-	protected $attachments;
-
-	/**
-	 * @var \Kirby\Email\Body|null
-	 */
-	protected $body;
-
-	/**
-	 * @var array|null
-	 */
-	protected $bcc;
-
-	/**
-	 * @var \Closure|null
-	 */
-	protected $beforeSend;
-
-	/**
-	 * @var array|null
-	 */
-	protected $cc;
-
-	/**
-	 * @var string|null
-	 */
-	protected $from;
-
-	/**
-	 * @var string|null
-	 */
-	protected $fromName;
-
-	/**
-	 * @var string|null
-	 */
-	protected $replyTo;
-
-	/**
-	 * @var string|null
-	 */
-	protected $replyToName;
-
-	/**
-	 * @var bool
-	 */
-	protected $isSent = false;
-
-	/**
-	 * @var string|null
-	 */
-	protected $subject;
-
-	/**
-	 * @var array|null
-	 */
-	protected $to;
-
-	/**
-	 * @var array|null
-	 */
-	protected $transport;
+	protected array|null $attachments = null;
+	protected Body|null $body = null;
+	protected array|null $bcc = null;
+	protected Closure|null $beforeSend = null;
+	protected array|null $cc = null;
+	protected string|null $from = null;
+	protected string|null $fromName = null;
+	protected string|null $replyTo = null;
+	protected string|null $replyToName = null;
+	protected bool $isSent = false;
+	protected string|null $subject = null;
+	protected array|null $to = null;
+	protected array|null $transport = null;
 
 	/**
 	 * Email constructor
-	 *
-	 * @param array $props
-	 * @param bool $debug
 	 */
 	public function __construct(array $props = [], bool $debug = false)
 	{
@@ -123,8 +65,6 @@ class Email
 
 	/**
 	 * Returns the email attachments
-	 *
-	 * @return array
 	 */
 	public function attachments(): array
 	{
@@ -133,18 +73,14 @@ class Email
 
 	/**
 	 * Returns the email body
-	 *
-	 * @return \Kirby\Email\Body|null
 	 */
-	public function body()
+	public function body(): Body|null
 	{
 		return $this->body;
 	}
 
 	/**
 	 * Returns "bcc" recipients
-	 *
-	 * @return array
 	 */
 	public function bcc(): array
 	{
@@ -154,8 +90,6 @@ class Email
 	/**
 	 * Returns the beforeSend callback closure,
 	 * which has access to the PHPMailer instance
-	 *
-	 * @return \Closure|null
 	 */
 	public function beforeSend(): Closure|null
 	{
@@ -164,8 +98,6 @@ class Email
 
 	/**
 	 * Returns "cc" recipients
-	 *
-	 * @return array
 	 */
 	public function cc(): array
 	{
@@ -174,8 +106,6 @@ class Email
 
 	/**
 	 * Returns default transport settings
-	 *
-	 * @return array
 	 */
 	protected function defaultTransport(): array
 	{
@@ -186,8 +116,6 @@ class Email
 
 	/**
 	 * Returns the "from" email address
-	 *
-	 * @return string
 	 */
 	public function from(): string
 	{
@@ -196,8 +124,6 @@ class Email
 
 	/**
 	 * Returns the "from" name
-	 *
-	 * @return string|null
 	 */
 	public function fromName(): string|null
 	{
@@ -206,18 +132,14 @@ class Email
 
 	/**
 	 * Checks if the email has an HTML body
-	 *
-	 * @return bool
 	 */
-	public function isHtml()
+	public function isHtml(): bool
 	{
 		return empty($this->body()->html()) === false;
 	}
 
 	/**
 	 * Checks if the email has been sent successfully
-	 *
-	 * @return bool
 	 */
 	public function isSent(): bool
 	{
@@ -226,8 +148,6 @@ class Email
 
 	/**
 	 * Returns the "reply to" email address
-	 *
-	 * @return string
 	 */
 	public function replyTo(): string
 	{
@@ -236,8 +156,6 @@ class Email
 
 	/**
 	 * Returns the "reply to" name
-	 *
-	 * @return string|null
 	 */
 	public function replyToName(): string|null
 	{
@@ -247,13 +165,12 @@ class Email
 	/**
 	 * Converts single or multiple email addresses to a sanitized format
 	 *
-	 * @param string|array|null $email
-	 * @param bool $multiple
-	 * @return array|mixed|string
 	 * @throws \Exception
 	 */
-	protected function resolveEmail($email = null, bool $multiple = true)
-	{
+	protected function resolveEmail(
+		string|array|null $email = null,
+		bool $multiple = true
+	): array|string {
 		if ($email === null) {
 			return $multiple === true ? [] : '';
 		}
@@ -284,8 +201,6 @@ class Email
 
 	/**
 	 * Sends the email
-	 *
-	 * @return bool
 	 */
 	public function send(): bool
 	{
@@ -295,10 +210,9 @@ class Email
 	/**
 	 * Sets the email attachments
 	 *
-	 * @param array|null $attachments
 	 * @return $this
 	 */
-	protected function setAttachments($attachments = null)
+	protected function setAttachments(array|null $attachments = null): static
 	{
 		$this->attachments = $attachments ?? [];
 		return $this;
@@ -307,10 +221,9 @@ class Email
 	/**
 	 * Sets the email body
 	 *
-	 * @param string|array $body
 	 * @return $this
 	 */
-	protected function setBody($body)
+	protected function setBody(string|array $body): static
 	{
 		if (is_string($body) === true) {
 			$body = ['text' => $body];
@@ -323,10 +236,9 @@ class Email
 	/**
 	 * Sets "bcc" recipients
 	 *
-	 * @param string|array|null $bcc
 	 * @return $this
 	 */
-	protected function setBcc($bcc = null)
+	protected function setBcc(string|array|null $bcc = null): static
 	{
 		$this->bcc = $this->resolveEmail($bcc);
 		return $this;
@@ -335,10 +247,9 @@ class Email
 	/**
 	 * Sets the "beforeSend" callback
 	 *
-	 * @param \Closure|null $beforeSend
 	 * @return $this
 	 */
-	protected function setBeforeSend(Closure|null $beforeSend = null)
+	protected function setBeforeSend(Closure|null $beforeSend = null): static
 	{
 		$this->beforeSend = $beforeSend;
 		return $this;
@@ -347,10 +258,9 @@ class Email
 	/**
 	 * Sets "cc" recipients
 	 *
-	 * @param string|array|null $cc
 	 * @return $this
 	 */
-	protected function setCc($cc = null)
+	protected function setCc(string|array|null $cc = null): static
 	{
 		$this->cc = $this->resolveEmail($cc);
 		return $this;
@@ -359,10 +269,9 @@ class Email
 	/**
 	 * Sets the "from" email address
 	 *
-	 * @param string $from
 	 * @return $this
 	 */
-	protected function setFrom(string $from)
+	protected function setFrom(string $from): static
 	{
 		$this->from = $this->resolveEmail($from, false);
 		return $this;
@@ -371,10 +280,9 @@ class Email
 	/**
 	 * Sets the "from" name
 	 *
-	 * @param string|null $fromName
 	 * @return $this
 	 */
-	protected function setFromName(string $fromName = null)
+	protected function setFromName(string|null $fromName = null): static
 	{
 		$this->fromName = $fromName;
 		return $this;
@@ -383,10 +291,9 @@ class Email
 	/**
 	 * Sets the "reply to" email address
 	 *
-	 * @param string|null $replyTo
 	 * @return $this
 	 */
-	protected function setReplyTo(string $replyTo = null)
+	protected function setReplyTo(string|null $replyTo = null): static
 	{
 		$this->replyTo = $this->resolveEmail($replyTo, false);
 		return $this;
@@ -395,10 +302,9 @@ class Email
 	/**
 	 * Sets the "reply to" name
 	 *
-	 * @param string|null $replyToName
 	 * @return $this
 	 */
-	protected function setReplyToName(string $replyToName = null)
+	protected function setReplyToName(string|null $replyToName = null): static
 	{
 		$this->replyToName = $replyToName;
 		return $this;
@@ -407,10 +313,9 @@ class Email
 	/**
 	 * Sets the email subject
 	 *
-	 * @param string $subject
 	 * @return $this
 	 */
-	protected function setSubject(string $subject)
+	protected function setSubject(string $subject): static
 	{
 		$this->subject = $subject;
 		return $this;
@@ -419,10 +324,9 @@ class Email
 	/**
 	 * Sets the recipients of the email
 	 *
-	 * @param string|array $to
 	 * @return $this
 	 */
-	protected function setTo($to)
+	protected function setTo(string|array $to): static
 	{
 		$this->to = $this->resolveEmail($to);
 		return $this;
@@ -431,10 +335,9 @@ class Email
 	/**
 	 * Sets the email transport settings
 	 *
-	 * @param array|null $transport
 	 * @return $this
 	 */
-	protected function setTransport($transport = null)
+	protected function setTransport(array|null $transport = null): static
 	{
 		$this->transport = $transport;
 		return $this;
@@ -442,8 +345,6 @@ class Email
 
 	/**
 	 * Returns the email subject
-	 *
-	 * @return string
 	 */
 	public function subject(): string
 	{
@@ -452,8 +353,6 @@ class Email
 
 	/**
 	 * Returns the email recipients
-	 *
-	 * @return array
 	 */
 	public function to(): array
 	{
@@ -462,8 +361,6 @@ class Email
 
 	/**
 	 * Returns the email transports settings
-	 *
-	 * @return array
 	 */
 	public function transport(): array
 	{

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -43,7 +43,7 @@ class Email
 	protected bool $isSent = false;
 	protected string $subject;
 	protected array $to;
-	protected array|null $transport;
+	protected array $transport;
 
 	/**
 	 * Email constructor
@@ -107,7 +107,7 @@ class Email
 		$this->replyToName = $replyToName;
 		$this->subject     = $subject;
 		$this->to	       = $this->resolveEmail($to);
-		$this->transport   = $transport;
+		$this->transport   = $transport ?? ['type' => 'mail'];
 
 		// @codeCoverageIgnoreStart
 		if (static::$debug === false && $debug === false) {
@@ -157,16 +157,6 @@ class Email
 	public function cc(): array
 	{
 		return $this->cc;
-	}
-
-	/**
-	 * Returns default transport settings
-	 */
-	protected function defaultTransport(): array
-	{
-		return [
-			'type' => 'mail'
-		];
 	}
 
 	/**
@@ -283,6 +273,6 @@ class Email
 	 */
 	public function transport(): array
 	{
-		return $this->transport ?? $this->defaultTransport();
+		return $this->transport;
 	}
 }

--- a/src/Email/PHPMailer.php
+++ b/src/Email/PHPMailer.php
@@ -20,8 +20,6 @@ class PHPMailer extends Email
 	/**
 	 * Sends email via PHPMailer library
 	 *
-	 * @param bool $debug
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public function send(bool $debug = false): bool

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -55,7 +55,7 @@ class EmailTest extends TestCase
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('$from, $subject are required');
 
-		$email = $this->_email([
+		$this->_email([
 			'from' => null
 		]);
 	}
@@ -218,4 +218,21 @@ class EmailTest extends TestCase
 
 		$mail->send(true);
 	}
+
+	public function testClone()
+	{
+		$email = $this->_email([
+			'from' 	  => $from = 'no-reply@supercompany.com',
+			'body'	  => $body = 'We will never reply',
+			'to' 	  => $to = 'someone@gmail.com',
+			'subject' => $subject = 'Thank you'
+		]);
+		$clone = $email->clone(to: 'homer@simpson.com');
+
+		$this->assertSame($from, $clone->from());
+		$this->assertSame($body, $clone->body()->text());
+		$this->assertSame(['homer@simpson.com' => null], $clone->to());
+		$this->assertSame($subject, $clone->subject());
+	}
+
 }

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -53,7 +53,7 @@ class EmailTest extends TestCase
 	public function testRequiredProperty()
 	{
 		$this->expectException('Exception');
-		$this->expectExceptionMessage('The property "from" is required');
+		$this->expectExceptionMessage('$from, $subject are required');
 
 		$email = $this->_email([
 			'from' => null


### PR DESCRIPTION
A first test how a migration away from the `Properties` trait could look like