### PR TITLE
Minor options refactoring; fix double escaping in select field

### DIFF
--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Field\FieldOptions;
+
 return [
 	'extends' => 'radio',
 	'props' => [
@@ -20,5 +22,16 @@ return [
 		'placeholder' => function (string $placeholder = '—') {
 			return $placeholder;
 		},
+	],
+	'methods' => [
+		'getOptions' => function () {
+			$props = FieldOptions::polyfill($this->props);
+
+			// disable safe mode as the select field does not
+			// render HTML for the option text
+			$options = FieldOptions::factory($props['options'], false);
+
+			return $options->render($this->model());
+		}
 	]
 ];

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -69,7 +69,7 @@ export default {
 			}
 		},
 		onSubmit(values) {
-			// ensure that all values are actually commited to content store
+			// ensure that all values are actually committed to content store
 			this.$store.dispatch("content/update", [null, values]);
 			this.$events.$emit("keydown.cmd.s", values);
 		}

--- a/src/Blueprint/Collection.php
+++ b/src/Blueprint/Collection.php
@@ -45,21 +45,22 @@ class Collection extends BaseCollection
 
 	/**
 	 * Validate the type of every item that is being
-	 * added to the collection. They cneed to have
+	 * added to the collection. They need to have
 	 * the class defined by static::TYPE.
 	 */
 	public function __set(string $key, $value): void
 	{
-		if (
-			is_a($value, static::TYPE) === false
-		) {
+		if (is_a($value, static::TYPE) === false) {
 			throw new TypeError('Each value in the collection must be an instance of ' . static::TYPE);
 		}
 
 		parent::__set($key, $value);
 	}
 
-	public static function factory(array $items)
+	/**
+	 * Creates a collection from a nested array structure
+	 */
+	public static function factory(array $items): static
 	{
 		$collection = new static();
 		$className  = static::TYPE;
@@ -77,7 +78,11 @@ class Collection extends BaseCollection
 		return $collection;
 	}
 
-	public function render(ModelWithContent $model)
+	/**
+	 * Renders each item with a model and returns
+	 * an array of all rendered results
+	 */
+	public function render(ModelWithContent $model): array
 	{
 		$props = [];
 

--- a/src/Blueprint/Node.php
+++ b/src/Blueprint/Node.php
@@ -53,7 +53,6 @@ class Node
 		return Factory::make(static::class, $props);
 	}
 
-
 	public static function load(string|array $props): static
 	{
 		// load by path

--- a/src/Field/FieldOptions.php
+++ b/src/Field/FieldOptions.php
@@ -25,7 +25,14 @@ class FieldOptions extends Node
 		 * The option source, either a fixed collection or
 		 * a dynamic provider
 		 */
-		public Options|OptionsProvider|null $options = null
+		public Options|OptionsProvider|null $options = null,
+
+		/**
+		 * Whether to escape special HTML characters in
+		 * the option text for safe output in the Panel;
+		 * only set to `false` if the text is later escaped!
+		 */
+		public bool $safeMode = true
 	) {
 	}
 
@@ -36,7 +43,7 @@ class FieldOptions extends Node
 		return parent::defaults();
 	}
 
-	public static function factory(array $props): static
+	public static function factory(array $props, bool $safeMode = true): static
 	{
 		$options = match ($props['type']) {
 			'api'    => OptionsApi::factory($props),
@@ -44,7 +51,7 @@ class FieldOptions extends Node
 			default  => Options::factory($props['options'] ?? [])
 		};
 
-		return new static($options);
+		return new static($options, $safeMode);
 	}
 
 	public static function polyfill(array $props = []): array
@@ -91,7 +98,7 @@ class FieldOptions extends Node
 		}
 
 		// resolve OptionsProvider (OptionsApi or OptionsQuery) to Options
-		return $this->options = $this->options->resolve($model);
+		return $this->options = $this->options->resolve($model, $this->safeMode);
 	}
 
 	public function render(ModelWithContent $model): array

--- a/src/Field/FieldOptions.php
+++ b/src/Field/FieldOptions.php
@@ -6,6 +6,7 @@ use Kirby\Blueprint\Node;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Option\Options;
 use Kirby\Option\OptionsApi;
