### PR TITLE
Throw user back to login page on challenge expiry

### DIFF
--- a/panel/src/components/Forms/Login.vue
+++ b/panel/src/components/Forms/Login.vue
@@ -1,13 +1,5 @@
 <template>
 	<form class="k-login-form" @submit.prevent="login">
-		<h1 class="sr-only">
-			{{ $t("login") }}
-		</h1>
-
-		<k-login-alert v-if="issue" @click="issue = null">
-			{{ issue }}
-		</k-login-alert>
-
 		<div class="k-login-fields">
 			<button
 				v-if="canToggle === true"
@@ -51,7 +43,6 @@ export default {
 		return {
 			currentForm: null,
 			isLoading: false,
-			issue: "",
 			user: {
 				email: "",
 				password: "",
@@ -128,7 +119,7 @@ export default {
 			}
 		},
 		async login() {
-			this.issue = null;
+			this.$emit("error", null);
 			this.isLoading = true;
 
 			// clear field data that is not needed for login
@@ -149,7 +140,7 @@ export default {
 					globals: ["$system", "$translation"]
 				});
 			} catch (error) {
-				this.issue = error.message;
+				this.$emit("error", error);
 			} finally {
 				this.isLoading = false;
 			}

--- a/panel/src/components/Forms/LoginCode.vue
+++ b/panel/src/components/Forms/LoginCode.vue
@@ -1,13 +1,5 @@
 <template>
 	<form class="k-login-form k-login-code-form" @submit.prevent="login">
-		<h1 class="sr-only">
-			{{ $t("login") }}
-		</h1>
-
-		<k-login-alert v-if="issue" @click="issue = null">
-			{{ issue }}
-		</k-login-alert>
-
 		<k-user-info :user="pending.email" />
 
 		<k-text-field
@@ -51,8 +43,7 @@ export default {
 		return {
 			code: "",
 			isLoadingBack: false,
-			isLoadingLogin: false,
-			issue: ""
+			isLoadingLogin: false
 		};
 	},
 	computed: {
@@ -70,7 +61,7 @@ export default {
 			this.$go("/logout");
 		},
 		async login() {
-			this.issue = null;
+			this.$emit("error", null);
 			this.isLoadingLogin = true;
 
 			try {
@@ -83,7 +74,7 @@ export default {
 					this.$reload();
 				}
 			} catch (error) {
-				this.issue = error.message;
+				this.$emit("error", error);
 			} finally {
 				this.isLoadingLogin = false;
 			}

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -61,6 +61,13 @@ export default {
 				return;
 			}
 
+			if (error.details.challengeDestroyed === true) {
+				// reset from the LoginCode component back to Login
+				await this.$reload({
+					globals: ["$system"]
+				});
+			}
+
 			this.issue = error.message;
 		}
 	}

--- a/panel/src/components/Views/LoginView.vue
+++ b/panel/src/components/Views/LoginView.vue
@@ -1,14 +1,20 @@
 <template>
 	<k-panel>
-		<k-view v-if="form === 'login'" align="center" class="k-login-view">
-			<k-login-plugin :methods="methods" />
-		</k-view>
-		<k-view
-			v-else-if="form === 'code'"
-			align="center"
-			class="k-login-code-view"
-		>
-			<k-login-code v-bind="$props" />
+		<k-view align="center" :class="viewClass">
+			<!-- <div> as a wrapper so that <k-view>
+			     has a single child for Flexbox layout -->
+			<div>
+				<h1 class="sr-only">
+					{{ $t("login") }}
+				</h1>
+
+				<k-login-alert v-if="issue" @click="issue = null">
+					{{ issue }}
+				</k-login-alert>
+
+				<k-login-code v-if="form === 'code'" v-bind="$props" @error="onError" />
+				<k-login-plugin v-else :methods="methods" @error="onError" />
+			</div>
 		</k-view>
 	</k-panel>
 </template>
@@ -24,21 +30,39 @@ export default {
 		methods: Array,
 		pending: Object
 	},
+	data() {
+		return {
+			issue: ""
+		};
+	},
 	computed: {
 		form() {
 			if (this.pending.email) {
 				return "code";
 			}
 
-			if (!this.$user) {
-				return "login";
+			return "login";
+		},
+		viewClass() {
+			if (this.form === "code") {
+				return "k-login-code-view";
 			}
 
-			return null;
+			return "k-login-view";
 		}
 	},
 	created() {
 		this.$store.dispatch("content/clear");
+	},
+	methods: {
+		async onError(error) {
+			if (error === null) {
+				this.issue = null;
+				return;
+			}
+
+			this.issue = error.message;
+		}
 	}
 };
 </script>

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -105,10 +105,10 @@ class Auth
 			'long'       => $long === true
 		]);
 
