### PR TITLE
Keep `$page->childrenAndDrafts()` updated

### DIFF
--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -19,16 +19,24 @@ trait HasChildren
 	/**
 	 * The list of available published children
 	 *
-	 * @var \Kirby\Cms\Pages
+	 * @var \Kirby\Cms\Pages|null
 	 */
 	public $children;
 
 	/**
 	 * The list of available draft children
 	 *
-	 * @var \Kirby\Cms\Pages
+	 * @var \Kirby\Cms\Pages|null
 	 */
 	public $drafts;
+
+	/**
+	 * The combined list of available published
+	 * and draft children
+	 *
+	 * @var \Kirby\Cms\Pages|null
+	 */
+	public $childrenAndDrafts;
 
 	/**
 	 * Returns all published children
@@ -51,7 +59,11 @@ trait HasChildren
 	 */
 	public function childrenAndDrafts()
 	{
-		return $this->children()->merge($this->drafts());
+		if (is_a($this->childrenAndDrafts, 'Kirby\Cms\Pages') === true) {
+			return $this->childrenAndDrafts;
+		}
+
+		return $this->childrenAndDrafts = $this->children()->merge($this->drafts());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- The `$page->childrenAndDrafts()` collection is now immediately updated when a child page or draft is modified #2767

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