+use Kirby\Option\OptionsProvider;
 use Kirby\Option\OptionsQuery;
 
 /**
@@ -20,7 +21,11 @@ use Kirby\Option\OptionsQuery;
 class FieldOptions extends Node
 {
 	public function __construct(
-		public Options|OptionsApi|OptionsQuery|null $options = null
+		/**
+		 * The option source, either a fixed collection or
+		 * a dynamic provider
+		 */
+		public Options|OptionsProvider|null $options = null
 	) {
 	}
 
@@ -85,7 +90,7 @@ class FieldOptions extends Node
 			return $this->options;
 		}
 
-		// resolve OptionsApi or OptionsQuery to Options
+		// resolve OptionsProvider (OptionsApi or OptionsQuery) to Options
 		return $this->options = $this->options->resolve($model);
 	}
 

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -8,7 +8,7 @@ use Kirby\Blueprint\NodeText;
 use Kirby\Cms\ModelWithContent;
 
 /**
- * Option for select fields, radio fields, etc
+ * Option for select fields, radio fields, etc.
  *
  * @package   Kirby Option
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -19,7 +19,7 @@ use Kirby\Cms\ModelWithContent;
 class Option
 {
 	public function __construct(
-		public float|int|string|null $value,
+		public string|int|float|null $value,
 		public bool $disabled = false,
 		public NodeIcon|null $icon = null,
 		public NodeText|null $info = null,
@@ -28,7 +28,7 @@ class Option
 		$this->text ??= new NodeText(['en' => $this->value]);
 	}
 
-	public static function factory(float|int|string|null|array $props): static
+	public static function factory(string|int|float|null|array $props): static
 	{
 		if (is_array($props) === false) {
 			$props = ['value' => $props];

--- a/src/Option/Options.php
+++ b/src/Option/Options.php
@@ -6,7 +6,8 @@ use Kirby\Blueprint\Collection;
 use Kirby\Cms\ModelWithContent;
 
 /**
- * Options
+ * Collection of possible options for
+ * select fields, radio fields, etc.
  *
  * @package   Kirby Option
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -30,6 +31,7 @@ class Options extends Collection
 		$collection = new static();
 
 		foreach ($items as $key => $option) {
+			// convert an associative value => text array into props;
 			// skip if option is already an array of option props
 			if (
 				is_array($option) === false ||

--- a/src/Option/OptionsApi.php
+++ b/src/Option/OptionsApi.php
@@ -88,8 +88,12 @@ class OptionsApi extends OptionsProvider
 	 * Creates the actual options by loading
 	 * data from the API and resolving it to
 	 * the correct text-value entries
+	 *
+	 * @param bool $safeMode Whether to escape special HTML characters in
+	 *                       the option text for safe output in the Panel;
+	 *                       only set to `false` if the text is later escaped!
 	 */
-	public function resolve(ModelWithContent $model): Options
+	public function resolve(ModelWithContent $model, bool $safeMode = true): Options
 	{
 		// use cached options if present
 		// @codeCoverageIgnoreStart
@@ -112,13 +116,16 @@ class OptionsApi extends OptionsProvider
 		$data = Nest::create($data);
 		$data = Query::factory($this->query)->resolve($data);
 
+		$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
+
 		// create options by resolving text and value query strings
 		// for each item from the data
 		$options = $data->toArray(fn ($item) => [
 			// value is always a raw string
 			'value' => $model->toString($this->value, ['item' => $item]),
 			// text is only a raw string when using {< >}
-			'text' => $model->toSafeString($this->text, ['item' => $item]),
+			// or when the safe mode is explicitly disabled (select field)
+			'text' => $model->$safeMethod($this->text, ['item' => $item]),
 		]);
 
 		// create Options object and render this subsequently

--- a/src/Option/OptionsProvider.php
+++ b/src/Option/OptionsProvider.php
@@ -26,5 +26,13 @@ abstract class OptionsProvider
 		return $this->resolve($model)->render($model);
 	}
 
