### PR TITLE
Fixes generating `uuid` value when `content.uuid` option disabled

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -155,7 +155,9 @@ trait FileActions
 		$copy = $page->clone()->file($this->filename());
 
 		// overwrite with new UUID (remove old, add new)
-		$copy = $copy->save(['uuid' => Uuid::generate()]);
+		if ($uuid = static::uuidGenerate()) {
+			$copy = $copy->save(['uuid' => $uuid]);
+		}
 
 		return $copy;
 	}
@@ -191,7 +193,7 @@ trait FileActions
 
 		// make sure that a UUID gets generated and
 		// added to content right away
-		$content['uuid'] = Uuid::generate();
+		$content['uuid'] ??= static::uuidGenerate();
 
 		// create a form for the file
 		$form = Form::for($file, ['values' => $content]);

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -8,6 +8,7 @@ use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use Kirby\Form\Form;
 use Kirby\Uuid\Uuid;
+use Kirby\Uuid\Uuids;
 
 /**
  * FileActions
@@ -155,8 +156,8 @@ trait FileActions
 		$copy = $page->clone()->file($this->filename());
 
 		// overwrite with new UUID (remove old, add new)
-		if ($uuid = static::uuidGenerate()) {
-			$copy = $copy->save(['uuid' => $uuid]);
+		if (Uuids::enabled() === true) {
+			$copy = $copy->save(['uuid' => Uuid::generate()]);
 		}
 
 		return $copy;
@@ -193,7 +194,9 @@ trait FileActions
 
 		// make sure that a UUID gets generated and
 		// added to content right away
-		$content['uuid'] ??= static::uuidGenerate();
+		if (Uuids::enabled() === true) {
+			$content['uuid'] ??= Uuid::generate();
+		}
 
 		// create a form for the file
 		$form = Form::for($file, ['values' => $content]);

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -9,6 +9,7 @@ use Kirby\Form\Form;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Identifiable;
 use Kirby\Uuid\Uuid;
+use Kirby\Uuid\Uuids;
 use Throwable;
 
 /**
@@ -635,6 +636,19 @@ abstract class ModelWithContent extends Model implements Identifiable
 	public function uuid(): Uuid|null
 	{
 		return Uuid::for($this);
+	}
+
+	/**
+	 * Returns a new ID string if `content.uuid` option not disabled
+	 * @since 3.8.1
+	 */
+	public static function uuidGenerate(): string|null
+	{
+		if (Uuids::enabled() === false) {
+			return null;
+		}
+
+		return Uuid::generate();
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -9,7 +9,6 @@ use Kirby\Form\Form;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Identifiable;
 use Kirby\Uuid\Uuid;
-use Kirby\Uuid\Uuids;
 use Throwable;
 
 /**
@@ -636,19 +635,6 @@ abstract class ModelWithContent extends Model implements Identifiable
 	public function uuid(): Uuid|null
 	{
 		return Uuid::for($this);
-	}
-
-	/**
-	 * Returns a new ID string if `content.uuid` option not disabled
-	 * @since 3.8.1
-	 */
-	public static function uuidGenerate(): string|null
-	{
-		if (Uuids::enabled() === false) {
-			return null;
-		}
-
-		return Uuid::generate();
 	}
 
 	/**

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -443,7 +443,9 @@ trait PageActions
 		}
 
 		// overwrite with new UUID (remove old, add new)
-		$copy = $copy->save(['uuid' => Uuid::generate()]);
+		if ($uuid = static::uuidGenerate()) {
+			$copy = $copy->save(['uuid' => $uuid]);
+		}
 
 		// add copy to siblings
 		static::updateParentCollections($copy, 'append', $parentModel);
@@ -467,7 +469,7 @@ trait PageActions
 		// make sure that a UUID gets generated and
 		// added to content right away
 		$props['content'] ??= [];
-		$props['content']['uuid'] ??= Uuid::generate();
+		$props['content']['uuid'] ??= static::uuidGenerate();
 
 		// create a temporary page object
 		$page = Page::factory($props);

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -14,6 +14,7 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Uuid;
+use Kirby\Uuid\Uuids;
 
 /**
  * PageActions
@@ -443,8 +444,8 @@ trait PageActions
 		}
 
 		// overwrite with new UUID (remove old, add new)
-		if ($uuid = static::uuidGenerate()) {
-			$copy = $copy->save(['uuid' => $uuid]);
+		if (Uuids::enabled() === true) {
+			$copy = $copy->save(['uuid' => Uuid::generate()]);
 		}
 
 		// add copy to siblings
@@ -469,7 +470,10 @@ trait PageActions
 		// make sure that a UUID gets generated and
 		// added to content right away
 		$props['content'] ??= [];
-		$props['content']['uuid'] ??= static::uuidGenerate();
+
+		if (Uuids::enabled() === true) {
+			$props['content']['uuid'] ??= Uuid::generate();
+		}
 
 		// create a temporary page object
 		$page = Page::factory($props);


### PR DESCRIPTION
### Fixes
- Fixes generating `uuid` value for models when `content.uuid` option disabled #4787

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
