### PR TITLE
DELETE `lock`: fail gracefully if already deleted

### DIFF
--- a/config/api/routes/lock.php
+++ b/config/api/routes/lock.php
@@ -4,6 +4,9 @@
 /**
  * Content Lock Routes
  */
+
+use Kirby\Exception\NotFoundException;
+
 return [
 	[
 		'pattern' => '(:all)/lock',
@@ -25,7 +28,11 @@ return [
 		'pattern' => '(:all)/lock',
 		'method'  => 'DELETE',
 		'action'  => function (string $path) {
-			return $this->parent($path)->lock()?->remove();
+			try {
+				return $this->parent($path)->lock()?->remove();
+			} catch (NotFoundException) {
+				return true;
+			}
 		}
 	],
 	[
@@ -39,7 +46,11 @@ return [
 		'pattern' => '(:all)/unlock',
 		'method'  => 'DELETE',
 		'action'  => function (string $path) {
-			return  $this->parent($path)->lock()?->resolve();
+			try {
+				return $this->parent($path)->lock()?->resolve();
+			} catch (NotFoundException) {
+				return true;
+			}
 		}
 	],
 ];


### PR DESCRIPTION
Fixes #4897

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fixed console errors for failed `lock` request when deleting page with unsaved changes
#4897


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
