### PR TITLE
Fix creating page with UUID in blueprint query

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -467,7 +467,7 @@ trait PageActions
 		// make sure that a UUID gets generated and
 		// added to content right away
 		$props['content'] ??= [];
-		$props['content']['uuid'] = Uuid::generate();
+		$props['content']['uuid'] ??= Uuid::generate();
 
 		// create a temporary page object
 		$page = Page::factory($props);

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -464,21 +464,19 @@ trait PageActions
 		$props['template'] = $props['model'] = strtolower($props['template'] ?? 'default');
 		$props['isDraft']  = ($props['draft'] ?? true);
 
+		// make sure that a UUID gets generated and
+		// added to content right away
+		$props['content'] ??= [];
+		$props['content']['uuid'] = Uuid::generate();
+
 		// create a temporary page object
 		$page = Page::factory($props);
 
-		// make sure that a UUID gets generated and
-		// added to the page object right away
-		$page = $page->clone(['content' => ['uuid' => Uuid::generate()]]);
-
-		// gather content
-		$content = $props['content'] ?? [];
-
 		// create a form for the page
-		$form = Form::for($page, ['values' => $content]);
+		$form = Form::for($page, ['values' => $props['content']]);
 
 		// inject the content
-		$page->content()->update($form->strings(true));
+		$page = $page->clone(['content' => $form->strings(true)]);
 
 		// run the hooks and creation action
 		$page = $page->commit('create', ['page' => $page, 'input' => $props], function ($page, $props) {

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -467,18 +467,18 @@ trait PageActions
 		// create a temporary page object
 		$page = Page::factory($props);
 
+		// make sure that a UUID gets generated and
+		// added to the page object right away
+		$page = $page->clone(['content' => ['uuid' => Uuid::generate()]]);
+
 		// gather content
 		$content = $props['content'] ?? [];
-
-		// make sure that a UUID gets generated and
-		// added to content right away
-		$content['uuid'] = Uuid::generate();
 
 		// create a form for the page
 		$form = Form::for($page, ['values' => $content]);
 
 		// inject the content
-		$page = $page->clone(['content' => $form->strings(true)]);
+		$page->content()->update($form->strings(true));
 
 		// run the hooks and creation action
 		$page = $page->commit('create', ['page' => $page, 'input' => $props], function ($page, $props) {

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -909,17 +909,16 @@ class PageActionsTest extends TestCase
 		$app = $this->app->clone([
 			'hooks' => [
 				'page.create:before' => function (Page $page, $input) use ($phpunit, &$calls) {
-					$phpunit->assertInstanceOf('Kirby\Cms\Page', $page);
-					$phpunit->assertSame([
-						'slug' => 'test',
-						'model' => 'default',
-						'template' => 'default',
-						'isDraft' => true
-					], $input);
+					$phpunit->assertInstanceOf(Page::class, $page);
+					$phpunit->assertSame('test', $input['slug']);
+					$phpunit->assertSame('default', $input['model']);
+					$phpunit->assertSame('default', $input['template']);
+					$phpunit->assertTrue($input['isDraft']);
+					$phpunit->assertArrayHasKey('uuid', $input['content']);
 					$calls++;
 				},
 				'page.create:after' => function (Page $page) use ($phpunit, &$calls) {
-					$phpunit->assertInstanceOf('Kirby\Cms\Page', $page);
+					$phpunit->assertInstanceOf(Page::class, $page);
 					$phpunit->assertSame('test', $page->slug());
 					$calls++;
 				}
@@ -943,14 +942,14 @@ class PageActionsTest extends TestCase
 		$app = $this->app->clone([
 			'hooks' => [
 				'page.delete:before' => function (Page $page, $force) use ($phpunit, &$calls) {
-					$phpunit->assertInstanceOf('Kirby\Cms\Page', $page);
+					$phpunit->assertInstanceOf(Page::class, $page);
 					$phpunit->assertFalse($force);
 					$phpunit->assertFileExists($page->root());
 					$calls++;
 				},
 				'page.delete:after' => function ($status, Page $page) use ($phpunit, &$calls) {
 					$phpunit->assertTrue($status);
-					$phpunit->assertInstanceOf('Kirby\Cms\Page', $page);
+					$phpunit->assertInstanceOf(Page::class, $page);
 					$phpunit->assertFileDoesNotExist($page->root());
 					$calls++;
 				}


### PR DESCRIPTION
Fixes #4736

### Explanation
- `Form` class calls blueprint which (sadly still) runs all queries
- When uuid gets called from one of those queries, it creates the page already, page rules for duplicate detection throws exception
- `Form::for($page` - `$page` is the one that gets passed to blueprint queries
- Thus `$page` passed to `Form::for()` already needs to include generated UUID

## TODO
- [x] @sebastiangreger @doup can you confirm this fixes your issues?
- [x] Review by team