### PR TITLE
Add dir attribute to body element to fix layout issues in drag ghosts

### DIFF
--- a/panel/src/components/Layout/Panel.vue
+++ b/panel/src/components/Layout/Panel.vue
@@ -7,7 +7,7 @@
 		:data-role="role"
 		:data-translation="$translation.code"
 		:data-user="user"
-		:dir="$translation.direction"
+		:dir="dir"
 		class="k-panel"
 	>
 		<slot />
@@ -37,6 +37,9 @@ export default {
 		dialog() {
 			return this.$helper.clone(this.$store.state.dialog);
 		},
+		dir() {
+			return this.$translation.direction;
+		},
 		language() {
 			return this.$language ? this.$language.code : null;
 		},
@@ -45,6 +48,19 @@ export default {
 		},
 		user() {
 			return this.$user ? this.$user.id : null;
+		}
+	},
+	watch: {
+		dir: {
+			handler() {
+				/**
+				 * Some elements – i.e. drag ghosts -
+				 * are injected into the body and not the panel div.
+				 * They need the dir to be displayed correctly
+				 */
+				document.body.dir = this.dir;
+			},
+			immediate: true
 		}
 	},
 	created() {


### PR DESCRIPTION
### Fixes

- Text no longer jumps during drag/sorting #4400 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
