### PR TITLE
Fix file UUIDs when duplicating within subpages 

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -53,7 +53,8 @@ trait PageActions
 					// regenerate UUIDs of all page children
 					if ($children !== false) {
 						foreach ($copy->index(true) as $child) {
-							// no $children because we already operate on the index
+							// always adapt files of subpages as they are currently always copied;
+							// but don't adapt children because we already operate on the index
 							$this->adaptCopy($child, true);
 						}
 					}
@@ -85,7 +86,8 @@ trait PageActions
 			// regenerate UUIDs of all page children
 			if ($children !== false) {
 				foreach ($copy->index(true) as $child) {
-					// no $children because we already operate on the index
+					// always adapt files of subpages as they are currently always copied;
+					// but don't adapt children because we already operate on the index
 					$this->adaptCopy($child, true);
 				}
 			}

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -54,7 +54,7 @@ trait PageActions
 					if ($children !== false) {
 						foreach ($copy->index(true) as $child) {
 							// no $children because we already operate on the index
-							$this->adaptCopy($child, $files);
+							$this->adaptCopy($child, true);
 						}
 					}
 				}
@@ -86,7 +86,7 @@ trait PageActions
 			if ($children !== false) {
 				foreach ($copy->index(true) as $child) {
 					// no $children because we already operate on the index
-					$this->adaptCopy($child, $files);
+					$this->adaptCopy($child, true);
 				}
 			}
 		}


### PR DESCRIPTION
## This PR …

Implements @lukasbestle idea on https://github.com/getkirby/kirby/issues/4875#issuecomment-1336258807

### Fixes
- Fixes regenerating UUIDs for files when duplicating nested page wih Panel UI #4875

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
