### PR TITLE
PHP 8.2 prep: Parsedown - fix `mb_convert_encoding` deprecation

### DIFF
--- a/dependencies/parsedown-extra/ParsedownExtra.php
+++ b/dependencies/parsedown-extra/ParsedownExtra.php
@@ -571,7 +571,8 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument();
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        $elementMarkup = htmlentities($elementMarkup);
+		$elementMarkup = htmlspecialchars_decode($elementMarkup);
 
         # Ensure that saveHTML() is not remove new line characters. New lines will be split by this character.
         $DOMDocument->formatOutput = true;


### PR DESCRIPTION
https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated
