### PR TITLE
Refactor `Helpers::handleErrors()`

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -64,27 +64,36 @@ class Helpers
 	 * @since 3.7.4
 	 *
 	 * @param \Closure $action Any action that may cause an error or warning
-	 * @param \Closure $handler Custom callback like for `set_error_handler()`;
-	 *                          the first argument is a return value override passed
-	 *                          by reference, the additional arguments come from
-	 *                          `set_error_handler()`; returning `false` activates
-	 *                          error handling by Whoops and/or PHP
-	 * @return mixed Return value of the `$action` closure, possibly overridden by `$handler`
+	 * @param \Closure $condition Closure that returns bool to determine if to
+	 *                            suppress an error, receives arguments for
+	 *                            `set_error_handler()`
+	 * @param mixed $fallback Value to return when error is suppressed
+	 * @return mixed Return value of the `$action` closure,
+	 *               possibly overridden by `$fallback`
 	 */
-	public static function handleErrors(Closure $action, Closure $handler)
+	public static function handleErrors(Closure $action, Closure $condition, $fallback = null)
 	{
-		$override = $oldHandler = null;
-		$oldHandler = set_error_handler(function () use (&$override, &$oldHandler, $handler) {
-			$handlerResult = $handler($override, ...func_get_args());
+		$override = null;
 
-			if ($handlerResult === false) {
+		$handler = set_error_handler(function () use (&$override, &$handler, $condition, $fallback) {
+			// check if suppress condition is met
+			$suppress = $condition(...func_get_args());
+
+			if ($suppress === false) {
 				// handle other warnings with Whoops if loaded
-				if (is_callable($oldHandler) === true) {
-					return $oldHandler(...func_get_args());
+				if (is_callable($handler) === true) {
+					return $handler(...func_get_args());
 				}
 
 				// otherwise use the standard error handler
 				return false; // @codeCoverageIgnore
+			}
+
+			// use fallback to override return for suppressed errors
+			$override = $fallback;
+
+			if (is_callable($override) === true) {
+				$override = $override();
 			}
 
 			// no additional error handling

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -79,7 +79,7 @@ class Helpers
 			// check if suppress condition is met
 			$suppress = $condition(...func_get_args());
 
-			if ($suppress === false) {
+			if ($suppress !== true) {
 				// handle other warnings with Whoops if loaded
 				if (is_callable($handler) === true) {
 					return $handler(...func_get_args());

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -394,17 +394,10 @@ class Dir
 
 		return Helpers::handleErrors(
 			fn (): bool => mkdir($dir),
-			function (&$override, int $errno, string $errstr): bool {
-				// if the dir was already created (race condition),
-				// consider it a success
-				if (Str::endsWith($errstr, 'File exists') === true) {
-					// drop the warning
-					return $override = true;
-				}
-
-				// handle every other warning normally
-				return false;
-			}
+			// if the dir was already created (race condition),
+			fn (int $errno, string $errstr): bool => Str::endsWith($errstr, 'File exists'),
+			// consider it a success
+			true
 		);
 	}
 

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -784,19 +784,10 @@ class F
 	{
 		return Helpers::handleErrors(
 			fn (): bool => unlink($file),
-			function (&$override, int $errno, string $errstr): bool {
-				// if the file or link was already deleted (race condition),
-				// consider it a success
-				if (Str::endsWith($errstr, 'No such file or directory') === true) {
-					$override = true;
-
-					// drop the warning
-					return true;
-				}
-
-				// handle every other warning normally
-				return false;
-			}
+			// if the file or link was already deleted (race condition),
+			fn (int $errno, string $errstr): bool => Str::endsWith($errstr, 'No such file or directory'),
+			// consider it a success
+			true
 		);
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactored
- New syntax for `Helpers::handleErrors()`:
```php
Helpers::handleErrors(
    fn () => // error to suppress,
    fn (int $errno, string $errstr): bool => // condition when to suppress error
    $value // return value for when the error is suppressed
);
```

This breaks the method quite a bit, but given that it is very, very niche and only was introduced in 3.7.4, I think it is ok to do this in 3.8.0 without any deprecation path prior to this.


### Breaking changes
- `Helpers::handleErrors()`'s 2nd parameter now only determines whether the error is suppressed, its 3rd parameter defines what is returned when an error is suppressed


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
