### PR TITLE
Populate the UUID cache when a UUID is printed

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -303,6 +303,25 @@ trait FileActions
 	}
 
 	/**
+	 * Stores the content on disk
+	 *
+	 * @internal
+	 * @param array|null $data
+	 * @param string|null $languageCode
+	 * @param bool $overwrite
+	 * @return static
+	 */
+	public function save(array $data = null, string $languageCode = null, bool $overwrite = false)
+	{
+		$file = parent::save($data, $languageCode, $overwrite);
+
+		// update model in siblings collection
+		$file->parent()->files()->set($file->id(), $file);
+
+		return $file;
+	}
+
+	/**
 	 * Remove all public versions of this file
 	 *
 	 * @return $this

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -401,17 +401,10 @@ abstract class ModelWithContent extends Model implements Identifiable
 	public function save(array $data = null, string $languageCode = null, bool $overwrite = false)
 	{
 		if ($this->kirby()->multilang() === true) {
-			$model = $this->saveTranslation($data, $languageCode, $overwrite);
-		} else {
-			$model = $this->saveContent($data, $overwrite);
+			return $this->saveTranslation($data, $languageCode, $overwrite);
 		}
 
-		// update model in siblings collection
-		if (method_exists($model, 'siblings') === true) {
-			$model->siblings()->add($model);
-		}
-
-		return $model;
+		return $this->saveContent($data, $overwrite);
 	}
 
 	/**

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -811,6 +811,25 @@ trait PageActions
 	}
 
 	/**
+	 * Stores the content on disk
+	 *
+	 * @internal
+	 * @param array|null $data
+	 * @param string|null $languageCode
+	 * @param bool $overwrite
+	 * @return static
+	 */
+	public function save(array $data = null, string $languageCode = null, bool $overwrite = false)
+	{
+		$page = parent::save($data, $languageCode, $overwrite);
+
+		// overwrite the updated page in the parent collection
+		static::updateParentCollections($page, 'set');
+
+		return $page;
+	}
+
+	/**
 	 * Convert a page from listed or
 	 * unlisted to draft.
 	 *

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -319,6 +319,10 @@ class Uuid
 		// it doesn't exist yet
 		$this->id();
 
+		// make sure the id is cached
+		// that it can be found again
+		$this->populate();
+
 		return $this->uri->toString();
 	}
 


### PR DESCRIPTION
## This PR …

When a UUID is converted to string, the UUID is generated if it is missing. But so far, the UUID wasn't added to the cache. This means that it couldn't be found afterwards, which broke the pages picker. This PR would fix that by also populating the cache in the toString method. @distantnative needs to check if that would have any unwanted side effects. 

### Fixes

- #4703

### Breaking changes

- None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
