### PR TITLE
`NodeI18n`: reuse `I18n` logic

### DIFF
--- a/src/Blueprint/NodeI18n.php
+++ b/src/Blueprint/NodeI18n.php
@@ -39,15 +39,12 @@ class NodeI18n extends NodeProperty
 
 	public function render(ModelWithContent $model): string|null
 	{
-		$locale = I18n::locale();
-
-		if (isset($this->translations[$locale]) === true) {
-			return $this->translations[$locale];
+		if ($text = I18n::translate($this->translations)) {
+			return $text;
 		}
 
 		if (isset($this->translations['*']) === true) {
-			$translations = $this->translations['*'];
-			return I18n::translation($locale)[$translations] ?? $translations;
+			return I18n::translate($this->translations['*'], $this->translations['*']);
 		}
 
 		return $this->translations['en'] ?? null;

--- a/src/Blueprint/NodeI18n.php
+++ b/src/Blueprint/NodeI18n.php
@@ -44,9 +44,14 @@ class NodeI18n extends NodeProperty
 		}
 
 		if (isset($this->translations['*']) === true) {
-			return I18n::translate($this->translations['*'], $this->translations['*']);
+			$key = $this->translations['*'];
+			return I18n::translate($key, $key);
 		}
 
-		return $this->translations['en'] ?? null;
+		if (isset($this->translations['en']) === true) {
+			return $this->translations['en'];
+		}
+
+		return array_values($this->translations)[0] ?? null;
 	}
 }

--- a/src/Blueprint/NodeI18n.php
+++ b/src/Blueprint/NodeI18n.php
@@ -39,19 +39,6 @@ class NodeI18n extends NodeProperty
 
 	public function render(ModelWithContent $model): string|null
 	{
-		if ($text = I18n::translate($this->translations)) {
-			return $text;
-		}
-
-		if (isset($this->translations['*']) === true) {
-			$key = $this->translations['*'];
-			return I18n::translate($key, $key);
-		}
-
-		if (isset($this->translations['en']) === true) {
-			return $this->translations['en'];
-		}
-
-		return array_values($this->translations)[0] ?? null;
+		return I18n::translate($this->translations, $this->translations);
 	}
 }

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -205,9 +205,6 @@ class I18n
 	 * Returns the current or any other translation
 	 * by locale. If the translation does not exist
 	 * yet, the loader will try to load it, if defined.
-	 *
-	 * @param string|null $locale
-	 * @return array
 	 */
 	public static function translation(string $locale = null): array
 	{
@@ -232,8 +229,6 @@ class I18n
 
 	/**
 	 * Returns all loaded or defined translations
-	 *
-	 * @return array
 	 */
 	public static function translations(): array
 	{
@@ -242,16 +237,17 @@ class I18n
 
 	/**
 	 * Returns (and creates) a decimal number formatter for a given locale
-	 *
-	 * @return \NumberFormatter|null
 	 */
-	protected static function decimalNumberFormatter(string $locale): ?NumberFormatter
+	protected static function decimalNumberFormatter(string $locale): NumberFormatter|null
 	{
-		if (isset(static::$decimalsFormatters[$locale])) {
+		if (isset(static::$decimalsFormatters[$locale]) === true) {
 			return static::$decimalsFormatters[$locale];
 		}
 
-		if (extension_loaded('intl') !== true || class_exists('NumberFormatter') !== true) {
+		if (
+			extension_loaded('intl') !== true ||
+			class_exists('NumberFormatter') !== true
+		) {
 			return null; // @codeCoverageIgnore
 		}
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -146,10 +146,17 @@ class I18n
 			if (isset($key[$lang]) === true) {
 				return $key[$lang];
 			}
+			// use global wildcard as i18n key
+			if (isset($key['*']) === true) {
+				return static::translate($key['*'], $key['*']);
+			}
 			// use fallback
 			if (is_array($fallback) === true) {
-				return $fallback[$locale] ?? $fallback['en'] ?? reset($fallback);
+				return $fallback[$locale] ??
+					   $fallback['en'] ??
+					   reset($fallback);
 			}
+
 			return $fallback;
 		}
 

--- a/tests/Blueprint/NodeI18nTest.php
+++ b/tests/Blueprint/NodeI18nTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+/**
+ * @covers \Kirby\Blueprint\NodeI18n
+ */
+class NodeI18nTest extends TestCase
+{
+	/**
+	 * @covers ::__construct
+	 * @covers ::render
+	 */
+	public function testConstructWithArray()
+	{
+		$translated = new NodeI18n(['en' => 'Test']);
+		$this->assertSame('Test', $translated->render($this->model()));
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::render
+	 */
+	public function testConstructWithI18nKey()
+	{
+		$translated = new NodeI18n(['*' => 'avatar']);
+		$this->assertSame('Profile picture', $translated->render($this->model()));
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactory()
+	{
+		$translated = NodeI18n::factory('Test');
+		$this->assertSame(['en' => 'Test'], $translated->translations);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderWithNonEnglishFallback()
+	{
+		$translated = new NodeI18n(['de' => 'Täst']);
+		$this->assertSame('Täst', $translated->render($this->model()));
+	}
+}

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -266,6 +266,52 @@ class I18nTest extends TestCase
 	}
 
 	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayWithI18nKey()
+	{
+		I18n::$locale = 'de';
+
+		I18n::$translations = [
+			'de' => ['save' => 'Speichern']
+		];
+
+		$this->assertSame('Speichern', I18n::translate([
+			'*' => 'save'
+		]));
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayWithFallbackEnglish()
+	{
+		I18n::$locale = 'de';
+
+		$translations = [
+			'en' => 'Some',
+			'es' => 'Algunos'
+		];
+
+		$this->assertSame('Some', I18n::translate($translations, $translations));
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayWithFallbackFirstLanguage()
+	{
+		I18n::$locale = 'en';
+
+		$translations = [
+			'es' => 'Algunos',
+			'de' => 'Einige',
+		];
+
+		$this->assertSame('Algunos', I18n::translate($translations, $translations));
+	}
+
+	/**
 	 * @covers ::translateCount
 	 */
 	public function testTranslateCount()


### PR DESCRIPTION
We can use `I18n::translate()` logic here instead of duplicating it.
This will likely also fix https://github.com/getkirby/kirby/issues/4726 as it implements fallback for locales with underscores when the blueprint just specifies short versions.

### Enhancements
- `I18n::translate()` supports passing an i18n key as `*` array key  