### PR TITLE
Better show multiple error lines for error dialog

### DIFF
--- a/panel/src/components/Dialogs/ErrorDialog.vue
+++ b/panel/src/components/Dialogs/ErrorDialog.vue
@@ -77,6 +77,9 @@ export default {
 .k-error-details dd:not(:last-of-type) {
 	margin-bottom: 1.5em;
 }
+.k-error-details li {
+	white-space: pre-line;
+}
 .k-error-details li:not(:last-child) {
 	border-bottom: 1px solid var(--color-background);
 	padding-bottom: 0.25rem;


### PR DESCRIPTION
## This PR …

If a custom field has multiple fields and throws multiple errors and want to multiple errors, error dialog shows like before screenshot

You can simply throws exception with `\n`

````php
public function validations(): array
{
    return [
        'custom-field' => function ($value) {
            throw new InvalidArgumentException(implode("\n", ['Error one', 'Error two', 'Error three']));
        }
    ];
}
````

### Before

![captures_chrome-capture-2022-8-4 (3)](https://user-images.githubusercontent.com/3393422/188310671-84238189-89cd-4f79-a359-6c40095dedc4.png)

### After
![captures_chrome-capture-2022-8-4 (2)](https://user-images.githubusercontent.com/3393422/188310655-640e270f-fb09-463c-9655-b0a457a1c1f2.png)

### Enhancements
- Better show multiple error lines for error dialog

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
