### PR TITLE
`Xml::attr()`: deprecate empty string as value

### DIFF
--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -94,9 +94,11 @@ class Xml
 		// TODO: In 3.10, treat $value === '' to render as name=""
 		if ($value === null || $value === '' || $value === []) {
 			// TODO: Remove in 3.10
+			// @codeCoverageIgnoreStart
 			if ($value === '') {
 				Helpers::deprecated('Passing an empty string as value to `Xml::attr()` has been deprecated. In a future version, passing an empty string won\'t omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`.');
 			}
+			// @codeCoverageIgnoreEnd
 
 			return null;
 		}

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Kirby\Cms\Helpers;
 use SimpleXMLElement;
 
 /**
@@ -90,10 +91,18 @@ class Xml
 			return implode(' ', $attributes);
 		}
 
+		// TODO: In 3.10, treat $value === '' to render as name=""
 		if ($value === null || $value === '' || $value === []) {
+			// TODO: Remove in 3.10
+			if ($value === '') {
+				Helpers::deprecated('Passing an empty string as value to `Xml::attr()` has been deprecated. In a future version, passing an empty string won\'t omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`.');
+			}
+
 			return null;
 		}
 
+		// TODO: In 3.10, add deprecation message for space = empty attribute
+		// TODO: In 3.11, render space as space
 		if ($value === ' ') {
 			return $name . '=""';
 		}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Deprecated
- Passing an empty string as value to `Xml::attr()` has been deprecated and will throw a warning. In a future version, passing an empty string won't omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`

Closes #4752.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
