### PR TITLE
Improvements for the CLI

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1231,6 +1231,10 @@ class App
 	 */
 	public function render(string $path = null, string $method = null)
 	{
+		if (($_ENV['KIRBY_RENDER'] ?? true) === false) {
+			return null;
+		}
+
 		return $this->io($this->call($path, $method));
 	}
 

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -52,6 +52,7 @@ trait AppPlugins
 		'blueprints' => [],
 		'cacheTypes' => [],
 		'collections' => [],
+		'commands' => [],
 		'components' => [],
 		'controllers' => [],
 		'collectionFilters' => [],
@@ -213,6 +214,17 @@ trait AppPlugins
 	protected function extendCacheTypes(array $cacheTypes): array
 	{
 		return $this->extensions['cacheTypes'] = array_merge($this->extensions['cacheTypes'], $cacheTypes);
+	}
+
+	/**
+	 * Registers additional CLI commands
+	 *
+	 * @param array $commands
+	 * @return array
+	 */
+	protected function extendCommands(array $commands): array
+	{
+		return $this->extensions['commands'] = array_merge($this->extensions['commands'], $commands);
 	}
 
 	/**

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -306,6 +306,7 @@ class Core
 			'blueprints'  => fn (array $roots) => $roots['site'] . '/blueprints',
 			'cache'       => fn (array $roots) => $roots['site'] . '/cache',
 			'collections' => fn (array $roots) => $roots['site'] . '/collections',
+			'commands'    => fn (array $roots) => $roots['site'] . '/commands',
 			'config'      => fn (array $roots) => $roots['site'] . '/config',
 			'controllers' => fn (array $roots) => $roots['site'] . '/controllers',
 			'languages'   => fn (array $roots) => $roots['site'] . '/languages',

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -363,6 +363,25 @@ class AppPluginsTest extends TestCase
 		Collection::$filters = $prevFilters;
 	}
 
+	public function testCommands()
+	{
+		$pages = new Pages([]);
+		$kirby = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'commands' => [
+				'test' => $command = [
+					'command' => function () {
+
+					}
+				]
+			],
+		]);
+
+		$this->assertSame($command, $kirby->extension('commands', 'test'));
+	}
+
 	public function testController()
 	{
 		$kirby = new App([

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -373,7 +373,6 @@ class AppPluginsTest extends TestCase
 			'commands' => [
 				'test' => $command = [
 					'command' => function () {
-
 					}
 				]
 			],

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -1380,5 +1380,4 @@ class AppTest extends TestCase
 
 		unset($_ENV['KIRBY_RENDER']);
 	}
-
 }

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
 use Kirby\Http\Route;
 use Kirby\Session\Session;
 use Kirby\Toolkit\Str;
@@ -1349,4 +1350,35 @@ class AppTest extends TestCase
 		$page = $app->page('test');
 		$this->assertSame($page, $app->page('page://my-page'));
 	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRender()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => $this->tmp,
+				'templates' => $this->tmp
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'home',
+					]
+				]
+			]
+		]);
+
+		F::write($this->tmp . '/default.php', 'Hello');
+
+		$this->assertSame('Hello', $app->render()->body());
+
+		$_ENV['KIRBY_RENDER'] = false;
+
+		$this->assertNull($app->render());
+
+		unset($_ENV['KIRBY_RENDER']);
+	}
+
 }

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -291,6 +291,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('blueprints', $roots);
 		$this->assertArrayHasKey('cache', $roots);
 		$this->assertArrayHasKey('collections', $roots);
+		$this->assertArrayHasKey('commands', $roots);
 		$this->assertArrayHasKey('config', $roots);
 		$this->assertArrayHasKey('controllers', $roots);
 		$this->assertArrayHasKey('languages', $roots);


### PR DESCRIPTION
## Features

### New command extension API
Adds the option to define CLI commands in Kirby plugins: 

```php
<?php

Kirby::plugin('getkirby/commander', [
    'commands' => [
        'commander' => [
            'command' => function ($cli) {
                $cli->success('Nice command!');
            }
        ]
    ]
]);
```

### New commands root
Adds a new `commands` root which is set to `site/commands` by default

### Option to disable the renderer 
`$kirby->render()` can now be disabled temporarily by setting 

```php
$_ENV['KIRBY_RENDER'] = false
```

This is used by the CLI to load the index.php without getting any output. This way, the CLI can access the correct `$kirby` instance with all custom roots and options. This is also super useful for any other script that needs to access `$kirby` without rendering output. I moved this to `$_ENV` instead of a constant to be able to enable rendering again, once the index.php is loaded. It might still be useful afterwards.

### Breaking changes

None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
