### PR TITLE
Fix object field in blocks

### DIFF
--- a/config/fields/object.php
+++ b/config/fields/object.php
@@ -19,7 +19,7 @@ return [
 		/**
 		 * Set the default values for the object
 		 */
-		'default' => function (array $default = []) {
+		'default' => function ($default = null) {
 			return $default;
 		},
 


### PR DESCRIPTION
## This PR …

The blocks field only accepted arrays as default value. This breaks the entire field if it is used inside the blocks field. 

### Fixes

-  #4693 

### Breaking changes

- None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
