### PR TITLE
Don’t use language specific URLs for permalinks

### DIFF
--- a/src/Uuid/ModelUuid.php
+++ b/src/Uuid/ModelUuid.php
@@ -104,7 +104,6 @@ abstract class ModelUuid extends Uuid
 			$this->populate();
 		}
 
-		$site = App::instance()->site()->url();
-		return $site . '/@/' . static::TYPE . '/' . $this->id();
+		return App::instance()->url() . '/@/' . static::TYPE . '/' . $this->id();
 	}
 }


### PR DESCRIPTION
## This PR …

The URL method for UUIDs used the site URL as base for the permalinks. But the site URL will contain the language code in a multi language site. Therefore we must use `$kirby->url()` instead as a neutral base URL. 

### Fixes

- https://github.com/getkirby/kirby/issues/4698

### Breaking changes

- None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
