### PR TITLE
Better error messages for blocks and layout fields 

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -70,7 +70,7 @@
   "error.blocks.max.singular": "You must not add more than one block",
   "error.blocks.min.plural": "You must add at least {min} blocks",
   "error.blocks.min.singular": "You must add at least one block",
-  "error.blocks.validation": "There's an error on \"{field}\" in \"{fieldset}\" block",
+  "error.blocks.validation": "There's an error on the \"{field}\" field  in block no. {index} using the \"{fieldset}\" fieldset",
 
   "error.email.preset.notFound": "The email preset \"{name}\" cannot be found",
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -70,7 +70,7 @@
   "error.blocks.max.singular": "You must not add more than one block",
   "error.blocks.min.plural": "You must add at least {min} blocks",
   "error.blocks.min.singular": "You must add at least one block",
-  "error.blocks.validation": "There's an error on the \"{field}\" field in block {index} using the \"{fieldset}\" fieldset",
+  "error.blocks.validation": "There's an error on the \"{field}\" field in block {index} using the \"{fieldset}\" block type",
 
   "error.email.preset.notFound": "The email preset \"{name}\" cannot be found",
 
@@ -107,7 +107,7 @@
   "error.language.name": "Please enter a valid name for the language",
   "error.language.notFound": "The language could not be found",
 
-  "error.layout.validation.block": "There's an error on the \"{field}\" field in block {blockIndex} using the \"{fieldset}\" fieldset in layout {layoutIndex}",
+  "error.layout.validation.block": "There's an error on the \"{field}\" field in block {blockIndex} using the \"{fieldset}\" block type in layout {layoutIndex}",
   "error.layout.validation.settings": "There's an error in layout {index} settings",
 
   "error.license.format": "Please enter a valid license key",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -70,7 +70,7 @@
   "error.blocks.max.singular": "You must not add more than one block",
   "error.blocks.min.plural": "You must add at least {min} blocks",
   "error.blocks.min.singular": "You must add at least one block",
-  "error.blocks.validation": "There's an error in block {index}",
+  "error.blocks.validation": "There's an error on \"{field}\" in \"{fieldset}\" block",
 
   "error.email.preset.notFound": "The email preset \"{name}\" cannot be found",
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -70,7 +70,7 @@
   "error.blocks.max.singular": "You must not add more than one block",
   "error.blocks.min.plural": "You must add at least {min} blocks",
   "error.blocks.min.singular": "You must add at least one block",
-  "error.blocks.validation": "There's an error on the \"{field}\" field  in block no. {index} using the \"{fieldset}\" fieldset",
+  "error.blocks.validation": "There's an error on the \"{field}\" field in block {index} using the \"{fieldset}\" fieldset",
 
   "error.email.preset.notFound": "The email preset \"{name}\" cannot be found",
 
@@ -107,7 +107,7 @@
   "error.language.name": "Please enter a valid name for the language",
   "error.language.notFound": "The language could not be found",
 
-  "error.layout.validation.block": "There's an error in block {blockIndex} in layout {layoutIndex}",
+  "error.layout.validation.block": "There's an error on the \"{field}\" field in block {blockIndex} using the \"{fieldset}\" fieldset in layout {layoutIndex}",
   "error.layout.validation.settings": "There's an error in layout {index} settings",
 
   "error.license.format": "Please enter a valid license key",

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -272,9 +272,9 @@ class BlocksField extends FieldClass
 							throw new InvalidArgumentException([
 								'key' => 'blocks.validation',
 								'data' => [
-									'field' => $field->label(),
+									'field'    => $field->label(),
 									'fieldset' => $fieldset->name(),
-									'index' => $index
+									'index'    => $index
 								]
 							]);
 						}

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -274,6 +274,7 @@ class BlocksField extends FieldClass
 								'data' => [
 									'field' => $field->label(),
 									'fieldset' => $fieldset->name(),
+									'index' => $index
 								]
 							]);
 						}

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -253,7 +253,8 @@ class BlocksField extends FieldClass
 					$blockType = $block['type'];
 
 					try {
-						$blockFields = $fields[$blockType] ?? $this->fields($blockType) ?? [];
+						$fieldset    = $this->fieldset($blockType);
+						$blockFields = $fields[$blockType] ?? $fieldset->fields() ?? [];
 					} catch (Throwable) {
 						// skip invalid blocks
 						continue;
@@ -271,7 +272,8 @@ class BlocksField extends FieldClass
 							throw new InvalidArgumentException([
 								'key' => 'blocks.validation',
 								'data' => [
-									'index' => $index,
+									'field' => $field->label(),
+									'fieldset' => $fieldset->name(),
 								]
 							]);
 						}

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -200,6 +200,7 @@ class LayoutField extends BlocksField
 							$blockType = $block['type'];
 
 							try {
+								$fieldset    = $this->fieldset($blockType);
 								$blockFields = $fields[$blockType] ?? $this->fields($blockType) ?? [];
 							} catch (Throwable) {
 								// skip invalid blocks
@@ -219,6 +220,8 @@ class LayoutField extends BlocksField
 										'key' => 'layout.validation.block',
 										'data' => [
 											'blockIndex'  => $blockIndex,
+											'field'       => $field->label(),
+											'fieldset'    => $fieldset->name(),
 											'layoutIndex' => $layoutIndex
 										]
 									]);

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -433,7 +433,9 @@ class BlocksFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertSame(['blocks' => 'There\'s an error in block 2'], $field->errors());
+		$this->assertSame([
+			'blocks' => 'There\'s an error on the "Video-URL" field  in block no. 2 using the "Video" fieldset'
+		], $field->errors());
 	}
 
 	public function testEmpty()

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -434,7 +434,7 @@ class BlocksFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertSame([
-			'blocks' => 'There\'s an error on the "Video-URL" field  in block no. 2 using the "Video" fieldset'
+			'blocks' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" fieldset'
 		], $field->errors());
 	}
 

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -434,7 +434,7 @@ class BlocksFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertSame([
-			'blocks' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" fieldset'
+			'blocks' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" block type'
 		], $field->errors());
 	}
 

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -221,7 +221,7 @@ class LayoutFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertSame([
-			'layout' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" fieldset in layout 1'
+			'layout' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" block type in layout 1'
 		], $field->errors());
 	}
 

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -220,7 +220,9 @@ class LayoutFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertSame(['layout' => 'There\'s an error in block 2 in layout 1'], $field->errors());
+		$this->assertSame([
+			'layout' => 'There\'s an error on the "Video-URL" field in block 2 using the "Video" fieldset in layout 1'
+		], $field->errors());
 	}
 
 	public function testValidationsSettings()


### PR DESCRIPTION
## This PR …

![captures_chrome-capture-2022-8-4 (1)](https://user-images.githubusercontent.com/3393422/188309093-6aa26687-1ef2-4b05-b329-281b15aa29c9.png)

### Enhancements

- Better error messages for blocks and layout fields https://kirby.nolt.io/313

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
