### PR TITLE
Case-sensitive `Xml::attr()`

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -144,6 +144,11 @@ class Html extends Xml
 			return $value === true ? strtolower($name) : null;
 		}
 
+		// HTML attribute names are case-insensitive
+		if (is_string($name) === true) {
+			$name = strtolower($name);
+		}
+
 		// all other cases can share the XML variant
 		$attr = parent::attr($name, $value);
 

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -95,11 +95,11 @@ class Xml
 		}
 
 		if ($value === ' ') {
-			return strtolower($name) . '=""';
+			return $name . '=""';
 		}
 
 		if (is_bool($value) === true) {
-			return $value === true ? strtolower($name) . '="' . strtolower($name) . '"' : null;
+			return $value === true ? $name . '="' . $name . '"' : null;
 		}
 
 		if (is_array($value) === true) {
@@ -115,7 +115,7 @@ class Xml
 			$value = static::encode($value);
 		}
 
-		return strtolower($name) . '="' . $value . '"';
+		return $name . '="' . $value . '"';
 	}
 
 	/**

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -22,9 +22,9 @@ class XmlTest extends TestCase
 	{
 		return [
 			[[],                         null,  ''],
-			[['B' => 'b', 'A' => 'a'],   null,  'a="a" b="b"'],
-			[['B' => 'b', 'A' => 'a'],   true,  'a="a" b="b"'],
-			[['B' => 'b', 'A' => 'a'],   false, 'b="b" a="a"'],
+			[['B' => 'b', 'A' => 'a'],   null,  'A="a" B="b"'],
+			[['B' => 'b', 'A' => 'a'],   true,  'A="a" B="b"'],
+			[['B' => 'b', 'A' => 'a'],   false, 'B="b" A="a"'],
 			[['a' => 'a', 'b' => true],  null,  'a="a" b="b"'],
 			[['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => ''],    null,  'a="a"'],


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `Toolkit\Xml::attr()` is case-sensitive now
#4908

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
