### PR TITLE
`Disk quota exceeded` error handling

### DIFF
--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -889,10 +889,15 @@ class F
 			}
 		);
 
-		// if everything is ok rename temporary file with original
-		if ($result === true) {
-			rename($temp, $file);
-			return true;
+		try {
+			// if everything is ok, rename temporary file with original
+			if ($result === true) {
+				rename($temp, $file);
+
+				return true;
+			}
+		} catch (Throwable) {
+			$result = false;
 		}
 
 		// removes the temporary file if the result is failed (on warnings)

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -866,8 +866,9 @@ class F
 		// to before it starts overwriting the original file
 		$temp = $file . '~';
 
+		// @codeCoverageIgnoreStart
 		$result = Helpers::handleErrors(
-			fn (): bool => file_put_contents($temp, $content, $mode),
+			fn (): bool => file_put_contents($temp, $content, $mode) !== false,
 			function (&$override, int $errno, string $errstr) use ($temp): bool {
 				// ensure the temp file gets deleted even
 				// if an exception gets thrown
@@ -888,6 +889,7 @@ class F
 				return false;
 			}
 		);
+		// @codeCoverageIgnoreEnd
 
 		try {
 			// if everything is ok, rename temporary file with original

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -21,7 +21,7 @@ class FTest extends TestCase
 		$this->fixtures = __DIR__ . '/fixtures/f';
 		$this->sample   = $this->fixtures . '/test.txt';
 		$this->tmp      = __DIR__ . '/tmp';
-		$this->test    = $this->tmp . '/moved.txt';
+		$this->test     = $this->tmp . '/moved.txt';
 
 		Dir::remove($this->tmp);
 		Dir::make($this->tmp);
@@ -805,6 +805,7 @@ class FTest extends TestCase
 	public function testWrite()
 	{
 		$this->assertTrue(F::write($this->test, 'my content'));
+		$this->assertFalse(file_exists($this->test . '~'));
 	}
 
 	/**
@@ -831,6 +832,22 @@ class FTest extends TestCase
 
 		$result = unserialize(F::read($this->test));
 		$this->assertEquals($input, $result);
+	}
+
+	/**
+	 * @covers ::write
+	 */
+	public function testWriteHandleWarning()
+	{
+		// try to write a directory
+		$path = $this->tmp . '/test';
+		$temp = $path . '~';
+
+		Dir::make($path);
+		$result = F::write($path, ['a' => 'a']);
+
+		$this->assertFalse($result);
+		$this->assertFalse(file_exists($temp));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

When the disk quota was exceeded on the server, the data was lost by overwriting the contents empty. The `F::write` method now tries to overwrite a temporary file (`default.txt~`). If successful, the temporary file will be overwritten(rename) with the original file. So the original file is always safe.

### Enhancements
- Data/content is now safe when server disk quota exceeded

### Breaking changes

- Contains a breaking change for those using `~` at the end of the content filenames: `/content/site.txt~`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
