### PR TITLE
`F::load()`: guard from output

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1062,7 +1062,7 @@ class App
 
 		// load the main config options
 		$root    = $this->root('config');
-		$options = F::load($root . '/config.php', []);
+		$options = F::load($root . '/config.php', [], allowOutput: false);
 
 		// merge into one clean options array
 		return $this->options = array_replace_recursive(Config::$data, $options);
@@ -1080,7 +1080,7 @@ class App
 		$root = $this->root('config');
 
 		// first load `config/env.php` to access its `url` option
-		$envOptions = F::load($root . '/env.php', []);
+		$envOptions = F::load($root . '/env.php', [], allowOutput: false);
 
 		// use the option from the main `config.php`,
 		// but allow the `env.php` to override it

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -717,7 +717,7 @@ trait AppPlugins
 			$class = str_replace(['.', '-', '_'], '', $name) . 'Page';
 
 			// load the model class
-			F::loadOnce($model);
+			F::loadOnce($model, allowOutput: false);
 
 			if (class_exists($class) === true) {
 				$models[$name] = $class;
@@ -908,7 +908,7 @@ trait AppPlugins
 			$styles = $dir . '/index.css';
 
 			if (is_file($entry) === true) {
-				F::loadOnce($entry);
+				F::loadOnce($entry, allowOutput: false);
 			} elseif (is_file($script) === true || is_file($styles) === true) {
 				// if no PHP file is present but an index.js or index.css,
 				// register as anonymous plugin (without actual extensions)

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -731,7 +731,7 @@ class Blueprint
 		$preset = static::$presets[$props['preset']];
 
 		if (is_string($preset) === true) {
-			$preset = require $preset;
+			$preset = F::load($preset, allowOutput: false);
 		}
 
 		return $preset($props);

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -123,7 +123,7 @@ class Collections
 		$file = $kirby->root('collections') . '/' . $name . '.php';
 
 		if (is_file($file) === true) {
-			$collection = F::load($file);
+			$collection = F::load($file, allowOutput: false);
 
 			if ($collection instanceof Closure) {
 				return $collection;

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -81,7 +81,7 @@ class Languages extends Collection
 		$files     = glob(App::instance()->root('languages') . '/*.php');
 
 		foreach ($files as $file) {
-			$props = F::load($file);
+			$props = F::load($file, allowOutput: false);
 
 			if (is_array($props) === true) {
 				// inject the language code from the filename

--- a/src/Cms/Loader.php
+++ b/src/Cms/Loader.php
@@ -160,12 +160,12 @@ class Loader
 	{
 		if (is_string($item) === true) {
 			$item = match (F::extension($item)) {
-				'php'   => require $item,
+				'php'   => F::load($item, allowOutput: false),
 				default => Data::read($item)
 			};
 		}
 
-		if (is_callable($item)) {
+		if (is_callable($item) === true) {
 			$item = $item($this->kirby);
 		}
 

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -308,7 +308,7 @@ trait UserActions
 		$path = $this->root() . '/index.php';
 
 		if (is_file($path) === true) {
-			$credentials = F::load($path);
+			$credentials = F::load($path, allowOutput: false);
 
 			return is_array($credentials) === false ? [] : $credentials;
 		} else {

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -148,7 +148,7 @@ class Users extends Collection
 			// get role information
 			$path = $root . '/' . $userDirectory . '/index.php';
 			if (is_file($path) === true) {
-				$credentials = F::load($path);
+				$credentials = F::load($path, allowOutput: false);
 			}
 
 			// create user model based on role

--- a/src/Data/PHP.php
+++ b/src/Data/PHP.php
@@ -61,7 +61,7 @@ class PHP extends Handler
 			throw new Exception('The file "' . $file . '" does not exist');
 		}
 
-		return (array)F::load($file, []);
+		return (array)F::load($file, [], allowOutput: false);
 	}
 
 	/**

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -786,12 +786,20 @@ class Environment
 
 		// load the config for the host
 		if (empty($host) === false) {
-			$configHost = F::load($root . '/config.' . $host . '.php', []);
+			$configHost = F::load(
+				file: $root . '/config.' . $host . '.php',
+				fallback: [],
+				allowOutput: false
+			);
 		}
 
 		// load the config for the server IP
 		if (empty($addr) === false) {
-			$configAddr = F::load($root . '/config.' . $addr . '.php', []);
+			$configAddr = F::load(
+				file: $root . '/config.' . $addr . '.php',
+				fallback: [],
+				allowOutput: false
+			);
 		}
 
 		return array_replace_recursive($configHost, $configAddr);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -187,7 +187,7 @@ class Response
 	public static function guardAgainstOutput(Closure $callback, ...$args): mixed
 	{
 		$before = headers_sent();
-		$result = $callback($args);
+		$result = $callback(...$args);
 		$after  = headers_sent($file, $line);
 
 		if ($before === false && $after === true) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -184,6 +184,10 @@ class Response
 		die(static::redirect($url, $code));
 	}
 
+	/**
+	 * Ensures that the callback does not produce the first body output
+	 * (used to show when loading a file creates side effects)
+	 */
 	public static function guardAgainstOutput(Closure $callback, ...$args): mixed
 	{
 		$before = headers_sent();

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Http;
 
+use Closure;
 use Exception;
+use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use Throwable;
 
@@ -180,6 +182,19 @@ class Response
 	public static function go(string $url = '/', int $code = 302): void
 	{
 		die(static::redirect($url, $code));
+	}
+
+	public static function guardAgainstOutput(Closure $callback, ...$args): mixed
+	{
+		$before = headers_sent();
+		$result = $callback($args);
+		$after  = headers_sent();
+
+		if ($before === false && $after === true) {
+			throw new LogicException('Disallowed output from file $file:$line, possible accidental whitespace?');
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -188,10 +188,10 @@ class Response
 	{
 		$before = headers_sent();
 		$result = $callback($args);
-		$after  = headers_sent();
+		$after  = headers_sent($file, $line);
 
 		if ($before === false && $after === true) {
-			throw new LogicException('Disallowed output from file $file:$line, possible accidental whitespace?');
+			throw new LogicException("Disallowed output from file $file:$line, possible accidental whitespace?");
 		}
 
 		return $result;

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -232,7 +232,7 @@ class Component
 				throw new Exception('Component definition ' . $definition . ' does not exist');
 			}
 
-			static::$types[$type] = $definition = F::load($definition);
+			static::$types[$type] = $definition = F::load($definition, allowOutput: false);
 		}
 
 		return $definition;
@@ -254,7 +254,11 @@ class Component
 
 		if (isset($definition['extends']) === true) {
 			// extend other definitions
-			$options = array_replace_recursive(static::defaults(), static::load($definition['extends']), $definition);
+			$options = array_replace_recursive(
+				static::defaults(),
+				static::load($definition['extends']),
+				$definition
+			);
 		} else {
 			// inject defaults
 			$options = array_replace_recursive(static::defaults(), $definition);
@@ -266,10 +270,14 @@ class Component
 				if (isset(static::$mixins[$mixin]) === true) {
 					if (is_string(static::$mixins[$mixin]) === true) {
 						// resolve a path to a mixin on demand
-						static::$mixins[$mixin] = include static::$mixins[$mixin];
+
+						static::$mixins[$mixin] = F::load(static::$mixins[$mixin], allowOutput: false);
 					}
 
-					$options = array_replace_recursive(static::$mixins[$mixin], $options);
+					$options = array_replace_recursive(
+						static::$mixins[$mixin],
+						$options
+					);
 				}
 			}
 		}

--- a/tests/Blueprint/NodeI18nTest.php
+++ b/tests/Blueprint/NodeI18nTest.php
@@ -3,7 +3,7 @@
 namespace Kirby\Blueprint;
 
 /**
- * @covers \Kirby\Blueprint\NodeI18n
+ * @coversDefaultClass \Kirby\Blueprint\NodeI18n
  */
 class NodeI18nTest extends TestCase
 {

--- a/tests/Filesystem/fixtures/f/load/output.php
+++ b/tests/Filesystem/fixtures/f/load/output.php
@@ -1,0 +1,3 @@
+<?php
+
+Kirby\Http\HeadersSent::$value = true;

--- a/tests/Http/mocks.php
+++ b/tests/Http/mocks.php
@@ -2,9 +2,32 @@
 
 namespace Kirby\Http;
 
+class HeadersSent
+{
+	public static $value = false;
+}
+
 class IniStore
 {
 	public static $data = [];
+}
+
+/**
+ * Mock for the PHP headers_sent() function (otherwise not available on CLI)
+ */
+function headers_sent(string &$file = null, int &$line = null): bool
+{
+	if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+		throw new Exception('Mock headers_sent() was loaded outside of the test environment. This should never happen.');
+	}
+
+	if (HeadersSent::$value === true) {
+		$file = 'file.php';
+		$line = 123;
+		return true;
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- `F::load()` and `F::loadOnce()`: guarded from unintended output 
#4391

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
