### PR TITLE
URL field preview is better shown with ellipsis when it is long

### DIFF
--- a/panel/src/components/Forms/Previews/UrlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UrlFieldPreview.vue
@@ -34,6 +34,8 @@ export default {
 <style>
 .k-url-field-preview {
 	padding: 0.325rem 0.75rem;
+	overflow-x: hidden;
+	text-overflow: ellipsis;
 }
 .k-url-field-preview a {
 	color: var(--color-focus);


### PR DESCRIPTION
###  Enhancements

- URL field preview is better shown with ellipsis when it is long #4677

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
