### PR TITLE
ContentTranslation: `::exists()` for virtual pages

### DIFF
--- a/src/Cms/ContentTranslation.php
+++ b/src/Cms/ContentTranslation.php
@@ -121,12 +121,11 @@ class ContentTranslation
 
 	/**
 	 * Checks if the translation file exists
-	 *
-	 * @return bool
 	 */
 	public function exists(): bool
 	{
-		return file_exists($this->contentFile()) === true;
+		return empty($this->content) === false ||
+			   file_exists($this->contentFile()) === true;
 	}
 
 	/**

--- a/tests/Cms/Content/ContentTranslationTest.php
+++ b/tests/Cms/Content/ContentTranslationTest.php
@@ -73,6 +73,15 @@ class ContentTranslationTest extends TestCase
 		]);
 
 		$this->assertFalse($translation->exists());
+
+
+		$translation = new ContentTranslation([
+			'parent'  => $page,
+			'code'    => 'de',
+			'content' => ['a' => 'A']
+		]);
+
+		$this->assertTrue($translation->exists());
 	}
 
 	public function testToArrayAndDebugInfo()
@@ -88,7 +97,7 @@ class ContentTranslationTest extends TestCase
 		$expected = [
 			'code'    => 'de',
 			'content' => $content,
-			'exists'  => false,
+			'exists'  => true,
 			'slug'    => null
 		];
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `$translation->exists()` now works for virtual pages  
#4674

### Breaking changes
- `$translation->exists()` now returns true for translations without an actual content file but where an content array has been provided


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
