### PR TITLE
Fix sanitize options when no options for a value

### DIFF
--- a/config/fields/mixins/options.php
+++ b/config/fields/mixins/options.php
@@ -40,7 +40,8 @@ return [
 		},
 		'sanitizeOptions' => function ($values) {
 			$options = array_column($this->options(), 'value');
-			return array_intersect($values, $options);
+			$options = array_intersect($values, $options);
+			return array_values($options);
 		},
 	]
 ];

--- a/tests/Form/Fields/MultiselectFieldTest.php
+++ b/tests/Form/Fields/MultiselectFieldTest.php
@@ -46,4 +46,15 @@ class MultiselectFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
+
+	public function testSanitizeOptions()
+	{
+		$field = $this->field('multiselect', [
+			'value'   => 'a, b',
+			'options' => ['b', 'c'],
+		]);
+
+		$this->assertCount(1, $field->value());
+		$this->assertArrayHasKey(0, $field->value());
+	}
 }


### PR DESCRIPTION
## This PR …

If no option is found for an existing value, that index is removed from the array. An unordered (For ex: [1,2] instead of [0,1,2]) array is converted to an object when passed to javascript. So `map()` is only valid for arrays.

The issue is fixed with the `array_values()` method.

### Fixes
- Fixes multiselect field when no options for a value  #4848

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
