### PR TITLE
document that `Uri::domain()` might return more than the domain

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -207,7 +207,9 @@ class Uri
 	}
 
 	/**
-	 * Returns the domain without scheme, path or query
+	 * Returns the domain without scheme, path or query.
+	 * Includes auth part when not empty.
+	 * Includes port number when different from 80 or 443.
 	 */
 	public function domain(): string|null
 	{


### PR DESCRIPTION
The current documentation says that the function "Returns the domain without scheme, path or query."
But it actually also returns port numbers and eventual auth parts. This was a bit unexpected when I used it, since they aren't technically part of a "domain". 

## This PR …
Documents that the function `Uri::domain()` might contain the auth and port parts, by explicitly mentioning them in the docblock. 

## Ready?
yes :)

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
