### PR TITLE
CI: Mock for `error_log()` to prevent ghost output

### DIFF
--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -8,6 +8,8 @@ use ReflectionMethod;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
+require_once dirname(__DIR__) . '/mocks.php';
+
 /**
  * @coversDefaultClass \Kirby\Cms\AppErrors
  */
@@ -53,6 +55,7 @@ class AppErrorsTest extends TestCase
 		$this->_getBufferedContent($handler);
 
 		$this->assertSame('Some error message', $result);
+		$this->assertStringContainsString('Exception: Some error message in', ErrorLog::$log);
 	}
 
 	/**

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -8,6 +8,8 @@ use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
+require_once __DIR__ . '/mocks.php';
+
 class TestCase extends BaseTestCase
 {
 	protected $app;
@@ -39,6 +41,9 @@ class TestCase extends BaseTestCase
 		App::destroy();
 		Dir::remove($this->tmp);
 		Blueprint::$loaded = [];
+
+		// mock class
+		ErrorLog::$log = '';
 	}
 
 	public function kirby($props = [])

--- a/tests/Cms/mocks.php
+++ b/tests/Cms/mocks.php
@@ -5,6 +5,25 @@ namespace Kirby\Cms;
 use Exception;
 
 /**
+ * Mock for the PHP error_log() function to ensure reliable testing
+ */
+function error_log(string $message): bool
+{
+	if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+		throw new Exception('Mock error_log() function was loaded outside of the test environment. This should never happen.');
+	}
+
+	ErrorLog::$log .= $message;
+
+	return true;
+}
+
+class ErrorLog
+{
+	public static $log = '';
+}
+
+/**
  * Mock for the PHP time() function to ensure reliable testing
  *
  * @return int A fake timestamp


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactoring

- Fixed ghost output during PHPUnit test runs

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
