### PR TITLE
Better attr() helper (and new friends) for templates and snippets

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -33,11 +33,26 @@ if (Helpers::hasOverride('attr') === false) { // @codeCoverageIgnore
 	 * @param array|null $attr A list of attributes as key/value array
 	 * @param string|null $before An optional string that will be prepended if the result is not empty
 	 * @param string|null $after An optional string that will be appended if the result is not empty
-	 * @return string|null
+	 * @return \Kirby\Toolkit\Attributes
 	 */
-	function attr(array|null $attr = null, string|null $before = null, string|null $after = null): string|null
+	function attr(?array $attr = null, ?string $before = null, ?string $after = null): Attributes
 	{
-		return Html::attr($attr, null, $before, $after);
+		return Attributes::from($attr)
+			->before($before)
+			->after($after);
+	}
+}
+
+if (Helpers::hasOverride('classes') === false) { // @codeCoverageIgnore
+	/**
+	 * Returns the result of a collection by name
+	 *
+	 * @param string $classes
+	 * @return \Kirby\Toolkit\Attributes
+	 */
+	function classes(array|string $classes = []): Attributes
+	{
+		return Attributes::from()->class($classes);
 	}
 }
 
@@ -476,6 +491,20 @@ if (Helpers::hasOverride('params') === false) { // @codeCoverageIgnore
 	function params(): array
 	{
 		return App::instance()->request()->url()->params()->toArray();
+	}
+}
+
+if (Helpers::hasOverride('prepends') === false) { // @codeCoverageIgnore
+	/**
+	 * Generates a list of HTML attribute whose value will be merged
+	 * instead of replaced, when merging its value.
+	 *
+	 * @param mixed $value A list of attributes as key/value array
+	 * @return \Kirby\Toolkit\Attribute
+	 */
+	function prepends(mixed $value): Attribute
+	{
+		return Attribute::prepends($value);
 	}
 }
 

--- a/src/Toolkit/Attribute.php
+++ b/src/Toolkit/Attribute.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+/**
+ * The `Attribute` class represents the value of an HTML attributes
+ * and provides various utilities for merging and joinging attribute
+ * values.
+ *
+ * @package   Kirby Toolkit
+ * @author    Fabian Michael <hallo@fabianmichael.de>
+ * @link      https://fabianmichael.de
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Attribute
+{
+	protected mixed $value;
+	protected bool $prepends = false;
+
+	protected function __construct(mixed $value, bool|null $prepends = null)
+	{
+		if (is_a($value, static::class)) {
+			// If an instance of this class is passed as value,
+			// extract all informartion and transfer to this instance.
+			$this->value = $value->value();
+			$prepends = $value->prepends;
+		} else {
+			$this->value = $value;
+		}
+
+		$this->prepends = $prepends ?? false;
+	}
+
+	/**
+	 * Creates a new instance from an arbitrary value. Passing an
+	 * instance of this class to this method will return that
+	 * instance instead.
+	 */
+	public static function from(mixed $value = null): static
+	{
+		return new static($value, false);
+	}
+
+	/**
+	 * Creates an instance of this class, whose value will be merged
+	 * instead of repleat
+	 */
+	public static function prepends(mixed $value = null): static
+	{
+		return new static($value, true);
+	}
+
+	/**
+	 * If an attribute is merged with a new value, this will either
+	 * return a new instance with the new value
+	 */
+	public function merge(mixed $attribute): static
+	{
+		if ($this->prepends) {
+			$append = (string) $attribute;
+
+			if (!empty($append) && strlen($append) > 0) {
+				return static::prepends($this->value . r(!empty($this->value), ' ') . $append);
+			}
+		}
+
+		return new static($attribute);
+	}
+
+	/**
+	 * Returns the raw value.
+	 */
+	public function value(): mixed
+	{
+		return $this->value;
+	}
+
+	public function __toString()
+	{
+		return (string) $this->value;
+	}
+}

