### PR TITLE
Improve `Toolkit\Xml`

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -390,7 +390,7 @@ class Html extends Xml
 	 * @param int $level Indentation level
 	 * @return string The generated HTML
 	 */
-	public static function tag(string $name, $content = '', array $attr = null, string $indent = null, int $level = 0): string
+	public static function tag(string $name, $content = '', array $attr = [], string $indent = null, int $level = 0): string
 	{
 		// treat an explicit `null` value as an empty tag
 		// as void tags are already covered below

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -19,17 +19,13 @@ class Html extends Xml
 {
 	/**
 	 * An internal store for an HTML entities translation table
-	 *
-	 * @var array
 	 */
-	public static $entities;
+	public static array|null $entities;
 
 	/**
 	 * List of HTML tags that can be used inline
-	 *
-	 * @var array
 	 */
-	public static $inlineList = [
+	public static array $inlineList = [
 		'b',
 		'i',
 		'small',

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -18,10 +18,8 @@ class Xml
 {
 	/**
 	 * HTML to XML conversion table for entities
-	 *
-	 * @var array
 	 */
-	public static $entities = [
+	public static array|null $entities = [
 		'&nbsp;' => '&#160;', '&iexcl;' => '&#161;', '&cent;' => '&#162;', '&pound;' => '&#163;', '&curren;' => '&#164;', '&yen;' => '&#165;', '&brvbar;' => '&#166;', '&sect;' => '&#167;',
 		'&uml;' => '&#168;', '&copy;' => '&#169;', '&ordf;' => '&#170;', '&laquo;' => '&#171;', '&not;' => '&#172;', '&shy;' => '&#173;', '&reg;' => '&#174;', '&macr;' => '&#175;',
 		'&deg;' => '&#176;', '&plusmn;' => '&#177;', '&sup2;' => '&#178;', '&sup3;' => '&#179;', '&acute;' => '&#180;', '&micro;' => '&#181;', '&para;' => '&#182;', '&middot;' => '&#183;',
@@ -66,13 +64,13 @@ class Xml
 	/**
 	 * Generates a single attribute or a list of attributes
 	 *
-	 * @param string|array $name String: A single attribute with that name will be generated.
-	 *                           Key-value array: A list of attributes will be generated. Don't pass a second argument in that case.
+	 * @param string|array|null $name String: A single attribute with that name will be generated.
+	 *                                Key-value array: A list of attributes will be generated. Don't pass a second argument in that case.
 	 * @param mixed $value If used with a `$name` string, pass the value of the attribute here.
 	 *                     If used with a `$name` array, this can be set to `false` to disable attribute sorting.
 	 * @return string|null The generated XML attributes string
 	 */
-	public static function attr($name, $value = null): string|null
+	public static function attr(string|array|null $name, $value = null): string|null
 	{
 		if (is_array($name) === true) {
 			if ($value !== false) {
@@ -147,8 +145,13 @@ class Xml
 	 * @param int $level The indentation level (used internally)
 	 * @return string The XML string
 	 */
-	public static function create($props, string $name = 'root', bool $head = true, string $indent = '  ', int $level = 0): string
-	{
+	public static function create(
+		array|string $props,
+		string $name = 'root',
+		bool $head = true,
+		string $indent = '  ',
+		int $level = 0
+	): string {
 		if (is_array($props) === true) {
 			if (A::isAssociative($props) === true) {
 				// a tag with attributes or named children
@@ -208,17 +211,10 @@ class Xml
 	 * echo Xml::decode('some &uuml;ber <em>crazy</em> stuff');
 	 * // output: some über crazy stuff
 	 * ```
-	 *
-	 * @param string|null $string
-	 * @return string
 	 */
 	public static function decode(string|null $string): string
 	{
-		if ($string === null) {
-			$string = '';
-		}
-
-		$string = strip_tags($string);
+		$string = strip_tags($string ?? '');
 		return html_entity_decode($string, ENT_COMPAT, 'utf-8');
 	}
 
@@ -233,9 +229,7 @@ class Xml
 	 * // output: some &#252;ber crazy stuff
 	 * ```
 	 *
-	 * @param string|null $string
 	 * @param bool $html True = Convert to HTML-safe first
-	 * @return string
 	 */
 	public static function encode(string|null $string, bool $html = true): string
 	{
@@ -256,8 +250,6 @@ class Xml
 
 	/**
 	 * Returns the HTML-to-XML entity translation table
-	 *
-	 * @return array
 	 */
 	public static function entities(): array
 	{
@@ -267,7 +259,6 @@ class Xml
 	/**
 	 * Parses an XML string and returns an array
 	 *
-	 * @param string $xml
 	 * @return array|null Parsed array or `null` on error
 	 */
 	public static function parse(string $xml): array|null
@@ -285,11 +276,9 @@ class Xml
 	 * Breaks a SimpleXMLElement down into a simpler tree
 	 * structure of arrays and strings
 	 *
-	 * @param \SimpleXMLElement $element
 	 * @param bool $collectName Whether the element name should be collected (for the root element)
-	 * @return array|string
 	 */
-	public static function simplify(SimpleXMLElement $element, bool $collectName = true)
+	public static function simplify(SimpleXMLElement $element, bool $collectName = true): array|string
 	{
 		// get all XML namespaces of the whole document to iterate over later;
 		// we don't need the global namespace (empty string) in the list
@@ -408,9 +397,6 @@ class Xml
 
 	/**
 	 * Properly encodes tag contents
-	 *
-	 * @param mixed $value
-	 * @return string|null
 	 */
 	public static function value($value): string|null
 	{

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -110,8 +110,12 @@ class Xml
 			return $name . '=""';
 		}
 
-		if (is_bool($value) === true) {
-			return $value === true ? $name . '="' . $name . '"' : null;
+		if ($value === true) {
+			return $name . '="' . $name . '"';
+		}
+
+		if ($value === false) {
+			return null;
 		}
 
 		if (is_array($value) === true) {
@@ -194,7 +198,7 @@ class Xml
 		} else {
 			// scalar value
 
-			$result = static::tag($name, $props, null, $indent, $level);
+			$result = static::tag($name, $props, [], $indent, $level);
 		}
 
 		if ($head === true) {
@@ -368,7 +372,7 @@ class Xml
 	 * @param int $level Indentation level
 	 * @return string The generated XML
 	 */
-	public static function tag(string $name, $content = '', array $attr = null, string|null $indent = null, int $level = 0): string
+	public static function tag(string $name, $content = '', array $attr = [], string $indent = null, int $level = 0): string
 	{
 		$attr       = static::attr($attr);
 		$start      = '<' . $name . ($attr ? ' ' . $attr : '') . '>';

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -64,13 +64,13 @@ class Xml
 	/**
 	 * Generates a single attribute or a list of attributes
 	 *
-	 * @param string|array|null $name String: A single attribute with that name will be generated.
-	 *                                Key-value array: A list of attributes will be generated. Don't pass a second argument in that case.
+	 * @param string|array $name String: A single attribute with that name will be generated.
+	 *                           Key-value array: A list of attributes will be generated. Don't pass a second argument in that case.
 	 * @param mixed $value If used with a `$name` string, pass the value of the attribute here.
 	 *                     If used with a `$name` array, this can be set to `false` to disable attribute sorting.
 	 * @return string|null The generated XML attributes string
 	 */
-	public static function attr(string|array|null $name, $value = null): string|null
+	public static function attr(string|array $name, $value = null): string|null
 	{
 		if (is_array($name) === true) {
 			if ($value !== false) {

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -174,7 +174,7 @@ class XmlTest extends TestCase
 		$tag = Xml::tag('name', 'content');
 		$this->assertSame('<name>content</name>', $tag);
 
-		$tag = Xml::tag('name', 'content', null, '  ', 1);
+		$tag = Xml::tag('name', 'content', [], '  ', 1);
 		$this->assertSame('  <name>content</name>', $tag);
 
 		$tag = Xml::tag('name', 'content', ['foo' => 'bar']);


### PR DESCRIPTION
## Breaking changes

- `Html::tag()` and `Xml::tag()` no longer accept a `null` value for the `$attr` argument. The default value has been changed to an empty array. If you explicitly pass `null` for this argument, please change it to an empty array as well.