### PR TITLE
Fix `->words()` field method

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -326,7 +326,7 @@ return function (App $app) {
 		 * Returns the number of words in the text
 		 */
 		'words' => function (Field $field) {
-			return str_word_count(strip_tags($field->value));
+			return str_word_count(strip_tags($field->value ?? ''));
 		},
 
 		// manipulators

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -722,6 +722,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$text = 'this is an example text';
 		$this->assertSame(5, $this->field($text)->words());
+		$this->assertSame(0, $this->field(null)->words());
 	}
 
 	public function testXml()


### PR DESCRIPTION
## This PR …

~Actually for solution, we can use simply `strip_tags($field->value ?? '')` but I preferred the `Str::unhtml()` method.~

### Fixes
- `->words()` field method works as expected on `null` values #4904 

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
