### PR TITLE
More efficient lock check

### DIFF
--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -5,21 +5,15 @@
  * Content Lock Routes
  */
 return [
-    [
-        'pattern' => '(:all)/lock',
-        'method'  => 'GET',
-        'action'  => function (string $path) {
-			if ($lock = $this->parent($path)->lock()) {
-                return [
-					'lock' => $lock->toArray()
-				];
-			}
-
-            return [
-                'lock' => false
-            ];
-        }
-    ],
+	[
+		'pattern' => '(:all)/lock',
+		'method'  => 'GET',
+		'action'  => function (string $path) {
+			return [
+				'lock' => $this->parent($path)->lock()?->toArray() ?? false
+			];
+		}
+	],
 	[
 		'pattern' => '(:all)/lock',
 		'method'  => 'PATCH',

--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -5,6 +5,21 @@
  * Content Lock Routes
  */
 return [
+    [
+        'pattern' => '(:all)/lock',
+        'method'  => 'GET',
+        'action'  => function (string $path) {
+			if ($lock = $this->parent($path)->lock()) {
+                return [
+					'lock' => $lock->toArray()
+				];
+			}
+
+            return [
+                'lock' => false
+            ];
+        }
+    ],
 	[
 		'pattern' => '(:all)/lock',
 		'method'  => 'PATCH',

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -163,12 +163,9 @@ export default {
 		this.$events.$off("keydown.cmd.s", this.onSave);
 	},
 	methods: {
-		check() {
-			this.$reload({
-				navigate: false,
-				only: "$view.props.lock",
-				silent: true
-			});
+		async check() {
+			const { lock } = await this.$api.get(this.$view.path + "/lock");
+			this.$set(this.$view.props, "lock", lock);
 		},
 		async onLock(lock = true) {
 			const api = [this.$view.path + "/lock", null, null, true];

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -196,6 +196,19 @@ class ContentLock
 	}
 
 	/**
+	 * Returns the state for the
+	 * form buttons in the frontend
+	 */
+	public function state(): ?string
+	{
+		return match(true) {
+			$this->isUnlocked() => 'unlock',
+			$this->isLocked()   => 'lock',
+			default => null
+		};
+	}
+
+	/**
 	 * Returns a usable lock array
 	 * for the frontend
 	 *
@@ -203,18 +216,10 @@ class ContentLock
 	 */
 	public function toArray(): array
 	{
-		if ($this->isUnlocked() === true) {
-			return ['state' => 'unlock'];
-		}
-
-		if ($this->isLocked() === true) {
-			return [
-				'state' => 'lock',
-				'data'  => $this->get()
-			];
-		}
-
-		return ['state' => null];
+		return [
+			'state' => $this->state(),
+			'data'  => $this->get()
+		];
 	}
 
 	/**

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -201,7 +201,7 @@ class ContentLock
 	 */
 	public function state(): ?string
 	{
-		return match(true) {
+		return match (true) {
 			$this->isUnlocked() => 'unlock',
 			$this->isLocked()   => 'lock',
 			default => null

--- a/src/Cms/ContentLock.php
+++ b/src/Cms/ContentLock.php
@@ -196,6 +196,28 @@ class ContentLock
 	}
 
 	/**
+	 * Returns a usable lock array
+	 * for the frontend
+	 *
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		if ($this->isUnlocked() === true) {
+			return ['state' => 'unlock'];
+		}
+
+		if ($this->isLocked() === true) {
+			return [
+				'state' => 'lock',
+				'data'  => $this->get()
+			];
+		}
+
+		return ['state' => null];
+	}
+
+	/**
 	 * Removes current lock and adds lock user to unlock data
 	 *
 	 * @return bool

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -235,18 +235,7 @@ abstract class Model
 	public function lock(): array|false
 	{
 		if ($lock = $this->model->lock()) {
-			if ($lock->isUnlocked() === true) {
-				return ['state' => 'unlock'];
-			}
-
-			if ($lock->isLocked() === true) {
-				return [
-					'state' => 'lock',
-					'data'  => $lock->get()
-				];
-			}
-
-			return ['state' => null];
+			return $lock->toArray();
 		}
 
 		return false;

--- a/tests/Cms/Api/routes/LockRoutesTest.php
+++ b/tests/Cms/Api/routes/LockRoutesTest.php
@@ -41,5 +41,4 @@ class LockRoutesTest extends TestCase
 
 		$this->assertSame($expected, $response);
 	}
-
 }

--- a/tests/Cms/Api/routes/LockRoutesTest.php
+++ b/tests/Cms/Api/routes/LockRoutesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase;
+
+class LockRoutesTest extends TestCase
+{
+	protected $app;
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'options' => [
+				'api.allowImpersonation' => true
+			],
+			'roots' => [
+				'index' => '/dev/null'
+			]
+		]);
+	}
+
+	public function testGet()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'a',
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$response = $app->api()->call('pages/a/lock');
+		$expected = [
+			'lock' => false
+		];
+
+		$this->assertSame($expected, $response);
+	}
+
+}

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -37,7 +37,7 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('default', $props['blueprint']);
-		$this->assertSame(['state' => null], $props['lock']);
+		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
 
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
@@ -91,7 +91,7 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
-		$this->assertSame(['state' => null], $props['lock']);
+		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
 
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
@@ -159,7 +159,7 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
-		$this->assertSame(['state' => null], $props['lock']);
+		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
 
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -3,13 +3,20 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
+use Kirby\Cms\ContentLock;
+use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
-class CustomContentLockIsLocked
+class CustomContentLockIsLocked extends ContentLock
 {
+	public function __construct()
+	{
+		$this->model = new ModelPage(['slug' => 'test']);
+	}
+
 	public function get(): array
 	{
 		return ['email' => 'foo@bar.com'];
@@ -26,7 +33,7 @@ class CustomContentLockIsLocked
 	}
 }
 
-class CustomContentLockIsUnlocked
+class CustomContentLockIsUnlocked extends CustomContentLockIslocked
 {
 	public function isUnlocked(): bool
 	{
@@ -416,7 +423,7 @@ class ModelTest extends TestCase
 
 		// no lock or unlock
 		$site = new ModelSite();
-		$this->assertSame(['state' => null], $site->panel()->lock());
+		$this->assertSame(['state' => null, 'data' => false], $site->panel()->lock());
 
 		// lock
 		$site = new ModelSiteTestForceLocked();
@@ -426,7 +433,7 @@ class ModelTest extends TestCase
 
 		// unlock
 		$site = new ModelSiteTestForceUnlocked();
-		$this->assertSame(['state' => 'unlock'], $site->panel()->lock());
+		$this->assertSame('unlock', $site->panel()->lock()['state']);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

When we switched to Fiber, we removed the GET route for locks and instead reloaded the view every 10 seconds and passed an only rule, to only return `$view.props.lock`. The only problem: To build the `$view` array, the backend would process a lot more than necessary. Even with the only rule, tabs, content, permissions and more would be reevaluated on every call every 10 seconds. This is not noticable if the view is fast, but when there are complex queries involved it can get really messy and the UUIDs don't make this problem better. 

That's why I brought back the GET request for the lock status and instead of using the Fiber call, the checks are now done through the API again. I've unified the code, which is used in the Fiber view and in the lock check. They now return identical objects or false if locking is disabled. This means that we can still get the first state from Fiber and every next update is done through the API. Ideally, we would have additional Fiber routes that could do the same thing without relying on the API at some point. But this seems like a rather simple fix for a pretty big issue. 

@distantnative I think you really should have a look at this. You are most familiar with locking. I hope I didn't miss anything.

### Fixes

- #4740

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
