### PR TITLE
UsersView: only show filter when more than 1 role

### DIFF
--- a/panel/src/components/Views/UsersView.vue
+++ b/panel/src/components/Views/UsersView.vue
@@ -17,7 +17,7 @@
 					/>
 				</template>
 
-				<template #right>
+				<template v-if="roles.length > 1" #right>
 					<k-button-group>
 						<k-dropdown>
 							<k-button


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Users view: role filter is not shown anymore if there is only one role available


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
