### PR TITLE
Fix site search with parameters results

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -172,6 +172,11 @@ return [
 			return $options['words'] ? '\b' . preg_quote($value) . '\b' : preg_quote($value);
 		}, $searchWords);
 
+		// returns an empty collection if there is no search word
+		if (empty($searchWords) === true) {
+			return $collection->limit(0);
+		}
+
 		$preg    = '!(' . implode('|', $searchWords) . ')!i';
 		$results = $collection->filter(function ($item) use ($query, $preg, $options, $lowerQuery, $exactQuery) {
 			$data = $item->content()->toArray();

--- a/tests/Cms/Site/SitePagesTest.php
+++ b/tests/Cms/Site/SitePagesTest.php
@@ -105,6 +105,65 @@ class SitePagesTest extends TestCase
 		$this->assertCount(2, $collection);
 	}
 
+	public function testSearchMinlength()
+	{
+		$site = new Site([
+			'children' => [
+				['slug' => 'home'],
+				['slug' => 'foo'],
+				['slug' => 'bar'],
+				['slug' => 'foo-a'],
+				['slug' => 'bar-b'],
+			]
+		]);
+
+		$collection = $site->search('foo', [
+			'minlength' => 5
+		]);
+
+		$this->assertCount(0, $collection);
+	}
+
+	public function testSearchStopWords()
+	{
+		$site = new Site([
+			'children' => [
+				['slug' => 'home'],
+				['slug' => 'foo'],
+				['slug' => 'bar'],
+				['slug' => 'baz'],
+				['slug' => 'foo-bar'],
+				['slug' => 'foo-baz'],
+			]
+		]);
+
+		$collection = $site->search('foo bar', [
+			'stopwords' => ['bar']
+		]);
+
+		$this->assertCount(3, $collection);
+	}
+
+	public function testSearchStopWordsNoResults()
+	{
+		$site = new Site([
+			'children' => [
+				['slug' => 'home'],
+				['slug' => 'foo'],
+				['slug' => 'bar'],
+				['slug' => 'baz'],
+				['slug' => 'foo-bar'],
+				['slug' => 'foo-baz'],
+			]
+		]);
+
+		$collection = $site->search('new foo', [
+			'stopwords' => ['foo']
+		]);
+
+		$this->assertCount(0, $collection);
+	}
+
 	public function testPages()
 	{
 		$site = new Site([


### PR DESCRIPTION
## This PR …
If the search words are empty, it will return empty results instead of returning all results.

### Fixes
- Site search with parameters now returns correct results #4641 

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