-	abstract public function resolve(ModelWithContent $model): Options;
+	/**
+	 * Dynamically determines the actual options and resolves
+	 * them to the correct text-value entries
+	 *
+	 * @param bool $safeMode Whether to escape special HTML characters in
+	 *                       the option text for safe output in the Panel;
+	 *                       only set to `false` if the text is later escaped!
+	 */
+	abstract public function resolve(ModelWithContent $model, bool $safeMode = true): Options;
 }

--- a/tests/Field/FieldOptionsTest.php
+++ b/tests/Field/FieldOptionsTest.php
@@ -22,6 +22,7 @@ class FieldOptionsTest extends TestCase
 			'url' => $url = 'https://api.getkirby.com'
 		]);
 		$this->assertInstanceOf(OptionsApi::class, $options->options);
+		$this->assertTrue($options->safeMode);
 		$this->assertSame($url, $options->options->url);
 
 		$options = FieldOptions::factory([
@@ -29,11 +30,24 @@ class FieldOptionsTest extends TestCase
 			'query' => $query = 'site.children'
 		]);
 		$this->assertInstanceOf(OptionsQuery::class, $options->options);
+		$this->assertTrue($options->safeMode);
 		$this->assertSame($query, $options->options->query);
 
-		$options = FieldOptions::factory(['type'  => 'array', 'options' => ['a', 'b']]);
+		$options = FieldOptions::factory(['type' => 'array', 'options' => ['a', 'b']]);
 		$this->assertInstanceOf(Options::class, $options->options);
+		$this->assertTrue($options->safeMode);
 		$this->assertSame(2, $options->options->count());
