### PR TITLE
Switch from `class_uses()` to duck test for `File::setModel()` 

### DIFF
--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -444,7 +444,7 @@ class File
 	 */
 	protected function setModel(object|null $model = null): static
 	{
-		if ($model !== null && in_array(IsFile::class, class_uses($model)) !== true) {
+		if ($model !== null && method_exists($model, 'hasIsFileTrait') !== true) {
 			throw new InvalidArgumentException('The model object must use the "Kirby\Filesystem\IsFile" trait');
 		}
 

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -109,6 +109,16 @@ trait IsFile
 		return file_exists($this->root()) === true;
 	}
 
+	/**
+	 * To check the existence of the IsFile trait
+	 *
+	 * @todo Switch to class constant in traits when min PHP version 8.2 required
+	 * @codeCoverageIgnore
+	 */
+	protected function hasIsFileTrait(): bool
+	{
+		return true;
+	}
 
 	/**
 	 * Returns the app instance

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -8,6 +8,11 @@ use PHPUnit\Framework\TestCase as TestCase;
 
 require_once __DIR__ . '/mocks.php';
 
+class InvalidFileModel
+{
+	public string $foo = 'bar';
+}
+
 /**
  * @coversDefaultClass \Kirby\Filesystem\File
  */
@@ -462,7 +467,7 @@ class FileTest extends TestCase
 
 		new File([
 			'root' => $this->fixtures . '/test.js',
-			'model' => Page::factory(['slug' => 'test'])
+			'model' => new InvalidFileModel()
 		]);
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- File class extending works as before #4748

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
