### PR TITLE
`Xml::attr()`: support simple values

### DIFF
--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -80,10 +80,13 @@ class Xml
 
 			$attributes = [];
 			foreach ($name as $key => $val) {
-				$a = static::attr($key, $val);
+				if (is_int($key) === true) {
+					$key = $val;
+					$val = true;
+				}
 
-				if ($a) {
-					$attributes[] = $a;
+				if ($attribute = static::attr($key, $val)) {
+					$attributes[] = $attribute;
 				}
 			}
 

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -126,7 +126,8 @@ class HtmlTest extends TestCase
 			[['a' => 'a', 'b' => ''],    null,  'a="a"'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],
-			[['a' => 'a', 'b' => []],    null,  'a="a"']
+			[['a' => 'a', 'b' => []],    null,  'a="a"'],
+			[['a', 'b' => true],         null,  'a b']
 		];
 	}
 

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -30,7 +30,8 @@ class XmlTest extends TestCase
 			[['a' => 'a', 'b' => ''],    null,  'a="a"'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],
-			[['a' => 'a', 'b' => []],    null,  'a="a"']
+			[['a' => 'a', 'b' => []],    null,  'a="a"'],
+			[['a', 'b' => true],         null,  'a="a" b="b"']
 		];
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- `Xml::attr()` and `Html::attr()` accept non-associative values (e.g. `Xml::attr(['attrA'])`) which get rendered like passing `true` (e.g. `attrA="attrA"`/`attrA`)

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [X] Unit tests for fixed bug/feature
- [X] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
