### PR TITLE
Fix date field year change issue

### DIFF
--- a/panel/src/components/Forms/Calendar.vue
+++ b/panel/src/components/Forms/Calendar.vue
@@ -9,14 +9,14 @@
 					:disabled="disabled"
 					:required="true"
 					:value="current.month"
-					@input="current.month = $event"
+					@input="current.month = Number($event)"
 				/>
 				<k-select-input
 					:options="years"
 					:disabled="disabled"
 					:required="true"
 					:value="current.year"
-					@input="current.year = $event"
+					@input="current.year = Number($event)"
 				/>
 			</span>
 			<k-button icon="angle-right" @click="onNext" />


### PR DESCRIPTION
## This PR …
This issue was related about casting.  I'm not sure what kind of casting problem the removal of the `v-model` caused, but when the year changed, the data returns as a `string` and I fixed it by casting with the `Number()` method.

### Fixes
- Date field `Maximum call stack size exceeded` error #4968

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