+
+		$options = FieldOptions::factory(
+			[
+				'type'  => 'query',
+				'query' => $query = 'site.children'
+			],
+			false
+		);
+		$this->assertInstanceOf(OptionsQuery::class, $options->options);
+		$this->assertFalse($options->safeMode);
+		$this->assertSame($query, $options->options->query);
 	}
 
 	/**
@@ -77,10 +91,24 @@ class FieldOptionsTest extends TestCase
 		$options = FieldOptions::factory([
 			'type'  => 'api',
 			'url'   =>  __DIR__ . '/../Option/fixtures/data.json',
-			'query' => 'Directory.Companies'
+			'query' => 'Directory.Companies',
+			'text'  => '{{ item.slogan }}'
 		]);
 		$this->assertInstanceOf(Options::class, $options->resolve($model));
-		$this->assertSame('a', $options->render($model)[0]['value']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $options->render($model)[0]['text']);
+
+		// without safe mode
+		$options = FieldOptions::factory(
+			[
+				'type'  => 'api',
+				'url'   =>  __DIR__ . '/../Option/fixtures/data.json',
+				'query' => 'Directory.Companies',
+				'text'  => '{{ item.slogan }}'
+			],
+			false
+		);
+		$this->assertInstanceOf(Options::class, $options->resolve($model));
+		$this->assertSame('We are <b>great</b>', $options->render($model)[0]['text']);
 
 		$options = FieldOptions::factory([
 			'type'  => 'query',

--- a/tests/Form/Fields/SelectFieldTest.php
+++ b/tests/Form/Fields/SelectFieldTest.php
@@ -8,12 +8,108 @@ class SelectFieldTest extends TestCase
 	{
 		$field = $this->field('select');
 
-		$this->assertEquals('select', $field->type());
-		$this->assertEquals('select', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->icon());
-		$this->assertEquals([], $field->options());
+		$this->assertSame('select', $field->type());
+		$this->assertSame('select', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame(null, $field->icon());
+		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
+	}
+
+	public function testOptionsQuery()
+	{
+		$app = $this->app()->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'a',
+						'content'  => [
+							'tags' => 'design'
+						],
+						'files' => [
+							[
+								'filename' => 'a.jpg',
+								'content'  => [
+									'tags' => 'design'
+								]
+							],
+							[
+								'filename' => 'b.jpg',
+								'content'  => [
+									'tags' => 'photography, <script>alert("XSS")</script>'
+								]
+							],
+							[
+								'filename' => 'c.jpg',
+								'content'  => [
+									'tags' => 'design, architecture'
+								]
+							]
+						]
+					],
+					[
+						'slug' => 'b',
+						'content'  => [
+							'tags' => 'photography, <script>alert("XSS")</script>'
+						],
+					],
+					[
+						'slug' => 'c',
+						'content'  => [
+							'tags' => 'design, architecture'
+						],
+					]
+				]
+			]
+		]);
+
+		$expected = [
+			[
+				'disabled' => false,
+				'icon' => null,
+				'info' => null,
+				'text' => 'design',
+				'value' => 'design'
+			],
+			[
+				'disabled' => false,
+				'icon' => null,
+				'info' => null,
+				'text' => 'photography',
+				'value' => 'photography'
+			],
+			[
+				'disabled' => false,
+				'icon' => null,
+				'info' => null,
+				// safe because the select field does not render HTML
+				'text' => '<script>alert("XSS")</script>',
+				'value' => '<script>alert("XSS")</script>'
+			],
+			[
+				'disabled' => false,
+				'icon' => null,
+				'info' => null,
+				'text' => 'architecture',
+				'value' => 'architecture'
+			]
+		];
+
+		$field = $this->field('select', [
+			'model'   => $app->page('b'),
+			'options' => 'query',
+			'query'   => 'page.siblings.pluck("tags", ",", true)',
+		]);
+
+		$this->assertSame($expected, $field->options());
+
+		$field = $this->field('select', [
+			'model'   => $app->file('a/b.jpg'),
+			'options' => 'query',
+			'query'   => 'file.siblings.pluck("tags", ",", true)',
+		]);
+
+		$this->assertSame($expected, $field->options());
 	}
 
 	public function valueInputProvider()

--- a/tests/Form/Fields/TagsFieldTest.php
+++ b/tests/Form/Fields/TagsFieldTest.php
@@ -8,17 +8,17 @@ class TagsFieldTest extends TestCase
 	{
 		$field = $this->field('tags');
 
-		$this->assertEquals('tags', $field->type());
-		$this->assertEquals('tags', $field->name());
-		$this->assertEquals('all', $field->accept());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->default());
-		$this->assertEquals([], $field->options());
-		$this->assertEquals(null, $field->min());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(',', $field->separator());
-		$this->assertEquals('tag', $field->icon());
-		$this->assertEquals(null, $field->counter());
+		$this->assertSame('tags', $field->type());
+		$this->assertSame('tags', $field->name());
+		$this->assertSame('all', $field->accept());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->default());
+		$this->assertSame([], $field->options());
+		$this->assertSame(null, $field->min());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(',', $field->separator());
+		$this->assertSame('tag', $field->icon());
+		$this->assertSame(null, $field->counter());
 		$this->assertTrue($field->save());
 	}
 
@@ -42,7 +42,7 @@ class TagsFieldTest extends TestCase
 							[
 								'filename' => 'b.jpg',
 								'content'  => [
-									'tags' => 'design, photography'
+									'tags' => 'photography, <script>alert("XSS")</script>'
 								]
 							],
 							[
@@ -56,7 +56,7 @@ class TagsFieldTest extends TestCase
 					[
 						'slug' => 'b',
 						'content'  => [
-							'tags' => 'design, photography'
+							'tags' => 'photography, <script>alert("XSS")</script>'
 						],
 					],
 					[
@@ -71,25 +71,32 @@ class TagsFieldTest extends TestCase
 
 		$expected = [
 			[
-				'value' => 'design',
-				'text'  => 'design',
 				'disabled' => false,
 				'icon' => null,
-				'info' => null
+				'info' => null,
+				'text' => 'design',
+				'value' => 'design'
 			],
 			[
-				'value' => 'photography',
-				'text'  => 'photography',
 				'disabled' => false,
 				'icon' => null,
-				'info' => null
+				'info' => null,
+				'text' => 'photography',
+				'value' => 'photography'
 			],
 			[
-				'value' => 'architecture',
-				'text'  => 'architecture',
 				'disabled' => false,
 				'icon' => null,
-				'info' => null
+				'info' => null,
+				'text' => '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;',
+				'value' => '<script>alert("XSS")</script>'
+			],
+			[
+				'disabled' => false,
+				'icon' => null,
+				'info' => null,
+				'text' => 'architecture',
+				'value' => 'architecture'
 			]
 		];
 
@@ -99,7 +106,7 @@ class TagsFieldTest extends TestCase
 			'query'   => 'page.siblings.pluck("tags", ",", true)',
 		]);
 
-		$this->assertEquals($expected, $field->options());
+		$this->assertSame($expected, $field->options());
 
 		$field = $this->field('tags', [
 			'model'   => $app->file('a/b.jpg'),
@@ -107,7 +114,7 @@ class TagsFieldTest extends TestCase
 			'query'   => 'file.siblings.pluck("tags", ",", true)',
 		]);
 
-		$this->assertEquals($expected, $field->options());
+		$this->assertSame($expected, $field->options());
 	}
 
 	public function testMin()
@@ -120,7 +127,7 @@ class TagsFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('min', $field->errors());
-		$this->assertEquals(2, $field->min());
+		$this->assertSame(2, $field->min());
 		$this->assertTrue($field->required());
 	}
 
@@ -133,7 +140,7 @@ class TagsFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(1, $field->max());
+		$this->assertSame(1, $field->max());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
@@ -145,7 +152,7 @@ class TagsFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -128,7 +128,7 @@ class OptionsApiTest extends TestCase
 	/**
 	 * @covers ::resolve
 	 */
