### PR TITLE
Stats section `info` prop can be translated

### DIFF
--- a/config/sections/stats.php
+++ b/config/sections/stats.php
@@ -47,10 +47,12 @@ return [
 					continue;
 				}
 
+				$info = $report['info'] ?? null;
+
 				$reports[] = [
 					'label' => I18n::translate($report['label'], $report['label']),
 					'value' => $value($report['value'] ?? null),
-					'info'  => $value($report['info'] ?? null),
+					'info'  => $value(I18n::translate($info, $info)),
 					'link'  => $value($report['link'] ?? null),
 					'theme' => $value($report['theme'] ?? null)
 				];

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -132,4 +132,30 @@ class StatsSectionTest extends TestCase
 
 		$this->assertSame([], $section->reports());
 	}
+
+	public function testReportsTranslatedInfo()
+	{
+		$section = new Section('stats', [
+			'name'     => 'test',
+			'model'    => Page::factory(['slug' => 'test']),
+			'reports'  => [
+				[
+					'label' => 'C',
+					'value' => 'Value C',
+					'info'  => [
+						'en' => 'Extra information',
+						'de' => 'Zusatzinformation'
+					],
+					'link'  => null,
+					'theme' => null,
+				]
+			]
+		]);
+
+		$report = $section->reports()[0];
+
+		$this->assertSame('C', $report['label']);
+		$this->assertSame('Value C', $report['value']);
+		$this->assertSame('Extra information', $report['info']);
+	}
 }


### PR DESCRIPTION
### Enhancements

- Stats section `info` prop can be translated #4840

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
