### PR TITLE
Fix `A::average()` for empty array

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -634,8 +634,12 @@ class A
 	 * @param int $decimals The number of decimals to return
 	 * @return float The average value
 	 */
-	public static function average(array $array, int $decimals = 0): float
+	public static function average(array $array, int $decimals = 0): float|null
 	{
+		if (empty($array) === true) {
+			return null;
+		}
+
 		return round((array_sum($array) / sizeof($array)), $decimals);
 	}
 

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -631,6 +631,7 @@ class ATest extends TestCase
 		$this->assertSame(6.0, A::average($array));
 		$this->assertSame(5.5, A::average($array, 1));
 		$this->assertSame(5.54, A::average($array, 2));
+		$this->assertNull(A::average([]));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fixed calling `A::average()` with empty array
#4269

### Breaking changes
- `A::average()` return `null` when passed an empty array


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
