### PR TITLE
Ease deprecation of `headline` option

### DIFF
--- a/config/presets/files.php
+++ b/config/presets/files.php
@@ -5,7 +5,7 @@ use Kirby\Toolkit\I18n;
 return function (array $props) {
 	$props['sections'] = [
 		'files' => [
-			'label'    => $props['headline'] ?? $props['label'] ?? I18n::translate('files'),
+			'label'    => $props['label'] ?? $props['headline'] ?? I18n::translate('files'),
 			'type'     => 'files',
 			'layout'   => $props['layout'] ?? 'cards',
 			'template' => $props['template'] ?? null,

--- a/config/presets/files.php
+++ b/config/presets/files.php
@@ -5,7 +5,6 @@ use Kirby\Toolkit\I18n;
 return function (array $props) {
 	$props['sections'] = [
 		'files' => [
-			// TODO: Remove `headline` check in 3.9.0
 			'label'    => $props['headline'] ?? $props['label'] ?? I18n::translate('files'),
 			'type'     => 'files',
 			'layout'   => $props['layout'] ?? 'cards',
@@ -17,7 +16,6 @@ return function (array $props) {
 
 	// remove global options
 	unset(
-		// TODO: Remove in 3.9.0
 		$props['headline'],
 		$props['label'],
 		$props['layout'],

--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -1,22 +1,14 @@
 <?php
 
-use Kirby\Cms\Helpers;
 use Kirby\Toolkit\I18n;
 
 return [
 	'props' => [
 		/**
 		 * The headline for the section. This can be a simple string or a template with additional info from the parent page.
-		 * @deprecated Will be removed in Kirby 3.9.0
-		 * @todo remove in 3.9.0
+		 * @deprecated 3.8.0 Use `label` instead
 		 */
 		'headline' => function ($headline = null) {
-			// @codeCoverageIgnoreStart
-			if ($headline !== null) {
-				Helpers::deprecated('`headline` prop for sections has been deprecated and will be removed in Kirby 3.9.0. Use `label` instead.');
-			}
-			// @codeCoverageIgnoreEnd
-
 			return I18n::translate($headline, $headline);
 		},
 		/**
@@ -30,12 +22,12 @@ return [
 	],
 	'computed' => [
 		'headline' => function () {
-			if ($this->headline) {
-				return $this->model()->toString($this->headline);
-			}
-
 			if ($this->label) {
 				return $this->model()->toString($this->label);
+			}
+
+			if ($this->headline) {
+				return $this->model()->toString($this->headline);
 			}
 
 			return ucfirst($this->name);


### PR DESCRIPTION
We decided that this is a bit too harsh and we will delay error messages for now.