### PR TITLE
`Database\Query`: Where with `AND`/`OR` as values

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -910,20 +910,9 @@ class Query
 	 * @param mixed $current Current value (like $this->where)
 	 * @return string
 	 */
-	protected function filterQuery(array $args, $current, string $mode = null)
+	protected function filterQuery(array $args, $current, string $mode = 'AND')
 	{
 		$result = '';
-		$last   = A::last($args);
-
-		// if there's a where clause mode attribute attached…
-		if (in_array($last, ['AND', 'OR'], true) === true) {
-			// remove that from the list of arguments
-			array_pop($args);
-			// and use it as mode if not explicitly provided
-			$mode ??= $last;
-		} else {
-			$mode ??= 'AND';
-		}
 
 		switch (count($args)) {
 			case 1:

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -93,6 +93,16 @@ class QueryTest extends TestCase
 			'password' => 'beatles',
 			'balance'  => 50
 		]);
+
+		$this->database->table('users')->insert([
+			'role_id'  => 4,
+			'username' => 'foo',
+			'fname'    => 'Foo',
+			'lname'    => 'Bar',
+			'email'    => 'foo@bar.com',
+			'password' => 'AND',
+			'balance'  => 0
+		]);
 	}
 
 	public function testJoin()
@@ -216,7 +226,7 @@ class QueryTest extends TestCase
 			->table('users')
 			->all();
 
-		$this->assertCount(3, $users);
+		$this->assertCount(4, $users);
 	}
 
 	public function testMagicCall()
@@ -246,7 +256,7 @@ class QueryTest extends TestCase
 			->all();
 
 		// all passwords is same, query result count should one with distinct
-		$this->assertCount(1, $users);
+		$this->assertCount(2, $users);
 	}
 
 	public function testMin()
@@ -255,7 +265,7 @@ class QueryTest extends TestCase
 			->table('users')
 			->min('balance');
 
-		$this->assertSame((float)50, $balance);
+		$this->assertSame((float)0, $balance);
 	}
 
 	public function testMax()
@@ -329,7 +339,7 @@ class QueryTest extends TestCase
 			->having('balance', '<=', 100)
 			->all();
 
-		$this->assertCount(2, $users);
+		$this->assertCount(3, $users);
 	}
 
 	public function testWhere()
@@ -374,23 +384,13 @@ class QueryTest extends TestCase
 
 		$this->assertSame(2, $count);
 
-		// AND mode
+		// 'AND' as value
 		$count = $this->database
 			->table('users')
-			->where('balance', '>', 0)
-			->where('balance', '<', 150, 'AND')
+			->where('password', '=', 'AND')
 			->count();
 
-		$this->assertSame(2, $count);
-
-		// OR mode
-		$count = $this->database
-			->table('users')
-			->where('balance', '>', 0)
-			->where('balance', '<', 150, 'OR')
-			->count();
-
-		$this->assertSame(4, $count);
+		$this->assertSame(1, $count);
 	}
 
 	public function testWhereInvalidPredicate()
@@ -449,7 +449,7 @@ class QueryTest extends TestCase
 			->orWhere('balance <= 100')
 			->count();
 
-		$this->assertSame(3, $count);
+		$this->assertSame(4, $count);
 
 		// with value 0
 		$count = $this->database
@@ -460,7 +460,7 @@ class QueryTest extends TestCase
 			->orWhere('balance', '<=', 0)
 			->count();
 
-		$this->assertSame(1, $count);
+		$this->assertSame(2, $count);
 	}
 
 	public function testWhereCallback()
@@ -482,14 +482,14 @@ class QueryTest extends TestCase
 		$results = $query->page(1, 10);
 		$pagination = $results->pagination();
 
-		$this->assertCount(4, $results);
+		$this->assertCount(5, $results);
 		$this->assertSame('John', $results->first()->fname());
 		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
 		$this->assertSame(1, $pagination->pages());
-		$this->assertSame(4, $pagination->total());
+		$this->assertSame(5, $pagination->total());
 		$this->assertSame(1, $pagination->page());
 		$this->assertSame(1, $pagination->start());
-		$this->assertSame(4, $pagination->end());
+		$this->assertSame(5, $pagination->end());
 		$this->assertSame(10, $pagination->limit());
 
 		// example two
