### PR TITLE
Delete temporary uploaded files after processing

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -38,14 +38,17 @@ return [
 			// move_uploaded_file() not working with unit test
 			// @codeCoverageIgnoreStart
 			return $this->upload(function ($source, $filename) use ($path) {
-				return $this->parent($path)->createFile([
+				$props = [
 					'content' => [
 						'sort' => $this->requestBody('sort')
 					],
 					'source'   => $source,
 					'template' => $this->requestBody('template'),
 					'filename' => $filename
-				]);
+				];
+
+				// move the source file from the temp dir
+				return $this->parent($path)->createFile($props, true);
 			});
 			// @codeCoverageIgnoreEnd
 		}
@@ -95,8 +98,9 @@ return [
 		'pattern' => $pattern . '/files/(:any)',
 		'method'  => 'POST',
 		'action'  => function (string $path, string $filename) {
+			// move the source file from the temp dir
 			return $this->upload(
-				fn ($source) => $this->file($path, $filename)->replace($source)
+				fn ($source) => $this->file($path, $filename)->replace($source, true)
 			);
 		}
 	],

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -82,11 +82,16 @@ return [
 			$this->user($id)->avatar()?->delete();
 
 			return $this->upload(
-				fn ($source, $filename) => $this->user($id)->createFile([
-					'filename' => 'profile.' . F::extension($filename),
-					'template' => 'avatar',
-					'source'   => $source
-				]),
+				function ($source, $filename) {
+					$props = [
+						'filename' => 'profile.' . F::extension($filename),
+						'template' => 'avatar',
+						'source'   => $source
+					];
+
+					// move the source file from the temp dir
+					return $this->user($id)->createFile($props, true);
+				},
 				single: true
 			);
 		}

