### PR TITLE
Fix `subpages` option for pages field 

### DIFF
--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -34,7 +34,7 @@
 				<template #options="{ item: page }">
 					<k-button v-bind="toggleBtn(page)" @click="toggle(page)" />
 					<k-button
-						v-if="page"
+						v-if="model"
 						:disabled="!page.hasChildren"
 						:tooltip="$t('open')"
 						icon="angle-right"


### PR DESCRIPTION
## This PR …

This issue is a regression from 3.6.0 🤯 Now fixed the issue easily with checking `model` prop.

### Fixes
- Pages field `subpages` option works correctly again #4309

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
