### PR TITLE
Fix disabled styling for picker fields

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -139,7 +139,7 @@ export default {
 </script>
 
 <style>
-.k-files-field[data-disabled="true"] * {
+.k-files-field[data-disabled="true"] .k-item * {
 	pointer-events: all !important;
 }
 </style>

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -49,7 +49,7 @@ export default {
 </script>
 
 <style>
-.k-pages-field[data-disabled="true"] * {
+.k-pages-field[data-disabled="true"] .k-item * {
 	pointer-events: all !important;
 }
 </style>

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -49,7 +49,7 @@ export default {
 </script>
 
 <style>
-.k-users-field[data-disabled="true"] * {
+.k-users-field[data-disabled="true"] .k-item * {
 	pointer-events: all !important;
 }
 </style>


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

The picker fields were placing a quite aggressive `pointer-events: all !important` CSS rule on all sub tags when'd disabled to ensure that items that had already been selected remain clickable. However, this also resulted in the pointer cursor still showing up above the empty placeholder etc.

So tweaked the CSS rule to only ensure the pointer events on all `k-item` and sub-tags.

### Fixes
- Picker fields: fixed styling for disabled/non-translatable state
#4306


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
