### PR TITLE
New V::uuid validator

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -7,6 +7,7 @@ use Exception;
 use Kirby\Cms\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Idn;
+use Kirby\Uuid\Uuid;
 use ReflectionFunction;
 use Throwable;
 
@@ -628,5 +629,12 @@ V::$validators = [
 		// Added localhost support and removed 127.*.*.* ip restriction
 		$regex = '_^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:localhost)|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$_iu';
 		return preg_match($regex, $value ?? '') !== 0;
+	},
+
+	/**
+	 * Checks for a valid Uuid, optionally for specific model type
+	 */
+	'uuid' => function (string $value, string $type = null): bool {
+		return Uuid::is($value, $type);
 	}
 ];

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -618,6 +618,35 @@ class VTest extends TestCase
 		$this->assertFalse(V::time('24:24:24'));
 	}
 
+	public function testUuid()
+	{
+		$this->assertTrue(V::uuid('site://'));
+		$this->assertTrue(V::uuid('page://something'));
+		$this->assertTrue(V::uuid('user://something'));
+		$this->assertTrue(V::uuid('file://something'));
+		$this->assertTrue(V::uuid('file://something/else'));
+		// TODO: activate for  uuid-block-structure-support
+		// $this->assertTrue(V::uuid('struct://something'));
+		// $this->assertTrue(V::uuid('block://something'));
+		// $this->assertTrue(V::uuid('block://something/else'));
+
+		$this->assertTrue(V::uuid('site://', 'site'));
+		$this->assertTrue(V::uuid('page://something', 'page'));
+		$this->assertTrue(V::uuid('user://something', 'user'));
+		$this->assertTrue(V::uuid('file://something', 'file'));
+
+		$this->assertFalse(V::uuid('site://', 'block'));
+		$this->assertFalse(V::uuid('page://something', 'block'));
+		$this->assertFalse(V::uuid('user://something', 'block'));
+		$this->assertFalse(V::uuid('file://something', 'block'));
+
+		$this->assertFalse(V::uuid('file:/something'));
+		$this->assertFalse(V::uuid('foo://something'));
+		$this->assertFalse(V::uuid('page//something'));
+		$this->assertFalse(V::uuid('page//something', 'page'));
+		$this->assertFalse(V::uuid('not a page://something'));
+    }
+
 	public function testUrl()
 	{
 		// based on https://mathiasbynens.be/demo/url-regex

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -645,7 +645,7 @@ class VTest extends TestCase
 		$this->assertFalse(V::uuid('page//something'));
 		$this->assertFalse(V::uuid('page//something', 'page'));
 		$this->assertFalse(V::uuid('not a page://something'));
-    }
+	}
 
 	public function testUrl()
 	{


### PR DESCRIPTION
## This PR …

### Enhancement

Adds a `V::uuid()` validator (Alias of `Uuid::is(string, $type)`; tests adapted from there) …something I intuitively expected but missed in my first steps with UUID. Maybe it's of interest for core?

## Ready?

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)