### PR TITLE
Detect `@` alias for IDEs

### DIFF
--- a/panel/jsconfig.json
+++ b/panel/jsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@/*": [
+				"./src/*"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Now `@` alias path supported for IDEs, especially/known for Jetbrains and VSCode. Based on SO solution: https://stackoverflow.com/a/66878724/1769465