+		$timeout = $this->kirby->option('auth.challenge.timeout', 10 * 60);
+
 		$challenge = null;
 		if ($user = $this->kirby->users()->find($email)) {
-			$timeout = $this->kirby->option('auth.challenge.timeout', 10 * 60);
-
 			foreach ($this->enabledChallenges() as $name) {
 				$class = static::$challenges[$name] ?? null;
 				if (
@@ -124,7 +124,6 @@ class Auth
 
 					if ($code !== null) {
 						$session->set('kirby.challenge.code', password_hash($code, PASSWORD_DEFAULT));
-						$session->set('kirby.challenge.timeout', time() + $timeout);
 					}
 
 					break;
@@ -150,9 +149,10 @@ class Auth
 			}
 		}
 
-		// always set the email, even if the challenge won't be
-		// created to avoid leaking whether the user exists
+		// always set the email and timeout, even if the challenge
+		// won't be created; this avoids leaking whether the user exists
 		$session->set('kirby.challenge.email', $email);
+		$session->set('kirby.challenge.timeout', time() + $timeout);
 
 		// sleep for a random amount of milliseconds
 		// to make automated attacks harder and to
@@ -796,11 +796,35 @@ class Auth
 		try {
 			$session = $this->kirby->session();
 
-			// first check if we have an active challenge at all
+			// time-limiting; check this early so that we can destroy the session no
+			// matter if the user exists (avoids leaking user information to attackers)
+			$timeout = $session->get('kirby.challenge.timeout');
+			if ($timeout !== null && time() > $timeout) {
+				// this challenge can never be completed,
+				// so delete it immediately
+				$this->logout();
+
+				throw new PermissionException([
+					'details'  => ['challengeDestroyed' => true],
+					'fallback' => 'Authentication challenge timeout'
+				]);
+			}
+
+			// check if we have an active challenge
 			$email     = $session->get('kirby.challenge.email');
 			$challenge = $session->get('kirby.challenge.type');
 			if (is_string($email) !== true || is_string($challenge) !== true) {
-				throw new InvalidArgumentException('No authentication challenge is active');
+				// if the challenge timed out on the previous request, the
+				// challenge data was already deleted from the session, so we can
+				// set `challengeDestroyed` to `true` in this response as well;
+				// however we must only base this on the email, not the type
+				// (otherwise "faked" challenges would be leaked)
+				$challengeDestroyed = is_string($email) !== true;
+
+				throw new InvalidArgumentException([
+					'details'  => compact('challengeDestroyed'),
+					'fallback' => 'No authentication challenge is active'
+				]);
 			}
 
 			$user = $this->kirby->users()->find($email);
@@ -817,12 +841,6 @@ class Auth
 			if ($this->isBlocked($email) === true) {
 				$this->kirby->trigger('user.login:failed', compact('email'));
 				throw new PermissionException('Rate limit exceeded');
-			}
-
-			// time-limiting
-			$timeout = $session->get('kirby.challenge.timeout');
-			if ($timeout !== null && time() > $timeout) {
-				throw new PermissionException('Authentication challenge timeout');
 			}
 
 			if (
@@ -860,7 +878,14 @@ class Auth
 			if ($this->kirby->option('debug') === true) {
 				throw $e;
 			} else {
-				throw new PermissionException(['key' => 'access.code']);
+				// specifically copy over the marker for a destroyed challenge
+				// even in production (used by the Panel to reset to the login form)
+				$challengeDestroyed = $e->getDetails()['challengeDestroyed'] ?? false;
+
+				throw new PermissionException([
+					'details' => compact('challengeDestroyed'),
+					'key'     => 'access.code'
+				]);
 			}
 		}
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- When a login challenge has expired, the user is redirected to the login page #4087

### Refactoring

- Custom login views no longer need to display errors themselves with `k-login-alert`, instead they can `this.$emit("error", error)`

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
