### PR TITLE
`Str::safeTemplate()`: Consistent fallback

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -497,10 +497,11 @@ return function (App $app) {
 		 *
 		 * @param \Kirby\Cms\Field $field
 		 * @param array $data
-		 * @param string $fallback Fallback for tokens in the template that cannot be replaced
+		 * @param string|null $fallback Fallback for tokens in the template that cannot be replaced
+		 *                              (`null` to keep the original token)
 		 * @return \Kirby\Cms\Field
 		 */
-		'replace' => function (Field $field, array $data = [], string $fallback = '') use ($app) {
+		'replace' => function (Field $field, array $data = [], string|null $fallback = '') use ($app) {
 			if ($parent = $field->parent()) {
 				// never pass `null` as the $template to avoid the fallback to the model ID
 				$field->value = $parent->toString($field->value ?? '', $data, $fallback);

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -526,10 +526,11 @@ abstract class ModelWithContent extends Model implements Identifiable
 	 *
 	 * @param string|null $template Template string or `null` to use the model ID
 	 * @param array $data
-	 * @param string $fallback Fallback for tokens in the template that cannot be replaced
+	 * @param string|null $fallback Fallback for tokens in the template that cannot be replaced
+	 *                              (`null` to keep the original token)
 	 * @return string
 	 */
-	public function toSafeString(string $template = null, array $data = [], string $fallback = ''): string
+	public function toSafeString(string $template = null, array $data = [], string|null $fallback = ''): string
 	{
 		return $this->toString($template, $data, $fallback, 'safeTemplate');
 	}
@@ -539,11 +540,12 @@ abstract class ModelWithContent extends Model implements Identifiable
 	 *
 	 * @param string|null $template Template string or `null` to use the model ID
 	 * @param array $data
-	 * @param string $fallback Fallback for tokens in the template that cannot be replaced
+	 * @param string|null $fallback Fallback for tokens in the template that cannot be replaced
+	 *                              (`null` to keep the original token)
 	 * @param string $handler For internal use
 	 * @return string
 	 */
-	public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
+	public function toString(string $template = null, array $data = [], string|null $fallback = '', string $handler = 'template'): string
 	{
 		if ($template === null) {
 			return $this->id() ?? '';

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -823,10 +823,11 @@ class User extends ModelWithContent
 	 *
 	 * @param string|null $template
 	 * @param array|null $data
-	 * @param string $fallback Fallback for tokens in the template that cannot be replaced
+	 * @param string|null $fallback Fallback for tokens in the template that cannot be replaced
+	 *                              (`null` to keep the original token)
 	 * @return string
 	 */
-	public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
+	public function toString(string $template = null, array $data = [], string|null $fallback = '', string $handler = 'template'): string
 	{
 		$template ??= $this->email();
 		return parent::toString($template, $data, $fallback, $handler);

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -884,7 +884,7 @@ class Str
 	public static function safeTemplate(string $string = null, array $data = [], array $options = []): string
 	{
 		$callback = ($options['callback'] ?? null) instanceof Closure ? $options['callback'] : null;
-		$fallback = $options['fallback'] ?? '';
+		$fallback = $options['fallback'] ?? null;
 
 		// replace and escape
 		$string = static::template($string, $data, [
@@ -1202,7 +1202,14 @@ class Str
 
 			// callback on result if given
 			if ($callback !== null) {
-				$result = $callback((string)$result, $query, $data);
+				$callbackResult = $callback((string)$result, $query, $data);
+
+				if ($result === null && $callbackResult === '') {
+					// the empty string came just from string casting,
+					// keep the null value and ignore the callback result
+				} else {
+					$result = $callbackResult;
+				}
 			}
 
 			// if we still don't have a result, keep the original placeholder

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -644,6 +644,20 @@ class FieldMethodsTest extends TestCase
 
 		$this->assertSame('Title: Hello world', $page->text()->replace()->value());
 		$this->assertSame('', $page->doesNotExist()->replace()->value());
+
+		// with fallback
+		$this->assertSame(
+			'Hello ',
+			$this->field('Hello {{ invalid }}')->replace(['message' => 'world'])->value()
+		);
+		$this->assertSame(
+			'Hello fallback',
+			$this->field('Hello {{ invalid }}')->replace(['message' => 'world'], 'fallback')->value()
+		);
+		$this->assertSame(
+			'Hello {{ invalid }}',
+			$this->field('Hello {{ invalid }}')->replace(['message' => 'world'], null)->value()
+		);
 	}
 
 	public function testShort()

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -173,6 +173,83 @@ class ModelWithContentTest extends TestCase
 		], $model->blueprints('menu'));
 	}
 
+	public function testToSafeString()
+	{
+		$model = new Page(['slug' => 'foo', 'content' => ['title' => 'value &']]);
+		$this->assertSame('Hello value &amp; foo', $model->toSafeString('Hello {{ model.title }} {{ model.slug }}'));
+		$this->assertSame('Hello value & foo', $model->toSafeString('Hello {< model.title >} {{ model.slug }}'));
+	}
+
+	public function testToSafeStringWithData()
+	{
+		$model = new Site();
+		$this->assertSame(
+			'Hello home in value &amp; value',
+			$model->toSafeString('Hello {{ model.homePageId }} in {{ key }}', ['key' => 'value & value'])
+		);
+		$this->assertSame(
+			'Hello home in value & value',
+			$model->toSafeString('Hello {{ model.homePageId }} in {< key >}', ['key' => 'value & value'])
+		);
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertSame(
+			'Hello foo/home in value &amp; value',
+			$model->toSafeString('Hello {{ model.slug }}/{{ site.homePageId }} in {{ key }}', ['key' => 'value & value'])
+		);
+		$this->assertSame(
+			'Hello foo/home in value & value',
+			$model->toSafeString('Hello {{ model.slug }}/{{ site.homePageId }} in {< key >}', ['key' => 'value & value'])
+		);
+	}
+
+	public function testToSafeStringWithFallback()
+	{
+		$model = new Site();
+		$this->assertSame('Hello ', $model->toSafeString('Hello {{ invalid }}', []));
+		$this->assertSame('Hello world', $model->toSafeString('Hello {{ invalid }}', [], 'world'));
+		$this->assertSame('Hello {{ invalid }}', $model->toSafeString('Hello {{ invalid }}', [], null));
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertSame('Hello foo/', $model->toSafeString('Hello {{ model.slug }}/{{ invalid }}', []));
+		$this->assertSame('Hello foo/world', $model->toSafeString('Hello {{ model.slug }}/{{ invalid }}', [], 'world'));
+		$this->assertSame('Hello foo/{{ invalid }}', $model->toSafeString('Hello {{ model.slug }}/{{ invalid }}', [], null));
+	}
+
+	public function testToString()
+	{
+		$model = new Site();
+		$this->assertSame('Hello home', $model->toString('Hello {{ model.homePageId }}'));
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertSame('Hello foo/home', $model->toString('Hello {{ model.slug }}/{{ site.homePageId }}'));
+	}
+
+	public function testToStringWithData()
+	{
+		$model = new Site();
+		$this->assertSame('Hello home in value', $model->toString('Hello {{ model.homePageId }} in {{ key }}', ['key' => 'value']));
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertSame(
+			'Hello foo/home in value',
+			$model->toString('Hello {{ model.slug }}/{{ site.homePageId }} in {{ key }}', ['key' => 'value'])
+		);
+	}
+
+	public function testToStringWithFallback()
+	{
+		$model = new Site();
+		$this->assertSame('Hello ', $model->toString('Hello {{ invalid }}', []));
+		$this->assertSame('Hello world', $model->toString('Hello {{ invalid }}', [], 'world'));
+		$this->assertSame('Hello {{ invalid }}', $model->toString('Hello {{ invalid }}', [], null));
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertSame('Hello foo/', $model->toString('Hello {{ model.slug }}/{{ invalid }}', []));
+		$this->assertSame('Hello foo/world', $model->toString('Hello {{ model.slug }}/{{ invalid }}', [], 'world'));
+		$this->assertSame('Hello foo/{{ invalid }}', $model->toString('Hello {{ model.slug }}/{{ invalid }}', [], null));
+	}
+
 	public function testToStringWithoutValue()
 	{
 		$model = new Site();

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -850,10 +850,19 @@ class StrTest extends TestCase
 		]));
 
 		// fallback
-		$this->assertSame('From - to -', Str::safeTemplate(
+		$this->assertSame('From here to {{ b }}', Str::safeTemplate(
 			'From {{ a }} to {{ b }}',
-			[],
+			['a' => 'here']
+		));
+		$this->assertSame('From here to -', Str::safeTemplate(
+			'From {{ a }} to {{ b }}',
+			['a' => 'here'],
 			['fallback' => '-']
+		));
+		$this->assertSame('From here to ', Str::safeTemplate(
+			'From {{ a }} to {{ b }}',
+			['a' => 'here'],
+			['fallback' => '']
 		));
 
 		// callback
@@ -874,6 +883,30 @@ class StrTest extends TestCase
 					$this->assertSame($data, $callbackData);
 					return strtoupper($result);
 				}
+			]
+		));
+
+		// callback with fallback
+		$this->assertSame('This is a FALLBACK with <HTML>', Str::safeTemplate(
+			'This is a {{ invalid }} with {< html >}',
+			$data,
+			[
+				'callback' => function ($result, $query, $callbackData) use ($data) {
+					$this->assertSame($data, $callbackData);
+					return strtoupper($result);
+				},
+				'fallback' => 'fallback'
+			]
+		));
+		$this->assertSame('This is a {{ invalid }} with <HTML>', Str::safeTemplate(
+			'This is a {{ invalid }} with {< html >}',
+			$data,
+			[
+				'callback' => function ($result, $query, $callbackData) use ($data) {
+					$this->assertSame($data, $callbackData);
+					return strtoupper($result);
+				},
+				'fallback' => null
 			]
 		));
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- The `$field->replace()`, `$modelWithContent->toString()`, `$modelWithContent->toSafeString()` and `Str::safeTemplate()` methods now support the fallback value `null` (which leaves invalid tokens in the output string).

### Breaking changes

- The default token fallback in `Str::safeTemplate()` changed from an empty string to `null` (which leaves invalid tokens in the output string). This behavior is consistent with `Str::template()`.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
