### PR TITLE
Fix disabled cache on empty auth header

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -716,6 +716,10 @@ class Auth
 
 		if (
 			$basicAuth === true &&
+
+			// only get the auth object if the option is enabled
+			// to avoid triggering `$responder->usesAuth()` if
+			// the option is disabled
 			$request->auth() &&
 			$request->auth()->type() === 'basic'
 		) {

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -712,9 +712,13 @@ class Auth
 	public function type(bool $allowImpersonation = true): string
 	{
 		$basicAuth = $this->kirby->option('api.basicAuth', false);
-		$auth      = $this->kirby->request()->auth();
+		$request   = $this->kirby->request();
 
-		if ($basicAuth === true && $auth && $auth->type() === 'basic') {
+		if (
+			$basicAuth === true &&
+			$request->auth() &&
+			$request->auth()->type() === 'basic'
+		) {
 			return 'basic';
 		}
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -151,7 +151,7 @@ class Request
 			$kirby->response()->usesAuth(true);
 		}
 
-		if ($auth = $this->options['auth'] ?? $this->header('authorization')) {
+		if ($auth = $this->authString()) {
 			$type = Str::lower(Str::before($auth, ' '));
 			$data = Str::after($auth, ' ');
 
@@ -271,9 +271,7 @@ class Request
 	 */
 	public function hasAuth(): bool
 	{
-		$header = $this->options['auth'] ?? $this->header('authorization');
-
-		return $header !== null;
+		return $this->authString() !== null;
 	}
 
 	/**
@@ -381,5 +379,28 @@ class Request
 		}
 
 		return $this->url ??= Uri::current();
+	}
+
+	/**
+	 * Returns the raw auth string from the `auth` option
+	 * or `Authorization` header unless both are empty
+	 */
+	protected function authString(): string|null
+	{
+		// both variants need to be checked separately
+		// because empty strings are treated as invalid
+		// but the `??` operator wouldn't do the fallback
+
+		$option = $this->options['auth'] ?? null;
+		if (empty($option) === false) {
+			return $option;
+		}
+
+		$header = $this->header('authorization');
+		if (empty($header) === false) {
+			return $header;
+		}
+
+		return null;
 	}
 }

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -140,6 +140,112 @@ class AuthTest extends TestCase
 	}
 
 	/**
+	 * @covers ::type
+	 */
+	public function testTypeBasic1()
+	{
+		$app = $this->app->clone([
+			'server' => [
+				'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('testuser:testpass')
+			]
+		]);
+
+		// existing basic auth should be preferred
+		// over impersonation
+		$app->auth()->impersonate('kirby');
+
+		$this->assertSame('basic', $app->auth()->type());
+
+		// auth object should have been accessed
+		$this->assertTrue($app->response()->usesAuth());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeBasic2()
+	{
+		// non-existing basic auth should
+		// fall back to impersonation
+		$this->auth->impersonate('kirby');
+
+		$this->assertSame('impersonate', $this->auth->type());
+
+		// auth object should have been accessed
+		$this->assertTrue($this->app->response()->usesAuth());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeBasic3()
+	{
+		// non-existing basic auth without
+		// impersonation should fall back to session
+		$this->assertSame('session', $this->auth->type());
+
+		// auth object should have been accessed
+		$this->assertTrue($this->app->response()->usesAuth());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeBasic4()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'api' => [
+					'basicAuth' => false
+				]
+			],
+			'server' => [
+				'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('testuser:testpass')
+			]
+		]);
+
+		// disabled option should fall back to session
+		$this->assertSame('session', $app->auth()->type());
+
+		// auth object should *not* have been accessed
+		$this->assertFalse($app->response()->usesAuth());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeImpersonate()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'api' => [
+					'basicAuth' => false
+				]
+			]
+		]);
+
+		$app->auth()->impersonate('kirby');
+
+		$this->assertSame('impersonate', $app->auth()->type());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeSession()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'api' => [
+					'basicAuth' => false
+				]
+			]
+		]);
+
+		$this->assertSame('session', $app->auth()->type());
+	}
+
+	/**
 	 * @covers ::status
 	 * @covers ::user
 	 */

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -159,6 +159,39 @@ class RequestTest extends TestCase
 		$this->assertTrue($app->response()->usesAuth());
 	}
 
+	/**
+	 * @dataProvider hasAuthProvider
+	 */
+	public function testHasAuth($option, $header, $expected)
+	{
+		new App([
+			'server' => [
+				'HTTP_AUTHORIZATION' => $header
+			]
+		]);
+
+		$request = new Request([
+			'auth' => $option
+		]);
+
+		$this->assertSame($expected, $request->hasAuth());
+	}
+
+	public function hasAuthProvider(): array
+	{
+		return [
+			[null, null, false],
+			[null, '', false],
+			['', null, false],
+			['', '', false],
+			['Basic abc', '', true],
+			['', 'Basic abc', true],
+			['Basic abc', null, true],
+			[null, 'Basic abc', true],
+			['Basic abc', 'Basic def', true],
+		];
+	}
+
 	public function testMethod()
 	{
 		$request = new Request();


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Caching is no longer disabled when the request passes an empty `Authorization` header. #4634
- Calling `$app->user()` no longer sets the response flag for "uses auth header" unless the `api.basicAuth` option is enabled.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
