### PR TITLE
PHP 8.2 prep: deprecated dynamic properties

### DIFF
--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Text;
 
+use AllowDynamicProperties;
 use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
@@ -19,7 +20,11 @@ use Kirby\Uuid\Uuid;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @todo remove the following psalm suppress when PHP >= 8.2 required
+ * @psalm-suppress AllowDynamicProperties
  */
+#[AllowDynamicProperties]
 class KirbyTag
 {
 	public static array $aliases = [];

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -22,7 +22,7 @@ use Kirby\Uuid\Uuid;
  * @license   https://opensource.org/licenses/MIT
  *
  * @todo remove the following psalm suppress when PHP >= 8.2 required
- * @psalm-suppress AllowDynamicProperties
+ * @psalm-suppress UndefinedAttributeClass
  */
 #[AllowDynamicProperties]
 class KirbyTag

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -20,7 +20,7 @@ use TypeError;
  * @license   https://opensource.org/licenses/MIT
  *
  * @todo remove the following psalm suppress when PHP >= 8.2 required
- * @psalm-suppress AllowDynamicProperties
+ * @psalm-suppress UndefinedAttributeClass
  */
 #[AllowDynamicProperties]
 class Component

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use AllowDynamicProperties;
 use ArgumentCountError;
 use Closure;
 use Kirby\Exception\Exception;
@@ -17,7 +18,11 @@ use TypeError;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @todo remove the following psalm suppress when PHP >= 8.2 required
+ * @psalm-suppress AllowDynamicProperties
  */
+#[AllowDynamicProperties]
 class Component
 {
 	/**

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class BlockTest extends TestCase
 {
+	protected $app;
 	protected $page;
 
 	public function setUp(): void

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class BlocksTest extends TestCase
 {
+	protected $app;
 	protected $page;
 
 	public function setUp(): void

--- a/tests/Cms/Items/ItemTest.php
+++ b/tests/Cms/Items/ItemTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 class ItemTest extends TestCase
 {
+	protected $app;
+	protected $page;
+
 	public function setUp(): void
 	{
 		$this->app = new App([

--- a/tests/Cms/Items/ItemsTest.php
+++ b/tests/Cms/Items/ItemsTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 class ItemsTest extends TestCase
 {
+	protected $app;
+	protected $page;
+
 	public function setUp(): void
 	{
 		$this->app = new App([

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -35,6 +35,7 @@ class MockPageForStatsSection extends Page
 class StatsSectionTest extends TestCase
 {
 	protected $app;
+	protected $model;
 
 	public function setUp(): void
 	{

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -17,6 +17,7 @@ class FTest extends TestCase
 {
 	protected $fixtures;
 	protected $hasErrorHandler = false;
+	protected $sample;
 	protected $test;
 	protected $tmp;
 

--- a/tests/Uuid/TestCase.php
+++ b/tests/Uuid/TestCase.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
+	protected $app;
 	protected $tmp;
 
 	protected function setUp(): void


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

PHP 8.2 deprecates dynamic properties (https://stitcher.io/blog/new-in-php-82#deprecate-dynamic-properties-rfc). This PR adds missing properties where possible (e.g. unit tests) and adds the `AllowDynamicProperties` attribute to the `KirbyTag` and `Component` classes where it doesn't seem to be easy to define all properties.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] ~~Add changes to release notes draft in Notion~~
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
