### PR TITLE
`Query`: add support for optional chaining and simple comparisons

### DIFF
--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -30,7 +30,7 @@ class Argument
 	{
 		$argument = trim($argument);
 
-		// Remove grouping parantheses
+		// remove grouping parantheses
 		if (
 			Str::startsWith($argument, '(') &&
 			Str::endsWith($argument, ')')

--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -35,7 +35,7 @@ class Argument
 			Str::startsWith($argument, '(') &&
 			Str::endsWith($argument, ')')
 		) {
-			$argument = substr($argument, 1, -1);
+			$argument = trim(substr($argument, 1, -1));
 		}
 
 		// string with single or double quotes

--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  */
-final class Argument
+class Argument
 {
 	public function __construct(
 		public mixed $value
@@ -23,12 +23,20 @@ final class Argument
 	}
 
 	/**
-	 * Sanitizes argument string into
+	 * Sanitizes argument string into actual
 	 * PHP type/object as new Argument instance
 	 */
 	public static function factory(string $argument): static
 	{
 		$argument = trim($argument);
+
+		// Remove grouping parantheses
+		if (
+			Str::startsWith($argument, '(') &&
+			Str::endsWith($argument, ')')
+		) {
+			$argument = substr($argument, 1, -1);
+		}
 
 		// string with single or double quotes
 		if (

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -29,7 +29,6 @@ class Arguments extends Collection
 	public const OUTSIDE = self::NO_PNTH . '|' . self::NO_SQBR . '|' .
 						   self::NO_DLQU . '|' . self::NO_SLQU;
 
-
 	/**
 	 * Splits list of arguments into individual
 	 * Argument instances while respecting skip groups

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -15,25 +15,40 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  */
-final class Arguments extends Collection
+class Arguments extends Collection
 {
-	public const NO_PNTH = '\([^(]+\)(*SKIP)(*FAIL)';
+	// skip all matches inside of parantheses
+	public const NO_PNTH = '\([^)]+\)(*SKIP)(*FAIL)';
+	// skip all matches inside of square brackets
 	public const NO_SQBR = '\[[^]]+\](*SKIP)(*FAIL)';
+	// skip all matches inside of double quotes
 	public const NO_DLQU = '\"(?:[^"\\\\]|\\\\.)*\"(*SKIP)(*FAIL)';
+	// skip all matches inside of single quotes
 	public const NO_SLQU = '\'(?:[^\'\\\\]|\\\\.)*\'(*SKIP)(*FAIL)';
+	// skip all matches inside of any of the above skip groups
+	public const OUTSIDE = self::NO_PNTH . '|' . self::NO_SQBR . '|' .
+						   self::NO_DLQU . '|' . self::NO_SLQU;
 
+
+	/**
+	 * Splits list of arguments into individual
+	 * Argument instances while respecting skip groups
+	 */
 	public static function factory(string $arguments): static
 	{
 		$arguments = A::map(
 			// split by comma, but not inside skip groups
-			preg_split('!,|' . self::NO_PNTH . '|' . self::NO_SQBR . '|' .
-					self::NO_DLQU . '|' . self::NO_SLQU . '!', $arguments),
+			preg_split('!,|' . self::OUTSIDE . '!', $arguments),
 			fn ($argument) => Argument::factory($argument)
 		);
 
 		return new static($arguments);
 	}
 
+	/**
+	 * Resolve each argument, so that they can
+	 * passed together to the actual method call
+	 */
 	public function resolve(array|object $data = []): array
 	{
 		return A::map(

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -57,7 +57,7 @@ class Expression
 		// split by multiples of `?` and `:`, but not inside skip groups
 		// (parantheses, quotes etc.)
 		return preg_split(
-			'/\s*([\?\:]+)\s*|' . Arguments::OUTSIDE . '/',
+			'/\s+([\?\:]+)\s+|' . Arguments::OUTSIDE . '/',
 			trim($string),
 			flags: PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
 		);

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -58,8 +58,8 @@ class Expression
 		// (parantheses, quotes etc.)
 		return preg_split(
 			'/\s*([\?\:]+)\s*|' . Arguments::OUTSIDE . '/',
-			$string,
-			flags: PREG_SPLIT_DELIM_CAPTURE
+			trim($string),
+			flags: PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
 		);
 	}
 
@@ -97,7 +97,7 @@ class Expression
 			// `a ? b : c`
 			// if `a` isn't false, return `b`, otherwise `c`
 			if ($part === '?') {
-				if ($this->parts[$index + 2] !== ':') {
+				if (($this->parts[$index + 2] ?? null) !== ':') {
 					throw new LogicException('Query: Incomplete ternary operator (missing matching `? :`)');
 				}
 

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Kirby\Query;
+
+use Kirby\Exception\LogicException;
+use Kirby\Toolkit\A;
+
+/**
+ * The Expression class adds support for simple shorthand
+ * comparisons (`a ? b : c`, `a ?: c` and `a ?? b`)
+ *
+ * @package   Kirby Query
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Expression
+{
+	public function __construct(
+		public array $parts
+	) {
+	}
+
+	public static function factory(string $expression, Query $parent = null): static|Segments
+	{
+		// split into different expression parts and operators
+		$parts = static::parse($expression);
+
+		// shortcut: if expression has only one part, directly
+		// continue with the segments chain
+		if (count($parts) === 1) {
+			return Segments::factory(query: $parts[0], parent: $parent);
+		}
+
+		// turn all non-operator parts into an Argument
+		// which takes care of converting string, arrays booleans etc.
+		// into actual types and treats all other parts as their own queries
+		$parts = A::map(
+			$parts,
+			fn ($part) =>
+				in_array($part, ['?', ':', '?:', '??'])
+					? $part
+					: Argument::factory($part)
+		);
+
+		return new static(parts: $parts);
+	}
+
+	/**
+	 * Splits a comparison string into an array
+	 * of expressions and operators
+	 * @internal
+	 */
+	public static function parse(string $string): array
+	{
+		// split by multiples of `?` and `:`, but not inside skip groups
+		// (parantheses, quotes etc.)
+		return preg_split(
+			'/\s*([\?\:]+)\s*|' . Arguments::OUTSIDE . '/',
+			$string,
+			flags: PREG_SPLIT_DELIM_CAPTURE
+		);
+	}
+
+	/**
+	 * Resolves the expression by evaluating
+	 * the supported comparisons and consecutively
+	 * resolving the resulting query/argument
+	 */
+	public function resolve(array|object $data = []): mixed
+	{
+		$base = null;
+
+		foreach ($this->parts as $index => $part) {
+			// `a ?? b`
+			// if the base/previous (e.g. `a`) isn't null,
+			// stop the expression chain and return `a`
+			if ($part === '??') {
+				if ($base !== null) {
+					return $base;
+				}
+
+				continue;
+			}
+
+			// `a ?: b`
+			// if `a` isn't false, return `a`, otherwise `b`
+			if ($part === '?:') {
+				if ($base != false) {
+					return $base;
+				}
+
+				return $this->parts[$index + 1]->resolve($data);
+			}
+
+			// `a ? b : c`
+			// if `a` isn't false, return `b`, otherwise `c`
+			if ($part === '?') {
+				if ($this->parts[$index + 2] !== ':') {
+					throw new LogicException('Query: Incomplete ternary operator (missing matching `? :`)');
+				}
+
+				if ($base != false) {
+					return $this->parts[$index + 1]->resolve($data);
+				}
+
+				return $this->parts[$index + 3]->resolve($data);
+			}
+
+			$base = $part->resolve($data);
+		}
+
+		return $base;
+	}
+}

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -12,9 +12,16 @@ use Kirby\Cms\User;
 use Kirby\Toolkit\I18n;
 
 /**
- * The Query class can be used to
- * query arrays and objects, including their
- * methods with a very simple string-based syntax.
+ * The Query class can be used to query arrays and objects,
+ * including their methods with a very simple string-based syntax.
+ *
+ * Namespace structure - what handles what:
+ * - Query			Main interface, direct entries
+ * - Expression		Simple comparisons (`a ? b :c`)
+ * - Segments		Chain of method calls (`site.find('notes').url`)
+ * - Segment		Single method call (`find('notes')`)
+ * - Arguments		Method call parameters (`'template', '!=', 'note'`)
+ * - Argument		Single parameter, resolving into actual types
  *
  * @package   Kirby Query
  * @author    Bastian Allgeier <bastian@getkirby.com>,
@@ -90,7 +97,7 @@ class Query
 		}
 
 		// loop through all segments to resolve query
-		return Segments::factory($this->query, $this)->resolve($data);
+		return Expression::factory($this->query, $this)->resolve($data);
 	}
 }
 

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -28,6 +28,7 @@ class Segment
 
 	/**
 	 * Throws an exception for an access to an invalid method
+	 * @internal
 	 *
 	 * @param mixed $data Variable on which the access was tried
 	 * @param string $name Name of the method/property that was accessed
@@ -45,7 +46,7 @@ class Segment
 
 		$nonExisting = in_array($type, ['array', 'object']) ? 'non-existing ' : '';
 
-		$error = 'Access to ' . $nonExisting . $label . ' ' . $name . ' on ' . $type;
+		$error = 'Access to ' . $nonExisting . $label . ' "' . $name . '" on ' . $type;
 
 		throw new BadMethodCallException($error);
 	}
@@ -110,7 +111,7 @@ class Segment
 		}
 
 		if ($args !== []) {
-			throw new InvalidArgumentException('Cannot access array element ' . $this->method . ' with arguments');
+			throw new InvalidArgumentException('Cannot access array element "' . $this->method . '" with arguments');
 		}
 
 		return $value;

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -31,17 +31,20 @@ class Segments extends Collection
 	public static function factory(string $query, Query $parent = null): static
 	{
 		$segments = static::parse($query);
-		$index    = 0;
+		$position = 0;
 
 		$segments = A::map(
 			$segments,
-			function ($segment) use (&$index) {
+			function ($segment) use (&$position) {
+				// leave connectors as they are
 				if (in_array($segment, ['.', '.?']) === true) {
 					return $segment;
 				}
 
-				$index++;
-				return Segment::factory($segment, $index - 1);
+				// turn all other parts into Segment objects
+				// and pass their position in the chain (ignoring connectors)
+				$position++;
+				return Segment::factory($segment, $position - 1);
 			}
 		);
 

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -30,26 +30,59 @@ class Segments extends Collection
 	 */
 	public static function factory(string $query, Query $parent = null): static
 	{
-		$segments = preg_split(
-			'!\.|(\(([^()]+|(?1))*+\))(*SKIP)(*FAIL)!',
-			trim($query),
-			-1,
-			PREG_SPLIT_NO_EMPTY
-		);
+		$segments = static::parse($query);
+		$index    = 0;
 
 		$segments = A::map(
-			array_keys($segments),
-			fn ($index) => Segment::factory($segments[$index], $index)
+			$segments,
+			function ($segment) use (&$index) {
+				if (in_array($segment, ['.', '.?']) === true) {
+					return $segment;
+				}
+
+				$index++;
+				return Segment::factory($segment, $index - 1);
+			}
 		);
 
 		return new static($segments, $parent);
 	}
 
+	/**
+	 * Splits the string of a segment chaing into an
+	 * array of segments as well as conenctors (`.` or `.?`)
+	 * @internal
+	 */
+	public static function parse(string $string): array
+	{
+		return preg_split(
+			'/(\.\??)|(\(([^()]+|(?2))*+\))(*SKIP)(*FAIL)/',
+			trim($string),
+			flags: PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
+		);
+	}
+
+	/**
+	 * Resolves the segments chain by looping through
+	 * each segment call to be applied to the value of
+	 * all previous segment calls, returning gracefully at
+	 * `.?` when current value is `null`
+	 */
 	public function resolve(array|object $data = [])
 	{
 		$value = null;
 
 		foreach ($this->data as $segment) {
+			// optional chaining: stop if current value is null
+			if ($segment === '.?' && $value === null) {
+				return null;
+			}
+
+			// for regular connectors, just skip
+			if ($segment === '.') {
+				continue;
+			}
+
 			// offer possibility to intercept on objects
 			if ($value !== null) {
 				$value = $this->parent?->intercept($value) ?? $value;

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -37,7 +37,7 @@ class Segments extends Collection
 			$segments,
 			function ($segment) use (&$position) {
 				// leave connectors as they are
-				if (in_array($segment, ['.', '.?']) === true) {
+				if (in_array($segment, ['.', '?.']) === true) {
 					return $segment;
 				}
 
@@ -53,13 +53,13 @@ class Segments extends Collection
 
 	/**
 	 * Splits the string of a segment chaing into an
-	 * array of segments as well as conenctors (`.` or `.?`)
+	 * array of segments as well as conenctors (`.` or `?.`)
 	 * @internal
 	 */
 	public static function parse(string $string): array
 	{
 		return preg_split(
-			'/(\.\??)|(\(([^()]+|(?2))*+\))(*SKIP)(*FAIL)/',
+			'/(\??\.)|(\(([^()]+|(?2))*+\))(*SKIP)(*FAIL)/',
 			trim($string),
 			flags: PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
 		);
@@ -69,7 +69,7 @@ class Segments extends Collection
 	 * Resolves the segments chain by looping through
 	 * each segment call to be applied to the value of
 	 * all previous segment calls, returning gracefully at
-	 * `.?` when current value is `null`
+	 * `?.` when current value is `null`
 	 */
 	public function resolve(array|object $data = [])
 	{
@@ -77,7 +77,7 @@ class Segments extends Collection
 
 		foreach ($this->data as $segment) {
 			// optional chaining: stop if current value is null
-			if ($segment === '.?' && $value === null) {
+			if ($segment === '?.' && $value === null) {
 				return null;
 			}
 

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  */
-final class Segments extends Collection
+class Segments extends Collection
 {
 	public function __construct(
 		array $data = [],

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -43,6 +43,9 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
 
 		$argument = Argument::factory(' false ');
 		$this->assertFalse($argument->value);
+
+		$argument = Argument::factory(' ( "foo") ');
+		$this->assertSame('foo', $argument->value);
 	}
 
 	/**

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -63,6 +63,10 @@ class ExpressionTest extends \PHPUnit\Framework\TestCase
 			[
 				'null ?? (null ?? null ?? (false ? "what" : 42)) ?? "no"',
 				['null', '??', '(null ?? null ?? (false ? "what" : 42))', '??', '"no"']
+			],
+			[
+				'page.cover.toFile?.url ?? page.image?.url',
+				['page.cover.toFile?.url', '??', 'page.image?.url']
 			]
 		];
 	}

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Query;
 
+use Kirby\Exception\LogicException;
+
 /**
  * @coversDefaultClass Kirby\Query\Expression
  */
@@ -106,5 +108,18 @@ class ExpressionTest extends \PHPUnit\Framework\TestCase
 		$expression = Expression::factory('user.isYello(true) ? user.says("me") : "you"');
 		$data = ['user' => new TestUser()];
 		$this->assertSame('me', $expression->resolve($data));
+	}
+
+	/**
+	 * @covers ::resolve
+	 */
+	public function testResolveIncompleteTernary()
+	{
+		$expression = Expression::factory('"a" ? "b"');
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Query: Incomplete ternary operator (missing matching `? :`)');
+
+		$expression->resolve();
 	}
 }

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -10,6 +10,7 @@ use Kirby\Exception\LogicException;
 class ExpressionTest extends \PHPUnit\Framework\TestCase
 {
 	/**
+	 * @covers ::__construct
 	 * @covers ::factory
 	 */
 	public function testFactory()
@@ -32,7 +33,7 @@ class ExpressionTest extends \PHPUnit\Framework\TestCase
 		$this->assertInstanceOf(Segments::class, $expression);
 	}
 
-	protected function providerParse(): array
+	public function providerParse(): array
 	{
 		return [
 			[
@@ -76,7 +77,7 @@ class ExpressionTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($result, $parts);
 	}
 
-	protected function providerResolve(): array
+	public function providerResolve(): array
 	{
 		return [
 			['true ? "yes" : "no"', 'yes'],

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Kirby\Query;
+
+/**
+ * @coversDefaultClass Kirby\Query\Expression
+ */
+class ExpressionTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactory()
+	{
+		$expression = Expression::factory('a ? b : c');
+		$this->assertSame(5, count($expression->parts));
+		$this->assertInstanceOf(Argument::class, $expression->parts[0]);
+		$this->assertIsString($expression->parts[1]);
+		$this->assertInstanceOf(Argument::class, $expression->parts[2]);
+		$this->assertIsString($expression->parts[3]);
+		$this->assertInstanceOf(Argument::class, $expression->parts[4]);
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryWithoutComparison()
+	{
+		$expression = Expression::factory('foo.bar(true).url');
+		$this->assertInstanceOf(Segments::class, $expression);
+	}
+
+	protected function providerParse(): array
+	{
+		return [
+			[
+				'a ? b : c',
+				['a', '?', 'b', ':', 'c']
+			],
+			[
+				'a ?: c',
+				['a', '?:', 'c']
+			],
+			[
+				'a ?? b',
+				['a', '??', 'b']
+			],
+			[
+				'a ?? b ?? c ?? d',
+				['a', '??', 'b', '??', 'c', '??', 'd']
+			],
+			[
+				'a ? "x ? y : z" : c',
+				['a', '?', '"x ? y : z"', ':', 'c']
+			],
+			[
+				'a ? (x ?: z) : c',
+				['a', '?', '(x ?: z)', ':', 'c']
+			],
+			[
+				'null ?? (null ?? null ?? (false ? "what" : 42)) ?? "no"',
+				['null', '??', '(null ?? null ?? (false ? "what" : 42))', '??', '"no"']
+			]
+		];
+	}
+
+	/**
+	 * @covers ::parse
+	 * @dataProvider providerParse
+	 */
+	public function testParse(string $expression, array $result)
+	{
+		$parts = Expression::parse($expression);
+		$this->assertSame($result, $parts);
+	}
+
+	protected function providerResolve(): array
+	{
+		return [
+			['true ? "yes" : "no"', 'yes'],
+			['false ? "yes" : "no"', 'no'],
+			['0 ? "yes" : "no"', 'no'],
+			['"yes" ?: "no"', 'yes'],
+			['0 ?: "no"', 'no'],
+			['null ?? null ?? null ?? "yes"', 'yes'],
+			['"yes" ?? "no"', 'yes'],
+			['null ?? (null ?? null ?? (false ? "what" : 42)) ?? "no"', 42.0],
+		];
+	}
+
+	/**
+	 * @covers ::resolve
+	 * @dataProvider providerResolve
+	 */
+	public function testResolve(string $input, mixed $result)
+	{
+		$expression = Expression::factory($input);
+		$this->assertSame($result, $expression->resolve());
+	}
+
+	/**
+	 * @covers ::resolve
+	 */
+	public function testResolveWithObject()
+	{
+		$expression = Expression::factory('user.isYello(true) ? user.says("me") : "you"');
+		$data = ['user' => new TestUser()];
+		$this->assertSame('me', $expression->resolve($data));
+	}
+}

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -42,6 +42,16 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @covers ::resolve
 	 */
+	public function testResolveWithComparisonExpresion()
+	{
+		$query = new Query('user.nothing ?? (user.nothing ?? user.isYello(false)) ? user.says("error") : (user.nothing ?? user.says("success"))');
+		$data  = ['user' => new TestUser()];
+		$this->assertSame('success', $query->resolve($data));
+	}
+
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveWithExactArrayMatch()
 	{
 		$query = new Query('user');

--- a/tests/Query/SegmentTest.php
+++ b/tests/Query/SegmentTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Query;
 
+use Kirby\Exception\BadMethodCallException;
+use Kirby\Exception\InvalidArgumentException;
 use stdClass;
 
 class MyObj
@@ -53,8 +55,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testErrorWithScalars($scalar, $label)
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to method foo on ' . $label);
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to method "foo" on ' . $label);
 
 		Segment::error($scalar, 'foo', 'method');
 	}
@@ -64,8 +66,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testErrorWithObject()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to non-existing method foo on object');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to non-existing method "foo" on object');
 
 		Segment::error(new stdClass(), 'foo', 'method');
 	}
@@ -131,8 +133,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveArrayInvalidKey()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to non-existing property foo on array');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to non-existing property "foo" on array');
 
 		$segment = Segment::factory('foo');
 		$segment->resolve(['bar' => 2]);
@@ -144,8 +146,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveArrayArgOnNonClosure()
 	{
-		$this->expectException('Kirby\Exception\InvalidArgumentException');
-		$this->expectExceptionMessage('Cannot access array element foo with arguments');
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Cannot access array element "foo" with arguments');
 
 		$segment = Segment::factory('foo(2)', 1);
 		$segment->resolve(['foo' => 'bar']);
@@ -180,8 +182,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveObjectInvalid()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to method/property foo on string');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to method/property "foo" on string');
 
 		$segment = Segment::factory('foo', 1);
 		$segment->resolve('bar');
@@ -193,8 +195,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveObjectInvalidMethod()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to non-existing method/property notfound on object');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to non-existing method/property "notfound" on object');
 
 		$obj     = new MyObj();
 		$segment = Segment::factory('notfound', 1);
@@ -207,8 +209,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveObjectMethodWithoutArgs()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to non-existing method notfound on object');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to non-existing method "notfound" on object');
 
 		$obj     = new MyObj();
 		$segment = Segment::factory('notfound(2)', 1);
@@ -220,8 +222,8 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveWithArrayNullValueError()
 	{
-		$this->expectException('Kirby\Exception\BadMethodCallException');
-		$this->expectExceptionMessage('Access to method/property method on null');
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Access to method/property "method" on null');
 
 		$segment = Segment::factory('method', 1);
 		$segment->resolve(null);

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -30,7 +30,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame(2, $segments->nth(4)->position);
 	}
 
-	protected function providerParse(): array
+	public function providerParse(): array
 	{
 		return [
 			[

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -174,7 +174,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayScalarValueError($scalar, $type)
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to method/property method on ' . $type);
+		$this->expectExceptionMessage('Access to method/property "method" on ' . $type);
 
 		$segments = Segments::factory('value.method');
 		$data     = ['value' => $scalar];
@@ -197,7 +197,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayNullValueError()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to method/property method on null');
+		$this->expectExceptionMessage('Access to method/property "method" on null');
 
 		$segments = Segments::factory('value.method');
 		$data     = ['value' => null];
@@ -220,7 +220,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayCallError()
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Cannot access array element user with arguments');
+		$this->expectExceptionMessage('Cannot access array element "user" with arguments');
 
 		$segments = Segments::factory('user("test")');
 		$data     = ['user' => new TestUser()];
@@ -233,7 +233,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayMissingKey1()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing property user on array');
+		$this->expectExceptionMessage('Access to non-existing property "user" on array');
 
 		$segments = Segments::factory('user');
 		$segments->resolve();
@@ -245,7 +245,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayMissingKey2()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing property user on array');
+		$this->expectExceptionMessage('Access to non-existing property "user" on array');
 
 		$segments = Segments::factory('user.username');
 		$segments->resolve();
@@ -288,7 +288,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithObjectPropertyCallError()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing method test on object');
+		$this->expectExceptionMessage('Access to non-existing method "test" on object');
 
 		$obj = new stdClass();
 		$obj->test = 'testtest';
@@ -486,7 +486,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithObjectMissingMethod1()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing method/property username on object');
+		$this->expectExceptionMessage('Access to non-existing method/property "username" on object');
 
 		$segments = Segments::factory('user.username');
 		$data     = ['user' => new stdClass()];
@@ -499,7 +499,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithObjectMissingMethod2()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing method username on object');
+		$this->expectExceptionMessage('Access to non-existing method "username" on object');
 
 		$segments = Segments::factory('user.username(12)');
 		$data     = ['user' => new stdClass()];
@@ -516,7 +516,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 		$this->assertNull($segments->resolve($data));
 
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to method/property says on null');
+		$this->expectExceptionMessage('Access to method/property "says" on null');
 
 		$segments = Segments::factory('user.nothing.says("hi")');
 		$segments->resolve($data);

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -34,20 +34,20 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	{
 		return [
 			[
-				'foo.bar(homer.simpson).?url',
-				['foo', '.', 'bar(homer.simpson)', '.?', 'url']
+				'foo.bar(homer.simpson)?.url',
+				['foo', '.', 'bar(homer.simpson)', '?.', 'url']
 			],
 			[
 				'user.check("gin", "tonic", user.array("gin", "tonic").args)',
 				['user', '.', 'check("gin", "tonic", user.array("gin", "tonic").args)']
 			],
 			[
-				'a().b(foo.bar).?c(homer.simpson(2))',
-				['a()', '.', 'b(foo.bar)', '.?', 'c(homer.simpson(2))']
+				'a().b(foo.bar)?.c(homer.simpson(2))',
+				['a()', '.', 'b(foo.bar)', '?.', 'c(homer.simpson(2))']
 			],
 			[
-				'foo.bar(() => foo.homer.?url).foo.?bar',
-				['foo', '.', 'bar(() => foo.homer.?url)', '.', 'foo', '.?', 'bar']
+				'foo.bar(() => foo.homer?.url).foo?.bar',
+				['foo', '.', 'bar(() => foo.homer?.url)', '.', 'foo', '?.', 'bar']
 			]
 		];
 	}
@@ -511,7 +511,7 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveWithOptionalChaining()
 	{
-		$segments = Segments::factory('user.nothing.?says("hi")');
+		$segments = Segments::factory('user.nothing?.says("hi")');
 		$data     = ['user' => new TestUser()];
 		$this->assertNull($segments->resolve($data));
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Feature
- Kirby query language gains new functionalities:
  - Optional chaining: `page('note').cover.toFile?.url` does not crash anymore when no cover file is present, but returns `null`
  - Simple comparisons: support for `a ? b : c`, `a ?: c` and `a ?? b`


## Contributors
- thanks to @adamkiss for hilf help on the regular expressions

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
