### PR TITLE
Set default locale for intl extension from config

### DIFF
--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -135,8 +135,18 @@ class Locale
 	{
 		$locale = static::normalize($locale);
 
+		// locale for core string functions
 		foreach ($locale as $key => $value) {
 			setlocale($key, $value);
+		}
+
+		// locale for the intl extension
+		$timeLocale = $locale[LC_TIME] ?? $locale[LC_ALL] ?? null;
+		if (
+			$timeLocale !== null &&
+			function_exists('locale_set_default') === true
+		) {
+			locale_set_default($timeLocale);
 		}
 	}
 

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -141,10 +141,9 @@ class Locale
 		}
 
 		// locale for the intl extension
-		$timeLocale = $locale[LC_TIME] ?? $locale[LC_ALL] ?? null;
 		if (
-			$timeLocale !== null &&
-			function_exists('locale_set_default') === true
+			function_exists('locale_set_default') === true &&
+			$timeLocale = $locale[LC_TIME] ?? $locale[LC_ALL] ?? null
 		) {
 			locale_set_default($timeLocale);
 		}

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -27,6 +27,7 @@ class LocaleTest extends TestCase
 
 		// now set a baseline
 		setlocale(LC_ALL, 'C');
+		locale_set_default('en-US');
 	}
 
 	public function tearDown(): void
@@ -158,9 +159,11 @@ class LocaleTest extends TestCase
 	public function testSetString()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
+		$this->assertSame('en-US', locale_get_default());
 
 		Locale::set('de_DE.' . $this->localeSuffix);
 		$this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_ALL, '0'));
+		$this->assertSame('de_DE.' . $this->localeSuffix, locale_get_default());
 	}
 
 	/**
@@ -169,6 +172,7 @@ class LocaleTest extends TestCase
 	public function testSetArray1()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
+		$this->assertSame('en-US', locale_get_default());
 
 		Locale::set([
 			'LC_ALL'   => 'de_AT.' . $this->localeSuffix,
@@ -178,6 +182,7 @@ class LocaleTest extends TestCase
 		$this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
 		$this->assertSame('de_CH.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
 		$this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
+		$this->assertSame('de_AT.' . $this->localeSuffix, locale_get_default());
 	}
 
 	/**
@@ -186,14 +191,17 @@ class LocaleTest extends TestCase
 	public function testSetArray2()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
+		$this->assertSame('en-US', locale_get_default());
 
 		Locale::set([
 			'LC_CTYPE' => 'de_DE.' . $this->localeSuffix,
 			LC_NUMERIC => 'de_CH.' . $this->localeSuffix,
-			'LC_ALL'   => 'de_AT.' . $this->localeSuffix
+			'LC_ALL'   => 'de_AT.' . $this->localeSuffix,
+			'LC_TIME'  => 'de_CH.' . $this->localeSuffix
 		]);
 		$this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
 		$this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_NUMERIC, '0'));
 		$this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
+		$this->assertSame('de_CH.' . $this->localeSuffix, locale_get_default());
 	}
 }


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- The `intl` date handler now consistently uses the configured default locale #4304

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