@@ -499,8 +499,8 @@ class QueryTest extends TestCase
 		$this->assertCount(1, $results);
 		$this->assertSame('George', $results->first()->fname());
 		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
-		$this->assertSame(4, $pagination->pages());
-		$this->assertSame(4, $pagination->total());
+		$this->assertSame(5, $pagination->pages());
+		$this->assertSame(5, $pagination->total());
 		$this->assertSame(3, $pagination->page());
 		$this->assertSame(3, $pagination->start());
 		$this->assertSame(3, $pagination->end());
@@ -510,14 +510,14 @@ class QueryTest extends TestCase
 		$results = $query->page(2, 3);
 		$pagination = $results->pagination();
 
-		$this->assertCount(1, $results);
+		$this->assertCount(2, $results);
 		$this->assertSame('Mark', $results->first()->fname());
 		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
 		$this->assertSame(2, $pagination->pages());
-		$this->assertSame(4, $pagination->total());
+		$this->assertSame(5, $pagination->total());
 		$this->assertSame(2, $pagination->page());
 		$this->assertSame(4, $pagination->start());
-		$this->assertSame(4, $pagination->end());
+		$this->assertSame(5, $pagination->end());
 		$this->assertSame(3, $pagination->limit());
 	}
 }

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -101,7 +101,7 @@ class QueryTest extends TestCase
 			'lname'    => 'Bar',
 			'email'    => 'foo@bar.com',
 			'password' => 'AND',
-			'balance'  => 0
+			'balance'  => -30
 		]);
 	}
 
@@ -255,7 +255,7 @@ class QueryTest extends TestCase
 			->select('password')
 			->all();
 
-		// all passwords is same, query result count should one with distinct
+		// there are two different passwords in use
 		$this->assertCount(2, $users);
 	}
 
@@ -265,7 +265,7 @@ class QueryTest extends TestCase
 			->table('users')
 			->min('balance');
 
-		$this->assertSame((float)0, $balance);
+		$this->assertSame((float)-30, $balance);
 	}
 
 	public function testMax()
@@ -336,10 +336,10 @@ class QueryTest extends TestCase
 		$users = $this->database
 			->table('users')
 			->group('id')
-			->having('balance', '<=', 100)
+			->having('balance', '<=', 70)
 			->all();
 
-		$this->assertCount(3, $users);
+		$this->assertCount(2, $users);
 	}
 
 	public function testWhere()

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -97,7 +97,7 @@ class QueryTest extends TestCase
 		$this->database->table('users')->insert([
 			'role_id'  => 4,
 			'username' => 'foo',
-			'fname'    => 'Foo',
+			'fname'    => 'Mark',
 			'lname'    => 'Bar',
 			'email'    => 'foo@bar.com',
 			'password' => 'AND',
@@ -160,7 +160,7 @@ class QueryTest extends TestCase
 			->table('users')
 			->sum('balance');
 
-		$this->assertSame((float)500, $sum);
+		$this->assertSame((float)470, $sum);
 	}
 
 	public function testAvg()
@@ -437,6 +437,15 @@ class QueryTest extends TestCase
 			->count();
 
 		$this->assertSame(2, $count);
+
+		// 'AND' as value
+		$count = $this->database
+			->table('users')
+			->where('fname', '=', 'Mark')
+			->andWhere('password', '=', 'AND')
+			->count();
+
+		$this->assertSame(1, $count);
 	}
 
 	public function testOrWhere()
@@ -461,6 +470,15 @@ class QueryTest extends TestCase
 			->count();
 
 		$this->assertSame(2, $count);
+
+		// 'AND' as value
+		$count = $this->database
+			->table('users')
+			->where('balance', '>=', 100)
+			->orWhere('password', '=', 'AND')
+			->count();
+
+		$this->assertSame(4, $count);
 	}
 
 	public function testWhereCallback()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

https://github.com/getkirby/kirby/pull/4650#issuecomment-1250835295


### Fixes
- Database queries can now filter by `'AND'` and `'OR'` as actual values (via `->where()`, `->andWhere()` and `->orWhere()`)

### Breaking changes
- Database queries: subsequent `->where()` clauses don't support passing the mode (`AND`|`OR`) as last parameter anymore, but will interpret these as actual values to filter against. `->andWhere()` or `->orWhere()` instead.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
