### PR TITLE
New `$cache->enabled()` method

### DIFF
--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -16,6 +16,15 @@ use APCUIterator;
 class ApcuCache extends Cache
 {
 	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		return apcu_enabled();
+	}
+
+	/**
 	 * Determines if an item exists in the cache
 	 */
 	public function exists(string $key): bool

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -51,6 +51,18 @@ abstract class Cache
 	}
 
 	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		// TODO: Make this method abstract in a future
+		// release to ensure that cache drivers override it;
+		// until then, we assume that the cache is enabled
+		return true;
+	}
+
+	/**
 	 * Determines if an item exists in the cache
 	 */
 	public function exists(string $key): bool

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -52,6 +52,15 @@ class FileCache extends Cache
 	}
 
 	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		return is_writable($this->root) === true;
+	}
+
+	/**
 	 * Returns the full root including prefix
 	 */
 	public function root(): string
@@ -182,7 +191,7 @@ class FileCache extends Cache
 				$files = scandir($dir);
 
 				if ($files === false) {
-					$files = [];
+					$files = []; // @codeCoverageIgnore
 				}
 
 				$files = array_diff($files, ['.', '..']);

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -16,9 +16,14 @@ use Memcached as MemcachedExt;
 class MemCached extends Cache
 {
 	/**
-	 * store for the memcache connection
+	 * Store for the memcache connection
 	 */
 	protected MemcachedExt $connection;
+
+	/**
+	 * Stores whether the connection was successful
+	 */
+	protected bool $enabled;
 
 	/**
 	 * Sets all parameters which are needed to connect to Memcached
@@ -38,10 +43,19 @@ class MemCached extends Cache
 		parent::__construct(array_merge($defaults, $options));
 
 		$this->connection = new MemcachedExt();
-		$this->connection->addServer(
+		$this->enabled = $this->connection->addServer(
 			$this->options['host'],
 			$this->options['port']
 		);
+	}
+
+	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		return $this->enabled;
 	}
 
 	/**

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -19,6 +19,15 @@ class MemoryCache extends Cache
 	protected array $store = [];
 
 	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		return true;
+	}
+
+	/**
 	 * Writes an item to the cache for a given number of minutes and
 	 * returns whether the operation was successful
 	 *

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -14,6 +14,15 @@ namespace Kirby\Cache;
 class NullCache extends Cache
 {
 	/**
+	 * Returns whether the cache is ready to
+	 * store values
+	 */
+	public function enabled(): bool
+	{
+		return true;
+	}
+
+	/**
 	 * Writes an item to the cache for a given number of minutes and
 	 * returns whether the operation was successful
 	 *

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -18,8 +18,17 @@ class ApcuCacheTest extends TestCase
 			apcu_enabled() === false
 		) {
 			$this->markTestSkipped('APCu is not available.');
-			return;
 		}
+	}
+
+	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new ApcuCache();
+
+		$this->assertTrue($cache->enabled());
 	}
 
 	/**

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -8,7 +8,7 @@ use ReflectionMethod;
 require_once __DIR__ . '/mocks.php';
 
 /**
- * @coversDefaultClass \Kirby\Cache\NullCache
+ * @coversDefaultClass \Kirby\Cache\Cache
  */
 class CacheTest extends TestCase
 {
@@ -87,6 +87,16 @@ class CacheTest extends TestCase
 		$this->assertSame(1, $count);
 		$this->assertSame('foo', $cache->getOrSet('bar', $callback));
 		$this->assertSame(1, $count);
+	}
+
+	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new TestCache();
+
+		$this->assertTrue($cache->enabled());
 	}
 
 	/**

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -15,7 +15,7 @@ class FileCacheTest extends TestCase
 {
 	public function tearDown(): void
 	{
-		Dir::remove(__DIR__ . '/fixtures/file');
+		Dir::remove(__DIR__ . '/tmp');
 	}
 
 	/**
@@ -25,7 +25,7 @@ class FileCacheTest extends TestCase
 	public function testConstruct()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file'
+			'root' => $root = __DIR__ . '/tmp'
 		]);
 
 		$this->assertSame($root, $cache->root());
@@ -39,12 +39,38 @@ class FileCacheTest extends TestCase
 	public function testConstructWithPrefix()
 	{
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/fixtures/file',
+			'root'   => $root = __DIR__ . '/tmp',
 			'prefix' => 'test'
 		]);
 
 		$this->assertSame($root . '/test', $cache->root());
 		$this->assertDirectoryExists($root . '/test');
+	}
+
+	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new FileCache([
+			'root' => __DIR__ . '/tmp'
+		]);
+
+		$this->assertTrue($cache->enabled());
+	}
+
+	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabledNotWritable()
+	{
+		$cache = new FileCache([
+			'root' => $root = __DIR__ . '/tmp'
+		]);
+
+		chmod($root, 0444);
+
+		$this->assertFalse($cache->enabled());
 	}
 
 	/**
@@ -56,56 +82,56 @@ class FileCacheTest extends TestCase
 		$method->setAccessible(true);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file'
+			'root' => $root = __DIR__ . '/tmp'
 		]);
 		$this->assertSame($root . '/test', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'extension' => 'cache'
 		]);
 		$this->assertSame($root . '/test.cache', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/fixtures/file',
+			'root'   => $root = __DIR__ . '/tmp',
 			'prefix' => 'test1'
 		]);
 		$this->assertSame($root . '/test1/test', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'prefix'    => 'test1',
 			'extension' => 'cache'
 		]);
 		$this->assertSame($root . '/test1/test.cache', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/_empty/test', $method->invoke($cache, '/test'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/test/_empty', $method->invoke($cache, 'test/'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/test/_backslash/foo/bar', $method->invoke($cache, 'test\\foo/bar'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/test/_backslash/_empty/foo/_backslash/bar', $method->invoke($cache, 'test\\/foo\\bar'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/_empty/test/_empty', $method->invoke($cache, '/test/'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/_9d891e731f75deae56884d79e9816736b7488080/test',
@@ -113,7 +139,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -121,12 +147,12 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame($root . '/_3a52ce780950d4d969792a2559cd519d7ee8c727/test-page', $method->invoke($cache, './test-page'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame(
 			$root . '/_3a52ce780950d4d969792a2559cd519d7ee8c727/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -134,7 +160,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/pages/test/_empty',
@@ -142,7 +168,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/pages/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -150,7 +176,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'extension' => 'cache'
 		]);
 		$this->assertSame(
@@ -159,7 +185,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/fixtures/file',
+			'root'   => $root = __DIR__ . '/tmp',
 			'prefix' => 'prefix'
 		]);
 		$this->assertSame(
@@ -168,7 +194,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'prefix'    => 'prefix',
 			'extension' => 'cache'
 		]);
@@ -191,7 +217,7 @@ class FileCacheTest extends TestCase
 	public function testOperations()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file'
+			'root' => $root = __DIR__ . '/tmp'
 		]);
 
 		$time = time();
@@ -226,7 +252,7 @@ class FileCacheTest extends TestCase
 	public function testOperationsWithExtension()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'extension' => 'cache'
 		]);
 
@@ -260,11 +286,11 @@ class FileCacheTest extends TestCase
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 			'prefix' => 'test1'
 		]);
 		$cache2 = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 			'prefix' => 'test2'
 		]);
 
@@ -303,7 +329,7 @@ class FileCacheTest extends TestCase
 	public function testFlush()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file'
+			'root' => $root = __DIR__ . '/tmp'
 		]);
 
 		$cache->set('a', 'A basic value');
@@ -328,11 +354,11 @@ class FileCacheTest extends TestCase
 	public function testFlushWithPrefix()
 	{
 		$cache1 = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 			'prefix' => 'test1'
 		]);
 		$cache2 = new FileCache([
-			'root' => $root = __DIR__ . '/fixtures/file',
+			'root' => $root = __DIR__ . '/tmp',
 			'prefix' => 'test2'
 		]);
 
@@ -364,7 +390,7 @@ class FileCacheTest extends TestCase
 	public function testRemoveEmptyDirectories()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'extension' => 'cache'
 		]);
 
@@ -388,7 +414,7 @@ class FileCacheTest extends TestCase
 	public function testRemoveEmptyDirectoriesWithNotEmptyDirs()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/fixtures/file',
+			'root'      => $root = __DIR__ . '/tmp',
 			'extension' => 'cache'
 		]);
 

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -33,6 +33,16 @@ class MemCachedTest extends TestCase
 	}
 
 	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new MemCached();
+
+		$this->assertTrue($cache->enabled());
+	}
+
+	/**
 	 * @covers ::set
 	 * @covers ::retrieve
 	 * @covers ::remove

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -12,6 +12,16 @@ require_once __DIR__ . '/mocks.php';
 class MemoryCacheTest extends TestCase
 {
 	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new MemoryCache();
+
+		$this->assertTrue($cache->enabled());
+	}
+
+	/**
 	 * @covers ::set
 	 * @covers ::retrieve
 	 * @covers ::remove

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -10,6 +10,16 @@ use PHPUnit\Framework\TestCase;
 class NullCacheTest extends TestCase
 {
 	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new NullCache();
+
+		$this->assertTrue($cache->enabled());
+	}
+
+	/**
 	 * @covers ::set
 	 * @covers ::retrieve
 	 * @covers ::remove


### PR DESCRIPTION
**⚠️ Requirement for the update check feature**

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `$cache->enabled()` method to check if the cache is ready to store values beyond the current request

### Breaking changes

None

## Migration guide (plugin devs)

Custom cache drivers should implement the new `enabled()` method. The method will be required in a future Kirby release. Until you implement this method, Kirby will assume that your cache driver is always enabled.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
