### PR TITLE
Structure field: use `$this->fields`

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -173,7 +173,7 @@ return [
 		},
 		'form' => function (array $values = []) {
 			return new Form([
-				'fields' => $this->attrs['fields'],
+				'fields' => $this->fields,
 				'values' => $values,
 				'model'  => $this->model
 			]);


### PR DESCRIPTION

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

This PR is one of these that I am a bit concerned of because our field setup is a mess (= hard to understand) and I can't trust unit tests to have our back as much here. From my understanding the change should be ok though: While I first thought it would result in a loop, as the computed `fields` also calls the `form()` method, this does not seem to be the case. When the computed prop function is called, `$this->field` contains the result of the normal `props` function which afterwards gets overwritten by the result from the computed function.

### Refactoring
- Structure field uses `$this->fields` instead of `$this->attrs['fields']`
#4909

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
