### PR TITLE
PHPUnit: Prevent creation of stray site directory

### DIFF
--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -122,7 +122,7 @@ class FilesTest extends TestCase
 	 */
 	public function testFindByUuid()
 	{
-		$app = new App([
+		$app = $this->app->clone([
 			'site' => [
 				'files' => [
 					[

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -273,7 +273,7 @@ class PagesTest extends TestCase
 
 	public function testFindByUuid()
 	{
-		$app = new App([
+		$app = $this->app->clone([
 			'site' => [
 				'children' => [
 					['slug' => 'a', 'content' => ['uuid' => 'test-a']],

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Composer\Autoload\ClassLoader;
 use Kirby\Cms\System\UpdateStatus;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Filesystem\Dir;
 
 /**
  * @coversDefaultClass Kirby\Cms\Plugin
@@ -14,6 +15,9 @@ class PluginTest extends TestCase
 {
 	protected static $classLoader;
 	protected static $updateStatusHost;
+
+	protected $app;
+	protected $tmp = __DIR__ . '/tmp';
 
 	public static function setUpBeforeClass(): void
 	{
@@ -34,11 +38,20 @@ class PluginTest extends TestCase
 	public function setUp(): void
 	{
 		App::destroy();
+
+		Dir::make($this->tmp);
+
+		$this->app = new App([
+			'roots' => [
+				'index' => $this->tmp
+			]
+		]);
 	}
 
 	public function tearDown(): void
 	{
 		App::destroy();
+		Dir::remove($this->tmp);
 	}
 
 	/**
@@ -240,9 +253,8 @@ class PluginTest extends TestCase
 	 */
 	public function testMediaRoot()
 	{
-		new App([
+		$this->app->clone([
 			'roots' => [
-				'index' => '/dev/null',
 				'media' => $media = __DIR__ . '/media'
 			]
 		]);
@@ -257,10 +269,7 @@ class PluginTest extends TestCase
 	 */
 	public function testMediaUrl()
 	{
-		new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
+		$this->app->clone([
 			'urls' => [
 				'index' => '/'
 			]
@@ -316,7 +325,7 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$app = new App();
+		$app = $this->app->clone();
 
 		$this->assertSame('bar', $app->plugin('developer/plugin')->option('foo'));
 		$this->assertSame('bar', $app->option('developer.plugin.foo'));
@@ -477,7 +486,7 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusDisabled1()
 	{
-		new App([
+		$this->app->clone([
 			'options' => [
 				'updates' => [
 					'plugins' => false
@@ -498,7 +507,7 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusDisabled2()
 	{
-		new App([
+		$this->app->clone([
 			'options' => [
 				'updates' => [
 					'plugins' => [
@@ -524,7 +533,7 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusDisabled3()
 	{
-		new App([
+		$this->app->clone([
 			'options' => [
 				'updates' => false
 			]
@@ -547,7 +556,7 @@ class PluginTest extends TestCase
 		// security mode yet because the hub is missing
 		// where plugin devs can manage the security status
 		// of their plugins
-		new App([
+		$this->app->clone([
 			'options' => [
 				'updates' => 'security'
 			]
@@ -566,7 +575,7 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusNoCustomConfig()
 	{
-		new App([
+		$this->app->clone([
 			'options' => [
 				'updates' => [
 					'plugins' => [


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactoring

- More of our PHPUnit tests use a temporary directory now to prevent tests from creating a stray `site` directory in the top-level of the project

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