--- a/src/Toolkit/Attributes.php
+++ b/src/Toolkit/Attributes.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+/**
+ * The `Attribute` class represents a set of HTML attributes for
+ * usage within templates.
+ *
+ * @package   Kirby Toolkit
+ * @author    Fabian Michael <hallo@fabianmichael.de>
+ * @link      https://fabianmichael.de
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Attributes
+{
+	protected array $data = [];
+	protected string|null $before = null;
+	protected string|null $after = null;
+
+	public static array $prepends = [
+		'class',
+	];
+
+	protected function __construct(array|self $data = [])
+	{
+		foreach ($data as $name => $value) {
+			$this->set($name, $value);
+		}
+	}
+
+	public static function from(array|self $data = []): static
+	{
+		return is_a($data, static::class) ? $data : new static($data);
+	}
+
+	public function get(string $name): ?Attribute
+	{
+		return $this->data[$name] ?? null;
+	}
+
+	public function merge(array|self $data = []): static
+	{
+		$data = is_a($data, static::class) ? $data->data : $data;
+
+		foreach ($data as $name => $value) {
+			$this->set($name, $value);
+		}
+
+		return $this;
+	}
+
+	public function set(string $name, mixed $value): static
+	{
+		if ($name === 'class') {
+			$value = static::resolveClasses($value);
+		}
+
+		if (isset($this->data[$name])) {
+			$this->data[$name] = $this->data[$name]->merge($value);
+		} else {
+			$this->data[$name] = in_array($name, static::$prepends)
+				? Attribute::prepends($value)
+				: Attribute::from($value);
+		}
+
+		return $this;
+	}
+
+	public function class(array|string $classes): static
+	{
+		$this->set('class', $classes);
+
+		return $this;
+	}
+
+	protected static function resolveClasses(array|string $classes): string
+	{
+		$value = [];
+
+		foreach (A::wrap($classes) as $key => $class) {
+			if (is_numeric($key)) {
+				$value[] = $class;
+			} elseif ($class) {
+				$value[] = $key;
+			}
+		}
+
+		return implode(' ', array_unique($value));
+	}
+
+	public function toArray(): array
+	{
+		return array_map(fn ($item) => $item->value(), $this->data);
+	}
+
+	public function before(string|null $before): static
+	{
+		$this->before = $before;
+
+		return $this;
+	}
+
+	public function after(string|null $after): static
+	{
+		$this->before = $after;
+
+		return $this;
+	}
+
+	public function __toString()
+	{
+		return (string) Html::attr(
+			$this->toArray(),
+			before: $this->before,
+			after: $this->after
+		);
+	}
+}


### PR DESCRIPTION
## Better attribute handling for snippets and templates

Whenever a snippet or component (see #4837) is included into a template, one often wants to pass additional variables and other parameters. Vue.js and Laravel blade templates provide means for merging the HTML attributes of components with ones fromt he outside. 

### Example

A button component exists as a snippet in `site/snippets/button.php`:

```php
<button class="button"><?= html($text ?? 'Button text') ?></button>
```

A common situation would be the requirement to add attributes when calling the `snippet('button')` helper class, e.g. `class`, `data-*`, `title`, `aria-*` etc. Developers cannot handly every possible attribute for each component. The previous `attr()` helper could help here:

```php
<button <?= attr($attr ?? []) ?> class="button"><?= html($text ?? 'Button text') ?></button>
```

This works better, but we still cannot extend the `class` attribute easily. Enter the new `attr()` helpers:

```php
<button <?= attr([
    'class' => 'button',
])->merge($attr ?? []) ?>><?= html($text ?? 'Button text') ?></button>
```

Even shorter:

```php
<button <?= classes('button')->merge($attr ?? []) ?>><?= html($text ?? 'Button text') ?></button>
```

This becomes even cooler, because the classes can be assigned conditionally as an array:

```php
<?php

$text = $text ?? 'Button text';
$size = $size ?? 'normal';
$theme = $theme ?? null;
$attr = $attr ?? [];

?>
<button <?= attr([
    'role' => 'button',
])->class([
    'button',
    "button--{$size}",
    "button--{$theme}" => $theme, // will only be merged, if $theme is trueish
])->merge($attr) ?>><?= html($text) ?></button>
```

This is already cool and makes working with attributes for snippets much easier, e.g. is we use the button in `site/snippets/menu.php`:

```php
<nav class="menu">
    […]
    <?php snippet('button', [
        'text' => 'Toggle Menu',
        'attr' => [
            'class' => 'menu__button',
            'aria-controls' => 'menu-popup',
            'aria-expanded' => false,
            'role' => 'teapot', // overrrides the default attribute
        ],
    ]) ?>
</nav>
```

We can even have additional attributes, that will just be merged instead of overridden, acting like the `class` attribute by wrapping their default value with the `prepends()` helper function:

```php
<?php

$text = $text ?? 'Button text';
$size = $size ?? 'normal';
$theme = $theme ?? null;
$attr = $attr ?? [];

?>
<button <?= attr([
    'role' => 'button',
    'style' => prepends('--data-text-length: ' . mb_strlen($text) . ';'), // don’t forget the trailing semicolon, values are always joined by a single space.
])->class([
    'button',
    "button--{$size}",
    "button--{$theme}" => $theme,
])->merge($attr) ?>><?= html($text) ?></button>
```

Now we can also extend the style attribute without overriding its complete value:

```php
<nav class="menu">
    […]
    <?php snippet('button', [
        'text' => 'Toggle Menu',
        'attr' => [
            'class' => 'menu__button',
            'aria-controls' => 'menu-popup',
            'aria-expanded' => false,
            'role' => 'teapot', // overrrides the default attribute
            'style' => '--menu-order: 5;', // this will be appended to the style attribute’s value
        ],
    ]) ?>
</nav>
```

If our snippet does not have any attributes by default, we can also add conditional spacing like in `Html::attr()` by calling the `before()` and `after()` methods:

```php
<button<?= attr($attr ?? [])->before(' ')><?= html($text ?? null) ?>></button>
```

### Fixes

This allows for much more flexibility attempting to work with components. The basic API provided by this plugin would possibly be deeper integrated into the core. For example, the `snippet()` helper could take an optional `$attr` parameter, that would default to an empty array `[]`, so `$attr ?? []` would not have to be called within each snippet manually.

I am also not sure, whether my placement and naming of the classes is optimal, but you are much better in structuring code than I am. If I can assist you any further, please let me know.

### Breaking changes

The `attr()` helper will now return a `Kirby\Toolkit\Attributes` object instead of a string. But casting the object to a string will return the same result, as the previous `attr()` helper.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
