### PR TITLE
Pages section: add current label to status flag

### DIFF
--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -13,7 +13,10 @@ export default {
 
 				page.flag = {
 					status: page.status,
-					tooltip: this.$t("page.status"),
+					tooltip:
+						this.$t("page.status") +
+						": " +
+						this.$t("page.status." + page.status),
 					disabled: !isEnabled,
 					click: () => this.$dialog(page.link + "/changeStatus")
 				};


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

I went for a `Status: Drafts` pattern as this allows to reuse existing i18n strings from multiple translations.

### Enhancements
- Pages section: the status flag button now features a tooltip that includes the non-customised label of the current status
#4927



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
