### PR TITLE
Fix duplicating UUIDs on duplicating pages 

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -48,8 +48,6 @@ trait PageActions
 							$file->save(['uuid' => Uuid::generate()], $language->code());
 						}
 					}
-
-					return $copy;
 				}
 
 				// remove all translated slugs
@@ -57,9 +55,11 @@ trait PageActions
 					$language->isDefault() === false &&
 					$copy->translation($language)->exists() === true
 				) {
-					return $copy->save(['slug' => null], $language->code());
+					$copy = $copy->save(['slug' => null], $language->code());
 				}
 			}
+
+			return $copy;
 		}
 
 		// overwrite with new UUID for the page and files (remove old, add new)

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -931,6 +931,9 @@ class PageActionsTest extends TestCase
 		$copyFile = $copy->file('foo.jpg');
 
 		$this->assertNotSame($origFile->uuid()->id(), $copyFile->uuid()->id());
+
+		// check if the files collection has been properly updated
+		$this->assertSame($copy->files()->find('foo.jpg')->uuid()->id(), $copyFile->uuid()->id());
 	}
 
 	public function testChangeSlugHooks()

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -838,6 +838,43 @@ class PageActionsTest extends TestCase
 		$this->assertSame($page, $childrenAndDrafts->find('test'));
 	}
 
+	public function testDuplicateMultiLangSlug()
+	{
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$page = $app->site()->createChild([
+			'slug'    => 'test',
+		]);
+
+		$page = $page->update([
+			'slug'  => 'test-de'
+		], 'de');
+
+		$this->assertFileExists($page->contentFile('en'));
+		$this->assertFileExists($page->contentFile('de'));
+		$this->assertSame('test', $page->slug());
+		$this->assertSame('test-de', $page->slug('de'));
+
+		$copy = $page->duplicate('test-copy');
+
+		$this->assertSame('test-copy', $copy->slug());
+		$this->assertSame('test-copy', $copy->slug('de'));
+	}
+
 	public function testDuplicateFiles()
 	{
 		$this->app->impersonate('kirby');


### PR DESCRIPTION
## This PR …

Fixes the following issues;

✅ Duplicating files uuid for duplicating pages
✅ Duplicating pages uuid for duplicating pages *

_* I've found the issue while testing the issue. Reproducible with duplicating a page while secondary lang enabled_

### Fixes

- Fixed duplicating UUIDs for pages and files on duplicating pages #4831

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
