### PR TITLE
Replace `is_a()` with `instanceof`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -4,7 +4,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\FileVersion;
+use Kirby\Cms\Page;
 use Kirby\Cms\Template;
+use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Email\PHPMailer as Emailer;
 use Kirby\Filesystem\F;
@@ -177,11 +179,11 @@ return [
 			$keys = array_keys($data);
 			$keys[] = 'id';
 
-			if (is_a($item, 'Kirby\Cms\User') === true) {
+			if ($item instanceof User) {
 				$keys[] = 'name';
 				$keys[] = 'email';
 				$keys[] = 'role';
-			} elseif (is_a($item, 'Kirby\Cms\Page') === true) {
+			} elseif ($item instanceof Page) {
 				// apply the default score for pages
 				$options['score'] = array_merge([
 					'id'    => 64,

--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -51,7 +51,7 @@ return [
 				$parent = $this->model();
 			}
 
-			if (is_a($parent, 'Kirby\Cms\File') === true) {
+			if ($parent instanceof File) {
 				$parent = $parent->parent();
 			}
 
@@ -62,7 +62,7 @@ return [
 					'filename' => $filename,
 				]);
 
-				if (is_a($file, 'Kirby\Cms\File') === false) {
+				if ($file instanceof File === false) {
 					throw new Exception('The file could not be uploaded');
 				}
 

--- a/config/sections/fields.php
+++ b/config/sections/fields.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
 use Kirby\Form\Form;
 
 return [
@@ -31,7 +33,10 @@ return [
 		'fields' => function () {
 			$fields = $this->form->fields()->toArray();
 
-			if (is_a($this->model, 'Kirby\Cms\Page') === true || is_a($this->model, 'Kirby\Cms\Site') === true) {
+			if (
+				$this->model instanceof Page ||
+				$this->model instanceof Site
+			) {
 				// the title should never be updated directly via
 				// fields section to avoid conflicts with the rename dialog
 				unset($fields['title']);

--- a/config/sections/mixins/parent.php
+++ b/config/sections/mixins/parent.php
@@ -1,5 +1,9 @@
 <?php
 
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
 use Kirby\Exception\Exception;
 
 return [
@@ -24,10 +28,10 @@ return [
 				}
 
 				if (
-					is_a($parent, 'Kirby\Cms\Page') === false &&
-					is_a($parent, 'Kirby\Cms\Site') === false &&
-					is_a($parent, 'Kirby\Cms\File') === false &&
-					is_a($parent, 'Kirby\Cms\User') === false
+					$parent instanceof Page === false &&
+					$parent instanceof Site === false &&
+					$parent instanceof File === false &&
+					$parent instanceof User === false
 				) {
 					throw new Exception('The parent for the section "' . $this->name() . '" has to be a page, site or user object');
 				}

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -1,6 +1,8 @@
 <?php
 
 use Kirby\Cms\Blueprint;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
@@ -53,8 +55,8 @@ return [
 			$parent = $this->parentModel();
 
 			if (
-				is_a($parent, 'Kirby\Cms\Site') === false &&
-				is_a($parent, 'Kirby\Cms\Page') === false
+				$parent instanceof Site === false &&
+				$parent instanceof Page === false
 			) {
 				throw new InvalidArgumentException('The parent is invalid. You must choose the site or a page as parent.');
 			}

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -268,7 +268,7 @@ class Api
 	protected function match(array $array, mixed $object = null): string|null
 	{
 		foreach ($array as $definition => $model) {
-			if (is_a($object, $model['type']) === true) {
+			if ($object instanceof $model['type']) {
 				return $definition;
 			}
 		}

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -5,6 +5,7 @@ namespace Kirby\Api;
 use Closure;
 use Exception;
 use Kirby\Cms\User;
+use Kirby\Exception\Exception as ExceptionException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
@@ -145,7 +146,7 @@ class Api
 
 			// set PHP locales based on *user* language
 			// so that e.g. strftime() gets formatted correctly
-			if (is_a($user, User::class) === true) {
+			if ($user instanceof User) {
 				$language = $user->language();
 
 				// get the locale from the translation
@@ -186,7 +187,7 @@ class Api
 
 		if (
 			is_object($output) === true &&
-			is_a($output, Response::class) !== true
+			$output instanceof Response === false
 		) {
 			return $this->resolve($output)->toResponse();
 		}
@@ -234,7 +235,7 @@ class Api
 		}
 
 		// lazy-load data wrapped in Closures
-		if (is_a($this->data[$key], Closure::class) === true) {
+		if ($this->data[$key] instanceof Closure) {
 			return $this->data[$key]->call($this, ...$args);
 		}
 
@@ -382,8 +383,8 @@ class Api
 	public function resolve(mixed $object): Model|Collection
 	{
 		if (
-			is_a($object, Model::class) === true ||
-			is_a($object, Collection::class) === true
+			$object instanceof Model ||
+			$object instanceof Collection
 		) {
 			return $object;
 		}
@@ -603,7 +604,7 @@ class Api
 		];
 
 		// extend the information for Kirby Exceptions
-		if (is_a($e, 'Kirby\Exception\Exception') === true) {
+		if ($e instanceof ExceptionException) {
 			$result['key']     = $e->getKey();
 			$result['details'] = $e->getDetails();
 			$result['code']    = $e->getHttpCode();

--- a/src/Api/Collection.php
+++ b/src/Api/Collection.php
@@ -49,7 +49,7 @@ class Collection
 
 		if (
 			isset($schema['type']) === true &&
-			is_a($this->data, $schema['type']) === false
+			$this->data instanceof $schema['type'] === false
 		) {
 			throw new Exception('Invalid collection type');
 		}

--- a/src/Api/Collection.php
+++ b/src/Api/Collection.php
@@ -40,7 +40,7 @@ class Collection
 		$this->view   = $schema['view'] ?? null;
 
 		if ($data === null) {
-			if (is_a($schema['default'] ?? null, Closure::class) === false) {
+			if (($schema['default'] ?? null) instanceof Closure === false) {
 				throw new Exception('Missing collection data');
 			}
 

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -49,7 +49,7 @@ class Model
 		}
 
 		if ($data === null) {
-			if (is_a($schema['default'] ?? null, Closure::class) === false) {
+			if (($schema['default'] ?? null) instanceof Closure === false) {
 				throw new Exception('Missing model data');
 			}
 
@@ -58,7 +58,7 @@ class Model
 
 		if (
 			isset($schema['type']) === true &&
-			is_a($this->data, $schema['type']) === false
+			$this->data instanceof $schema['type'] === false
 		) {
 			throw new Exception(sprintf('Invalid model type "%s" expected: "%s"', get_class($this->data), $schema['type']));
 		}

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -144,7 +144,7 @@ class Model
 		foreach ($this->fields as $key => $resolver) {
 			if (
 				array_key_exists($key, $select) === false ||
-				is_a($resolver, Closure::class) === false
+				$resolver instanceof Closure === false
 			) {
 				continue;
 			}
@@ -156,8 +156,8 @@ class Model
 			}
 
 			if (
-				is_a($value, Collection::class) === true ||
-				is_a($value, Model::class) === true
+				$value instanceof Collection ||
+				$value instanceof self
 			) {
 				$selection = $select[$key];
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -77,7 +77,7 @@ abstract class Cache
 		$value = $this->retrieve($key);
 
 		// check for a valid cache value
-		if (is_a($value, Value::class) === false) {
+		if ($value instanceof Value === false) {
 			return $default;
 		}
 
@@ -116,7 +116,7 @@ abstract class Cache
 		$value = $this->retrieve($key);
 
 		// check for a valid Value object
-		if (is_a($value, Value::class) === false) {
+		if ($value instanceof Value === false) {
 			return false;
 		}
 
@@ -153,7 +153,7 @@ abstract class Cache
 		$value = $this->retrieve($key);
 
 		// check for a valid Value object
-		if (is_a($value, Value::class) === false) {
+		if ($value instanceof Value === false) {
 			return false;
 		}
 

--- a/src/Cms/AppCaches.php
+++ b/src/Cms/AppCaches.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Cache\Cache;
 use Kirby\Cache\NullCache;
 use Kirby\Exception\InvalidArgumentException;
 
@@ -54,7 +55,7 @@ trait AppCaches
 		$cache = new $className($options);
 
 		// check if it is a usable cache object
-		if (is_a($cache, 'Kirby\Cache\Cache') !== true) {
+		if ($cache instanceof Cache === false) {
 			throw new InvalidArgumentException([
 				'key'  => 'app.invalid.cacheType',
 				'data' => ['type' => $type]

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -2,9 +2,12 @@
 
 namespace Kirby\Cms;
 
+use Closure;
+use Kirby\Exception\Exception;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
 use Kirby\Toolkit\I18n;
+use Throwable;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\Handler;
 use Whoops\Handler\PlainTextHandler;
@@ -84,7 +87,7 @@ trait AppErrors
 			$handler = new CallbackHandler(function ($exception, $inspector, $run) {
 				$fatal = $this->option('fatal');
 
-				if (is_a($fatal, 'Closure') === true) {
+				if ($fatal instanceof Closure) {
 					echo $fatal($this, $exception);
 				} else {
 					include $this->root('kirby') . '/views/fatal.php';
@@ -109,11 +112,11 @@ trait AppErrors
 	protected function handleJsonErrors(): void
 	{
 		$handler = new CallbackHandler(function ($exception, $inspector, $run) {
-			if (is_a($exception, 'Kirby\Exception\Exception') === true) {
+			if ($exception instanceof Exception) {
 				$httpCode = $exception->getHttpCode();
 				$code     = $exception->getCode();
 				$details  = $exception->getDetails();
-			} elseif (is_a($exception, '\Throwable') === true) {
+			} elseif ($exception instanceof Throwable) {
 				$httpCode = 500;
 				$code     = $exception->getCode();
 				$details  = null;

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -120,14 +120,14 @@ trait AppPlugins
 	protected function extendApi($api): array
 	{
 		if (is_array($api) === true) {
-			if (is_a($api['routes'] ?? [], 'Closure') === true) {
+			if (($api['routes'] ?? []) instanceof Closure) {
 				$api['routes'] = $api['routes']($this);
 			}
 
 			return $this->extensions['api'] = A::merge($this->extensions['api'], $api, A::MERGE_APPEND);
-		} else {
-			return $this->extensions['api'];
 		}
+
+		return $this->extensions['api'];
 	}
 
 	/**
@@ -520,7 +520,7 @@ trait AppPlugins
 	 */
 	protected function extendRoutes($routes): array
 	{
-		if (is_a($routes, 'Closure') === true) {
+		if ($routes instanceof Closure) {
 			$routes = $routes($this);
 		}
 

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -160,7 +160,7 @@ trait AppTranslations
 		$locale = basename($locale);
 
 		// prefer loading them from the translations collection
-		if (is_a($this->translations, 'Kirby\Cms\Translations') === true) {
+		if ($this->translations instanceof Translations) {
 			if ($translation = $this->translations()->find($locale)) {
 				return $translation;
 			}
@@ -185,7 +185,7 @@ trait AppTranslations
 	 */
 	public function translations()
 	{
-		if (is_a($this->translations, 'Kirby\Cms\Translations') === true) {
+		if ($this->translations instanceof Translations) {
 			return $this->translations;
 		}
 

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -136,7 +136,7 @@ trait AppUsers
 	 */
 	public function users()
 	{
-		if (is_a($this->users, 'Kirby\Cms\Users') === true) {
+		if ($this->users instanceof Users) {
 			return $this->users;
 		}
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -11,6 +11,7 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\F;
 use Kirby\Http\Idn;
 use Kirby\Http\Request\Auth\BasicAuth;
+use Kirby\Session\Session;
 use Kirby\Toolkit\A;
 use Throwable;
 
@@ -873,7 +874,7 @@ class Auth
 		}
 
 		// try session in header or cookie
-		if (is_a($session, 'Kirby\Session\Session') === false) {
+		if ($session instanceof Session === false) {
 			return $this->kirby->session(['detect' => true]);
 		}
 

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -157,7 +157,7 @@ class Block extends Item
 		if (empty($type) === false && $class = (static::$models[$type] ?? null)) {
 			$object = new $class($params);
 
-			if (is_a($object, 'Kirby\Cms\Block') === true) {
+			if ($object instanceof self) {
 				return $object;
 			}
 		}
@@ -166,7 +166,7 @@ class Block extends Item
 		if ($class = (static::$models['Kirby\Cms\Block'] ?? null)) {
 			$object = new $class($params);
 
-			if (is_a($object, 'Kirby\Cms\Block') === true) {
+			if ($object instanceof self) {
 				return $object;
 			}
 		}

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -58,7 +58,7 @@ class Blueprint
 			throw new InvalidArgumentException('A blueprint model is required');
 		}
 
-		if (is_a($props['model'], ModelWithContent::class) === false) {
+		if ($props['model'] instanceof ModelWithContent === false) {
 			throw new InvalidArgumentException('Invalid blueprint model');
 		}
 

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -87,9 +87,12 @@ class Collection extends BaseCollection
 	 */
 	public function add($object)
 	{
-		if (is_a($object, self::class) === true) {
+		if ($object instanceof self) {
 			$this->data = array_merge($this->data, $object->data);
-		} elseif (is_object($object) === true && method_exists($object, 'id') === true) {
+		} elseif (
+			is_object($object) === true &&
+			method_exists($object, 'id') === true
+		) {
 			$this->__set($object->id(), $object);
 		} else {
 			$this->append($object);
@@ -210,7 +213,7 @@ class Collection extends BaseCollection
 				return $this->not(...$key);
 			}
 
-			if (is_a($key, 'Kirby\Toolkit\Collection') === true) {
+			if ($key instanceof BaseCollection) {
 				$collection = $collection->not(...$key->keys());
 			} elseif (is_object($key) === true) {
 				$key = $key->id();

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Closure;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Controller;
@@ -124,7 +125,7 @@ class Collections
 		if (is_file($file) === true) {
 			$collection = F::load($file);
 
-			if (is_a($collection, 'Closure')) {
+			if ($collection instanceof Closure) {
 				return $collection;
 			}
 		}

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -194,7 +194,7 @@ class Email
 				} else {
 					$result[] = $item;
 				}
-			} elseif (is_a($item, $class) === true) {
+			} elseif ($item instanceof $class) {
 				// value is a model object, get value through content method(s)
 				if ($contentKey !== null) {
 					$result[(string)$item->$contentKey()] = (string)$item->$contentValue();

--- a/src/Cms/Field.php
+++ b/src/Cms/Field.php
@@ -187,7 +187,7 @@ class Field
 			return $this;
 		}
 
-		if (is_a($fallback, 'Kirby\Cms\Field') === true) {
+		if ($fallback instanceof self) {
 			return $fallback;
 		}
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -160,7 +160,7 @@ class File extends ModelWithContent
 	 */
 	public function blueprint()
 	{
-		if (is_a($this->blueprint, 'Kirby\Cms\FileBlueprint') === true) {
+		if ($this->blueprint instanceof FileBlueprint) {
 			return $this->blueprint;
 		}
 
@@ -263,11 +263,10 @@ class File extends ModelWithContent
 			return $this->id;
 		}
 
-		if (is_a($this->parent(), 'Kirby\Cms\Page') === true) {
-			return $this->id = $this->parent()->id() . '/' . $this->filename();
-		}
-
-		if (is_a($this->parent(), 'Kirby\Cms\User') === true) {
+		if (
+			$this->parent() instanceof Page ||
+			$this->parent() instanceof User
+		) {
 			return $this->id = $this->parent()->id() . '/' . $this->filename();
 		}
 
@@ -396,7 +395,11 @@ class File extends ModelWithContent
 	 */
 	public function page()
 	{
-		return is_a($this->parent(), 'Kirby\Cms\Page') === true ? $this->parent() : null;
+		if ($this->parent() instanceof Page) {
+			return $this->parent();
+		}
+
+		return null;
 	}
 
 	/**
@@ -437,7 +440,7 @@ class File extends ModelWithContent
 	 */
 	public function parents()
 	{
-		if (is_a($this->parent(), 'Kirby\Cms\Page') === true) {
+		if ($this->parent() instanceof Page) {
 			return $this->parent()->parents()->prepend($this->parent()->id(), $this->parent());
 		}
 
@@ -568,7 +571,11 @@ class File extends ModelWithContent
 	 */
 	public function site()
 	{
-		return is_a($this->parent(), 'Kirby\Cms\Site') === true ? $this->parent() : $this->kirby()->site();
+		if ($this->parent() instanceof Site) {
+			return $this->parent();
+		}
+
+		return $this->kirby()->site();
 	}
 
 	/**

--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Filesystem\Asset;
 
 /**
  * Trait for image resizing, blurring etc.
@@ -53,7 +54,7 @@ trait FileModifications
 			$quality = $options;
 		} elseif (is_string($options)) {
 			$crop = $options;
-		} elseif (is_a($options, 'Kirby\Cms\Field') === true) {
+		} elseif ($options instanceof Field) {
 			$crop = $options->value();
 		} elseif (is_array($options)) {
 			$quality = $options['quality'] ?? $quality;
@@ -202,9 +203,9 @@ trait FileModifications
 		$result    = $component($this->kirby(), $this, $options);
 
 		if (
-			is_a($result, 'Kirby\Cms\FileVersion') === false &&
-			is_a($result, 'Kirby\Cms\File') === false &&
-			is_a($result, 'Kirby\Filesystem\Asset') === false
+			$result instanceof FileVersion === false &&
+			$result instanceof File === false &&
+			$result instanceof Asset === false
 		) {
 			throw new InvalidArgumentException('The file::version component must return a File, FileVersion or Asset object');
 		}

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -43,7 +43,7 @@ class FilePicker extends Picker
 		// find the right default query
 		if (empty($this->options['query']) === false) {
 			$query = $this->options['query'];
-		} elseif (is_a($model, 'Kirby\Cms\File') === true) {
+		} elseif ($model instanceof File) {
 			$query = 'file.siblings';
 		} else {
 			$query = $model::CLASS_ALIAS . '.files';

--- a/src/Cms/FileVersion.php
+++ b/src/Cms/FileVersion.php
@@ -45,7 +45,7 @@ class FileVersion
 		}
 
 		// content fields
-		if (is_a($this->original(), 'Kirby\Cms\File') === true) {
+		if ($this->original() instanceof File) {
 			return $this->original()->content()->get($method, $arguments);
 		}
 	}

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -40,15 +40,18 @@ class Files extends Collection
 	public function add($object)
 	{
 		// add a files collection
-		if (is_a($object, self::class) === true) {
+		if ($object instanceof self) {
 			$this->data = array_merge($this->data, $object->data);
 
 		// add a file by id
-		} elseif (is_string($object) === true && $file = App::instance()->file($object)) {
+		} elseif (
+			is_string($object) === true &&
+			$file = App::instance()->file($object)
+		) {
 			$this->__set($file->id(), $file);
 
 		// add a file object
-		} elseif (is_a($object, 'Kirby\Cms\File') === true) {
+		} elseif ($object instanceof File) {
 			$this->__set($object->id(), $object);
 
 		// give a useful error message on invalid input;

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -45,7 +45,7 @@ trait HasChildren
 	 */
 	public function children()
 	{
-		if (is_a($this->children, 'Kirby\Cms\Pages') === true) {
+		if ($this->children instanceof Pages) {
 			return $this->children;
 		}
 
@@ -59,7 +59,7 @@ trait HasChildren
 	 */
 	public function childrenAndDrafts()
 	{
-		if (is_a($this->childrenAndDrafts, 'Kirby\Cms\Pages') === true) {
+		if ($this->childrenAndDrafts instanceof Pages) {
 			return $this->childrenAndDrafts;
 		}
 
@@ -118,7 +118,7 @@ trait HasChildren
 	 */
 	public function drafts()
 	{
-		if (is_a($this->drafts, 'Kirby\Cms\Pages') === true) {
+		if ($this->drafts instanceof Pages) {
 			return $this->drafts;
 		}
 

--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -111,7 +111,7 @@ trait HasFiles
 	 */
 	public function files()
 	{
-		if (is_a($this->files, 'Kirby\Cms\Files') === true) {
+		if ($this->files instanceof Files) {
 			return $this->files;
 		}
 

--- a/src/Cms/Html.php
+++ b/src/Cms/Html.php
@@ -121,7 +121,7 @@ class Html extends \Kirby\Toolkit\Html
 	{
 		// support for Kirby's file objects
 		if (
-			is_a($file, 'Kirby\Cms\File') === true &&
+			$file instanceof File &&
 			$file->extension() === 'svg'
 		) {
 			return $file->read();

--- a/src/Cms/Ingredients.php
+++ b/src/Cms/Ingredients.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use Closure;
+
 /**
  * The Ingredients class is the foundation for
  * `$kirby->urls()` and `$kirby->roots()` objects.
@@ -75,7 +77,7 @@ class Ingredients
 	public static function bake(array $ingredients)
 	{
 		foreach ($ingredients as $name => $ingredient) {
-			if (is_a($ingredient, 'Closure') === true) {
+			if ($ingredient instanceof Closure) {
 				$ingredients[$name] = $ingredient($ingredients);
 			}
 		}

--- a/src/Cms/Loader.php
+++ b/src/Cms/Loader.php
@@ -205,7 +205,7 @@ class Loader
 		// convert closure dropdowns to an array definition
 		// otherwise they cannot be merged properly later
 		foreach ($dropdowns as $key => $dropdown) {
-			if (is_a($dropdown, 'Closure') === true) {
+			if ($dropdown instanceof Closure) {
 				$area['dropdowns'][$key] = [
 					'options' => $dropdown
 				];

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -102,7 +102,7 @@ class Media
 		if (is_string($model) === true) {
 			$root = $kirby->root('media') . '/assets/' . $model . '/' . $hash;
 		// parent files for file model that already included hash
-		} elseif (is_a($model, '\Kirby\Cms\File')) {
+		} elseif ($model instanceof File) {
 			$root = dirname($model->mediaRoot());
 		// model files
 		} else {

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -359,7 +359,7 @@ abstract class ModelWithContent extends Model
 			return null;
 		}
 
-		if ($expect !== null && is_a($result, $expect) !== true) {
+		if ($expect !== null && $result instanceof $expect === false) {
 			return null;
 		}
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -86,7 +86,7 @@ abstract class ModelWithContent extends Model
 
 		// single language support
 		if ($this->kirby()->multilang() === false) {
-			if (is_a($this->content, 'Kirby\Cms\Content') === true) {
+			if ($this->content instanceof Content) {
 				return $this->content;
 			}
 
@@ -99,7 +99,7 @@ abstract class ModelWithContent extends Model
 			// only fetch from cache for the default language
 			if (
 				$languageCode === null &&
-				is_a($this->content, 'Kirby\Cms\Content') === true
+				$this->content instanceof Content
 			) {
 				return $this->content;
 			}
@@ -351,7 +351,7 @@ abstract class ModelWithContent extends Model
 		try {
 			$result = Str::query($query, [
 				'kirby'             => $this->kirby(),
-				'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
+				'site'              => $this instanceof Site ? $this : $this->site(),
 				'model'             => $this,
 				static::CLASS_ALIAS => $this
 			]);
@@ -548,7 +548,7 @@ abstract class ModelWithContent extends Model
 
 		$result = Str::$handler($template, array_replace([
 			'kirby'             => $this->kirby(),
-			'site'              => is_a($this, 'Kirby\Cms\Site') ? $this : $this->site(),
+			'site'              => $this instanceof Site ? $this : $this->site(),
 			'model'             => $this,
 			static::CLASS_ALIAS => $this,
 		], $data), ['fallback' => $fallback]);

--- a/src/Cms/NestObject.php
+++ b/src/Cms/NestObject.php
@@ -25,7 +25,7 @@ class NestObject extends Obj
 		$result = [];
 
 		foreach ((array)$this as $key => $value) {
-			if (is_a($value, 'Kirby\Cms\Field') === true) {
+			if ($value instanceof Field) {
 				$result[$key] = $value->value();
 				continue;
 			}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -362,7 +362,7 @@ class Page extends ModelWithContent
 
 			foreach ($controllerData as $key => $value) {
 				if (array_key_exists($key, $classes) === true) {
-					if (is_a($value, $classes[$key]) === true) {
+					if ($value instanceof $classes[$key]) {
 						$data[$key] = $value;
 					} else {
 						throw new InvalidArgumentException('The returned variable "' . $key . '" from the controller "' . $this->template()->name() . '" is not of the required type "' . $classes[$key] . '"');

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Closure;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
@@ -229,7 +230,7 @@ class Page extends ModelWithContent
 	 */
 	public function blueprint()
 	{
-		if (is_a($this->blueprint, 'Kirby\Cms\PageBlueprint') === true) {
+		if ($this->blueprint instanceof PageBlueprint) {
 			return $this->blueprint;
 		}
 
@@ -545,7 +546,7 @@ class Page extends ModelWithContent
 	 */
 	public function is($page): bool
 	{
-		if (is_a($page, 'Kirby\Cms\Page') === false) {
+		if ($page instanceof self === false) {
 			if (is_string($page) === false) {
 				return false;
 			}
@@ -553,7 +554,7 @@ class Page extends ModelWithContent
 			$page = $this->kirby()->page($page);
 		}
 
-		if (is_a($page, 'Kirby\Cms\Page') === false) {
+		if ($page instanceof self === false) {
 			return false;
 		}
 
@@ -623,7 +624,7 @@ class Page extends ModelWithContent
 		}
 
 		// check for a custom ignore rule
-		if (is_a($ignore, 'Closure') === true) {
+		if ($ignore instanceof Closure) {
 			if ($ignore($this) === true) {
 				return false;
 			}
@@ -862,7 +863,7 @@ class Page extends ModelWithContent
 		if ($class = (static::$models[$name] ?? null)) {
 			$object = new $class($props);
 
-			if (is_a($object, 'Kirby\Cms\Page') === true) {
+			if ($object instanceof self) {
 				return $object;
 			}
 		}

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -104,7 +104,7 @@ class PagePicker extends Picker
 		}
 
 		// the selected model is the site. there's nothing above
-		if (is_a($model, 'Kirby\Cms\Site') === true) {
+		if ($model instanceof Site) {
 			return [
 				'id'     => null,
 				'parent' => null,

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -57,15 +57,18 @@ class Pages extends Collection
 		$site = App::instance()->site();
 
 		// add a pages collection
-		if (is_a($object, self::class) === true) {
+		if ($object instanceof self) {
 			$this->data = array_merge($this->data, $object->data);
 
 		// add a page by id
-		} elseif (is_string($object) === true && $page = $site->find($object)) {
+		} elseif (
+			is_string($object) === true &&
+			$page = $site->find($object)
+		) {
 			$this->__set($page->id(), $page);
 
 		// add a page object
-		} elseif (is_a($object, 'Kirby\Cms\Page') === true) {
+		} elseif ($object instanceof Page) {
 			$this->__set($object->id(), $object);
 
 		// give a useful error message on invalid input;
@@ -157,7 +160,7 @@ class Pages extends Collection
 		$children = new static([], $model);
 		$kirby    = $model->kirby();
 
-		if (is_a($model, 'Kirby\Cms\Page') === true) {
+		if ($model instanceof Page) {
 			$parent = $model;
 			$site   = $model->site();
 		} else {
@@ -275,7 +278,7 @@ class Pages extends Collection
 		}
 
 		// try to find the page by its (translated) URI by stepping through the page tree
-		$start = is_a($this->parent, 'Kirby\Cms\Page') === true ? $this->parent->id() : '';
+		$start = $this->parent instanceof Page ? $this->parent->id() : '';
 		if ($page = $this->findByIdRecursive($key, $start, App::instance()->multilang(), true)) {
 			return $page;
 		}
@@ -346,7 +349,7 @@ class Pages extends Collection
 		// get object property by cache mode
 		$index = $drafts === true ? $this->indexWithDrafts : $this->index;
 
-		if (is_a($index, 'Kirby\Cms\Pages') === true) {
+		if ($index instanceof self) {
 			return $index;
 		}
 
@@ -417,14 +420,14 @@ class Pages extends Collection
 		}
 
 		// merge an entire collection
-		if (is_a($args[0], self::class) === true) {
+		if ($args[0] instanceof self) {
 			$collection = clone $this;
 			$collection->data = array_merge($collection->data, $args[0]->data);
 			return $collection;
 		}
 
 		// append a single page
-		if (is_a($args[0], 'Kirby\Cms\Page') === true) {
+		if ($args[0] instanceof Page) {
 			$collection = clone $this;
 			return $collection->set($args[0]->id(), $args[0]);
 		}

--- a/src/Cms/Section.php
+++ b/src/Cms/Section.php
@@ -44,7 +44,7 @@ class Section extends Component
 			throw new InvalidArgumentException('Undefined section model');
 		}
 
-		if (is_a($attrs['model'], 'Kirby\Cms\Model') === false) {
+		if ($attrs['model'] instanceof Model === false) {
 			throw new InvalidArgumentException('Invalid section model');
 		}
 

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -176,7 +176,7 @@ class Site extends ModelWithContent
 	 */
 	public function blueprint()
 	{
-		if (is_a($this->blueprint, 'Kirby\Cms\SiteBlueprint') === true) {
+		if ($this->blueprint instanceof SiteBlueprint) {
 			return $this->blueprint;
 		}
 
@@ -235,7 +235,7 @@ class Site extends ModelWithContent
 	 */
 	public function errorPage()
 	{
-		if (is_a($this->errorPage, 'Kirby\Cms\Page') === true) {
+		if ($this->errorPage instanceof Page) {
 			return $this->errorPage;
 		}
 
@@ -274,7 +274,7 @@ class Site extends ModelWithContent
 	 */
 	public function homePage()
 	{
-		if (is_a($this->homePage, 'Kirby\Cms\Page') === true) {
+		if ($this->homePage instanceof Page) {
 			return $this->homePage;
 		}
 
@@ -327,7 +327,7 @@ class Site extends ModelWithContent
 	 */
 	public function is($site): bool
 	{
-		if (is_a($site, 'Kirby\Cms\Site') === false) {
+		if ($site instanceof self === false) {
 			return false;
 		}
 
@@ -392,7 +392,7 @@ class Site extends ModelWithContent
 			return $this->find($path);
 		}
 
-		if (is_a($this->page, 'Kirby\Cms\Page') === true) {
+		if ($this->page instanceof Page) {
 			return $this->page;
 		}
 
@@ -636,7 +636,7 @@ class Site extends ModelWithContent
 		}
 
 		// handle invalid pages
-		if (is_a($page, 'Kirby\Cms\Page') === false) {
+		if ($page instanceof Page === false) {
 			throw new InvalidArgumentException('Invalid page object');
 		}
 

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -46,7 +46,7 @@ class Structure extends Collection
 	 */
 	public function __set(string $id, $props): void
 	{
-		if (is_a($props, 'Kirby\Cms\StructureObject') === true) {
+		if ($props instanceof StructureObject) {
 			$object = $props;
 		} else {
 			if (is_array($props) === false) {

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -81,7 +81,7 @@ class StructureObject extends Model
 	 */
 	public function content()
 	{
-		if (is_a($this->content, 'Kirby\Cms\Content') === true) {
+		if ($this->content instanceof Content) {
 			return $this->content;
 		}
 
@@ -110,7 +110,7 @@ class StructureObject extends Model
 	 */
 	public function is($structure): bool
 	{
-		if (is_a($structure, 'Kirby\Cms\StructureObject') === false) {
+		if ($structure instanceof self === false) {
 			return false;
 		}
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -8,6 +8,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\User as Panel;
+use Kirby\Session\Session;
 use Kirby\Toolkit\Str;
 
 /**
@@ -178,7 +179,7 @@ class User extends ModelWithContent
 	 */
 	public function blueprint()
 	{
-		if (is_a($this->blueprint, 'Kirby\Cms\Blueprint') === true) {
+		if ($this->blueprint instanceof Blueprint) {
 			return $this->blueprint;
 		}
 
@@ -509,7 +510,7 @@ class User extends ModelWithContent
 		if ($class = (static::$models[$name] ?? null)) {
 			$object = new $class($props);
 
-			if (is_a($object, 'Kirby\Cms\User') === true) {
+			if ($object instanceof self) {
 				return $object;
 			}
 		}
@@ -618,7 +619,7 @@ class User extends ModelWithContent
 	 */
 	public function role()
 	{
-		if (is_a($this->role, 'Kirby\Cms\Role') === true) {
+		if ($this->role instanceof Role) {
 			return $this->role;
 		}
 
@@ -781,7 +782,7 @@ class User extends ModelWithContent
 		// use passed session options or session object if set
 		if (is_array($session) === true) {
 			$session = $this->kirby()->session($session);
-		} elseif (is_a($session, 'Kirby\Session\Session') === false) {
+		} elseif ($session instanceof Session === false) {
 			$session = $this->kirby()->session(['detect' => true]);
 		}
 

--- a/src/Cms/UserPicker.php
+++ b/src/Cms/UserPicker.php
@@ -43,7 +43,7 @@ class UserPicker extends Picker
 		// find the right default query
 		if (empty($this->options['query']) === false) {
 			$query = $this->options['query'];
-		} elseif (is_a($model, 'Kirby\Cms\User') === true) {
+		} elseif ($model instanceof User) {
 			$query = 'user.siblings';
 		} else {
 			$query = 'kirby.users';
@@ -53,7 +53,7 @@ class UserPicker extends Picker
 		$users = $model->query($query);
 
 		// catch invalid data
-		if (is_a($users, 'Kirby\Cms\Users') === false) {
+		if ($users instanceof Users === false) {
 			throw new InvalidArgumentException('Your query must return a set of users');
 		}
 

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -358,7 +358,7 @@ class UserRules
 	 */
 	public static function validRole(User $user, string $role): bool
 	{
-		if (is_a($user->kirby()->roles()->find($role), 'Kirby\Cms\Role') === true) {
+		if ($user->kirby()->roles()->find($role) instanceof Role) {
 			return true;
 		}
 

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -45,15 +45,18 @@ class Users extends Collection
 	public function add($object)
 	{
 		// add a users collection
-		if (is_a($object, self::class) === true) {
+		if ($object instanceof self) {
 			$this->data = array_merge($this->data, $object->data);
 
 		// add a user by id
-		} elseif (is_string($object) === true && $user = App::instance()->user($object)) {
+		} elseif (
+			is_string($object) === true &&
+			$user = App::instance()->user($object)
+		) {
 			$this->__set($user->id(), $user);
 
 		// add a user object
-		} elseif (is_a($object, 'Kirby\Cms\User') === true) {
+		} elseif ($object instanceof User) {
 			$this->__set($object->id(), $object);
 
 		// give a useful error message on invalid input;

--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -64,7 +64,7 @@ class Data
 
 		$handler = new $handler();
 
-		if (is_a($handler, Handler::class) === false) {
+		if ($handler instanceof Handler === false) {
 			throw new Exception('Handler for type: "' . $type . '" needs to extend Kirby\\Data\\Handler');
 		}
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -428,7 +428,10 @@ class Database
 		}
 
 		// define the default flag for the fetch method
-		if ($options['fetch'] instanceof Closure || $options['fetch'] === 'array') {
+		if (
+			$options['fetch'] instanceof Closure ||
+			$options['fetch'] === 'array'
+		) {
 			$flags = PDO::FETCH_ASSOC;
 		} else {
 			$flags = PDO::FETCH_CLASS|PDO::FETCH_PROPS_LATE;

--- a/src/Email/PHPMailer.php
+++ b/src/Email/PHPMailer.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Email;
 
+use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use PHPMailer\PHPMailer\PHPMailer as Mailer;
 
@@ -96,10 +97,10 @@ class PHPMailer extends Email
 		// accessible phpMailer instance
 		$beforeSend = $this->beforeSend();
 
-		if (empty($beforeSend) === false && is_a($beforeSend, 'Closure') === true) {
+		if ($beforeSend instanceof Closure) {
 			$mailer = $beforeSend->call($this, $mailer) ?? $mailer;
 
-			if (is_a($mailer, 'PHPMailer\PHPMailer\PHPMailer') === false) {
+			if ($mailer instanceof Mailer === false) {
 				throw new InvalidArgumentException('"beforeSend" option return should be instance of PHPMailer\PHPMailer\PHPMailer class');
 			}
 		}

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form;
 
+use Closure;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
@@ -86,7 +87,7 @@ class Field extends Component
 	{
 		if (
 			isset($this->options['api']) === true &&
-			is_a($this->options['api'], 'Closure') === true
+			$this->options['api'] instanceof Closure
 		) {
 			return $this->options['api']->call($this);
 		}
@@ -112,7 +113,7 @@ class Field extends Component
 			return null;
 		}
 
-		if (is_a($save, 'Closure') === true) {
+		if ($save instanceof Closure) {
 			return $save->call($this, $value);
 		}
 
@@ -472,7 +473,7 @@ class Field extends Component
 				continue;
 			}
 
-			if (is_a($validation, 'Closure') === true) {
+			if ($validation instanceof Closure) {
 				try {
 					$validation->call($this, $this->value());
 				} catch (Exception $e) {

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form;
 
+use Closure;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\HasSiblings;
@@ -767,7 +768,7 @@ abstract class FieldClass
 				continue;
 			}
 
-			if (is_a($validation, 'Closure') === true) {
+			if ($validation instanceof Closure) {
 				try {
 					$validation->call($this, $value);
 				} catch (Exception $e) {

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form;
 
+use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\Model;
 use Kirby\Data\Data;
@@ -262,7 +263,7 @@ class Form
 
 		// convert closures to values
 		foreach ($values as $key => $value) {
-			if (is_a($value, 'Closure') === true) {
+			if ($value instanceof Closure) {
 				$values[$key] = $value($original[$key] ?? null);
 			}
 		}

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -87,7 +87,7 @@ class Options
 
 		// add the model by the proper alias
 		foreach (static::aliases() as $className => $alias) {
-			if (is_a($model, $className) === true) {
+			if ($model instanceof $className) {
 				$data[$alias] = $model;
 			}
 		}

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -154,7 +154,7 @@ class OptionsQuery
 
 		// slow but precise resolving
 		foreach ($this->aliases as $className => $alias) {
-			if (is_a($object, $className) === true) {
+			if ($object instanceof $className) {
 				return $alias;
 			}
 		}

--- a/src/Form/OptionsQuery.php
+++ b/src/Form/OptionsQuery.php
@@ -181,7 +181,7 @@ class OptionsQuery
 			$result = new Collection($result);
 		}
 
-		if (is_a($result, 'Kirby\Toolkit\Collection') === false) {
+		if ($result instanceof Collection === false) {
 			throw new InvalidArgumentException('Invalid query result data');
 		}
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -99,19 +99,19 @@ class Request
 		$this->method  = $this->detectRequestMethod($options['method'] ?? null);
 
 		if (isset($options['body']) === true) {
-			$this->body = is_a($options['body'], Body::class) ? $options['body'] : new Body($options['body']);
+			$this->body = $options['body'] instanceof Body ? $options['body'] : new Body($options['body']);
 		}
 
 		if (isset($options['files']) === true) {
-			$this->files = is_a($options['files'], Files::class) ? $options['files'] : new Files($options['files']);
+			$this->files = $options['files'] instanceof Files ? $options['files'] : new Files($options['files']);
 		}
 
 		if (isset($options['query']) === true) {
-			$this->query = is_a($options['query'], Query::class) === true ? $options['query'] : new Query($options['query']);
+			$this->query = $options['query'] instanceof Query ? $options['query'] : new Query($options['query']);
 		}
 
 		if (isset($options['url']) === true) {
-			$this->url = is_a($options['url'], Uri::class) === true ? $options['url'] : new Uri($options['url']);
+			$this->url = $options['url'] instanceof Uri ? $options['url'] : new Uri($options['url']);
 		}
 	}
 

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -109,7 +109,7 @@ class Router
 		while ($loop === true) {
 			$route = $this->find($path, $method, $ignore);
 
-			if (is_a($this->beforeEach, Closure::class) === true) {
+			if ($this->beforeEach instanceof Closure) {
 				($this->beforeEach)($route, $path, $method);
 			}
 
@@ -125,7 +125,7 @@ class Router
 				$ignore[] = $route;
 			}
 
-			if (is_a($this->afterEach, Closure::class) === true) {
+			if ($this->afterEach instanceof Closure) {
 				$final  = $loop === false;
 				$result = ($this->afterEach)($route, $path, $method, $result, $final);
 			}

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -317,7 +317,7 @@ class Uri
 			$params = [];
 		}
 
-		$this->params = is_a($params, Params::class) === true ? $params : new Params($params);
+		$this->params = $params instanceof Params ? $params : new Params($params);
 		return $this;
 	}
 
@@ -335,7 +335,7 @@ class Uri
 	 */
 	public function setPath(Path|string|array|null $path = null): static
 	{
-		$this->path = is_a($path, Path::class) === true ? $path : new Path($path);
+		$this->path = $path instanceof Path ? $path : new Path($path);
 		return $this;
 	}
 
@@ -363,7 +363,7 @@ class Uri
 	 */
 	public function setQuery(Query|string|array|null $query = null): static
 	{
-		$this->query = is_a($query, Query::class) === true ? $query : new Query($query);
+		$this->query = $query instanceof Query ? $query : new Query($query);
 		return $this;
 	}
 

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Exception\Exception;
 use Kirby\Http\Response;
+use Throwable;
 
 /**
  * The Json abstract response class provides
@@ -38,18 +40,18 @@ abstract class Json
 	public static function response(mixed $data, array $options = []): Response
 	{
 		// handle redirects
-		if (is_a($data, 'Kirby\Panel\Redirect') === true) {
+		if ($data instanceof Redirect) {
 			$data = [
 				'redirect' => $data->location(),
 				'code'     => $data->code()
 			];
 
 		// handle Kirby exceptions
-		} elseif (is_a($data, 'Kirby\Exception\Exception') === true) {
+		} elseif ($data instanceof Exception) {
 			$data = static::error($data->getMessage(), $data->getHttpCode());
 
 		// handle exceptions
-		} elseif (is_a($data, 'Throwable') === true) {
+		} elseif ($data instanceof Throwable) {
 			$data = static::error($data->getMessage(), 500);
 
 		// only expect arrays from here on

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel;
 
+use Closure;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
@@ -48,12 +49,8 @@ abstract class Model
 		$option   = 'panel.' . $type . '.' . $this->model::CLASS_ALIAS . 'DragText';
 		$callback = $this->model->kirby()->option($option);
 
-		if (
-			empty($callback) === false &&
-			is_a($callback, 'Closure') === true &&
-			($dragText = $callback($this->model, ...$args)) !== null
-		) {
-			return $dragText;
+		if ($callback instanceof Closure) {
+			return $callback($this->model, ...$args);
 		}
 
 		return null;
@@ -210,8 +207,8 @@ abstract class Model
 
 		// validate the query result
 		if (
-			is_a($image, 'Kirby\Cms\File') === true ||
-			is_a($image, 'Kirby\Filesystem\Asset') === true
+			$image instanceof CmsFile ||
+			$image instanceof Asset
 		) {
 			return $image;
 		}

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel;
 
+use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\Url as CmsUrl;
 use Kirby\Cms\User;
@@ -234,7 +235,7 @@ class Panel
 	public static function response(mixed $result, array $options = []): Response
 	{
 		// pass responses directly down to the Kirby router
-		if (is_a($result, 'Kirby\Http\Response') === true) {
+		if ($result instanceof Response) {
 			return $result;
 		}
 
@@ -412,7 +413,7 @@ class Panel
 		foreach ($dropdowns as $name => $dropdown) {
 			// Handle shortcuts for dropdowns. The name is the pattern
 			// and options are defined in a Closure
-			if (is_a($dropdown, 'Closure') === true) {
+			if ($dropdown instanceof Closure) {
 				$dropdown = [
 					'pattern' => $name,
 					'action'  => $dropdown

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -2,11 +2,14 @@
 
 namespace Kirby\Panel;
 
+use Closure;
 use Kirby\Cms\App;
+use Kirby\Exception\Exception;
 use Kirby\Http\Response;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * The View response class handles Fiber
@@ -320,7 +323,7 @@ class View
 			$menuSetting = $area['menu'] ?? false;
 
 			// menu settings can be a callback that can return true, false or disabled
-			if (is_a($menuSetting, 'Closure') === true) {
+			if ($menuSetting instanceof Closure) {
 				$menuSetting = $menuSetting($areas, $permissions, $current);
 			}
 
@@ -369,15 +372,15 @@ class View
 	public static function response(mixed $data, array $options = []): Response
 	{
 		// handle redirects
-		if (is_a($data, 'Kirby\Panel\Redirect') === true) {
+		if ($data instanceof Redirect) {
 			return Response::redirect($data->location(), $data->code());
 
 		// handle Kirby exceptions
-		} elseif (is_a($data, 'Kirby\Exception\Exception') === true) {
+		} elseif ($data instanceof Exception) {
 			$data = static::error($data->getMessage(), $data->getHttpCode());
 
 		// handle regular exceptions
-		} elseif (is_a($data, 'Throwable') === true) {
+		} elseif ($data instanceof Throwable) {
 			$data = static::error($data->getMessage(), 500);
 
 		// only expect arrays from here on

--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -2,8 +2,10 @@
 
 namespace Kirby\Parsley;
 
+use DOMComment;
 use DOMNode;
 use DOMNodeList;
+use DOMText;
 use Kirby\Toolkit\Html;
 
 /**
@@ -101,12 +103,12 @@ class Inline
 	 */
 	public static function parseNode(DOMNode $node, array $marks = []): string|null
 	{
-		if (is_a($node, 'DOMText') === true) {
+		if ($node instanceof DOMText) {
 			return Html::encode($node->textContent);
 		}
 
 		// ignore comments
-		if (is_a($node, 'DOMComment') === true) {
+		if ($node instanceof DOMComment) {
 			return null;
 		}
 

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -3,7 +3,9 @@
 namespace Kirby\Parsley;
 
 use DOMDocument;
+use DOMElement;
 use DOMNode;
+use DOMText;
 use Kirby\Parsley\Schema\Plain;
 use Kirby\Toolkit\Dom;
 
@@ -159,7 +161,7 @@ class Parsley
 	 */
 	public function isBlock(DOMNode $element): bool
 	{
-		if (is_a($element, 'DOMElement') === false) {
+		if ($element instanceof DOMElement === false) {
 			return false;
 		}
 
@@ -171,11 +173,11 @@ class Parsley
 	 */
 	public function isInline(DOMNode $element): bool
 	{
-		if (is_a($element, 'DOMText') === true) {
+		if ($element instanceof DOMText) {
 			return true;
 		}
 
-		if (is_a($element, 'DOMElement') === true) {
+		if ($element instanceof DOMElement) {
 			// all spans will be treated as inline elements
 			if ($element->tagName === 'span') {
 				return true;

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Parsley\Schema;
 
+use DOMElement;
+use DOMText;
 use Kirby\Parsley\Element;
 use Kirby\Toolkit\Str;
 
@@ -26,12 +28,12 @@ class Blocks extends Plain
 
 		// get all the text for the quote
 		foreach ($node->children() as $child) {
-			if (is_a($child, 'DOMText') === true) {
+			if ($child instanceof DOMText) {
 				$text[] = trim($child->textContent);
 			}
 
 			if (
-				is_a($child, 'DOMElement') === true &&
+				$child instanceof DOMElement &&
 				$child->tagName !== 'footer'
 			) {
 				$text[] = (new Element($child))->innerHTML($this->marks());
@@ -61,7 +63,7 @@ class Blocks extends Plain
 	 */
 	public function fallback(Element|string $element): array|null
 	{
-		if (is_a($element, Element::class) === true) {
+		if ($element instanceof Element) {
 			$html = $element->innerHtml();
 
 			// wrap the inner HTML in a p tag if it doesn't
@@ -192,9 +194,9 @@ class Blocks extends Plain
 			$innerHtml = '';
 
 			foreach ($li->children() as $child) {
-				if (is_a($child, 'DOMText') === true) {
+				if ($child instanceof DOMText) {
 					$innerHtml .= $child->textContent;
-				} elseif (is_a($child, 'DOMElement') === true) {
+				} elseif ($child instanceof DOMElement) {
 					$child = new Element($child);
 
 					if (in_array($child->tagName(), ['ul', 'ol']) === true) {

--- a/src/Parsley/Schema/Plain.php
+++ b/src/Parsley/Schema/Plain.php
@@ -26,7 +26,7 @@ class Plain extends Schema
 	 */
 	public function fallback(Element|string $element): array|null
 	{
-		if (is_a($element, Element::class) === true) {
+		if ($element instanceof Element) {
 			$text = $element->innerText();
 		} elseif (is_string($element) === true) {
 			$text = trim($element);

--- a/src/Sane/Svg.php
+++ b/src/Sane/Svg.php
@@ -411,7 +411,7 @@ class Svg extends Xml
 
 			// the target must not contain any other <use> elements
 			if (
-				is_a($target, DOMElement::class) === true &&
+				$target instanceof DOMElement &&
 				$target->getElementsByTagName('use')->count() > 0
 			) {
 				$errors[] = new InvalidArgumentException(

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -727,7 +727,7 @@ class Session
 		$this->renewable    = $data['renewable'];
 
 		// reload data into existing object to avoid breaking memory references
-		if (is_a($this->data, 'Kirby\Session\SessionData')) {
+		if ($this->data instanceof SessionData) {
 			$this->data()->reload($data['data']);
 		} else {
 			$this->data = new SessionData($this, $data['data']);

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -40,7 +40,7 @@ class Sessions
 	{
 		if (is_string($store)) {
 			$this->store = new FileSessionStore($store);
-		} elseif (is_a($store, 'Kirby\Session\SessionStore') === true) {
+		} elseif ($store instanceof SessionStore) {
 			$this->store = $store;
 		} else {
 			throw new InvalidArgumentException([

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -121,7 +121,7 @@ class KirbyTag
 		}
 
 		if (
-			is_a($parent, File::class) === true &&
+			$parent instanceof File &&
 			$file = $parent->page()->file($path)
 		) {
 			return $file;
@@ -203,7 +203,7 @@ class KirbyTag
 	{
 		$callback = static::$types[$this->type]['html'] ?? null;
 
-		if (is_a($callback, Closure::class) === true) {
+		if ($callback instanceof Closure) {
 			return (string)$callback($this);
 		}
 

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Closure;
 use Exception;
 
 /**
@@ -38,7 +39,7 @@ class A
 	public static function apply(array $array, ...$args): array
 	{
 		array_walk_recursive($array, function (&$item) use ($args) {
-			if (is_a($item, 'Closure')) {
+			if ($item instanceof Closure) {
 				$item = $item(...$args);
 			}
 		});
@@ -687,7 +688,7 @@ class A
 	public static function update(array $array, array $update): array
 	{
 		foreach ($update as $key => $value) {
-			if (is_a($value, 'Closure') === true) {
+			if ($value instanceof Closure) {
 				$array[$key] = call_user_func($value, static::get($array, $key));
 			} else {
 				$array[$key] = $value;

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use ArgumentCountError;
+use Closure;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
@@ -179,7 +180,7 @@ class Component
 	protected function applyProps(array $props): void
 	{
 		foreach ($props as $propName => $propFunction) {
-			if (is_a($propFunction, 'Closure') === true) {
+			if ($propFunction instanceof Closure) {
 				if (isset($this->attrs[$propName]) === true) {
 					try {
 						$this->$propName = $this->props[$propName] = $propFunction->call($this, $this->attrs[$propName]);
@@ -209,7 +210,7 @@ class Component
 	protected function applyComputed(array $computed): void
 	{
 		foreach ($computed as $computedName => $computedFunction) {
-			if (is_a($computedFunction, 'Closure') === true) {
+			if ($computedFunction instanceof Closure) {
 				$this->$computedName = $this->computed[$computedName] = $computedFunction->call($this);
 			}
 		}
@@ -283,7 +284,7 @@ class Component
 	 */
 	public function toArray(): array
 	{
-		if (is_a($this->options['toArray'] ?? null, 'Closure') === true) {
+		if (($this->options['toArray'] ?? null) instanceof Closure) {
 			return $this->options['toArray']->call($this);
 		}
 

--- a/src/Toolkit/Controller.php
+++ b/src/Toolkit/Controller.php
@@ -58,7 +58,7 @@ class Controller
 
 		$function = F::load($file);
 
-		if (is_a($function, 'Closure') === false) {
+		if ($function instanceof Closure === false) {
 			return null;
 		}
 

--- a/src/Toolkit/Date.php
+++ b/src/Toolkit/Date.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
@@ -32,7 +33,7 @@ class Date extends DateTime
 			$datetime = date('r', $datetime);
 		}
 
-		if (is_a($datetime, 'DateTimeInterface') === true) {
+		if ($datetime instanceof DateTimeInterface) {
 			$datetime = $datetime->format('r');
 		}
 

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -9,6 +9,7 @@ use DOMDocumentType;
 use DOMElement;
 use DOMNode;
 use DOMProcessingInstruction;
+use DOMText;
 use DOMXPath;
 use Kirby\Cms\App;
 use Kirby\Exception\Exception;
@@ -577,7 +578,7 @@ class Dom
 		// convert the `DOMNodeList` to an array first, otherwise removing
 		// nodes would shift the list and make subsequent operations fail
 		foreach (iterator_to_array($this->doc->childNodes, false) as $child) {
-			if (is_a($child, 'DOMDocumentType') === true) {
+			if ($child instanceof DOMDocumentType) {
 				$this->sanitizeDoctype($child, $options, $errors);
 			}
 		}
@@ -634,7 +635,7 @@ class Dom
 		foreach ($node->childNodes as $childNode) {
 			// discard text nodes as they can be unexpected
 			// directly in the parent element
-			if (is_a($childNode, 'DOMText') === true) {
+			if ($childNode instanceof DOMText) {
 				continue;
 			}
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -217,7 +217,7 @@ class I18n
 			return static::$translations[$locale];
 		}
 
-		if (is_a(static::$load, 'Closure') === true) {
+		if (static::$load instanceof Closure) {
 			return static::$translations[$locale] = (static::$load)($locale);
 		}
 
@@ -283,7 +283,7 @@ class I18n
 			return null;
 		}
 
-		if (is_a($translation, 'Closure') === true) {
+		if ($translation instanceof Closure) {
 			return $translation($count);
 		}
 

--- a/src/Toolkit/Pagination.php
+++ b/src/Toolkit/Pagination.php
@@ -75,7 +75,7 @@ class Pagination
 
 		$params = [];
 
-		if (is_a($a, static::class) === true) {
+		if ($a instanceof static) {
 			/**
 			 * First argument is a pagination/self object
 			 */

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Closure;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 
@@ -98,7 +99,7 @@ class Query
 				if (array_key_exists($method, $data) === true) {
 					$value = $data[$method];
 
-					if (is_a($value, 'Closure') === true) {
+					if ($value instanceof Closure) {
 						$value = $value(...$args);
 					} elseif ($args !== []) {
 						throw new InvalidArgumentException('Cannot access array element ' . $method . ' with arguments');

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Closure;
 use DateTime;
 use Exception;
 use IntlDateFormatter;
@@ -332,7 +333,7 @@ class Str
 		}
 
 		// $format is an IntlDateFormatter instance
-		if (is_a($format, 'IntlDateFormatter') === true) {
+		if ($format instanceof IntlDateFormatter) {
 			return $format->format($time ?? time());
 		}
 
@@ -714,15 +715,15 @@ class Str
 	public static function replace($string, $search, $replace, $limit = -1)
 	{
 		// convert Kirby collections to arrays
-		if (is_a($string, 'Kirby\Toolkit\Collection') === true) {
+		if ($string instanceof Collection) {
 			$string = $string->toArray();
 		}
 
-		if (is_a($search, 'Kirby\Toolkit\Collection') === true) {
+		if ($search instanceof Collection) {
 			$search  = $search->toArray();
 		}
 
-		if (is_a($replace, 'Kirby\Toolkit\Collection') === true) {
+		if ($replace instanceof Collection) {
 			$replace = $replace->toArray();
 		}
 
@@ -878,7 +879,7 @@ class Str
 	 */
 	public static function safeTemplate(string $string = null, array $data = [], array $options = []): string
 	{
-		$callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
+		$callback = ($options['callback'] ?? null) instanceof Closure ? $options['callback'] : null;
 		$fallback = $options['fallback'] ?? '';
 
 		// replace and escape
@@ -1169,7 +1170,7 @@ class Str
 	public static function template(string $string = null, array $data = [], array $options = []): string
 	{
 		$fallback = $options['fallback'] ?? null;
-		$callback = is_a(($options['callback'] ?? null), 'Closure') === true ? $options['callback'] : null;
+		$callback = ($options['callback'] ?? null) instanceof Closure ? $options['callback'] : null;
 		$start    = (string)($options['start'] ?? '{{');
 		$end      = (string)($options['end'] ?? '}}');
 

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Toolkit;
 
+use Countable;
 use Exception;
+use Kirby\Cms\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Idn;
 use ReflectionFunction;
@@ -573,7 +575,7 @@ V::$validators = [
 	'size' => function ($value, $size, $operator = '=='): bool {
 		// if value is field object, first convert it to a readable value
 		// it is important to check at the beginning as the value can be string or numeric
-		if (is_a($value, '\Kirby\Cms\Field') === true) {
+		if ($value instanceof Field) {
 			$value = $value->value();
 		}
 
@@ -584,7 +586,7 @@ V::$validators = [
 		} elseif (is_array($value) === true) {
 			$count = count($value);
 		} elseif (is_object($value) === true) {
-			if ($value instanceof \Countable) {
+			if ($value instanceof Countable) {
 				$count = count($value);
 			} elseif (method_exists($value, 'count') === true) {
 				$count = $value->count();

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Exception\Exception;
 use Kirby\Filesystem\F;
 use ReflectionMethod;
+use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
 /**
@@ -390,7 +391,7 @@ class AppErrorsTest extends TestCase
 	{
 		ob_start();
 
-		if (is_a($path, '\Whoops\Handler\CallbackHandler') === true) {
+		if ($path instanceof CallbackHandler) {
 			$path->handle();
 		} else {
 			F::load($path);

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -77,7 +77,7 @@ class TestCase extends BaseTestCase
 			$this->assertEquals($id, $input->id());
 		}
 
-		if (is_a($id, Page::class)) {
+		if ($id instanceof Page) {
 			$this->assertEquals($input, $id);
 		}
 	}
@@ -90,7 +90,7 @@ class TestCase extends BaseTestCase
 			$this->assertEquals($id, $input->id());
 		}
 
-		if (is_a($id, File::class)) {
+		if ($id instanceof File) {
 			$this->assertEquals($input, $id);
 		}
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

To improve static analysis.
Also more performant.

### Refactoring
- Use PHP's `instanceof` instead of `is_a()`


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
