### PR TITLE
Remove `mixed` type hint

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -91,7 +91,7 @@ class Api
 	 *
 	 * @throws \Kirby\Exception\NotFoundException
 	 */
-	public function __call(string $method, array $args = []): mixed
+	public function __call(string $method, array $args = [])
 	{
 		return $this->data($method, ...$args);
 	}
@@ -108,7 +108,7 @@ class Api
 	 * Runs the authentication method
 	 * if set
 	 */
-	public function authenticate(): mixed
+	public function authenticate()
 	{
 		return $this->authentication()?->call($this) ?? true;
 	}
@@ -130,7 +130,7 @@ class Api
 	 * @throws \Kirby\Exception\NotFoundException
 	 * @throws \Exception
 	 */
-	public function call(string|null $path = null, string $method = 'GET', array $requestData = []): mixed
+	public function call(string|null $path = null, string $method = 'GET', array $requestData = [])
 	{
 		$path = rtrim($path ?? '', '/');
 
@@ -223,7 +223,7 @@ class Api
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If no data for `$key` exists
 	 */
-	public function data(string|null $key = null, mixed ...$args): mixed
+	public function data(string|null $key = null, mixed ...$args)
 	{
 		if ($key === null) {
 			return $this->data;
@@ -314,7 +314,7 @@ class Api
 		string|null $type = null,
 		string|null $key = null,
 		mixed $default = null
-	): mixed {
+	) {
 		if ($type === null) {
 			return $this->requestData;
 		}
@@ -332,7 +332,7 @@ class Api
 	/**
 	 * Returns the request body if available
 	 */
-	public function requestBody(string|null $key = null, mixed $default = null): mixed
+	public function requestBody(string|null $key = null, mixed $default = null)
 	{
 		return $this->requestData('body', $key, $default);
 	}
@@ -340,7 +340,7 @@ class Api
 	/**
 	 * Returns the files from the request if available
 	 */
-	public function requestFiles(string|null $key = null, mixed $default = null): mixed
+	public function requestFiles(string|null $key = null, mixed $default = null)
 	{
 		return $this->requestData('files', $key, $default);
 	}
@@ -348,7 +348,7 @@ class Api
 	/**
 	 * Returns all headers from the request if available
 	 */
-	public function requestHeaders(string|null $key = null, mixed $default = null): mixed
+	public function requestHeaders(string|null $key = null, mixed $default = null)
 	{
 		return $this->requestData('headers', $key, $default);
 	}
@@ -364,7 +364,7 @@ class Api
 	/**
 	 * Returns the request query if available
 	 */
-	public function requestQuery(string|null $key = null, mixed $default = null): mixed
+	public function requestQuery(string|null $key = null, mixed $default = null)
 	{
 		return $this->requestData('query', $key, $default);
 	}
@@ -497,7 +497,7 @@ class Api
 	/**
 	 * Renders the API call
 	 */
-	public function render(string $path, string $method = 'GET', array $requestData = []): mixed
+	public function render(string $path, string $method = 'GET', array $requestData = [])
 	{
 		try {
 			$result = $this->call($path, $method, $requestData);

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -223,7 +223,7 @@ class Api
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If no data for `$key` exists
 	 */
-	public function data(string|null $key = null, mixed ...$args)
+	public function data(string|null $key = null, ...$args)
 	{
 		if ($key === null) {
 			return $this->data;
@@ -264,7 +264,7 @@ class Api
 	 * @param array models or collections
 	 * @return string|null key of match
 	 */
-	protected function match(array $array, mixed $object = null): string|null
+	protected function match(array $array, $object = null): string|null
 	{
 		foreach ($array as $definition => $model) {
 			if ($object instanceof $model['type']) {
@@ -280,7 +280,7 @@ class Api
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If no model for `$name` exists
 	 */
-	public function model(string|null $name = null, mixed $object = null): Model
+	public function model(string|null $name = null, $object = null): Model
 	{
 		// Try to auto-match object with API models
 		$name ??= $this->match($this->models, $object);
@@ -313,7 +313,7 @@ class Api
 	public function requestData(
 		string|null $type = null,
 		string|null $key = null,
-		mixed $default = null
+		$default = null
 	) {
 		if ($type === null) {
 			return $this->requestData;
@@ -332,7 +332,7 @@ class Api
 	/**
 	 * Returns the request body if available
 	 */
-	public function requestBody(string|null $key = null, mixed $default = null)
+	public function requestBody(string|null $key = null, $default = null)
 	{
 		return $this->requestData('body', $key, $default);
 	}
@@ -340,7 +340,7 @@ class Api
 	/**
 	 * Returns the files from the request if available
 	 */
-	public function requestFiles(string|null $key = null, mixed $default = null)
+	public function requestFiles(string|null $key = null, $default = null)
 	{
 		return $this->requestData('files', $key, $default);
 	}
@@ -348,7 +348,7 @@ class Api
 	/**
 	 * Returns all headers from the request if available
 	 */
-	public function requestHeaders(string|null $key = null, mixed $default = null)
+	public function requestHeaders(string|null $key = null, $default = null)
 	{
 		return $this->requestData('headers', $key, $default);
 	}
@@ -364,7 +364,7 @@ class Api
 	/**
 	 * Returns the request query if available
 	 */
-	public function requestQuery(string|null $key = null, mixed $default = null)
+	public function requestQuery(string|null $key = null, $default = null)
 	{
 		return $this->requestData('query', $key, $default);
 	}
@@ -375,7 +375,7 @@ class Api
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If `$object` cannot be resolved
 	 */
-	public function resolve(mixed $object): Model|Collection
+	public function resolve($object): Model|Collection
 	{
 		if (
 			$object instanceof Model ||

--- a/src/Api/Collection.php
+++ b/src/Api/Collection.php
@@ -21,17 +21,17 @@ use Kirby\Toolkit\Str;
 class Collection
 {
 	protected Api $api;
-	protected mixed $data;
-	protected mixed $model;
-	protected mixed $select;
-	protected mixed $view;
+	protected $data;
+	protected $model;
+	protected $select;
+	protected $view;
 
 	/**
 	 * Collection constructor
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct(Api $api, mixed $data, array $schema)
+	public function __construct(Api $api, $data, array $schema)
 	{
 		$this->api    = $api;
 		$this->data   = $data;
@@ -59,7 +59,7 @@ class Collection
 	 * @return $this
 	 * @throws \Exception
 	 */
-	public function select(mixed $keys = null): static
+	public function select($keys = null): static
 	{
 		if ($keys === false) {
 			return $this;

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -23,17 +23,17 @@ use Kirby\Toolkit\Str;
 class Model
 {
 	protected Api $api;
-	protected mixed $data;
-	protected mixed $fields;
-	protected mixed $select;
-	protected mixed $views;
+	protected $data;
+	protected $fields;
+	protected $select;
+	protected $views;
 
 	/**
 	 * Model constructor
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct(Api $api, mixed $data, array $schema)
+	public function __construct(Api $api, $data, array $schema)
 	{
 		$this->api    = $api;
 		$this->data   = $data;
@@ -68,7 +68,7 @@ class Model
 	 * @return $this
 	 * @throws \Exception
 	 */
-	public function select(mixed $keys = null): static
+	public function select($keys = null): static
 	{
 		if ($keys === false) {
 			return $this;

--- a/src/Blueprint/Collection.php
+++ b/src/Blueprint/Collection.php
@@ -77,7 +77,7 @@ class Collection extends BaseCollection
 		return $collection;
 	}
 
-	public function render(ModelWithContent $model): mixed
+	public function render(ModelWithContent $model)
 	{
 		$props = [];
 

--- a/src/Blueprint/Factory.php
+++ b/src/Blueprint/Factory.php
@@ -44,7 +44,7 @@ class Factory
 		return $properties;
 	}
 
-	public static function forNamedType(ReflectionNamedType|null $type, mixed $value)
+	public static function forNamedType(ReflectionNamedType|null $type, $value)
 	{
 		// get the class name for the single type
 		$className = $type->getName();
@@ -73,7 +73,7 @@ class Factory
 		return $properties;
 	}
 
-	public static function forProperty(string $class, string $property, mixed $value)
+	public static function forProperty(string $class, string $property, $value)
 	{
 		if (is_null($value) === true) {
 			return $value;
@@ -107,7 +107,7 @@ class Factory
 	 * the first named type is used to create
 	 * the factory or pass a built-in value
 	 */
-	public static function forUnionType(ReflectionUnionType $type, mixed $value)
+	public static function forUnionType(ReflectionUnionType $type, $value)
 	{
 		return static::forNamedType($type->getTypes()[0], $value);
 	}

--- a/src/Blueprint/Factory.php
+++ b/src/Blueprint/Factory.php
@@ -44,7 +44,7 @@ class Factory
 		return $properties;
 	}
 
-	public static function forNamedType(ReflectionNamedType|null $type, mixed $value): mixed
+	public static function forNamedType(ReflectionNamedType|null $type, mixed $value)
 	{
 		// get the class name for the single type
 		$className = $type->getName();
@@ -73,7 +73,7 @@ class Factory
 		return $properties;
 	}
 
-	public static function forProperty(string $class, string $property, mixed $value): mixed
+	public static function forProperty(string $class, string $property, mixed $value)
 	{
 		if (is_null($value) === true) {
 			return $value;
@@ -107,7 +107,7 @@ class Factory
 	 * the first named type is used to create
 	 * the factory or pass a built-in value
 	 */
-	public static function forUnionType(ReflectionUnionType $type, mixed $value): mixed
+	public static function forUnionType(ReflectionUnionType $type, mixed $value)
 	{
 		return static::forNamedType($type->getTypes()[0], $value);
 	}

--- a/src/Blueprint/Node.php
+++ b/src/Blueprint/Node.php
@@ -85,7 +85,7 @@ class Node
 		return $props;
 	}
 
-	public function render(ModelWithContent $model): mixed
+	public function render(ModelWithContent $model)
 	{
 		// apply default values
 		$this->defaults();

--- a/src/Blueprint/Node.php
+++ b/src/Blueprint/Node.php
@@ -110,7 +110,7 @@ class Node
 	/**
 	 * Universal setter for properties
 	 */
-	public function set(string $property, mixed $value): static
+	public function set(string $property, $value): static
 	{
 		$this->$property = Factory::forProperty(static::class, $property, $value);
 		return $this;

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -73,7 +73,7 @@ class ApcuCache extends Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	public function set(string $key, mixed $value, int $minutes = 0): bool
+	public function set(string $key, $value, int $minutes = 0): bool
 	{
 		$key     = $this->key($key);
 		$value   = (new Value($value, $minutes))->toJson();

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -140,7 +140,7 @@ abstract class Cache
 	 *   $value = $cache->get('value', 'default value');
 	 * </code>
 	 */
-	public function get(string $key, mixed $default = null)
+	public function get(string $key, $default = null)
 	{
 		// get the Value
 		$value = $this->retrieve($key);
@@ -234,5 +234,5 @@ abstract class Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	abstract public function set(string $key, mixed $value, int $minutes = 0): bool;
+	abstract public function set(string $key, $value, int $minutes = 0): bool;
 }

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -140,7 +140,7 @@ abstract class Cache
 	 *   $value = $cache->get('value', 'default value');
 	 * </code>
 	 */
-	public function get(string $key, mixed $default = null): mixed
+	public function get(string $key, mixed $default = null)
 	{
 		// get the Value
 		$value = $this->retrieve($key);
@@ -171,7 +171,7 @@ abstract class Cache
 		string $key,
 		Closure $result,
 		int $minutes = 0
-	): mixed {
+	) {
 		$value  = $this->get($key);
 		$result = $value ?? $result();
 

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -125,7 +125,7 @@ class FileCache extends Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	public function set(string $key, mixed $value, int $minutes = 0): bool
+	public function set(string $key, $value, int $minutes = 0): bool
 	{
 		$file = $this->file($key);
 

--- a/src/Cache/MemCached.php
+++ b/src/Cache/MemCached.php
@@ -67,7 +67,7 @@ class MemCached extends Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	public function set(string $key, mixed $value, int $minutes = 0): bool
+	public function set(string $key, $value, int $minutes = 0): bool
 	{
 		$key     = $this->key($key);
 		$value   = (new Value($value, $minutes))->toJson();

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -36,7 +36,7 @@ class MemoryCache extends Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	public function set(string $key, mixed $value, int $minutes = 0): bool
+	public function set(string $key, $value, int $minutes = 0): bool
 	{
 		$this->store[$key] = new Value($value, $minutes);
 		return true;

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -31,7 +31,7 @@ class NullCache extends Cache
 	 *   $cache->set('value', 'my value', 15);
 	 * </code>
 	 */
-	public function set(string $key, mixed $value, int $minutes = 0): bool
+	public function set(string $key, $value, int $minutes = 0): bool
 	{
 		return true;
 	}

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -20,7 +20,7 @@ class Value
 	/**
 	 * Cached value
 	 */
-	protected mixed $value;
+	protected $value;
 
 	/**
 	 * the number of minutes until the value expires
@@ -41,7 +41,7 @@ class Value
 	 *                     or an absolute UNIX timestamp
 	 * @param int $created the UNIX timestamp when the value has been created
 	 */
-	public function __construct(mixed $value, int $minutes = 0, int|null $created = null)
+	public function __construct($value, int $minutes = 0, int|null $created = null)
 	{
 		$this->value   = $value;
 		$this->minutes = $minutes;

--- a/src/Cache/Value.php
+++ b/src/Cache/Value.php
@@ -129,7 +129,7 @@ class Value
 	/**
 	 * Returns the pure value
 	 */
-	public function value(): mixed
+	public function value()
 	{
 		return $this->value;
 	}

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -31,7 +31,7 @@ class Api extends BaseApi
 		string|null $path = null,
 		string $method = 'GET',
 		array $requestData = []
-	): mixed {
+	) {
 		$this->setRequestMethod($method);
 		$this->setRequestData($requestData);
 
@@ -49,7 +49,7 @@ class Api extends BaseApi
 	/**
 	 * @throws \Kirby\Exception\NotFoundException if the field type cannot be found or the field cannot be loaded
 	 */
-	public function fieldApi(mixed $model, string $name, string|null $path = null): mixed
+	public function fieldApi(mixed $model, string $name, string|null $path = null)
 	{
 		$field = Form::for($model)->field($name);
 

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -49,7 +49,7 @@ class Api extends BaseApi
 	/**
 	 * @throws \Kirby\Exception\NotFoundException if the field type cannot be found or the field cannot be loaded
 	 */
-	public function fieldApi(mixed $model, string $name, string|null $path = null)
+	public function fieldApi($model, string $name, string|null $path = null)
 	{
 		$field = Form::for($model)->field($name);
 

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -41,7 +41,7 @@ class Helpers
 	 * @param bool $echo
 	 * @return string
 	 */
-	public static function dump(mixed $variable, bool $echo = true): string
+	public static function dump($variable, bool $echo = true): string
 	{
 		$kirby = App::instance();
 

--- a/src/Cms/Nest.php
+++ b/src/Cms/Nest.php
@@ -19,7 +19,7 @@ namespace Kirby\Cms;
 class Nest
 {
 	public static function create(
-		mixed $data,
+		$data,
 		object|null $parent = null
 	): NestCollection|NestObject|Field {
 		if (is_scalar($data) === true) {

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -33,7 +33,7 @@ class Plugin extends Model
 	/**
 	 * Allows access to any composer.json field by method call
 	 */
-	public function __call(string $key, array $arguments = null): mixed
+	public function __call(string $key, array $arguments = null)
 	{
 		return $this->info()[$key] ?? null;
 	}
@@ -161,7 +161,7 @@ class Plugin extends Model
 	/**
 	 * Returns a Kirby option value for this plugin
 	 */
-	public function option(string $key): mixed
+	public function option(string $key)
 	{
 		return $this->kirby()->option($this->prefix() . '.' . $key);
 	}

--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -74,7 +74,7 @@ class Data
 	/**
 	 * Decodes data with the specified handler
 	 */
-	public static function decode(mixed $string, string $type): array
+	public static function decode($string, string $type): array
 	{
 		return static::handler($type)->decode($string);
 	}
@@ -82,7 +82,7 @@ class Data
 	/**
 	 * Encodes data with the specified handler
 	 */
-	public static function encode(mixed $data, string $type): string
+	public static function encode($data, string $type): string
 	{
 		return static::handler($type)->encode($data);
 	}
@@ -104,7 +104,7 @@ class Data
 	 */
 	public static function write(
 		string $file,
-		mixed $data = [],
+		$data = [],
 		string|null $type = null
 	): bool {
 		return static::handler($type ?? F::extension($file))->write($file, $data);

--- a/src/Data/Handler.php
+++ b/src/Data/Handler.php
@@ -23,12 +23,12 @@ abstract class Handler
 	 *
 	 * @throws \Exception if the file can't be parsed
 	 */
-	abstract public static function decode(mixed $string): array;
+	abstract public static function decode($string): array;
 
 	/**
 	 * Converts an array to an encoded string
 	 */
-	abstract public static function encode(mixed $data): string;
+	abstract public static function encode($data): string;
 
 	/**
 	 * Reads data from a file
@@ -46,7 +46,7 @@ abstract class Handler
 	/**
 	 * Writes data to a file
 	 */
-	public static function write(string $file, mixed $data = []): bool
+	public static function write(string $file, $data = []): bool
 	{
 		return F::write($file, static::encode($data));
 	}

--- a/src/Data/Json.php
+++ b/src/Data/Json.php
@@ -18,7 +18,7 @@ class Json extends Handler
 	/**
 	 * Converts an array to an encoded JSON string
 	 */
-	public static function encode(mixed $data): string
+	public static function encode($data): string
 	{
 		return json_encode(
 			$data,
@@ -29,7 +29,7 @@ class Json extends Handler
 	/**
 	 * Parses an encoded JSON string and returns a multi-dimensional array
 	 */
-	public static function decode(mixed $string): array
+	public static function decode($string): array
 	{
 		if ($string === null || $string === '') {
 			return [];

--- a/src/Data/PHP.php
+++ b/src/Data/PHP.php
@@ -22,7 +22,7 @@ class PHP extends Handler
 	 *
 	 * @param string $indent For internal use only
 	 */
-	public static function encode(mixed $data, string $indent = ''): string
+	public static function encode($data, string $indent = ''): string
 	{
 		switch (gettype($data)) {
 			case 'array':
@@ -47,7 +47,7 @@ class PHP extends Handler
 	/**
 	 * PHP strings shouldn't be decoded manually
 	 */
-	public static function decode(mixed $string): array
+	public static function decode($string): array
 	{
 		throw new BadMethodCallException('The PHP::decode() method is not implemented');
 	}
@@ -67,7 +67,7 @@ class PHP extends Handler
 	/**
 	 * Creates a PHP file with the given data
 	 */
-	public static function write(string $file, mixed $data = []): bool
+	public static function write(string $file, $data = []): bool
 	{
 		$php = static::encode($data);
 		$php = "<?php\n\nreturn $php;";

--- a/src/Data/Txt.php
+++ b/src/Data/Txt.php
@@ -20,7 +20,7 @@ class Txt extends Handler
 	/**
 	 * Converts an array to an encoded Kirby txt string
 	 */
-	public static function encode(mixed $data): string
+	public static function encode($data): string
 	{
 		$result = [];
 
@@ -79,7 +79,7 @@ class Txt extends Handler
 	/**
 	 * Parses a Kirby txt string and returns a multi-dimensional array
 	 */
-	public static function decode(mixed $string): array
+	public static function decode($string): array
 	{
 		if ($string === null || $string === '') {
 			return [];

--- a/src/Data/Xml.php
+++ b/src/Data/Xml.php
@@ -19,7 +19,7 @@ class Xml extends Handler
 	/**
 	 * Converts an array to an encoded XML string
 	 */
-	public static function encode(mixed $data): string
+	public static function encode($data): string
 	{
 		return XmlConverter::create($data, 'data');
 	}
@@ -27,7 +27,7 @@ class Xml extends Handler
 	/**
 	 * Parses an encoded XML string and returns a multi-dimensional array
 	 */
-	public static function decode(mixed $string): array
+	public static function decode($string): array
 	{
 		if ($string === null || $string === '') {
 			return [];

--- a/src/Data/Yaml.php
+++ b/src/Data/Yaml.php
@@ -19,7 +19,7 @@ class Yaml extends Handler
 	/**
 	 * Converts an array to an encoded YAML string
 	 */
-	public static function encode(mixed $data): string
+	public static function encode($data): string
 	{
 		// $data, $indent, $wordwrap, $no_opening_dashes
 		return Spyc::YAMLDump($data, false, false, true);
@@ -28,7 +28,7 @@ class Yaml extends Handler
 	/**
 	 * Parses an encoded YAML string and returns a multi-dimensional array
 	 */
-	public static function decode(mixed $string): array
+	public static function decode($string): array
 	{
 		if ($string === null || $string === '') {
 			return [];

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -347,7 +347,7 @@ class F
 	 *
 	 * @param array $data Optional array of variables to extract in the variable scope
 	 */
-	public static function load(string $file, mixed $fallback = null, array $data = [])
+	public static function load(string $file, $fallback = null, array $data = [])
 	{
 		if (is_file($file) === false) {
 			return $fallback;
@@ -841,7 +841,7 @@ class F
 	 * @param mixed $content Either a string, an object or an array. Arrays and objects will be serialized.
 	 * @param bool $append true: append the content to an existing file if available. false: overwrite.
 	 */
-	public static function write(string $file, mixed $content, bool $append = false): bool
+	public static function write(string $file, $content, bool $append = false): bool
 	{
 		if (is_array($content) === true || is_object($content) === true) {
 			$content = serialize($content);

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -347,7 +347,7 @@ class F
 	 *
 	 * @param array $data Optional array of variables to extract in the variable scope
 	 */
-	public static function load(string $file, mixed $fallback = null, array $data = []): mixed
+	public static function load(string $file, mixed $fallback = null, array $data = [])
 	{
 		if (is_file($file) === false) {
 			return $fallback;
@@ -394,7 +394,7 @@ class F
 	 *
 	 * @param array $data Optional array of variables to extract in the variable scope
 	 */
-	protected static function loadIsolated(string $file, array $data = []): mixed
+	protected static function loadIsolated(string $file, array $data = [])
 	{
 		// extract the $data variables in this scope to be accessed by the included file;
 		// protect $file against being overwritten by a $data variable

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -52,7 +52,7 @@ trait IsFile
 	 *
 	 * @throws \Kirby\Exception\BadMethodCallException
 	 */
-	public function __call(string $method, array $arguments = []): mixed
+	public function __call(string $method, array $arguments = [])
 	{
 		// public property access
 		if (isset($this->$method) === true) {

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -637,7 +637,7 @@ class Environment
 	 * @param mixed $default Optional default value, which should be
 	 *                       returned if no element has been found
 	 */
-	public function get(string|false|null $key = null, mixed $default = null)
+	public function get(string|false|null $key = null, $default = null)
 	{
 		if (is_string($key) === false) {
 			return $this->info;
@@ -660,7 +660,7 @@ class Environment
 	 * @param mixed $default Optional default value, which should be
 	 *                       returned if no element has been found
 	 */
-	public static function getGlobally(string|false|null $key = null, mixed $default = null)
+	public static function getGlobally(string|false|null $key = null, $default = null)
 	{
 		// first try the global `Environment` object if the CMS is running
 		$app = App::instance(null, true);
@@ -833,7 +833,7 @@ class Environment
 	/**
 	 * Sanitizes some `$_SERVER` keys
 	 */
-	public static function sanitize(string|array $key, mixed $value = null)
+	public static function sanitize(string|array $key, $value = null)
 	{
 		if (is_array($key) === true) {
 			foreach ($key as $k => $v) {

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -637,7 +637,7 @@ class Environment
 	 * @param mixed $default Optional default value, which should be
 	 *                       returned if no element has been found
 	 */
-	public function get(string|false|null $key = null, mixed $default = null): mixed
+	public function get(string|false|null $key = null, mixed $default = null)
 	{
 		if (is_string($key) === false) {
 			return $this->info;
@@ -660,7 +660,7 @@ class Environment
 	 * @param mixed $default Optional default value, which should be
 	 *                       returned if no element has been found
 	 */
-	public static function getGlobally(string|false|null $key = null, mixed $default = null): mixed
+	public static function getGlobally(string|false|null $key = null, mixed $default = null)
 	{
 		// first try the global `Environment` object if the CMS is running
 		$app = App::instance(null, true);
@@ -833,7 +833,7 @@ class Environment
 	/**
 	 * Sanitizes some `$_SERVER` keys
 	 */
-	public static function sanitize(string|array $key, mixed $value = null): mixed
+	public static function sanitize(string|array $key, mixed $value = null)
 	{
 		if (is_array($key) === true) {
 			foreach ($key as $k => $v) {

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -319,7 +319,7 @@ class Remote
 	/**
 	 * Internal method to handle post field data
 	 */
-	protected function postfields(mixed $data)
+	protected function postfields($data)
 	{
 		if (is_object($data) || is_array($data)) {
 			return http_build_query($data);

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -52,7 +52,7 @@ class Remote
 	/**
 	 * Magic getter for request info data
 	 */
-	public function __call(string $method, array $arguments = []): mixed
+	public function __call(string $method, array $arguments = [])
 	{
 		$method = str_replace('-', '_', Str::kebab($method));
 		return $this->info[$method] ?? null;
@@ -319,7 +319,7 @@ class Remote
 	/**
 	 * Internal method to handle post field data
 	 */
-	protected function postfields(mixed $data): mixed
+	protected function postfields(mixed $data)
 	{
 		if (is_object($data) || is_array($data)) {
 			return http_build_query($data);

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -259,7 +259,7 @@ class Request
 	 * Returns any data field from the request
 	 * if it exists
 	 */
-	public function get(string|array|null $key = null, mixed $fallback = null): mixed
+	public function get(string|array|null $key = null, mixed $fallback = null)
 	{
 		return A::get($this->data(), $key, $fallback);
 	}
@@ -277,7 +277,7 @@ class Request
 	/**
 	 * Returns a header by key if it exists
 	 */
-	public function header(string $key, mixed $fallback = null): mixed
+	public function header(string $key, mixed $fallback = null)
 	{
 		$headers = array_change_key_case($this->headers());
 		return $headers[strtolower($key)] ?? $fallback;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -259,7 +259,7 @@ class Request
 	 * Returns any data field from the request
 	 * if it exists
 	 */
-	public function get(string|array|null $key = null, mixed $fallback = null)
+	public function get(string|array|null $key = null, $fallback = null)
 	{
 		return A::get($this->data(), $key, $fallback);
 	}
@@ -277,7 +277,7 @@ class Request
 	/**
 	 * Returns a header by key if it exists
 	 */
-	public function header(string $key, mixed $fallback = null)
+	public function header(string $key, $fallback = null)
 	{
 		$headers = array_change_key_case($this->headers());
 		return $headers[strtolower($key)] ?? $fallback;

--- a/src/Http/Request/Data.php
+++ b/src/Http/Request/Data.php
@@ -40,7 +40,7 @@ trait Data
 	 * of the data array by key or multiple values by
 	 * passing an array of keys.
 	 */
-	public function get(string|array $key, mixed $default = null): mixed
+	public function get(string|array $key, mixed $default = null)
 	{
 		if (is_array($key) === true) {
 			$result = [];

--- a/src/Http/Request/Data.php
+++ b/src/Http/Request/Data.php
@@ -40,7 +40,7 @@ trait Data
 	 * of the data array by key or multiple values by
 	 * passing an array of keys.
 	 */
-	public function get(string|array $key, mixed $default = null)
+	public function get(string|array $key, $default = null)
 	{
 		if (is_array($key) === true) {
 			$result = [];

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -63,7 +63,7 @@ class Route
 	/**
 	 * Magic getter for route attributes
 	 */
-	public function __call(string $key, array $arguments = null): mixed
+	public function __call(string $key, array $arguments = null)
 	{
 		return $this->attributes[$key] ?? null;
 	}

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -100,7 +100,7 @@ class Router
 		string|null $path = null,
 		string $method = 'GET',
 		Closure|null $callback = null
-	): mixed {
+	) {
 		$path ??= '';
 		$ignore = [];
 		$result = null;
@@ -139,7 +139,7 @@ class Router
 	 * the routing action immediately
 	 * @since 3.7.0
 	 */
-	public static function execute(string|null $path = null, string $method = 'GET', array $routes = [], Closure|null $callback = null): mixed
+	public static function execute(string|null $path = null, string $method = 'GET', array $routes = [], Closure|null $callback = null)
 	{
 		return (new static($routes))->call($path, $method, $callback);
 	}

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -135,7 +135,7 @@ class Uri
 	/**
 	 * Magic setter
 	 */
-	public function __set(string $property, mixed $value): void
+	public function __set(string $property, $value): void
 	{
 		if (method_exists($this, 'set' . $property) === true) {
 			$this->{'set' . $property}($value);

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -85,7 +85,7 @@ class Uri
 	/**
 	 * Magic caller to access all properties
 	 */
-	public function __call(string $property, array $arguments = []): mixed
+	public function __call(string $property, array $arguments = [])
 	{
 		return $this->$property ?? null;
 	}
@@ -127,7 +127,7 @@ class Uri
 	/**
 	 * Magic getter
 	 */
-	public function __get(string $property): mixed
+	public function __get(string $property)
 	{
 		return $this->$property ?? null;
 	}

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -28,7 +28,7 @@ class Url
 	/**
 	 * Facade for all Uri object methods
 	 */
-	public static function __callStatic(string $method, array $arguments): mixed
+	public static function __callStatic(string $method, array $arguments)
 	{
 		return (new Uri($arguments[0] ?? static::current()))->$method(...array_slice($arguments, 1));
 	}

--- a/src/Option/OptionsProvider.php
+++ b/src/Option/OptionsProvider.php
@@ -17,10 +17,11 @@ use Kirby\Cms\ModelWithContent;
 abstract class OptionsProvider
 {
 	public Options|null $options = null;
+
 	/**
 	 * Returns options as array
 	 */
-	public function render(ModelWithContent $model): mixed
+	public function render(ModelWithContent $model)
 	{
 		return $this->resolve($model)->render($model);
 	}

--- a/src/Panel/Dialog.php
+++ b/src/Panel/Dialog.php
@@ -23,7 +23,7 @@ class Dialog extends Json
 	/**
 	 * Renders dialogs
 	 */
-	public static function response(mixed $data, array $options = []): Response
+	public static function response($data, array $options = []): Response
 	{
 		// interpret true as success
 		if ($data === true) {

--- a/src/Panel/Dropdown.php
+++ b/src/Panel/Dropdown.php
@@ -72,7 +72,7 @@ class Dropdown extends Json
 	/**
 	 * Renders dropdowns
 	 */
-	public static function response(mixed $data, array $options = []): Response
+	public static function response($data, array $options = []): Response
 	{
 		if (is_array($data) === true) {
 			$data = [

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -37,7 +37,7 @@ abstract class Json
 	/**
 	 * Prepares the JSON response for the Panel
 	 */
-	public static function response(mixed $data, array $options = []): Response
+	public static function response($data, array $options = []): Response
 	{
 		// handle redirects
 		if ($data instanceof Redirect) {

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -232,7 +232,7 @@ class Panel
 	 * Creates a Response object from the result of
 	 * a Panel route call
 	 */
-	public static function response(mixed $result, array $options = []): Response
+	public static function response($result, array $options = []): Response
 	{
 		// pass responses directly down to the Kirby router
 		if ($result instanceof Response) {

--- a/src/Panel/Search.php
+++ b/src/Panel/Search.php
@@ -20,7 +20,7 @@ class Search extends Json
 {
 	protected static string $key = '$search';
 
-	public static function response(mixed $data, array $options = []): Response
+	public static function response($data, array $options = []): Response
 	{
 		if (is_array($data) === true) {
 			$data = [

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -369,7 +369,7 @@ class View
 	 * JSON response or full HTML document based
 	 * on the request header or query params
 	 */
-	public static function response(mixed $data, array $options = []): Response
+	public static function response($data, array $options = []): Response
 	{
 		// handle redirects
 		if ($data instanceof Redirect) {

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -93,7 +93,7 @@ class KirbyTag
 		return $this->$attr ?? null;
 	}
 
-	public function attr(string $name, mixed $default = null)
+	public function attr(string $name, $default = null)
 	{
 		$name = strtolower($name);
 		return $this->$name ?? $default;
@@ -151,7 +151,7 @@ class KirbyTag
 		return $this->data['kirby'] ?? App::instance();
 	}
 
-	public function option(string $key, mixed $default = null)
+	public function option(string $key, $default = null)
 	{
 		return $this->options[$key] ?? $default;
 	}

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -74,7 +74,7 @@ class KirbyTag
 	/**
 	 * Magic data and property getter
 	 */
-	public function __call(string $name, array $arguments = []): mixed
+	public function __call(string $name, array $arguments = [])
 	{
 		return $this->data[$name] ?? $this->$name;
 	}
@@ -87,13 +87,13 @@ class KirbyTag
 		return (new static($type, ...$arguments))->render();
 	}
 
-	public function __get(string $attr): mixed
+	public function __get(string $attr)
 	{
 		$attr = strtolower($attr);
 		return $this->$attr ?? null;
 	}
 
-	public function attr(string $name, mixed $default = null): mixed
+	public function attr(string $name, mixed $default = null)
 	{
 		$name = strtolower($name);
 		return $this->$name ?? $default;
@@ -151,7 +151,7 @@ class KirbyTag
 		return $this->data['kirby'] ?? App::instance();
 	}
 
-	public function option(string $key, mixed $default = null): mixed
+	public function option(string $key, mixed $default = null)
 	{
 		return $this->options[$key] ?? $default;
 	}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -76,7 +76,7 @@ class A
 	public static function get(
 		$array,
 		string|int|array|null $key,
-		mixed $default = null
+		$default = null
 	) {
 		if (is_array($array) === false) {
 			return $array;
@@ -712,7 +712,7 @@ class A
 	 * Wraps the given value in an array
 	 * if it's not an array yet.
 	 */
-	public static function wrap(mixed $array = null): array
+	public static function wrap($array = null): array
 	{
 		if ($array === null) {
 			return [];

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -77,7 +77,7 @@ class A
 		$array,
 		string|int|array|null $key,
 		mixed $default = null
-	): mixed {
+	) {
 		if (is_array($array) === false) {
 			return $array;
 		}
@@ -303,7 +303,7 @@ class A
 	 * @param array $array The source array
 	 * @return mixed The first element
 	 */
-	public static function first(array $array): mixed
+	public static function first(array $array)
 	{
 		return array_shift($array);
 	}
@@ -325,7 +325,7 @@ class A
 	 * @param array $array The source array
 	 * @return mixed The last element
 	 */
-	public static function last(array $array): mixed
+	public static function last(array $array)
 	{
 		return array_pop($array);
 	}


### PR DESCRIPTION
The `mixed` type hint creates breaking changes for plugins that extend our classes, but on its own it doesn't add any benefits.