### PR TITLE
New `Cache::getOrSet()` method

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -156,16 +156,17 @@ abstract class Cache
 	 */
 	public function getOrSet(
 		string $key,
-		Closure $getter,
+		Closure $result,
 		int $minutes = 0
 	): mixed {
-		if ($value = $this->get($key)) {
-			return $value;
+		$value  = $this->get($key);
+		$result = $value ?? $result();
+
+		if ($value === null) {
+			$this->set($key, $result, $minutes);
 		}
 
-		$value = $getter();
-		$this->set($key, $value, $minutes);
-		return $value;
+		return $result;
 	}
 
 	/**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -152,6 +152,7 @@ abstract class Cache
 	 * Returns a value by either getting it from the cache
 	 * or via the callback function which then it stored in
 	 * the cache for future retrieval
+	 * @since 3.8.0
 	 */
 	public function getOrSet(
 		string $key,

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -150,7 +150,7 @@ abstract class Cache
 
 	/**
 	 * Returns a value by either getting it from the cache
-	 * or via the callback function which then it stored in
+	 * or via the callback function which then is stored in
 	 * the cache for future retrieval. This method cannot be
 	 * used for `null` as value to be cached.
 	 * @since 3.8.0

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -151,7 +151,8 @@ abstract class Cache
 	/**
 	 * Returns a value by either getting it from the cache
 	 * or via the callback function which then it stored in
-	 * the cache for future retrieval
+	 * the cache for future retrieval. This method cannot be
+	 * used for `null` as value to be cached.
 	 * @since 3.8.0
 	 */
 	public function getOrSet(

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cache;
 
+use Closure;
+
 /**
  * Cache foundation
  * This abstract class is used as
@@ -144,6 +146,25 @@ abstract class Cache
 
 		// return the pure value
 		return $value->value();
+	}
+
+	/**
+	 * Returns a value by either getting it from the cache
+	 * or via the callback function which then it stored in
+	 * the cache for future retrieval
+	 */
+	public function getOrSet(
+		string $key, Closure
+		$getter,
+		int $minutes = 0
+	): mixed {
+		if ($value = $this->get($key)) {
+			return $value;
+		}
+
+		$value = $getter();
+		$this->set($key, $value, $minutes);
+		return $value;
 	}
 
 	/**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -154,8 +154,8 @@ abstract class Cache
 	 * the cache for future retrieval
 	 */
 	public function getOrSet(
-		string $key, Closure
-		$getter,
+		string $key,
+		Closure $getter,
 		int $minutes = 0
 	): mixed {
 		if ($value = $this->get($key)) {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -30,66 +30,32 @@ abstract class Cache
 	}
 
 	/**
-	 * Writes an item to the cache for a given number of minutes and
-	 * returns whether the operation was successful;
-	 * this needs to be defined by the driver
-	 *
-	 * <code>
-	 *   // put an item in the cache for 15 minutes
-	 *   $cache->set('value', 'my value', 15);
-	 * </code>
+	 * Checks when the cache has been created;
+	 * returns the creation timestamp on success
+	 * and false if the item does not exist
 	 */
-	abstract public function set(string $key, mixed $value, int $minutes = 0): bool;
-
-	/**
-	 * Adds the prefix to the key if given
-	 */
-	protected function key(string $key): string
+	public function created(string $key): int|false
 	{
-		if (empty($this->options['prefix']) === false) {
-			$key = $this->options['prefix'] . '/' . $key;
-		}
-
-		return $key;
-	}
-
-	/**
-	 * Internal method to retrieve the raw cache value;
-	 * needs to return a Value object or null if not found;
-	 * this needs to be defined by the driver
-	 */
-	abstract public function retrieve(string $key): Value|null;
-
-	/**
-	 * Gets an item from the cache
-	 *
-	 * <code>
-	 *   // get an item from the cache driver
-	 *   $value = $cache->get('value');
-	 *
-	 *   // return a default value if the requested item isn't cached
-	 *   $value = $cache->get('value', 'default value');
-	 * </code>
-	 */
-	public function get(string $key, mixed $default = null): mixed
-	{
-		// get the Value
+		// get the Value object
 		$value = $this->retrieve($key);
 
-		// check for a valid cache value
+		// check for a valid Value object
 		if ($value instanceof Value === false) {
-			return $default;
+			return false;
 		}
 
-		// remove the item if it is expired
-		if ($value->expires() > 0 && time() >= $value->expires()) {
-			$this->remove($key);
-			return $default;
-		}
-
-		// return the pure value
-		return $value->value();
+		// return the expires timestamp
+		return $value->created();
 	}
+
+	/**
+	 * Determines if an item exists in the cache
+	 */
+	public function exists(string $key): bool
+	{
+		return $this->expired($key) === false;
+	}
+
 
 	/**
 	 * Calculates the expiration timestamp
@@ -143,22 +109,53 @@ abstract class Cache
 	}
 
 	/**
-	 * Checks when the cache has been created;
-	 * returns the creation timestamp on success
-	 * and false if the item does not exist
+	 * Flushes the entire cache and returns
+	 * whether the operation was successful;
+	 * this needs to be defined by the driver
 	 */
-	public function created(string $key): int|false
+	abstract public function flush(): bool;
+
+	/**
+	 * Gets an item from the cache
+	 *
+	 * <code>
+	 *   // get an item from the cache driver
+	 *   $value = $cache->get('value');
+	 *
+	 *   // return a default value if the requested item isn't cached
+	 *   $value = $cache->get('value', 'default value');
+	 * </code>
+	 */
+	public function get(string $key, mixed $default = null): mixed
 	{
-		// get the Value object
+		// get the Value
 		$value = $this->retrieve($key);
 
-		// check for a valid Value object
+		// check for a valid cache value
 		if ($value instanceof Value === false) {
-			return false;
+			return $default;
 		}
 
-		// return the expires timestamp
-		return $value->created();
+		// remove the item if it is expired
+		if ($value->expires() > 0 && time() >= $value->expires()) {
+			$this->remove($key);
+			return $default;
+		}
+
+		// return the pure value
+		return $value->value();
+	}
+
+	/**
+	 * Adds the prefix to the key if given
+	 */
+	protected function key(string $key): string
+	{
+		if (empty($this->options['prefix']) === false) {
+			$key = $this->options['prefix'] . '/' . $key;
+		}
+
+		return $key;
 	}
 
 	/**
@@ -170,11 +167,11 @@ abstract class Cache
 	}
 
 	/**
-	 * Determines if an item exists in the cache
+	 * Returns all passed cache options
 	 */
-	public function exists(string $key): bool
+	public function options(): array
 	{
-		return $this->expired($key) === false;
+		return $this->options;
 	}
 
 	/**
@@ -185,17 +182,21 @@ abstract class Cache
 	abstract public function remove(string $key): bool;
 
 	/**
-	 * Flushes the entire cache and returns
-	 * whether the operation was successful;
+	 * Internal method to retrieve the raw cache value;
+	 * needs to return a Value object or null if not found;
 	 * this needs to be defined by the driver
 	 */
-	abstract public function flush(): bool;
+	abstract public function retrieve(string $key): Value|null;
 
 	/**
-	 * Returns all passed cache options
+	 * Writes an item to the cache for a given number of minutes and
+	 * returns whether the operation was successful;
+	 * this needs to be defined by the driver
+	 *
+	 * <code>
+	 *   // put an item in the cache for 15 minutes
+	 *   $cache->set('value', 'my value', 15);
+	 * </code>
 	 */
-	public function options(): array
-	{
-		return $this->options;
-	}
+	abstract public function set(string $key, mixed $value, int $minutes = 0): bool;
 }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -70,6 +70,26 @@ class CacheTest extends TestCase
 	}
 
 	/**
+	 * @covers ::getOrSet
+	 */
+	public function testGetOrSet()
+	{
+		$cache = new TestCache();
+		$count = 0;
+
+		$callback = function () use (&$count) {
+			$count++;
+			return 'foo';
+		};
+
+		$this->assertSame(0, $count);
+		$this->assertSame('foo', $cache->getOrSet('bar', $callback));
+		$this->assertSame(1, $count);
+		$this->assertSame('foo', $cache->getOrSet('bar', $callback));
+		$this->assertSame(1, $count);
+	}
+
+	/**
 	 * @covers ::expiration
 	 */
 	public function testExpiration()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Feature
- New `Cache::getOrSet($key, $callback, $minutes)` method: Retrieves the value from cache if possible, if not via callback function and adds it to the cache

Makes for much compacter code:
```php
$value = $cache->getOrSet('my.key', function () { ... });
```
instead of
```php
$value = $cache->get('my.key');

if ($value !== null) {
    return $value;
}

// logic to retrieve value
$value = ....

$cache->set('my.key', $value);
return $value;
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
