### PR TITLE
New hooks: `language.*:before|after`

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -211,9 +211,9 @@ class Language extends Model
 		}
 
 		// trigger before hook
-		$kirby->trigger('language.create:before', compact('props'));
-
 		$language = new static($props);
+
+		$kirby->trigger('language.create:before', ['language' => $language, 'input' => $props]);
 
 		// validate the new language
 		LanguageRules::create($language);
@@ -225,10 +225,10 @@ class Language extends Model
 		}
 
 		// update the main languages collection in the app instance
-		App::instance()->languages(false)->append($language->code(), $language);
+		$kirby->languages(false)->append($language->code(), $language);
 
 		// trigger after hook
-		$kirby->trigger('language.create:after', compact('language', 'props'));
+		$kirby->trigger('language.create:after', ['language' => $language, 'input' => $props]));
 
 		return $language;
 	}
@@ -679,7 +679,7 @@ class Language extends Model
 		// trigger before hook
 		$kirby->trigger('language.update:before', [
 			'language' => $this,
-			'props' => $props
+			'input' => $props
 		]);
 
 		// convert the current default to a non-default language
@@ -713,7 +713,7 @@ class Language extends Model
 		$kirby->trigger('language.update:after', [
 			'newLanguage' => $language,
 			'oldLanguage' => $this,
-			'props' => $props
+			'input' => $props
 		]);
 
 		return $language;

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -210,6 +210,9 @@ class Language extends Model
 			$props['default'] = true;
 		}
 
+		// trigger before hook
+		$kirby->trigger('language.create:before', compact('props'));
+
 		$language = new static($props);
 
 		// validate the new language
@@ -223,6 +226,9 @@ class Language extends Model
 
 		// update the main languages collection in the app instance
 		App::instance()->languages(false)->append($language->code(), $language);
+
+		// trigger after hook
+		$kirby->trigger('language.create:after', compact('language', 'props'));
 
 		return $language;
 	}

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -666,6 +666,12 @@ class Language extends Model
 		// validate the updated language
 		LanguageRules::update($updated);
 
+		// trigger before hook
+		$kirby->trigger('language.update:before', [
+			'language' => $this,
+			'props' => $props
+		]);
+
 		// convert the current default to a non-default language
 		if ($updated->isDefault() === true) {
 			$kirby->defaultLanguage()?->clone(['default' => false])->save();
@@ -692,6 +698,13 @@ class Language extends Model
 
 		// make sure the language is also updated in the Kirby language collection
 		App::instance()->languages(false)->set($language->code(), $language);
+
+		// trigger after hook
+		$kirby->trigger('language.update:after', [
+			'newLanguage' => $language,
+			'oldLanguage' => $this,
+			'props' => $props
+		]);
 
 		return $language;
 	}

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -210,10 +210,16 @@ class Language extends Model
 			$props['default'] = true;
 		}
 
-		// trigger before hook
 		$language = new static($props);
 
-		$kirby->trigger('language.create:before', ['language' => $language, 'input' => $props]);
+		// trigger before hook
+		$kirby->trigger(
+			'language.create:before',
+			[
+				'input'    => $props,
+				'language' => $language
+			]
+		);
 
 		// validate the new language
 		LanguageRules::create($language);
@@ -228,7 +234,13 @@ class Language extends Model
 		$kirby->languages(false)->append($language->code(), $language);
 
 		// trigger after hook
-		$kirby->trigger('language.create:after', ['language' => $language, 'input' => $props]));
+		$kirby->trigger(
+			'language.create:after',
+			[
+				'input'    => $props,
+				'language' => $language
+			]
+		);
 
 		return $language;
 	}

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -248,6 +248,11 @@ class Language extends Model
 		$code      = $this->code();
 		$isLast    = $languages->count() === 1;
 
+		// trigger before hook
+		$kirby->trigger('language.delete:before', [
+			'language' => $this
+		]);
+
 		if (F::remove($this->root()) !== true) {
 			throw new Exception('The language could not be deleted');
 		}
@@ -260,6 +265,11 @@ class Language extends Model
 
 		// get the original language collection and remove the current language
 		$kirby->languages(false)->remove($code);
+
+		// trigger after hook
+		$kirby->trigger('language.delete:after', [
+			'language' => $this
+		]);
 
 		return true;
 	}

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -504,4 +504,35 @@ class LanguageTest extends TestCase
 
 		$this->assertSame('English', $language->name());
 	}
