### PR TITLE
Fix panel favicon for dark mode

### DIFF
--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -149,11 +149,12 @@ class Document
 	}
 
 	/**
-	 * Returns array of favion icons
+	 * Returns array of favicon icons
 	 * based on config option
 	 * @since 3.7.0
 	 *
 	 * @param string $url URL prefix for default icons
+	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function favicon(string $url = ''): array
 	{
@@ -163,13 +164,13 @@ class Document
 				'type' => 'image/png',
 				'url'  => $url . '/apple-touch-icon.png',
 			],
-			'shortcut icon' => [
-				'type' => 'image/svg+xml',
-				'url'  => $url . '/favicon.svg',
-			],
 			'alternate icon' => [
 				'type' => 'image/png',
 				'url'  => $url . '/favicon.png',
+			],
+			'shortcut icon' => [
+				'type' => 'image/svg+xml',
+				'url'  => $url . '/favicon.svg',
 			]
 		]);
 


### PR DESCRIPTION
## This PR …

The SVG had to be loaded last (I think) for the panel to show the correct favicon in dark mode.

### Enhancements
- Now the correct favicon for the panel is shown in dark mode

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
