### PR TITLE
Fix broken label/headline in info section

### DIFF
--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -25,9 +25,9 @@ return [
 	],
 	'toArray' => function () {
 		return [
-			'headline' => $this->headline,
-			'text'     => $this->text,
-			'theme'    => $this->theme
+			'label' => $this->headline,
+			'text'  => $this->text,
+			'theme' => $this->theme
 		];
 	}
 ];

--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -25,9 +25,9 @@ return [
 	],
 	'toArray' => function () {
 		return [
-			'label' => $this->headline,
-			'text'  => $this->text,
-			'theme' => $this->theme
+			'headline' => $this->headline,
+			'text'     => $this->text,
+			'theme'    => $this->theme
 		];
 	}
 ];

--- a/panel/src/components/Sections/InfoSection.vue
+++ b/panel/src/components/Sections/InfoSection.vue
@@ -1,7 +1,7 @@
 <template>
 	<section class="k-info-section">
-		<k-headline class="k-info-section-headline">
-			{{ headline }}
+		<k-headline class="k-info-section-label">
+			{{ label }}
 		</k-headline>
 		<k-box :theme="theme">
 			<k-text :html="text" />
@@ -15,14 +15,14 @@ export default {
 	mixins: [SectionMixin],
 	data() {
 		return {
-			headline: null,
+			label: null,
 			text: null,
 			theme: null
 		};
 	},
 	async created() {
 		const response = await this.load();
-		this.headline = response.headline;
+		this.label = response.label;
 		this.text = response.text;
 		this.theme = response.theme || "info";
 	}
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <style>
-.k-info-section-headline {
+.k-info-section-label {
 	margin-bottom: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## This PR …

After moving to label instead of headline for the info section, we introduced a regression which actually broke both variants.

### Fixes

- The info section label can be set again with the deprecated headline option or the new label option. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