+
+	public function testCreateHooks()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		new App([
+			'roots' => [
+				'index' => $this->fixtures = __DIR__ . '/fixtures/CreateHooksTest',
+			],
+			'hooks' => [
+				'language.create:before' => function (array $props) use ($phpunit, &$calls) {
+					$phpunit->assertSame('de', $props['code']);
+					$phpunit->assertTrue($props['default']);
+					$calls++;
+				},
+				'language.create:after' => function (Language $language, array $props) use ($phpunit, &$calls) {
+					$phpunit->assertInstanceOf(Language::class, $language);
+					$phpunit->assertSame('de', $props['code']);
+					$phpunit->assertTrue($props['default']);
+					$calls++;
+				}
+			]
+		]);
+
+		Language::create([
+			'code' => 'de'
+		]);
+
+		$this->assertSame(2, $calls);
+	}
 }

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -577,4 +577,39 @@ class LanguageTest extends TestCase
 
 		$this->assertSame(2, $calls);
 	}
+
+	public function testDeleteHooks()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		new App([
+			'roots' => [
+				'index' => $this->fixtures = __DIR__ . '/fixtures/DeleteHooksTest',
+			],
+			'hooks' => [
+				'language.delete:before' => function (Language $language) use ($phpunit, &$calls) {
+					$phpunit->assertInstanceOf(Language::class, $language);
+					$phpunit->assertSame('en', $language->code());
+					$phpunit->assertSame('English', $language->name());
+					$calls++;
+				},
+				'language.delete:after' => function (Language $language) use ($phpunit, &$calls) {
+					$phpunit->assertInstanceOf(Language::class, $language);
+					$phpunit->assertSame('en', $language->code());
+					$phpunit->assertSame('English', $language->name());
+					$calls++;
+				}
+			]
+		]);
+
+		$language = Language::create([
+			'code' => 'en',
+			'name' => 'English'
+		]);
+		$language->delete();
+
+
+		$this->assertSame(2, $calls);
+	}
 }

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -515,15 +515,16 @@ class LanguageTest extends TestCase
 				'index' => $this->fixtures = __DIR__ . '/fixtures/CreateHooksTest',
 			],
 			'hooks' => [
-				'language.create:before' => function (array $props) use ($phpunit, &$calls) {
-					$phpunit->assertSame('de', $props['code']);
-					$phpunit->assertTrue($props['default']);
+				'language.create:before' => function (Language $language, array $input) use ($phpunit, &$calls) {
+					$phpunit->assertInstanceOf(Language::class, $language);
+					$phpunit->assertSame('de', $input['code']);
+					$phpunit->assertTrue($input['default']);
 					$calls++;
 				},
-				'language.create:after' => function (Language $language, array $props) use ($phpunit, &$calls) {
+				'language.create:after' => function (Language $language, array $input) use ($phpunit, &$calls) {
 					$phpunit->assertInstanceOf(Language::class, $language);
-					$phpunit->assertSame('de', $props['code']);
-					$phpunit->assertTrue($props['default']);
+					$phpunit->assertSame('de', $input['code']);
+					$phpunit->assertTrue($input['default']);
 					$calls++;
 				}
 			]
@@ -549,22 +550,22 @@ class LanguageTest extends TestCase
 				'index' => $this->fixtures,
 			],
 			'hooks' => [
-				'language.update:before' => function (Language $language, array $props) use ($phpunit, &$calls) {
+				'language.update:before' => function (Language $language, array $input) use ($phpunit, &$calls) {
 					$phpunit->assertInstanceOf(Language::class, $language);
 					$phpunit->assertSame('en', $language->code());
 					$phpunit->assertTrue($language->isDefault());
-					$phpunit->assertSame('English', $props['name']);
+					$phpunit->assertSame('English', $input['name']);
 					$phpunit->assertSame('en', $language->name());
 					$calls++;
 				},
-				'language.update:after' => function (Language $oldLanguage, Language $newLanguage, array $props) use ($phpunit, &$calls) {
+				'language.update:after' => function (Language $oldLanguage, Language $newLanguage, array $input) use ($phpunit, &$calls) {
 					$phpunit->assertInstanceOf(Language::class, $oldLanguage);
 					$phpunit->assertInstanceOf(Language::class, $newLanguage);
 					$phpunit->assertSame('en', $oldLanguage->code());
 					$phpunit->assertSame('en', $newLanguage->code());
 					$phpunit->assertTrue($oldLanguage->isDefault());
 					$phpunit->assertTrue($newLanguage->isDefault());
-					$phpunit->assertSame('English', $props['name']);
+					$phpunit->assertSame('English', $input['name']);
 					$phpunit->assertSame('en', $oldLanguage->name());
 					$phpunit->assertSame('English', $newLanguage->name());
 					$calls++;


### PR DESCRIPTION
### 🎉 Features

- New language hooks: https://kirby.nolt.io/419
  - `language.create:before|after`: It is triggered when a new language is created.
  - `language.update:before|after`: It is triggered when the language is updated.
  - `language.delete:before|after`: It is triggered when the language is deleted.

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
