### PR TITLE
Disabled button: improve accessibility

### DIFF
--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -1,15 +1,16 @@
 <template>
-	<span
+	<button
 		:id="id"
 		:data-disabled="true"
 		:data-responsive="responsive"
 		:data-theme="theme"
 		:title="tooltip"
 		class="k-button"
+		aria-disabled="true"
 	>
 		<k-icon v-if="icon" :type="icon" :alt="tooltip" class="k-button-icon" />
 		<span v-if="$slots.default" class="k-button-text"><slot /></span>
-	</span>
+	</button>
 </template>
 
 <script>


### PR DESCRIPTION
So far, disabled buttons don't exists for screenreader. Which is bad when we communicated things like status etc. via disabled buttons. So we need to improve this.

## TODO
- [ ] @bastianallgeier focus state needs some styling I think. How to make it work no matter what context the disabled button is in?