### PR TITLE
New `F::unlink()` safest method

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
 
@@ -44,6 +45,46 @@ class Helpers
 	{
 		$kirby = App::instance();
 		return ($kirby->component('dump'))($kirby, $variable, $echo);
+	}
+
+	/**
+	 * Performs an action with custom handling
+	 * for all PHP errors and warnings
+	 * @since 3.7.4
+	 *
+	 * @param \Closure $action Any action that may cause an error or warning
+	 * @param \Closure $handler Custom callback like for `set_error_handler()`;
+	 *                          the first argument is a return value override passed
+	 *                          by reference, the additional arguments come from
+	 *                          `set_error_handler()`; returning `false` activates
+	 *                          error handling by Whoops and/or PHP
+	 * @return mixed Return value of the `$action` closure, possibly overridden by `$handler`
+	 */
+	public static function handleErrors(Closure $action, Closure $handler)
+	{
+		$override = $oldHandler = null;
+		$oldHandler = set_error_handler(function () use (&$override, &$oldHandler, $handler) {
+			$handlerResult = $handler($override, ...func_get_args());
+
+			if ($handlerResult === false) {
+				// handle other warnings with Whoops if loaded
+				if (is_callable($oldHandler) === true) {
+					return $oldHandler(...func_get_args());
+				}
+
+				// otherwise use the standard error handler
+				return false; // @codeCoverageIgnore
+			}
+
+			// no additional error handling
+			return true;
+		});
+
+		$result = $action();
+
+		restore_error_handler();
+
+		return $override ?? $result;
 	}
 
 	/**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -537,7 +537,7 @@ class Dir
 		}
 
 		if (is_link($dir) === true) {
-			return unlink($dir);
+			return F::unlink($dir);
 		}
 
 		foreach (scandir($dir) as $childName) {
@@ -547,12 +547,10 @@ class Dir
 
 			$child = $dir . '/' . $childName;
 
-			if (is_link($child) === true) {
-				unlink($child);
-			} elseif (is_dir($child) === true) {
+			if (is_dir($child) === true && is_link($child) === false) {
 				static::remove($child);
 			} else {
-				F::remove($child);
+				F::unlink($child);
 			}
 		}
 

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -729,11 +729,7 @@ class F
 
 		$file = realpath($file);
 
-		if (file_exists($file) === false) {
-			return true;
-		}
-
-		return unlink($file);
+		return static::unlink($file);
 	}
 
 	/**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -3,6 +3,7 @@
 namespace Kirby\Filesystem;
 
 use Exception;
+use Kirby\Cms\Helpers;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Throwable;
@@ -844,6 +845,30 @@ class F
 	public static function typeToExtensions(string $type): ?array
 	{
 		return static::$types[$type] ?? null;
+	}
+
+	/**
+	 * Ensures that a file or link is deleted (with race condition handling)
+	 * @since 3.7.4
+	 */
+	public static function unlink(string $file): bool
+	{
+		return Helpers::handleErrors(
+			fn (): bool => unlink($file),
+			function (&$override, int $errno, string $errstr): bool {
+				// if the file or link was already deleted (race condition),
+				// consider it a success
+				if (Str::endsWith($errstr, 'No such file or directory') === true) {
+					$override = true;
+
+					// drop the warning
+					return true;
+				}
+
+				// handle every other warning normally
+				return false;
+			}
+		);
 	}
 
 	/**

--- a/src/Session/FileSessionStore.php
+++ b/src/Session/FileSessionStore.php
@@ -7,6 +7,7 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
 use Kirby\Toolkit\Str;
 
 /**
@@ -322,7 +323,7 @@ class FileSessionStore extends SessionStore
 		}
 
 		// file still exists, delete it
-		if (@unlink($path) !== true) {
+		if (@F::unlink($path) !== true) {
 			// @codeCoverageIgnoreStart
 			throw new Exception([
 				'key'       => 'session.filestore.unexpectedFilesystemError',


### PR DESCRIPTION
## This PR …

### Features

- New `Helpers::handleErrors()` method for custom PHP error handling
- New `F::unlink()` method for idempotent deletion of files and links (native PHP `unlink()` without a warning when the file is already deleted)

### Fixes
- Deleting files throughout the codebase now happens in an idempotent way (if the file is already deleted, no error is thrown) to avoid race conditions, e.g. when cache entries or sessions are cleaned #3039

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