--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -56,11 +56,14 @@ return [
 			}
 
 			return $api->upload(function ($source, $filename) use ($parent, $params, $map) {
-				$file = $parent->createFile([
+				$props = [
 					'source'   => $source,
 					'template' => $params['template'] ?? null,
 					'filename' => $filename,
-				]);
+				];
+
+				// move the source file from the temp dir
+				$file = $parent->createFile($props, true);
 
 				if ($file instanceof File === false) {
 					throw new Exception('The file could not be uploaded');

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -169,11 +169,12 @@ trait FileActions
 	 * way of generating files.
 	 *
 	 * @param array $props
+	 * @param bool $move If set to `true`, the source will be deleted
 	 * @return static
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 * @throws \Kirby\Exception\LogicException
 	 */
-	public static function create(array $props)
+	public static function create(array $props, bool $move = false)
 	{
 		if (isset($props['source'], $props['parent']) === false) {
 			throw new InvalidArgumentException('Please provide the "source" and "parent" props for the File');
@@ -204,12 +205,16 @@ trait FileActions
 		$file = $file->clone(['content' => $form->strings(true)]);
 
 		// run the hook
-		return $file->commit('create', compact('file', 'upload'), function ($file, $upload) {
+		$arguments = compact('file', 'upload');
+		return $file->commit('create', $arguments, function ($file, $upload) use ($move) {
 			// remove all public versions, lock and clear UUID cache
 			$file->unpublish();
 
+			// only move the original source if intended
+			$method = $move === true ? 'move' : 'copy';
+
 			// overwrite the original
-			if (F::copy($upload->root(), $file->root(), true) !== true) {
+			if (F::$method($upload->root(), $file->root(), true) !== true) {
 				throw new LogicException('The file could not be created');
 			}
 
@@ -280,10 +285,11 @@ trait FileActions
 	 * source.
 	 *
 	 * @param string $source
+	 * @param bool $move If set to `true`, the source will be deleted
 	 * @return static
 	 * @throws \Kirby\Exception\LogicException
 	 */
-	public function replace(string $source)
+	public function replace(string $source, bool $move = false)
 	{
 		$file = $this->clone();
 
@@ -292,12 +298,15 @@ trait FileActions
 			'upload' => $file->asset($source)
 		];
 
-		return $this->commit('replace', $arguments, function ($file, $upload) {
+		return $this->commit('replace', $arguments, function ($file, $upload) use ($move) {
 			// delete all public versions
 			$file->unpublish(true);
 
+			// only move the original source if intended
+			$method = $move === true ? 'move' : 'copy';
+
 			// overwrite the original
-			if (F::copy($upload->root(), $file->root(), true) !== true) {
+			if (F::$method($upload->root(), $file->root(), true) !== true) {
 				throw new LogicException('The file could not be created');
 			}
 

--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -57,16 +57,17 @@ trait HasFiles
 	 * Creates a new file
 	 *
 	 * @param array $props
+	 * @param bool $move If set to `true`, the source will be deleted
 	 * @return \Kirby\Cms\File
 	 */
-	public function createFile(array $props)
+	public function createFile(array $props, bool $move = false)
 	{
 		$props = array_merge($props, [
 			'parent' => $this,
 			'url'    => null
 		]);
 
-		return File::create($props);
+		return File::create($props, $move);
 	}
 
 	/**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -514,7 +514,14 @@ class F
 			static::remove($newRoot);
 		}
 
-		// actually move the file if it exists
+		$directory = dirname($newRoot);
+
+		// create the parent directory if it does not exist
+		if (is_dir($directory) === false) {
+			Dir::make($directory, true);
+		}
+
+		// actually move the file
 		if (rename($oldRoot, $newRoot) !== true) {
 			return false;
 		}

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -193,6 +193,32 @@ class FileActionsTest extends TestCase
 			'parent'   => $parent
 		]);
 
+		$this->assertFileExists($source);
+		$this->assertFileExists($result->root());
+		$this->assertFileExists($parent->root() . '/test.md');
+		$this->assertInstanceOf(BaseFile::class, $result->asset());
+
+		// make sure file received UUID right away
+		$this->assertIsString($result->content()->get('uuid')->value());
+	}
+
+	/**
+	 * @dataProvider parentProvider
+	 */
+	public function testCreateMove($parent)
+	{
+		$source = $this->tmp . '/source.md';
+
+		// create the dummy source
+		F::write($source, '# Test');
+
+		$result = File::create([
+			'filename' => 'test.md',
+			'source'   => $source,
+			'parent'   => $parent
+		], true);
+
+		$this->assertFileDoesNotExist($source);
 		$this->assertFileExists($result->root());
 		$this->assertFileExists($parent->root() . '/test.md');
 		$this->assertInstanceOf(BaseFile::class, $result->asset());
@@ -379,12 +405,45 @@ class FileActionsTest extends TestCase
 			'parent'   => $parent
 		]);
 
+		$this->assertFileExists($original);
 		$this->assertSame(F::read($original), F::read($originalFile->root()));
 		$this->assertInstanceOf(BaseFile::class, $originalFile->asset());
 
 		$replacedFile = $originalFile->replace($replacement);
 
+		$this->assertFileExists($original);
+		$this->assertFileExists($replacement);
 		$this->assertSame(F::read($replacement), F::read($replacedFile->root()));
+		$this->assertInstanceOf(BaseFile::class, $replacedFile->asset());
+	}
+
+	/**
+	 * @dataProvider parentProvider
+	 */
+	public function testReplaceMove($parent)
+	{
+		$original    = $this->tmp . '/original.md';
+		$replacement = $this->tmp . '/replacement.md';
+
+		// create the dummy files
+		F::write($original, '# Original');
+		F::write($replacement, '# Replacement');
+
+		$originalFile = File::create([
+			'filename' => 'test.md',
+			'source'   => $original,
+			'parent'   => $parent
+		]);
+
+		$this->assertFileExists($original);
+		$this->assertSame(F::read($original), F::read($originalFile->root()));
+		$this->assertInstanceOf(BaseFile::class, $originalFile->asset());
+
+		$replacedFile = $originalFile->replace($replacement, true);
+
+		$this->assertFileExists($original);
+		$this->assertFileDoesNotExist($replacement);
+		$this->assertSame('# Replacement', F::read($replacedFile->root()));
 		$this->assertInstanceOf(BaseFile::class, $replacedFile->asset());
 	}
 

--- a/tests/Cms/Files/HasFilesTest.php
+++ b/tests/Cms/Files/HasFilesTest.php
@@ -3,6 +3,8 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
+use Kirby\Filesystem\File as BaseFile;
 
 class HasFileTraitUser
 {
@@ -32,7 +34,14 @@ class HasFilesTest extends TestCase
 		$this->app = new App([
 			'roots' => [
 				'index' => $this->tmp = __DIR__ . '/tmp'
-			]
+			],
+			'users' => [
+				[
+					'email' => 'admin@domain.com',
+					'role'  => 'admin'
+				]
+			],
+			'user' => 'admin@domain.com'
 		]);
 
 		Dir::make($this->tmp);
@@ -57,6 +66,52 @@ class HasFilesTest extends TestCase
 			['test.mov', 'videos', true],
 			['test.jpg', 'videos', false],
 		];
+	}
+
+	public function testCreateFile()
+	{
+		$source = $this->tmp . '/source.md';
+
+		// create the dummy source
+		F::write($source, '# Test');
+
+		$parent = $this->app->site();
+
+		$result = $parent->createFile([
+			'filename' => 'test.md',
+			'source'   => $source
+		]);
+
+		$this->assertFileExists($source);
+		$this->assertFileExists($result->root());
+		$this->assertFileExists($parent->root() . '/test.md');
+		$this->assertInstanceOf(BaseFile::class, $result->asset());
+
+		// make sure file received UUID right away
+		$this->assertIsString($result->content()->get('uuid')->value());
+	}
+
+	public function testCreateFileMove()
+	{
+		$source = $this->tmp . '/source.md';
+
+		// create the dummy source
+		F::write($source, '# Test');
+
+		$parent = $this->app->site();
+
+		$result = $parent->createFile([
+			'filename' => 'test.md',
+			'source'   => $source
+		], true);
+
+		$this->assertFileDoesNotExist($source);
+		$this->assertFileExists($result->root());
+		$this->assertFileExists($parent->root() . '/test.md');
+		$this->assertInstanceOf(BaseFile::class, $result->asset());
+
+		// make sure file received UUID right away
+		$this->assertIsString($result->content()->get('uuid')->value());
 	}
 
 	public function testFileWithSlash()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- `F::move()` now ensures that the parent directory exists, which is consistent with `F::copy()`
- `File::create()`, `$parent->createFile()` and `$file->replace()` support a new mode that moves the source file instead of copying it

### Fixes

- Uploaded files are deleted from the temporary directory after they have been successfully stored in the content directory. #2476

🚨 **Attention:** Do *not* close the issue as it was only partly solved.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
