### PR TITLE
i18n/en - feburary fix

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -393,7 +393,7 @@
 	"months.april": "April",
 	"months.august": "August",
 	"months.december": "December",
-	"months.february": "Feburary",
+	"months.february": "February",
 	"months.january": "January",
 	"months.july": "July",
 	"months.june": "June",


### PR DESCRIPTION
### Fixes
i18 - english translation had a February name set to `Feburary`