### PR TITLE
Fix `A::append()` with non-associative arrays

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -25,7 +25,7 @@ class A
 	 */
 	public static function append(array $array, array $append): array
 	{
-		return $array + $append;
+		return static::merge($array, $append, A::MERGE_APPEND);
 	}
 
 	/**
@@ -165,7 +165,10 @@ class A
 	{
 		$merged = $array1;
 
-		if (static::isAssociative($array1) === false && $mode === static::MERGE_REPLACE) {
+		if (
+			static::isAssociative($array1) === false &&
+			$mode === static::MERGE_REPLACE
+		) {
 			return $array2;
 		}
 
@@ -175,7 +178,11 @@ class A
 				$merged[] = $value;
 
 			// recursively merge the two array values
-			} elseif (is_array($value) === true && isset($merged[$key]) === true && is_array($merged[$key]) === true) {
+			} elseif (
+				is_array($value) === true &&
+				isset($merged[$key]) === true &&
+				is_array($merged[$key]) === true
+			) {
 				$merged[$key] = static::merge($merged[$key], $value, $mode);
 
 			// simply overwrite with the value from the second array

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -19,6 +19,30 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::append
+	 */
+	public function testAppend()
+	{
+		// associative
+		$one    = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
+		$two    = ['d' => 'D', 'e' => 'E', 'f' => 'F'];
+		$result = A::append($one, $two);
+		$this->assertSame(['a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D', 'e' => 'E', 'f' => 'F'], $result);
+
+		// numeric
+		$one    = ['a', 'b', 'c'];
+		$two    = ['d', 'e', 'f'];
+		$result = A::append($one, $two);
+		$this->assertSame(['a', 'b', 'c', 'd', 'e', 'f'], $result);
+
+		// mixed
+		$one    = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
+		$two    = ['d', 'e', 'f'];
+		$result = A::append($one, $two);
+		$this->assertSame(['a' => 'A', 'b' => 'B', 'c' => 'C', 'd', 'e', 'f'], $result);
+	}
+
+	/**
 	 * @covers ::apply
 	 */
 	public function testApply()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `A::append()` has been fixed for non-associative arrays. It is now an alias for `A::merge()` with the `A::MERGE_APPEND` flag.
#4345

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
