### PR TITLE
Fix structure field index number

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -168,7 +168,7 @@ export default {
 				return 1;
 			}
 
-			return (this.page - 1) * this.limit;
+			return (this.page - 1) * this.limit + 1;
 		},
 		/**
 		 * Returns if new entries can be added


### PR DESCRIPTION
## This PR …

This PR fixes broken index numbers in new table layout.

Related commit: https://github.com/getkirby/kirby/commit/c065bf513cad1fa5c900f16cb698393e02f94492#diff-8c97c5ba46d791ed23c29c05fe32dbfe6aeaea9ca71df35a72d63e938f9b1096

### Fixes
- When structure field is used with limit, index number now shows correctly #4695 

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
