### PR TITLE
Database\Query: Use strict mode for in_array check

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -407,7 +407,7 @@ class Query
 		$mode = A::last($args);
 
 		// if there's a where clause mode attribute attached…
-		if (in_array($mode, ['AND', 'OR']) === true) {
+		if (in_array($mode, ['AND', 'OR'], true) === true) {
 			// remove that from the list of arguments
 			array_pop($args);
 		}
@@ -431,7 +431,7 @@ class Query
 		$mode = A::last($args);
 
 		// if there's a where clause mode attribute attached…
-		if (in_array($mode, ['AND', 'OR']) === true) {
+		if (in_array($mode, ['AND', 'OR'], true) === true) {
 			// remove that from the list of arguments
 			array_pop($args);
 		}
@@ -941,7 +941,7 @@ class Query
 		$result = '';
 
 		// if there's a where clause mode attribute attached…
-		if (in_array($mode, ['AND', 'OR'])) {
+		if (in_array($mode, ['AND', 'OR'], true) === true) {
 			// remove that from the list of arguments
 			array_pop($args);
 		} else {

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -333,6 +333,22 @@ class QueryTest extends TestCase
 
 	public function testWhere()
 	{
+		// numeric comparison
+		$count = $this->database
+			->table('users')
+			->where('balance', '>', 100)
+			->count();
+
+		$this->assertSame(2, $count);
+
+		// numeric comparison (value 0)
+		$count = $this->database
+			->table('users')
+			->where('balance', '>', 0)
+			->count();
+
+		$this->assertSame(4, $count);
+
 		// like 1
 		$count = $this->database
 			->table('users')
@@ -356,14 +372,27 @@ class QueryTest extends TestCase
 			->count();
 
 		$this->assertSame(2, $count);
+	}
 
-		// invalid predicate
+	public function testWhereInvalidPredicate()
+	{
 		$this->expectException('InvalidArgumentException');
 		$this->expectExceptionMessage('Invalid predicate INV');
 
 		$this->database
 			->table('users')
 			->where('username', 'INV', ['john', 'paul'])
+			->count();
+	}
+
+	public function testWhereInvalidPredicateOperator()
+	{
+		$this->expectException('InvalidArgumentException');
+		$this->expectExceptionMessage('Invalid predicate/operator <!>');
+
+		$this->database
+			->table('users')
+			->where('username', '<!>', 'john')
 			->count();
 	}
 
@@ -378,6 +407,17 @@ class QueryTest extends TestCase
 			->count();
 
 		$this->assertSame(1, $count);
+
+		// with value 0
+		$count = $this->database
+			->table('users')
+			->where([
+				'role_id' => 3
+			])
+			->andWhere('balance', '>', 0)
+			->count();
+
+		$this->assertSame(2, $count);
 	}
 
 	public function testOrWhere()
@@ -391,6 +431,17 @@ class QueryTest extends TestCase
 			->count();
 
 		$this->assertSame(3, $count);
+
+		// with value 0
+		$count = $this->database
+			->table('users')
+			->where([
+				'role_id' => 1
+			])
+			->orWhere('balance', '<=', 0)
+			->count();
+
+		$this->assertSame(1, $count);
 	}
 
 	public function testWhereCallback()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Calling `$query->where()` (including `orWhere()` and `andWhere()`) on a database query object with the last argument being the number zero no longer creates an invalid query in PHP 7.4 #4518

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
