### PR TITLE
Allow UUID v4 mode for generated UUIDs

### DIFF
--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -4,6 +4,7 @@ namespace Kirby\Uuid;
 
 use Closure;
 use Generator;
+use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
@@ -196,6 +197,10 @@ class Uuid
 	{
 		if (static::$generator !== null) {
 			return (static::$generator)($length);
+		}
+
+		if (App::instance()->option('content.uuid') === 'uuid-v4') {
+			return Str::uuid();
 		}
 
 		return Str::random($length, 'alphaNum');

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -184,7 +184,22 @@ class UuidTest extends TestCase
 		$id = Uuid::generate(5);
 		$this->assertSame(5, strlen($id));
 
-		// custom generator callback
+		// UUID v4 mode
+		$this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => 'uuid-v4'
+				]
+			]
+		]);
+		$id = Uuid::generate();
+		$this->assertSame(36, strlen($id));
+
+		// UUID v4 mode with custom length (no effect)
+		$id = Uuid::generate(5);
+		$this->assertSame(36, strlen($id));
+
+		// custom generator callback (overrides the UUID v4 mode)
 		Uuid::$generator = fn ($length) => 'veryunique' . $length;
 		$this->assertSame('veryunique13', Uuid::generate(13));
 		Uuid::$generator = null;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- Added a new option `'content.uuid' => 'uuid-v4'` to switch the built-in UUID generator to UUID v4 mode

Origin: https://forum.getkirby.com/t/why-is-kirby-using-16-character-uuids/26758/5

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
