### PR TITLE
Composer `test` without coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,8 @@
 			"@test"
 		],
 		"fix": "php-cs-fixer fix",
-		"test": "phpunit --stderr --coverage-html=tests/coverage",
+		"test": "phpunit --stderr",
+		"test:coverage": "phpunit --stderr --coverage-html=tests/coverage",
 		"zip": "composer archive --format=zip --file=dist"
 	}
 }


### PR DESCRIPTION
Default `test` script without coverage (to be a bit faster)