### PR TITLE
Consistent style for table row while dragging

### DIFF
--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -445,8 +445,9 @@ export default {
 
 .k-table-row-ghost {
 	background: var(--color-white);
-	box-shadow: rgba(17, 17, 17, 0.25) 0 5px 10px;
-	outline: 2px solid var(--color-focus);
+	box-shadow: var(--shadow-outline);
+	outline: 2px solid var(--color-black);
+	border-radius: var(--rounded);
 	margin-bottom: 2px;
 	cursor: grabbing;
 	cursor: -moz-grabbing;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- Table rows use same outline styling when dragged as cards and lists

Before:
<img width="1440" alt="Screenshot 2022-09-21 at 13 50 04" src="https://user-images.githubusercontent.com/3788865/191496755-ed38dcc7-c5ea-4ac8-8fc5-eebfc906a796.png">



After:
<img width="1440" alt="Screenshot 2022-09-21 at 13 49 26" src="https://user-images.githubusercontent.com/3788865/191496771-741eb46a-28ca-4180-85cf-9f9913df0871.png">


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