-	public function testResolveHtmlEscpae()
+	public function testResolveHtmlEscape()
 	{
 		$model = new Page(['slug' => 'test']);
 
@@ -146,7 +146,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
-
 		// text unescaped using {< >}
 		$options = new OptionsApi(
 			url: __DIR__ . '/fixtures/data.json',
@@ -155,6 +154,19 @@ class OptionsApiTest extends TestCase
 			value: '{{ item.slogan }}'
 		);
 		$result = $options->render($model);
+		$this->assertSame('We are <b>great</b>', $result[0]['text']);
+		$this->assertSame('We are <b>great</b>', $result[0]['value']);
+		$this->assertSame('We are <b>better</b>', $result[1]['text']);
+		$this->assertSame('We are <b>better</b>', $result[1]['value']);
+
+		// test unescaped with disabled safe mode
+		$options = new OptionsApi(
+			url: __DIR__ . '/fixtures/data.json',
+			query: 'Directory.Companies',
+			text: '{{ item.slogan }}',
+			value: '{{ item.slogan }}'
+		);
+		$result = $options->resolve($model, false)->render($model);
 		$this->assertSame('We are <b>great</b>', $result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
 		$this->assertSame('We are <b>better</b>', $result[1]['text']);

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -306,7 +306,7 @@ class OptionsQueryTest extends TestCase
 	/**
 	 * @covers ::resolve
 	 */
-	public function testResolveHtmlEscpae()
+	public function testResolveHtmlEscape()
 	{
 		$model   = new MyPage(['slug' => 'a']);
 
@@ -322,13 +322,23 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $options[1]['text']);
 		$this->assertSame('We are <b>better</b>', $options[1]['value']);
 
-
 		// text unescaped via {< >}
 		$options = (new OptionsQuery(
 			query: 'page.myHtmlArray',
 			text: '{< item.slogan >}',
 			value: '{{ item.slogan }}'
 		))->render($model);
+		$this->assertSame('We are <b>great</b>', $options[0]['text']);
+		$this->assertSame('We are <b>great</b>', $options[0]['value']);
+		$this->assertSame('We are <b>better</b>', $options[1]['text']);
+		$this->assertSame('We are <b>better</b>', $options[1]['value']);
+
+		// test unescaped with disabled safe mode
+		$options = (new OptionsQuery(
+			query: 'page.myHtmlArray',
+			text: '{{ item.slogan }}',
+			value: '{{ item.slogan }}'
+		))->resolve($model, false)->render($model);
 		$this->assertSame('We are <b>great</b>', $options[0]['text']);
 		$this->assertSame('We are <b>great</b>', $options[0]['value']);
 		$this->assertSame('We are <b>better</b>', $options[1]['text']);


### PR DESCRIPTION
Sorry for the mixed PR, wanted to avoid merge conflicts; I recommend to review the two commits separately.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Dynamic options for the select field (from API or query) are no longer displayed with double-escaping in the Panel

### Refactoring

- Minor code improvements to the `Blueprint` and `Option` classes

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
