### PR TITLE
Fix double-encoding in table layout

### DIFF
--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -96,9 +96,13 @@ return [
 	'methods' => [
 		'columnsValues' => function (array $item, $model) {
 			$item['title'] = [
-				'text' => $item['text'],
+				'text' => $model->toString($this->text),
 				'href' => $model->panel()->url(true)
 			];
+
+			if ($this->info) {
+				$item['info'] = $model->toString($this->info);
+			}
 
 			foreach ($this->columns as $columnName => $column) {
 				// don't overwrite essential columns
@@ -107,11 +111,7 @@ return [
 				}
 
 				if (empty($column['value']) === false) {
-					if ($column['type'] ?? false === 'html') {
-						$value = $model->toString($column['value']);
-					} else {
-						$value = $model->toSafeString($column['value']);
-					}
+					$value = $model->toString($column['value']);
 				} else {
 					$value = $model->content()->get($column['id'] ?? $columnName)->value();
 				}

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -96,11 +96,15 @@ return [
 	'methods' => [
 		'columnsValues' => function (array $item, $model) {
 			$item['title'] = [
+				// override toSafeString() coming from `$item`
+				// because the table cells don't use v-html
 				'text' => $model->toString($this->text),
 				'href' => $model->panel()->url(true)
 			];
 
 			if ($this->info) {
+				// override toSafeString() coming from `$item`
+				// because the table cells don't use v-html
 				$item['info'] = $model->toString($this->info);
 			}
 

--- a/tests/Cms/Sections/mixins/LayoutMixinTest.php
+++ b/tests/Cms/Sections/mixins/LayoutMixinTest.php
@@ -212,10 +212,6 @@ class LayoutMixinTest extends TestCase
 					'type'  => 'html',
 					'value' => '{{ page.html }}'
 				],
-				'safeHtml' => [
-					'label' => 'Safe HTML',
-					'value' => '{{ page.html }}'
-				],
 				'removed' => false
 			]
 		]);
@@ -235,7 +231,6 @@ class LayoutMixinTest extends TestCase
 			'image' => null,
 			'dateCell' => '2012-12-12',
 			'htmlCell' => '<i>Some HTML</i>',
-			'safeHtmlCell' => '&lt;i&gt;Some HTML&lt;/i&gt;'
 		];
 
 		$this->assertSame($expected, $section->columnsValues($item, $model));


### PR DESCRIPTION
## This PR …

The column values for the table layout were double encoded. For the Item.vue component, we send safe strings for the text and info. The component uses a span with v-html attribute. That's why the safe string is needed here as default. The field preview components don't do this though. They already rely on Vue's xss prevention – except the HtmlFieldPreview component. That's why all the documented column types actually need unescaped values to avoid double-encoding. 

### Fixes

- Values in the table layout are no longer escaped twice #4442

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
