### PR TITLE
Apply toggles field preview as bubbles

### DIFF
--- a/panel/src/components/Forms/Previews/index.js
+++ b/panel/src/components/Forms/Previews/index.js
@@ -40,3 +40,4 @@ Vue.component("k-multiselect-field-preview", BubblesFieldPreview);
 Vue.component("k-radio-field-preview", BubblesFieldPreview);
 Vue.component("k-select-field-preview", BubblesFieldPreview);
 Vue.component("k-tags-field-preview", BubblesFieldPreview);
+Vue.component("k-toggles-field-preview", BubblesFieldPreview);


### PR DESCRIPTION
## This PR …

![captures_chrome-capture-2022-7-12](https://user-images.githubusercontent.com/3393422/184331517-2a96768d-00e2-475b-81eb-b09b7bd7b4a9.png)


### Enhancements

- The `toggles` field preview now uses bubbles #4566 


### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- ~[ ] Unit tests for fixed bug/feature~
- ~[ ] In-code documentation (wherever needed)~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
