### PR TITLE
Sane\Xml: Allow any domain in basic XML files

### DIFF
--- a/src/Sane/DomHandler.php
+++ b/src/Sane/DomHandler.php
@@ -41,9 +41,9 @@ class DomHandler extends Handler
 	/**
 	 * Allowed hostnames for HTTP(S) URLs
 	 *
-	 * @var array
+	 * @var array|true
 	 */
-	public static $allowedDomains = [];
+	public static $allowedDomains = true;
 
 	/**
 	 * Names of allowed XML processing instructions

--- a/src/Sane/Html.php
+++ b/src/Sane/Html.php
@@ -36,13 +36,6 @@ class Html extends DomHandler
 	];
 
 	/**
-	 * Allowed hostnames for HTTP(S) URLs
-	 *
-	 * @var array
-	 */
-	public static $allowedDomains = true;
-
-	/**
 	 * Associative array of all allowed tag names with the value
 	 * of either an array with the list of all allowed attributes
 	 * for this tag, `true` to allow any attribute from the

--- a/src/Sane/Svg.php
+++ b/src/Sane/Svg.php
@@ -267,6 +267,13 @@ class Svg extends Xml
 	];
 
 	/**
+	 * Allowed hostnames for HTTP(S) URLs
+	 *
+	 * @var array|true
+	 */
+	public static $allowedDomains = [];
+
+	/**
 	 * Associative array of all allowed namespace URIs
 	 *
 	 * @var array

--- a/tests/Sane/fixtures/xml/allowed/gpx.xml
+++ b/tests/Sane/fixtures/xml/allowed/gpx.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/WaypointExtension/v1" xmlns:gpxtrx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Dakota 20" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/WaypointExtension/v1 http://www8.garmin.com/xmlschemas/WaypointExtensionv1.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+	<metadata>
+		<link href="http://www.garmin.com"><text>Garmin International</text></link>
+		<time>2021-06-13T14:34:41Z</time>
+	</metadata>
+</gpx>

--- a/tests/Sane/fixtures/xml/sanitized/external-source-1.xml
+++ b/tests/Sane/fixtures/xml/sanitized/external-source-1.xml
@@ -1,3 +1,3 @@
 <xml xmlns:xlink="http://www.w3.org/1999/xlink">
-  <p/>
+  <p style="background: url('https://malicious.com/script.php')"/>
 </xml>

--- a/tests/Sane/fixtures/xml/sanitized/external-source-1_disallowed.xml
+++ b/tests/Sane/fixtures/xml/sanitized/external-source-1_disallowed.xml
@@ -1,0 +1,3 @@
+<xml xmlns:xlink="http://www.w3.org/1999/xlink">
+  <p/>
+</xml>

--- a/tests/Sane/fixtures/xml/sanitized/external-source-2.xml
+++ b/tests/Sane/fixtures/xml/sanitized/external-source-2.xml
@@ -1,3 +1,3 @@
 <xml xmlns:xlink="http://www.w3.org/1999/xlink">
-  <image height="200" width="200"/>
+  <image href="https://malicious.com/script.php')" height="200" width="200"/>
 </xml>

--- a/tests/Sane/fixtures/xml/sanitized/external-source-2_disallowed.xml
+++ b/tests/Sane/fixtures/xml/sanitized/external-source-2_disallowed.xml
@@ -1,0 +1,3 @@
+<xml xmlns:xlink="http://www.w3.org/1999/xlink">
+  <image height="200" width="200"/>
+</xml>


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Uploaded XML files are no longer blocked because they contain links to external domains #3433

### Breaking changes

- Kirby's upload sanitizer no longer checks XML files for external links because they can be pretty common in many XML-based formats; if you want to keep the strict behavior, set `Kirby\Sane\Xml::$allowedDomains = []`, set this property to a custom allowlist or write a custom Sane handler for your XML-based format

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
