### PR TITLE
Automatic `alt` text for assets, file versions

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -112,6 +112,12 @@ class Image extends File
 	 */
 	public function html(array $attr = []): string
 	{
+		// if no alt text explicitly provided,
+		// try to infer from model content file
+		if ($alt = $this->model?->alt()) {
+			$attr['alt'] ??= $alt;
+		}
+
 		if ($url = $this->url()) {
 			return Html::img($url, $attr);
 		}

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Image;
 
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
 use Kirby\Exception\Exception;
 use Kirby\Exception\LogicException;
 use PHPUnit\Framework\TestCase as TestCase;
@@ -79,6 +81,20 @@ class ImageTest extends TestCase
 	{
 		$file = $this->_image();
 		$this->assertSame('<img alt="" src="https://foo.bar/cat.jpg">', $file->html());
+
+		$page = new Page(['slug' => 'test']);
+		$file = new File([
+			'filename' => 'cat.jpg',
+			'parent'   => $page,
+			'content'  => ['alt' => 'Test text']
+		]);
+		$image = new Image([
+			'root'  => __DIR__ . '/fixtures/image/cat.jpg',
+			'url'   => 'https://foo.bar/cat.jpg',
+			'model' => $file
+		]);
+
+		$this->assertSame('<img alt="Test text" src="https://foo.bar/cat.jpg">', $image->html());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

We already use the `alt` content field as automatic fallback when using `Cms\File::html()`. However, this does not get called for thumbs or other instances based on `FileVersion` or the `Image` class...

### Enhancement
- `Image\Image` uses its model's `alt` content field as fallback for rendering an `alt` tag to better provide accessible defaults


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
