### PR TITLE
Fix error messages for field methods

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -62,9 +62,22 @@ return function (App $app) {
 		 * @return \Kirby\Cms\Blocks
 		 */
 		'toBlocks' => function (Field $field) {
-			$blocks = Blocks::parse($field->value());
-			$blocks = Blocks::factory($blocks, ['parent' => $field->parent()]);
-			return $blocks->filter('isHidden', false);
+			try {
+				$blocks = Blocks::parse($field->value());
+				$blocks = Blocks::factory($blocks, [
+					'parent' => $field->parent()
+				]);
+				return $blocks->filter('isHidden', false);
+
+			} catch (Throwable) {
+				$message = 'Invalid blocks data for "' . $field->key() . '" field';
+
+				if ($field->parent() !== null) {
+					$message .= ' on parent "' . $field->parent()->title() . '"';
+				}
+
+				throw new InvalidArgumentException($message);
+			}
 		},
 
 		/**

--- a/config/methods.php
+++ b/config/methods.php
@@ -62,21 +62,9 @@ return function (App $app) {
 		 * @return \Kirby\Cms\Blocks
 		 */
 		'toBlocks' => function (Field $field) {
-			try {
-				$blocks = Blocks::factory(Blocks::parse($field->value()), [
-					'parent' => $field->parent(),
-				]);
-
-				return $blocks->filter('isHidden', false);
-			} catch (Throwable) {
-				if ($field->parent() === null) {
-					$message = 'Invalid blocks data for "' . $field->key() . '" field';
-				} else {
-					$message = 'Invalid blocks data for "' . $field->key() . '" field on parent "' . $field->parent()->title() . '"';
-				}
-
-				throw new InvalidArgumentException($message);
-			}
+			$blocks = Blocks::parse($field->value());
+			$blocks = Blocks::factory($blocks, ['parent' => $field->parent()]);
+			return $blocks->filter('isHidden', false);
 		},
 
 		/**
@@ -250,10 +238,10 @@ return function (App $app) {
 			try {
 				return new Structure(Data::decode($field->value, 'yaml'), $field->parent());
 			} catch (Exception) {
-				if ($field->parent() === null) {
-					$message = 'Invalid structure data for "' . $field->key() . '" field';
-				} else {
-					$message = 'Invalid structure data for "' . $field->key() . '" field on parent "' . $field->parent()->title() . '"';
+				$message = 'Invalid structure data for "' . $field->key() . '" field';
+
+				if ($parent = $field->parent()) {
+					$message .= ' on parent "' . $parent->title() . '"';
 				}
 
 				throw new InvalidArgumentException($message);

--- a/config/methods.php
+++ b/config/methods.php
@@ -68,7 +68,6 @@ return function (App $app) {
 					'parent' => $field->parent()
 				]);
 				return $blocks->filter('isHidden', false);
-
 			} catch (Throwable) {
 				$message = 'Invalid blocks data for "' . $field->key() . '" field';
 

--- a/config/methods.php
+++ b/config/methods.php
@@ -71,8 +71,8 @@ return function (App $app) {
 			} catch (Throwable) {
 				$message = 'Invalid blocks data for "' . $field->key() . '" field';
 
-				if ($field->parent() !== null) {
-					$message .= ' on parent "' . $field->parent()->title() . '"';
+				if ($parent = $field->parent()) {
+					$message .= ' on parent "' . $parent->title() . '"';
 				}
 
 				throw new InvalidArgumentException($message);

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -371,28 +371,10 @@ class FieldMethodsTest extends TestCase
 		];
 
 		$yaml  = Yaml::encode($data);
-		$field = $this->field($yaml);
+		$field = $this->field($yaml, kirby()->page('files'));
 
 		$this->expectException('Kirby\Exception\InvalidArgumentException');
-		$this->expectExceptionMessage('Invalid structure data for "test" field');
-
-		$field->toStructure();
-	}
-
-	public function testToStructureWithInvalidDataWithParent()
-	{
-		$data = [
-			['title' => 'a'],
-			['title' => 'b'],
-			'title'
-		];
-
-		$yaml  = Yaml::encode($data);
-		$page  = new Page(['slug' => 'test']);
-		$field = $this->field($yaml, $page);
-
-		$this->expectException('Kirby\Exception\InvalidArgumentException');
-		$this->expectExceptionMessage('Invalid structure data for "test" field on parent "test"');
+		$this->expectExceptionMessage('Invalid structure data for "test" field on parent "files"');
 
 		$field->toStructure();
 	}
@@ -813,6 +795,25 @@ class FieldMethodsTest extends TestCase
 			$this->assertSame($row['content'], $block->content()->data());
 			$this->assertNotEmpty($block->toHtml());
 		}
+	}
+
+	public function testToBlocksWithInvalidData()
+	{
+		$data = [
+			[
+				'content' => [
+					'text' => 'foo',
+				]
+			]
+		];
+
+		$json   = Json::encode($data);
+		$field  = new Field(kirby()->page('files'), 'test', $json);
+
+		$this->expectException('Kirby\Exception\InvalidArgumentException');
+		$this->expectExceptionMessage('Invalid blocks data for "test" field on parent "files"');
+
+		$field->toBlocks();
 	}
 
 	public function testToLayouts()

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -19,9 +19,9 @@ class FieldMethodsTest extends TestCase
 		]);
 	}
 
-	public function field($value = '')
+	public function field($value = '', $parent = null)
 	{
-		return new Field(null, 'test', $value);
+		return new Field($parent, 'test', $value);
 	}
 
 	public function testFieldMethodCaseInsensitivity()
@@ -376,7 +376,25 @@ class FieldMethodsTest extends TestCase
 		$this->expectException('Kirby\Exception\InvalidArgumentException');
 		$this->expectExceptionMessage('Invalid structure data for "test" field');
 
-		$structure = $field->toStructure();
+		$field->toStructure();
+	}
+
+	public function testToStructureWithInvalidDataWithParent()
+	{
+		$data = [
+			['title' => 'a'],
+			['title' => 'b'],
+			'title'
+		];
+
+		$yaml  = Yaml::encode($data);
+		$page  = new Page(['slug' => 'test']);
+		$field = $this->field($yaml, $page);
+
+		$this->expectException('Kirby\Exception\InvalidArgumentException');
+		$this->expectExceptionMessage('Invalid structure data for "test" field on parent "test"');
+
+		$field->toStructure();
 	}
 
 	public function testToDefaultUrl()


### PR DESCRIPTION
DRY-ed the error message and added unit tests for `$field->toBlocks()` and `$field->toStructure()`.

Would be great to have this merged for 3.8 as this would improve code coverage for UUID PR.