### PR TITLE
Fix optional chaining on non-null segment

### DIFF
--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -81,8 +81,9 @@ class Segments extends Collection
 				return null;
 			}
 
-			// for regular connectors, just skip
-			if ($segment === '.') {
+			// for regular connectors and optional chaining on non-null,
+			// just skip this connecting segment
+			if ($segment === '.' || $segment === '?.') {
 				continue;
 			}
 

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -511,6 +511,10 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolveWithOptionalChaining()
 	{
+		$segments = Segments::factory('user?.says("hi")');
+		$data     = ['user' => new TestUser()];
+		$this->assertSame('hi', $segments->resolve($data));
+
 		$segments = Segments::factory('user.nothing?.says("hi")');
 		$data     = ['user' => new TestUser()];
 		$this->assertNull($segments->resolve($data));


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Kirby queries: optional chaining on non-null values works now properly

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
