### PR TITLE
`Str::excerpt()`: prevent extra space

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -473,7 +473,7 @@ class Str
 			// when tags are skipped we can be sure that words stay separate
 			$string = preg_replace('#\s*<([^\/])#', ' <${1}', $string);
 
-			// strip tags
+			// in strip mode, we always return plain text
 			$string = strip_tags($string);
 		}
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -469,7 +469,12 @@ class Str
 	public static function excerpt($string, $chars = 140, $strip = true, $rep = ' …')
 	{
 		if ($strip === true) {
-			$string = strip_tags(str_replace('<', ' <', $string));
+			// ensure that opening tags are preceded by a space, so that
+			// when tags are skipped we can be sure that words stay separate
+			$string = preg_replace('#\s*<([^\/])#', ' <${1}', $string);
+
+			// strip tags
+			$string = strip_tags($string);
 		}
 
 		// replace line breaks with spaces

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -369,6 +369,18 @@ class StrTest extends TestCase
 	}
 
 	/**
+	 * @covers ::excerpt
+	 */
+	public function testExcerptWithTagFollowedByInterpunctuation()
+	{
+		$string   = 'Why not <a href="https://getkirby.com/">Get Kirby</a>?';
+		$expected = 'Why not Get Kirby?';
+		$result   = Str::excerpt($string, 100);
+
+		$this->assertSame($expected, $result);
+	}
+
+	/**
 	 * @covers ::float
 	 */
 	public function testFloat()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `Str::except()` does not add superfluous space after stripped tag and before interpunctuation
#4301


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
