### PR TITLE
Enhancements for gallery block

### DIFF
--- a/config/blocks/gallery/gallery.php
+++ b/config/blocks/gallery/gallery.php
@@ -1,5 +1,10 @@
-<?php /** @var \Kirby\Cms\Block $block */ ?>
-<figure>
+<?php
+/** @var \Kirby\Cms\Block $block */
+$caption = $block->caption();
+$crop    = $block->crop()->isTrue();
+$ratio   = $block->ratio()->or('auto');
+?>
+<figure<?= Html::attr(['data-ratio' => $ratio, 'data-crop' => $crop], null, ' ') ?>>
   <ul>
     <?php foreach ($block->images()->toFiles() as $image): ?>
     <li>
@@ -7,4 +12,9 @@
     </li>
     <?php endforeach ?>
   </ul>
+  <?php if ($caption->isNotEmpty()): ?>
+  <figcaption>
+    <?= $caption ?>
+  </figcaption>
+  <?php endif ?>
 </figure>

--- a/config/blocks/gallery/gallery.yml
+++ b/config/blocks/gallery/gallery.yml
@@ -14,3 +14,27 @@ fields:
       template: blocks/image
     image:
       ratio: 1/1
+  caption:
+    label: field.blocks.image.caption
+    type: writer
+    icon: text
+    inline: true
+  ratio:
+    label: field.blocks.image.ratio
+    type: select
+    placeholder: Auto
+    width: 1/2
+    options:
+      1/1: "1:1"
+      16/9: "16:9"
+      10/8: "10:8"
+      21/9: "21:9"
+      7/5: "7:5"
+      4/3: "4:3"
+      5/3: "5:3"
+      3/2: "3:2"
+      3/1: "3:1"
+  crop:
+    label: field.blocks.image.crop
+    type: toggle
+    width: 1/2

--- a/panel/src/components/Forms/Blocks/Types/Gallery.vue
+++ b/panel/src/components/Forms/Blocks/Types/Gallery.vue
@@ -1,18 +1,36 @@
 <template>
-	<ul @dblclick="open">
-		<template v-if="content.images.length === 0">
-			<li />
-			<li />
-			<li />
-			<li />
-			<li />
-		</template>
-		<template v-else>
-			<li v-for="image in content.images" :key="image.id">
-				<img :src="image.url" :srcset="image.image.srcset" :alt="image.alt" />
-			</li>
-		</template>
-	</ul>
+	<figure>
+		<ul @dblclick="open">
+			<template v-if="content.images.length === 0">
+				<li
+					v-for="index in 5"
+					:key="index"
+					class="k-block-type-gallery-placeholder"
+				>
+					<k-aspect-ratio :ratio="ratio" />
+				</li>
+			</template>
+			<template v-else>
+				<li v-for="image in content.images" :key="image.id">
+					<k-aspect-ratio :ratio="ratio" :cover="crop">
+						<img
+							:src="image.url"
+							:srcset="image.image.srcset"
+							:alt="image.alt"
+						/>
+					</k-aspect-ratio>
+				</li>
+			</template>
+		</ul>
+		<figcaption v-if="content.caption">
+			<k-writer
+				:inline="true"
+				:marks="captionMarks"
+				:value="content.caption"
+				@input="$emit('update', { caption: $event })"
+			/>
+		</figcaption>
+	</figure>
 </template>
 
 <script>
@@ -20,7 +38,19 @@
  * @displayName BlockTypeGallery
  * @internal
  */
-export default {};
+export default {
+	computed: {
+		captionMarks() {
+			return this.field("caption", { marks: true }).marks;
+		},
+		crop() {
+			return this.content.crop || false;
+		},
+		ratio() {
+			return this.content.ratio || false;
+		}
+	}
+};
 </script>
 
 <style>
@@ -33,18 +63,13 @@ export default {};
 	justify-content: center;
 	cursor: pointer;
 }
-.k-block-type-gallery li:empty {
-	padding-bottom: 100%;
+.k-block-type-gallery-placeholder {
 	background: var(--color-background);
 }
-.k-block-type-gallery li {
-	display: flex;
-	position: relative;
-	align-items: center;
-	justify-content: center;
-}
-.k-block-type-gallery li img {
-	flex-grow: 1;
-	max-width: 100%;
+.k-block-type-gallery figcaption {
+	padding-top: 0.5rem;
+	color: var(--color-gray-600);
+	font-size: var(--text-sm);
+	text-align: center;
 }
 </style>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
 		</include>
 
 		<exclude>
+			<directory suffix=".php">./config/blocks</directory>
 			<directory suffix=".php">./config/templates</directory>
 			<file>./config/aliases.php</file>
 			<file>./config/setup.php</file>


### PR DESCRIPTION

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- Gallery block features new ratio, crop and caption fields
- Gallery block preview displays image according to selected ratio  
#4481


<img width="819" alt="Screenshot 2022-09-17 at 13 26 57" src="https://user-images.githubusercontent.com/3788865/190854274-fbcffb67-aec4-4f8a-85ec-dff1ecb23595.png">
<img width="823" alt="Screenshot 2022-09-17 at 13 26 52" src="https://user-images.githubusercontent.com/3788865/190854275-c0f9eb1c-e3d2-4760-9f7c-c23eeccd7538.png">

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
