### PR TITLE
Parent model for filesystem

### DIFF
--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -333,6 +333,14 @@ class File
 	}
 
 	/**
+	 * Returns the parent file model
+	 */
+	public function model(): object|null
+	{
+		return $this->model;
+	}
+
+	/**
 	 * Returns the file's last modification time
 	 *
 	 * @param string|null $handler date, intl or strftime

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -31,7 +31,7 @@ class File
 
 	/**
 	 * Parent file model
-	 * The model object must use the "Kirby\Filesystem\IsFile" trait
+	 * The model object must use the `\Kirby\Filesystem\IsFile` trait
 	 */
 	protected object|null $model = null;
 

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -31,8 +31,9 @@ class File
 
 	/**
 	 * Parent file model
+	 * The model object must use the "Kirby\Filesystem\IsFile" trait
 	 *
-	 * @var \Kirby\Filesystem\IsFile|null
+	 * @var object|null
 	 */
 	protected $model;
 
@@ -431,7 +432,7 @@ class File
 	/**
 	 * Setter for the parent file model
 	 *
-	 * @param \Kirby\Filesystem\IsFile|null $model
+	 * @param object|null $model
 	 * @return $this
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -426,11 +426,7 @@ class File
 	 */
 	public function root(): string|null
 	{
-		if ($this->root !== null) {
-			return $this->root;
-		}
-
-		return $this->root = $this->model?->root();
+		return $this->root ??= $this->model?->root();
 	}
 
 	/**
@@ -478,18 +474,10 @@ class File
 	 */
 	public function url(): string|null
 	{
-		if ($this->url !== null) {
-			return $this->url;
-		}
-
 		// lazily determine the URL from the model object
 		// only if it's needed to avoid breaking custom file::url
 		// components that rely on `$cmsFile->asset()` methods
-		if ($this->model !== null) {
-			return $this->url = $this->model->url();
-		}
-
-		return null;
+		return $this->url ??= $this->model?->url();
 	}
 
 	/**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -4,6 +4,7 @@ namespace Kirby\Filesystem;
 
 use IntlDateFormatter;
 use Kirby\Cms\App;
+use Kirby\Cms\File as CmsFile;
 use Kirby\Exception\Exception;
 use Kirby\Http\Response;
 use Kirby\Sane\Sane;
@@ -425,6 +426,18 @@ class File
 	public function root(): string|null
 	{
 		return $this->root;
+	}
+
+	/**
+	 * Setter for the parent file model
+	 *
+	 * @param \Kirby\Cms\File $model
+	 * @return $this
+	 */
+	protected function setModel(?CmsFile $model = null)
+	{
+		$this->model = $model;
+		return $this;
 	}
 
 	/**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -467,7 +467,18 @@ class File
 	 */
 	public function url(): string|null
 	{
-		return $this->url ??= $this->model !== null ? $this->model->url() : null;
+		if ($this->url !== null) {
+			return $this->url;
+		}
+
+		// lazily determine the URL from the model object
+		// only if it's needed to avoid breaking custom file::url
+		// components that rely on `$cmsFile->asset()` methods
+		if ($this->model !== null) {
+			return $this->url = $this->model->url();
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -4,8 +4,8 @@ namespace Kirby\Filesystem;
 
 use IntlDateFormatter;
 use Kirby\Cms\App;
-use Kirby\Cms\File as CmsFile;
 use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Response;
 use Kirby\Sane\Sane;
 use Kirby\Toolkit\Escape;
@@ -32,7 +32,7 @@ class File
 	/**
 	 * Parent file model
 	 *
-	 * @var \Kirby\Cms\File
+	 * @var \Kirby\Filesystem\IsFile|null
 	 */
 	protected $model;
 
@@ -431,11 +431,17 @@ class File
 	/**
 	 * Setter for the parent file model
 	 *
-	 * @param \Kirby\Cms\File $model
+	 * @param \Kirby\Filesystem\IsFile|null $model
 	 * @return $this
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	protected function setModel(?CmsFile $model = null)
+	protected function setModel($model = null)
 	{
+		if ($model !== null && in_array(IsFile::class, class_uses($model)) !== true) {
+			throw new InvalidArgumentException('The model object must use the "Kirby\Filesystem\IsFile" trait');
+		}
+
 		$this->model = $model;
 		return $this;
 	}

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -333,7 +333,7 @@ class File
 	}
 
 	/**
-	 * Returns the parent file model
+	 * Returns the parent file model, which uses this instance as proxied file asset
 	 */
 	public function model(): object|null
 	{
@@ -436,11 +436,11 @@ class File
 	}
 
 	/**
-	 * Setter for the parent file model
+	 * Setter for the parent file model, which uses this instance as proxied file asset
 	 *
 	 * @return $this
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws \Kirby\Exception\InvalidArgumentException When the model does not use the `Kirby\Filesystem\IsFile` trait
 	 */
 	protected function setModel(object|null $model = null): static
 	{

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -29,6 +29,13 @@ class File
 	use Properties;
 
 	/**
+	 * Parent file model
+	 *
+	 * @var \Kirby\Cms\File
+	 */
+	protected $model;
+
+	/**
 	 * Absolute file path
 	 */
 	protected string|null $root = null;
@@ -447,7 +454,7 @@ class File
 	 */
 	public function url(): string|null
 	{
-		return $this->url;
+		return $this->url ??= $this->model !== null ? $this->model->url() : null;
 	}
 
 	/**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -107,8 +107,8 @@ class File
 	 */
 	public function copy(string $target, bool $force = false): static
 	{
-		if (F::copy($this->root, $target, $force) !== true) {
-			throw new Exception('The file "' . $this->root . '" could not be copied');
+		if (F::copy($this->root(), $target, $force) !== true) {
+			throw new Exception('The file "' . $this->root() . '" could not be copied');
 		}
 
 		return new static($target);
@@ -133,8 +133,8 @@ class File
 	 */
 	public function delete(): bool
 	{
-		if (F::remove($this->root) !== true) {
-			throw new Exception('The file "' . $this->root . '" could not be deleted');
+		if (F::remove($this->root()) !== true) {
+			throw new Exception('The file "' . $this->root() . '" could not be deleted');
 		}
 
 		return true;
@@ -149,7 +149,7 @@ class File
 	 */
 	public function download(string|null $filename = null): string
 	{
-		return Response::download($this->root, $filename ?? $this->filename());
+		return Response::download($this->root(), $filename ?? $this->filename());
 	}
 
 	/**
@@ -157,7 +157,7 @@ class File
 	 */
 	public function exists(): bool
 	{
-		return file_exists($this->root) === true;
+		return file_exists($this->root()) === true;
 	}
 
 	/**
@@ -165,7 +165,7 @@ class File
 	 */
 	public function extension(): string
 	{
-		return F::extension($this->root);
+		return F::extension($this->root());
 	}
 
 	/**
@@ -173,7 +173,7 @@ class File
 	 */
 	public function filename(): string
 	{
-		return basename($this->root);
+		return basename($this->root());
 	}
 
 	/**
@@ -181,7 +181,7 @@ class File
 	 */
 	public function hash(): string
 	{
-		return md5($this->root);
+		return md5($this->root());
 	}
 
 	/**
@@ -214,7 +214,7 @@ class File
 	 */
 	public function is(string $value): bool
 	{
-		return F::is($this->root, $value);
+		return F::is($this->root(), $value);
 	}
 
 	/**
@@ -222,7 +222,7 @@ class File
 	 */
 	public function isReadable(): bool
 	{
-		return is_readable($this->root) === true;
+		return is_readable($this->root()) === true;
 	}
 
 	/**
@@ -247,7 +247,7 @@ class File
 	 */
 	public function isWritable(): bool
 	{
-		return F::isWritable($this->root);
+		return F::isWritable($this->root());
 	}
 
 	/**
@@ -331,7 +331,7 @@ class File
 	 */
 	public function mime(): string|null
 	{
-		return Mime::type($this->root);
+		return Mime::type($this->root());
 	}
 
 	/**
@@ -346,7 +346,7 @@ class File
 		$kirby = $this->kirby();
 
 		return F::modified(
-			$this->root,
+			$this->root(),
 			$format,
 			$handler ?? ($kirby ? $kirby->option('date.handler', 'date') : 'date')
 		);
@@ -359,8 +359,8 @@ class File
 	 */
 	public function move(string $newRoot, bool $overwrite = false): static
 	{
-		if (F::move($this->root, $newRoot, $overwrite) !== true) {
-			throw new Exception('The file: "' . $this->root . '" could not be moved to: "' . $newRoot . '"');
+		if (F::move($this->root(), $newRoot, $overwrite) !== true) {
+			throw new Exception('The file: "' . $this->root() . '" could not be moved to: "' . $newRoot . '"');
 		}
 
 		return new static($newRoot);
@@ -372,7 +372,7 @@ class File
 	 */
 	public function name(): string
 	{
-		return pathinfo($this->root, PATHINFO_FILENAME);
+		return pathinfo($this->root(), PATHINFO_FILENAME);
 	}
 
 	/**
@@ -385,7 +385,7 @@ class File
 	 */
 	public function niceSize(string|false|null $locale = null): string
 	{
-		return F::niceSize($this->root, $locale);
+		return F::niceSize($this->root(), $locale);
 	}
 
 	/**
@@ -393,7 +393,7 @@ class File
 	 */
 	public function read(): string|false
 	{
-		return F::read($this->root);
+		return F::read($this->root());
 	}
 
 	/**
@@ -401,7 +401,7 @@ class File
 	 */
 	public function realpath(): string
 	{
-		return realpath($this->root);
+		return realpath($this->root());
 	}
 
 	/**
@@ -412,10 +412,10 @@ class File
 	 */
 	public function rename(string $newName, bool $overwrite = false): static
 	{
-		$newRoot = F::rename($this->root, $newName, $overwrite);
+		$newRoot = F::rename($this->root(), $newName, $overwrite);
 
 		if ($newRoot === false) {
-			throw new Exception('The file: "' . $this->root . '" could not be renamed to: "' . $newName . '"');
+			throw new Exception('The file: "' . $this->root() . '" could not be renamed to: "' . $newName . '"');
 		}
 
 		return new static($newRoot);
@@ -426,7 +426,11 @@ class File
 	 */
 	public function root(): string|null
 	{
-		return $this->root;
+		if ($this->root !== null) {
+			return $this->root;
+		}
+
+		return $this->root = $this->model?->root();
 	}
 
 	/**
@@ -513,7 +517,7 @@ class File
 	 */
 	public function sha1(): string
 	{
-		return sha1_file($this->root);
+		return sha1_file($this->root());
 	}
 
 	/**
@@ -521,7 +525,7 @@ class File
 	 */
 	public function size(): int
 	{
-		return F::size($this->root);
+		return F::size($this->root());
 	}
 
 	/**
@@ -563,7 +567,7 @@ class File
 	 */
 	public function type(): string|null
 	{
-		return F::type($this->root);
+		return F::type($this->root());
 	}
 
 	/**
@@ -587,8 +591,8 @@ class File
 	 */
 	public function write(string $content): bool
 	{
-		if (F::write($this->root, $content) !== true) {
-			throw new Exception('The file "' . $this->root . '" could not be written');
+		if (F::write($this->root(), $content) !== true) {
+			throw new Exception('The file "' . $this->root() . '" could not be written');
 		}
 
 		return true;

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -32,10 +32,8 @@ class File
 	/**
 	 * Parent file model
 	 * The model object must use the "Kirby\Filesystem\IsFile" trait
-	 *
-	 * @var object|null
 	 */
-	protected $model;
+	protected object|null $model = null;
 
 	/**
 	 * Absolute file path
@@ -432,12 +430,11 @@ class File
 	/**
 	 * Setter for the parent file model
 	 *
-	 * @param object|null $model
 	 * @return $this
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	protected function setModel($model = null)
+	protected function setModel(object|null $model = null): static
 	{
 		if ($model !== null && in_array(IsFile::class, class_uses($model)) !== true) {
 			throw new InvalidArgumentException('The model object must use the "Kirby\Filesystem\IsFile" trait');

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -84,10 +84,13 @@ trait IsFile
 			return $this->asset;
 		}
 
-		$props = $props ?? [
-			'root' => $this->root(),
-			'url'  => $this->url()
-		];
+		if (is_array($props) === false) {
+			$props = [
+				'root' => $props ?? $this->root()
+			];
+		}
+
+		$props['model'] ??= $this;
 
 		return $this->asset = match ($this->type()) {
 			'image' => new Image($props),

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -84,10 +84,10 @@ trait IsFile
 			return $this->asset;
 		}
 
-		if (is_array($props) === false) {
-			$props = [
-				'root' => $props ?? $this->root()
-			];
+		$props ??= [];
+
+		if (is_string($props) === true) {
+			$props = ['root' => $props];
 		}
 
 		$props['model'] ??= $this;

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Filesystem;
 
+use Kirby\Cms\File as CmsFile;
+use Kirby\Cms\Page;
 use PHPUnit\Framework\TestCase as TestCase;
 
 require_once __DIR__ . '/mocks.php';
@@ -411,8 +413,8 @@ class FileTest extends TestCase
 	 */
 	public function testModel()
 	{
-		$parent = \Kirby\Cms\Page::factory(['slug' => 'test']);
-		$model = \Kirby\Cms\File::factory([
+		$parent = Page::factory(['slug' => 'test']);
+		$model = CmsFile::factory([
 			'filename' => 'test.js',
 			'parent' => $parent
 		]);
@@ -460,7 +462,7 @@ class FileTest extends TestCase
 
 		new File([
 			'root' => $this->fixtures . '/test.js',
-			'model' => \Kirby\Cms\Page::factory(['slug' => 'test'])
+			'model' => Page::factory(['slug' => 'test'])
 		]);
 	}
 

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -297,6 +297,15 @@ class FileTest extends TestCase
 	}
 
 	/**
+	 * @covers ::isReadable
+	 */
+	public function testIsReadable()
+	{
+		$file = $this->_file();
+		$this->assertSame(is_readable($file->root()), $file->isReadable());
+	}
+
+	/**
 	 * @covers ::isResizable
 	 */
 	public function testIsResizable()
@@ -394,6 +403,65 @@ class FileTest extends TestCase
 	{
 		$file = $this->_file();
 		$this->assertSame('text/plain', $file->mime());
+	}
+
+	/**
+	 * @covers ::model
+	 * @covers ::setModel
+	 */
+	public function testModel()
+	{
+		$parent = \Kirby\Cms\Page::factory(['slug' => 'test']);
+		$model = \Kirby\Cms\File::factory([
+			'filename' => 'test.js',
+			'parent' => $parent
+		]);
+
+		$file = new File([
+			'root' => $this->fixtures . '/test.js',
+			'model' => $model
+		]);
+
+		$this->assertTrue(in_array(IsFile::class, class_uses($file->model())));
+		$this->assertSame($model, $file->model());
+	}
+
+	/**
+	 * @covers ::model
+	 * @covers ::setModel
+	 */
+	public function testParentModel()
+	{
+		$parent = Page::factory([
+			'slug' => 'test',
+			'files' => [
+				['filename' => 'a.jpg'],
+				['filename' => 'b.jpg'],
+				['filename' => 'c.jpg'],
+			]
+		]);
+
+		$file = $parent->file('a.jpg');
+		$asset = $file->asset();
+
+		$this->assertTrue(in_array(IsFile::class, class_uses($asset->model())));
+		$this->assertSame($file, $asset->model());
+		$this->assertSame($file->url(), $asset->url());
+		$this->assertSame($file->root(), $asset->root());
+	}
+
+	/**
+	 * @covers ::setModel
+	 */
+	public function testInvalidModel()
+	{
+		$this->expectException('\Kirby\Exception\InvalidArgumentException');
+		$this->expectExceptionMessage('The model object must use the "Kirby\Filesystem\IsFile" trait');
+
+		new File([
+			'root' => $this->fixtures . '/test.js',
+			'model' => \Kirby\Cms\Page::factory(['slug' => 'test'])
+		]);
 	}
 
 	/**

--- a/tests/Filesystem/IsFileTest.php
+++ b/tests/Filesystem/IsFileTest.php
@@ -43,7 +43,22 @@ class IsFileTest extends TestCase
 	public function testAsset()
 	{
 		$asset = $this->_asset();
-		$this->assertInstanceOf('Kirby\Filesystem\File', $asset->asset());
+		$file = $asset->asset();
+
+		$this->assertInstanceOf('Kirby\Filesystem\File', $file);
+		$this->assertSame($file, $asset->asset());
+	}
+
+	/**
+	 * @covers ::asset
+	 */
+	public function testAssetStringProp()
+	{
+		$asset = $this->_asset();
+		$file =  $asset->asset('/dev/null/blank.pdf');
+
+		$this->assertInstanceOf('Kirby\Filesystem\File', $file);
+		$this->assertSame('/dev/null/blank.pdf', $file->root());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

When a method of the filesystem object was called in the `file::url` component, there was an infinite loop and the system was throwing an error. Now, instead of sending the `url` and `root` attributes when instancing the filesystem object, the issue is solved by sending its parent file object.

### Fixes
- Calling a `$file` method inside a custom `file::url` component no longer causes an infinite loop #4274

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
