### PR TITLE
Missing on form submit event

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -570,7 +570,7 @@ export default {
 		 * @param {array} values
 		 */
 		onFormInput(e) {
-			this.$emit("onFormInput", e);
+			this.$emit("formInput", e);
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -566,8 +566,7 @@ export default {
 			}
 		},
 		/**
-		 * When the field's value changes
-		 * @param {array} values
+		 * Triggered whenever any form field value changes
 		 */
 		onFormInput(e) {
 			this.$emit("onFormInput", e);

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -24,6 +24,7 @@
 			@discard="onFormDiscard"
 			@paginate="onFormPaginate($event.offset)"
 			@submit="onFormSubmit"
+			@input="onFormInput"
 		/>
 
 		<!-- Empty State -->
@@ -563,6 +564,13 @@ export default {
 			} else {
 				return true;
 			}
+		},
+		/**
+		 * When the field's value changes
+		 * @param {array} values
+		 */
+		onFormInput(e) {
+			this.$emit("onFormInput", e);
 		}
 	}
 };


### PR DESCRIPTION
## This PR add a new onFormSubmit event in the StructureField vue file

Useful for Kirby panel Vue plugin
It replace the failed PR #4513

### Breaking changes
This time, I hope there'll be no issue with this.
It's just a new event, it do not fire the onInput event like #4513

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
