### PR TITLE
Call language routes that return `false` only once

### DIFF
--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -33,7 +33,11 @@ class LanguageRoutes
 				'method'  => 'ALL',
 				'env'     => 'site',
 				'action'  => function ($path = null) use ($language) {
-					if ($result = $language->router()->call($path)) {
+					$result = $language->router()->call($path);
+
+					// explicitly test for null as $result can
+					// contain falsy values that should still be returned
+					if ($result !== null) {
 						return $result;
 					}
 

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -53,4 +53,73 @@ class LanguageRoutesTest extends TestCase
 		$app->call('de/notes');
 		$this->assertSame($app->language()->code(), 'de');
 	}
+
+	public function testNotNextWhenFalsyReturn()
+	{
+		$a = $b = $c = $d = $e = 0;
+
+		$app = $this->app->clone([
+			'options' => [
+				'routes' => [
+					[
+						'pattern' => 'route-a',
+						'action'  => function () use (&$a) {
+							$a++;
+							return false;
+						},
+					],
+					[
+						'pattern' => 'route-b',
+						'language' => '*',
+						'action'  => function ($language) use (&$b) {
+							$b++;
+							return false;
+						},
+					],
+					[
+						'pattern' => 'route-c',
+						'language' => 'en',
+						'action'  => function ($language) use (&$c) {
+							$c++;
+							return false;
+						},
+					],
+					[
+						'pattern' => 'route-d',
+						'language' => 'de',
+						'action'  => function ($language) use (&$d) {
+							$d++;
+							return false;
+						},
+					],
+					[
+						'pattern' => 'route-e',
+						'language' => '*',
+						'action'  => function ($language) use (&$e) {
+							$e++;
+							return null;
+						},
+					],
+				],
+			]
+		]);
+
+		$this->assertSame(0, $a);
+		$this->assertSame(0, $b);
+		$this->assertSame(0, $c);
+		$this->assertSame(0, $d);
+		$this->assertSame(0, $e);
+
+		$app->call('route-a');
+		$app->call('route-b');
+		$app->call('route-c');
+		$app->call('de/route-d');
+		$app->call('route-e');
+
+		$this->assertSame(1, $a);
+		$this->assertSame(1, $b);
+		$this->assertSame(1, $c);
+		$this->assertSame(1, $d);
+		$this->assertSame(2, $e);
+	}
 }


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Language routes that return a falsy value are only called once now 
#4305

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [X] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
