### PR TITLE
Add `playsinline` attribute for videos if `autoplay` is set

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -289,13 +289,13 @@ return [
 				// booleans: autoplay, controls, loop, muted
 				// strings : poster, preload
 				// for ex  : `autoplay` will not work if `false` is a `string` instead of a `boolean`
-				$attrs['autoplay'] = $autoplay = Str::toType($tag->autoplay, 'bool');
-				$attrs['controls'] = Str::toType($tag->controls ?? true, 'bool');
-				$attrs['loop']     = Str::toType($tag->loop, 'bool');
-				$attrs['muted']    = Str::toType($tag->muted ?? $autoplay, 'bool');
+				$attrs['autoplay']    = $autoplay = Str::toType($tag->autoplay, 'bool');
+				$attrs['controls']    = Str::toType($tag->controls ?? true, 'bool');
+				$attrs['loop']        = Str::toType($tag->loop, 'bool');
+				$attrs['muted']       = Str::toType($tag->muted ?? $autoplay, 'bool');
 				$attrs['playsinline'] = Str::toType($tag->playsinline ?? $autoplay, 'bool');
-				$attrs['poster']   = $tag->poster;
-				$attrs['preload']  = $tag->preload;
+				$attrs['poster']      = $tag->poster;
+				$attrs['preload']     = $tag->preload;
 			}
 
 			// handles local and remote video file

--- a/config/tags.php
+++ b/config/tags.php
@@ -246,6 +246,7 @@ return [
 			'height',
 			'loop',
 			'muted',
+			'playsinline',
 			'poster',
 			'preload',
 			'style',
@@ -292,6 +293,7 @@ return [
 				$attrs['controls'] = Str::toType($tag->controls ?? true, 'bool');
 				$attrs['loop']     = Str::toType($tag->loop, 'bool');
 				$attrs['muted']    = Str::toType($tag->muted ?? $autoplay, 'bool');
+				$attrs['playsinline'] = Str::toType($tag->playsinline ?? $autoplay, 'bool');
 				$attrs['poster']   = $tag->poster;
 				$attrs['preload']  = $tag->preload;
 			}

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -535,18 +535,18 @@ class KirbyTagsTest extends TestCase
 			'options' => [
 				'kirbytext' => [
 					'video' => [
-						'autoplay' => true,
-						'caption'  => 'Lorem ipsum',
-						'controls' => false,
-						'class'    => 'video-class',
-						'height'   => 350,
-						'loop'     => true,
-						'muted'    => true,
+						'autoplay'    => true,
+						'caption'     => 'Lorem ipsum',
+						'controls'    => false,
+						'class'       => 'video-class',
+						'height'      => 350,
+						'loop'        => true,
+						'muted'       => true,
 						'playsinline' => true,
-						'poster'   => 'sample.jpg',
-						'preload'  => 'auto',
-						'style'    => 'border: none',
-						'width'    => 500
+						'poster'      => 'sample.jpg',
+						'preload'     => 'auto',
+						'style'       => 'border: none',
+						'width'       => 500
 					]
 				]
 			],

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -502,6 +502,7 @@ class KirbyTagsTest extends TestCase
                                 height: 350
                                 loop: true
                                 muted: true
+                                playsinline: true
                                 poster: sample.jpg
                                 preload: auto
                                 style: border: none
@@ -521,7 +522,7 @@ class KirbyTagsTest extends TestCase
 		$image = $page->file('sample.jpg');
 		$video = $page->file('sample.mp4');
 
-		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
+		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted playsinline poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
@@ -541,6 +542,7 @@ class KirbyTagsTest extends TestCase
 						'height'   => 350,
 						'loop'     => true,
 						'muted'    => true,
+						'playsinline' => true,
 						'poster'   => 'sample.jpg',
 						'preload'  => 'auto',
 						'style'    => 'border: none',
@@ -569,7 +571,36 @@ class KirbyTagsTest extends TestCase
 		$image = $page->file('sample.jpg');
 		$video = $page->file('sample.mp4');
 
-		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
+		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted playsinline poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
+		$this->assertSame($expected, $page->text()->kt()->value());
+	}
+
+	public function testVideoAutoplayAttrsOverride()
+	{
+		$kirby = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'content' => [
+							'text' => '(video: sample.mp4 autoplay: true muted: false playsinline: false)'
+						],
+						'files' => [
+							['filename' => 'sample.mp4']
+						]
+					]
+				]
+			]
+		]);
+
+		$page  = $kirby->page('test');
+		$image = $page->file('sample.mp4');
+
+		$expected = '<figure class="video"><video autoplay controls><source src="' . $image->url() . '" type="video/mp4"></video></figure>';
+
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -574,6 +574,35 @@ class KirbyTagsTest extends TestCase
 		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted playsinline poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
+	
+	public function testVideoAutoplayRelatedAttrs()
+	{
+		$kirby = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'content' => [
+							'text' => '(video: sample.mp4 autoplay: true)'
+						],
+						'files' => [
+							['filename' => 'sample.mp4']
+						]
+					]
+				]
+			]
+		]);
+
+		$page  = $kirby->page('test');
+		$video = $page->file('sample.mp4');
+
+		$expected = '<figure class="video"><video autoplay controls muted playsinline><source src="' . $video->url() . '" type="video/mp4"></video></figure>';
+
+		$this->assertSame($expected, $page->text()->kt()->value());
+	}
 
 	public function testVideoAutoplayAttrsOverride()
 	{

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -574,7 +574,7 @@ class KirbyTagsTest extends TestCase
 		$expected = '<figure class="video-class" style="border: none"><video autoplay height="350" loop muted playsinline poster="' . $image->url() . '" preload="auto" width="500"><source src="' . $video->url() . '" type="video/mp4"></video><figcaption>Lorem ipsum</figcaption></figure>';
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
-	
+
 	public function testVideoAutoplayRelatedAttrs()
 	{
 		$kirby = new App([


### PR DESCRIPTION
## This PR …

### Enhancements

- The `video` KirbyTag will automatically add the `playsinline` attribute whenever the `autoplay` option is enabled #4595

### Breaking changes

None relevant for release notes

## More details

The `playsinline` attribute is required in order to start video playback automatically on iOS:

> Video elements that include `<video autoplay>` play automatically when the
> video loads in Safari on macOS and iOS, only if those elements also include the
> `playsinline` attribute.

Source: https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030251

* This PR adds a `playsinline` attribute to the video Kirbytag.
* The attribute defaults to `true`, if `autoplay: true` is set, and `false` otherwise.

Closes #4595.

### Breaking changes
This changes how `(video: my-video.mp4 autoplay: true)` is rendered, so technically, this is a breaking change. That means that a video will be played inline (and not in full screen mode) on mobile user agents such as iOS and Android. 

```diff
- <video autoplay controls muted>...</video>
+ <video autoplay controls muted playsinline>...</video>
```
However, this won’t break a websites layout or cause other errors. I do think this is actually closer to end users expectations when using the `autoplay` attribute on the video Kirbytag.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
