### PR TITLE
Use Kirby\Cms\Url in go helper

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -3,10 +3,10 @@
 use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Html;
+use Kirby\Cms\Response;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\F;
-use Kirby\Http\Response;
 use Kirby\Http\Router;
 use Kirby\Toolkit\Date;
 use Kirby\Toolkit\I18n;


### PR DESCRIPTION
## This PR …

We used the wrong URL class in the go helper, which lead to invalid redirects when using 

```php
go($site->homePage())
```

### Fixes

- `go($site->homePage())` redirects to absolute URLs again.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)**
