### PR TITLE
`Dir::copy()`: Support skipping the global ignore list

### DIFF
--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -48,12 +48,16 @@ class Dir
 
 	/**
 	 * Copy the directory to a new destination
+	 *
+	 * @param array|false $ignore List of full paths to skip during copying
+	 *                            or `false` to copy all files, including
+	 *                            those listed in `Dir::$ignore`
 	 */
 	public static function copy(
 		string $dir,
 		string $target,
 		bool $recursive = true,
-		array $ignore = []
+		array|bool $ignore = []
 	): bool {
 		if (is_dir($dir) === false) {
 			throw new Exception('The directory "' . $dir . '" does not exist');
@@ -67,10 +71,13 @@ class Dir
 			throw new Exception('The target directory "' . $target . '" could not be created');
 		}
 
-		foreach (static::read($dir) as $name) {
+		foreach (static::read($dir, $ignore === false ? [] : null) as $name) {
 			$root = $dir . '/' . $name;
 
-			if (in_array($root, $ignore) === true) {
+			if (
+				is_array($ignore) === true &&
+				in_array($root, $ignore) === true
+			) {
 				continue;
 			}
 

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -55,6 +55,7 @@ class DirTest extends TestCase
 
 		$this->assertTrue(file_exists($target . '/a.txt'));
 		$this->assertTrue(file_exists($target . '/subfolder/b.txt'));
+		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
 	}
 
 	/**
@@ -71,6 +72,7 @@ class DirTest extends TestCase
 
 		$this->assertTrue(file_exists($target . '/a.txt'));
 		$this->assertFalse(file_exists($target . '/subfolder/b.txt'));
+		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
 	}
 
 	/**
@@ -88,6 +90,25 @@ class DirTest extends TestCase
 		$this->assertTrue(file_exists($target . '/a.txt'));
 		$this->assertTrue(is_dir($target . '/subfolder'));
 		$this->assertFalse(file_exists($target . '/subfolder/b.txt'));
+		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
+	}
+
+	/**
+	 * @covers ::copy
+	 */
+	public function testCopyNoIgnore()
+	{
+		$src    = $this->fixtures . '/copy';
+		$target = $this->tmp . '/copy';
+
+		$result = Dir::copy($src, $target, true, false);
+
+		$this->assertTrue($result);
+
+		$this->assertTrue(file_exists($target . '/a.txt'));
+		$this->assertTrue(is_dir($target . '/subfolder'));
+		$this->assertTrue(file_exists($target . '/subfolder/b.txt'));
+		$this->assertTrue(file_exists($target . '/subfolder/.gitignore'));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- The `Dir::copy()` method now supports `false` as the argument for `$ignore`. In this mode, all files are copied, including those listed in the global `Dir::$ignore` list.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
