### PR TITLE
File picker: name for `id` when parent model

### DIFF
--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -292,17 +292,22 @@ class File extends Model
 	public function pickerData(array $params = []): array
 	{
 		$name = $this->model->filename();
+		$id   = $this->model->id();
 
 		if (empty($params['model']) === false) {
 			$parent   = $this->model->parent();
+			// if the file belongs to the current parent model,
+			// store only name as ID to keep its path relative to the model
+			$id       = $parent === $params['model'] ? $name : $id;
 			$absolute = $parent !== $params['model'];
 		}
 
 		$params['text'] ??= '{{ file.filename }}';
 
 		return array_merge(parent::pickerData($params), [
-			'filename' => $name,
 			'dragText' => $this->dragText('auto', $absolute ?? false),
+			'filename' => $name,
+			'id'	   => $id,
 			'type'     => $this->model->type(),
 			'url'      => $this->model->url()
 		]);

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -90,8 +90,8 @@ class FilesFieldTest extends TestCase
 		$ids   = array_column($value, 'id');
 
 		$expected = [
-			'test/a.jpg',
-			'test/b.jpg'
+			'a.jpg',
+			'b.jpg'
 		];
 
 		$this->assertEquals($expected, $ids);
@@ -145,8 +145,8 @@ class FilesFieldTest extends TestCase
 		$ids   = array_column($value, 'id');
 
 		$expected = [
-			'test-draft/a.jpg',
-			'test-draft/b.jpg'
+			'a.jpg',
+			'b.jpg'
 		];
 
 		$this->assertEquals($expected, $ids);
@@ -270,8 +270,8 @@ class FilesFieldTest extends TestCase
 		$this->assertArrayHasKey('data', $api);
 		$this->assertArrayHasKey('pagination', $api);
 		$this->assertCount(3, $api['data']);
-		$this->assertSame('test/a.jpg', $api['data'][0]['id']);
-		$this->assertSame('test/b.jpg', $api['data'][1]['id']);
-		$this->assertSame('test/c.jpg', $api['data'][2]['id']);
+		$this->assertSame('a.jpg', $api['data'][0]['id']);
+		$this->assertSame('b.jpg', $api['data'][1]['id']);
+		$this->assertSame('c.jpg', $api['data'][2]['id']);
 	}
 }

--- a/tests/Form/Fields/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/FilePickerMixinTest.php
@@ -38,9 +38,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('test/a.jpg', $files[0]['id']);
-		$this->assertEquals('test/b.jpg', $files[1]['id']);
-		$this->assertEquals('test/c.jpg', $files[2]['id']);
+		$this->assertEquals('a.jpg', $files[0]['id']);
+		$this->assertEquals('b.jpg', $files[1]['id']);
+		$this->assertEquals('c.jpg', $files[2]['id']);
 	}
 
 	public function testFileFiles()
@@ -106,9 +106,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals($user->id() . '/a.jpg', $files[0]['id']);
-		$this->assertEquals($user->id() . '/b.jpg', $files[1]['id']);
-		$this->assertEquals($user->id() . '/c.jpg', $files[2]['id']);
+		$this->assertEquals('a.jpg', $files[0]['id']);
+		$this->assertEquals('b.jpg', $files[1]['id']);
+		$this->assertEquals('c.jpg', $files[2]['id']);
 	}
 
 	public function testSiteFiles()

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -675,6 +675,7 @@ class FileTest extends TestCase
 		$data  = $panel->pickerData(['model' => $page]);
 
 		$this->assertSame('(image: test.jpg)', $data['dragText']);
+		$this->assertSame('test.jpg', $data['id']);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Files field: for `store: id` only the name is stored again when the current model is the file's parent
#4870

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
