### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -24,13 +24,13 @@ class ApiTest extends TestCase
 		$api = new Api([]);
 
 		$this->assertNull($api->authentication());
-		$this->assertEquals([], $api->collections());
-		$this->assertEquals([], $api->data());
+		$this->assertSame([], $api->collections());
+		$this->assertSame([], $api->data());
 		$this->assertFalse($api->debug());
-		$this->assertEquals([], $api->models());
-		$this->assertEquals(['query' => [], 'body' => [], 'files' => []], $api->requestData());
-		$this->assertEquals('GET', $api->requestMethod());
-		$this->assertEquals([], $api->routes());
+		$this->assertSame([], $api->models());
+		$this->assertSame(['query' => [], 'body' => [], 'files' => []], $api->requestData());
+		$this->assertSame('GET', $api->requestMethod());
+		$this->assertSame([], $api->routes());
 	}
 
 	public function test__call()
@@ -41,7 +41,7 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('bar', $api->foo());
+		$this->assertSame('bar', $api->foo());
 	}
 
 	public function testAuthentication()
@@ -53,11 +53,11 @@ class ApiTest extends TestCase
 				'foo' => 'bar'
 			],
 			'authentication' => $callback = function () use ($phpunit) {
-				$phpunit->assertEquals('bar', $this->foo());
+				$phpunit->assertSame('bar', $this->foo());
 			}
 		]);
 
-		$this->assertEquals($callback, $api->authentication());
+		$this->assertSame($callback, $api->authentication());
 		$api->authenticate();
 	}
 
@@ -101,10 +101,10 @@ class ApiTest extends TestCase
 		$result = $api->call('testScalar', 'POST', [
 			'query' => ['foo' => 'bar']
 		]);
-		$this->assertEquals('bar', $result);
+		$this->assertSame('bar', $result);
 
 		$result = $api->call('testModel', 'POST');
-		$this->assertEquals([
+		$this->assertSame([
 			'code'   => 200,
 			'data'   => [
 				'value' => 'Awesome test model as string, yay'
@@ -138,18 +138,18 @@ class ApiTest extends TestCase
 			}
 		]);
 
-		$this->assertEquals('something', $api->call('foo'));
+		$this->assertSame('something', $api->call('foo'));
 		$this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_TIME, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
-		$this->assertEquals($originalLocale, setlocale(LC_CTYPE, 0));
+		$this->assertSame($originalLocale, setlocale(LC_CTYPE, 0));
 
 		$language = 'pt_BR';
-		$this->assertEquals('something', $api->call('foo'));
+		$this->assertSame('something', $api->call('foo'));
 		$this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_TIME, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
-		$this->assertEquals($originalLocale, setlocale(LC_CTYPE, 0));
+		$this->assertSame($originalLocale, setlocale(LC_CTYPE, 0));
 	}
 
 	public function testCollections()
@@ -185,7 +185,7 @@ class ApiTest extends TestCase
 			['id' => 'b'],
 		];
 
-		$this->assertEquals($expected, $data);
+		$this->assertSame($expected, $data);
 
 		// missing collection
 		$this->expectException(NotFoundException::class);
@@ -208,10 +208,10 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($data, $api->data());
-		$this->assertEquals('A', $api->data('a'));
-		$this->assertEquals('B', $api->data('b'));
-		$this->assertEquals('C', $api->data('c', 'C'));
+		$this->assertSame($data, $api->data());
+		$this->assertSame('A', $api->data('a'));
+		$this->assertSame('B', $api->data('b'));
+		$this->assertSame('C', $api->data('c', 'C'));
 
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Api data for "d" does not exist');
@@ -248,7 +248,7 @@ class ApiTest extends TestCase
 		$data     = $model->toArray();
 		$expected = ['id' => 'a'];
 
-		$this->assertEquals($expected, $data);
+		$this->assertSame($expected, $data);
 
 		// missing model
 		$this->expectException(NotFoundException::class);
@@ -302,35 +302,35 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($requestData, $api->requestData());
+		$this->assertSame($requestData, $api->requestData());
 
-		$this->assertEquals($query, $api->requestData('query'));
-		$this->assertEquals($query, $api->requestQuery());
-		$this->assertEquals('A', $api->requestData('query', 'a'));
-		$this->assertEquals('A', $api->requestQuery('a'));
-		$this->assertEquals('fallback', $api->requestData('query', 'x', 'fallback'));
-		$this->assertEquals('fallback', $api->requestQuery('x', 'fallback'));
+		$this->assertSame($query, $api->requestData('query'));
+		$this->assertSame($query, $api->requestQuery());
+		$this->assertSame('A', $api->requestData('query', 'a'));
+		$this->assertSame('A', $api->requestQuery('a'));
+		$this->assertSame('fallback', $api->requestData('query', 'x', 'fallback'));
+		$this->assertSame('fallback', $api->requestQuery('x', 'fallback'));
 
-		$this->assertEquals($body, $api->requestData('body'));
-		$this->assertEquals($body, $api->requestBody());
-		$this->assertEquals('B', $api->requestData('body', 'b'));
-		$this->assertEquals('B', $api->requestBody('b'));
-		$this->assertEquals('fallback', $api->requestData('body', 'x', 'fallback'));
-		$this->assertEquals('fallback', $api->requestBody('x', 'fallback'));
+		$this->assertSame($body, $api->requestData('body'));
+		$this->assertSame($body, $api->requestBody());
+		$this->assertSame('B', $api->requestData('body', 'b'));
+		$this->assertSame('B', $api->requestBody('b'));
+		$this->assertSame('fallback', $api->requestData('body', 'x', 'fallback'));
+		$this->assertSame('fallback', $api->requestBody('x', 'fallback'));
 
-		$this->assertEquals($files, $api->requestData('files'));
-		$this->assertEquals($files, $api->requestFiles());
-		$this->assertEquals('C', $api->requestData('files', 'c'));
-		$this->assertEquals('C', $api->requestFiles('c'));
-		$this->assertEquals('fallback', $api->requestData('files', 'x', 'fallback'));
-		$this->assertEquals('fallback', $api->requestFiles('x', 'fallback'));
+		$this->assertSame($files, $api->requestData('files'));
+		$this->assertSame($files, $api->requestFiles());
+		$this->assertSame('C', $api->requestData('files', 'c'));
+		$this->assertSame('C', $api->requestFiles('c'));
+		$this->assertSame('fallback', $api->requestData('files', 'x', 'fallback'));
+		$this->assertSame('fallback', $api->requestFiles('x', 'fallback'));
 
-		$this->assertEquals($headers, $api->requestData('headers'));
-		$this->assertEquals($headers, $api->requestHeaders());
-		$this->assertEquals('D', $api->requestData('headers', 'd'));
-		$this->assertEquals('D', $api->requestHeaders('d'));
-		$this->assertEquals('fallback', $api->requestData('headers', 'x', 'fallback'));
-		$this->assertEquals('fallback', $api->requestHeaders('x', 'fallback'));
+		$this->assertSame($headers, $api->requestData('headers'));
+		$this->assertSame($headers, $api->requestHeaders());
+		$this->assertSame('D', $api->requestData('headers', 'd'));
+		$this->assertSame('D', $api->requestHeaders('d'));
+		$this->assertSame('fallback', $api->requestData('headers', 'x', 'fallback'));
+		$this->assertSame('fallback', $api->requestHeaders('x', 'fallback'));
 	}
 
 	public function testRenderString()
@@ -347,7 +347,7 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $api->render('test', 'POST'));
+		$this->assertSame('test', $api->render('test', 'POST'));
 	}
 
 	public function testRenderArray()
@@ -367,7 +367,7 @@ class ApiTest extends TestCase
 		$result = $api->render('test', 'POST');
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode(['a' => 'A']), $result->body());
+		$this->assertSame(json_encode(['a' => 'A']), $result->body());
 	}
 
 	public function testRenderTrue()
@@ -393,7 +393,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 
 	public function testRenderFalse()
@@ -419,7 +419,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 
 	public function testRenderNull()
@@ -445,7 +445,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 
 	public function testRenderException()
@@ -473,7 +473,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 
 	public function testRenderExceptionWithDebugging()
@@ -509,7 +509,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 
 		unset($_SERVER['DOCUMENT_ROOT']);
 	}
@@ -545,7 +545,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 
 	public function testRenderKirbyExceptionWithDebugging()
@@ -587,7 +587,7 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 
 		unset($_SERVER['DOCUMENT_ROOT']);
 	}
@@ -608,7 +608,7 @@ class ApiTest extends TestCase
 
 		$result = $api->render('test', 'POST');
 
-		$this->assertEquals(500, $result->code());
+		$this->assertSame(500, $result->code());
 	}
 
 	public function testRequestMethod()
@@ -617,7 +617,7 @@ class ApiTest extends TestCase
 			'requestMethod' => 'POST',
 		]);
 
-		$this->assertEquals('POST', $api->requestMethod());
+		$this->assertSame('POST', $api->requestMethod());
 	}
 
 	public function testRoutes()
@@ -633,7 +633,7 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($routes, $api->routes());
+		$this->assertSame($routes, $api->routes());
 	}
 
 	public function testUpload()

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -114,7 +114,7 @@ class ApiTest extends TestCase
 		], $result);
 
 		$result = $api->call('testResponse', 'POST');
-		$this->assertEquals(new Response('test', 'text/plain', 201), $result);
+		$this->assertEquals(new Response('test', 'text/plain', 201), $result); // cannot use strict assertion (test for object contents)
 	}
 
 	public function testCallLocale()

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -56,7 +56,7 @@ class CacheTest extends TestCase
 		$this->assertSame(1234, $cache->get('foo'));
 
 		$cache->set('foo', null);
-		$this->assertSame(null, $cache->get('foo', 'default'));
+		$this->assertNull($cache->get('foo', 'default'));
 
 		$this->assertSame('default', $cache->get('doesnotexist', 'default'));
 
@@ -124,7 +124,7 @@ class CacheTest extends TestCase
 		$this->assertSame(time() + 720, $cache->expires('foo'));
 
 		$cache->set('foo', 'foo');
-		$this->assertSame(null, $cache->expires('foo'));
+		$this->assertNull($cache->expires('foo'));
 
 		$this->assertFalse($cache->expires('doesnotexist'));
 	}

--- a/tests/Cms/Api/ApiModelTestCase.php
+++ b/tests/Cms/Api/ApiModelTestCase.php
@@ -36,6 +36,6 @@ class ApiModelTestCase extends TestCase
 
 	public function assertAttr($object, $attr, $value)
 	{
-		$this->assertEquals($this->attr($object, $attr), $value);
+		$this->assertSame($this->attr($object, $attr), $value);
 	}
 }

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -14,13 +14,13 @@ class ApiTest extends TestCase
 	protected $api;
 	protected $locale;
 	protected $app;
-	protected $fixtures;
+	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/ApiTest'
+				'index' => $this->tmp
 			],
 			'site' => [
 				'children' => [
@@ -72,11 +72,12 @@ class ApiTest extends TestCase
 		$this->api = $this->app->api();
 
 		$this->locale = setlocale(LC_ALL, 0);
+		Dir::make($this->tmp);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove($this->tmp);
 		setlocale(LC_ALL, $this->locale);
 	}
 
@@ -284,7 +285,7 @@ class ApiTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('de', $api->language());
+		$this->assertSame('de', $api->language());
 	}
 
 	public function testFile()
@@ -324,10 +325,10 @@ class ApiTest extends TestCase
 		$app->impersonate('kirby');
 		$api = $app->api();
 
-		$this->assertEquals('test.jpg', $api->file('site', 'test.jpg')->filename());
-		$this->assertEquals('test.jpg', $api->file('pages/a', 'test.jpg')->filename());
-		$this->assertEquals('test.jpg', $api->file('pages/a+a', 'test.jpg')->filename());
-		$this->assertEquals('test.jpg', $api->file('users/test@getkirby.com', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', $api->file('site', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', $api->file('pages/a', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', $api->file('pages/a+a', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', $api->file('users/test@getkirby.com', 'test.jpg')->filename());
 	}
 
 	public function testFileNotFound()
@@ -364,8 +365,8 @@ class ApiTest extends TestCase
 		$a  = $this->app->page('a');
 		$aa = $this->app->page('a/aa');
 
-		$this->assertEquals($a, $this->api->page('a'));
-		$this->assertEquals($aa, $this->api->page('a+aa'));
+		$this->assertSame($a, $this->api->page('a'));
+		$this->assertSame($aa, $this->api->page('a+aa'));
 
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The page "does-not-exist" cannot be found');
@@ -388,8 +389,8 @@ class ApiTest extends TestCase
 		$app->impersonate('current@getkirby.com');
 		$api = $app->api();
 
-		$this->assertEquals('current@getkirby.com', $api->user()->email());
-		$this->assertEquals('test@getkirby.com', $api->user('test@getkirby.com')->email());
+		$this->assertSame('current@getkirby.com', $api->user()->email());
+		$this->assertSame('test@getkirby.com', $api->user('test@getkirby.com')->email());
 
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user "nope@getkirby.com" cannot be found');
@@ -398,7 +399,7 @@ class ApiTest extends TestCase
 
 	public function testUsers()
 	{
-		$this->assertEquals($this->app->users(), $this->api->users());
+		$this->assertSame($this->app->users(), $this->api->users());
 	}
 
 	public function testFileGetRoute()
@@ -406,14 +407,14 @@ class ApiTest extends TestCase
 		// regular
 		$result = $this->api->call('pages/a/files/a-regular-file.jpg', 'GET');
 
-		$this->assertEquals(200, $result['code']);
-		$this->assertEquals('a-regular-file.jpg', $result['data']['filename']);
+		$this->assertSame(200, $result['code']);
+		$this->assertSame('a-regular-file.jpg', $result['data']['filename']);
 
 		// with spaces in filename
 		$result = $this->api->call('pages/a/files/a filename with spaces.jpg', 'GET');
 
-		$this->assertEquals(200, $result['code']);
-		$this->assertEquals('a filename with spaces.jpg', $result['data']['filename']);
+		$this->assertSame(200, $result['code']);
+		$this->assertSame('a filename with spaces.jpg', $result['data']['filename']);
 	}
 
 	public function testAuthenticationWithoutCsrf()
@@ -615,6 +616,6 @@ class ApiTest extends TestCase
 		];
 
 		$this->assertInstanceOf(Response::class, $result);
-		$this->assertEquals(json_encode($expected), $result->body());
+		$this->assertSame(json_encode($expected), $result->body());
 	}
 }

--- a/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
+++ b/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
@@ -19,7 +19,7 @@ class ChildrenApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a', $result[0]['id']);
-		$this->assertEquals('b', $result[1]['id']);
+		$this->assertSame('a', $result[0]['id']);
+		$this->assertSame('b', $result[1]['id']);
 	}
 }

--- a/tests/Cms/Api/collections/FilesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/FilesApiCollectionTest.php
@@ -20,7 +20,7 @@ class FilesApiCollectionTest extends ApiCollectionTestCase
 		$result = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a.jpg', $result[0]['filename']);
-		$this->assertEquals('b.jpg', $result[1]['filename']);
+		$this->assertSame('a.jpg', $result[0]['filename']);
+		$this->assertSame('b.jpg', $result[1]['filename']);
 	}
 }

--- a/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
@@ -34,7 +34,7 @@ class LanguagesApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('en', $result[0]['code']);
-		$this->assertEquals('de', $result[1]['code']);
+		$this->assertSame('en', $result[0]['code']);
+		$this->assertSame('de', $result[1]['code']);
 	}
 }

--- a/tests/Cms/Api/collections/PagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/PagesApiCollectionTest.php
@@ -16,7 +16,7 @@ class PagesApiCollectionTest extends ApiCollectionTestCase
 		$result = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a', $result[0]['id']);
-		$this->assertEquals('b', $result[1]['id']);
+		$this->assertSame('a', $result[0]['id']);
+		$this->assertSame('b', $result[1]['id']);
 	}
 }

--- a/tests/Cms/Api/collections/RolesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/RolesApiCollectionTest.php
@@ -33,7 +33,7 @@ class RolesApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('admin', $result[0]['name']);
-		$this->assertEquals('editor', $result[1]['name']);
+		$this->assertSame('admin', $result[0]['name']);
+		$this->assertSame('editor', $result[1]['name']);
 	}
 }

--- a/tests/Cms/Api/collections/TranslationsApiCollectionTest.php
+++ b/tests/Cms/Api/collections/TranslationsApiCollectionTest.php
@@ -12,6 +12,6 @@ class TranslationsApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(1, $result);
-		$this->assertEquals('en', $result[0]['id']);
+		$this->assertSame('en', $result[0]['id']);
 	}
 }

--- a/tests/Cms/Api/collections/UsersApiCollectionTest.php
+++ b/tests/Cms/Api/collections/UsersApiCollectionTest.php
@@ -29,8 +29,8 @@ class UsersApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a@getkirby.com', $result[0]['email']);
-		$this->assertEquals('b@getkirby.com', $result[1]['email']);
+		$this->assertSame('a@getkirby.com', $result[0]['email']);
+		$this->assertSame('b@getkirby.com', $result[1]['email']);
 	}
 
 	public function testPassedCollection()
@@ -39,6 +39,6 @@ class UsersApiCollectionTest extends ApiCollectionTestCase
 		$result     = $collection->toArray();
 
 		$this->assertCount(1, $result);
-		$this->assertEquals('b@getkirby.com', $result[0]['email']);
+		$this->assertSame('b@getkirby.com', $result[0]['email']);
 	}
 }

--- a/tests/Cms/Api/models/PageApiModelTest.php
+++ b/tests/Cms/Api/models/PageApiModelTest.php
@@ -18,8 +18,8 @@ class PageApiModelTest extends ApiModelTestCase
 
 		$model = $this->api->resolve($page)->select('children')->toArray();
 
-		$this->assertEquals('test/a', $model['children'][0]['id']);
-		$this->assertEquals('test/b', $model['children'][1]['id']);
+		$this->assertSame('test/a', $model['children'][0]['id']);
+		$this->assertSame('test/b', $model['children'][1]['id']);
 	}
 
 	public function testContent()
@@ -47,8 +47,8 @@ class PageApiModelTest extends ApiModelTestCase
 
 		$model = $this->api->resolve($page)->select('drafts')->toArray();
 
-		$this->assertEquals('test/a', $model['drafts'][0]['id']);
-		$this->assertEquals('test/b', $model['drafts'][1]['id']);
+		$this->assertSame('test/a', $model['drafts'][0]['id']);
+		$this->assertSame('test/b', $model['drafts'][1]['id']);
 	}
 
 	public function testFiles()
@@ -63,8 +63,8 @@ class PageApiModelTest extends ApiModelTestCase
 
 		$model = $this->api->resolve($page)->select('files')->toArray();
 
-		$this->assertEquals('a.jpg', $model['files'][0]['filename']);
-		$this->assertEquals('b.jpg', $model['files'][1]['filename']);
+		$this->assertSame('a.jpg', $model['files'][0]['filename']);
+		$this->assertSame('b.jpg', $model['files'][1]['filename']);
 	}
 
 	public function testHasDrafts()

--- a/tests/Cms/Api/models/SiteApiModelTest.php
+++ b/tests/Cms/Api/models/SiteApiModelTest.php
@@ -19,7 +19,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$site      = $this->app->site();
 		$blueprint = $this->attr($site, 'blueprint');
 
-		$this->assertEquals('Test', $blueprint['title']);
+		$this->assertSame('Test', $blueprint['title']);
 	}
 
 	public function testChildren()
@@ -33,8 +33,8 @@ class SiteApiModelTest extends ApiModelTestCase
 
 		$children = $this->attr($site, 'children');
 
-		$this->assertEquals('a', $children[0]['id']);
-		$this->assertEquals('b', $children[1]['id']);
+		$this->assertSame('a', $children[0]['id']);
+		$this->assertSame('b', $children[1]['id']);
 	}
 
 	public function testContent()
@@ -60,8 +60,8 @@ class SiteApiModelTest extends ApiModelTestCase
 
 		$drafts = $this->attr($site, 'drafts');
 
-		$this->assertEquals('a', $drafts[0]['id']);
-		$this->assertEquals('b', $drafts[1]['id']);
+		$this->assertSame('a', $drafts[0]['id']);
+		$this->assertSame('b', $drafts[1]['id']);
 	}
 
 	public function testFiles()
@@ -75,8 +75,8 @@ class SiteApiModelTest extends ApiModelTestCase
 
 		$files = $this->attr($site, 'files');
 
-		$this->assertEquals('a.jpg', $files[0]['filename']);
-		$this->assertEquals('b.jpg', $files[1]['filename']);
+		$this->assertSame('a.jpg', $files[0]['filename']);
+		$this->assertSame('b.jpg', $files[1]['filename']);
 	}
 
 	public function testTitle()

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -26,8 +26,8 @@ class UserApiModelTest extends ApiModelTestCase
 
 		$model = $this->api->resolve($user)->select('files')->toArray();
 
-		$this->assertEquals('a.jpg', $model['files'][0]['filename']);
-		$this->assertEquals('b.jpg', $model['files'][1]['filename']);
+		$this->assertSame('a.jpg', $model['files'][0]['filename']);
+		$this->assertSame('b.jpg', $model['files'][1]['filename']);
 	}
 
 	public function testImage()

--- a/tests/Cms/Api/routes/AccountRoutesTest.php
+++ b/tests/Cms/Api/routes/AccountRoutesTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class AccountRoutesTest extends TestCase
 {
 	protected $app;
-	protected $fixtures;
+	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -28,7 +28,7 @@ class AccountRoutesTest extends TestCase
 				]
 			],
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/AccountRoutesTest'
+				'index' => $this->tmp
 			],
 			'users' => [
 				[
@@ -43,6 +43,7 @@ class AccountRoutesTest extends TestCase
 		]);
 
 		$this->app->impersonate('test@getkirby.com');
+		Dir::make($this->tmp);
 	}
 
 	public function tearDown(): void
@@ -50,7 +51,7 @@ class AccountRoutesTest extends TestCase
 		App::destroy();
 		Field::$types = [];
 		Section::$types = [];
-		Dir::remove($this->fixtures);
+		Dir::remove($this->tmp);
 	}
 
 	public function testAvatar()
@@ -64,7 +65,7 @@ class AccountRoutesTest extends TestCase
 
 		$response = $this->app->api()->call('account/avatar');
 
-		$this->assertEquals('profile.jpg', $response['data']['filename']);
+		$this->assertSame('profile.jpg', $response['data']['filename']);
 	}
 
 	public function testAvatarDelete()
@@ -265,7 +266,7 @@ class AccountRoutesTest extends TestCase
 
 		$response = $app->api()->call('account/files/a.jpg');
 
-		$this->assertEquals('a.jpg', $response['data']['filename']);
+		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
 	public function testFiles()
@@ -329,8 +330,8 @@ class AccountRoutesTest extends TestCase
 
 		$response = $app->api()->call('account/files');
 
-		$this->assertEquals('b.jpg', $response['data'][0]['filename']);
-		$this->assertEquals('a.jpg', $response['data'][1]['filename']);
+		$this->assertSame('b.jpg', $response['data'][0]['filename']);
+		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
 	public function testGet()
@@ -339,7 +340,7 @@ class AccountRoutesTest extends TestCase
 
 		$response = $app->api()->call('account');
 
-		$this->assertEquals('test@getkirby.com', $response['data']['email']);
+		$this->assertSame('test@getkirby.com', $response['data']['email']);
 	}
 
 	public function testRoles()

--- a/tests/Cms/Api/routes/AuthRoutesTest.php
+++ b/tests/Cms/Api/routes/AuthRoutesTest.php
@@ -35,7 +35,7 @@ class AuthRoutesTest extends TestCase
 
 		$response = $this->app->api()->call('auth');
 
-		$this->assertEquals('kirby@getkirby.com', $response['data']['email']);
+		$this->assertSame('kirby@getkirby.com', $response['data']['email']);
 	}
 
 	public function testLoginWithoutCSRF()

--- a/tests/Cms/Api/routes/LanguagesRoutesTest.php
+++ b/tests/Cms/Api/routes/LanguagesRoutesTest.php
@@ -43,8 +43,8 @@ class LanguagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('languages');
 
-		$this->assertEquals('en', $response['data'][0]['code']);
-		$this->assertEquals('de', $response['data'][1]['code']);
+		$this->assertSame('en', $response['data'][0]['code']);
+		$this->assertSame('de', $response['data'][1]['code']);
 	}
 
 	public function testListDisabled()
@@ -81,7 +81,7 @@ class LanguagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('languages/de');
 
-		$this->assertEquals('de', $response['data']['code']);
+		$this->assertSame('de', $response['data']['code']);
 	}
 
 	public function testGetDisabled()

--- a/tests/Cms/Api/routes/PagesRoutesTest.php
+++ b/tests/Cms/Api/routes/PagesRoutesTest.php
@@ -49,11 +49,11 @@ class PagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('pages/a');
 
-		$this->assertEquals('a', $response['data']['id']);
+		$this->assertSame('a', $response['data']['id']);
 
 		$response = $app->api()->call('pages/a+b');
 
-		$this->assertEquals('a/b', $response['data']['id']);
+		$this->assertSame('a/b', $response['data']['id']);
 	}
 
 	public function testChildren()
@@ -80,8 +80,8 @@ class PagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('pages/parent/children');
 
-		$this->assertEquals('parent/child-a', $response['data'][0]['id']);
-		$this->assertEquals('parent/child-b', $response['data'][1]['id']);
+		$this->assertSame('parent/child-a', $response['data'][0]['id']);
+		$this->assertSame('parent/child-b', $response['data'][1]['id']);
 	}
 
 	public function testChildrenWithStatusFilter()
@@ -119,9 +119,9 @@ class PagesRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(3, $response['data']);
-		$this->assertEquals('parent/child-a', $response['data'][0]['id']);
-		$this->assertEquals('parent/child-b', $response['data'][1]['id']);
-		$this->assertEquals('parent/draft-a', $response['data'][2]['id']);
+		$this->assertSame('parent/child-a', $response['data'][0]['id']);
+		$this->assertSame('parent/child-b', $response['data'][1]['id']);
+		$this->assertSame('parent/draft-a', $response['data'][2]['id']);
 
 		// published
 		$response = $app->api()->call('pages/parent/children', 'GET', [
@@ -129,8 +129,8 @@ class PagesRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(2, $response['data']);
-		$this->assertEquals('parent/child-a', $response['data'][0]['id']);
-		$this->assertEquals('parent/child-b', $response['data'][1]['id']);
+		$this->assertSame('parent/child-a', $response['data'][0]['id']);
+		$this->assertSame('parent/child-b', $response['data'][1]['id']);
 
 		// listed
 		$response = $app->api()->call('pages/parent/children', 'GET', [
@@ -138,7 +138,7 @@ class PagesRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('parent/child-a', $response['data'][0]['id']);
+		$this->assertSame('parent/child-a', $response['data'][0]['id']);
 
 		// unlisted
 		$response = $app->api()->call('pages/parent/children', 'GET', [
@@ -146,7 +146,7 @@ class PagesRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('parent/child-b', $response['data'][0]['id']);
+		$this->assertSame('parent/child-b', $response['data'][0]['id']);
 
 		// drafts
 		$response = $app->api()->call('pages/parent/children', 'GET', [
@@ -154,7 +154,7 @@ class PagesRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('parent/draft-a', $response['data'][0]['id']);
+		$this->assertSame('parent/draft-a', $response['data'][0]['id']);
 	}
 
 	public function testFiles()
@@ -253,8 +253,8 @@ class PagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('pages/a/files');
 
-		$this->assertEquals('b.jpg', $response['data'][0]['filename']);
-		$this->assertEquals('a.jpg', $response['data'][1]['filename']);
+		$this->assertSame('b.jpg', $response['data'][0]['filename']);
+		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
 	public function testFile()
@@ -278,6 +278,6 @@ class PagesRoutesTest extends TestCase
 
 		$response = $app->api()->call('pages/a/files/a.jpg');
 
-		$this->assertEquals('a.jpg', $response['data']['filename']);
+		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 }

--- a/tests/Cms/Api/routes/RolesRoutesTest.php
+++ b/tests/Cms/Api/routes/RolesRoutesTest.php
@@ -38,8 +38,8 @@ class RolesRoutesTest extends TestCase
 
 		$response = $app->api()->call('roles');
 
-		$this->assertEquals('admin', $response['data'][0]['name']);
-		$this->assertEquals('editor', $response['data'][1]['name']);
+		$this->assertSame('admin', $response['data'][0]['name']);
+		$this->assertSame('editor', $response['data'][1]['name']);
 	}
 
 	public function testGet()
@@ -48,7 +48,7 @@ class RolesRoutesTest extends TestCase
 
 		$response = $app->api()->call('roles/editor');
 
-		$this->assertEquals('editor', $response['data']['name']);
-		$this->assertEquals('Editor', $response['data']['title']);
+		$this->assertSame('editor', $response['data']['name']);
+		$this->assertSame('Editor', $response['data']['title']);
 	}
 }

--- a/tests/Cms/Api/routes/SiteRoutesTest.php
+++ b/tests/Cms/Api/routes/SiteRoutesTest.php
@@ -39,7 +39,7 @@ class SiteRoutesTest extends TestCase
 	{
 		$response = $this->app->api()->call('site', 'GET');
 
-		$this->assertEquals('Test Site', $response['data']['title']);
+		$this->assertSame('Test Site', $response['data']['title']);
 	}
 
 	public function testChildren()
@@ -62,8 +62,8 @@ class SiteRoutesTest extends TestCase
 		$response = $app->api()->call('site/children', 'GET');
 
 		$this->assertCount(2, $response['data']);
-		$this->assertEquals('a', $response['data'][0]['id']);
-		$this->assertEquals('b', $response['data'][1]['id']);
+		$this->assertSame('a', $response['data'][0]['id']);
+		$this->assertSame('b', $response['data'][1]['id']);
 	}
 
 	public function testChildrenWithStatusFilter()
@@ -95,9 +95,9 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(3, $response['data']);
-		$this->assertEquals('child-a', $response['data'][0]['id']);
-		$this->assertEquals('child-b', $response['data'][1]['id']);
-		$this->assertEquals('draft-a', $response['data'][2]['id']);
+		$this->assertSame('child-a', $response['data'][0]['id']);
+		$this->assertSame('child-b', $response['data'][1]['id']);
+		$this->assertSame('draft-a', $response['data'][2]['id']);
 
 		// published
 		$response = $app->api()->call('site/children', 'GET', [
@@ -105,8 +105,8 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(2, $response['data']);
-		$this->assertEquals('child-a', $response['data'][0]['id']);
-		$this->assertEquals('child-b', $response['data'][1]['id']);
+		$this->assertSame('child-a', $response['data'][0]['id']);
+		$this->assertSame('child-b', $response['data'][1]['id']);
 
 		// listed
 		$response = $app->api()->call('site/children', 'GET', [
@@ -114,7 +114,7 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('child-a', $response['data'][0]['id']);
+		$this->assertSame('child-a', $response['data'][0]['id']);
 
 		// unlisted
 		$response = $app->api()->call('site/children', 'GET', [
@@ -122,7 +122,7 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('child-b', $response['data'][0]['id']);
+		$this->assertSame('child-b', $response['data'][0]['id']);
 
 		// drafts
 		$response = $app->api()->call('site/children', 'GET', [
@@ -130,7 +130,7 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('draft-a', $response['data'][0]['id']);
+		$this->assertSame('draft-a', $response['data'][0]['id']);
 	}
 
 	public function testFiles()
@@ -186,8 +186,8 @@ class SiteRoutesTest extends TestCase
 
 		$response = $app->api()->call('site/files');
 
-		$this->assertEquals('b.jpg', $response['data'][0]['filename']);
-		$this->assertEquals('a.jpg', $response['data'][1]['filename']);
+		$this->assertSame('b.jpg', $response['data'][0]['filename']);
+		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
 	public function testFile()
@@ -206,7 +206,7 @@ class SiteRoutesTest extends TestCase
 
 		$response = $app->api()->call('site/files/a.jpg');
 
-		$this->assertEquals('a.jpg', $response['data']['filename']);
+		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
 	public function testFind()
@@ -242,7 +242,7 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $result['data']);
-		$this->assertEquals('a', $result['data'][0]['id']);
+		$this->assertSame('a', $result['data'][0]['id']);
 
 		// find multiple
 		$result = $app->api()->call('site/find', 'POST', [
@@ -254,9 +254,9 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(3, $result['data']);
-		$this->assertEquals('a', $result['data'][0]['id']);
-		$this->assertEquals('a/aa', $result['data'][1]['id']);
-		$this->assertEquals('b', $result['data'][2]['id']);
+		$this->assertSame('a', $result['data'][0]['id']);
+		$this->assertSame('a/aa', $result['data'][1]['id']);
+		$this->assertSame('b', $result['data'][2]['id']);
 	}
 
 
@@ -292,7 +292,7 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('parent/child', $response['data'][0]['id']);
+		$this->assertSame('parent/child', $response['data'][0]['id']);
 	}
 
 	public function testSearchWithPostRequest()
@@ -327,6 +327,6 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('parent/child', $response['data'][0]['id']);
+		$this->assertSame('parent/child', $response['data'][0]['id']);
 	}
 }

--- a/tests/Cms/Api/routes/TranslationsRoutesTest.php
+++ b/tests/Cms/Api/routes/TranslationsRoutesTest.php
@@ -34,8 +34,8 @@ class TranslationsRoutesTest extends TestCase
 
 		$response = $app->api()->call('translations/de');
 
-		$this->assertEquals('de', $response['data']['id']);
-		$this->assertEquals('Deutsch', $response['data']['name']);
-		$this->assertEquals('ltr', $response['data']['direction']);
+		$this->assertSame('de', $response['data']['id']);
+		$this->assertSame('Deutsch', $response['data']['name']);
+		$this->assertSame('ltr', $response['data']['direction']);
 	}
 }

--- a/tests/Cms/Api/routes/UsersRoutesTest.php
+++ b/tests/Cms/Api/routes/UsersRoutesTest.php
@@ -68,7 +68,7 @@ class UsersRoutesTest extends TestCase
 
 		$response = $this->app->api()->call('users/admin@getkirby.com/avatar');
 
-		$this->assertEquals('profile.jpg', $response['data']['filename']);
+		$this->assertSame('profile.jpg', $response['data']['filename']);
 	}
 
 	public function testAvatarDelete()
@@ -289,7 +289,7 @@ class UsersRoutesTest extends TestCase
 
 		$response = $app->api()->call('users/test@getkirby.com/files/a.jpg');
 
-		$this->assertEquals('a.jpg', $response['data']['filename']);
+		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
 	public function testFiles()
@@ -351,8 +351,8 @@ class UsersRoutesTest extends TestCase
 
 		$response = $app->api()->call('users/test@getkirby.com/files');
 
-		$this->assertEquals('b.jpg', $response['data'][0]['filename']);
-		$this->assertEquals('a.jpg', $response['data'][1]['filename']);
+		$this->assertSame('b.jpg', $response['data'][0]['filename']);
+		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
 	public function testGet()
@@ -361,7 +361,7 @@ class UsersRoutesTest extends TestCase
 
 		$response = $app->api()->call('users/admin@getkirby.com');
 
-		$this->assertEquals('admin@getkirby.com', $response['data']['email']);
+		$this->assertSame('admin@getkirby.com', $response['data']['email']);
 	}
 
 	public function testRoles()
@@ -388,7 +388,7 @@ class UsersRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('admin@getkirby.com', $response['data'][0]['email']);
+		$this->assertSame('admin@getkirby.com', $response['data'][0]['email']);
 	}
 
 	public function testSearchWithGetRequest()
@@ -402,7 +402,7 @@ class UsersRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('editor@getkirby.com', $response['data'][0]['email']);
+		$this->assertSame('editor@getkirby.com', $response['data'][0]['email']);
 	}
 
 	public function testSearchWithPostRequest()
@@ -416,7 +416,7 @@ class UsersRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(1, $response['data']);
-		$this->assertEquals('editor@getkirby.com', $response['data'][0]['email']);
+		$this->assertSame('editor@getkirby.com', $response['data'][0]['email']);
 	}
 
 	public function testSections()
@@ -472,7 +472,7 @@ class UsersRoutesTest extends TestCase
 	{
 		$response = $this->app->api()->call('users');
 
-		$this->assertEquals('admin@getkirby.com', $response['data'][0]['email']);
-		$this->assertEquals('editor@getkirby.com', $response['data'][1]['email']);
+		$this->assertSame('admin@getkirby.com', $response['data'][0]['email']);
+		$this->assertSame('editor@getkirby.com', $response['data'][1]['email']);
 	}
 }

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -38,7 +38,7 @@ class AppCachesTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
-		$this->assertEquals($kirby->root('cache'), $kirby->cache('pages')->options()['root']);
+		$this->assertSame($kirby->root('cache'), $kirby->cache('pages')->options()['root']);
 	}
 
 	public function testEnabledCacheWithOptions()
@@ -56,7 +56,7 @@ class AppCachesTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
-		$this->assertEquals($root, $kirby->cache('pages')->options()['root']);
+		$this->assertSame($root, $kirby->cache('pages')->options()['root']);
 
 		$kirby->cache('pages')->set('home', 'test');
 		$this->assertFileExists($root . '/getkirby.com_test/pages/home.cache');
@@ -77,7 +77,7 @@ class AppCachesTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(FileCache::class, $kirby->cache('pages'));
-		$this->assertEquals($root, $kirby->cache('pages')->options()['root']);
+		$this->assertSame($root, $kirby->cache('pages')->options()['root']);
 
 		$kirby->cache('pages')->set('home', 'test');
 		$this->assertFileExists($root . '/127.0.0.1_8000/pages/home.cache');

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -26,7 +26,7 @@ class AppCachesTest extends TestCase
 
 	public function testDisabledCache()
 	{
-		$this->assertEquals(NullCache::class, get_class($this->app()->cache('pages')));
+		$this->assertInstanceOf(NullCache::class, $this->app()->cache('pages'));
 	}
 
 	public function testEnabledCacheWithoutOptions()

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -86,7 +86,7 @@ class AppComponentsTest extends TestCase
 		$text     = 'Test';
 		$expected = '<p>Test</p>';
 
-		$this->assertEquals($expected, $this->kirby->kirbytext($text));
+		$this->assertSame($expected, $this->kirby->kirbytext($text));
 	}
 
 	public function testKirbytextWithSafeMode()
@@ -94,7 +94,7 @@ class AppComponentsTest extends TestCase
 		$text     = '<h1>**Test**</h1>';
 		$expected = '&lt;h1&gt;<strong>Test</strong>&lt;/h1&gt;';
 
-		$this->assertEquals($expected, $this->kirby->kirbytext($text, [
+		$this->assertSame($expected, $this->kirby->kirbytext($text, [
 			'markdown' => [
 				'safe'   => true,
 				'inline' => true
@@ -107,7 +107,7 @@ class AppComponentsTest extends TestCase
 		$text     = 'Test';
 		$expected = 'Test';
 
-		$this->assertEquals($expected, $this->kirby->kirbytext($text, [
+		$this->assertSame($expected, $this->kirby->kirbytext($text, [
 			'markdown' => [
 				'inline' => true
 			]
@@ -127,7 +127,7 @@ class AppComponentsTest extends TestCase
 		$text     = 'Test';
 		$expected = 'Test';
 
-		$this->assertEquals($expected, $this->kirby->markdown($text, ['inline' => true]));
+		$this->assertSame($expected, $this->kirby->markdown($text, ['inline' => true]));
 	}
 
 	public function testMarkdownWithSafeMode()
@@ -135,7 +135,7 @@ class AppComponentsTest extends TestCase
 		$text     = '<div>Test</div>';
 		$expected = '<p>&lt;div&gt;Test&lt;/div&gt;</p>';
 
-		$this->assertEquals($expected, $this->kirby->markdown($text, ['safe' => true]));
+		$this->assertSame($expected, $this->kirby->markdown($text, ['safe' => true]));
 	}
 
 	public function testMarkdownCachedInstance()
@@ -171,10 +171,10 @@ class AppComponentsTest extends TestCase
 		$text     = 'Test _case_';
 
 		$expected = '<pre><code><p>Test _case_</p></pre></code>';
-		$this->assertEquals($expected, $this->kirby->markdown($text));
+		$this->assertSame($expected, $this->kirby->markdown($text));
 
 		$expected = '<pre><code>Test _case_</pre></code>';
-		$this->assertEquals($expected, $this->kirby->markdown($text, ['inline' => true]));
+		$this->assertSame($expected, $this->kirby->markdown($text, ['inline' => true]));
 	}
 
 	public function testSmartypants()

--- a/tests/Cms/App/AppIoTest.php
+++ b/tests/Cms/App/AppIoTest.php
@@ -25,8 +25,8 @@ class AppIoTest extends TestCase
 			'httpCode' => 501
 		]));
 
-		$this->assertEquals(501, $response->code());
-		$this->assertEquals('Nope', $response->body());
+		$this->assertSame(501, $response->code());
+		$this->assertSame('Nope', $response->body());
 	}
 
 	public function testExceptionErrorPage()
@@ -44,24 +44,24 @@ class AppIoTest extends TestCase
 
 		$response = $app->io(new Exception('Nope'));
 
-		$this->assertEquals(500, $response->code());
-		$this->assertEquals('Error: Nope', $response->body());
+		$this->assertSame(500, $response->code());
+		$this->assertSame('Error: Nope', $response->body());
 	}
 
 	public function testExceptionWithInvalidHttpCode()
 	{
 		$response = $this->app()->io(new \Exception('Nope', 8000));
 
-		$this->assertEquals(500, $response->code());
-		$this->assertEquals('Nope', $response->body());
+		$this->assertSame(500, $response->code());
+		$this->assertSame('Nope', $response->body());
 	}
 
 	public function testEmpty()
 	{
 		$response = $this->app()->io('');
 
-		$this->assertEquals(404, $response->code());
-		$this->assertEquals('Not found', $response->body());
+		$this->assertSame(404, $response->code());
+		$this->assertSame('Not found', $response->body());
 	}
 
 	public function testResponder()
@@ -71,8 +71,8 @@ class AppIoTest extends TestCase
 
 		$response = $app->io($input);
 
-		$this->assertEquals(201, $response->code());
-		$this->assertEquals('Test', $response->body());
+		$this->assertSame(201, $response->code());
+		$this->assertSame('Test', $response->body());
 	}
 
 	public function testResponse()
@@ -114,8 +114,8 @@ class AppIoTest extends TestCase
 
 		$response = $this->app()->io($input);
 
-		$this->assertEquals(200, $response->code());
-		$this->assertEquals('Test template', $response->body());
+		$this->assertSame(200, $response->code());
+		$this->assertSame('Test template', $response->body());
 	}
 
 	public function testPageErrorPageException()
@@ -127,8 +127,8 @@ class AppIoTest extends TestCase
 
 		$response = $this->app()->io($input);
 
-		$this->assertEquals(403, $response->code());
-		$this->assertEquals('Exception message', $response->body());
+		$this->assertSame(403, $response->code());
+		$this->assertSame('Exception message', $response->body());
 	}
 
 	public function testPageErrorPageExceptionErrorPage()
@@ -151,23 +151,23 @@ class AppIoTest extends TestCase
 
 		$response = $app->io($input);
 
-		$this->assertEquals(403, $response->code());
-		$this->assertEquals('Error: Exception message', $response->body());
+		$this->assertSame(403, $response->code());
+		$this->assertSame('Error: Exception message', $response->body());
 	}
 
 	public function testString()
 	{
 		$response = $this->app()->io('Test');
 
-		$this->assertEquals(200, $response->code());
-		$this->assertEquals('Test', $response->body());
+		$this->assertSame(200, $response->code());
+		$this->assertSame('Test', $response->body());
 	}
 
 	public function testArray()
 	{
 		$response = $this->app()->io($array = ['foo' => 'bar']);
 
-		$this->assertEquals(200, $response->code());
-		$this->assertEquals(json_encode($array), $response->body());
+		$this->assertSame(200, $response->code());
+		$this->assertSame(json_encode($array), $response->body());
 	}
 }

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -24,7 +24,7 @@ class AppLanguagesTest extends TestCase
 
 		$this->assertTrue($app->multilang());
 		$this->assertCount(2, $app->languages());
-		$this->assertEquals('en', $app->languageCode());
+		$this->assertSame('en', $app->languageCode());
 	}
 
 	public function testLanguageCode()
@@ -43,9 +43,9 @@ class AppLanguagesTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('de', $app->languageCode('de'));
-		$this->assertEquals('en', $app->languageCode('en'));
-		$this->assertEquals('en', $app->languageCode());
-		$this->assertEquals(null, $app->languageCode('fr'));
+		$this->assertSame('de', $app->languageCode('de'));
+		$this->assertSame('en', $app->languageCode('en'));
+		$this->assertSame('en', $app->languageCode());
+		$this->assertSame(null, $app->languageCode('fr'));
 	}
 }

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -46,6 +46,6 @@ class AppLanguagesTest extends TestCase
 		$this->assertSame('de', $app->languageCode('de'));
 		$this->assertSame('en', $app->languageCode('en'));
 		$this->assertSame('en', $app->languageCode());
-		$this->assertSame(null, $app->languageCode('fr'));
+		$this->assertNull($app->languageCode('fr'));
 	}
 }

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -85,7 +85,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$kirby->impersonate('kirby');
-		$this->assertEquals('nice', $kirby->call('api/awesome'));
+		$this->assertSame('nice', $kirby->call('api/awesome'));
 	}
 
 	public function testApiRoutePlugins()
@@ -142,9 +142,9 @@ class AppPluginsTest extends TestCase
 
 		$app->impersonate('kirby');
 
-		$this->assertEquals('a', $app->api()->call('a'));
-		$this->assertEquals('b', $app->api()->call('b'));
-		$this->assertEquals('c', $app->api()->call('c'));
+		$this->assertSame('a', $app->api()->call('a'));
+		$this->assertSame('b', $app->api()->call('b'));
+		$this->assertSame('c', $app->api()->call('c'));
 	}
 
 	public function testApiRouteCallbackPlugins()
@@ -205,9 +205,9 @@ class AppPluginsTest extends TestCase
 
 		$app->impersonate('kirby');
 
-		$this->assertEquals('/dev/null', $app->api()->call('a'));
-		$this->assertEquals('b', $app->api()->call('b'));
-		$this->assertEquals('c', $app->api()->call('c'));
+		$this->assertSame('/dev/null', $app->api()->call('a'));
+		$this->assertSame('b', $app->api()->call('b'));
+		$this->assertSame('c', $app->api()->call('c'));
 	}
 
 	public function testApiRouteCallbackPluginWithOptionAccess()
@@ -240,7 +240,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$app->impersonate('kirby');
-		$this->assertEquals('Test', $app->api()->call('test'));
+		$this->assertSame('Test', $app->api()->call('test'));
 	}
 
 	public function testAuthChallenge()
@@ -296,7 +296,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($file, $kirby->extension('blueprints', 'pages/test'));
+		$this->assertSame($file, $kirby->extension('blueprints', 'pages/test'));
 	}
 
 	public function testCacheType()
@@ -357,7 +357,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(Collection::$filters['**'], $filter);
+		$this->assertSame(Collection::$filters['**'], $filter);
 
 		// restore previous filters
 		Collection::$filters = $prevFilters;
@@ -394,7 +394,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['foo' => 'bar'], $kirby->controller('test'));
+		$this->assertSame(['foo' => 'bar'], $kirby->controller('test'));
 	}
 
 	public function testFieldMethod()
@@ -411,7 +411,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals('test', $page->customField()->test());
+		$this->assertSame('test', $page->customField()->test());
 
 		// reset methods
 		Field::$methods = [];
@@ -436,8 +436,8 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(FormField::class, $field);
-		$this->assertEquals('simpson', $field->homer());
-		$this->assertEquals('shaw', $field->peter());
+		$this->assertSame('simpson', $field->homer());
+		$this->assertSame('shaw', $field->peter());
 	}
 
 	public function testKirbyTag()
@@ -460,11 +460,11 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $kirby->kirbytags('(test: foo)'));
-		$this->assertEquals('test', $kirby->kirbytags('(TEST: foo)'));
+		$this->assertSame('test', $kirby->kirbytags('(test: foo)'));
+		$this->assertSame('test', $kirby->kirbytags('(TEST: foo)'));
 
-		$this->assertEquals('test', $kirby->kirbytags('(foo: bar)'));
-		$this->assertEquals('test', $kirby->kirbytags('(FOO: bar)'));
+		$this->assertSame('test', $kirby->kirbytags('(foo: bar)'));
+		$this->assertSame('test', $kirby->kirbytags('(FOO: bar)'));
 	}
 
 	public function testPageMethod()
@@ -481,7 +481,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals('test', $page->test());
+		$this->assertSame('test', $page->test());
 
 		// reset methods
 		Page::$methods = [];
@@ -501,7 +501,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$pages = new Pages([]);
-		$this->assertEquals('test', $pages->test());
+		$this->assertSame('test', $pages->test());
 
 		// reset methods
 		Pages::$methods = [];
@@ -602,7 +602,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('testValue', $kirby->option('testOption'));
+		$this->assertSame('testValue', $kirby->option('testOption'));
 	}
 
 	public function testExtensionsFromFolders()
@@ -745,7 +745,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $kirby->call('test'));
+		$this->assertSame('test', $kirby->call('test'));
 	}
 
 	public function testRoutesCallback()
@@ -766,7 +766,7 @@ class AppPluginsTest extends TestCase
 			}
 		]);
 
-		$this->assertEquals('test', $kirby->call('test'));
+		$this->assertSame('test', $kirby->call('test'));
 	}
 
 	public function testSnippet()
@@ -780,7 +780,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($file, $kirby->extension('snippets', 'header'));
+		$this->assertSame($file, $kirby->extension('snippets', 'header'));
 	}
 
 	public function testTemplate()
@@ -794,7 +794,7 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($file, $kirby->extension('templates', 'project'));
+		$this->assertSame($file, $kirby->extension('templates', 'project'));
 	}
 
 	public function testTranslation()
@@ -815,11 +815,11 @@ class AppPluginsTest extends TestCase
 
 		I18n::$locale = 'en';
 
-		$this->assertEquals('English Test', I18n::translate('test'));
+		$this->assertSame('English Test', I18n::translate('test'));
 
 		I18n::$locale = 'de';
 
-		$this->assertEquals('Deutscher Test', I18n::translate('test'));
+		$this->assertSame('Deutscher Test', I18n::translate('test'));
 	}
 
 	public function testTranslationsInPlugin()
@@ -843,11 +843,11 @@ class AppPluginsTest extends TestCase
 
 		I18n::$locale = 'en';
 
-		$this->assertEquals('English Test', I18n::translate('test'));
+		$this->assertSame('English Test', I18n::translate('test'));
 
 		I18n::$locale = 'de';
 
-		$this->assertEquals('Deutscher Test', I18n::translate('test'));
+		$this->assertSame('Deutscher Test', I18n::translate('test'));
 	}
 
 	public function testUserMethod()
@@ -867,7 +867,7 @@ class AppPluginsTest extends TestCase
 			'email' => 'test@getkirby.com',
 			'name'  => 'Test User'
 		]);
-		$this->assertEquals('test', $user->test());
+		$this->assertSame('test', $user->test());
 
 		// reset methods
 		User::$methods = [];
@@ -906,7 +906,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$users = new Users([]);
-		$this->assertEquals('test', $users->test());
+		$this->assertSame('test', $users->test());
 
 		// reset methods
 		Users::$methods = [];
@@ -925,7 +925,7 @@ class AppPluginsTest extends TestCase
 			'hooks' => [
 				'system.loadPlugins:after' => function () use ($phpUnit, &$executed) {
 					if (count($this->plugins()) === 2) {
-						$phpUnit->assertEquals([
+						$phpUnit->assertSame([
 							'kirby/manual1' => new Plugin('kirby/manual1', []),
 							'kirby/manual2' => new Plugin('kirby/manual2', [])
 						], $this->plugins());
@@ -958,10 +958,10 @@ class AppPluginsTest extends TestCase
 			'kirby/manual1' => new Plugin('kirby/manual1', []),
 			'kirby/manual2' => new Plugin('kirby/manual2', [])
 		];
-		$this->assertEquals($expected, $kirby->plugins($expected));
+		$this->assertSame($expected, $kirby->plugins($expected));
 
 		// hook should have been called only once after the firs initialization
-		$this->assertEquals(1, $executed);
+		$this->assertSame(1, $executed);
 	}
 
 	public function testPluginLoaderAnonymous()
@@ -1019,8 +1019,8 @@ class AppPluginsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('https://rewritten.getkirby.com/test', $kirby->component('url')($kirby, 'test'));
-		$this->assertEquals('https://getkirby.com/test', $kirby->nativeComponent('url')($kirby, 'test'));
+		$this->assertSame('https://rewritten.getkirby.com/test', $kirby->component('url')($kirby, 'test'));
+		$this->assertSame('https://getkirby.com/test', $kirby->nativeComponent('url')($kirby, 'test'));
 	}
 
 	/**

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -625,7 +625,7 @@ class AppPluginsTest extends TestCase
 			'with_underscore' => 'withunderscorePage'
 		];
 
-		$this->assertEquals($expected, Page::$models);
+		$this->assertEquals($expected, Page::$models); // cannot use strict assertion (filesystem sorting)
 	}
 
 	public function testExtensionsFromOptions()
@@ -933,6 +933,7 @@ class AppPluginsTest extends TestCase
 							'kirby/manual2' => new Plugin('kirby/manual2', [])
 						], $this->plugins());
 					} else {
+						// cannot use strict assertion (test for object contents)
 						$phpUnit->assertEquals([
 							'kirby/test1' => new Plugin('kirby/test1', [
 								'hooks' => [
@@ -963,7 +964,7 @@ class AppPluginsTest extends TestCase
 		];
 		$this->assertSame($expected, $kirby->plugins($expected));
 
-		// hook should have been called only once after the firs initialization
+		// hook should have been called only once after the first initialization
 		$this->assertSame(1, $executed);
 	}
 

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -322,7 +322,10 @@ class AppPluginsTest extends TestCase
 
 	public function testCollection()
 	{
-		$pages = new Pages([]);
+		$pages = new Pages([
+			$page = new Page(['slug' => 'a', 'num' => 1])
+		]);
+
 		$kirby = new App([
 			'roots' => [
 				'index' => '/dev/null'
@@ -334,7 +337,7 @@ class AppPluginsTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals($pages, $kirby->collection('test'));
+		$this->assertSame($page, $kirby->collection('test')->first());
 	}
 
 	public function testCollectionFilters()

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -58,7 +58,7 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test');
 
 		$this->assertInstanceOf(Page::class, $result);
-		$this->assertEquals('test', $result->id());
+		$this->assertSame('test', $result->id());
 	}
 
 	public function testResolveSubPage()
@@ -82,7 +82,7 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test/subpage');
 
 		$this->assertInstanceOf(Page::class, $result);
-		$this->assertEquals('test/subpage', $result->id());
+		$this->assertSame('test/subpage', $result->id());
 	}
 
 	public function testResolvePageRepresentation()
@@ -149,7 +149,7 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test.jpg');
 
 		$this->assertInstanceOf(File::class, $result);
-		$this->assertEquals('test.jpg', $result->id());
+		$this->assertSame('test.jpg', $result->id());
 	}
 
 	public function testResolvePageFile()
@@ -178,7 +178,7 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test/test.jpg');
 
 		$this->assertInstanceOf(File::class, $result);
-		$this->assertEquals('test/test.jpg', $result->id());
+		$this->assertSame('test/test.jpg', $result->id());
 	}
 
 	public function testResolveMultilangPageRepresentation()
@@ -222,21 +222,21 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test');
 
 		$this->assertInstanceOf(Page::class, $result);
-		$this->assertEquals('test', $result->id());
-		$this->assertEquals('de', $app->language()->code());
+		$this->assertSame('test', $result->id());
+		$this->assertSame('de', $app->language()->code());
 
 		// missing representation
 		$result = $app->resolve('test.json');
 
 		$this->assertNull($result);
-		$this->assertEquals('de', $app->language()->code());
+		$this->assertSame('de', $app->language()->code());
 
 		// xml presentation
 		$result = $app->resolve('test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('de', $app->language()->code());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('de', $app->language()->code());
 
 		/**
 		 * Secondary language (EN)
@@ -246,21 +246,21 @@ class AppResolveTest extends TestCase
 		$result = $app->resolve('test', 'en');
 
 		$this->assertInstanceOf(Page::class, $result);
-		$this->assertEquals('test', $result->id());
-		$this->assertEquals('en', $app->language()->code());
+		$this->assertSame('test', $result->id());
+		$this->assertSame('en', $app->language()->code());
 
 		// missing representation
 		$result = $app->resolve('test.json', 'en');
 
 		$this->assertNull($result);
-		$this->assertEquals('en', $app->language()->code());
+		$this->assertSame('en', $app->language()->code());
 
 		// xml presentation
 		$result = $app->resolve('test.xml', 'en');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('en', $app->language()->code());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('en', $app->language()->code());
 	}
 
 	public function testRepresentationErrorType()

--- a/tests/Cms/App/AppRolesTest.php
+++ b/tests/Cms/App/AppRolesTest.php
@@ -16,7 +16,7 @@ class AppRolesTest extends TestCase
 		]);
 
 		$this->assertCount(2, $app->roles());
-		$this->assertEquals('editor', $app->roles()->last()->name());
+		$this->assertSame('editor', $app->roles()->last()->name());
 	}
 
 	public function testLoad()
@@ -28,6 +28,6 @@ class AppRolesTest extends TestCase
 		]);
 
 		$this->assertCount(2, $app->roles());
-		$this->assertEquals('editor', $app->roles()->last()->name());
+		$this->assertSame('editor', $app->roles()->last()->name());
 	}
 }

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -99,7 +99,7 @@ class AppTranslationsTest extends TestCase
 			$i++;
 		}
 
-		$this->assertEquals($i, $translations->count());
+		$this->assertCount($i, $translations);
 	}
 
 	public function testTranslationFromCurrentLanguage()
@@ -206,13 +206,13 @@ class AppTranslationsTest extends TestCase
 	{
 		$app = $this->app();
 
-		$this->assertEquals('Save', t('save'));
-		$this->assertEquals('Reset', t('reset'));
+		$this->assertSame('Save', t('save'));
+		$this->assertSame('Reset', t('reset'));
 
 		$app->setCurrentTranslation('de');
 
-		$this->assertEquals('Speichern', t('save'));
-		$this->assertEquals('Reset', t('reset'));
+		$this->assertSame('Speichern', t('save'));
+		$this->assertSame('Reset', t('reset'));
 	}
 
 	public function testTranslationInTemplate()
@@ -255,10 +255,10 @@ class AppTranslationsTest extends TestCase
 		]);
 
 		$result = $app->render('de/test');
-		$this->assertEquals('Knopf', $result->body());
+		$this->assertSame('Knopf', $result->body());
 
 		$result = $app->render('en/test');
-		$this->assertEquals('Button', $result->body());
+		$this->assertSame('Button', $result->body());
 	}
 
 	public function testExceptionWithoutLanguage()
@@ -271,8 +271,8 @@ class AppTranslationsTest extends TestCase
 			'fallback' => $fallbackError = 'This would be the fallback error'
 		]);
 
-		$this->assertEquals('error.test', $exception->getKey());
-		$this->assertEquals($fallbackError, $exception->getMessage());
+		$this->assertSame('error.test', $exception->getKey());
+		$this->assertSame($fallbackError, $exception->getMessage());
 	}
 
 	public function testExceptionWithDefaultLanguage()
@@ -283,7 +283,7 @@ class AppTranslationsTest extends TestCase
 			'key' => 'test'
 		]);
 
-		$this->assertEquals('This is a test error', $exception->getMessage());
+		$this->assertSame('This is a test error', $exception->getMessage());
 	}
 
 	public function testExceptionWithTranslation()
@@ -295,7 +295,7 @@ class AppTranslationsTest extends TestCase
 			'key' => 'test'
 		]);
 
-		$this->assertEquals('Das ist ein Testfehler', $exception->getMessage());
+		$this->assertSame('Das ist ein Testfehler', $exception->getMessage());
 	}
 
 	public function testExceptionPinned()
@@ -308,8 +308,8 @@ class AppTranslationsTest extends TestCase
 			'translate' => false
 		]);
 
-		$this->assertEquals('error.test', $exception->getKey());
-		$this->assertEquals('This would be the fallback error', $exception->getMessage());
+		$this->assertSame('error.test', $exception->getKey());
+		$this->assertSame('This would be the fallback error', $exception->getMessage());
 	}
 
 	public function testExceptionInvalidKey()
@@ -321,8 +321,8 @@ class AppTranslationsTest extends TestCase
 			'fallback' => 'This would be the fallback error'
 		]);
 
-		$this->assertEquals('error.no-real-key', $exception->getKey());
-		$this->assertEquals('This would be the fallback error', $exception->getMessage());
+		$this->assertSame('error.no-real-key', $exception->getKey());
+		$this->assertSame('This would be the fallback error', $exception->getMessage());
 	}
 
 	public function testLanguageTranslationWithSlugs()

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -125,7 +125,7 @@ class AppUsersTest extends TestCase
 		]);
 
 		$this->assertCount(1, $app->users());
-		$this->assertEquals('user@getkirby.com', $app->users()->first()->email());
+		$this->assertSame('user@getkirby.com', $app->users()->first()->email());
 	}
 
 	public function testSet()
@@ -139,7 +139,7 @@ class AppUsersTest extends TestCase
 		]);
 
 		$this->assertCount(1, $app->users());
-		$this->assertEquals('user@getkirby.com', $app->users()->first()->email());
+		$this->assertSame('user@getkirby.com', $app->users()->first()->email());
 	}
 
 	public function basicAuthApp()
@@ -169,7 +169,7 @@ class AppUsersTest extends TestCase
 		$user = $app->auth()->currentUserFromBasicAuth($auth);
 
 		$this->assertInstanceOf(User::class, $user);
-		$this->assertEquals('test@getkirby.com', $user->email());
+		$this->assertSame('test@getkirby.com', $user->email());
 	}
 
 	public function testUserFromBasicAuthDisabled()

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -61,7 +61,7 @@ class AuthCsrfTest extends TestCase
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
 		$_GET = ['csrf' => 'session-csrf'];
-		$this->assertEquals('session-csrf', $this->auth->csrf());
+		$this->assertSame('session-csrf', $this->auth->csrf());
 	}
 
 	/**
@@ -108,7 +108,7 @@ class AuthCsrfTest extends TestCase
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
 		$_GET = ['csrf' => 'option-csrf'];
-		$this->assertEquals('option-csrf', $this->auth->csrf());
+		$this->assertSame('option-csrf', $this->auth->csrf());
 	}
 
 	/**

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -65,7 +65,7 @@ class AuthTest extends TestCase
 	 */
 	public function testImpersonate()
 	{
-		$this->assertSame(null, $this->auth->user());
+		$this->assertNull($this->auth->user());
 
 		$user = $this->auth->impersonate('kirby');
 		$this->assertSame([

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -49,10 +49,14 @@ class BlockTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Test Field A', $block->content()->a());
-		$this->assertEquals('Test Field A', $block->a());
-		$this->assertEquals('Test Field B', $block->content()->b());
-		$this->assertEquals('Test Field B', $block->b());
+		$this->assertInstanceOf(Field::class, $block->content()->a());
+		$this->assertInstanceOf(Field::class, $block->a());
+		$this->assertInstanceOf(Field::class, $block->content()->b());
+		$this->assertInstanceOf(Field::class, $block->b());
+		$this->assertSame('Test Field A', $block->content()->a()->value());
+		$this->assertSame('Test Field A', $block->a()->value());
+		$this->assertSame('Test Field B', $block->content()->b()->value());
+		$this->assertSame('Test Field B', $block->b()->value());
 		$this->assertSame($content, $block->content()->toArray());
 	}
 

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -79,7 +79,7 @@ class BlueprintFieldTest extends TestCase
 			'type'  => 'info'
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testExtendField()

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -32,10 +32,10 @@ class BlueprintFieldTest extends TestCase
 			'type' => 'text'
 		]);
 
-		$this->assertEquals('test', $props['name']);
-		$this->assertEquals('text', $props['type']);
-		$this->assertEquals('Test', $props['label']);
-		$this->assertEquals('1/1', $props['width']);
+		$this->assertSame('test', $props['name']);
+		$this->assertSame('text', $props['type']);
+		$this->assertSame('Test', $props['label']);
+		$this->assertSame('1/1', $props['width']);
 	}
 
 	public function testFieldTypeFromName()
@@ -44,9 +44,9 @@ class BlueprintFieldTest extends TestCase
 			'name' => 'text',
 		]);
 
-		$this->assertEquals('text', $props['name']);
-		$this->assertEquals('text', $props['type']);
-		$this->assertEquals('Text', $props['label']);
+		$this->assertSame('text', $props['name']);
+		$this->assertSame('text', $props['type']);
+		$this->assertSame('Text', $props['label']);
 	}
 
 	public function testMissingFieldName()
@@ -103,9 +103,9 @@ class BlueprintFieldTest extends TestCase
 	{
 		$props = Blueprint::fieldProps('fields/test');
 
-		$this->assertEquals('test', $props['name']);
-		$this->assertEquals('Test', $props['label']);
-		$this->assertEquals('text', $props['type']);
+		$this->assertSame('test', $props['name']);
+		$this->assertSame('Test', $props['label']);
+		$this->assertSame('text', $props['type']);
 	}
 
 	public function testExtendFieldWithNonAssociativeOptions()
@@ -157,10 +157,10 @@ class BlueprintFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('headline', $props['fields']['headline']['name']);
-		$this->assertEquals('Headline', $props['fields']['headline']['label']);
-		$this->assertEquals('text', $props['fields']['headline']['type']);
-		$this->assertEquals('1/1', $props['fields']['headline']['width']);
+		$this->assertSame('headline', $props['fields']['headline']['name']);
+		$this->assertSame('Headline', $props['fields']['headline']['label']);
+		$this->assertSame('text', $props['fields']['headline']['type']);
+		$this->assertSame('1/1', $props['fields']['headline']['width']);
 	}
 
 	public function testFieldGroup()

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -96,7 +96,7 @@ class BlueprintFieldTest extends TestCase
 			'width' => '1/1'
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testExtendFieldFromString()
@@ -142,7 +142,7 @@ class BlueprintFieldTest extends TestCase
 			'width' => '1/1'
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testNestedFields()
@@ -188,6 +188,6 @@ class BlueprintFieldTest extends TestCase
 			'type' => 'group'
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 }

--- a/tests/Cms/Blueprints/BlueprintFieldsTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldsTest.php
@@ -44,7 +44,7 @@ class BlueprintFieldsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $fields);
+		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
 	public function testFieldFromString()
@@ -62,7 +62,7 @@ class BlueprintFieldsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $fields);
+		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
 	public function testFieldGroup()
@@ -105,7 +105,7 @@ class BlueprintFieldsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $fields);
+		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
 	public function testMultipleFieldGroups()
@@ -162,7 +162,7 @@ class BlueprintFieldsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $fields);
+		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
 	public function testFieldError()

--- a/tests/Cms/Blueprints/BlueprintFieldsTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldsTest.php
@@ -183,6 +183,6 @@ class BlueprintFieldsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 }

--- a/tests/Cms/Blueprints/BlueprintFieldsTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldsTest.php
@@ -26,7 +26,7 @@ class BlueprintFieldsTest extends TestCase
 	public function testEmptyFields()
 	{
 		$fields = Blueprint::fieldsProps(false);
-		$this->assertEquals([], $fields);
+		$this->assertSame([], $fields);
 	}
 
 	public function testNameOnlyField()

--- a/tests/Cms/Blueprints/BlueprintPresetsTest.php
+++ b/tests/Cms/Blueprints/BlueprintPresetsTest.php
@@ -55,7 +55,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testPagePresetNoFiles()
@@ -87,7 +87,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testPagePresetNoPages()
@@ -118,7 +118,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testPagePresetNoSidebar()
@@ -135,7 +135,7 @@ class BlueprintPresetsTest extends TestCase
 			'fields' => [],
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testPagePresetCustomSidebar()
@@ -170,7 +170,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	/**
@@ -200,7 +200,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testPagesPresetWithUnlisted()
@@ -235,7 +235,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertSame($expected, $props);
 	}
 
 	/**

--- a/tests/Cms/Blueprints/BlueprintPresetsTest.php
+++ b/tests/Cms/Blueprints/BlueprintPresetsTest.php
@@ -261,7 +261,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testFilesPresetWithLabel()
@@ -286,7 +286,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testFilesPresetWithLayout()
@@ -311,7 +311,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testFilesPresetWithTemplate()
@@ -336,7 +336,7 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
 	public function testFilesPresetWithImage()
@@ -361,6 +361,6 @@ class BlueprintPresetsTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $props);
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 }

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -216,7 +216,7 @@ class BlueprintTest extends TestCase
 			'model' => $this->model
 		]);
 
-		$this->assertEquals('Test', $blueprint->title());
+		$this->assertSame('Test', $blueprint->title());
 	}
 
 	/**
@@ -229,7 +229,7 @@ class BlueprintTest extends TestCase
 			'model' => $this->model
 		]);
 
-		$this->assertEquals('Test', $blueprint->title());
+		$this->assertSame('Test', $blueprint->title());
 	}
 
 	/**
@@ -241,14 +241,14 @@ class BlueprintTest extends TestCase
 			'model' => $this->model
 		]);
 
-		$this->assertEquals('Default', $blueprint->title());
+		$this->assertSame('Default', $blueprint->title());
 
 		$blueprint = new Blueprint([
 			'model' => $this->model,
 			'name'  => 'test'
 		]);
 
-		$this->assertEquals('Test', $blueprint->title());
+		$this->assertSame('Test', $blueprint->title());
 	}
 
 	/**
@@ -477,11 +477,11 @@ class BlueprintTest extends TestCase
 			$this->assertNull($e->getMessage(), 'Failed to get sections.');
 		}
 
-		$this->assertEquals(true, is_array($sections));
-		$this->assertEquals(1, sizeof($sections));
-		$this->assertEquals(true, array_key_exists('main', $sections));
-		$this->assertEquals(true, array_key_exists('label', $sections['main']));
-		$this->assertEquals('Invalid section type for section "main"', $sections['main']['label']);
+		$this->assertIsArray($sections);
+		$this->assertCount(1, $sections);
+		$this->assertArrayHasKey('main', $sections);
+		$this->assertArrayHasKey('label', $sections['main']);
+		$this->assertSame('Invalid section type for section "main"', $sections['main']['label']);
 	}
 
 	/**
@@ -508,7 +508,7 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('info', $blueprint->sections()['info']->type());
+		$this->assertSame('info', $blueprint->sections()['info']->type());
 
 		// by just passing true
 		$blueprint = new Blueprint([
@@ -518,7 +518,7 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('info', $blueprint->sections()['info']->type());
+		$this->assertSame('info', $blueprint->sections()['info']->type());
 	}
 
 	/**

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -163,7 +163,7 @@ class BlueprintTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $blueprint->toArray()['tabs']);
+		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
 	public function testFieldsToSections()
@@ -203,7 +203,7 @@ class BlueprintTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $blueprint->toArray()['tabs']);
+		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
 	/**

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -322,9 +322,9 @@ class BlueprintTest extends TestCase
 
 		$this->assertSame('foo', $field['after']);
 		$this->assertSame('bar', $field['before']);
-		$this->assertSame(true, $field['required']);
+		$this->assertTrue($field['required']);
 		$this->assertSame('text', $field['type']);
-		$this->assertSame(false, $field['translatable']);
+		$this->assertFalse($field['translatable']);
 		$this->assertSame('1/3', $field['width']);
 	}
 

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -425,8 +425,8 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($fields, $blueprint->fields());
-		$this->assertEquals($fields['test'], $blueprint->field('test'));
+		$this->assertSame($fields, $blueprint->fields());
+		$this->assertSame($fields['test'], $blueprint->field('test'));
 	}
 
 	/**

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -102,13 +102,13 @@ class CollectionTest extends TestCase
 	public function testGetAttributeWithField()
 	{
 		$object = new MockObject([
-			'id' => new Field(null, 'id', 'a')
+			'id' => $field = new Field(null, 'id', 'a')
 		]);
 
 		$collection = new Collection();
 		$value      = $collection->getAttribute($object, 'id');
 
-		$this->assertEquals('a', $value);
+		$this->assertSame($field, $value);
 	}
 
 	public function testAppend()

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -74,8 +74,8 @@ class CollectionTest extends TestCase
 			$c = new MockObject(['id' => 'c', 'name' => 'c'])
 		]);
 
-		$this->assertEquals($a, $collection->first());
-		$this->assertEquals($c, $collection->last());
+		$this->assertSame($a, $collection->first());
+		$this->assertSame($c, $collection->last());
 	}
 
 	public function testWithArray()
@@ -86,8 +86,8 @@ class CollectionTest extends TestCase
 			$c = ['id' => 'c', 'name' => 'c']
 		]);
 
-		$this->assertEquals($a, $collection->first());
-		$this->assertEquals($c, $collection->last());
+		$this->assertSame($a, $collection->first());
+		$this->assertSame($c, $collection->last());
 	}
 
 	public function testGetAttribute()
@@ -96,7 +96,7 @@ class CollectionTest extends TestCase
 		$collection = new Collection();
 		$value      = $collection->getAttribute($object, 'id');
 
-		$this->assertEquals('a', $value);
+		$this->assertSame('a', $value);
 	}
 
 	public function testGetAttributeWithField()
@@ -128,8 +128,8 @@ class CollectionTest extends TestCase
 		$collection = $collection->append('key-d', $d);
 		$collection = $collection->append('key-e', 'a simple string');
 
-		$this->assertEquals(['key-a', 'key-b', 'key-c', 'key-d', 'key-e'], $collection->keys());
-		$this->assertEquals([$a, $b, $c, $d, 'a simple string'], $collection->values());
+		$this->assertSame(['key-a', 'key-b', 'key-c', 'key-d', 'key-e'], $collection->keys());
+		$this->assertSame([$a, $b, $c, $d, 'a simple string'], $collection->values());
 
 		// with automatic keys
 		$collection = new Collection();
@@ -139,8 +139,8 @@ class CollectionTest extends TestCase
 		$collection = $collection->append($d);
 		$collection = $collection->append('a simple string');
 
-		$this->assertEquals(['a', 'b', 'c', 0, 1], $collection->keys());
-		$this->assertEquals([$a, $b, $c, $d, 'a simple string'], $collection->values());
+		$this->assertSame(['a', 'b', 'c', 0, 1], $collection->keys());
+		$this->assertSame([$a, $b, $c, $d, 'a simple string'], $collection->values());
 	}
 
 	public function testFindByUuid()
@@ -206,9 +206,9 @@ class CollectionTest extends TestCase
 			$c = new MockObject(['id' => 'c'])
 		]);
 
-		$this->assertEquals(0, $collection->indexOf($a));
-		$this->assertEquals(1, $collection->indexOf($b));
-		$this->assertEquals(2, $collection->indexOf($c));
+		$this->assertSame(0, $collection->indexOf($a));
+		$this->assertSame(1, $collection->indexOf($b));
+		$this->assertSame(2, $collection->indexOf($c));
 	}
 
 	public function testIndexOfWithString()
@@ -219,9 +219,9 @@ class CollectionTest extends TestCase
 			new MockObject(['id' => 'c'])
 		]);
 
-		$this->assertEquals(0, $collection->indexOf('a'));
-		$this->assertEquals(1, $collection->indexOf('b'));
-		$this->assertEquals(2, $collection->indexOf('c'));
+		$this->assertSame(0, $collection->indexOf('a'));
+		$this->assertSame(1, $collection->indexOf('b'));
+		$this->assertSame(2, $collection->indexOf('c'));
 	}
 
 	public function testNotWithObjects()
@@ -235,14 +235,14 @@ class CollectionTest extends TestCase
 		$result = $collection->not($a);
 
 		$this->assertCount(2, $result);
-		$this->assertEquals($b, $result->first());
-		$this->assertEquals($c, $result->last());
+		$this->assertSame($b, $result->first());
+		$this->assertSame($c, $result->last());
 
 		$result = $collection->not($a, $b);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($c, $result->first());
-		$this->assertEquals($c, $result->last());
+		$this->assertSame($c, $result->first());
+		$this->assertSame($c, $result->last());
 	}
 
 	public function testNotWithCollection()
@@ -257,7 +257,7 @@ class CollectionTest extends TestCase
 
 		$result = $collection->not($not);
 		$this->assertCount(1, $result);
-		$this->assertEquals('b', $result->first()->id());
+		$this->assertSame('b', $result->first()->id());
 	}
 
 	public function testNotWithSimpleArray()
@@ -328,14 +328,14 @@ class CollectionTest extends TestCase
 		$result = $collection->not('a');
 
 		$this->assertCount(2, $result);
-		$this->assertEquals($b, $result->first());
-		$this->assertEquals($c, $result->last());
+		$this->assertSame($b, $result->first());
+		$this->assertSame($c, $result->last());
 
 		$result = $collection->not('a', 'b');
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($c, $result->first());
-		$this->assertEquals($c, $result->last());
+		$this->assertSame($c, $result->first());
+		$this->assertSame($c, $result->last());
 	}
 
 	public function testPaginate()
@@ -350,22 +350,22 @@ class CollectionTest extends TestCase
 		$result = $collection->paginate(1);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($a, $result->first());
-		$this->assertEquals($a, $result->last());
+		$this->assertSame($a, $result->first());
+		$this->assertSame($a, $result->last());
 
 		// page: 2
 		$result = $collection->paginate(1, 2);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($b, $result->first());
-		$this->assertEquals($b, $result->last());
+		$this->assertSame($b, $result->first());
+		$this->assertSame($b, $result->last());
 
 		// page: 3
 		$result = $collection->paginate(1, 3);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($c, $result->first());
-		$this->assertEquals($c, $result->last());
+		$this->assertSame($c, $result->first());
+		$this->assertSame($c, $result->last());
 	}
 
 	public function testPrepend()
@@ -385,8 +385,8 @@ class CollectionTest extends TestCase
 		$collection = $collection->prepend('key-d', $d);
 		$collection = $collection->prepend('key-e', 'a simple string');
 
-		$this->assertEquals(['key-e', 'key-d', 'key-c', 'key-b', 'key-a'], $collection->keys());
-		$this->assertEquals(['a simple string', $d, $c, $b, $a], $collection->values());
+		$this->assertSame(['key-e', 'key-d', 'key-c', 'key-b', 'key-a'], $collection->keys());
+		$this->assertSame(['a simple string', $d, $c, $b, $a], $collection->values());
 
 		// with automatic keys
 		$collection = new Collection();
@@ -396,8 +396,8 @@ class CollectionTest extends TestCase
 		$collection = $collection->prepend($d);
 		$collection = $collection->prepend('a simple string');
 
-		$this->assertEquals([0, 1, 'c', 'b', 'a'], $collection->keys());
-		$this->assertEquals(['a simple string', $d, $c, $b, $a], $collection->values());
+		$this->assertSame([0, 1, 'c', 'b', 'a'], $collection->keys());
+		$this->assertSame(['a simple string', $d, $c, $b, $a], $collection->values());
 	}
 
 	public function testQuerySearch()
@@ -414,7 +414,7 @@ class CollectionTest extends TestCase
 		]);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals('project-b', $result->first()->id());
+		$this->assertSame('project-b', $result->first()->id());
 
 		// with options array
 		$result = $collection->query([
@@ -424,7 +424,7 @@ class CollectionTest extends TestCase
 		]);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals('project-b', $result->first()->id());
+		$this->assertSame('project-b', $result->first()->id());
 	}
 
 	public function testQueryPagination()
@@ -440,8 +440,8 @@ class CollectionTest extends TestCase
 		]);
 
 		$this->assertCount(1, $result);
-		$this->assertEquals('project-a', $result->first()->id());
-		$this->assertEquals(3, $result->pagination()->pages());
+		$this->assertSame('project-a', $result->first()->id());
+		$this->assertSame(3, $result->pagination()->pages());
 	}
 
 	public function testToArray()
@@ -454,7 +454,7 @@ class CollectionTest extends TestCase
 
 		$array = $collection->toArray();
 
-		$this->assertEquals($array, [
+		$this->assertSame($array, [
 			'a' => [
 				'id' => 'a'
 			],
@@ -479,7 +479,7 @@ class CollectionTest extends TestCase
 			return $object->id();
 		});
 
-		$this->assertEquals($array, [
+		$this->assertSame($array, [
 			'a' => 'a',
 			'b' => 'b',
 			'c' => 'c'

--- a/tests/Cms/Collections/CollectionsTest.php
+++ b/tests/Cms/Collections/CollectionsTest.php
@@ -72,13 +72,13 @@ class CollectionsTest extends TestCase
 		$collections = $app->collections();
 
 		$a = $collections->get('test');
-		$this->assertSame(0, $a->count());
+		$this->assertCount(0, $a);
 
 		$a->add('kirby');
-		$this->assertSame(1, $a->count());
+		$this->assertCount(1, $a);
 
 		$b = $collections->get('test');
-		$this->assertSame(0, $b->count());
+		$this->assertCount(0, $b);
 	}
 
 	public function testHas()

--- a/tests/Cms/Collections/CollectionsTest.php
+++ b/tests/Cms/Collections/CollectionsTest.php
@@ -35,7 +35,7 @@ class CollectionsTest extends TestCase
 			'b' => 'b'
 		]);
 
-		$this->assertEquals('ab', $result);
+		$this->assertSame('ab', $result);
 	}
 
 	public function testGetWithRearrangedData()
@@ -46,7 +46,7 @@ class CollectionsTest extends TestCase
 			'b' => 'b'
 		]);
 
-		$this->assertEquals('ab', $result);
+		$this->assertSame('ab', $result);
 	}
 
 	public function testGetWithDifferentData()
@@ -57,13 +57,13 @@ class CollectionsTest extends TestCase
 			'a' => 'a',
 			'b' => 'b'
 		]);
-		$this->assertEquals('ab', $result);
+		$this->assertSame('ab', $result);
 
 		$result = $app->collections()->get('string', [
 			'a' => 'c',
 			'b' => 'd'
 		]);
-		$this->assertEquals('cd', $result);
+		$this->assertSame('cd', $result);
 	}
 
 	public function testGetCloned()
@@ -72,13 +72,13 @@ class CollectionsTest extends TestCase
 		$collections = $app->collections();
 
 		$a = $collections->get('test');
-		$this->assertEquals(0, $a->count());
+		$this->assertSame(0, $a->count());
 
 		$a->add('kirby');
-		$this->assertEquals(1, $a->count());
+		$this->assertSame(1, $a->count());
 
 		$b = $collections->get('test');
-		$this->assertEquals(0, $b->count());
+		$this->assertSame(0, $b->count());
 	}
 
 	public function testHas()
@@ -96,13 +96,13 @@ class CollectionsTest extends TestCase
 		$this->assertInstanceOf(Collection::class, $result());
 
 		$result = $app->collections()->load('nested/test');
-		$this->assertEquals('a', $result());
+		$this->assertSame('a', $result());
 	}
 
 	public function testLoadNested()
 	{
 		$app = $this->_app();
 		$result = $app->collections()->load('nested/test');
-		$this->assertEquals('a', $result());
+		$this->assertSame('a', $result());
 	}
 }

--- a/tests/Cms/Collections/CollectionsTest.php
+++ b/tests/Cms/Collections/CollectionsTest.php
@@ -20,11 +20,11 @@ class CollectionsTest extends TestCase
 
 		// get
 		$result = $app->collections()->get('test');
-		$this->assertEquals($collection, $result);
+		$this->assertEquals($collection, $result); // cannot use strict assertion (different object)
 
 		// __call
 		$result = $app->collections()->test();
-		$this->assertEquals($collection, $result);
+		$this->assertEquals($collection, $result); // cannot use strict assertion (different object)
 	}
 
 	public function testGetWithData()

--- a/tests/Cms/Collections/PaginationTest.php
+++ b/tests/Cms/Collections/PaginationTest.php
@@ -100,8 +100,8 @@ class PaginationTest extends TestCase
 			'url'   => new Uri('https://getkirby.com')
 		]);
 
-		$this->assertSame(null, $pagination->firstPageUrl());
-		$this->assertSame(null, $pagination->lastPageUrl());
+		$this->assertNull($pagination->firstPageUrl());
+		$this->assertNull($pagination->lastPageUrl());
 	}
 
 	public function testNextPageUrl()

--- a/tests/Cms/Collections/SearchTest.php
+++ b/tests/Cms/Collections/SearchTest.php
@@ -147,22 +147,22 @@ class SearchTest extends TestCase
 
 	public function testFiles()
 	{
-		$this->assertSame(5, $this->app()->site()->index()->files()->count());
+		$this->assertCount(5, $this->app()->site()->index()->files());
 		$this->assertInstanceOf(Files::class, $files = Search::files('phone'));
-		$this->assertSame(2, $files->count());
+		$this->assertCount(2, $files);
 	}
 
 	public function testPages()
 	{
-		$this->assertSame(3, $this->app()->site()->index()->count());
+		$this->assertCount(3, $this->app()->site()->index());
 		$this->assertInstanceOf(Pages::class, $pages = Search::pages('products'));
-		$this->assertSame(1, $pages->count());
+		$this->assertCount(1, $pages);
 	}
 
 	public function testUsers()
 	{
-		$this->assertSame(5, $this->app()->users()->count());
+		$this->assertCount(5, $this->app()->users());
 		$this->assertInstanceOf(Users::class, $users = Search::users('user'));
-		$this->assertSame(3, $users->count());
+		$this->assertCount(3, $users);
 	}
 }

--- a/tests/Cms/Content/ContentLockTest.php
+++ b/tests/Cms/Content/ContentLockTest.php
@@ -111,9 +111,9 @@ class ContentLockTest extends TestCase
 		$app->impersonate('homer@simpson.com');
 		$data = $page->lock()->get();
 
-		$this->assertFalse(empty($data));
+		$this->assertNotEmpty($data);
 		$this->assertFalse($data['unlockable']);
-		$this->assertEquals('test@getkirby.com', $data['email']);
+		$this->assertSame('test@getkirby.com', $data['email']);
 		$this->assertArrayHasKey('time', $data);
 	}
 
@@ -129,9 +129,9 @@ class ContentLockTest extends TestCase
 		$app->impersonate('homer@simpson.com');
 		$data = $page->lock()->get();
 		$this->assertFileExists($this->fixtures . '/content/test/.lock');
-		$this->assertFalse(empty($data));
+		$this->assertNotEmpty($data);
 		$this->assertFalse($data['unlockable']);
-		$this->assertEquals('test@getkirby.com', $data['email']);
+		$this->assertSame('test@getkirby.com', $data['email']);
 		$this->assertArrayHasKey('time', $data);
 
 		$app->users()->remove($app->user('test@getkirby.com'));
@@ -184,10 +184,10 @@ class ContentLockTest extends TestCase
 		$app->impersonate('test@getkirby.com');
 
 		$this->assertTrue($page->lock()->create());
-		$this->assertFalse(empty($app->locks()->get($page)));
+		$this->assertNotEmpty($app->locks()->get($page));
 
 		$this->assertTrue($page->lock()->remove());
-		$this->assertTrue(empty($app->locks()->get($page)));
+		$this->assertEmpty($app->locks()->get($page));
 	}
 
 	public function testUnlockWithNoLock()
@@ -210,7 +210,7 @@ class ContentLockTest extends TestCase
 		$app->impersonate('homer@simpson.com');
 		$this->assertTrue($page->lock()->unlock());
 
-		$this->assertFalse(empty($app->locks()->get($page)['unlock']));
+		$this->assertNotEmpty($app->locks()->get($page)['unlock']);
 	}
 
 	public function testIsUnlocked()
@@ -251,7 +251,7 @@ class ContentLockTest extends TestCase
 
 		$app->impersonate('homer@simpson.com');
 		$this->assertTrue($page->lock()->unlock());
-		$this->assertFalse(empty($app->locks()->get($page)['unlock']));
+		$this->assertNotEmpty($app->locks()->get($page)['unlock']);
 
 		$app->impersonate('test@getkirby.com');
 		$this->assertTrue($page->lock()->isUnlocked());
@@ -270,18 +270,18 @@ class ContentLockTest extends TestCase
 
 		$app->impersonate('homer@simpson.com');
 		$this->assertTrue($page->lock()->unlock());
-		$this->assertEquals(count($app->locks()->get($page)['unlock']), 1);
+		$this->assertCount(1, $app->locks()->get($page)['unlock']);
 		$this->assertTrue($page->lock()->create());
 
 		$app->impersonate('peter@lustig.de');
 		$this->assertTrue($page->lock()->unlock());
-		$this->assertEquals(count($app->locks()->get($page)['unlock']), 2);
+		$this->assertCount(2, $app->locks()->get($page)['unlock']);
 
 		$app->impersonate('test@getkirby.com');
 		$this->assertTrue($page->lock()->isUnlocked());
 		$this->assertTrue($page->lock()->resolve());
 		$this->assertFalse($page->lock()->isUnlocked());
-		$this->assertEquals(count($app->locks()->get($page)['unlock']), 1);
+		$this->assertCount(1, $app->locks()->get($page)['unlock']);
 
 		$app->impersonate('homer@simpson.com');
 		$this->assertTrue($page->lock()->isUnlocked());
@@ -296,7 +296,7 @@ class ContentLockTest extends TestCase
 
 		$page->lock()->create();
 
-		$this->assertSame(null, $page->lock()->state());
+		$this->assertNull($page->lock()->state());
 
 		$app->impersonate('test@getkirby.com');
 
@@ -345,6 +345,6 @@ class ContentLockTest extends TestCase
 
 		// state is locked
 		$this->assertSame('unlock', $lockArray['state']);
-		$this->assertSame(false, $lockArray['data']);
+		$this->assertFalse($lockArray['data']);
 	}
 }

--- a/tests/Cms/Content/ContentLocksTest.php
+++ b/tests/Cms/Content/ContentLocksTest.php
@@ -50,7 +50,7 @@ class ContentLocksTest extends TestCase
 	{
 		$app = $this->app;
 		$page = $app->page('test');
-		$this->assertEquals('/test', $app->locks()->id($page));
+		$this->assertSame('/test', $app->locks()->id($page));
 	}
 
 	public function testGetSet()
@@ -60,11 +60,11 @@ class ContentLocksTest extends TestCase
 		$root = $this->fixtures . '/content/test';
 
 		// create fixtures directory
-		$this->assertEquals($root . '/.lock', $app->locks()->file($page));
+		$this->assertSame($root . '/.lock', $app->locks()->file($page));
 		Dir::make($root);
 
 		// check if empty
-		$this->assertEquals([], $app->locks()->get($page));
+		$this->assertSame([], $app->locks()->get($page));
 		$this->assertFalse(F::exists($app->locks()->file($page)));
 
 		// set data
@@ -75,7 +75,7 @@ class ContentLocksTest extends TestCase
 
 		// check if exists
 		$this->assertTrue(F::exists($app->locks()->file($page)));
-		$this->assertEquals([
+		$this->assertSame([
 			'lock' => ['user' => 'homer']
 		], $app->locks()->get($page));
 
@@ -83,7 +83,7 @@ class ContentLocksTest extends TestCase
 		$this->assertTrue($app->locks()->set($page, []));
 
 		// check if empty
-		$this->assertEquals([], $app->locks()->get($page));
+		$this->assertSame([], $app->locks()->get($page));
 		$this->assertFalse(F::exists($app->locks()->file($page)));
 	}
 }

--- a/tests/Cms/Content/ContentTest.php
+++ b/tests/Cms/Content/ContentTest.php
@@ -85,7 +85,7 @@ class ContentTest extends TestCase
 		$this->assertInstanceOf(Field::class, $field);
 		$this->assertSame('invalid', $field->key());
 		$this->assertSame($this->parent, $field->parent());
-		$this->assertSame(null, $field->value());
+		$this->assertNull($field->value());
 
 		// all fields
 		$fields = $this->content->get();
@@ -125,31 +125,31 @@ class ContentTest extends TestCase
 	{
 		$content1 = $this->content->not('a');
 		$this->assertNotSame($this->content, $content1);
-		$this->assertSame(null, $content1->get('a')->value());
+		$this->assertNull($content1->get('a')->value());
 		$this->assertSame('B', $content1->get('b')->value());
 
 		$content2 = $this->content->not('A');
 		$this->assertNotSame($this->content, $content2);
-		$this->assertSame(null, $content2->get('a')->value());
+		$this->assertNull($content2->get('a')->value());
 		$this->assertSame('B', $content2->get('b')->value());
 
 		$content3 = $this->content->not('MIxeD');
 		$this->assertNotSame($this->content, $content3);
-		$this->assertSame(null, $content3->get('mixed')->value());
+		$this->assertNull($content3->get('mixed')->value());
 		$this->assertSame('B', $content3->get('b')->value());
 
 		// multiple nots
 		$content4 = $this->content->not('a')->not('MIxed');
 		$this->assertNotSame($this->content, $content4);
-		$this->assertSame(null, $content4->get('a')->value());
-		$this->assertSame(null, $content4->get('mixed')->value());
+		$this->assertNull($content4->get('a')->value());
+		$this->assertNull($content4->get('mixed')->value());
 		$this->assertSame('B', $content4->get('b')->value());
 
 		// multiple nots in one go
 		$content5 = $this->content->not('a', 'MIxed');
 		$this->assertNotSame($this->content, $content5);
-		$this->assertSame(null, $content5->get('a')->value());
-		$this->assertSame(null, $content5->get('mixed')->value());
+		$this->assertNull($content5->get('a')->value());
+		$this->assertNull($content5->get('mixed')->value());
 		$this->assertSame('B', $content5->get('b')->value());
 	}
 

--- a/tests/Cms/Content/ContentTranslationTest.php
+++ b/tests/Cms/Content/ContentTranslationTest.php
@@ -17,9 +17,9 @@ class ContentTranslationTest extends TestCase
 			'code'   => 'de'
 		]);
 
-		$this->assertEquals($page, $translation->parent());
-		$this->assertEquals('de', $translation->code());
-		$this->assertEquals('de', $translation->id());
+		$this->assertSame($page, $translation->parent());
+		$this->assertSame('de', $translation->code());
+		$this->assertSame('de', $translation->id());
 	}
 
 	public function testContentAndSlug()
@@ -37,8 +37,8 @@ class ContentTranslationTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $translation->slug());
-		$this->assertEquals($content, $translation->content());
+		$this->assertSame('test', $translation->slug());
+		$this->assertSame($content, $translation->content());
 	}
 
 	public function testContentFile()
@@ -60,7 +60,7 @@ class ContentTranslationTest extends TestCase
 			'code'   => 'de',
 		]);
 
-		$this->assertEquals('/content/test/project.de.txt', $translation->contentFile());
+		$this->assertSame('/content/test/project.de.txt', $translation->contentFile());
 	}
 
 	public function testExists()
@@ -101,7 +101,7 @@ class ContentTranslationTest extends TestCase
 			'slug'    => null
 		];
 
-		$this->assertEquals($expected, $translation->toArray());
-		$this->assertEquals($expected, $translation->__debugInfo());
+		$this->assertSame($expected, $translation->toArray());
+		$this->assertSame($expected, $translation->__debugInfo());
 	}
 }

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -18,6 +18,7 @@ class EmailTest extends TestCase
 			'one'         => 'eins',
 			'two'         => 'zwei',
 			'transport'   => [],
+			'beforeSend'  => null,
 			'from'        => null,
 			'fromName'    => null,
 			'replyTo'     => null,
@@ -25,12 +26,11 @@ class EmailTest extends TestCase
 			'to'          => [],
 			'cc'          => [],
 			'bcc'         => [],
-			'attachments' => [],
-			'beforeSend'  => null
+			'attachments' => []
 		];
 
 		$email = new Email($props);
-		$this->assertEquals($expected, $email->toArray());
+		$this->assertSame($expected, $email->toArray());
 	}
 
 	public function testPresets()

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -51,8 +51,8 @@ class EmailTest extends TestCase
 			'to' => $to = 'nobody@web.de'
 		]);
 
-		$this->assertEquals([$to], $email->toArray()['to']);
-		$this->assertEquals([$cc], $email->toArray()['cc']);
+		$this->assertSame([$to], $email->toArray()['to']);
+		$this->assertSame([$cc], $email->toArray()['cc']);
 	}
 
 	public function testInvalidPreset()
@@ -76,7 +76,7 @@ class EmailTest extends TestCase
 				'name' => 'Alex'
 			]
 		]);
-		$this->assertEquals('Cheers, Alex!', $email->toArray()['body']);
+		$this->assertSame('Cheers, Alex!', $email->toArray()['body']);
 	}
 
 	public function testTemplateHtml()
@@ -87,7 +87,7 @@ class EmailTest extends TestCase
 			]
 		]);
 		$email = new Email(['template' => 'media']);
-		$this->assertEquals([
+		$this->assertSame([
 			'html' => '<b>Image:</b> <img src=""/>'
 		], $email->toArray()['body']);
 	}
@@ -101,7 +101,7 @@ class EmailTest extends TestCase
 			]
 		]);
 		$email = new Email(['template' => 'media']);
-		$this->assertEquals([
+		$this->assertSame([
 			'html' => '<b>Image:</b> <img src=""/>',
 			'text' => 'Image: Description'
 		], $email->toArray()['body']);
@@ -132,14 +132,14 @@ class EmailTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('sales@company.com', $email->toArray()['from']);
-		$this->assertEquals('Company Sales', $email->toArray()['fromName']);
-		$this->assertEquals(['ceo@company.com'], $email->toArray()['to']);
-		$this->assertEquals([
+		$this->assertSame('sales@company.com', $email->toArray()['from']);
+		$this->assertSame('Company Sales', $email->toArray()['fromName']);
+		$this->assertSame(['ceo@company.com'], $email->toArray()['to']);
+		$this->assertSame([
 			'someone@gmail.com',
 			'another@gmail.com' => 'Another Gmail'
 		], $email->toArray()['cc']);
-		$this->assertEquals([
+		$this->assertSame([
 			'/amazing/absolute/path.txt'
 		], $email->toArray()['attachments']);
 	}
@@ -181,16 +181,16 @@ class EmailTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('sales@company.com', $email->toArray()['from']);
-		$this->assertEquals('Amazing Sales!', $email->toArray()['fromName']);
-		$this->assertEquals('sales@company.com', $email->toArray()['replyTo']);
-		$this->assertEquals('Company Sales', $email->toArray()['replyToName']);
-		$this->assertEquals([
+		$this->assertSame('sales@company.com', $email->toArray()['from']);
+		$this->assertSame('Amazing Sales!', $email->toArray()['fromName']);
+		$this->assertSame('sales@company.com', $email->toArray()['replyTo']);
+		$this->assertSame('Company Sales', $email->toArray()['replyToName']);
+		$this->assertSame([
 			'ceo@company.com' => 'Company CEO',
 			'someone@gmail.com',
 			'another@gmail.com' => 'Another Gmail'
 		], $email->toArray()['to']);
-		$this->assertEquals([
+		$this->assertSame([
 			'/content/report.pdf',
 			'/content/graph.png',
 			'/amazing/absolute/path.txt'
@@ -206,7 +206,7 @@ class EmailTest extends TestCase
 
 		$email = new Email(['to' => $to]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			'ceo@company.com' => 'Company CEO',
 			'marketing@company.com' => 'Company Marketing'
 		], $email->toArray()['to']);
@@ -240,8 +240,8 @@ class EmailTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['ceo@company.com' => 'Mario'], $email->toArray()['to']);
-		$this->assertEquals('Welcome, Mario!', trim($email->toArray()['body']));
+		$this->assertSame(['ceo@company.com' => 'Mario'], $email->toArray()['to']);
+		$this->assertSame('Welcome, Mario!', trim($email->toArray()['body']));
 	}
 
 	public function testBeforeSend()

--- a/tests/Cms/Facades/RTest.php
+++ b/tests/Cms/Facades/RTest.php
@@ -17,6 +17,6 @@ class RTest extends TestCase
 
 	public function testInstance()
 	{
-		$this->assertEquals($this->app->request(), R::instance());
+		$this->assertSame($this->app->request(), R::instance());
 	}
 }

--- a/tests/Cms/Facades/STest.php
+++ b/tests/Cms/Facades/STest.php
@@ -27,6 +27,6 @@ class STest extends TestCase
 
 	public function testInstance()
 	{
-		$this->assertEquals($this->app->session(), S::instance());
+		$this->assertSame($this->app->session(), S::instance());
 	}
 }

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -23,7 +23,7 @@ class UrlTest extends TestCase
 
 	public function testHome()
 	{
-		$this->assertEquals('https://getkirby.com', Url::home());
+		$this->assertSame('https://getkirby.com', Url::home());
 	}
 
 	public function testTo()
@@ -64,15 +64,15 @@ class UrlTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('https://getkirby.com/en/a', Url::to('a'));
-		$this->assertEquals('https://getkirby.com/en/a', Url::to('a', 'en'));
-		$this->assertEquals('https://getkirby.com/de/a', Url::to('a', 'de'));
+		$this->assertSame('https://getkirby.com/en/a', Url::to('a'));
+		$this->assertSame('https://getkirby.com/en/a', Url::to('a', 'en'));
+		$this->assertSame('https://getkirby.com/de/a', Url::to('a', 'de'));
 
-		$this->assertEquals('https://getkirby.com/en/a', Url::to('a', ['language' => 'en']));
-		$this->assertEquals('https://getkirby.com/de/a', Url::to('a', ['language' => 'de']));
+		$this->assertSame('https://getkirby.com/en/a', Url::to('a', ['language' => 'en']));
+		$this->assertSame('https://getkirby.com/de/a', Url::to('a', ['language' => 'de']));
 
 		// translated slug
-		$this->assertEquals('https://getkirby.com/de/custom', Url::to('c', 'de'));
+		$this->assertSame('https://getkirby.com/de/custom', Url::to('c', 'de'));
 	}
 
 	public function testToTemplateAsset()
@@ -99,13 +99,13 @@ class UrlTest extends TestCase
 
 		$expected = 'https://getkirby.com/assets/css/default.css';
 
-		$this->assertEquals($expected, Url::toTemplateAsset('css', 'css'));
+		$this->assertSame($expected, Url::toTemplateAsset('css', 'css'));
 
 		F::write($app->root('assets') . '/js/default.js', 'test');
 
 		$expected = 'https://getkirby.com/assets/js/default.js';
 
-		$this->assertEquals($expected, Url::toTemplateAsset('js', 'js'));
+		$this->assertSame($expected, Url::toTemplateAsset('js', 'js'));
 
 		Dir::remove($fixtures);
 	}

--- a/tests/Cms/Facades/VisitorTest.php
+++ b/tests/Cms/Facades/VisitorTest.php
@@ -17,6 +17,6 @@ class VisitorTest extends TestCase
 
 	public function testInstance()
 	{
-		$this->assertEquals($this->app->visitor(), Visitor::instance());
+		$this->assertSame($this->app->visitor(), Visitor::instance());
 	}
 }

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -345,7 +345,9 @@ class FieldMethodsTest extends TestCase
 			'a',
 		]);
 
-		$this->assertEquals($pages, $this->field($content)->toPages());
+		$result = $this->field($content)->toPages();
+		$this->assertInstanceOf(Pages::class, $result);
+		$this->assertSame([$a], $result->data());
 
 		// multiple pages
 		$pages = new Pages([$a, $b], $app->site());
@@ -355,7 +357,9 @@ class FieldMethodsTest extends TestCase
 			'b'
 		]);
 
-		$this->assertEquals($pages, $this->field($content)->toPages());
+		$result = $this->field($content)->toPages();
+		$this->assertInstanceOf(Pages::class, $result);
+		$this->assertSame($pages->data(), $result->data());
 
 		// no results
 		$content = Yaml::encode([
@@ -363,7 +367,9 @@ class FieldMethodsTest extends TestCase
 			'd'
 		]);
 
-		$this->assertInstanceOf(Pages::class, $this->field($content)->toPages());
+		$result = $this->field($content)->toPages();
+		$this->assertInstanceOf(Pages::class, $result);
+		$this->assertSame([], $result->data());
 	}
 
 	public function testToStructure()

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -347,7 +347,7 @@ class FieldMethodsTest extends TestCase
 
 		$result = $this->field($content)->toPages();
 		$this->assertInstanceOf(Pages::class, $result);
-		$this->assertSame([$a], $result->data());
+		$this->assertSame(['a' => $a], $result->data());
 
 		// multiple pages
 		$pages = new Pages([$a, $b], $app->site());

--- a/tests/Cms/Fields/FieldTest.php
+++ b/tests/Cms/Fields/FieldTest.php
@@ -7,13 +7,13 @@ class FieldTest extends TestCase
 	public function test__debuginfo()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals(['title' => 'Title'], $field->__debugInfo());
+		$this->assertSame(['title' => 'Title'], $field->__debugInfo());
 	}
 
 	public function testKey()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals('title', $field->key());
+		$this->assertSame('title', $field->key());
 	}
 
 	public function testExists()
@@ -34,7 +34,7 @@ class FieldTest extends TestCase
 		$model = new Page(['slug' => 'test']);
 		$field = new Field($model, 'title', 'Title');
 
-		$this->assertEquals($model, $field->model());
+		$this->assertSame($model, $field->model());
 	}
 
 	public function testParent()
@@ -42,46 +42,46 @@ class FieldTest extends TestCase
 		$parent = new Page(['slug' => 'test']);
 		$field  = new Field($parent, 'title', 'Title');
 
-		$this->assertEquals($parent, $field->parent());
+		$this->assertSame($parent, $field->parent());
 	}
 
 	public function testToString()
 	{
 		$field = new Field(null, 'title', 'Title');
 
-		$this->assertEquals('Title', $field->toString());
-		$this->assertEquals('Title', $field->__toString());
-		$this->assertEquals('Title', (string)$field);
+		$this->assertSame('Title', $field->toString());
+		$this->assertSame('Title', $field->__toString());
+		$this->assertSame('Title', (string)$field);
 	}
 
 	public function testToArray()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals(['title' => 'Title'], $field->toArray());
+		$this->assertSame(['title' => 'Title'], $field->toArray());
 	}
 
 	public function testValue()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals('Title', $field->value());
+		$this->assertSame('Title', $field->value());
 	}
 
 	public function testValueSetter()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals('Title', $field->value());
+		$this->assertSame('Title', $field->value());
 		$field = $field->value('Modified');
-		$this->assertEquals('Modified', $field->value());
+		$this->assertSame('Modified', $field->value());
 	}
 
 	public function testValueCallbackSetter()
 	{
 		$field = new Field(null, 'title', 'Title');
-		$this->assertEquals('Title', $field->value());
+		$this->assertSame('Title', $field->value());
 		$field = $field->value(function ($value) {
 			return 'Modified';
 		});
-		$this->assertEquals('Modified', $field->value());
+		$this->assertSame('Modified', $field->value());
 	}
 
 	public function testInvalidValueSetter()
@@ -105,8 +105,8 @@ class FieldTest extends TestCase
 		$original = new Field(null, 'title', 'Title');
 		$modified = $original->test();
 
-		$this->assertEquals('Title', $original->value);
-		$this->assertEquals('Test', $modified->value);
+		$this->assertSame('Title', $original->value);
+		$this->assertSame('Test', $modified->value);
 	}
 
 	public function emptyDataProvider()
@@ -130,7 +130,7 @@ class FieldTest extends TestCase
 	public function testIsEmpty($input, $expected)
 	{
 		$field = new Field(null, 'test', $input);
-		$this->assertEquals($expected, $field->isEmpty());
+		$this->assertSame($expected, $field->isEmpty());
 	}
 
 	/**
@@ -139,7 +139,7 @@ class FieldTest extends TestCase
 	public function testIsNotEmpty($input, $expected)
 	{
 		$field = new Field(null, 'test', $input);
-		$this->assertEquals(!$expected, $field->isNotEmpty());
+		$this->assertSame(!$expected, $field->isNotEmpty());
 	}
 
 	public function testCallNonExistingMethod()
@@ -147,7 +147,7 @@ class FieldTest extends TestCase
 		$field  = new Field(null, 'test', 'value');
 		$result = $field->methodDoesNotExist();
 
-		$this->assertEquals($field, $result);
+		$this->assertSame($field, $result);
 	}
 
 	public function testOrWithFieldFallback()
@@ -156,6 +156,6 @@ class FieldTest extends TestCase
 		$field    = new Field(null, 'test', '');
 		$result   = $field->or($fallback);
 
-		$this->assertEquals($fallback, $result);
+		$this->assertSame($fallback, $result);
 	}
 }

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -109,7 +109,7 @@ class FileActionsTest extends TestCase
 		$result = $file->changeName('test');
 
 		$this->assertNotEquals($file->root(), $result->root());
-		$this->assertEquals('test.csv', $result->filename());
+		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
 		$this->assertFileExists($result->contentFile());
 	}
@@ -145,7 +145,7 @@ class FileActionsTest extends TestCase
 		$result = $file->changeName('test');
 
 		$this->assertNotEquals($file->root(), $result->root());
-		$this->assertEquals('test.csv', $result->filename());
+		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
 		$this->assertFileExists($result->contentFile('en'));
 		$this->assertFileExists($result->contentFile('de'));
@@ -230,8 +230,8 @@ class FileActionsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('A', $result->a()->value());
-		$this->assertEquals('B', $result->b()->value());
+		$this->assertSame('A', $result->a()->value());
+		$this->assertSame('B', $result->b()->value());
 	}
 
 	/**
@@ -266,8 +266,8 @@ class FileActionsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Custom A', $result->a()->value());
-		$this->assertEquals('B', $result->b()->value());
+		$this->assertSame('Custom A', $result->a()->value());
+		$this->assertSame('B', $result->b()->value());
 	}
 
 	/**
@@ -305,7 +305,7 @@ class FileActionsTest extends TestCase
 				'file.create:after' => function (File $file) use (&$after, $phpunit) {
 					$phpunit->assertTrue($file->siblings(true)->has($file));
 					$phpunit->assertTrue($file->parent()->files()->has($file));
-					$phpunit->assertEquals('test.md', $file->filename());
+					$phpunit->assertSame('test.md', $file->filename());
 
 					$after = true;
 				}
@@ -379,12 +379,12 @@ class FileActionsTest extends TestCase
 			'parent'   => $parent
 		]);
 
-		$this->assertEquals(F::read($original), F::read($originalFile->root()));
+		$this->assertSame(F::read($original), F::read($originalFile->root()));
 		$this->assertInstanceOf(BaseFile::class, $originalFile->asset());
 
 		$replacedFile = $originalFile->replace($replacement);
 
-		$this->assertEquals(F::read($replacement), F::read($replacedFile->root()));
+		$this->assertSame(F::read($replacement), F::read($replacedFile->root()));
 		$this->assertInstanceOf(BaseFile::class, $replacedFile->asset());
 	}
 
@@ -451,7 +451,7 @@ class FileActionsTest extends TestCase
 			'caption' => $caption = 'test'
 		]);
 
-		$this->assertEquals($caption, $file->caption()->value());
+		$this->assertSame($caption, $file->caption()->value());
 	}
 
 	public function testChangeNameHooks()

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -40,7 +40,7 @@ class FileBlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('gallery', $file->template());
+		$this->assertSame('gallery', $file->template());
 	}
 
 	public function testCustomTemplate()
@@ -55,7 +55,7 @@ class FileBlueprintTest extends TestCase
 			'template' => 'gallery'
 		]);
 
-		$this->assertEquals('gallery', $file->template());
+		$this->assertSame('gallery', $file->template());
 	}
 
 	public function testDefaultBlueprint()
@@ -99,7 +99,7 @@ class FileBlueprintTest extends TestCase
 		$blueprint = $file->blueprint();
 
 		$this->assertInstanceOf(FileBlueprint::class, $blueprint);
-		$this->assertEquals('Gallery', $blueprint->title());
+		$this->assertSame('Gallery', $blueprint->title());
 	}
 
 	public function testAccept()
@@ -369,6 +369,6 @@ class FileBlueprintTest extends TestCase
 		]);
 
 		$blueprint = $file->blueprint();
-		$this->assertEquals(['image/jpeg'], $blueprint->accept()['mime']);
+		$this->assertSame(['image/jpeg'], $blueprint->accept()['mime']);
 	}
 }

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -23,7 +23,7 @@ class FileBlueprintTest extends TestCase
 			'update'     => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertSame($expected, $blueprint->options());
 	}
 
 	public function testTemplateFromContent()

--- a/tests/Cms/Files/FileMethodsTest.php
+++ b/tests/Cms/Files/FileMethodsTest.php
@@ -39,12 +39,12 @@ class FileMethodsTest extends TestCase
 	public function testFileMethod()
 	{
 		$file = $this->app->file('test/test.jpg');
-		$this->assertEquals('file method', $file->test());
+		$this->assertSame('file method', $file->test());
 	}
 
 	public function testFilesMethod()
 	{
 		$files = $this->app->page('test')->files();
-		$this->assertEquals('files method', $files->test());
+		$this->assertSame('files method', $files->test());
 	}
 }

--- a/tests/Cms/Files/FileSiblingsTest.php
+++ b/tests/Cms/Files/FileSiblingsTest.php
@@ -115,7 +115,7 @@ class FileSiblingsTest extends TestCase
 		$siblings = $files->not($file);
 
 		$this->assertSame($files, $file->siblings());
-		$this->assertEquals($siblings, $file->siblings(false));
+		$this->assertEquals($siblings, $file->siblings(false)); // cannot use strict assertion (cloned object)
 	}
 
 	public function testTemplateSiblings()

--- a/tests/Cms/Files/FileSiblingsTest.php
+++ b/tests/Cms/Files/FileSiblingsTest.php
@@ -42,9 +42,9 @@ class FileSiblingsTest extends TestCase
 	{
 		$collection = $this->files();
 
-		$this->assertEquals(0, $collection->first()->indexOf());
-		$this->assertEquals(1, $collection->nth(1)->indexOf());
-		$this->assertEquals(3, $collection->last()->indexOf());
+		$this->assertSame(0, $collection->first()->indexOf());
+		$this->assertSame(1, $collection->nth(1)->indexOf());
+		$this->assertSame(3, $collection->last()->indexOf());
 	}
 
 	public function testIsFirst()
@@ -76,7 +76,7 @@ class FileSiblingsTest extends TestCase
 	{
 		$collection = $this->files();
 
-		$this->assertEquals($collection->first()->next(), $collection->nth(1));
+		$this->assertSame($collection->first()->next(), $collection->nth(1));
 	}
 
 	public function testNextAll()
@@ -86,15 +86,15 @@ class FileSiblingsTest extends TestCase
 
 		$this->assertCount(3, $first->nextAll());
 
-		$this->assertEquals($first->nextAll()->first(), $collection->nth(1));
-		$this->assertEquals($first->nextAll()->last(), $collection->nth(3));
+		$this->assertSame($first->nextAll()->first(), $collection->nth(1));
+		$this->assertSame($first->nextAll()->last(), $collection->nth(3));
 	}
 
 	public function testPrev()
 	{
 		$collection = $this->files();
 
-		$this->assertEquals($collection->last()->prev(), $collection->nth(2));
+		$this->assertSame($collection->last()->prev(), $collection->nth(2));
 	}
 
 	public function testPrevAll()
@@ -104,8 +104,8 @@ class FileSiblingsTest extends TestCase
 
 		$this->assertCount(3, $last->prevAll());
 
-		$this->assertEquals($last->prevAll()->first(), $collection->nth(0));
-		$this->assertEquals($last->prevAll()->last(), $collection->nth(2));
+		$this->assertSame($last->prevAll()->first(), $collection->nth(0));
+		$this->assertSame($last->prevAll()->last(), $collection->nth(2));
 	}
 
 	public function testSiblings()
@@ -114,7 +114,7 @@ class FileSiblingsTest extends TestCase
 		$file     = $files->nth(1);
 		$siblings = $files->not($file);
 
-		$this->assertEquals($files, $file->siblings());
+		$this->assertSame($files, $file->siblings());
 		$this->assertEquals($siblings, $file->siblings(false));
 	}
 

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -37,7 +37,7 @@ class FileTest extends TestCase
 	{
 		$file = $this->file();
 		$this->assertInstanceOf('Kirby\Filesystem\File', $file->asset());
-		$this->assertEquals('https://getkirby.com/projects/project-a/cover.jpg', $file->asset()->url());
+		$this->assertSame('https://getkirby.com/projects/project-a/cover.jpg', $file->asset()->url());
 	}
 
 	public function testContent()
@@ -48,7 +48,7 @@ class FileTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Test', $file->content()->get('test')->value());
+		$this->assertSame('Test', $file->content()->get('test')->value());
 	}
 
 	public function testDefaultContent()
@@ -60,7 +60,7 @@ class FileTest extends TestCase
 
 	public function testFilename()
 	{
-		$this->assertEquals($this->defaults()['filename'], $this->file()->filename());
+		$this->assertSame($this->defaults()['filename'], $this->file()->filename());
 	}
 
 	public function testPage()
@@ -102,13 +102,13 @@ class FileTest extends TestCase
 
 	public function testUrl()
 	{
-		$this->assertEquals($this->defaults()['url'], $this->file()->url());
+		$this->assertSame($this->defaults()['url'], $this->file()->url());
 	}
 
 	public function testToString()
 	{
 		$file = $this->file(['filename' => 'super.jpg']);
-		$this->assertEquals('super.jpg', $file->toString('{{ file.filename }}'));
+		$this->assertSame('super.jpg', $file->toString('{{ file.filename }}'));
 	}
 
 	public function testIsReadable()
@@ -209,15 +209,15 @@ class FileTest extends TestCase
 		$modified = filemtime($file);
 		$file     = $app->file('test.js');
 
-		$this->assertEquals($modified, $file->modified());
+		$this->assertSame($modified, $file->modified());
 
 		// default date handler
 		$format = 'd.m.Y';
-		$this->assertEquals(date($format, $modified), $file->modified($format));
+		$this->assertSame(date($format, $modified), $file->modified($format));
 
 		// custom date handler
 		$format = '%d.%m.%Y';
-		$this->assertEquals(@strftime($format, $modified), $file->modified($format, 'strftime'));
+		$this->assertSame(@strftime($format, $modified), $file->modified($format, 'strftime'));
 
 		Dir::remove(dirname($index));
 	}
@@ -241,7 +241,7 @@ class FileTest extends TestCase
 		$file = $app->file('test.js');
 
 		$this->assertNotEquals($modifiedFile, $file->modified());
-		$this->assertEquals($modifiedContent, $file->modified());
+		$this->assertSame($modifiedContent, $file->modified());
 
 		Dir::remove(dirname($index));
 	}
@@ -279,8 +279,8 @@ class FileTest extends TestCase
 
 		$file = $app->file('test.js');
 
-		$this->assertEquals($modifiedEnContent, $file->modified(null, null, 'en'));
-		$this->assertEquals($modifiedDeContent, $file->modified(null, null, 'de'));
+		$this->assertSame($modifiedEnContent, $file->modified(null, null, 'en'));
+		$this->assertSame($modifiedDeContent, $file->modified(null, null, 'de'));
 
 		Dir::remove(dirname($index));
 	}
@@ -473,20 +473,20 @@ class FileTest extends TestCase
 		// site file
 		$file = $app->file('site-file.jpg');
 
-		$this->assertEquals('https://getkirby.com/api/site/files/site-file.jpg', $file->apiUrl());
-		$this->assertEquals('site/files/site-file.jpg', $file->apiUrl(true));
+		$this->assertSame('https://getkirby.com/api/site/files/site-file.jpg', $file->apiUrl());
+		$this->assertSame('site/files/site-file.jpg', $file->apiUrl(true));
 
 		// page file
 		$file = $app->file('mother/child/page-file.jpg');
 
-		$this->assertEquals('https://getkirby.com/api/pages/mother+child/files/page-file.jpg', $file->apiUrl());
-		$this->assertEquals('pages/mother+child/files/page-file.jpg', $file->apiUrl(true));
+		$this->assertSame('https://getkirby.com/api/pages/mother+child/files/page-file.jpg', $file->apiUrl());
+		$this->assertSame('pages/mother+child/files/page-file.jpg', $file->apiUrl(true));
 
 		// user file
 		$user = $app->user('test@getkirby.com');
 		$file = $user->file('user-file.jpg');
 
-		$this->assertEquals('https://getkirby.com/api/users/test/files/user-file.jpg', $file->apiUrl());
-		$this->assertEquals('users/test/files/user-file.jpg', $file->apiUrl(true));
+		$this->assertSame('https://getkirby.com/api/users/test/files/user-file.jpg', $file->apiUrl());
+		$this->assertSame('users/test/files/user-file.jpg', $file->apiUrl(true));
 	}
 }

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -28,8 +28,8 @@ class FilesTest extends TestCase
 		$result = $files->add($file);
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a.jpg', $result->nth(0)->filename());
-		$this->assertEquals('b.jpg', $result->nth(1)->filename());
+		$this->assertSame('a.jpg', $result->nth(0)->filename());
+		$this->assertSame('b.jpg', $result->nth(1)->filename());
 	}
 
 	public function testAddCollection()
@@ -48,9 +48,9 @@ class FilesTest extends TestCase
 		$c = $a->add($b);
 
 		$this->assertCount(3, $c);
-		$this->assertEquals('a.jpg', $c->nth(0)->filename());
-		$this->assertEquals('b.jpg', $c->nth(1)->filename());
-		$this->assertEquals('c.jpg', $c->nth(2)->filename());
+		$this->assertSame('a.jpg', $c->nth(0)->filename());
+		$this->assertSame('b.jpg', $c->nth(1)->filename());
+		$this->assertSame('c.jpg', $c->nth(2)->filename());
 	}
 
 	public function testAddById()
@@ -81,9 +81,9 @@ class FilesTest extends TestCase
 		$files = $app->page('a')->files()->add('b/a.jpg');
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('a/a.jpg', $files->nth(0)->id());
-		$this->assertEquals('a/b.jpg', $files->nth(1)->id());
-		$this->assertEquals('b/a.jpg', $files->nth(2)->id());
+		$this->assertSame('a/a.jpg', $files->nth(0)->id());
+		$this->assertSame('a/b.jpg', $files->nth(1)->id());
+		$this->assertSame('b/a.jpg', $files->nth(2)->id());
 	}
 
 	public function testAddNull()

--- a/tests/Cms/Files/HasFilesTest.php
+++ b/tests/Cms/Files/HasFilesTest.php
@@ -74,7 +74,7 @@ class HasFilesTest extends TestCase
 		]);
 
 		$file = $page->file('child/file.jpg');
-		$this->assertEquals('mother/child/file.jpg', $file->id());
+		$this->assertSame('mother/child/file.jpg', $file->id());
 	}
 
 	/**
@@ -110,7 +110,7 @@ class HasFilesTest extends TestCase
 			new File(['filename' => $filename, 'parent' => $page])
 		]);
 
-		$this->assertEquals($expected, $parent->{'has' . $type}());
+		$this->assertSame($expected, $parent->{'has' . $type}());
 	}
 
 	public function testHasFiles()

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -46,8 +46,8 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('kirby');
-		$this->assertEquals('a.jpg', Find::file('pages/a', 'a.jpg')->filename());
-		$this->assertEquals('aa.jpg', Find::file('pages/a+aa', 'aa.jpg')->filename());
+		$this->assertSame('a.jpg', Find::file('pages/a', 'a.jpg')->filename());
+		$this->assertSame('aa.jpg', Find::file('pages/a+aa', 'aa.jpg')->filename());
 	}
 
 	/**
@@ -64,7 +64,7 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('kirby');
-		$this->assertEquals('test.jpg', Find::file('site', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', Find::file('site', 'test.jpg')->filename());
 	}
 
 	/**
@@ -84,7 +84,7 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('kirby');
-		$this->assertEquals('test.jpg', Find::file('users/test@getkirby.com', 'test.jpg')->filename());
+		$this->assertSame('test.jpg', Find::file('users/test@getkirby.com', 'test.jpg')->filename());
 	}
 
 	/**
@@ -183,8 +183,8 @@ class FindTest extends TestCase
 		$a  = $app->page('a');
 		$aa = $app->page('a/aa');
 
-		$this->assertEquals($a, Find::page('a'));
-		$this->assertEquals($aa, Find::page('a+aa'));
+		$this->assertSame($a, Find::page('a'));
+		$this->assertSame($aa, Find::page('a+aa'));
 	}
 
 	/**
@@ -327,7 +327,7 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('kirby');
-		$this->assertEquals('test@getkirby.com', Find::user('test@getkirby.com')->email());
+		$this->assertSame('test@getkirby.com', Find::user('test@getkirby.com')->email());
 	}
 
 	/**
@@ -349,7 +349,7 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('test@getkirby.com');
-		$this->assertEquals('test@getkirby.com', Find::user()->email());
+		$this->assertSame('test@getkirby.com', Find::user()->email());
 	}
 
 	/**
@@ -393,7 +393,7 @@ class FindTest extends TestCase
 		]);
 
 		$app->impersonate('test@getkirby.com');
-		$this->assertEquals('test@getkirby.com', Find::user('account')->email());
+		$this->assertSame('test@getkirby.com', Find::user('account')->email());
 	}
 
 	/**

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -641,7 +641,7 @@ class HelperFunctionsTest extends TestCase
 	{
 		$this->assertSame('a', r(1 === 1, 'a', 'b'));
 		$this->assertSame('b', r(1 === 2, 'a', 'b'));
-		$this->assertSame(null, r(1 === 2, 'a'));
+		$this->assertNull(r(1 === 2, 'a'));
 	}
 
 	public function testRouter()

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -117,7 +117,7 @@ class HelpersTest extends TestCase
 			$this->assertSame('Some warning', $errstr);
 		});
 
-		$this->assertSame(true, Helpers::handleErrors(
+		$this->assertTrue(Helpers::handleErrors(
 			fn () => trigger_error('Some warning', E_USER_WARNING),
 			function (int $errno, string $errstr) {
 				$this->assertSame(E_USER_WARNING, $errno);

--- a/tests/Cms/Ingredients/IngredientsTest.php
+++ b/tests/Cms/Ingredients/IngredientsTest.php
@@ -20,14 +20,14 @@ class IngredientsTest extends TestCase
 
 	public function testGet()
 	{
-		$this->assertEquals('A', $this->ingredients->a);
-		$this->assertEquals('B', $this->ingredients->b);
+		$this->assertSame('A', $this->ingredients->a);
+		$this->assertSame('B', $this->ingredients->b);
 	}
 
 	public function testCall()
 	{
-		$this->assertEquals('A', $this->ingredients->a());
-		$this->assertEquals('B', $this->ingredients->b());
+		$this->assertSame('A', $this->ingredients->a());
+		$this->assertSame('B', $this->ingredients->b());
 	}
 
 	public function testToArray()
@@ -37,7 +37,7 @@ class IngredientsTest extends TestCase
 			'b' => 'B'
 		];
 
-		$this->assertEquals($expected, $this->ingredients->toArray());
-		$this->assertEquals($expected, $this->ingredients->__debugInfo());
+		$this->assertSame($expected, $this->ingredients->toArray());
+		$this->assertSame($expected, $this->ingredients->__debugInfo());
 	}
 }

--- a/tests/Cms/Ingredients/UrlsTest.php
+++ b/tests/Cms/Ingredients/UrlsTest.php
@@ -26,7 +26,7 @@ class UrlsTest extends TestCase
 
 		$urls = $app->urls();
 
-		$this->assertEquals($url, $urls->$method());
+		$this->assertSame($url, $urls->$method());
 	}
 
 	public function customBaseUrlProvider(): array
@@ -52,7 +52,7 @@ class UrlsTest extends TestCase
 		]);
 
 		$urls = $app->urls();
-		$this->assertEquals($url, $urls->$method());
+		$this->assertSame($url, $urls->$method());
 	}
 
 	public function customUrlProvider(): array
@@ -79,7 +79,7 @@ class UrlsTest extends TestCase
 		]);
 
 		$urls = $app->urls();
-		$this->assertEquals($url, $urls->$method());
+		$this->assertSame($url, $urls->$method());
 	}
 
 	public function testCurrent()
@@ -90,7 +90,7 @@ class UrlsTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals('/', $app->url('current'));
+		$this->assertSame('/', $app->url('current'));
 	}
 
 	public function testCurrentInSubfolderSetup()
@@ -103,8 +103,8 @@ class UrlsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('http://localhost/starterkit', $app->url('index'));
-		$this->assertEquals('http://localhost/starterkit', $app->url('current'));
+		$this->assertSame('http://localhost/starterkit', $app->url('index'));
+		$this->assertSame('http://localhost/starterkit', $app->url('current'));
 
 		$app = $this->app->clone([
 			'cli' => false,
@@ -115,8 +115,8 @@ class UrlsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('http://localhost/starterkit', $app->url('index'));
-		$this->assertEquals('http://localhost/starterkit/sub/folder', $app->url('current'));
+		$this->assertSame('http://localhost/starterkit', $app->url('index'));
+		$this->assertSame('http://localhost/starterkit/sub/folder', $app->url('current'));
 	}
 
 	public function testCurrentWithCustomIndex()
@@ -130,7 +130,7 @@ class UrlsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('http://getkirby.com', $app->url('current'));
+		$this->assertSame('http://getkirby.com', $app->url('current'));
 	}
 
 	public function testCurrentWithCustomPath()
@@ -142,7 +142,7 @@ class UrlsTest extends TestCase
 			'path' => 'test/path'
 		]);
 
-		$this->assertEquals('/test/path', $app->url('current'));
+		$this->assertSame('/test/path', $app->url('current'));
 	}
 
 	public function testCurrentWithCustomPathAndCustomIndex()
@@ -157,6 +157,6 @@ class UrlsTest extends TestCase
 			'path' => 'test/path'
 		]);
 
-		$this->assertEquals('http://getkirby.com/test/path', $app->url('current'));
+		$this->assertSame('http://getkirby.com/test/path', $app->url('current'));
 	}
 }

--- a/tests/Cms/Items/ItemsTest.php
+++ b/tests/Cms/Items/ItemsTest.php
@@ -48,8 +48,8 @@ class ItemsTest extends TestCase
 
 		$this->assertCount(2, $items);
 		$this->assertSame($items, $items->first()->siblings());
-		$this->assertEquals('a', $items->first()->id());
-		$this->assertEquals('b', $items->last()->id());
+		$this->assertSame('a', $items->first()->id());
+		$this->assertSame('b', $items->last()->id());
 	}
 
 	public function testParent()

--- a/tests/Cms/KirbyTextTest.php
+++ b/tests/Cms/KirbyTextTest.php
@@ -19,9 +19,9 @@ class KirbyTextTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>test</p>', $app->kirbytext('Test'));
+		$this->assertSame('<p>test</p>', $app->kirbytext('Test'));
 		// Let's see if it works twice
-		$this->assertEquals('<p>test</p>', $app->kirbytext('Test'));
+		$this->assertSame('<p>test</p>', $app->kirbytext('Test'));
 	}
 
 	public function testAfterHook()
@@ -37,8 +37,8 @@ class KirbyTextTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Test', $app->kirbytext('Test'));
+		$this->assertSame('Test', $app->kirbytext('Test'));
 		// Let's see if it works twice
-		$this->assertEquals('Test', $app->kirbytext('Test'));
+		$this->assertSame('Test', $app->kirbytext('Test'));
 	}
 }

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -51,9 +51,9 @@ class LanguageRouterTest extends TestCase
 		$routes   = $router->routes();
 
 		$this->assertCount(1, $routes);
-		$this->assertEquals('(:any)', $routes[0]['pattern']);
-		$this->assertEquals('en', $routes[0]['language']);
-		$this->assertEquals('en', $router->call('anything'));
+		$this->assertSame('(:any)', $routes[0]['pattern']);
+		$this->assertSame('en', $routes[0]['language']);
+		$this->assertSame('en', $router->call('anything'));
 	}
 
 	public function testRouteWithoutLanguageScope()
@@ -93,9 +93,9 @@ class LanguageRouterTest extends TestCase
 		$routes   = $router->routes();
 
 		$this->assertCount(1, $routes);
-		$this->assertEquals('(:any)', $routes[0]['pattern']);
-		$this->assertEquals('en|de', $routes[0]['language']);
-		$this->assertEquals('slug', $router->call('slug'));
+		$this->assertSame('(:any)', $routes[0]['pattern']);
+		$this->assertSame('en|de', $routes[0]['language']);
+		$this->assertSame('slug', $router->call('slug'));
 	}
 
 	public function testRouteWildcard()
@@ -117,9 +117,9 @@ class LanguageRouterTest extends TestCase
 		$routes   = $router->routes();
 
 		$this->assertCount(1, $routes);
-		$this->assertEquals('(:any)', $routes[0]['pattern']);
-		$this->assertEquals('*', $routes[0]['language']);
-		$this->assertEquals('slug', $router->call('slug'));
+		$this->assertSame('(:any)', $routes[0]['pattern']);
+		$this->assertSame('*', $routes[0]['language']);
+		$this->assertSame('slug', $router->call('slug'));
 	}
 
 	public function testRouteWithPageScope()
@@ -145,7 +145,7 @@ class LanguageRouterTest extends TestCase
 		$language = $app->language('en');
 		$router   = $language->router();
 
-		$this->assertEquals('slug', $router->call('notes/slug'));
+		$this->assertSame('slug', $router->call('notes/slug'));
 	}
 
 	public function testRouteWithPageScopeAndMultiplePatterns()
@@ -174,8 +174,8 @@ class LanguageRouterTest extends TestCase
 		$language = $app->language('en');
 		$router   = $language->router();
 
-		$this->assertEquals('slug', $router->call('notes/a/slug'));
-		$this->assertEquals('slug', $router->call('notes/b/slug'));
+		$this->assertSame('slug', $router->call('notes/a/slug'));
+		$this->assertSame('slug', $router->call('notes/b/slug'));
 	}
 
 	public function testRouteWithPageScopeAndInvalidPage()

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -136,9 +136,9 @@ class LanguageTest extends TestCase
 		$this->assertSame([
 			LC_CTYPE => 'en_US.utf8'
 		], $language->locale());
-		$this->assertSame(null, $language->locale(LC_ALL));
+		$this->assertNull($language->locale(LC_ALL));
 		$this->assertSame('en_US.utf8', $language->locale(LC_CTYPE));
-		$this->assertSame(null, $language->locale(LC_MONETARY));
+		$this->assertNull($language->locale(LC_MONETARY));
 	}
 
 	public function testLocaleArray3()
@@ -258,12 +258,12 @@ class LanguageTest extends TestCase
 		$data = include $file;
 
 		$this->assertSame('de', $data['code']);
-		$this->assertSame(false, $data['default']);
+		$this->assertFalse($data['default']);
 		$this->assertSame('ltr', $data['direction']);
 		$this->assertSame(['LC_ALL' => 'de'], $data['locale']);
 		$this->assertSame('de', $data['name']);
 		$this->assertSame([], $data['translations']);
-		$this->assertSame(null, $data['url'] ?? null);
+		$this->assertNull($data['url'] ?? null);
 
 
 		// custom url
@@ -477,7 +477,7 @@ class LanguageTest extends TestCase
 		]);
 
 		$this->assertSame('en', $language->code());
-		$this->assertSame(true, $language->isDefault());
+		$this->assertTrue($language->isDefault());
 		$this->assertSame('ltr', $language->direction());
 		$this->assertSame('en', $language->name());
 		$this->assertSame('/en', $language->url());

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -35,8 +35,8 @@ class LanguageTest extends TestCase
 			'code' => 'en'
 		]);
 
-		$this->assertEquals('en', $language->code());
-		$this->assertEquals('en', $language->id());
+		$this->assertSame('en', $language->code());
+		$this->assertSame('en', $language->id());
 	}
 
 	public function testDefaultDefault()
@@ -75,21 +75,21 @@ class LanguageTest extends TestCase
 			'direction' => 'rtl'
 		]);
 
-		$this->assertEquals('rtl', $language->direction());
+		$this->assertSame('rtl', $language->direction());
 
 		$language = new Language([
 			'code'      => 'en',
 			'direction' => 'ltr'
 		]);
 
-		$this->assertEquals('ltr', $language->direction());
+		$this->assertSame('ltr', $language->direction());
 
 		$language = new Language([
 			'code'      => 'en',
 			'direction' => 'invalid'
 		]);
 
-		$this->assertEquals('ltr', $language->direction());
+		$this->assertSame('ltr', $language->direction());
 	}
 
 	public function testLocale()
@@ -99,10 +99,10 @@ class LanguageTest extends TestCase
 			'locale' => 'en_US'
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			LC_ALL => 'en_US'
 		], $language->locale());
-		$this->assertEquals('en_US', $language->locale(LC_ALL));
+		$this->assertSame('en_US', $language->locale(LC_ALL));
 	}
 
 	public function testLocaleArray1()
@@ -115,13 +115,13 @@ class LanguageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			LC_ALL   => 'en_US',
 			LC_CTYPE => 'en_US.utf8'
 		], $language->locale());
-		$this->assertEquals('en_US', $language->locale(LC_ALL));
-		$this->assertEquals('en_US.utf8', $language->locale(LC_CTYPE));
-		$this->assertEquals('en_US', $language->locale(LC_MONETARY));
+		$this->assertSame('en_US', $language->locale(LC_ALL));
+		$this->assertSame('en_US.utf8', $language->locale(LC_CTYPE));
+		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
 	public function testLocaleArray2()
@@ -133,12 +133,12 @@ class LanguageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			LC_CTYPE => 'en_US.utf8'
 		], $language->locale());
-		$this->assertEquals(null, $language->locale(LC_ALL));
-		$this->assertEquals('en_US.utf8', $language->locale(LC_CTYPE));
-		$this->assertEquals(null, $language->locale(LC_MONETARY));
+		$this->assertSame(null, $language->locale(LC_ALL));
+		$this->assertSame('en_US.utf8', $language->locale(LC_CTYPE));
+		$this->assertSame(null, $language->locale(LC_MONETARY));
 	}
 
 	public function testLocaleArray3()
@@ -151,13 +151,13 @@ class LanguageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			LC_ALL   => 'en_US',
 			LC_CTYPE => 'en_US.utf8'
 		], $language->locale());
-		$this->assertEquals('en_US', $language->locale(LC_ALL));
-		$this->assertEquals('en_US.utf8', $language->locale(LC_CTYPE));
-		$this->assertEquals('en_US', $language->locale(LC_MONETARY));
+		$this->assertSame('en_US', $language->locale(LC_ALL));
+		$this->assertSame('en_US.utf8', $language->locale(LC_CTYPE));
+		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
 	public function testLocaleInvalid()
@@ -176,7 +176,7 @@ class LanguageTest extends TestCase
 			'code' => 'en',
 		]);
 
-		$this->assertEquals('en', $language->locale(LC_ALL));
+		$this->assertSame('en', $language->locale(LC_ALL));
 	}
 
 	public function testName()
@@ -186,7 +186,7 @@ class LanguageTest extends TestCase
 			'name' => 'English'
 		]);
 
-		$this->assertEquals('English', $language->name());
+		$this->assertSame('English', $language->name());
 	}
 
 	public function testNameDefault()
@@ -195,7 +195,7 @@ class LanguageTest extends TestCase
 			'code' => 'en',
 		]);
 
-		$this->assertEquals('en', $language->name());
+		$this->assertSame('en', $language->name());
 	}
 
 	public function testUrlWithRelativeValue()
@@ -205,7 +205,7 @@ class LanguageTest extends TestCase
 			'url'  => 'super'
 		]);
 
-		$this->assertEquals('/super', $language->url());
+		$this->assertSame('/super', $language->url());
 	}
 
 	public function testUrlWithAbsoluteValue()
@@ -215,7 +215,7 @@ class LanguageTest extends TestCase
 			'url'  => 'https://en.getkirby.com'
 		]);
 
-		$this->assertEquals('https://en.getkirby.com', $language->url());
+		$this->assertSame('https://en.getkirby.com', $language->url());
 	}
 
 	public function testUrlWithDash()
@@ -225,7 +225,7 @@ class LanguageTest extends TestCase
 			'url'  => '/'
 		]);
 
-		$this->assertEquals('/', $language->url());
+		$this->assertSame('/', $language->url());
 	}
 
 	public function testUrlDefault()
@@ -234,7 +234,7 @@ class LanguageTest extends TestCase
 			'code' => 'en',
 		]);
 
-		$this->assertEquals('/en', $language->url());
+		$this->assertSame('/en', $language->url());
 	}
 
 	public function testSave()
@@ -257,13 +257,13 @@ class LanguageTest extends TestCase
 
 		$data = include $file;
 
-		$this->assertEquals('de', $data['code']);
-		$this->assertEquals(false, $data['default']);
-		$this->assertEquals('ltr', $data['direction']);
-		$this->assertEquals(['LC_ALL' => 'de'], $data['locale']);
-		$this->assertEquals('de', $data['name']);
-		$this->assertEquals([], $data['translations']);
-		$this->assertEquals(null, $data['url'] ?? null);
+		$this->assertSame('de', $data['code']);
+		$this->assertSame(false, $data['default']);
+		$this->assertSame('ltr', $data['direction']);
+		$this->assertSame(['LC_ALL' => 'de'], $data['locale']);
+		$this->assertSame('de', $data['name']);
+		$this->assertSame([], $data['translations']);
+		$this->assertSame(null, $data['url'] ?? null);
 
 
 		// custom url
@@ -276,7 +276,7 @@ class LanguageTest extends TestCase
 
 		$data = include $file;
 
-		$this->assertEquals('/', $data['url']);
+		$this->assertSame('/', $data['url']);
 
 
 		// custom translations
@@ -291,7 +291,7 @@ class LanguageTest extends TestCase
 
 		$data = include $file;
 
-		$this->assertEquals(['foo' => 'bar'], $data['translations']);
+		$this->assertSame(['foo' => 'bar'], $data['translations']);
 
 
 		// custom props in file
@@ -305,7 +305,7 @@ class LanguageTest extends TestCase
 
 		$data = include $file;
 
-		$this->assertEquals('test', $data['custom']);
+		$this->assertSame('test', $data['custom']);
 
 		Dir::remove($fixtures);
 	}
@@ -337,8 +337,8 @@ class LanguageTest extends TestCase
 			'url'       => '/de'
 		];
 
-		$this->assertEquals($expected, $language->toArray());
-		$this->assertEquals($expected, $language->__debugInfo());
+		$this->assertSame($expected, $language->toArray());
+		$this->assertSame($expected, $language->__debugInfo());
 	}
 
 	public function testExists()
@@ -374,7 +374,7 @@ class LanguageTest extends TestCase
 			'code' => 'de'
 		]);
 
-		$this->assertEquals($fixtures . '/site/languages/de.php', $language->root());
+		$this->assertSame($fixtures . '/site/languages/de.php', $language->root());
 	}
 
 	public function pathProvider()
@@ -401,7 +401,7 @@ class LanguageTest extends TestCase
 			'url'  => $input
 		]);
 
-		$this->assertEquals($expected, $language->path());
+		$this->assertSame($expected, $language->path());
 	}
 
 	public function patternProvider()
@@ -430,7 +430,7 @@ class LanguageTest extends TestCase
 			'url'  => $input
 		]);
 
-		$this->assertEquals($expected, $language->pattern());
+		$this->assertSame($expected, $language->pattern());
 	}
 
 	public function baseUrlProvider()
@@ -467,7 +467,7 @@ class LanguageTest extends TestCase
 			'url'  => $url
 		]);
 
-		$this->assertEquals($expected, $language->baseUrl());
+		$this->assertSame($expected, $language->baseUrl());
 	}
 
 	public function testCreate()

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -113,7 +113,7 @@ class LanguagesTest extends TestCase
 		]);
 
 		$this->assertSame('tr', $language->code());
-		$this->assertSame(false, $language->isDefault());
+		$this->assertFalse($language->isDefault());
 		$this->assertSame('ltr', $language->direction());
 		$this->assertSame('tr', $language->name());
 		$this->assertSame('/tr', $language->url());

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -47,8 +47,8 @@ class LanguagesTest extends TestCase
 	public function testLoad()
 	{
 		$this->assertCount(2, $this->languages);
-		$this->assertEquals(['en', 'de'], $this->languages->codes());
-		$this->assertEquals('en', $this->languages->default()->code());
+		$this->assertSame(['en', 'de'], $this->languages->codes());
+		$this->assertSame('en', $this->languages->default()->code());
 	}
 
 	public function testLoadFromFiles()
@@ -71,15 +71,15 @@ class LanguagesTest extends TestCase
 		$languages = Languages::load();
 
 		$this->assertCount(2, $languages);
-		$this->assertEquals(['de', 'en'], $languages->codes());
-		$this->assertEquals('en', $languages->default()->code());
+		$this->assertSame(['de', 'en'], $languages->codes());
+		$this->assertSame('en', $languages->default()->code());
 
 		Dir::remove($root);
 	}
 
 	public function testDefault()
 	{
-		$this->assertEquals('en', $this->languages->default()->code());
+		$this->assertSame('en', $this->languages->default()->code());
 	}
 
 	public function testMultipleDefault()

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -44,9 +44,11 @@ class LayoutsTest extends TestCase
 		$blocks  = $columns->first()->blocks();
 
 		$this->assertSame('heading', $blocks->first()->type());
-		$this->assertEquals('Heading', $blocks->first()->text());
+		$this->assertInstanceOf(Field::class, $blocks->first()->text());
+		$this->assertSame('Heading', $blocks->first()->text()->value());
 		$this->assertSame('text', $blocks->last()->type());
-		$this->assertEquals('Text', $blocks->last()->text());
+		$this->assertInstanceOf(Field::class, $blocks->last()->text());
+		$this->assertSame('Text', $blocks->last()->text()->value());
 	}
 
 	public function testHasBlockType()

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -43,9 +43,9 @@ class LayoutsTest extends TestCase
 		$columns = $layouts->first()->columns();
 		$blocks  = $columns->first()->blocks();
 
-		$this->assertEquals('heading', $blocks->first()->type());
+		$this->assertSame('heading', $blocks->first()->type());
 		$this->assertEquals('Heading', $blocks->first()->text());
-		$this->assertEquals('text', $blocks->last()->type());
+		$this->assertSame('text', $blocks->last()->type());
 		$this->assertEquals('Text', $blocks->last()->text());
 	}
 

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -35,8 +35,8 @@ class MediaTest extends TestCase
 		$result = Media::link($this->app->site(), $file->mediaHash(), $file->filename());
 
 		$this->assertInstanceOf(Response::class, $result);
-		$this->assertEquals(200, $result->code());
-		$this->assertEquals('image/svg+xml', $result->type());
+		$this->assertSame(200, $result->code());
+		$this->assertSame('image/svg+xml', $result->type());
 	}
 
 	public function testLinkPageFile()
@@ -47,8 +47,8 @@ class MediaTest extends TestCase
 		$result = Media::link($this->app->page('projects'), $file->mediaHash(), $file->filename());
 
 		$this->assertInstanceOf(Response::class, $result);
-		$this->assertEquals(200, $result->code());
-		$this->assertEquals('image/svg+xml', $result->type());
+		$this->assertSame(200, $result->code());
+		$this->assertSame('image/svg+xml', $result->type());
 	}
 
 	public function testLinkWithInvalidHash()
@@ -60,7 +60,7 @@ class MediaTest extends TestCase
 		$result = Media::link($this->app->page('projects'), $file->mediaToken() . '-12345', $file->filename());
 
 		$this->assertInstanceOf(Response::class, $result);
-		$this->assertEquals(307, $result->code());
+		$this->assertSame(307, $result->code());
 
 		// with a completely invalid hash
 		$file   = $this->app->file('projects/test.svg');

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -97,13 +97,13 @@ class MediaTest extends TestCase
 		$this->assertTrue(Media::publish($file, $dest = $versionB2 . '/test.jpg'));
 
 		// the file should be copied
-		$this->assertTrue(is_dir($versionB2));
-		$this->assertTrue(is_file($dest));
+		$this->assertDirectoryExists($versionB2);
+		$this->assertFileExists($dest);
 
 		// older versions should be removed
-		$this->assertFalse(is_dir($versionA1));
-		$this->assertFalse(is_dir($versionA2));
-		$this->assertFalse(is_dir($versionB1));
+		$this->assertDirectoryDoesNotExist($versionA1);
+		$this->assertDirectoryDoesNotExist($versionA2);
+		$this->assertDirectoryDoesNotExist($versionB1);
 	}
 
 	public function testUnpublish()
@@ -128,17 +128,17 @@ class MediaTest extends TestCase
 		Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
 		Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
 
-		$this->assertTrue(is_dir($versionA1));
-		$this->assertTrue(is_dir($versionA2));
-		$this->assertTrue(is_dir($versionB1));
-		$this->assertTrue(is_dir($versionB2));
+		$this->assertDirectoryExists($versionA1);
+		$this->assertDirectoryExists($versionA2);
+		$this->assertDirectoryExists($versionB1);
+		$this->assertDirectoryExists($versionB2);
 
 		Media::unpublish($directory, $file);
 
-		$this->assertFalse(is_dir($versionA1));
-		$this->assertFalse(is_dir($versionA2));
-		$this->assertFalse(is_dir($versionB1));
-		$this->assertFalse(is_dir($versionB2));
+		$this->assertDirectoryDoesNotExist($versionA1);
+		$this->assertDirectoryDoesNotExist($versionA2);
+		$this->assertDirectoryDoesNotExist($versionB1);
+		$this->assertDirectoryDoesNotExist($versionB2);
 	}
 
 	public function testUnpublishAndIgnore()
@@ -163,17 +163,17 @@ class MediaTest extends TestCase
 		Dir::make($versionB1 = $directory . '/' . $newToken . '-1234');
 		Dir::make($versionB2 = $directory . '/' . $newToken . '-5678');
 
-		$this->assertTrue(is_dir($versionA1));
-		$this->assertTrue(is_dir($versionA2));
-		$this->assertTrue(is_dir($versionB1));
-		$this->assertTrue(is_dir($versionB2));
+		$this->assertDirectoryExists($versionA1);
+		$this->assertDirectoryExists($versionA2);
+		$this->assertDirectoryExists($versionB1);
+		$this->assertDirectoryExists($versionB2);
 
 		Media::unpublish($directory, $file, $versionB1);
 
-		$this->assertTrue(is_dir($versionB1));
-		$this->assertFalse(is_dir($versionA1));
-		$this->assertFalse(is_dir($versionA2));
-		$this->assertFalse(is_dir($versionB2));
+		$this->assertDirectoryExists($versionB1);
+		$this->assertDirectoryDoesNotExist($versionA1);
+		$this->assertDirectoryDoesNotExist($versionA2);
+		$this->assertDirectoryDoesNotExist($versionB2);
 	}
 
 	public function testUnpublishNonExistingDirectory()

--- a/tests/Cms/Models/ModelTest.php
+++ b/tests/Cms/Models/ModelTest.php
@@ -40,7 +40,7 @@ class ModelTest extends TestCase
 		$model = new MyModel([
 			'kirby' => $kirby
 		]);
-		$this->assertEquals($kirby, $model->kirby());
+		$this->assertSame($kirby, $model->kirby());
 	}
 
 	public function testSite()
@@ -49,7 +49,7 @@ class ModelTest extends TestCase
 		$model = new MyModel([
 			'site' => $site
 		]);
-		$this->assertEquals($site, $model->site());
+		$this->assertSame($site, $model->site());
 	}
 
 	public function testToString()
@@ -58,8 +58,8 @@ class ModelTest extends TestCase
 			'id' => 'test'
 		]);
 
-		$this->assertEquals('test', $model->__toString());
-		$this->assertEquals('test', (string)$model);
+		$this->assertSame('test', $model->__toString());
+		$this->assertSame('test', (string)$model);
 	}
 
 	public function testToArray()
@@ -68,6 +68,6 @@ class ModelTest extends TestCase
 			'id' => 'test'
 		]);
 
-		$this->assertEquals(['id' => 'test'], $model->toArray());
+		$this->assertSame(['id' => 'test'], $model->toArray());
 	}
 }

--- a/tests/Cms/Nests/NestCollectionTest.php
+++ b/tests/Cms/Nests/NestCollectionTest.php
@@ -32,6 +32,6 @@ class NestCollectionTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $collection->toArray());
+		$this->assertSame($expected, $collection->toArray());
 	}
 }

--- a/tests/Cms/Nests/NestObjectTest.php
+++ b/tests/Cms/Nests/NestObjectTest.php
@@ -13,7 +13,7 @@ class NestObjectTest extends TestCase
 			'b' => 'B'
 		]);
 
-		$this->assertEquals($expected, $o->toArray());
+		$this->assertSame($expected, $o->toArray());
 	}
 
 	public function testToArrayWithFields()
@@ -28,7 +28,7 @@ class NestObjectTest extends TestCase
 			'b' => 'B'
 		];
 
-		$this->assertEquals($expected, $o->toArray());
+		$this->assertSame($expected, $o->toArray());
 	}
 
 	public function testToArrayWithNestedObjects()
@@ -45,6 +45,6 @@ class NestObjectTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $o->toArray());
+		$this->assertSame($expected, $o->toArray());
 	}
 }

--- a/tests/Cms/Nests/NestTest.php
+++ b/tests/Cms/Nests/NestTest.php
@@ -18,7 +18,7 @@ class NestTest extends TestCase
 	{
 		$n = Nest::create([]);
 		$this->assertInstanceOf(NestCollection::class, $n);
-		$this->assertSame(0, $n->count());
+		$this->assertCount(0, $n);
 	}
 
 	public function testCreateObject()

--- a/tests/Cms/Nests/NestTest.php
+++ b/tests/Cms/Nests/NestTest.php
@@ -11,7 +11,7 @@ class NestTest extends TestCase
 		$n = Nest::create($expected = 'a');
 
 		$this->assertInstanceOf(Field::class, $n);
-		$this->assertEquals($expected, $n);
+		$this->assertEquals($expected, $n); // cannot use strict assertion (string conversion)
 	}
 
 	public function testCreateEmptyCollection()

--- a/tests/Cms/Nests/NestTest.php
+++ b/tests/Cms/Nests/NestTest.php
@@ -30,7 +30,7 @@ class NestTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(NestObject::class, $n);
-		$this->assertEquals($expected, $n->toArray());
+		$this->assertSame($expected, $n->toArray());
 	}
 
 	public function testCreateCollection()
@@ -38,7 +38,7 @@ class NestTest extends TestCase
 		$n = Nest::create($expected = ['A', 2, false]);
 
 		$this->assertInstanceOf(NestCollection::class, $n);
-		$this->assertEquals('A', $n->first()->value());
-		$this->assertEquals(false, $n->last()->value());
+		$this->assertSame('A', $n->first()->value());
+		$this->assertFalse($n->last()->value());
 	}
 }

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -460,7 +460,7 @@ class PageActionsTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertSame(null, $page->headline()->value());
+		$this->assertNull($page->headline()->value());
 
 		$drafts = $this->app->site()->drafts();
 		$childrenAndDrafts = $this->app->site()->childrenAndDrafts();
@@ -568,7 +568,7 @@ class PageActionsTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertSame(null, $page->headline()->value());
+		$this->assertNull($page->headline()->value());
 
 		$drafts = $this->app->site()->drafts();
 		$childrenAndDrafts = $this->app->site()->childrenAndDrafts();

--- a/tests/Cms/Pages/PageBlueprintTest.php
+++ b/tests/Cms/Pages/PageBlueprintTest.php
@@ -125,7 +125,7 @@ class PageBlueprintTest extends TestCase
 			'num'   => $input
 		]);
 
-		$this->assertEquals($expected, $blueprint->num());
+		$this->assertSame($expected, $blueprint->num());
 	}
 
 	public function testStatus()
@@ -154,7 +154,7 @@ class PageBlueprintTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	public function testStatusWithCustomText()
@@ -179,7 +179,7 @@ class PageBlueprintTest extends TestCase
 			'status' => $expected,
 		]);
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	public function testStatusTranslations()
@@ -225,7 +225,7 @@ class PageBlueprintTest extends TestCase
 			'status' => $input,
 		]);
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	public function testInvalidStatus()
@@ -252,7 +252,7 @@ class PageBlueprintTest extends TestCase
 			'status' => $input,
 		]);
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	public function testExtendStatus()
@@ -305,7 +305,7 @@ class PageBlueprintTest extends TestCase
 			'status' => $input
 		]);
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	public function testExtendStatusFromString()
@@ -334,7 +334,7 @@ class PageBlueprintTest extends TestCase
 			'status' => 'status/default'
 		]);
 
-		$this->assertEquals($expected, $blueprint->status());
+		$this->assertSame($expected, $blueprint->status());
 	}
 
 	/**

--- a/tests/Cms/Pages/PageBlueprintTest.php
+++ b/tests/Cms/Pages/PageBlueprintTest.php
@@ -29,7 +29,7 @@ class PageBlueprintTest extends TestCase
 			'update'         => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertEquals($expected, $blueprint->options()); // cannot use strict assertion (array order)
 	}
 
 	public function testExtendedOptionsFromString()
@@ -62,7 +62,7 @@ class PageBlueprintTest extends TestCase
 			'update'         => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertEquals($expected, $blueprint->options()); // cannot use strict assertion (array order)
 	}
 
 	public function testExtendedOptions()
@@ -98,7 +98,7 @@ class PageBlueprintTest extends TestCase
 			'update'         => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertEquals($expected, $blueprint->options()); // cannot use strict assertion (array order)
 	}
 
 	public function numProvider()

--- a/tests/Cms/Pages/PageCacheTest.php
+++ b/tests/Cms/Pages/PageCacheTest.php
@@ -90,7 +90,7 @@ class PageCacheTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, $app->page('default')->isCacheable());
+		$this->assertSame($expected, $app->page('default')->isCacheable());
 	}
 
 	/**

--- a/tests/Cms/Pages/PageChildrenTest.php
+++ b/tests/Cms/Pages/PageChildrenTest.php
@@ -26,7 +26,7 @@ class PageChildrenTest extends TestCase
 		]);
 
 		$this->assertCount(1, $page->grandChildren());
-		$this->assertEquals('child', $page->grandChildren()->first()->slug());
+		$this->assertSame('child', $page->grandChildren()->first()->slug());
 	}
 
 	public function testHasChildren()

--- a/tests/Cms/Pages/PageContentTest.php
+++ b/tests/Cms/Pages/PageContentTest.php
@@ -18,7 +18,7 @@ class PageContentTest extends TestCase
 		]);
 
 		$this->assertEquals($content, $page->content()->toArray());
-		$this->assertEquals('lorem ipsum', $page->text()->value());
+		$this->assertSame('lorem ipsum', $page->text()->value());
 	}
 
 	public function testInvalidContent()
@@ -38,7 +38,7 @@ class PageContentTest extends TestCase
 			'content' => []
 		]);
 
-		$this->assertEquals($page->slug(), $page->title()->value());
+		$this->assertSame($page->slug(), $page->title()->value());
 	}
 
 	public function testTitle()
@@ -50,6 +50,6 @@ class PageContentTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Custom Title', $page->title()->value());
+		$this->assertSame('Custom Title', $page->title()->value());
 	}
 }

--- a/tests/Cms/Pages/PageContentTest.php
+++ b/tests/Cms/Pages/PageContentTest.php
@@ -17,7 +17,7 @@ class PageContentTest extends TestCase
 			'content' => $content = ['text' => 'lorem ipsum']
 		]);
 
-		$this->assertEquals($content, $page->content()->toArray());
+		$this->assertSame($content, $page->content()->toArray());
 		$this->assertSame('lorem ipsum', $page->text()->value());
 	}
 

--- a/tests/Cms/Pages/PageCreateTest.php
+++ b/tests/Cms/Pages/PageCreateTest.php
@@ -78,8 +78,8 @@ class PageCreateTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('A', $page->a()->value());
-		$this->assertEquals('B', $page->b()->value());
+		$this->assertSame('A', $page->a()->value());
+		$this->assertSame('B', $page->b()->value());
 	}
 
 	public function testCreateDraftWithDefaultsAndContent()
@@ -105,8 +105,8 @@ class PageCreateTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Custom A', $page->a()->value());
-		$this->assertEquals('B', $page->b()->value());
+		$this->assertSame('Custom A', $page->a()->value());
+		$this->assertSame('B', $page->b()->value());
 	}
 
 	public function testCreateListedPage()
@@ -151,9 +151,9 @@ class PageCreateTest extends TestCase
 		]);
 
 		$this->assertTrue($child->exists());
-		$this->assertEquals('the-template', $child->intendedTemplate()->name());
-		$this->assertEquals('child', $child->slug());
-		$this->assertEquals('mother/child', $child->id());
+		$this->assertSame('the-template', $child->intendedTemplate()->name());
+		$this->assertSame('child', $child->slug());
+		$this->assertSame('mother/child', $child->id());
 		$this->assertTrue($mother->drafts()->has($child->id()));
 	}
 
@@ -185,7 +185,7 @@ class PageCreateTest extends TestCase
 			'source'   => $source
 		]);
 
-		$this->assertEquals('test.md', $file->filename());
-		$this->assertEquals('test/test.md', $file->id());
+		$this->assertSame('test.md', $file->filename());
+		$this->assertSame('test/test.md', $file->id());
 	}
 }

--- a/tests/Cms/Pages/PageMethodsTest.php
+++ b/tests/Cms/Pages/PageMethodsTest.php
@@ -39,12 +39,12 @@ class PageMethodsTest extends TestCase
 	public function testPageMethod()
 	{
 		$page = $this->app->page('test');
-		$this->assertEquals('page method', $page->test());
+		$this->assertSame('page method', $page->test());
 	}
 
 	public function testPagesMethod()
 	{
 		$pages = $this->app->site()->children();
-		$this->assertEquals('pages method', $pages->test());
+		$this->assertSame('pages method', $pages->test());
 	}
 }

--- a/tests/Cms/Pages/PageModelTest.php
+++ b/tests/Cms/Pages/PageModelTest.php
@@ -29,7 +29,7 @@ class PageModelTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(ArticlePage::class, $page);
-		$this->assertEquals('test', $page->test());
+		$this->assertSame('test', $page->test());
 	}
 
 	public function testMissingPageModel()

--- a/tests/Cms/Pages/PagePickerTest.php
+++ b/tests/Cms/Pages/PagePickerTest.php
@@ -40,9 +40,9 @@ class PagePickerTest extends TestCase
 	{
 		$picker = new PagePicker();
 
-		$this->assertEquals($this->app->site(), $picker->model());
+		$this->assertSame($this->app->site(), $picker->model());
 		$this->assertCount(1, $picker->items());
-		$this->assertEquals('grandmother', $picker->items()->first()->id());
+		$this->assertSame('grandmother', $picker->items()->first()->id());
 	}
 
 	public function testParent()
@@ -52,8 +52,8 @@ class PagePickerTest extends TestCase
 		]);
 
 		$this->assertCount(1, $picker->items());
-		$this->assertEquals('grandmother/mother', $picker->items()->first()->id());
-		$this->assertEquals('grandmother', $picker->model()->id());
+		$this->assertSame('grandmother/mother', $picker->items()->first()->id());
+		$this->assertSame('grandmother', $picker->model()->id());
 	}
 
 	public function testParentStart()
@@ -62,7 +62,7 @@ class PagePickerTest extends TestCase
 			'parent' => 'grandmother/mother'
 		]);
 
-		$this->assertEquals($picker->start(), $this->app->site());
+		$this->assertSame($picker->start(), $this->app->site());
 	}
 
 	public function testQuery()
@@ -72,8 +72,8 @@ class PagePickerTest extends TestCase
 		]);
 
 		$this->assertCount(3, $picker->items());
-		$this->assertEquals('grandmother/mother/child-a', $picker->items()->first()->id());
-		$this->assertEquals('grandmother/mother/child-c', $picker->items()->last()->id());
+		$this->assertSame('grandmother/mother/child-a', $picker->items()->first()->id());
+		$this->assertSame('grandmother/mother/child-c', $picker->items()->last()->id());
 	}
 
 	public function testQueryAndParent()
@@ -84,8 +84,8 @@ class PagePickerTest extends TestCase
 		]);
 
 		$this->assertCount(3, $picker->items());
-		$this->assertEquals('grandmother/mother/child-a', $picker->items()->first()->id());
-		$this->assertEquals('grandmother/mother/child-c', $picker->items()->last()->id());
+		$this->assertSame('grandmother/mother/child-a', $picker->items()->first()->id());
+		$this->assertSame('grandmother/mother/child-c', $picker->items()->last()->id());
 	}
 
 	public function testQueryStart()
@@ -95,6 +95,6 @@ class PagePickerTest extends TestCase
 			'parent' => 'grandmother/mother'
 		]);
 
-		$this->assertEquals('grandmother', $picker->start()->id());
+		$this->assertSame('grandmother', $picker->start()->id());
 	}
 }

--- a/tests/Cms/Pages/PageSiblingsTest.php
+++ b/tests/Cms/Pages/PageSiblingsTest.php
@@ -272,7 +272,7 @@ class PageSiblingsTest extends TestCase
 		$siblings = $children->not($page);
 
 		$this->assertSame($children, $page->siblings());
-		$this->assertEquals($siblings, $page->siblings(false));
+		$this->assertEquals($siblings, $page->siblings(false)); // cannot use strict assertion (cloned object)
 	}
 
 	public function testDraftSiblings()

--- a/tests/Cms/Pages/PageSiblingsTest.php
+++ b/tests/Cms/Pages/PageSiblingsTest.php
@@ -141,9 +141,9 @@ class PageSiblingsTest extends TestCase
 	{
 		$collection = $this->site()->children();
 
-		$this->assertEquals(0, $collection->first()->indexOf());
-		$this->assertEquals(1, $collection->nth(1)->indexOf());
-		$this->assertEquals(2, $collection->last()->indexOf());
+		$this->assertSame(0, $collection->first()->indexOf());
+		$this->assertSame(1, $collection->nth(1)->indexOf());
+		$this->assertSame(2, $collection->last()->indexOf());
 	}
 
 	public function testIndexOfCustomCollection()
@@ -151,8 +151,8 @@ class PageSiblingsTest extends TestCase
 		$collection = $this->site()->children();
 		$page = $collection->first();
 
-		$this->assertEquals(0, $page->indexOf());
-		$this->assertEquals(2, $page->indexOf($collection->flip()));
+		$this->assertSame(0, $page->indexOf());
+		$this->assertSame(2, $page->indexOf($collection->flip()));
 	}
 
 	public function testIsFirst()
@@ -184,7 +184,7 @@ class PageSiblingsTest extends TestCase
 	{
 		$collection = $this->site()->children();
 
-		$this->assertEquals($collection->first()->next(), $collection->nth(1));
+		$this->assertSame($collection->first()->next(), $collection->nth(1));
 	}
 
 	public function testNextAll()
@@ -194,8 +194,8 @@ class PageSiblingsTest extends TestCase
 
 		$this->assertCount(2, $first->nextAll());
 
-		$this->assertEquals($first->nextAll()->first(), $collection->nth(1));
-		$this->assertEquals($first->nextAll()->last(), $collection->nth(2));
+		$this->assertSame($first->nextAll()->first(), $collection->nth(1));
+		$this->assertSame($first->nextAll()->last(), $collection->nth(2));
 	}
 
 	public function testNextListed()
@@ -226,7 +226,7 @@ class PageSiblingsTest extends TestCase
 	{
 		$collection = $this->site()->children();
 
-		$this->assertEquals($collection->last()->prev(), $collection->nth(1));
+		$this->assertSame($collection->last()->prev(), $collection->nth(1));
 	}
 
 	public function testPrevAll()
@@ -236,8 +236,8 @@ class PageSiblingsTest extends TestCase
 
 		$this->assertCount(2, $last->prevAll());
 
-		$this->assertEquals($last->prevAll()->first(), $collection->nth(0));
-		$this->assertEquals($last->prevAll()->last(), $collection->nth(1));
+		$this->assertSame($last->prevAll()->first(), $collection->nth(0));
+		$this->assertSame($last->prevAll()->last(), $collection->nth(1));
 	}
 
 	public function testPrevListed()
@@ -271,7 +271,7 @@ class PageSiblingsTest extends TestCase
 		$children = $site->children();
 		$siblings = $children->not($page);
 
-		$this->assertEquals($children, $page->siblings());
+		$this->assertSame($children, $page->siblings());
 		$this->assertEquals($siblings, $page->siblings(false));
 	}
 
@@ -293,7 +293,7 @@ class PageSiblingsTest extends TestCase
 		$drafts = $parent->drafts();
 		$draft  = $drafts->find('c');
 
-		$this->assertEquals($drafts, $draft->siblings());
+		$this->assertSame($drafts, $draft->siblings());
 	}
 
 	public function testTemplateSiblings()

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -626,10 +626,10 @@ class PageSortTest extends TestCase
 
 		$this->assertSame(array_reverse($chars), $this->site()->children()->keys());
 
-		$this->assertTrue(is_dir($this->fixtures . '/content/4_a'));
-		$this->assertTrue(is_dir($this->fixtures . '/content/3_b'));
-		$this->assertTrue(is_dir($this->fixtures . '/content/2_c'));
-		$this->assertTrue(is_dir($this->fixtures . '/content/1_d'));
+		$this->assertDirectoryExists($this->fixtures . '/content/4_a');
+		$this->assertDirectoryExists($this->fixtures . '/content/3_b');
+		$this->assertDirectoryExists($this->fixtures . '/content/2_c');
+		$this->assertDirectoryExists($this->fixtures . '/content/1_d');
 	}
 
 	public function testUpdateWithDateBasedNumbering()

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -45,16 +45,16 @@ class PageSortTest extends TestCase
 
 		$page = $page->save();
 
-		$this->assertEquals(1, $page->num());
-		$this->assertEquals('1_test', $page->dirname());
-		$this->assertEquals(1, $page->parentModel()->find('test')->num());
-		$this->assertEquals(1, $site->find('test')->num());
+		$this->assertSame(1, $page->num());
+		$this->assertSame('1_test', $page->dirname());
+		$this->assertSame(1, $page->parentModel()->find('test')->num());
+		$this->assertSame(1, $site->find('test')->num());
 
 		$page = $page->changeNum(2);
 
-		$this->assertEquals(2, $page->num());
-		$this->assertEquals('2_test', $page->dirname());
-		$this->assertEquals(2, $site->find('test')->num());
+		$this->assertSame(2, $page->num());
+		$this->assertSame('2_test', $page->dirname());
+		$this->assertSame(2, $site->find('test')->num());
 	}
 
 	public function testChangeStatusFromDraftToListed()
@@ -67,8 +67,8 @@ class PageSortTest extends TestCase
 
 		$listed = $page->changeStatus('listed');
 
-		$this->assertEquals('listed', $listed->status());
-		$this->assertEquals(1, $listed->num());
+		$this->assertSame('listed', $listed->status());
+		$this->assertSame(1, $listed->num());
 		$this->assertFalse($listed->parentModel()->drafts()->has($listed));
 		$this->assertTrue($listed->parentModel()->children()->listed()->has($listed));
 	}
@@ -83,8 +83,8 @@ class PageSortTest extends TestCase
 
 		$unlisted = $page->changeStatus('unlisted');
 
-		$this->assertEquals('unlisted', $unlisted->status());
-		$this->assertEquals(null, $unlisted->num());
+		$this->assertSame('unlisted', $unlisted->status());
+		$this->assertSame(null, $unlisted->num());
 		$this->assertFalse($unlisted->parentModel()->drafts()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
 	}
@@ -97,7 +97,7 @@ class PageSortTest extends TestCase
 
 		$listed = $page->changeStatus('listed');
 		$this->assertTrue($listed->isListed());
-		$this->assertEquals(1, $listed->num());
+		$this->assertSame(1, $listed->num());
 
 		$this->assertFalse($listed->parentModel()->children()->unlisted()->has($listed));
 		$this->assertTrue($listed->parentModel()->children()->listed()->has($listed));
@@ -105,7 +105,7 @@ class PageSortTest extends TestCase
 		$unlisted = $listed->changeStatus('unlisted');
 
 		$this->assertTrue($unlisted->isUnlisted());
-		$this->assertEquals(null, $unlisted->num());
+		$this->assertSame(null, $unlisted->num());
 
 		$this->assertFalse($unlisted->parentModel()->children()->listed()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
@@ -121,7 +121,7 @@ class PageSortTest extends TestCase
 		$unlisted = $page->changeStatus('unlisted');
 
 		$this->assertTrue($unlisted->isUnlisted());
-		$this->assertEquals(null, $unlisted->num());
+		$this->assertSame(null, $unlisted->num());
 
 		$this->assertFalse($unlisted->parentModel()->children()->listed()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
@@ -129,7 +129,7 @@ class PageSortTest extends TestCase
 		// change to listed
 		$listed = $unlisted->changeStatus('listed');
 		$this->assertTrue($listed->isListed());
-		$this->assertEquals(1, $listed->num());
+		$this->assertSame(1, $listed->num());
 
 		$this->assertFalse($listed->parentModel()->children()->unlisted()->has($listed));
 		$this->assertTrue($listed->parentModel()->children()->listed()->has($listed));
@@ -143,15 +143,15 @@ class PageSortTest extends TestCase
 
 		$page = $page->changeStatus('listed');
 
-		$this->assertEquals('listed', $page->status());
-		$this->assertEquals(1, $page->num());
+		$this->assertSame('listed', $page->status());
+		$this->assertSame(1, $page->num());
 		$this->assertFalse($page->isDraft());
 
 		$draft = $page->changeStatus('draft');
 
 		$this->assertTrue($draft->isDraft());
-		$this->assertEquals('draft', $draft->status());
-		$this->assertEquals(null, $draft->num());
+		$this->assertSame('draft', $draft->status());
+		$this->assertSame(null, $draft->num());
 		$this->assertTrue($draft->parentModel()->drafts()->has($draft));
 		$this->assertFalse($draft->parentModel()->children()->listed()->has($draft));
 	}
@@ -170,15 +170,15 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('draft', $page->status());
+		$this->assertSame('draft', $page->status());
 
 		$draft = $page->changeStatus('listed');
-		$this->assertEquals('listed', $draft->status());
+		$this->assertSame('listed', $draft->status());
 
 		$this->expectException(InvalidArgumentException::class);
 
 		$unlisted = $page->changeStatus('unlisted');
-		$this->assertEquals('unlisted', $unlisted->status());
+		$this->assertSame('unlisted', $unlisted->status());
 	}
 
 	public function testCreateDefaultNum()
@@ -221,31 +221,31 @@ class PageSortTest extends TestCase
 
 		// no siblings
 		$page = $app->page('one-child/child-a');
-		$this->assertEquals(1, $page->createNum());
+		$this->assertSame(1, $page->createNum());
 
 		// two listed siblings / no position
 		$page = $app->page('three-children/child-c');
-		$this->assertEquals(3, $page->createNum());
+		$this->assertSame(3, $page->createNum());
 
 		// one listed sibling / valid position
 		$page = $app->page('three-children/child-a');
-		$this->assertEquals(2, $page->createNum(2));
+		$this->assertSame(2, $page->createNum(2));
 
 		// one listed sibling / position too low
 		$page = $app->page('three-children/child-a');
-		$this->assertEquals(1, $page->createNum(-1));
+		$this->assertSame(1, $page->createNum(-1));
 
 		// one listed sibling / position too high
 		$page = $app->page('three-children/child-a');
-		$this->assertEquals(2, $page->createNum(3));
+		$this->assertSame(2, $page->createNum(3));
 
 		// draft / no position
 		$page = $app->page('three-children/draft');
-		$this->assertEquals(3, $page->createNum());
+		$this->assertSame(3, $page->createNum());
 
 		// draft / given position
 		$page = $app->page('three-children/draft');
-		$this->assertEquals(1, $page->createNum(1));
+		$this->assertSame(1, $page->createNum(1));
 	}
 
 	public function testCreateZeroBasedNum()
@@ -257,7 +257,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(0, $page->createNum());
+		$this->assertSame(0, $page->createNum());
 
 		$page = new Page([
 			'slug' => 'test',
@@ -266,7 +266,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(0, $page->createNum());
+		$this->assertSame(0, $page->createNum());
 	}
 
 	public function testCreateDateBasedNum()
@@ -292,7 +292,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(20121212, $page->createNum());
+		$this->assertSame(20121212, $page->createNum());
 	}
 
 	public function testCreateDateBasedNumWithDateHandler()
@@ -327,7 +327,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(20121212, $page->createNum());
+		$this->assertSame(20121212, $page->createNum());
 	}
 
 	public function testCreateNumWithTranslations()
@@ -370,12 +370,12 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(20190101, $page->createNum());
+		$this->assertSame(20190101, $page->createNum());
 
 		$app->setCurrentLanguage('de');
 		$app->setCurrentTranslation('de');
 
-		$this->assertEquals(20190101, $page->createNum());
+		$this->assertSame(20190101, $page->createNum());
 	}
 
 	public function testCreateCustomNum()
@@ -400,7 +400,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(2016, $app->page('test')->createNum());
+		$this->assertSame(2016, $app->page('test')->createNum());
 
 		// invalid
 		$app = new App([
@@ -419,7 +419,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(0, $app->page('test')->createNum());
+		$this->assertSame(0, $app->page('test')->createNum());
 
 		// multilang with default language fallback
 		$app = new App([
@@ -463,7 +463,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(2016, $app->page('test')->createNum());
+		$this->assertSame(2016, $app->page('test')->createNum());
 	}
 
 	public function testPublish()
@@ -476,7 +476,7 @@ class PageSortTest extends TestCase
 		$site      = $this->app->site();
 		$published = $page->publish();
 
-		$this->assertEquals('unlisted', $published->status());
+		$this->assertSame('unlisted', $published->status());
 
 		$this->assertFalse($page->parentModel()->drafts()->has($published));
 		$this->assertTrue($page->parentModel()->children()->has($published));
@@ -492,7 +492,7 @@ class PageSortTest extends TestCase
 
 		$published = $child->publish();
 
-		$this->assertEquals('unlisted', $published->status());
+		$this->assertSame('unlisted', $published->status());
 
 		$this->assertFalse($child->parentModel()->drafts()->has($published->id()));
 		$this->assertTrue($child->parentModel()->children()->has($published->id()));
@@ -509,8 +509,8 @@ class PageSortTest extends TestCase
 
 		$page = $page->publish();
 
-		$this->assertEquals('unlisted', $page->status());
-		$this->assertEquals('unlisted', $page->publish()->status());
+		$this->assertSame('unlisted', $page->status());
+		$this->assertSame('unlisted', $page->publish()->status());
 	}
 
 	public function sortProvider()
@@ -551,7 +551,7 @@ class PageSortTest extends TestCase
 		$page = $site->find($id);
 		$page = $page->changeSort($position);
 
-		$this->assertEquals($expected, implode(',', $site->children()->keys()));
+		$this->assertSame($expected, implode(',', $site->children()->keys()));
 	}
 
 	public function testSortDateBased()
@@ -597,12 +597,12 @@ class PageSortTest extends TestCase
 		$page = $site->find('b');
 		$page = $page->changeSort(3);
 
-		$this->assertEquals(1, $site->find('a')->num());
-		$this->assertEquals(2, $site->find('d')->num());
-		$this->assertEquals(3, $site->find('b')->num());
+		$this->assertSame(1, $site->find('a')->num());
+		$this->assertSame(2, $site->find('d')->num());
+		$this->assertSame(3, $site->find('b')->num());
 
-		$this->assertEquals(20180104, $site->find('c')->num());
-		$this->assertEquals(0, $site->find('e')->num());
+		$this->assertSame(20180104, $site->find('c')->num());
+		$this->assertSame(0, $site->find('e')->num());
 	}
 
 	public function testMassSorting()
@@ -615,16 +615,16 @@ class PageSortTest extends TestCase
 			$page = $page->changeStatus('unlisted');
 
 			$this->assertTrue($page->exists());
-			$this->assertEquals(null, $page->num());
+			$this->assertSame(null, $page->num());
 		}
 
-		$this->assertEquals($chars, $this->site()->children()->keys());
+		$this->assertSame($chars, $this->site()->children()->keys());
 
 		foreach ($this->site()->children()->flip()->values() as $index => $page) {
 			$page = $page->changeSort($index + 1);
 		}
 
-		$this->assertEquals(array_reverse($chars), $this->site()->children()->keys());
+		$this->assertSame(array_reverse($chars), $this->site()->children()->keys());
 
 		$this->assertTrue(is_dir($this->fixtures . '/content/4_a'));
 		$this->assertTrue(is_dir($this->fixtures . '/content/3_b'));
@@ -649,12 +649,12 @@ class PageSortTest extends TestCase
 		// publish the new page
 		$page = $page->changeStatus('listed');
 
-		$this->assertEquals(20121212, $page->num());
+		$this->assertSame(20121212, $page->num());
 
 		$modified = $page->update([
 			'date' => '2016-11-21'
 		]);
 
-		$this->assertEquals(20161121, $modified->num());
+		$this->assertSame(20161121, $modified->num());
 	}
 }

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -84,7 +84,7 @@ class PageSortTest extends TestCase
 		$unlisted = $page->changeStatus('unlisted');
 
 		$this->assertSame('unlisted', $unlisted->status());
-		$this->assertSame(null, $unlisted->num());
+		$this->assertNull($unlisted->num());
 		$this->assertFalse($unlisted->parentModel()->drafts()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
 	}
@@ -105,7 +105,7 @@ class PageSortTest extends TestCase
 		$unlisted = $listed->changeStatus('unlisted');
 
 		$this->assertTrue($unlisted->isUnlisted());
-		$this->assertSame(null, $unlisted->num());
+		$this->assertNull($unlisted->num());
 
 		$this->assertFalse($unlisted->parentModel()->children()->listed()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
@@ -121,7 +121,7 @@ class PageSortTest extends TestCase
 		$unlisted = $page->changeStatus('unlisted');
 
 		$this->assertTrue($unlisted->isUnlisted());
-		$this->assertSame(null, $unlisted->num());
+		$this->assertNull($unlisted->num());
 
 		$this->assertFalse($unlisted->parentModel()->children()->listed()->has($unlisted));
 		$this->assertTrue($unlisted->parentModel()->children()->unlisted()->has($unlisted));
@@ -151,7 +151,7 @@ class PageSortTest extends TestCase
 
 		$this->assertTrue($draft->isDraft());
 		$this->assertSame('draft', $draft->status());
-		$this->assertSame(null, $draft->num());
+		$this->assertNull($draft->num());
 		$this->assertTrue($draft->parentModel()->drafts()->has($draft));
 		$this->assertFalse($draft->parentModel()->children()->listed()->has($draft));
 	}
@@ -615,7 +615,7 @@ class PageSortTest extends TestCase
 			$page = $page->changeStatus('unlisted');
 
 			$this->assertTrue($page->exists());
-			$this->assertSame(null, $page->num());
+			$this->assertNull($page->num());
 		}
 
 		$this->assertSame($chars, $this->site()->children()->keys());

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -279,7 +279,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(date('Ymd'), $page->createNum());
+		$this->assertSame((int)date('Ymd'), $page->createNum());
 
 		// with date field
 		$page = new Page([
@@ -314,7 +314,7 @@ class PageSortTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(date('Ymd'), $page->createNum());
+		$this->assertSame((int)date('Ymd'), $page->createNum());
 
 		// with date field
 		$page = new Page([

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -252,7 +252,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertSame(null, $mother->parentId());
+		$this->assertNull($mother->parentId());
 		$this->assertSame('mother', $mother->find('child')->parentId());
 	}
 
@@ -283,7 +283,7 @@ class PageTest extends TestCase
 		$blog  = $app->page('blog');
 
 		$this->assertSame($blog, $child->parent()->next());
-		$this->assertSame(null, $child->parent()->prev());
+		$this->assertNull($child->parent()->prev());
 	}
 
 	public function testInvalidParent()

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -323,7 +323,8 @@ class PageTest extends TestCase
 			'slug' => 'test',
 		]);
 
-		$this->assertEquals('default', $page->template());
+		$this->assertInstanceOf(Template::class, $page->template());
+		$this->assertSame('default', $page->template()->name());
 	}
 
 	public function testIntendedTemplate()

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -48,7 +48,7 @@ class PageTest extends TestCase
 		// no blueprints
 		$page = new Page(['slug' => 'test', 'template' => 'a']);
 
-		$this->assertEquals(['A'], array_column($page->blueprints(), 'title'));
+		$this->assertSame(['A'], array_column($page->blueprints(), 'title'));
 
 		// two different blueprints
 		$page = new Page([
@@ -64,7 +64,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['C', 'A', 'B'], array_column($page->blueprints(), 'title'));
+		$this->assertSame(['C', 'A', 'B'], array_column($page->blueprints(), 'title'));
 
 		// including the same blueprint
 		$page = new Page([
@@ -80,7 +80,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['A', 'B'], array_column($page->blueprints(), 'title'));
+		$this->assertSame(['A', 'B'], array_column($page->blueprints(), 'title'));
 
 		// template option is simply true
 		$page = new Page([
@@ -93,7 +93,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['A'], array_column($page->blueprints(), 'title'));
+		$this->assertSame(['A'], array_column($page->blueprints(), 'title'));
 	}
 
 	public function testDepth()
@@ -116,9 +116,9 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(1, $site->find('grandma')->depth());
-		$this->assertEquals(2, $site->find('grandma/mother')->depth());
-		$this->assertEquals(3, $site->find('grandma/mother/child')->depth());
+		$this->assertSame(1, $site->find('grandma')->depth());
+		$this->assertSame(2, $site->find('grandma/mother')->depth());
+		$this->assertSame(3, $site->find('grandma/mother/child')->depth());
 	}
 
 	public function testId()
@@ -127,7 +127,7 @@ class PageTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertEquals('test', $page->id());
+		$this->assertSame('test', $page->id());
 	}
 
 	public function testEmptyId()
@@ -153,7 +153,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			'intro' => [
 				'label' => 'Intro',
 				'message' => [
@@ -166,7 +166,7 @@ class PageTest extends TestCase
 	public function testErrorsWithoutBlueprint()
 	{
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals([], $page->errors());
+		$this->assertSame([], $page->errors());
 	}
 
 	public function testErrorsWithInfoSectionInBlueprint()
@@ -185,7 +185,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([], $page->errors());
+		$this->assertSame([], $page->errors());
 	}
 
 	public function testInvalidId()
@@ -204,7 +204,7 @@ class PageTest extends TestCase
 			'num' => 1
 		]);
 
-		$this->assertEquals(1, $page->num());
+		$this->assertSame(1, $page->num());
 	}
 
 	public function testInvalidNum()
@@ -238,7 +238,7 @@ class PageTest extends TestCase
 			'parent' => $parent
 		]);
 
-		$this->assertEquals($parent, $page->parent());
+		$this->assertSame($parent, $page->parent());
 	}
 
 	public function testParentId()
@@ -252,8 +252,8 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(null, $mother->parentId());
-		$this->assertEquals('mother', $mother->find('child')->parentId());
+		$this->assertSame(null, $mother->parentId());
+		$this->assertSame('mother', $mother->find('child')->parentId());
 	}
 
 	public function testParentPrevNext()
@@ -282,8 +282,8 @@ class PageTest extends TestCase
 		$child = $app->page('projects/project-a');
 		$blog  = $app->page('blog');
 
-		$this->assertEquals($blog, $child->parent()->next());
-		$this->assertEquals(null, $child->parent()->prev());
+		$this->assertSame($blog, $child->parent()->next());
+		$this->assertSame(null, $child->parent()->prev());
 	}
 
 	public function testInvalidParent()
@@ -304,7 +304,7 @@ class PageTest extends TestCase
 			'site' => $site
 		]);
 
-		$this->assertEquals($site, $page->site());
+		$this->assertSame($site, $page->site());
 	}
 
 	public function testInvalidSite()
@@ -333,7 +333,7 @@ class PageTest extends TestCase
 			'template' => 'testTemplate'
 		]);
 
-		$this->assertEquals('testtemplate', $page->intendedTemplate()->name());
+		$this->assertSame('testtemplate', $page->intendedTemplate()->name());
 	}
 
 	public function testInvalidTemplate()
@@ -353,7 +353,7 @@ class PageTest extends TestCase
 			'url' => 'https://getkirby.com/test'
 		]);
 
-		$this->assertEquals('https://getkirby.com/test', $page->url());
+		$this->assertSame('https://getkirby.com/test', $page->url());
 	}
 
 	public function testUrlWithOptions()
@@ -363,7 +363,7 @@ class PageTest extends TestCase
 			'url' => 'https://getkirby.com/test'
 		]);
 
-		$this->assertEquals('https://getkirby.com/test/foo:bar?q=search', $page->url([
+		$this->assertSame('https://getkirby.com/test/foo:bar?q=search', $page->url([
 			'params' => 'foo:bar',
 			'query'  => 'q=search'
 		]));
@@ -375,7 +375,7 @@ class PageTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertEquals('/test', $page->url());
+		$this->assertSame('/test', $page->url());
 	}
 
 	public function testInvalidUrl()
@@ -401,7 +401,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('/', $app->site()->find('home')->url());
+		$this->assertSame('/', $app->site()->find('home')->url());
 	}
 
 	public function testHomeChildUrl()
@@ -422,7 +422,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('/home/a', $app->site()->find('home/a')->url());
+		$this->assertSame('/home/a', $app->site()->find('home/a')->url());
 	}
 
 	public function testMultiLangHomeChildUrl()
@@ -455,8 +455,8 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('/en/home/a', $app->site()->find('home/a')->url());
-		$this->assertEquals('/de/home/a', $app->site()->find('home/a')->url('de'));
+		$this->assertSame('/en/home/a', $app->site()->find('home/a')->url());
+		$this->assertSame('/de/home/a', $app->site()->find('home/a')->url('de'));
 	}
 
 	public function testPreviewUrl()
@@ -474,7 +474,7 @@ class PageTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertEquals('/test', $page->previewUrl());
+		$this->assertSame('/test', $page->previewUrl());
 	}
 
 	public function previewUrlProvider()
@@ -530,13 +530,13 @@ class PageTest extends TestCase
 			$expected = str_replace('{token}', 'token=' . hash_hmac('sha1', $page->id() . $page->template(), $page->root()), $expected);
 		}
 
-		$this->assertEquals($expected, $page->previewUrl());
+		$this->assertSame($expected, $page->previewUrl());
 	}
 
 	public function testSlug()
 	{
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals('test', $page->slug());
+		$this->assertSame('test', $page->slug());
 	}
 
 	public function testToken()
@@ -612,13 +612,13 @@ class PageTest extends TestCase
 	public function testToString()
 	{
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals('test', $page->toString('{{ page.slug }}'));
+		$this->assertSame('test', $page->toString('{{ page.slug }}'));
 	}
 
 	public function testUid()
 	{
 		$page = new Page(['slug' => 'test']);
-		$this->assertEquals('test', $page->uid());
+		$this->assertSame('test', $page->uid());
 	}
 
 	public function testUri()
@@ -641,7 +641,7 @@ class PageTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('grandma/mother/child', $site->find('grandma/mother/child')->uri());
+		$this->assertSame('grandma/mother/child', $site->find('grandma/mother/child')->uri());
 	}
 
 	public function testUriTranslated()
@@ -691,8 +691,8 @@ class PageTest extends TestCase
 		]);
 
 
-		$this->assertEquals('grandma/mother', $app->site()->find('grandma/mother')->uri());
-		$this->assertEquals('oma/mutter', $app->site()->find('grandma/mother')->uri('de'));
+		$this->assertSame('grandma/mother', $app->site()->find('grandma/mother')->uri());
+		$this->assertSame('oma/mutter', $app->site()->find('grandma/mother')->uri('de'));
 	}
 
 	public function testModified()
@@ -710,18 +710,18 @@ class PageTest extends TestCase
 		$modified = filemtime($file);
 		$page     = $app->page('test');
 
-		$this->assertEquals($modified, $page->modified());
+		$this->assertSame($modified, $page->modified());
 
 		// default date handler
 		$format = 'd.m.Y';
-		$this->assertEquals(date($format, $modified), $page->modified($format));
+		$this->assertSame(date($format, $modified), $page->modified($format));
 
 		// custom date handler without format
-		$this->assertEquals($modified, $page->modified(null, 'strftime'));
+		$this->assertSame($modified, $page->modified(null, 'strftime'));
 
 		// custom date handler with format
 		$format = '%d.%m.%Y';
-		$this->assertEquals(@strftime($format, $modified), $page->modified($format, 'strftime'));
+		$this->assertSame(@strftime($format, $modified), $page->modified($format, 'strftime'));
 	}
 
 	public function testModifiedInMultilangInstallation()
@@ -748,7 +748,7 @@ class PageTest extends TestCase
 		F::write($file = $index . '/test/test.en.txt', 'test');
 		touch($file, $modified = \time() + 2);
 
-		$this->assertEquals($modified, $app->page('test')->modified());
+		$this->assertSame($modified, $app->page('test')->modified());
 
 		// create the german page
 		F::write($file = $index . '/test/test.de.txt', 'test');
@@ -758,7 +758,7 @@ class PageTest extends TestCase
 		$app->setCurrentLanguage('de');
 		$app->setCurrentTranslation('de');
 
-		$this->assertEquals($modified, $app->page('test')->modified());
+		$this->assertSame($modified, $app->page('test')->modified());
 	}
 
 	public function testModifiedSpecifyingLanguage()
@@ -791,8 +791,8 @@ class PageTest extends TestCase
 
 		$page = $app->page('test');
 
-		$this->assertEquals($modifiedEnContent, $page->modified(null, null, 'en'));
-		$this->assertEquals($modifiedDeContent, $page->modified(null, null, 'de'));
+		$this->assertSame($modifiedEnContent, $page->modified(null, null, 'en'));
+		$this->assertSame($modifiedDeContent, $page->modified(null, null, 'de'));
 	}
 
 	public function testPanel()
@@ -829,8 +829,8 @@ class PageTest extends TestCase
 
 		$page = $app->page('mother/child');
 
-		$this->assertEquals('https://getkirby.com/api/pages/mother+child', $page->apiUrl());
-		$this->assertEquals('pages/mother+child', $page->apiUrl(true));
+		$this->assertSame('https://getkirby.com/api/pages/mother+child', $page->apiUrl());
+		$this->assertSame('pages/mother+child', $page->apiUrl(true));
 	}
 
 	public function testPageMethods()
@@ -843,7 +843,7 @@ class PageTest extends TestCase
 
 		$page = new Page(['slug' => 'test']);
 
-		$this->assertEquals('homer', $page->test());
+		$this->assertSame('homer', $page->test());
 
 		Page::$methods = [];
 	}

--- a/tests/Cms/Pages/PageTestCase.php
+++ b/tests/Cms/Pages/PageTestCase.php
@@ -18,17 +18,17 @@ class PageTestCase extends TestCase
 
 	public function assertPageSlug(string $slug)
 	{
-		$this->assertEquals($slug, $this->page()->slug());
+		$this->assertSame($slug, $this->page()->slug());
 	}
 
 	public function assertPageTemplate(string $template)
 	{
-		$this->assertEquals($template, $this->page()->template());
+		$this->assertSame($template, $this->page()->template());
 	}
 
 	public function assertPageField(string $key, string $value)
 	{
-		$this->assertEquals($value, $this->page()->content()->get($key)->value());
+		$this->assertSame($value, $this->page()->content()->get($key)->value());
 	}
 
 	public function assertPageModel(string $className)

--- a/tests/Cms/Pages/PageTranslationsTest.php
+++ b/tests/Cms/Pages/PageTranslationsTest.php
@@ -105,35 +105,35 @@ class PageTranslationsTest extends TestCase
 		$app = $this->app();
 
 		$page = $app->page('home');
-		$this->assertEquals('/en', $page->url());
-		$this->assertEquals('/de', $page->url('de'));
+		$this->assertSame('/en', $page->url());
+		$this->assertSame('/de', $page->url('de'));
 
 		$page = $app->page('grandma');
-		$this->assertEquals('/en/grandma', $page->url());
-		$this->assertEquals('/de/oma', $page->url('de'));
+		$this->assertSame('/en/grandma', $page->url());
+		$this->assertSame('/de/oma', $page->url('de'));
 
 		$page = $app->page('grandma/mother');
-		$this->assertEquals('/en/grandma/mother', $page->url());
-		$this->assertEquals('/de/oma/mutter', $page->url('de'));
+		$this->assertSame('/en/grandma/mother', $page->url());
+		$this->assertSame('/de/oma/mutter', $page->url('de'));
 
 		$page = $app->page('grandma/mother/child');
-		$this->assertEquals('/en/grandma/mother/child', $page->url());
-		$this->assertEquals('/de/oma/mutter/kind', $page->url('de'));
+		$this->assertSame('/en/grandma/mother/child', $page->url());
+		$this->assertSame('/de/oma/mutter/kind', $page->url('de'));
 	}
 
 	public function testContentInEnglish()
 	{
 		$page = $this->app()->page('grandma');
-		$this->assertEquals('Grandma', $page->title()->value());
-		$this->assertEquals('Untranslated', $page->untranslated()->value());
+		$this->assertSame('Grandma', $page->title()->value());
+		$this->assertSame('Untranslated', $page->untranslated()->value());
 	}
 
 	public function testContentInDeutsch()
 	{
 		$page = $this->app('de')->page('grandma');
-		$this->assertEquals('Oma', $page->title()->value());
+		$this->assertSame('Oma', $page->title()->value());
 
-		$this->assertEquals('Untranslated', $page->untranslated()->value());
+		$this->assertSame('Untranslated', $page->untranslated()->value());
 	}
 
 	public function testContent()
@@ -142,63 +142,63 @@ class PageTranslationsTest extends TestCase
 
 		// without language code
 		$content = $page->content();
-		$this->assertEquals('Grandma', $content->title()->value());
-		$this->assertEquals('Untranslated', $content->untranslated()->value());
+		$this->assertSame('Grandma', $content->title()->value());
+		$this->assertSame('Untranslated', $content->untranslated()->value());
 
 		// with default language code
 		$content = $page->content('en');
-		$this->assertEquals('Grandma', $content->title()->value());
-		$this->assertEquals('Untranslated', $content->untranslated()->value());
+		$this->assertSame('Grandma', $content->title()->value());
+		$this->assertSame('Untranslated', $content->untranslated()->value());
 
 		// with different language code
 		$content = $page->content('de');
-		$this->assertEquals('Oma', $content->title()->value());
-		$this->assertEquals('Untranslated', $content->untranslated()->value());
+		$this->assertSame('Oma', $content->title()->value());
+		$this->assertSame('Untranslated', $content->untranslated()->value());
 
 		// switch back to default
 		$content = $page->content('en');
-		$this->assertEquals('Grandma', $content->title()->value());
-		$this->assertEquals('Untranslated', $content->untranslated()->value());
+		$this->assertSame('Grandma', $content->title()->value());
+		$this->assertSame('Untranslated', $content->untranslated()->value());
 	}
 
 	public function testSlug()
 	{
 		$app = $this->app();
 
-		$this->assertEquals('grandma', $app->page('grandma')->slug());
-		$this->assertEquals('grandma', $app->page('grandma')->slug('en'));
-		$this->assertEquals('oma', $app->page('grandma')->slug('de'));
+		$this->assertSame('grandma', $app->page('grandma')->slug());
+		$this->assertSame('grandma', $app->page('grandma')->slug('en'));
+		$this->assertSame('oma', $app->page('grandma')->slug('de'));
 
-		$this->assertEquals('mother', $app->page('grandma/mother')->slug());
-		$this->assertEquals('mother', $app->page('grandma/mother')->slug('en'));
-		$this->assertEquals('mutter', $app->page('grandma/mother')->slug('de'));
+		$this->assertSame('mother', $app->page('grandma/mother')->slug());
+		$this->assertSame('mother', $app->page('grandma/mother')->slug('en'));
+		$this->assertSame('mutter', $app->page('grandma/mother')->slug('de'));
 
-		$this->assertEquals('child', $app->page('grandma/mother/child')->slug());
-		$this->assertEquals('child', $app->page('grandma/mother/child')->slug('en'));
-		$this->assertEquals('kind', $app->page('grandma/mother/child')->slug('de'));
+		$this->assertSame('child', $app->page('grandma/mother/child')->slug());
+		$this->assertSame('child', $app->page('grandma/mother/child')->slug('en'));
+		$this->assertSame('kind', $app->page('grandma/mother/child')->slug('de'));
 	}
 
 	public function testFindInEnglish()
 	{
 		$app = $this->app();
-		$this->assertEquals('grandma', $app->page('grandma')->id());
-		$this->assertEquals('grandma/mother', $app->page('grandma/mother')->id());
-		$this->assertEquals('grandma/mother/child', $app->page('grandma/mother/child')->id());
+		$this->assertSame('grandma', $app->page('grandma')->id());
+		$this->assertSame('grandma/mother', $app->page('grandma/mother')->id());
+		$this->assertSame('grandma/mother/child', $app->page('grandma/mother/child')->id());
 	}
 
 	public function testFindInDeutsch()
 	{
 		$app = $this->app('de');
-		$this->assertEquals('grandma', $app->page('oma')->id());
-		$this->assertEquals('grandma/mother', $app->page('oma/mutter')->id());
-		$this->assertEquals('grandma/mother/child', $app->page('oma/mutter/kind')->id());
+		$this->assertSame('grandma', $app->page('oma')->id());
+		$this->assertSame('grandma/mother', $app->page('oma/mutter')->id());
+		$this->assertSame('grandma/mother/child', $app->page('oma/mutter/kind')->id());
 	}
 
 	public function testTranslations()
 	{
 		$page = $this->app()->page('grandma');
 		$this->assertCount(2, $page->translations());
-		$this->assertEquals(['en', 'de'], $page->translations()->keys());
+		$this->assertSame(['en', 'de'], $page->translations()->keys());
 	}
 
 	public function testUntranslatableFields()

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -28,8 +28,8 @@ class PagesTest extends TestCase
 		$result = $pages->add($page);
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a', $result->nth(0)->slug());
-		$this->assertEquals('b', $result->nth(1)->slug());
+		$this->assertSame('a', $result->nth(0)->slug());
+		$this->assertSame('b', $result->nth(1)->slug());
 	}
 
 	public function testAddCollection()
@@ -46,9 +46,9 @@ class PagesTest extends TestCase
 		$c = $a->add($b);
 
 		$this->assertCount(3, $c);
-		$this->assertEquals('a', $c->nth(0)->slug());
-		$this->assertEquals('b', $c->nth(1)->slug());
-		$this->assertEquals('c', $c->nth(2)->slug());
+		$this->assertSame('a', $c->nth(0)->slug());
+		$this->assertSame('b', $c->nth(1)->slug());
+		$this->assertSame('c', $c->nth(2)->slug());
 	}
 
 	public function testAddById()
@@ -75,9 +75,9 @@ class PagesTest extends TestCase
 		$pages = $app->site()->children()->add('a/aa');
 
 		$this->assertCount(3, $pages);
-		$this->assertEquals('a', $pages->nth(0)->id());
-		$this->assertEquals('b', $pages->nth(1)->id());
-		$this->assertEquals('a/aa', $pages->nth(2)->id());
+		$this->assertSame('a', $pages->nth(0)->id());
+		$this->assertSame('b', $pages->nth(1)->id());
+		$this->assertSame('a/aa', $pages->nth(2)->id());
 	}
 
 	public function testAddNull()
@@ -128,7 +128,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.mp3', 'b.mp3'], $pages->audio()->pluck('filename'));
+		$this->assertSame(['a.mp3', 'b.mp3'], $pages->audio()->pluck('filename'));
 	}
 
 	public function testCode()
@@ -149,7 +149,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.js', 'b.js'], $pages->code()->pluck('filename'));
+		$this->assertSame(['a.js', 'b.js'], $pages->code()->pluck('filename'));
 	}
 
 	public function testConstructWithCollection()
@@ -185,7 +185,7 @@ class PagesTest extends TestCase
 			'b/bb',
 		];
 
-		$this->assertEquals($expected, $pages->children()->keys());
+		$this->assertSame($expected, $pages->children()->keys());
 	}
 
 	public function testDocuments()
@@ -206,7 +206,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.pdf', 'b.pdf'], $pages->documents()->pluck('filename'));
+		$this->assertSame(['a.pdf', 'b.pdf'], $pages->documents()->pluck('filename'));
 	}
 
 	public function testDrafts()
@@ -235,7 +235,7 @@ class PagesTest extends TestCase
 			'b/bb',
 		];
 
-		$this->assertEquals($expected, $pages->drafts()->keys());
+		$this->assertSame($expected, $pages->drafts()->keys());
 	}
 
 	public function testFiles()
@@ -255,7 +255,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.jpg', 'b.pdf'], $pages->files()->pluck('filename'));
+		$this->assertSame(['a.jpg', 'b.pdf'], $pages->files()->pluck('filename'));
 	}
 
 	public function testFind()
@@ -665,7 +665,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.jpg', 'b.png'], $pages->images()->pluck('filename'));
+		$this->assertSame(['a.jpg', 'b.png'], $pages->images()->pluck('filename'));
 	}
 
 	public function testIndex()
@@ -704,7 +704,7 @@ class PagesTest extends TestCase
 			'b/bb',
 		];
 
-		$this->assertEquals($expected, $pages->index()->keys());
+		$this->assertSame($expected, $pages->index()->keys());
 	}
 
 	public function testIndexWithDrafts()
@@ -751,7 +751,7 @@ class PagesTest extends TestCase
 			'b/bb',
 		];
 
-		$this->assertEquals($expected, $pages->index(true)->keys());
+		$this->assertSame($expected, $pages->index(true)->keys());
 	}
 
 	public function testIndexCacheMode()
@@ -844,11 +844,11 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a', 'b', 'c', 'd'], $pages->notTemplate(null)->pluck('slug'));
-		$this->assertEquals(['b', 'c'], $pages->notTemplate('a')->pluck('slug'));
-		$this->assertEquals(['c'], $pages->notTemplate(['a', 'b'])->pluck('slug'));
-		$this->assertEquals(['a', 'b', 'c', 'd'], $pages->notTemplate(['z'])->pluck('slug'));
-		$this->assertEquals([], $pages->notTemplate(['a', 'b', 'c'])->pluck('slug'));
+		$this->assertSame(['a', 'b', 'c', 'd'], $pages->notTemplate(null)->pluck('slug'));
+		$this->assertSame(['b', 'c'], $pages->notTemplate('a')->pluck('slug'));
+		$this->assertSame(['c'], $pages->notTemplate(['a', 'b'])->pluck('slug'));
+		$this->assertSame(['a', 'b', 'c', 'd'], $pages->notTemplate(['z'])->pluck('slug'));
+		$this->assertSame([], $pages->notTemplate(['a', 'b', 'c'])->pluck('slug'));
 	}
 
 	public function testNums()
@@ -864,7 +864,7 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals([1, 2], $pages->nums());
+		$this->assertSame([1, 2], $pages->nums());
 	}
 
 	public function testListed()
@@ -974,7 +974,7 @@ class PagesTest extends TestCase
 		]);
 
 		$pages = $pages->find('page')->children();
-		$this->assertEquals('ab', $pages->test());
+		$this->assertSame('ab', $pages->test());
 
 		Pages::$methods = [];
 	}
@@ -996,9 +996,9 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a', 'b', 'c'], $pages->template(null)->pluck('slug'));
-		$this->assertEquals(['a', 'c'], $pages->template('a')->pluck('slug'));
-		$this->assertEquals(['a', 'b', 'c'], $pages->template(['a', 'b'])->pluck('slug'));
+		$this->assertSame(['a', 'b', 'c'], $pages->template(null)->pluck('slug'));
+		$this->assertSame(['a', 'c'], $pages->template('a')->pluck('slug'));
+		$this->assertSame(['a', 'b', 'c'], $pages->template(['a', 'b'])->pluck('slug'));
 	}
 
 	public function testVideos()
@@ -1019,6 +1019,6 @@ class PagesTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a.mov', 'b.mp4'], $pages->videos()->pluck('filename'));
+		$this->assertSame(['a.mov', 'b.mp4'], $pages->videos()->pluck('filename'));
 	}
 }

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -51,7 +51,7 @@ class PluginAssetsTest extends TestCase
 		$response = PluginAssets::resolve('test/test', 'test.css');
 
 		$this->assertTrue(is_link($this->fixtures . '/media/plugins/test/test/test.css'));
-		$this->assertEquals(200, $response->code());
-		$this->assertEquals('text/css', $response->type());
+		$this->assertSame(200, $response->code());
+		$this->assertSame('text/css', $response->type());
 	}
 }

--- a/tests/Cms/ResponseTest.php
+++ b/tests/Cms/ResponseTest.php
@@ -24,7 +24,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect();
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => 'https://getkirby.test'], $response->headers());
+		$this->assertEquals(['Location' => 'https://getkirby.test'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('https://getkirby.com');
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers());
+		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	/**
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('https://täst.de');
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers());
+		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	/**
@@ -57,6 +57,6 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('/uri', 301);
 		$this->assertSame('', $response->body());
 		$this->assertSame(301, $response->code());
-		$this->assertEquals(['Location' => 'https://getkirby.test/uri'], $response->headers());
+		$this->assertEquals(['Location' => 'https://getkirby.test/uri'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 }

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -21,9 +21,9 @@ class RoleTest extends TestCase
 			'title' => 'Admin'
 		]);
 
-		$this->assertEquals('admin', $role->name());
-		$this->assertEquals('Admin', $role->title());
-		$this->assertEquals('Test', $role->description());
+		$this->assertSame('admin', $role->name());
+		$this->assertSame('Admin', $role->title());
+		$this->assertSame('Test', $role->description());
 	}
 
 	public function testFactory()
@@ -31,8 +31,8 @@ class RoleTest extends TestCase
 		$app  = $this->app();
 		$role = Role::load(__DIR__ . '/fixtures/blueprints/users/editor.yml');
 
-		$this->assertEquals('editor', $role->name());
-		$this->assertEquals('Editor', $role->title());
+		$this->assertSame('editor', $role->name());
+		$this->assertSame('Editor', $role->title());
 	}
 
 	public function testMissingRole()
@@ -48,8 +48,8 @@ class RoleTest extends TestCase
 		$app  = $this->app();
 		$role = Role::admin();
 
-		$this->assertEquals('admin', $role->name());
-		$this->assertEquals('Admin', $role->title());
+		$this->assertSame('admin', $role->name());
+		$this->assertSame('Admin', $role->title());
 	}
 
 	public function testNobody()
@@ -57,8 +57,8 @@ class RoleTest extends TestCase
 		$app  = $this->app();
 		$role = Role::nobody();
 
-		$this->assertEquals('nobody', $role->name());
-		$this->assertEquals('Nobody', $role->title());
+		$this->assertSame('nobody', $role->name());
+		$this->assertSame('Nobody', $role->title());
 		$this->assertTrue($role->isNobody());
 	}
 
@@ -72,7 +72,7 @@ class RoleTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Editor', $role->title());
+		$this->assertSame('Editor', $role->title());
 	}
 
 	public function testTranslateDescription()
@@ -85,7 +85,7 @@ class RoleTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Editor', $role->title());
+		$this->assertSame('Editor', $role->title());
 	}
 
 	public function testToArrayAndDebugInfo()
@@ -103,7 +103,7 @@ class RoleTest extends TestCase
 			'title'       => 'Editor'
 		];
 
-		$this->assertEquals($expected, $role->toArray());
-		$this->assertEquals($expected, $role->__debugInfo());
+		$this->assertSame($expected, $role->toArray());
+		$this->assertSame($expected, $role->__debugInfo());
 	}
 }

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -20,8 +20,8 @@ class RolesTest extends TestCase
 
 		// should contain the editor role from fixtures and the default admin role
 		$this->assertCount(2, $roles);
-		$this->assertEquals('admin', $roles->first()->name());
-		$this->assertEquals('editor', $roles->last()->name());
+		$this->assertSame('admin', $roles->first()->name());
+		$this->assertSame('editor', $roles->last()->name());
 	}
 
 	public function testLoad()
@@ -32,8 +32,8 @@ class RolesTest extends TestCase
 
 		// should contain the editor role from fixtures and the default admin role
 		$this->assertCount(2, $roles);
-		$this->assertEquals('admin', $roles->first()->name());
-		$this->assertEquals('editor', $roles->last()->name());
+		$this->assertSame('admin', $roles->first()->name());
+		$this->assertSame('editor', $roles->last()->name());
 	}
 
 	public function testLoadFromPlugins()
@@ -54,8 +54,8 @@ class RolesTest extends TestCase
 		$roles = Roles::load();
 
 		$this->assertCount(2, $roles);
-		$this->assertEquals('admin', $roles->first()->name());
-		$this->assertEquals('editor', $roles->last()->name());
+		$this->assertSame('admin', $roles->first()->name());
+		$this->assertSame('editor', $roles->last()->name());
 	}
 
 	public function testLoadFromPluginsCallbackString()

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -40,7 +40,7 @@ class RouterTest extends TestCase
 
 		$page = $app->call('');
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
+		$this->assertSame('home', $page->id());
 	}
 
 	public function testHomeFolderRoute()
@@ -55,7 +55,7 @@ class RouterTest extends TestCase
 
 		$response = $app->call('home');
 		$this->assertInstanceOf(Responder::class, $response);
-		$this->assertEquals(302, $response->code());
+		$this->assertSame(302, $response->code());
 	}
 
 	public function testHomeCustomFolderRoute()
@@ -75,7 +75,7 @@ class RouterTest extends TestCase
 
 		$response = $app->call('homie');
 		$this->assertInstanceOf(Responder::class, $response);
-		$this->assertEquals(302, $response->code());
+		$this->assertSame(302, $response->code());
 	}
 
 	public function testHomeRouteWithoutHomePage()
@@ -106,7 +106,7 @@ class RouterTest extends TestCase
 
 		$page = $app->call('projects');
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('projects', $page->id());
+		$this->assertSame('projects', $page->id());
 	}
 
 	public function testPageRepresentationRoute()
@@ -137,7 +137,7 @@ class RouterTest extends TestCase
 		$result = $app->call('test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
+		$this->assertSame('xml', $result->body());
 	}
 
 	public function testPageFileRoute()
@@ -159,7 +159,7 @@ class RouterTest extends TestCase
 
 		$file = $app->call('projects/cover.jpg');
 		$this->assertInstanceOf(File::class, $file);
-		$this->assertEquals('projects/cover.jpg', $file->id());
+		$this->assertSame('projects/cover.jpg', $file->id());
 	}
 
 	public function testSiteFileRoute()
@@ -176,7 +176,7 @@ class RouterTest extends TestCase
 
 		$file = $app->call('background.jpg');
 		$this->assertInstanceOf(File::class, $file);
-		$this->assertEquals('background.jpg', $file->id());
+		$this->assertSame('background.jpg', $file->id());
 	}
 
 	public function testNestedPageRoute()
@@ -198,7 +198,7 @@ class RouterTest extends TestCase
 
 		$page = $app->call('projects/project-a');
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('projects/project-a', $page->id());
+		$this->assertSame('projects/project-a', $page->id());
 	}
 
 	public function testNotFoundRoute()
@@ -283,7 +283,7 @@ class RouterTest extends TestCase
 
 		// the api route should still be there
 		$patterns = array_column($app->routes(), 'pattern');
-		$this->assertEquals('api/(:all)', $patterns[0]);
+		$this->assertSame('api/(:all)', $patterns[0]);
 	}
 
 	public function testDisabledPanel()
@@ -337,7 +337,7 @@ class RouterTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $app->call($path));
+		$this->assertSame('test', $app->call($path));
 	}
 
 	public function testBadMethodRoute()
@@ -378,17 +378,17 @@ class RouterTest extends TestCase
 		$page = $app->call('fr');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals('fr', $app->language()->code());
-		$this->assertEquals('fr', I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame('fr', $app->language()->code());
+		$this->assertSame('fr', I18n::locale());
 
 		// en
 		$page = $app->call('en');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals('en', $app->language()->code());
-		$this->assertEquals('en', I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame('en', $app->language()->code());
+		$this->assertSame('en', I18n::locale());
 
 		// redirect
 		$result = $app->call('/');
@@ -426,17 +426,17 @@ class RouterTest extends TestCase
 		$page = $app->call('/');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals('fr', $app->language()->code());
-		$this->assertEquals('fr', I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame('fr', $app->language()->code());
+		$this->assertSame('fr', I18n::locale());
 
 		// en
 		$page = $app->call('en');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals('en', $app->language()->code());
-		$this->assertEquals('en', I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame('en', $app->language()->code());
+		$this->assertSame('en', I18n::locale());
 	}
 
 	public function multiDomainProvider()
@@ -483,9 +483,9 @@ class RouterTest extends TestCase
 		$page = $app->call('');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals($language, $app->language()->code());
-		$this->assertEquals($language, I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame($language, $app->language()->code());
+		$this->assertSame($language, I18n::locale());
 	}
 
 	/**
@@ -528,9 +528,9 @@ class RouterTest extends TestCase
 		$page = $app->call('subfolder');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('home', $page->id());
-		$this->assertEquals($language, $app->language()->code());
-		$this->assertEquals($language, I18n::locale());
+		$this->assertSame('home', $page->id());
+		$this->assertSame($language, $app->language()->code());
+		$this->assertSame($language, I18n::locale());
 	}
 
 	public function acceptedLanguageProvider()
@@ -579,7 +579,7 @@ class RouterTest extends TestCase
 		$response = $app->call('/');
 
 		$this->assertInstanceOf(Responder::class, $response);
-		$this->assertEquals(['Location' => $redirect], $response->headers());
+		$this->assertSame(['Location' => $redirect], $response->headers());
 
 		// reset the accepted visitor language
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptedLanguage;
@@ -640,17 +640,17 @@ class RouterTest extends TestCase
 		$page = $app->call('en/projects');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('projects', $page->id());
-		$this->assertEquals('en', $app->language()->code());
-		$this->assertEquals('en', I18n::locale());
+		$this->assertSame('projects', $page->id());
+		$this->assertSame('en', $app->language()->code());
+		$this->assertSame('en', I18n::locale());
 
 		// fr
 		$page = $app->call('fr/projects');
 
 		$this->assertInstanceOf(Page::class, $page);
-		$this->assertEquals('projects', $page->id());
-		$this->assertEquals('fr', $app->language()->code());
-		$this->assertEquals('fr', I18n::locale());
+		$this->assertSame('projects', $page->id());
+		$this->assertSame('fr', $app->language()->code());
+		$this->assertSame('fr', I18n::locale());
 	}
 
 	public function testMultilangPageRepresentationRoute()
@@ -692,9 +692,9 @@ class RouterTest extends TestCase
 		$result = $app->call('fr/test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('fr', $app->language()->code());
-		$this->assertEquals('fr', I18n::locale());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('fr', $app->language()->code());
+		$this->assertSame('fr', I18n::locale());
 
 		// EN
 
@@ -706,9 +706,9 @@ class RouterTest extends TestCase
 		$result = $app->call('en/test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('en', $app->language()->code());
-		$this->assertEquals('en', I18n::locale());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('en', $app->language()->code());
+		$this->assertSame('en', I18n::locale());
 	}
 
 	public function testMultilangPageRepresentationRouteWithoutLanguageCode()
@@ -751,9 +751,9 @@ class RouterTest extends TestCase
 		$result = $app->call('test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('fr', $app->language()->code());
-		$this->assertEquals('fr', I18n::locale());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('fr', $app->language()->code());
+		$this->assertSame('fr', I18n::locale());
 
 		// EN
 
@@ -765,9 +765,9 @@ class RouterTest extends TestCase
 		$result = $app->call('en/test.xml');
 
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertEquals('xml', $result->body());
-		$this->assertEquals('en', $app->language()->code());
-		$this->assertEquals('en', I18n::locale());
+		$this->assertSame('xml', $result->body());
+		$this->assertSame('en', $app->language()->code());
+		$this->assertSame('en', I18n::locale());
 	}
 
 	public function testCustomMediaFolder()
@@ -782,7 +782,7 @@ class RouterTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($media, $app->url('media'));
+		$this->assertSame($media, $app->url('media'));
 
 		// call custom media route
 		$route = $app->router()->find('thumbs/pages/a/b/1234-5678/test.jpg', 'GET');
@@ -796,12 +796,12 @@ class RouterTest extends TestCase
 
 		// default media route should result in the fallback route
 		$route = $app->router()->find('media/pages/a/b/1234-5678/test.jpg', 'GET');
-		$this->assertEquals('(.*)', $route->pattern());
+		$this->assertSame('(.*)', $route->pattern());
 
 		$route = $app->router()->find('media/site/1234-5678/test.jpg', 'GET');
-		$this->assertEquals('(.*)', $route->pattern());
+		$this->assertSame('(.*)', $route->pattern());
 
 		$route = $app->router()->find('media/users/test@getkirby.com/1234-5678/test.jpg', 'GET');
-		$this->assertEquals('(.*)', $route->pattern());
+		$this->assertSame('(.*)', $route->pattern());
 	}
 }

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -136,7 +136,7 @@ class FilesSectionTest extends TestCase
 			'model' => $a,
 		]);
 
-		$this->assertSame(null, $section->link());
+		$this->assertNull($section->link());
 		$this->assertSame($a, $section->parent());
 		$this->assertSame('pages/a/files', $section->upload()['api']);
 

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -57,7 +57,7 @@ class FilesSectionTest extends TestCase
 			'label' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->headline());
+		$this->assertSame('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('files', [
@@ -69,7 +69,7 @@ class FilesSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Files', $section->headline());
+		$this->assertSame('Files', $section->headline());
 	}
 
 	public function testMax()
@@ -136,9 +136,9 @@ class FilesSectionTest extends TestCase
 			'model' => $a,
 		]);
 
-		$this->assertEquals(false, $section->link());
-		$this->assertEquals($a, $section->parent());
-		$this->assertEquals('pages/a/files', $section->upload()['api']);
+		$this->assertSame(null, $section->link());
+		$this->assertSame($a, $section->parent());
+		$this->assertSame('pages/a/files', $section->upload()['api']);
 
 		// different parent
 		$section = new Section('files', [
@@ -146,9 +146,9 @@ class FilesSectionTest extends TestCase
 			'parent' => 'site.find("b")'
 		]);
 
-		$this->assertEquals('/pages/b', $section->link());
-		$this->assertEquals($b, $section->parent());
-		$this->assertEquals('pages/b/files', $section->upload()['api']);
+		$this->assertSame('/pages/b', $section->link());
+		$this->assertSame($b, $section->parent());
+		$this->assertSame('pages/b/files', $section->upload()['api']);
 	}
 
 	public function testParentCollectionFail()
@@ -184,7 +184,7 @@ class FilesSectionTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->empty());
+		$this->assertSame('Test', $section->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -195,7 +195,7 @@ class FilesSectionTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $section->empty());
+		$this->assertSame('Test', $section->empty());
 	}
 
 	public function testDragText()
@@ -219,7 +219,7 @@ class FilesSectionTest extends TestCase
 		]);
 
 		$data = $section->data();
-		$this->assertEquals('(image: a.jpg)', $data[0]['dragText']);
+		$this->assertSame('(image: a.jpg)', $data[0]['dragText']);
 	}
 
 	public function testDragTextWithDifferentParent()
@@ -254,7 +254,7 @@ class FilesSectionTest extends TestCase
 		]);
 
 		$data = $section->data();
-		$this->assertEquals('(image: file://test-file-a)', $data[0]['dragText']);
+		$this->assertSame('(image: file://test-file-a)', $data[0]['dragText']);
 	}
 
 	public function testHelp()
@@ -266,7 +266,7 @@ class FilesSectionTest extends TestCase
 			'help'  => 'Test'
 		]);
 
-		$this->assertEquals('<p>Test</p>', $section->help());
+		$this->assertSame('<p>Test</p>', $section->help());
 
 		// translated help
 		$section = new Section('files', [
@@ -278,7 +278,7 @@ class FilesSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>Information</p>', $section->help());
+		$this->assertSame('<p>Information</p>', $section->help());
 	}
 
 	public function testSortBy()
@@ -306,9 +306,9 @@ class FilesSectionTest extends TestCase
 			'name'  => 'test',
 			'model' => $model
 		]);
-		$this->assertEquals('b.jpg', $section->data()[0]['filename']);
-		$this->assertEquals('z.jpg', $section->data()[1]['filename']);
-		$this->assertEquals('ä.jpg', $section->data()[2]['filename']);
+		$this->assertSame('b.jpg', $section->data()[0]['filename']);
+		$this->assertSame('z.jpg', $section->data()[1]['filename']);
+		$this->assertSame('ä.jpg', $section->data()[2]['filename']);
 
 		// custom sorting direction
 		$section = new Section('files', [
@@ -316,9 +316,9 @@ class FilesSectionTest extends TestCase
 			'model'  => $model,
 			'sortBy' => 'filename desc'
 		]);
-		$this->assertEquals('ä.jpg', $section->data()[0]['filename']);
-		$this->assertEquals('z.jpg', $section->data()[1]['filename']);
-		$this->assertEquals('b.jpg', $section->data()[2]['filename']);
+		$this->assertSame('ä.jpg', $section->data()[0]['filename']);
+		$this->assertSame('z.jpg', $section->data()[1]['filename']);
+		$this->assertSame('b.jpg', $section->data()[2]['filename']);
 
 		// custom flag
 		$section = new Section('files', [
@@ -326,9 +326,9 @@ class FilesSectionTest extends TestCase
 			'model'  => $model,
 			'sortBy' => 'filename SORT_LOCALE_STRING'
 		]);
-		$this->assertEquals('ä.jpg', $section->data()[0]['filename']);
-		$this->assertEquals('b.jpg', $section->data()[1]['filename']);
-		$this->assertEquals('z.jpg', $section->data()[2]['filename']);
+		$this->assertSame('ä.jpg', $section->data()[0]['filename']);
+		$this->assertSame('b.jpg', $section->data()[1]['filename']);
+		$this->assertSame('z.jpg', $section->data()[2]['filename']);
 
 		// flag & sorting direction
 		$section = new Section('files', [
@@ -336,9 +336,9 @@ class FilesSectionTest extends TestCase
 			'model'  => $model,
 			'sortBy' => 'filename desc SORT_LOCALE_STRING'
 		]);
-		$this->assertEquals('z.jpg', $section->data()[0]['filename']);
-		$this->assertEquals('b.jpg', $section->data()[1]['filename']);
-		$this->assertEquals('ä.jpg', $section->data()[2]['filename']);
+		$this->assertSame('z.jpg', $section->data()[0]['filename']);
+		$this->assertSame('b.jpg', $section->data()[1]['filename']);
+		$this->assertSame('ä.jpg', $section->data()[2]['filename']);
 
 		setlocale(LC_ALL, $locale);
 	}
@@ -398,9 +398,9 @@ class FilesSectionTest extends TestCase
 			'flip'  => true
 		]);
 
-		$this->assertEquals('c.jpg', $section->data()[0]['filename']);
-		$this->assertEquals('b.jpg', $section->data()[1]['filename']);
-		$this->assertEquals('a.jpg', $section->data()[2]['filename']);
+		$this->assertSame('c.jpg', $section->data()[0]['filename']);
+		$this->assertSame('b.jpg', $section->data()[1]['filename']);
+		$this->assertSame('a.jpg', $section->data()[2]['filename']);
 	}
 
 	public function testTranslatedInfo()

--- a/tests/Cms/Sections/InfoSectionTest.php
+++ b/tests/Cms/Sections/InfoSectionTest.php
@@ -28,7 +28,7 @@ class InfoSectionTest extends TestCase
 			'label' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->headline());
+		$this->assertSame('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('info', [
@@ -40,7 +40,7 @@ class InfoSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Information', $section->headline());
+		$this->assertSame('Information', $section->headline());
 	}
 
 	public function testText()
@@ -52,7 +52,7 @@ class InfoSectionTest extends TestCase
 			'text'     => 'Test'
 		]);
 
-		$this->assertEquals('<p>Test</p>', $section->text());
+		$this->assertSame('<p>Test</p>', $section->text());
 
 		// translated text
 		$section = new Section('info', [
@@ -64,7 +64,7 @@ class InfoSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>Information</p>', $section->text());
+		$this->assertSame('<p>Information</p>', $section->text());
 	}
 
 	public function testTheme()
@@ -75,7 +75,7 @@ class InfoSectionTest extends TestCase
 			'theme' => 'notice'
 		]);
 
-		$this->assertEquals('notice', $section->theme());
+		$this->assertSame('notice', $section->theme());
 	}
 
 	public function testToArray()
@@ -94,6 +94,6 @@ class InfoSectionTest extends TestCase
 			'theme' => 'notice'
 		];
 
-		$this->assertEquals($expected, $section->toArray());
+		$this->assertSame($expected, $section->toArray());
 	}
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -38,7 +38,7 @@ class PagesSectionTest extends TestCase
 			'label' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->headline());
+		$this->assertSame('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('pages', [
@@ -50,7 +50,7 @@ class PagesSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Pages', $section->headline());
+		$this->assertSame('Pages', $section->headline());
 	}
 
 	public function testHeadlineFromLabel()
@@ -62,7 +62,7 @@ class PagesSectionTest extends TestCase
 			'label' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->headline());
+		$this->assertSame('Test', $section->headline());
 
 		// translated label
 		$section = new Section('pages', [
@@ -74,7 +74,7 @@ class PagesSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Pages', $section->headline());
+		$this->assertSame('Pages', $section->headline());
 	}
 
 	public function testParent()
@@ -94,7 +94,7 @@ class PagesSectionTest extends TestCase
 			'model' => $parent,
 		]);
 
-		$this->assertEquals('test', $section->parent()->id());
+		$this->assertSame('test', $section->parent()->id());
 
 		// page.find
 		$section = new Section('pages', [
@@ -103,7 +103,7 @@ class PagesSectionTest extends TestCase
 			'parent' => 'page.find("a")'
 		]);
 
-		$this->assertEquals('test/a', $section->parent()->id());
+		$this->assertSame('test/a', $section->parent()->id());
 	}
 
 	public function testParentWithInvalidOption()
@@ -152,7 +152,7 @@ class PagesSectionTest extends TestCase
 			'status' => $input
 		]);
 
-		$this->assertEquals($expected, $section->status());
+		$this->assertSame($expected, $section->status());
 	}
 
 	public function addableStatusProvider()
@@ -187,7 +187,7 @@ class PagesSectionTest extends TestCase
 			'status'   => $input
 		]);
 
-		$this->assertEquals($expected, $section->add());
+		$this->assertSame($expected, $section->add());
 	}
 
 	public function testAddWhenSectionIsFull()
@@ -227,9 +227,9 @@ class PagesSectionTest extends TestCase
 			'name'  => 'test',
 			'model' => $page
 		]);
-		$this->assertEquals('Z', $section->data()[0]['text']);
-		$this->assertEquals('Ä', $section->data()[1]['text']);
-		$this->assertEquals('B', $section->data()[2]['text']);
+		$this->assertSame('Z', $section->data()[0]['text']);
+		$this->assertSame('Ä', $section->data()[1]['text']);
+		$this->assertSame('B', $section->data()[2]['text']);
 
 		// sort by field
 		$section = new Section('pages', [
@@ -237,9 +237,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title'
 		]);
-		$this->assertEquals('B', $section->data()[0]['text']);
-		$this->assertEquals('Z', $section->data()[1]['text']);
-		$this->assertEquals('Ä', $section->data()[2]['text']);
+		$this->assertSame('B', $section->data()[0]['text']);
+		$this->assertSame('Z', $section->data()[1]['text']);
+		$this->assertSame('Ä', $section->data()[2]['text']);
 
 		// custom sorting direction
 		$section = new Section('pages', [
@@ -247,9 +247,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title desc'
 		]);
-		$this->assertEquals('Ä', $section->data()[0]['text']);
-		$this->assertEquals('Z', $section->data()[1]['text']);
-		$this->assertEquals('B', $section->data()[2]['text']);
+		$this->assertSame('Ä', $section->data()[0]['text']);
+		$this->assertSame('Z', $section->data()[1]['text']);
+		$this->assertSame('B', $section->data()[2]['text']);
 
 		// custom flag
 		$section = new Section('pages', [
@@ -257,9 +257,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title SORT_LOCALE_STRING'
 		]);
-		$this->assertEquals('Ä', $section->data()[0]['text']);
-		$this->assertEquals('B', $section->data()[1]['text']);
-		$this->assertEquals('Z', $section->data()[2]['text']);
+		$this->assertSame('Ä', $section->data()[0]['text']);
+		$this->assertSame('B', $section->data()[1]['text']);
+		$this->assertSame('Z', $section->data()[2]['text']);
 
 		// flag & sorting direction
 		$section = new Section('pages', [
@@ -267,9 +267,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title desc SORT_LOCALE_STRING'
 		]);
-		$this->assertEquals('Z', $section->data()[0]['text']);
-		$this->assertEquals('B', $section->data()[1]['text']);
-		$this->assertEquals('Ä', $section->data()[2]['text']);
+		$this->assertSame('Z', $section->data()[0]['text']);
+		$this->assertSame('B', $section->data()[1]['text']);
+		$this->assertSame('Ä', $section->data()[2]['text']);
 
 		setlocale(LC_ALL, $locale);
 	}
@@ -349,9 +349,9 @@ class PagesSectionTest extends TestCase
 			'flip'  => true
 		]);
 
-		$this->assertEquals('B', $section->data()[0]['text']);
-		$this->assertEquals('A', $section->data()[1]['text']);
-		$this->assertEquals('C', $section->data()[2]['text']);
+		$this->assertSame('B', $section->data()[0]['text']);
+		$this->assertSame('A', $section->data()[1]['text']);
+		$this->assertSame('C', $section->data()[2]['text']);
 	}
 
 	public function sortableStatusProvider()
@@ -376,7 +376,7 @@ class PagesSectionTest extends TestCase
 			'status'   => $input
 		]);
 
-		$this->assertEquals($expected, $section->sortable());
+		$this->assertSame($expected, $section->sortable());
 	}
 
 	public function testImageString()
@@ -428,7 +428,7 @@ class PagesSectionTest extends TestCase
 			'templates' => 'blog'
 		]);
 
-		$this->assertEquals(['blog'], $section->templates());
+		$this->assertSame(['blog'], $section->templates());
 
 		// multiple templates
 		$section = new Section('pages', [
@@ -437,7 +437,7 @@ class PagesSectionTest extends TestCase
 			'templates' => ['blog', 'notes']
 		]);
 
-		$this->assertEquals(['blog', 'notes'], $section->templates());
+		$this->assertSame(['blog', 'notes'], $section->templates());
 
 		// template via alias
 		$section = new Section('pages', [
@@ -446,7 +446,7 @@ class PagesSectionTest extends TestCase
 			'template' => 'blog'
 		]);
 
-		$this->assertEquals(['blog'], $section->templates());
+		$this->assertSame(['blog'], $section->templates());
 	}
 
 	public function testEmpty()
@@ -457,7 +457,7 @@ class PagesSectionTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->empty());
+		$this->assertSame('Test', $section->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -468,7 +468,7 @@ class PagesSectionTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $section->empty());
+		$this->assertSame('Test', $section->empty());
 	}
 
 	public function testHelp()
@@ -480,7 +480,7 @@ class PagesSectionTest extends TestCase
 			'help'  => 'Test'
 		]);
 
-		$this->assertEquals('<p>Test</p>', $section->help());
+		$this->assertSame('<p>Test</p>', $section->help());
 
 		// translated help
 		$section = new Section('pages', [
@@ -492,7 +492,7 @@ class PagesSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>Information</p>', $section->help());
+		$this->assertSame('<p>Information</p>', $section->help());
 	}
 
 	public function testTranslatedInfo()

--- a/tests/Cms/Sections/SectionTest.php
+++ b/tests/Cms/Sections/SectionTest.php
@@ -55,8 +55,8 @@ class SectionTest extends TestCase
 			'model' => new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals('default', $section->example());
-		$this->assertEquals(['one', 'two'], $section->buttons());
+		$this->assertSame('default', $section->example());
+		$this->assertSame(['one', 'two'], $section->buttons());
 	}
 
 	public function testToResponse()
@@ -88,6 +88,6 @@ class SectionTest extends TestCase
 			'b'      => 'B'
 		];
 
-		$this->assertEquals($expected, $section->toResponse());
+		$this->assertSame($expected, $section->toResponse());
 	}
 }

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -59,7 +59,7 @@ class StatsSectionTest extends TestCase
 			'label' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->headline());
+		$this->assertSame('Test', $section->headline());
 
 		// translated headline
 		$section = new Section('stats', [
@@ -71,7 +71,7 @@ class StatsSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('Stats', $section->headline());
+		$this->assertSame('Stats', $section->headline());
 	}
 
 	public function testReports()

--- a/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
@@ -30,7 +30,7 @@ class EmptySectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertSame(null, $section->empty());
+		$this->assertNull($section->empty());
 	}
 
 	public function testEmpty()

--- a/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
@@ -30,7 +30,7 @@ class EmptySectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertEquals(null, $section->empty());
+		$this->assertSame(null, $section->empty());
 	}
 
 	public function testEmpty()
@@ -40,7 +40,7 @@ class EmptySectionMixinTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $section->empty());
+		$this->assertSame('Test', $section->empty());
 	}
 
 	public function testTranslateEmpty()
@@ -53,6 +53,6 @@ class EmptySectionMixinTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('EN', $section->empty());
+		$this->assertSame('EN', $section->empty());
 	}
 }

--- a/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
@@ -35,7 +35,7 @@ class MaxSectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertEquals(null, $section->max());
+		$this->assertSame(null, $section->max());
 	}
 
 	public function testMax()
@@ -45,7 +45,7 @@ class MaxSectionMixinTest extends TestCase
 			'max'   => 1
 		]);
 
-		$this->assertEquals(1, $section->max());
+		$this->assertSame(1, $section->max());
 	}
 
 	public function testIsNotFull()

--- a/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
@@ -35,7 +35,7 @@ class MaxSectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertSame(null, $section->max());
+		$this->assertNull($section->max());
 	}
 
 	public function testMax()

--- a/tests/Cms/Sections/mixins/MinSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MinSectionMixinTest.php
@@ -35,7 +35,7 @@ class MinSectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertEquals(null, $section->min());
+		$this->assertSame(null, $section->min());
 	}
 
 	public function testMin()
@@ -45,7 +45,7 @@ class MinSectionMixinTest extends TestCase
 			'min'   => 1
 		]);
 
-		$this->assertEquals(1, $section->min());
+		$this->assertSame(1, $section->min());
 	}
 
 	public function testIsInvalid()

--- a/tests/Cms/Sections/mixins/MinSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MinSectionMixinTest.php
@@ -35,7 +35,7 @@ class MinSectionMixinTest extends TestCase
 			'model' => $this->page,
 		]);
 
-		$this->assertSame(null, $section->min());
+		$this->assertNull($section->min());
 	}
 
 	public function testMin()

--- a/tests/Cms/Site/SiteActionsTest.php
+++ b/tests/Cms/Site/SiteActionsTest.php
@@ -53,7 +53,7 @@ class SiteActionsTest extends TestCase
 	public function testChangeTitle()
 	{
 		$site = $this->site()->changeTitle('Test');
-		$this->assertEquals('Test', $site->title()->value());
+		$this->assertSame('Test', $site->title()->value());
 	}
 
 	public function testCreateChild()
@@ -63,8 +63,8 @@ class SiteActionsTest extends TestCase
 			'template' => 'test',
 		]);
 
-		$this->assertEquals('test', $page->slug());
-		$this->assertEquals('test', $page->intendedTemplate()->name());
+		$this->assertSame('test', $page->slug());
+		$this->assertSame('test', $page->intendedTemplate()->name());
 	}
 
 	public function testCreateFile()
@@ -76,13 +76,13 @@ class SiteActionsTest extends TestCase
 			'source'   => $source
 		]);
 
-		$this->assertEquals('test.md', $file->filename());
+		$this->assertSame('test.md', $file->filename());
 	}
 
 	public function testSave()
 	{
 		$site = $this->site()->clone(['content' => ['copyright' => 2012]])->save();
-		$this->assertEquals(2012, $site->copyright()->value());
+		$this->assertSame(2012, $site->copyright()->value());
 	}
 
 	public function testUpdate()
@@ -91,7 +91,7 @@ class SiteActionsTest extends TestCase
 			'copyright' => 2018
 		]);
 
-		$this->assertEquals(2018, $site->copyright()->value());
+		$this->assertSame(2018, $site->copyright()->value());
 	}
 
 	public function testChangeTitleHooks()

--- a/tests/Cms/Site/SiteBlueprintTest.php
+++ b/tests/Cms/Site/SiteBlueprintTest.php
@@ -17,6 +17,6 @@ class SiteBlueprintTest extends TestCase
 			'update'      => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertSame($expected, $blueprint->options());
 	}
 }

--- a/tests/Cms/Site/SiteContentTest.php
+++ b/tests/Cms/Site/SiteContentTest.php
@@ -20,8 +20,8 @@ class SiteContentTest extends TestCase
 			'content' => $content
 		]);
 
-		$this->assertEquals($content, $site->content()->toArray());
-		$this->assertEquals('lorem ipsum', $site->text()->value());
+		$this->assertSame($content, $site->content()->toArray());
+		$this->assertSame('lorem ipsum', $site->text()->value());
 	}
 
 	public function testInvalidContent()

--- a/tests/Cms/Site/SiteMethodsTest.php
+++ b/tests/Cms/Site/SiteMethodsTest.php
@@ -34,6 +34,6 @@ class SiteMethodsTest extends TestCase
 	public function testSiteMethod()
 	{
 		$site = $this->app->site();
-		$this->assertEquals('site method', $site->test());
+		$this->assertSame('site method', $site->test());
 	}
 }

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -20,7 +20,7 @@ class SiteTest extends TestCase
 	public function testToString()
 	{
 		$site = new Site(['url' => 'https://getkirby.com']);
-		$this->assertEquals('https://getkirby.com', $site->toString('{{ site.url }}'));
+		$this->assertSame('https://getkirby.com', $site->toString('{{ site.url }}'));
 	}
 
 	public function testBreadcrumb()
@@ -50,10 +50,10 @@ class SiteTest extends TestCase
 
 		$crumb = $site->breadcrumb();
 
-		$this->assertEquals($site->find('home'), $crumb->nth(0));
-		$this->assertEquals($site->find('grandma'), $crumb->nth(1));
-		$this->assertEquals($site->find('grandma/mother'), $crumb->nth(2));
-		$this->assertEquals($site->find('grandma/mother/child'), $crumb->nth(3));
+		$this->assertSame($site->find('home'), $crumb->nth(0));
+		$this->assertSame($site->find('grandma'), $crumb->nth(1));
+		$this->assertSame($site->find('grandma/mother'), $crumb->nth(2));
+		$this->assertSame($site->find('grandma/mother/child'), $crumb->nth(3));
 	}
 
 	public function testBreadcrumbSideEffects()
@@ -88,13 +88,13 @@ class SiteTest extends TestCase
 		$page  = $site->visit('grandma/mother/child-b');
 		$crumb = $site->breadcrumb();
 
-		$this->assertEquals($site->find('home'), $crumb->nth(0));
-		$this->assertEquals($site->find('grandma'), $crumb->nth(1));
-		$this->assertEquals($site->find('grandma/mother'), $crumb->nth(2));
-		$this->assertEquals($site->find('grandma/mother/child-b'), $crumb->nth(3));
+		$this->assertSame($site->find('home'), $crumb->nth(0));
+		$this->assertSame($site->find('grandma'), $crumb->nth(1));
+		$this->assertSame($site->find('grandma/mother'), $crumb->nth(2));
+		$this->assertSame($site->find('grandma/mother/child-b'), $crumb->nth(3));
 
-		$this->assertEquals('child-a', $page->prev()->slug());
-		$this->assertEquals('child-c', $page->next()->slug());
+		$this->assertSame('child-a', $page->prev()->slug());
+		$this->assertSame('child-c', $page->next()->slug());
 	}
 
 	public function testModified()
@@ -112,15 +112,15 @@ class SiteTest extends TestCase
 		$modified = filemtime($file);
 		$site     = $app->site();
 
-		$this->assertEquals($modified, $site->modified());
+		$this->assertSame($modified, $site->modified());
 
 		// default date handler
 		$format = 'd.m.Y';
-		$this->assertEquals(date($format, $modified), $site->modified($format));
+		$this->assertSame(date($format, $modified), $site->modified($format));
 
 		// custom date handler
 		$format = '%d.%m.%Y';
-		$this->assertEquals(@strftime($format, $modified), $site->modified($format, 'strftime'));
+		$this->assertSame(@strftime($format, $modified), $site->modified($format, 'strftime'));
 
 		Dir::remove($index);
 	}
@@ -149,7 +149,7 @@ class SiteTest extends TestCase
 		F::write($file = $index . '/site.en.txt', 'test');
 		touch($file, $modified = \time() + 2);
 
-		$this->assertEquals($modified, $app->site()->modified());
+		$this->assertSame($modified, $app->site()->modified());
 
 		// create the german site
 		F::write($file = $index . '/site.de.txt', 'test');
@@ -159,7 +159,7 @@ class SiteTest extends TestCase
 		$app->setCurrentLanguage('de');
 		$app->setCurrentTranslation('de');
 
-		$this->assertEquals($modified, $app->site()->modified());
+		$this->assertSame($modified, $app->site()->modified());
 
 		Dir::remove($index);
 	}
@@ -229,7 +229,7 @@ class SiteTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, $site->previewUrl());
+		$this->assertSame($expected, $site->previewUrl());
 	}
 
 	public function testToArray()

--- a/tests/Cms/Site/SiteTranslationsTest.php
+++ b/tests/Cms/Site/SiteTranslationsTest.php
@@ -59,32 +59,32 @@ class SiteTranslationsTest extends TestCase
 	{
 		$site = $this->site();
 
-		$this->assertEquals('/en', $site->url());
-		$this->assertEquals('/de', $site->url('de'));
+		$this->assertSame('/en', $site->url());
+		$this->assertSame('/de', $site->url('de'));
 
 		// non-existing language
-		$this->assertEquals('/', $site->url('fr'));
+		$this->assertSame('/', $site->url('fr'));
 	}
 
 	public function testContentInEnglish()
 	{
 		$site = $this->site();
-		$this->assertEquals('Site', $site->title()->value());
-		$this->assertEquals('Untranslated', $site->untranslated()->value());
+		$this->assertSame('Site', $site->title()->value());
+		$this->assertSame('Untranslated', $site->untranslated()->value());
 	}
 
 	public function testContentInDeutsch()
 	{
 		$site = $this->app('de')->site();
-		$this->assertEquals('Seite', $site->title()->value());
-		$this->assertEquals('Untranslated', $site->untranslated()->value());
+		$this->assertSame('Seite', $site->title()->value());
+		$this->assertSame('Untranslated', $site->untranslated()->value());
 	}
 
 	public function testTranslations()
 	{
 		$site = $this->site();
 		$this->assertCount(2, $site->translations());
-		$this->assertEquals(['en', 'de'], $site->translations()->keys());
+		$this->assertSame(['en', 'de'], $site->translations()->keys());
 	}
 
 	public function visitProvider()
@@ -142,9 +142,9 @@ class SiteTranslationsTest extends TestCase
 		$site = $app->site();
 		$page = $site->visit('test', $languageCode);
 
-		$this->assertEquals($languageCode, $app->language()->code());
-		$this->assertEquals('test', $page->slug());
-		$this->assertEquals($siteTitle, $site->title()->value());
-		$this->assertEquals($pageTitle, $page->title()->value());
+		$this->assertSame($languageCode, $app->language()->code());
+		$this->assertSame('test', $page->slug());
+		$this->assertSame($siteTitle, $site->title()->value());
+		$this->assertSame($pageTitle, $page->title()->value());
 	}
 }

--- a/tests/Cms/Structures/StructureObjectTest.php
+++ b/tests/Cms/Structures/StructureObjectTest.php
@@ -10,7 +10,7 @@ class StructureObjectTest extends TestCase
 			'id' => 'test'
 		]);
 
-		$this->assertEquals('test', $object->id());
+		$this->assertSame('test', $object->id());
 	}
 
 	public function testInvalidId()
@@ -38,7 +38,7 @@ class StructureObjectTest extends TestCase
 			'content' => $content
 		]);
 
-		$this->assertEquals($content, $object->content()->toArray());
+		$this->assertSame($content, $object->content()->toArray());
 	}
 
 	public function testToDate()
@@ -50,7 +50,7 @@ class StructureObjectTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('12.12.2012', $object->date()->toDate('d.m.Y'));
+		$this->assertSame('12.12.2012', $object->date()->toDate('d.m.Y'));
 	}
 
 	public function testDefaultContent()
@@ -59,7 +59,7 @@ class StructureObjectTest extends TestCase
 			'id' => 'test',
 		]);
 
-		$this->assertEquals([], $object->content()->toArray());
+		$this->assertSame([], $object->content()->toArray());
 	}
 
 	public function testFields()
@@ -75,8 +75,8 @@ class StructureObjectTest extends TestCase
 		$this->assertInstanceOf(Field::class, $object->title());
 		$this->assertInstanceOf(Field::class, $object->text());
 
-		$this->assertEquals('Title', $object->title()->value());
-		$this->assertEquals('Text', $object->text()->value());
+		$this->assertSame('Title', $object->title()->value());
+		$this->assertSame('Text', $object->text()->value());
 	}
 
 	public function testFieldsParent()
@@ -91,8 +91,8 @@ class StructureObjectTest extends TestCase
 			'parent' => $parent
 		]);
 
-		$this->assertEquals($parent, $object->title()->parent());
-		$this->assertEquals($parent, $object->text()->parent());
+		$this->assertSame($parent, $object->title()->parent());
+		$this->assertSame($parent, $object->text()->parent());
 	}
 
 	public function testParent()
@@ -103,7 +103,7 @@ class StructureObjectTest extends TestCase
 			'parent' => $parent
 		]);
 
-		$this->assertEquals($parent, $object->parent());
+		$this->assertSame($parent, $object->parent());
 	}
 
 	public function testInvalidParent()
@@ -134,6 +134,6 @@ class StructureObjectTest extends TestCase
 			'content' => $content
 		]);
 
-		$this->assertEquals($expected, $object->toArray());
+		$this->assertSame($expected, $object->toArray());
 	}
 }

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -13,7 +13,7 @@ class StructureTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(StructureObject::class, $structure->first());
-		$this->assertEquals('0', $structure->first()->id());
+		$this->assertSame('0', $structure->first()->id());
 	}
 
 	public function testParent()
@@ -23,7 +23,7 @@ class StructureTest extends TestCase
 			['test' => 'Test']
 		], $parent);
 
-		$this->assertEquals($parent, $structure->first()->parent());
+		$this->assertSame($parent, $structure->first()->parent());
 	}
 
 	public function testToArray()
@@ -86,7 +86,7 @@ class StructureTest extends TestCase
 		$this->assertEquals('C', $structure->last()->name());
 		$this->assertEquals('B', $structure->last()->prev()->name());
 
-		$this->assertEquals(2, $structure->last()->indexOf());
+		$this->assertSame(2, $structure->last()->indexOf());
 
 		$this->assertTrue($structure->first()->isFirst());
 		$this->assertTrue($structure->last()->isLast());

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -34,13 +34,13 @@ class StructureTest extends TestCase
 		];
 
 		$expected = [
-			['id' => 0, 'name' => 'A'],
-			['id' => 1, 'name' => 'B'],
+			['id' => '0', 'name' => 'A'],
+			['id' => '1', 'name' => 'B'],
 		];
 
 		$structure = new Structure($data);
 
-		$this->assertEquals($expected, $structure->toArray());
+		$this->assertSame($expected, $structure->toArray());
 	}
 
 	public function testGroup()
@@ -66,10 +66,13 @@ class StructureTest extends TestCase
 		$this->assertCount(2, $grouped->first());
 		$this->assertCount(1, $grouped->last());
 
-		$this->assertEquals('A', $grouped->first()->first()->name());
-		$this->assertEquals('C', $grouped->first()->last()->name());
+		$this->assertInstanceOf(Field::class, $grouped->first()->first()->name());
+		$this->assertInstanceOf(Field::class, $grouped->first()->last()->name());
+		$this->assertSame('A', $grouped->first()->first()->name()->value());
+		$this->assertSame('C', $grouped->first()->last()->name()->value());
 
-		$this->assertEquals('B', $grouped->last()->first()->name());
+		$this->assertInstanceOf(Field::class, $grouped->last()->first()->name());
+		$this->assertSame('B', $grouped->last()->first()->name()->value());
 	}
 
 	public function testSiblings()
@@ -80,11 +83,14 @@ class StructureTest extends TestCase
 			['name' => 'C']
 		]);
 
-
-		$this->assertEquals('A', $structure->first()->name());
-		$this->assertEquals('B', $structure->first()->next()->name());
-		$this->assertEquals('C', $structure->last()->name());
-		$this->assertEquals('B', $structure->last()->prev()->name());
+		$this->assertInstanceOf(Field::class, $structure->first()->name());
+		$this->assertInstanceOf(Field::class, $structure->first()->next()->name());
+		$this->assertInstanceOf(Field::class, $structure->last()->name());
+		$this->assertInstanceOf(Field::class, $structure->last()->prev()->name());
+		$this->assertSame('A', $structure->first()->name()->value());
+		$this->assertSame('B', $structure->first()->next()->name()->value());
+		$this->assertSame('C', $structure->last()->name()->value());
+		$this->assertSame('B', $structure->last()->prev()->name()->value());
 
 		$this->assertSame(2, $structure->last()->indexOf());
 

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -79,11 +79,11 @@ class TestCase extends BaseTestCase
 		$this->assertInstanceOf(Page::class, $input);
 
 		if (is_string($id)) {
-			$this->assertEquals($id, $input->id());
+			$this->assertSame($id, $input->id());
 		}
 
 		if ($id instanceof Page) {
-			$this->assertEquals($input, $id);
+			$this->assertSame($input, $id);
 		}
 	}
 
@@ -92,11 +92,11 @@ class TestCase extends BaseTestCase
 		$this->assertInstanceOf(File::class, $input);
 
 		if (is_string($id)) {
-			$this->assertEquals($id, $input->id());
+			$this->assertSame($id, $input->id());
 		}
 
 		if ($id instanceof File) {
-			$this->assertEquals($input, $id);
+			$this->assertSame($input, $id);
 		}
 	}
 
@@ -127,6 +127,6 @@ class TestCase extends BaseTestCase
 		], $appProps));
 
 		$action->call($this, $app);
-		$this->assertEquals(count($hooks), $triggered);
+		$this->assertSame(count($hooks), $triggered);
 	}
 }

--- a/tests/Cms/Translations/TranslationTest.php
+++ b/tests/Cms/Translations/TranslationTest.php
@@ -14,11 +14,11 @@ class TranslationTest extends TestCase
 			'test'                  => 'Test'
 		]);
 
-		$this->assertEquals('Kirby', $translation->author());
-		$this->assertEquals('English', $translation->name());
-		$this->assertEquals('ltr', $translation->direction());
-		$this->assertEquals('en_GB', $translation->locale());
-		$this->assertEquals('Test', $translation->get('test'));
+		$this->assertSame('Kirby', $translation->author());
+		$this->assertSame('English', $translation->name());
+		$this->assertSame('ltr', $translation->direction());
+		$this->assertSame('en_GB', $translation->locale());
+		$this->assertSame('Test', $translation->get('test'));
 	}
 
 	public function testLoad()

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -115,7 +115,8 @@ class UserActionsTest extends TestCase
 		$user = $this->app->user('editor@domain.com');
 		$user = $user->changeRole('editor');
 
-		$this->assertEquals('editor', $user->role());
+		$this->assertInstanceOf(Role::class, $user->role());
+		$this->assertSame('editor', $user->role()->name());
 	}
 
 	public function testCreateAdmin()
@@ -128,7 +129,8 @@ class UserActionsTest extends TestCase
 		$this->assertTrue($user->exists());
 
 		$this->assertSame('new@domain.com', $user->email());
-		$this->assertEquals('admin', $user->role());
+		$this->assertInstanceOf(Role::class, $user->role());
+		$this->assertSame('admin', $user->role()->name());
 	}
 
 	public function testCreateUserWithUnicodeEmail()
@@ -164,7 +166,8 @@ class UserActionsTest extends TestCase
 		$this->assertTrue($user->exists());
 
 		$this->assertSame('new@domain.com', $user->email());
-		$this->assertEquals('editor', $user->role());
+		$this->assertInstanceOf(Role::class, $user->role());
+		$this->assertSame('editor', $user->role()->name());
 	}
 
 	public function testCreateWithContent()

--- a/tests/Cms/Users/UserBlueprintTest.php
+++ b/tests/Cms/Users/UserBlueprintTest.php
@@ -16,7 +16,7 @@ class UserBlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('User', $blueprint->description());
+		$this->assertSame('User', $blueprint->description());
 	}
 
 	public function testOptions()
@@ -36,6 +36,6 @@ class UserBlueprintTest extends TestCase
 			'update'         => null,
 		];
 
-		$this->assertEquals($expected, $blueprint->options());
+		$this->assertSame($expected, $blueprint->options());
 	}
 }

--- a/tests/Cms/Users/UserMethodsTest.php
+++ b/tests/Cms/Users/UserMethodsTest.php
@@ -20,7 +20,7 @@ class UserMethodsTest extends TestCase
 			'id'    => 'test',
 			'email' => 'user@domain.com'
 		]);
-		$this->assertEquals('test', $user->id());
+		$this->assertSame('test', $user->id());
 	}
 
 	public function testLanguage()
@@ -30,7 +30,7 @@ class UserMethodsTest extends TestCase
 			'language' => 'en',
 		]);
 
-		$this->assertEquals('en', $user->language());
+		$this->assertSame('en', $user->language());
 	}
 
 	public function testDefaultLanguage()
@@ -39,7 +39,7 @@ class UserMethodsTest extends TestCase
 			'email' => 'user@domain.com',
 		]);
 
-		$this->assertEquals('en', $user->language());
+		$this->assertSame('en', $user->language());
 	}
 
 	public function testRole()
@@ -56,7 +56,7 @@ class UserMethodsTest extends TestCase
 			'kirby' => $kirby
 		]);
 
-		$this->assertEquals('editor', $user->role()->name());
+		$this->assertSame('editor', $user->role()->name());
 	}
 
 	public function testDefaultRole()
@@ -65,6 +65,6 @@ class UserMethodsTest extends TestCase
 			'email' => 'user@domain.com',
 		]);
 
-		$this->assertEquals('nobody', $user->role()->name());
+		$this->assertSame('nobody', $user->role()->name());
 	}
 }

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -73,7 +73,8 @@ class UserTest extends TestCase
 			'name' => $name = 'Homer Simpson',
 		]);
 
-		$this->assertEquals($name, $user->name());
+		$this->assertInstanceOf(Field::class, $user->name());
+		$this->assertSame($name, $user->name()->value());
 	}
 
 	public function testNameSanitized()
@@ -82,7 +83,8 @@ class UserTest extends TestCase
 			'name' => '<strong>Homer</strong> Simpson',
 		]);
 
-		$this->assertEquals('Homer Simpson', $user->name());
+		$this->assertInstanceOf(Field::class, $user->name());
+		$this->assertSame('Homer Simpson', $user->name()->value());
 	}
 
 	public function testNameOrEmail()
@@ -92,6 +94,7 @@ class UserTest extends TestCase
 			'name'  => $name = 'Homer Simpson',
 		]);
 
+		$this->assertInstanceOf(Field::class, $user->nameOrEmail());
 		$this->assertSame($name, $user->nameOrEmail()->value());
 		$this->assertSame('name', $user->nameOrEmail()->key());
 
@@ -100,6 +103,7 @@ class UserTest extends TestCase
 			'name'  => ''
 		]);
 
+		$this->assertInstanceOf(Field::class, $user->nameOrEmail());
 		$this->assertSame($email, $user->nameOrEmail()->value());
 		$this->assertSame('email', $user->nameOrEmail()->key());
 	}
@@ -137,15 +141,15 @@ class UserTest extends TestCase
 		$modified = filemtime($file);
 		$user     = $app->user('test');
 
-		$this->assertEquals($modified, $user->modified());
+		$this->assertSame((string)$modified, $user->modified());
 
 		// default date handler
 		$format = 'd.m.Y';
-		$this->assertEquals(date($format, $modified), $user->modified($format));
+		$this->assertSame(date($format, $modified), $user->modified($format));
 
 		// custom date handler
 		$format = '%d.%m.%Y';
-		$this->assertEquals(@strftime($format, $modified), $user->modified($format, 'strftime'));
+		$this->assertSame(@strftime($format, $modified), $user->modified($format, 'strftime'));
 
 		Dir::remove($index);
 	}
@@ -183,8 +187,8 @@ class UserTest extends TestCase
 
 		$user = $app->user('test');
 
-		$this->assertEquals($modifiedEnContent, $user->modified('U', null, 'en'));
-		$this->assertEquals($modifiedDeContent, $user->modified('U', null, 'de'));
+		$this->assertSame((string)$modifiedEnContent, $user->modified('U', null, 'en'));
+		$this->assertSame((string)$modifiedDeContent, $user->modified('U', null, 'de'));
 
 		Dir::remove($index);
 	}

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -35,7 +35,7 @@ class UserTest extends TestCase
 			'content' => $content = ['name' => 'Test']
 		]);
 
-		$this->assertEquals($content, $user->content()->toArray());
+		$this->assertSame($content, $user->content()->toArray());
 	}
 
 	public function testInvalidContent()
@@ -57,7 +57,7 @@ class UserTest extends TestCase
 			'email' => $email = 'user@domain.com',
 		]);
 
-		$this->assertEquals($email, $user->email());
+		$this->assertSame($email, $user->email());
 	}
 
 	public function testInvalidEmail()
@@ -110,7 +110,7 @@ class UserTest extends TestCase
 			'email' => 'test@getkirby.com'
 		]);
 
-		$this->assertEquals('test@getkirby.com', $user->toString());
+		$this->assertSame('test@getkirby.com', $user->toString());
 	}
 
 	public function testToStringWithTemplate()
@@ -119,7 +119,7 @@ class UserTest extends TestCase
 			'email' => 'test@getkirby.com'
 		]);
 
-		$this->assertEquals('Email: test@getkirby.com', $user->toString('Email: {{ user.email }}'));
+		$this->assertSame('Email: test@getkirby.com', $user->toString('Email: {{ user.email }}'));
 	}
 
 	public function testModified()
@@ -328,7 +328,7 @@ class UserTest extends TestCase
 			'name'  => 'Test User'
 		]);
 
-		$this->assertEquals('homer', $user->test());
+		$this->assertSame('homer', $user->test());
 
 		User::$methods = [];
 	}

--- a/tests/Cms/Users/UsersTest.php
+++ b/tests/Cms/Users/UsersTest.php
@@ -122,7 +122,7 @@ class UsersTest extends TestCase
 		]);
 
 		$files = $app->users()->files();
-		$this->assertSame(3, $files->count());
+		$this->assertCount(3, $files);
 		$this->assertSame('a.jpg', $files->first()->filename());
 		$this->assertSame('c.jpg', $files->find('user-c/c.jpg')->filename());
 	}

--- a/tests/Cms/Users/UsersTest.php
+++ b/tests/Cms/Users/UsersTest.php
@@ -19,8 +19,8 @@ class UsersTest extends TestCase
 		$result = $users->add($user);
 
 		$this->assertCount(2, $result);
-		$this->assertEquals('a@getkirby.com', $result->nth(0)->email());
-		$this->assertEquals('b@getkirby.com', $result->nth(1)->email());
+		$this->assertSame('a@getkirby.com', $result->nth(0)->email());
+		$this->assertSame('b@getkirby.com', $result->nth(1)->email());
 	}
 
 	public function testAddCollection()
@@ -37,9 +37,9 @@ class UsersTest extends TestCase
 		$c = $a->add($b);
 
 		$this->assertCount(3, $c);
-		$this->assertEquals('a@getkirby.com', $c->nth(0)->email());
-		$this->assertEquals('b@getkirby.com', $c->nth(1)->email());
-		$this->assertEquals('c@getkirby.com', $c->nth(2)->email());
+		$this->assertSame('a@getkirby.com', $c->nth(0)->email());
+		$this->assertSame('b@getkirby.com', $c->nth(1)->email());
+		$this->assertSame('c@getkirby.com', $c->nth(2)->email());
 	}
 
 	public function testAddById()
@@ -63,9 +63,9 @@ class UsersTest extends TestCase
 		$users = $users->add('c@getkirby.com');
 
 		$this->assertCount(3, $users);
-		$this->assertEquals('a@getkirby.com', $users->nth(0)->email());
-		$this->assertEquals('b@getkirby.com', $users->nth(1)->email());
-		$this->assertEquals('c@getkirby.com', $users->nth(2)->email());
+		$this->assertSame('a@getkirby.com', $users->nth(0)->email());
+		$this->assertSame('b@getkirby.com', $users->nth(1)->email());
+		$this->assertSame('c@getkirby.com', $users->nth(2)->email());
 	}
 
 	public function testAddNull()
@@ -137,10 +137,10 @@ class UsersTest extends TestCase
 		$first = $users->first();
 		$last  = $users->last();
 
-		$this->assertEquals($first, $users->find($first->id()));
-		$this->assertEquals($last, $users->find($last->id()));
-		$this->assertEquals($first, $users->find($first->email()));
-		$this->assertEquals($last, $users->find($last->email()));
+		$this->assertSame($first, $users->find($first->id()));
+		$this->assertSame($last, $users->find($last->id()));
+		$this->assertSame($first, $users->find($first->email()));
+		$this->assertSame($last, $users->find($last->email()));
 	}
 
 	public function testFindByEmail()
@@ -150,10 +150,10 @@ class UsersTest extends TestCase
 			new User(['email' => 'B@getKirby.com']),
 		]);
 
-		$this->assertEquals('a@getkirby.com', $users->find('a@getkirby.com')->email());
-		$this->assertEquals('a@getkirby.com', $users->find('A@getkirby.com')->email());
-		$this->assertEquals('b@getkirby.com', $users->find('B@getkirby.com')->email());
-		$this->assertEquals('b@getkirby.com', $users->find('b@getkirby.com')->email());
+		$this->assertSame('a@getkirby.com', $users->find('a@getkirby.com')->email());
+		$this->assertSame('a@getkirby.com', $users->find('A@getkirby.com')->email());
+		$this->assertSame('b@getkirby.com', $users->find('B@getkirby.com')->email());
+		$this->assertSame('b@getkirby.com', $users->find('b@getkirby.com')->email());
 	}
 
 	public function testFindByUuid()
@@ -190,7 +190,7 @@ class UsersTest extends TestCase
 			new User(['email' => 'B@getKirby.com']),
 		]);
 
-		$this->assertEquals(2, $users->test());
+		$this->assertSame(2, $users->test());
 
 		Users::$methods = [];
 	}

--- a/tests/Database/DbTest.php
+++ b/tests/Database/DbTest.php
@@ -168,14 +168,14 @@ class DbTest extends TestCase
 	public function testSelect()
 	{
 		$result = Db::select('users');
-		$this->assertSame(3, $result->count());
+		$this->assertCount(3, $result);
 
 		$result = Db::select('users', 'username', ['username' => 'paul']);
-		$this->assertSame(1, $result->count());
+		$this->assertCount(1, $result);
 		$this->assertSame('paul', $result->first()->username());
 
 		$result = Db::select('users', 'username', null, 'username ASC', 1, 1);
-		$this->assertSame(1, $result->count());
+		$this->assertCount(1, $result);
 		$this->assertSame('john', $result->first()->username());
 	}
 

--- a/tests/Email/PHPMailerTest.php
+++ b/tests/Email/PHPMailerTest.php
@@ -121,12 +121,12 @@ class PHPMailerTest extends TestCase
 			'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
 				$phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
 				$phpunit->assertSame('smtp', $mailer->Mailer);
-				$phpunit->assertSame(null, $mailer->Host);
-				$phpunit->assertSame(false, $mailer->SMTPAuth);
-				$phpunit->assertSame(null, $mailer->Username);
-				$phpunit->assertSame(null, $mailer->Password);
+				$phpunit->assertNull($mailer->Host);
+				$phpunit->assertFalse($mailer->SMTPAuth);
+				$phpunit->assertNull($mailer->Username);
+				$phpunit->assertNull($mailer->Password);
 				$phpunit->assertSame('ssl', $mailer->SMTPSecure);
-				$phpunit->assertSame(null, $mailer->Port);
+				$phpunit->assertNull($mailer->Port);
 
 				$beforeSend = true;
 			}

--- a/tests/Exception/ErrorPageExceptionTest.php
+++ b/tests/Exception/ErrorPageExceptionTest.php
@@ -12,8 +12,8 @@ class ErrorPageExceptionTest extends TestCase
 	public function testDefaults()
 	{
 		$exception = new ErrorPageException();
-		$this->assertEquals('error.errorPage', $exception->getKey());
-		$this->assertEquals('Triggered error page', $exception->getMessage());
-		$this->assertEquals(404, $exception->getHttpCode());
+		$this->assertSame('error.errorPage', $exception->getKey());
+		$this->assertSame('Triggered error page', $exception->getMessage());
+		$this->assertSame(404, $exception->getHttpCode());
 	}
 }

--- a/tests/Field/FieldOptionsTest.php
+++ b/tests/Field/FieldOptionsTest.php
@@ -36,7 +36,7 @@ class FieldOptionsTest extends TestCase
 		$options = FieldOptions::factory(['type' => 'array', 'options' => ['a', 'b']]);
 		$this->assertInstanceOf(Options::class, $options->options);
 		$this->assertTrue($options->safeMode);
-		$this->assertSame(2, $options->options->count());
+		$this->assertCount(2, $options->options);
 
 		$options = FieldOptions::factory(
 			[

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -53,9 +53,9 @@ class DirTest extends TestCase
 
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($target . '/a.txt'));
-		$this->assertTrue(file_exists($target . '/subfolder/b.txt'));
-		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
+		$this->assertFileExists($target . '/a.txt');
+		$this->assertFileExists($target . '/subfolder/b.txt');
+		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
 	/**
@@ -70,9 +70,9 @@ class DirTest extends TestCase
 
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($target . '/a.txt'));
-		$this->assertFalse(file_exists($target . '/subfolder/b.txt'));
-		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
+		$this->assertFileExists($target . '/a.txt');
+		$this->assertFileDoesNotExist($target . '/subfolder/b.txt');
+		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
 	/**
@@ -87,10 +87,10 @@ class DirTest extends TestCase
 
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($target . '/a.txt'));
+		$this->assertFileExists($target . '/a.txt');
 		$this->assertTrue(is_dir($target . '/subfolder'));
-		$this->assertFalse(file_exists($target . '/subfolder/b.txt'));
-		$this->assertFalse(file_exists($target . '/subfolder/.gitignore'));
+		$this->assertFileDoesNotExist($target . '/subfolder/b.txt');
+		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
 	/**
@@ -105,10 +105,10 @@ class DirTest extends TestCase
 
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($target . '/a.txt'));
+		$this->assertFileExists($target . '/a.txt');
 		$this->assertTrue(is_dir($target . '/subfolder'));
-		$this->assertTrue(file_exists($target . '/subfolder/b.txt'));
-		$this->assertTrue(file_exists($target . '/subfolder/.gitignore'));
+		$this->assertFileExists($target . '/subfolder/b.txt');
+		$this->assertFileExists($target . '/subfolder/.gitignore');
 	}
 
 	/**

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -409,7 +409,7 @@ class DirTest extends TestCase
 
 		$this->assertSame('a', $inventory['children'][0]['model']);
 		$this->assertSame('b', $inventory['children'][1]['model']);
-		$this->assertSame(null, $inventory['children'][2]['model']);
+		$this->assertNull($inventory['children'][2]['model']);
 
 		Page::$models = [];
 	}
@@ -453,7 +453,7 @@ class DirTest extends TestCase
 
 		$this->assertSame('a', $inventory['children'][0]['model']);
 		$this->assertSame('b', $inventory['children'][1]['model']);
-		$this->assertSame(null, $inventory['children'][2]['model']);
+		$this->assertNull($inventory['children'][2]['model']);
 
 		Page::$models = [];
 	}

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -88,7 +88,7 @@ class DirTest extends TestCase
 		$this->assertTrue($result);
 
 		$this->assertFileExists($target . '/a.txt');
-		$this->assertTrue(is_dir($target . '/subfolder'));
+		$this->assertDirectoryExists($target . '/subfolder');
 		$this->assertFileDoesNotExist($target . '/subfolder/b.txt');
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
@@ -106,7 +106,7 @@ class DirTest extends TestCase
 		$this->assertTrue($result);
 
 		$this->assertFileExists($target . '/a.txt');
-		$this->assertTrue(is_dir($target . '/subfolder'));
+		$this->assertDirectoryExists($target . '/subfolder');
 		$this->assertFileExists($target . '/subfolder/b.txt');
 		$this->assertFileExists($target . '/subfolder/.gitignore');
 	}
@@ -599,9 +599,9 @@ class DirTest extends TestCase
 	{
 		Dir::make($this->tmp);
 
-		$this->assertTrue(is_dir($this->tmp));
+		$this->assertDirectoryExists($this->tmp);
 		$this->assertTrue(Dir::remove($this->tmp));
-		$this->assertFalse(is_dir($this->tmp));
+		$this->assertDirectoryDoesNotExist($this->tmp);
 	}
 
 	/**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -172,7 +172,7 @@ class FTest extends TestCase
 		F::write($src, 'test');
 
 		$this->assertTrue(F::link($src, $link));
-		$this->assertTrue(is_file($link));
+		$this->assertFileExists($link);
 	}
 
 	/**
@@ -789,7 +789,7 @@ class FTest extends TestCase
 		$this->assertTrue(F::unlink($this->tmp . '/link-exists'));
 		$this->assertTrue(F::unlink($this->tmp . '/link-invalid'));
 
-		$this->assertFalse(is_file($this->tmp . '/file'));
+		$this->assertFileDoesNotExist($this->tmp . '/file');
 		$this->assertFalse(is_link($this->tmp . '/link-exists'));
 		$this->assertFalse(is_link($this->tmp . '/link-invalid'));
 	}

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -884,7 +884,7 @@ class FTest extends TestCase
 		F::write($this->test, $input);
 
 		$result = unserialize(F::read($this->test));
-		$this->assertEquals($input, $result);
+		$this->assertEquals($input, $result); // cannot use strict assertion (serialization)
 	}
 
 	/**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -879,7 +879,9 @@ class FTest extends TestCase
 	 */
 	public function testWriteObject()
 	{
-		$input = new \stdClass();
+		$input = new \stdClass([
+			'a' => 'b'
+		]);
 
 		F::write($this->test, $input);
 

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -26,7 +26,7 @@ class FTest extends TestCase
 		$this->fixtures = __DIR__ . '/fixtures/f';
 		$this->sample   = $this->fixtures . '/test.txt';
 		$this->tmp      = __DIR__ . '/tmp';
-		$this->test    = $this->tmp . '/moved.txt';
+		$this->test     = $this->tmp . '/moved.txt';
 
 		Dir::remove($this->tmp);
 		Dir::make($this->tmp);

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -72,9 +72,9 @@ class FTest extends TestCase
 		$origin = $this->tmp . '/a.txt';
 		F::write($origin, 'test');
 
-		$this->assertFalse(file_exists($this->test));
+		$this->assertFileDoesNotExist($this->test);
 		$this->assertTrue(F::copy($origin, $this->test));
-		$this->assertTrue(file_exists($this->test));
+		$this->assertFileExists($this->test);
 	}
 
 	/**
@@ -464,25 +464,25 @@ class FTest extends TestCase
 		F::write($origin = $this->tmp . '/a.txt', 'test');
 
 		// simply move file
-		$this->assertFalse(file_exists($this->test));
-		$this->assertTrue(file_exists($origin));
+		$this->assertFileDoesNotExist($this->test);
+		$this->assertFileExists($origin);
 
 		$this->assertTrue(F::move($origin, $this->test));
 
-		$this->assertTrue(file_exists($this->test));
-		$this->assertFalse(file_exists($origin));
+		$this->assertFileExists($this->test);
+		$this->assertFileDoesNotExist($origin);
 
 		// replace file via moving
 		F::copy($this->test, $origin);
 
-		$this->assertTrue(file_exists($origin));
-		$this->assertTrue(file_exists($this->test));
+		$this->assertFileExists($origin);
+		$this->assertFileExists($this->test);
 
 		$this->assertFalse(F::move($this->test, $origin));
 		$this->assertTrue(F::move($this->test, $origin, true));
 
-		$this->assertFalse(file_exists($this->test));
-		$this->assertTrue(file_exists($origin));
+		$this->assertFileDoesNotExist($this->test);
+		$this->assertFileExists($origin);
 	}
 
 	/**
@@ -668,36 +668,36 @@ class FTest extends TestCase
 		F::write($origin = $this->tmp . '/a.txt', 'test');
 
 		// simply rename file
-		$this->assertFalse(file_exists($this->test));
-		$this->assertTrue(file_exists($origin));
+		$this->assertFileDoesNotExist($this->test);
+		$this->assertFileExists($origin);
 
 		$this->assertSame($this->test, F::rename($origin, 'moved'));
 
-		$this->assertTrue(file_exists($this->test));
-		$this->assertFalse(file_exists($origin));
+		$this->assertFileExists($this->test);
+		$this->assertFileDoesNotExist($origin);
 
 		// rename file with same name
 
-		$this->assertTrue(file_exists($this->test));
-		$this->assertFalse(file_exists($origin));
+		$this->assertFileExists($this->test);
+		$this->assertFileDoesNotExist($origin);
 
 		$this->assertSame($this->test, F::rename($this->test, 'moved'));
 		$this->assertSame($this->test, F::rename($this->test, 'moved', true));
 
-		$this->assertTrue(file_exists($this->test));
-		$this->assertFalse(file_exists($origin));
+		$this->assertFileExists($this->test);
+		$this->assertFileDoesNotExist($origin);
 
 		// replace file via renaming
 		F::copy($this->test, $origin);
 
-		$this->assertTrue(file_exists($this->test));
-		$this->assertTrue(file_exists($origin));
+		$this->assertFileExists($this->test);
+		$this->assertFileExists($origin);
 
 		$this->assertFalse(F::rename($this->test, 'a'));
 		$this->assertSame($origin, F::rename($this->test, 'a', true));
 
-		$this->assertFalse(file_exists($this->test));
-		$this->assertTrue(file_exists($origin));
+		$this->assertFileDoesNotExist($this->test);
+		$this->assertFileExists($origin);
 	}
 
 	/**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -500,7 +500,7 @@ class FTest extends TestCase
 	public function testMimeToExtension()
 	{
 		$this->assertSame('jpg', F::mimeToExtension('image/jpeg'));
-		$this->assertSame(false, F::mimeToExtension('image/something'));
+		$this->assertFalse(F::mimeToExtension('image/something'));
 	}
 
 	/**
@@ -509,7 +509,7 @@ class FTest extends TestCase
 	public function testMimeToType()
 	{
 		$this->assertSame('image', F::mimeToType('image/jpeg'));
-		$this->assertSame(false, F::mimeToType('image/something'));
+		$this->assertFalse(F::mimeToType('image/something'));
 	}
 
 	/**

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -728,7 +728,7 @@ class FileTest extends TestCase
 		$this->assertSame('blank.pdf', $file->toArray()['filename']);
 		$this->assertSame('blank', $file->toArray()['name']);
 		$this->assertSame('pdf', $file->toArray()['extension']);
-		$this->assertSame(false, $file->toArray()['isResizable']);
+		$this->assertFalse($file->toArray()['isResizable']);
 		$this->assertSame($file->toArray(), $file->__debugInfo());
 	}
 

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -108,14 +108,14 @@ class FileTest extends TestCase
 		$file = new File($oldRoot);
 		$file->write('test');
 
-		$this->assertTrue(file_exists($oldRoot));
-		$this->assertFalse(file_exists($newRoot));
+		$this->assertFileExists($oldRoot);
+		$this->assertFileDoesNotExist($newRoot);
 		$this->assertSame($oldRoot, $file->root());
 
 		$new = $file->copy($newRoot);
 
-		$this->assertTrue(file_exists($oldRoot));
-		$this->assertTrue(file_exists($newRoot));
+		$this->assertFileExists($oldRoot);
+		$this->assertFileExists($newRoot);
 		$this->assertInstanceOf(File::class, $new);
 		$this->assertSame($newRoot, $new->root());
 	}
@@ -501,14 +501,14 @@ class FileTest extends TestCase
 		$file = new File($oldRoot);
 		$file->write('test');
 
-		$this->assertTrue(file_exists($oldRoot));
-		$this->assertFalse(file_exists($newRoot));
+		$this->assertFileExists($oldRoot);
+		$this->assertFileDoesNotExist($newRoot);
 		$this->assertSame($oldRoot, $file->root());
 
 		$moved = $file->move($newRoot);
 
-		$this->assertFalse(file_exists($oldRoot));
-		$this->assertTrue(file_exists($newRoot));
+		$this->assertFileDoesNotExist($oldRoot);
+		$this->assertFileExists($newRoot);
 		$this->assertSame($newRoot, $moved->root());
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -463,7 +463,7 @@ class FieldClassTest extends TestCase
 		$array = $field->toArray();
 
 		$this->assertSame($props, $field->props());
-		$this->assertEquals($props + ['signature' => $array['signature']], $array);
+		$this->assertEquals($props + ['signature' => $array['signature']], $array); // cannot use strict assertion (array order)
 	}
 
 	/**

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -58,8 +58,8 @@ class FieldTest extends TestCase
 			'after' => 'test'
 		]);
 
-		$this->assertEquals('test', $field->after());
-		$this->assertEquals('test', $field->after);
+		$this->assertSame('test', $field->after());
+		$this->assertSame('test', $field->after);
 
 		// translated
 		$field = new Field('test', [
@@ -70,8 +70,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('en', $field->after());
-		$this->assertEquals('en', $field->after);
+		$this->assertSame('en', $field->after());
+		$this->assertSame('en', $field->after);
 
 		// with query
 		$field = new Field('test', [
@@ -79,8 +79,8 @@ class FieldTest extends TestCase
 			'after' => '{{ page.slug }}'
 		]);
 
-		$this->assertEquals('blog', $field->after());
-		$this->assertEquals('blog', $field->after);
+		$this->assertSame('blog', $field->after());
+		$this->assertSame('blog', $field->after);
 	}
 
 	public function testAutofocus()
@@ -123,8 +123,8 @@ class FieldTest extends TestCase
 			'before' => 'test'
 		]);
 
-		$this->assertEquals('test', $field->before());
-		$this->assertEquals('test', $field->before);
+		$this->assertSame('test', $field->before());
+		$this->assertSame('test', $field->before);
 
 		// translated
 		$field = new Field('test', [
@@ -135,8 +135,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('en', $field->before());
-		$this->assertEquals('en', $field->before);
+		$this->assertSame('en', $field->before());
+		$this->assertSame('en', $field->before);
 
 		// with query
 		$field = new Field('test', [
@@ -144,8 +144,8 @@ class FieldTest extends TestCase
 			'before' => '{{ page.slug }}'
 		]);
 
-		$this->assertEquals('blog', $field->before());
-		$this->assertEquals('blog', $field->before);
+		$this->assertSame('blog', $field->before());
+		$this->assertSame('blog', $field->before);
 	}
 
 	public function testDefault()
@@ -172,9 +172,9 @@ class FieldTest extends TestCase
 			'default' => 'test'
 		]);
 
-		$this->assertEquals('test', $field->default());
-		$this->assertEquals('test', $field->default);
-		$this->assertEquals('test', $field->data(true));
+		$this->assertSame('test', $field->default());
+		$this->assertSame('test', $field->default);
+		$this->assertSame('test', $field->data(true));
 
 		// don't overwrite existing values
 		$field = new Field('test', [
@@ -183,11 +183,11 @@ class FieldTest extends TestCase
 			'value'   => 'something'
 		]);
 
-		$this->assertEquals('test', $field->default());
-		$this->assertEquals('test', $field->default);
-		$this->assertEquals('something', $field->value());
-		$this->assertEquals('something', $field->value);
-		$this->assertEquals('something', $field->data(true));
+		$this->assertSame('test', $field->default());
+		$this->assertSame('test', $field->default);
+		$this->assertSame('something', $field->value());
+		$this->assertSame('something', $field->value);
+		$this->assertSame('something', $field->data(true));
 
 		// with query
 		$field = new Field('test', [
@@ -195,9 +195,9 @@ class FieldTest extends TestCase
 			'default' => '{{ page.slug }}'
 		]);
 
-		$this->assertEquals('blog', $field->default());
-		$this->assertEquals('blog', $field->default);
-		$this->assertEquals('blog', $field->data(true));
+		$this->assertSame('blog', $field->default());
+		$this->assertSame('blog', $field->default);
+		$this->assertSame('blog', $field->data(true));
 	}
 
 	public function testDisabled()
@@ -239,7 +239,7 @@ class FieldTest extends TestCase
 			'model' => $page,
 		]);
 
-		$this->assertEquals([], $field->errors());
+		$this->assertSame([], $field->errors());
 
 		// required
 		$field = new Field('test', [
@@ -251,7 +251,7 @@ class FieldTest extends TestCase
 			'required' => 'Please enter something',
 		];
 
-		$this->assertEquals($expected, $field->errors());
+		$this->assertSame($expected, $field->errors());
 	}
 
 	public function testHelp()
@@ -268,8 +268,8 @@ class FieldTest extends TestCase
 			'help' => 'test'
 		]);
 
-		$this->assertEquals('<p>test</p>', $field->help());
-		$this->assertEquals('<p>test</p>', $field->help);
+		$this->assertSame('<p>test</p>', $field->help());
+		$this->assertSame('<p>test</p>', $field->help);
 
 		// translated
 		$field = new Field('test', [
@@ -280,8 +280,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>en</p>', $field->help());
-		$this->assertEquals('<p>en</p>', $field->help);
+		$this->assertSame('<p>en</p>', $field->help());
+		$this->assertSame('<p>en</p>', $field->help);
 	}
 
 	public function testIcon()
@@ -306,8 +306,8 @@ class FieldTest extends TestCase
 			'icon'  => 'test'
 		]);
 
-		$this->assertEquals('test', $field->icon());
-		$this->assertEquals('test', $field->icon);
+		$this->assertSame('test', $field->icon());
+		$this->assertSame('test', $field->icon);
 
 		Field::$types = [
 			'test' => [
@@ -324,8 +324,8 @@ class FieldTest extends TestCase
 			'model' => $page,
 		]);
 
-		$this->assertEquals('test', $field->icon());
-		$this->assertEquals('test', $field->icon);
+		$this->assertSame('test', $field->icon());
+		$this->assertSame('test', $field->icon);
 	}
 
 	public function emptyValuesProvider()
@@ -355,8 +355,8 @@ class FieldTest extends TestCase
 			'value' => $value
 		]);
 
-		$this->assertEquals($expected, $field->isEmpty());
-		$this->assertEquals($expected, $field->isEmpty($value));
+		$this->assertSame($expected, $field->isEmpty());
+		$this->assertSame($expected, $field->isEmpty($value));
 	}
 
 	public function testIsEmptyWithCustomFunction()
@@ -437,7 +437,7 @@ class FieldTest extends TestCase
 			'model' => $model = new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals($model->kirby(), $field->kirby());
+		$this->assertSame($model->kirby(), $field->kirby());
 	}
 
 	public function testLabel()
@@ -454,8 +454,8 @@ class FieldTest extends TestCase
 			'label' => 'test'
 		]);
 
-		$this->assertEquals('test', $field->label());
-		$this->assertEquals('test', $field->label);
+		$this->assertSame('test', $field->label());
+		$this->assertSame('test', $field->label);
 
 		// translated
 		$field = new Field('test', [
@@ -466,8 +466,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('en', $field->label());
-		$this->assertEquals('en', $field->label);
+		$this->assertSame('en', $field->label());
+		$this->assertSame('en', $field->label);
 
 		// with query
 		$field = new Field('test', [
@@ -475,8 +475,8 @@ class FieldTest extends TestCase
 			'label' => '{{ page.slug }}'
 		]);
 
-		$this->assertEquals('blog', $field->label());
-		$this->assertEquals('blog', $field->label);
+		$this->assertSame('blog', $field->label());
+		$this->assertSame('blog', $field->label);
 	}
 
 	public function testMixinMin()
@@ -502,7 +502,7 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->isRequired());
-		$this->assertEquals(5, $field->min());
+		$this->assertSame(5, $field->min());
 
 		$field = new Field('test', [
 			'model' => $page,
@@ -510,7 +510,7 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->isRequired());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 
 		$field = new Field('test', [
 			'model'    => $page,
@@ -519,7 +519,7 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->isRequired());
-		$this->assertEquals(5, $field->min());
+		$this->assertSame(5, $field->min());
 	}
 
 	public function testModel()
@@ -532,7 +532,7 @@ class FieldTest extends TestCase
 			'model' => $model = new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals($model, $field->model());
+		$this->assertSame($model, $field->model());
 	}
 
 	public function testName()
@@ -546,7 +546,7 @@ class FieldTest extends TestCase
 			'model' => $model = new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals('test', $field->name());
+		$this->assertSame('test', $field->name());
 
 		// specific name
 		$field = new Field('test', [
@@ -554,7 +554,7 @@ class FieldTest extends TestCase
 			'name'  => 'mytest'
 		]);
 
-		$this->assertEquals('mytest', $field->name());
+		$this->assertSame('mytest', $field->name());
 	}
 
 	public function testPlaceholder()
@@ -571,8 +571,8 @@ class FieldTest extends TestCase
 			'placeholder' => 'test'
 		]);
 
-		$this->assertEquals('test', $field->placeholder());
-		$this->assertEquals('test', $field->placeholder);
+		$this->assertSame('test', $field->placeholder());
+		$this->assertSame('test', $field->placeholder);
 
 		// translated
 		$field = new Field('test', [
@@ -583,8 +583,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('en', $field->placeholder());
-		$this->assertEquals('en', $field->placeholder);
+		$this->assertSame('en', $field->placeholder());
+		$this->assertSame('en', $field->placeholder);
 
 		// with query
 		$field = new Field('test', [
@@ -592,8 +592,8 @@ class FieldTest extends TestCase
 			'placeholder' => '{{ page.slug }}'
 		]);
 
-		$this->assertEquals('blog', $field->placeholder());
-		$this->assertEquals('blog', $field->placeholder);
+		$this->assertSame('blog', $field->placeholder());
+		$this->assertSame('blog', $field->placeholder);
 	}
 
 	public function testSave()
@@ -644,7 +644,7 @@ class FieldTest extends TestCase
 			'value' => ['a', 'b', 'c']
 		]);
 
-		$this->assertEquals('a, b, c', $field->data());
+		$this->assertSame('a, b, c', $field->data());
 	}
 
 	public function testToArray()
@@ -666,10 +666,10 @@ class FieldTest extends TestCase
 
 		$array = $field->toArray();
 
-		$this->assertEquals('test', $array['name']);
-		$this->assertEquals('test', $array['type']);
-		$this->assertEquals('bar', $array['foo']);
-		$this->assertEquals('1/1', $array['width']);
+		$this->assertSame('test', $array['name']);
+		$this->assertSame('test', $array['type']);
+		$this->assertSame('bar', $array['foo']);
+		$this->assertSame('1/1', $array['width']);
 
 		$this->assertArrayHasKey('signature', $array);
 		$this->assertArrayNotHasKey('model', $array);
@@ -743,8 +743,8 @@ class FieldTest extends TestCase
 			'model' => $page,
 		]);
 
-		$this->assertEquals('1/1', $field->width());
-		$this->assertEquals('1/1', $field->width);
+		$this->assertSame('1/1', $field->width());
+		$this->assertSame('1/1', $field->width);
 
 		// specific width
 		$field = new Field('test', [
@@ -752,8 +752,8 @@ class FieldTest extends TestCase
 			'width' => '1/2'
 		]);
 
-		$this->assertEquals('1/2', $field->width());
-		$this->assertEquals('1/2', $field->width);
+		$this->assertSame('1/2', $field->width());
+		$this->assertSame('1/2', $field->width);
 	}
 
 	public function testValidate()
@@ -772,7 +772,7 @@ class FieldTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals([], $field->errors());
+		$this->assertSame([], $field->errors());
 
 		// required
 		$field = new Field('test', [
@@ -788,7 +788,7 @@ class FieldTest extends TestCase
 			'integer'  => 'Please enter a valid integer',
 		];
 
-		$this->assertEquals($expected, $field->errors());
+		$this->assertSame($expected, $field->errors());
 
 		// invalid
 		$field = new Field('test', [
@@ -803,7 +803,7 @@ class FieldTest extends TestCase
 			'integer' => 'Please enter a valid integer',
 		];
 
-		$this->assertEquals($expected, $field->errors());
+		$this->assertSame($expected, $field->errors());
 	}
 
 	public function testWhenRequired()

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -16,7 +16,7 @@ class BlocksFieldTest extends TestCase
 
 		$this->assertSame('blocks', $field->type());
 		$this->assertSame('blocks', $field->name());
-		$this->assertSame(null, $field->max());
+		$this->assertNull($field->max());
 		$this->assertInstanceOf(Fieldsets::class, $field->fieldsets());
 		$this->assertSame([], $field->value());
 		$this->assertTrue($field->save());

--- a/tests/Form/Fields/CheckboxesFieldTest.php
+++ b/tests/Form/Fields/CheckboxesFieldTest.php
@@ -8,10 +8,10 @@ class CheckboxesFieldTest extends TestCase
 	{
 		$field = $this->field('checkboxes');
 
-		$this->assertEquals('checkboxes', $field->type());
-		$this->assertEquals('checkboxes', $field->name());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->options());
+		$this->assertSame('checkboxes', $field->type());
+		$this->assertSame('checkboxes', $field->name());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
 	}
 
@@ -26,14 +26,14 @@ class CheckboxesFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, $field->value());
+		$this->assertSame($expected, $field->value());
 	}
 
 	public function testEmptyValue()
 	{
 		$field = $this->field('checkboxes');
 
-		$this->assertEquals([], $field->value());
+		$this->assertSame([], $field->value());
 	}
 
 	public function testDefaultValueWithInvalidOptions()
@@ -47,8 +47,8 @@ class CheckboxesFieldTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['a', 'b'], $field->default());
-		$this->assertEquals('a, b', $field->data(true));
+		$this->assertSame(['a', 'b'], $field->default());
+		$this->assertSame('a, b', $field->data(true));
 	}
 
 	public function testStringConversion()
@@ -62,7 +62,7 @@ class CheckboxesFieldTest extends TestCase
 			'value' => 'a,b,c,d'
 		]);
 
-		$this->assertEquals('a, b, c', $field->data());
+		$this->assertSame('a, b, c', $field->data());
 	}
 
 	public function testIgnoreInvalidOptions()
@@ -76,7 +76,7 @@ class CheckboxesFieldTest extends TestCase
 			'value' => 'a, b, d'
 		]);
 
-		$this->assertEquals(['a', 'b'], $field->value());
+		$this->assertSame(['a', 'b'], $field->value());
 	}
 
 	public function testMin()
@@ -112,7 +112,7 @@ class CheckboxesFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -11,9 +11,9 @@ class DateFieldTest extends TestCase
 		$this->assertSame('date', $field->type());
 		$this->assertSame('date', $field->name());
 		$this->assertSame('', $field->value());
-		$this->assertSame(null, $field->min());
-		$this->assertSame(null, $field->max());
-		$this->assertSame(false, $field->time());
+		$this->assertNull($field->min());
+		$this->assertNull($field->max());
+		$this->assertFalse($field->time());
 		$this->assertTrue($field->save());
 	}
 
@@ -24,7 +24,7 @@ class DateFieldTest extends TestCase
 		]);
 
 		$this->assertSame('', $field->value());
-		$this->assertSame(null, $field->toString());
+		$this->assertNull($field->toString());
 	}
 
 	public function testMinMax()

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -108,7 +108,7 @@ class DateFieldTest extends TestCase
 			['12.12.2012', date('Y-m-d H:i:s', strtotime('2012-12-12'))],
 			['2016-11-21', date('Y-m-d H:i:s', strtotime('2016-11-21'))],
 			['2016-11-21 12:12:12', date('Y-m-d H:i:s', strtotime('2016-11-21 12:10:00')), 5],
-			['something', null],
+			['something', ''],
 		];
 	}
 
@@ -153,6 +153,6 @@ class DateFieldTest extends TestCase
 			'time'  => ['step' => $step]
 		]);
 
-		$this->assertEquals($expected, $field->value());
+		$this->assertSame($expected, $field->value());
 	}
 }

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -8,12 +8,12 @@ class DateFieldTest extends TestCase
 	{
 		$field = $this->field('date');
 
-		$this->assertEquals('date', $field->type());
-		$this->assertEquals('date', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->min());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(false, $field->time());
+		$this->assertSame('date', $field->type());
+		$this->assertSame('date', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame(null, $field->min());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(false, $field->time());
 		$this->assertTrue($field->save());
 	}
 
@@ -24,7 +24,7 @@ class DateFieldTest extends TestCase
 		]);
 
 		$this->assertSame('', $field->value());
-		$this->assertEquals('', $field->toString());
+		$this->assertSame(null, $field->toString());
 	}
 
 	public function testMinMax()
@@ -119,14 +119,14 @@ class DateFieldTest extends TestCase
 			'value' => '12.12.2012',
 		]);
 
-		$this->assertEquals('2012-12-12', $field->data());
+		$this->assertSame('2012-12-12', $field->data());
 
 		// empty value
 		$field = $this->field('date', [
 			'value'  => null,
 		]);
 
-		$this->assertEquals('', $field->data());
+		$this->assertSame('', $field->data());
 	}
 
 	/**

--- a/tests/Form/Fields/EmailFieldTest.php
+++ b/tests/Form/Fields/EmailFieldTest.php
@@ -8,13 +8,13 @@ class EmailFieldTest extends TestCase
 	{
 		$field = $this->field('email');
 
-		$this->assertEquals('email', $field->type());
-		$this->assertEquals('email', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals('email', $field->icon());
-		$this->assertEquals('mail@example.com', $field->placeholder());
-		$this->assertEquals(null, $field->counter());
-		$this->assertEquals('email', $field->autocomplete());
+		$this->assertSame('email', $field->type());
+		$this->assertSame('email', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame('email', $field->icon());
+		$this->assertSame('mail@example.com', $field->placeholder());
+		$this->assertSame(null, $field->counter());
+		$this->assertSame('email', $field->autocomplete());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/EmailFieldTest.php
+++ b/tests/Form/Fields/EmailFieldTest.php
@@ -13,7 +13,7 @@ class EmailFieldTest extends TestCase
 		$this->assertSame('', $field->value());
 		$this->assertSame('email', $field->icon());
 		$this->assertSame('mail@example.com', $field->placeholder());
-		$this->assertSame(null, $field->counter());
+		$this->assertNull($field->counter());
 		$this->assertSame('email', $field->autocomplete());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -70,8 +70,8 @@ class FilesFieldTest extends TestCase
 		$this->assertSame([], $field->value());
 		$this->assertSame([], $field->default());
 		$this->assertSame('list', $field->layout());
-		$this->assertSame(null, $field->max());
-		$this->assertSame(true, $field->multiple());
+		$this->assertNull($field->max());
+		$this->assertTrue($field->multiple());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -65,13 +65,13 @@ class FilesFieldTest extends TestCase
 			'model' => $this->model()
 		]);
 
-		$this->assertEquals('files', $field->type());
-		$this->assertEquals('files', $field->name());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->default());
-		$this->assertEquals('list', $field->layout());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(true, $field->multiple());
+		$this->assertSame('files', $field->type());
+		$this->assertSame('files', $field->name());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->default());
+		$this->assertSame('list', $field->layout());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(true, $field->multiple());
 		$this->assertTrue($field->save());
 	}
 
@@ -94,7 +94,7 @@ class FilesFieldTest extends TestCase
 			'b.jpg'
 		];
 
-		$this->assertEquals($expected, $ids);
+		$this->assertSame($expected, $ids);
 	}
 
 	public function testMin()
@@ -109,7 +109,7 @@ class FilesFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(3, $field->min());
+		$this->assertSame(3, $field->min());
 		$this->assertTrue($field->required());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
@@ -126,7 +126,7 @@ class FilesFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(1, $field->max());
+		$this->assertSame(1, $field->max());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
@@ -149,7 +149,7 @@ class FilesFieldTest extends TestCase
 			'b.jpg'
 		];
 
-		$this->assertEquals($expected, $ids);
+		$this->assertSame($expected, $ids);
 	}
 
 	public function testQueryWithPageParent()
@@ -158,7 +158,7 @@ class FilesFieldTest extends TestCase
 			'model' => new Page(['slug' => 'test']),
 		]);
 
-		$this->assertEquals('page.files', $field->query());
+		$this->assertSame('page.files', $field->query());
 	}
 
 	public function testQueryWithSiteParent()
@@ -167,7 +167,7 @@ class FilesFieldTest extends TestCase
 			'model' => new Site(),
 		]);
 
-		$this->assertEquals('site.files', $field->query());
+		$this->assertSame('site.files', $field->query());
 	}
 
 	public function testQueryWithUserParent()
@@ -176,7 +176,7 @@ class FilesFieldTest extends TestCase
 			'model' => new User(['email' => 'test@getkirby.com']),
 		]);
 
-		$this->assertEquals('user.files', $field->query());
+		$this->assertSame('user.files', $field->query());
 	}
 
 	public function testEmpty()
@@ -186,7 +186,7 @@ class FilesFieldTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -196,7 +196,7 @@ class FilesFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testRequiredProps()
@@ -207,7 +207,7 @@ class FilesFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Form/Fields/GapFieldTest.php
+++ b/tests/Form/Fields/GapFieldTest.php
@@ -8,8 +8,8 @@ class GapFieldTest extends TestCase
 	{
 		$field = $this->field('gap');
 
-		$this->assertEquals('gap', $field->type());
-		$this->assertEquals('gap', $field->name());
+		$this->assertSame('gap', $field->type());
+		$this->assertSame('gap', $field->name());
 		$this->assertFalse($field->save());
 	}
 }

--- a/tests/Form/Fields/HeadlineFieldTest.php
+++ b/tests/Form/Fields/HeadlineFieldTest.php
@@ -8,10 +8,10 @@ class HeadlineFieldTest extends TestCase
 	{
 		$field = $this->field('headline');
 
-		$this->assertEquals('headline', $field->type());
-		$this->assertEquals('headline', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->label());
+		$this->assertSame('headline', $field->type());
+		$this->assertSame('headline', $field->name());
+		$this->assertSame(null, $field->value());
+		$this->assertSame(null, $field->label());
 		$this->assertFalse($field->save());
 		$this->assertTrue($field->numbered());
 	}

--- a/tests/Form/Fields/HeadlineFieldTest.php
+++ b/tests/Form/Fields/HeadlineFieldTest.php
@@ -10,8 +10,8 @@ class HeadlineFieldTest extends TestCase
 
 		$this->assertSame('headline', $field->type());
 		$this->assertSame('headline', $field->name());
-		$this->assertSame(null, $field->value());
-		$this->assertSame(null, $field->label());
+		$this->assertNull($field->value());
+		$this->assertNull($field->label());
 		$this->assertFalse($field->save());
 		$this->assertTrue($field->numbered());
 	}

--- a/tests/Form/Fields/HiddenFieldTest.php
+++ b/tests/Form/Fields/HiddenFieldTest.php
@@ -8,9 +8,9 @@ class HiddenFieldTest extends TestCase
 	{
 		$field = $this->field('hidden');
 
-		$this->assertEquals('hidden', $field->type());
-		$this->assertEquals('hidden', $field->name());
-		$this->assertEquals(null, $field->value());
+		$this->assertSame('hidden', $field->type());
+		$this->assertSame('hidden', $field->name());
+		$this->assertSame(null, $field->value());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/HiddenFieldTest.php
+++ b/tests/Form/Fields/HiddenFieldTest.php
@@ -10,7 +10,7 @@ class HiddenFieldTest extends TestCase
 
 		$this->assertSame('hidden', $field->type());
 		$this->assertSame('hidden', $field->name());
-		$this->assertSame(null, $field->value());
+		$this->assertNull($field->value());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/InfoFieldTest.php
+++ b/tests/Form/Fields/InfoFieldTest.php
@@ -10,11 +10,11 @@ class InfoFieldTest extends TestCase
 	{
 		$field = $this->field('info');
 
-		$this->assertEquals('info', $field->type());
-		$this->assertEquals('info', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->label());
-		$this->assertEquals(null, $field->text());
+		$this->assertSame('info', $field->type());
+		$this->assertSame('info', $field->name());
+		$this->assertSame(null, $field->value());
+		$this->assertSame(null, $field->label());
+		$this->assertSame(null, $field->text());
 		$this->assertFalse($field->save());
 	}
 
@@ -25,7 +25,7 @@ class InfoFieldTest extends TestCase
 			'text' => 'test'
 		]);
 
-		$this->assertEquals('<p>test</p>', $field->text());
+		$this->assertSame('<p>test</p>', $field->text());
 
 		// translated text
 		$field = $this->field('info', [
@@ -35,7 +35,7 @@ class InfoFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<p>en</p>', $field->text());
+		$this->assertSame('<p>en</p>', $field->text());
 
 		// text template
 		$field = $this->field('info', [
@@ -48,6 +48,6 @@ class InfoFieldTest extends TestCase
 			])
 		]);
 
-		$this->assertEquals('<p>Test</p>', $field->text());
+		$this->assertSame('<p>Test</p>', $field->text());
 	}
 }

--- a/tests/Form/Fields/InfoFieldTest.php
+++ b/tests/Form/Fields/InfoFieldTest.php
@@ -12,9 +12,9 @@ class InfoFieldTest extends TestCase
 
 		$this->assertSame('info', $field->type());
 		$this->assertSame('info', $field->name());
-		$this->assertSame(null, $field->value());
-		$this->assertSame(null, $field->label());
-		$this->assertSame(null, $field->text());
+		$this->assertNull($field->value());
+		$this->assertNull($field->label());
+		$this->assertNull($field->text());
 		$this->assertFalse($field->save());
 	}
 

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -12,7 +12,7 @@ class LayoutFieldTest extends TestCase
 
 		$this->assertSame('layout', $field->type());
 		$this->assertSame('layout', $field->name());
-		$this->assertSame(null, $field->max());
+		$this->assertNull($field->max());
 		$this->assertInstanceOf(Fieldsets::class, $field->fieldsets());
 		$this->assertSame([], $field->value());
 		$this->assertSame([['1/1']], $field->layouts());

--- a/tests/Form/Fields/LineFieldTest.php
+++ b/tests/Form/Fields/LineFieldTest.php
@@ -8,8 +8,8 @@ class LineFieldTest extends TestCase
 	{
 		$field = $this->field('line');
 
-		$this->assertEquals('line', $field->type());
-		$this->assertEquals('line', $field->name());
+		$this->assertSame('line', $field->type());
+		$this->assertSame('line', $field->name());
 		$this->assertFalse($field->save());
 	}
 }

--- a/tests/Form/Fields/ListFieldTest.php
+++ b/tests/Form/Fields/ListFieldTest.php
@@ -11,8 +11,8 @@ class ListFieldTest extends TestCase
 		$this->assertSame('list', $field->type());
 		$this->assertSame('list', $field->name());
 		$this->assertSame('', $field->value());
-		$this->assertSame(null, $field->label());
-		$this->assertSame(null, $field->text());
+		$this->assertNull($field->label());
+		$this->assertNull($field->text());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/FilePickerMixinTest.php
@@ -38,9 +38,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('a.jpg', $files[0]['id']);
-		$this->assertEquals('b.jpg', $files[1]['id']);
-		$this->assertEquals('c.jpg', $files[2]['id']);
+		$this->assertSame('a.jpg', $files[0]['id']);
+		$this->assertSame('b.jpg', $files[1]['id']);
+		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
 	public function testFileFiles()
@@ -72,9 +72,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('test/a.jpg', $files[0]['id']);
-		$this->assertEquals('test/b.jpg', $files[1]['id']);
-		$this->assertEquals('test/c.jpg', $files[2]['id']);
+		$this->assertSame('test/a.jpg', $files[0]['id']);
+		$this->assertSame('test/b.jpg', $files[1]['id']);
+		$this->assertSame('test/c.jpg', $files[2]['id']);
 	}
 
 	public function testUserFiles()
@@ -106,9 +106,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('a.jpg', $files[0]['id']);
-		$this->assertEquals('b.jpg', $files[1]['id']);
-		$this->assertEquals('c.jpg', $files[2]['id']);
+		$this->assertSame('a.jpg', $files[0]['id']);
+		$this->assertSame('b.jpg', $files[1]['id']);
+		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
 	public function testSiteFiles()
@@ -139,9 +139,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('a.jpg', $files[0]['id']);
-		$this->assertEquals('b.jpg', $files[1]['id']);
-		$this->assertEquals('c.jpg', $files[2]['id']);
+		$this->assertSame('a.jpg', $files[0]['id']);
+		$this->assertSame('b.jpg', $files[1]['id']);
+		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
 	public function testCustomQuery()
@@ -183,9 +183,9 @@ class FilePickerMixinTest extends TestCase
 		$files = $field->files();
 
 		$this->assertCount(3, $files);
-		$this->assertEquals('a.jpg', $files[0]['id']);
-		$this->assertEquals('b.jpg', $files[1]['id']);
-		$this->assertEquals('c.jpg', $files[2]['id']);
+		$this->assertSame('a.jpg', $files[0]['id']);
+		$this->assertSame('b.jpg', $files[1]['id']);
+		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
 	public function testMap()
@@ -231,6 +231,6 @@ class FilePickerMixinTest extends TestCase
 			'test/c.jpg'
 		];
 
-		$this->assertEquals($expected, $files);
+		$this->assertSame($expected, $files);
 	}
 }

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -51,14 +51,14 @@ class PagePickerMixinTest extends TestCase
 		$pages    = $response['data'];
 		$model    = $response['model'];
 
-		$this->assertEquals('Test', $model['title']);
+		$this->assertSame('Test', $model['title']);
 		$this->assertNull($model['id']);
 		$this->assertNull($model['parent']);
 
 		$this->assertCount(3, $pages);
-		$this->assertEquals('a', $pages[0]['id']);
-		$this->assertEquals('b', $pages[1]['id']);
-		$this->assertEquals('c', $pages[2]['id']);
+		$this->assertSame('a', $pages[0]['id']);
+		$this->assertSame('b', $pages[1]['id']);
+		$this->assertSame('c', $pages[2]['id']);
 	}
 
 	public function testPagesWithParent()
@@ -104,12 +104,12 @@ class PagePickerMixinTest extends TestCase
 		$pages    = $response['data'];
 		$model    = $response['model'];
 
-		$this->assertEquals('a', $model['title']);
-		$this->assertEquals('a', $model['id']);
+		$this->assertSame('a', $model['title']);
+		$this->assertSame('a', $model['id']);
 		$this->assertNull($model['parent']);
 
 		$this->assertCount(1, $pages);
-		$this->assertEquals('a/aa', $pages[0]['id']);
+		$this->assertSame('a/aa', $pages[0]['id']);
 	}
 
 	public function testPageChildren()
@@ -204,9 +204,9 @@ class PagePickerMixinTest extends TestCase
 
 		$this->assertNull($model);
 		$this->assertCount(3, $pages);
-		$this->assertEquals('test/a', $pages[0]['id']);
-		$this->assertEquals('test/b', $pages[1]['id']);
-		$this->assertEquals('test/c', $pages[2]['id']);
+		$this->assertSame('test/a', $pages[0]['id']);
+		$this->assertSame('test/b', $pages[1]['id']);
+		$this->assertSame('test/c', $pages[2]['id']);
 	}
 
 	public function testMap()
@@ -243,6 +243,6 @@ class PagePickerMixinTest extends TestCase
 		$response = $field->pages();
 		$pages    = $response['data'];
 
-		$this->assertEquals(['test/a', 'test/b', 'test/c'], $pages);
+		$this->assertSame(['test/a', 'test/b', 'test/c'], $pages);
 	}
 }

--- a/tests/Form/Fields/Mixins/UserPickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/UserPickerMixinTest.php
@@ -52,9 +52,9 @@ class UserPickerMixinTest extends TestCase
 		$users = $field->users();
 
 		$this->assertCount(3, $users);
-		$this->assertEquals('a@getkirby.com', $users[0]['email']);
-		$this->assertEquals('b@getkirby.com', $users[1]['email']);
-		$this->assertEquals('c@getkirby.com', $users[2]['email']);
+		$this->assertSame('a@getkirby.com', $users[0]['email']);
+		$this->assertSame('b@getkirby.com', $users[1]['email']);
+		$this->assertSame('c@getkirby.com', $users[2]['email']);
 	}
 
 	public function testUsersWithQuery()
@@ -83,8 +83,8 @@ class UserPickerMixinTest extends TestCase
 		$users = $field->users();
 
 		$this->assertCount(2, $users);
-		$this->assertEquals('b@getkirby.com', $users[0]['email']);
-		$this->assertEquals('c@getkirby.com', $users[1]['email']);
+		$this->assertSame('b@getkirby.com', $users[0]['email']);
+		$this->assertSame('c@getkirby.com', $users[1]['email']);
 	}
 
 	public function testMap()
@@ -114,7 +114,7 @@ class UserPickerMixinTest extends TestCase
 
 		$users = $field->users();
 
-		$this->assertEquals([
+		$this->assertSame([
 			'a@getkirby.com',
 			'b@getkirby.com',
 			'c@getkirby.com',

--- a/tests/Form/Fields/MultiselectFieldTest.php
+++ b/tests/Form/Fields/MultiselectFieldTest.php
@@ -13,11 +13,11 @@ class MultiselectFieldTest extends TestCase
 		$this->assertSame([], $field->value());
 		$this->assertSame([], $field->default());
 		$this->assertSame([], $field->options());
-		$this->assertSame(null, $field->min());
-		$this->assertSame(null, $field->max());
+		$this->assertNull($field->min());
+		$this->assertNull($field->max());
 		$this->assertSame(',', $field->separator());
-		$this->assertSame(null, $field->icon());
-		$this->assertSame(null, $field->counter());
+		$this->assertNull($field->icon());
+		$this->assertNull($field->counter());
 		$this->assertTrue($field->search());
 		$this->assertFalse($field->sort());
 		$this->assertTrue($field->save());

--- a/tests/Form/Fields/MultiselectFieldTest.php
+++ b/tests/Form/Fields/MultiselectFieldTest.php
@@ -8,16 +8,16 @@ class MultiselectFieldTest extends TestCase
 	{
 		$field = $this->field('multiselect');
 
-		$this->assertEquals('multiselect', $field->type());
-		$this->assertEquals('multiselect', $field->name());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->default());
-		$this->assertEquals([], $field->options());
-		$this->assertEquals(null, $field->min());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(',', $field->separator());
-		$this->assertEquals(null, $field->icon());
-		$this->assertEquals(null, $field->counter());
+		$this->assertSame('multiselect', $field->type());
+		$this->assertSame('multiselect', $field->name());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->default());
+		$this->assertSame([], $field->options());
+		$this->assertSame(null, $field->min());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(',', $field->separator());
+		$this->assertSame(null, $field->icon());
+		$this->assertSame(null, $field->counter());
 		$this->assertTrue($field->search());
 		$this->assertFalse($field->sort());
 		$this->assertTrue($field->save());

--- a/tests/Form/Fields/NumberFieldTest.php
+++ b/tests/Form/Fields/NumberFieldTest.php
@@ -10,11 +10,11 @@ class NumberFieldTest extends TestCase
 
 		$this->assertSame('number', $field->type());
 		$this->assertSame('number', $field->name());
-		$this->assertSame(null, $field->value());
-		$this->assertSame(null, $field->default());
-		$this->assertSame(null, $field->min());
-		$this->assertSame(null, $field->max());
-		$this->assertSame(null, $field->step());
+		$this->assertNull($field->value());
+		$this->assertNull($field->default());
+		$this->assertNull($field->min());
+		$this->assertNull($field->max());
+		$this->assertNull($field->step());
 		$this->assertTrue($field->save());
 	}
 
@@ -51,7 +51,7 @@ class NumberFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 
 		if ($input === null) {
-			$this->assertSame(null, $field->step());
+			$this->assertNull($field->step());
 		} else {
 			$this->assertSame($expected, $field->step());
 		}

--- a/tests/Form/Fields/NumberFieldTest.php
+++ b/tests/Form/Fields/NumberFieldTest.php
@@ -8,13 +8,13 @@ class NumberFieldTest extends TestCase
 	{
 		$field = $this->field('number');
 
-		$this->assertEquals('number', $field->type());
-		$this->assertEquals('number', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->default());
-		$this->assertEquals(0, $field->min());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(null, $field->step());
+		$this->assertSame('number', $field->type());
+		$this->assertSame('number', $field->name());
+		$this->assertSame(null, $field->value());
+		$this->assertSame(null, $field->default());
+		$this->assertSame(null, $field->min());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(null, $field->step());
 		$this->assertTrue($field->save());
 	}
 
@@ -47,13 +47,13 @@ class NumberFieldTest extends TestCase
 			'step'    => $input
 		]);
 
-		$this->assertEquals($expected, $field->value());
-		$this->assertEquals($expected, $field->default());
+		$this->assertSame($expected, $field->value());
+		$this->assertSame($expected, $field->default());
 
 		if ($input === null) {
-			$this->assertEquals(null, $field->step());
+			$this->assertSame(null, $field->step());
 		} else {
-			$this->assertEquals($expected, $field->step());
+			$this->assertSame($expected, $field->step());
 		}
 	}
 
@@ -85,6 +85,6 @@ class NumberFieldTest extends TestCase
 			'value' => 1000
 		]);
 
-		$this->assertEquals(1000, $field->value());
+		$this->assertSame(1000.0, $field->value());
 	}
 }

--- a/tests/Form/Fields/ObjectFieldTest.php
+++ b/tests/Form/Fields/ObjectFieldTest.php
@@ -45,7 +45,7 @@ class ObjectFieldTest extends TestCase
 
 		$this->assertSame('object', $field->type());
 		$this->assertSame('object', $field->name());
-		$this->assertTrue(is_array($field->fields()));
+		$this->assertIsArray($field->fields());
 		$this->assertSame('', $field->value());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -47,12 +47,12 @@ class PagesFieldTest extends TestCase
 			'model' => $this->model()
 		]);
 
-		$this->assertEquals('pages', $field->type());
-		$this->assertEquals('pages', $field->name());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->default());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(true, $field->multiple());
+		$this->assertSame('pages', $field->type());
+		$this->assertSame('pages', $field->name());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->default());
+		$this->assertSame(null, $field->max());
+		$this->assertSame(true, $field->multiple());
 		$this->assertTrue($field->save());
 	}
 
@@ -75,7 +75,7 @@ class PagesFieldTest extends TestCase
 			'a/ab'
 		];
 
-		$this->assertEquals($expected, $ids);
+		$this->assertSame($expected, $ids);
 	}
 
 	public function testMin()
@@ -90,7 +90,7 @@ class PagesFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(3, $field->min());
+		$this->assertSame(3, $field->min());
 		$this->assertTrue($field->required());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
@@ -107,7 +107,7 @@ class PagesFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(1, $field->max());
+		$this->assertSame(1, $field->max());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
@@ -118,7 +118,7 @@ class PagesFieldTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -128,7 +128,7 @@ class PagesFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testRequiredProps()
@@ -139,7 +139,7 @@ class PagesFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -51,8 +51,8 @@ class PagesFieldTest extends TestCase
 		$this->assertSame('pages', $field->name());
 		$this->assertSame([], $field->value());
 		$this->assertSame([], $field->default());
-		$this->assertSame(null, $field->max());
-		$this->assertSame(true, $field->multiple());
+		$this->assertNull($field->max());
+		$this->assertTrue($field->multiple());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/RadioFieldTest.php
+++ b/tests/Form/Fields/RadioFieldTest.php
@@ -8,11 +8,11 @@ class RadioFieldTest extends TestCase
 	{
 		$field = $this->field('radio');
 
-		$this->assertEquals('radio', $field->type());
-		$this->assertEquals('radio', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->icon());
-		$this->assertEquals([], $field->options());
+		$this->assertSame('radio', $field->type());
+		$this->assertSame('radio', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame(null, $field->icon());
+		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/RadioFieldTest.php
+++ b/tests/Form/Fields/RadioFieldTest.php
@@ -11,7 +11,7 @@ class RadioFieldTest extends TestCase
 		$this->assertSame('radio', $field->type());
 		$this->assertSame('radio', $field->name());
 		$this->assertSame('', $field->value());
-		$this->assertSame(null, $field->icon());
+		$this->assertNull($field->icon());
 		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/RangeFieldTest.php
+++ b/tests/Form/Fields/RangeFieldTest.php
@@ -10,11 +10,11 @@ class RangeFieldTest extends TestCase
 
 		$this->assertSame('range', $field->type());
 		$this->assertSame('range', $field->name());
-		$this->assertSame(null, $field->value());
-		$this->assertSame(null, $field->default());
-		$this->assertSame(null, $field->min());
+		$this->assertNull($field->value());
+		$this->assertNull($field->default());
+		$this->assertNull($field->min());
 		$this->assertSame(100.0, $field->max());
-		$this->assertSame(null, $field->step());
+		$this->assertNull($field->step());
 		$this->assertTrue($field->tooltip());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/RangeFieldTest.php
+++ b/tests/Form/Fields/RangeFieldTest.php
@@ -8,13 +8,13 @@ class RangeFieldTest extends TestCase
 	{
 		$field = $this->field('range');
 
-		$this->assertEquals('range', $field->type());
-		$this->assertEquals('range', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->default());
-		$this->assertEquals(0, $field->min());
-		$this->assertEquals(100, $field->max());
-		$this->assertEquals(null, $field->step());
+		$this->assertSame('range', $field->type());
+		$this->assertSame('range', $field->name());
+		$this->assertSame(null, $field->value());
+		$this->assertSame(null, $field->default());
+		$this->assertSame(null, $field->min());
+		$this->assertSame(100.0, $field->max());
+		$this->assertSame(null, $field->step());
 		$this->assertTrue($field->tooltip());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/SelectFieldTest.php
+++ b/tests/Form/Fields/SelectFieldTest.php
@@ -11,7 +11,7 @@ class SelectFieldTest extends TestCase
 		$this->assertSame('select', $field->type());
 		$this->assertSame('select', $field->name());
 		$this->assertSame('', $field->value());
-		$this->assertSame(null, $field->icon());
+		$this->assertNull($field->icon());
 		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/SlugFieldTest.php
+++ b/tests/Form/Fields/SlugFieldTest.php
@@ -8,16 +8,16 @@ class SlugFieldTest extends TestCase
 	{
 		$field = $this->field('slug');
 
-		$this->assertEquals('slug', $field->type());
-		$this->assertEquals('slug', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals('url', $field->icon());
-		$this->assertEquals('', $field->allow());
-		$this->assertEquals(null, $field->path());
-		$this->assertEquals(null, $field->sync());
-		$this->assertEquals(null, $field->placeholder());
-		$this->assertEquals(null, $field->counter());
-		$this->assertEquals(false, $field->wizard());
+		$this->assertSame('slug', $field->type());
+		$this->assertSame('slug', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame('url', $field->icon());
+		$this->assertSame('', $field->allow());
+		$this->assertSame(null, $field->path());
+		$this->assertSame(null, $field->sync());
+		$this->assertSame(null, $field->placeholder());
+		$this->assertSame(null, $field->counter());
+		$this->assertSame(false, $field->wizard());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/SlugFieldTest.php
+++ b/tests/Form/Fields/SlugFieldTest.php
@@ -13,11 +13,11 @@ class SlugFieldTest extends TestCase
 		$this->assertSame('', $field->value());
 		$this->assertSame('url', $field->icon());
 		$this->assertSame('', $field->allow());
-		$this->assertSame(null, $field->path());
-		$this->assertSame(null, $field->sync());
-		$this->assertSame(null, $field->placeholder());
-		$this->assertSame(null, $field->counter());
-		$this->assertSame(false, $field->wizard());
+		$this->assertNull($field->path());
+		$this->assertNull($field->sync());
+		$this->assertNull($field->placeholder());
+		$this->assertNull($field->counter());
+		$this->assertFalse($field->wizard());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -19,7 +19,7 @@ class StructureFieldTest extends TestCase
 
 		$this->assertSame('structure', $field->type());
 		$this->assertSame('structure', $field->name());
-		$this->assertSame(null, $field->limit());
+		$this->assertNull($field->limit());
 		$this->assertTrue(is_array($field->fields()));
 		$this->assertSame([], $field->value());
 		$this->assertTrue($field->save());

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -20,7 +20,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('structure', $field->type());
 		$this->assertSame('structure', $field->name());
 		$this->assertNull($field->limit());
-		$this->assertTrue(is_array($field->fields()));
+		$this->assertIsArray($field->fields());
 		$this->assertSame([], $field->value());
 		$this->assertTrue($field->save());
 	}

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -205,8 +205,8 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($value, $field->value());
-		$this->assertEquals($value, $field->data());
+		$this->assertEquals($value, $field->value()); // cannot use strict assertion (array order)
+		$this->assertEquals($value, $field->data()); // cannot use strict assertion (array order)
 
 		// empty mother form
 		$motherForm = $field->form();
@@ -225,7 +225,7 @@ class StructureFieldTest extends TestCase
 		$motherForm = $field->form($value[0]);
 		$expected   = $value[0];
 
-		$this->assertEquals($expected, $motherForm->data());
+		$this->assertEquals($expected, $motherForm->data()); // cannot use strict assertion (array order)
 
 		$childrenField = $motherForm->fields()->children();
 

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -17,11 +17,11 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('structure', $field->type());
-		$this->assertEquals('structure', $field->name());
-		$this->assertEquals(null, $field->limit());
+		$this->assertSame('structure', $field->type());
+		$this->assertSame('structure', $field->name());
+		$this->assertSame(null, $field->limit());
 		$this->assertTrue(is_array($field->fields()));
-		$this->assertEquals([], $field->value());
+		$this->assertSame([], $field->value());
 		$this->assertTrue($field->save());
 	}
 
@@ -47,9 +47,9 @@ class StructureFieldTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $field->data());
-		$this->assertEquals('a, b', $field->data()[0]['tags']);
-		$this->assertEquals(['a', 'b'], $field->value()[0]['tags']);
+		$this->assertSame($expected, $field->data());
+		$this->assertSame('a, b', $field->data()[0]['tags']);
+		$this->assertSame(['a', 'b'], $field->value()[0]['tags']);
 	}
 
 	public function testColumnsFromFields()
@@ -122,7 +122,7 @@ class StructureFieldTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals(['camelcase'], array_keys($field->columns()));
+		$this->assertSame(['camelcase'], array_keys($field->columns()));
 	}
 
 	public function testMin()
@@ -140,7 +140,7 @@ class StructureFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(2, $field->min());
+		$this->assertSame(2, $field->min());
 		$this->assertTrue($field->required());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
@@ -161,7 +161,7 @@ class StructureFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(1, $field->max());
+		$this->assertSame(1, $field->max());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
@@ -229,27 +229,27 @@ class StructureFieldTest extends TestCase
 
 		$childrenField = $motherForm->fields()->children();
 
-		$this->assertEquals('structure', $childrenField->type());
-		$this->assertEquals('test', $childrenField->model());
+		$this->assertSame('structure', $childrenField->type());
+		$this->assertSame('test', $childrenField->model());
 
 		// empty children form
 		$childrenForm = $childrenField->form();
 
-		$this->assertEquals(null, $childrenForm->data()['name']);
+		$this->assertSame('', $childrenForm->data()['name']);
 
 		// filled children form
 		$childrenForm = $childrenField->form([
 			'name' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $childrenForm->data()['name']);
+		$this->assertSame('Test', $childrenForm->data()['name']);
 
 		// children name field
 		$childrenNameField = $childrenField->form()->fields()->name();
 
-		$this->assertEquals('text', $childrenNameField->type());
-		$this->assertEquals('test', $childrenNameField->model());
-		$this->assertEquals(null, $childrenNameField->data());
+		$this->assertSame('text', $childrenNameField->type());
+		$this->assertSame('test', $childrenNameField->model());
+		$this->assertSame('', $childrenNameField->data());
 	}
 
 	public function testFloatsWithNonUsLocale()
@@ -281,7 +281,7 @@ class StructureFieldTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -295,7 +295,7 @@ class StructureFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testTranslate()
@@ -360,8 +360,8 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('A', $field->data(true)[0]['a']);
-		$this->assertEquals('B', $field->data(true)[0]['b']);
+		$this->assertSame('A', $field->data(true)[0]['a']);
+		$this->assertSame('B', $field->data(true)[0]['b']);
 	}
 
 	public function testRequiredProps()
@@ -376,7 +376,7 @@ class StructureFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -213,13 +213,13 @@ class StructureFieldTest extends TestCase
 		$data       = $motherForm->data();
 
 		$expected = [
-			'name'     => null,
+			'name'     => '',
 			'children' => []
 		];
 
 		unset($data['uuid']);
 
-		$this->assertEquals($expected, $data);
+		$this->assertSame($expected, $data);
 
 		// filled mother form
 		$motherForm = $field->form($value[0]);

--- a/tests/Form/Fields/TagsFieldTest.php
+++ b/tests/Form/Fields/TagsFieldTest.php
@@ -14,11 +14,11 @@ class TagsFieldTest extends TestCase
 		$this->assertSame([], $field->value());
 		$this->assertSame([], $field->default());
 		$this->assertSame([], $field->options());
-		$this->assertSame(null, $field->min());
-		$this->assertSame(null, $field->max());
+		$this->assertNull($field->min());
+		$this->assertNull($field->max());
 		$this->assertSame(',', $field->separator());
 		$this->assertSame('tag', $field->icon());
-		$this->assertSame(null, $field->counter());
+		$this->assertNull($field->counter());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/TelFieldTest.php
+++ b/tests/Form/Fields/TelFieldTest.php
@@ -8,13 +8,13 @@ class TelFieldTest extends TestCase
 	{
 		$field = $this->field('tel');
 
-		$this->assertEquals('tel', $field->type());
-		$this->assertEquals('tel', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals('phone', $field->icon());
-		$this->assertEquals(null, $field->placeholder());
-		$this->assertEquals(null, $field->counter());
-		$this->assertEquals('tel', $field->autocomplete());
+		$this->assertSame('tel', $field->type());
+		$this->assertSame('tel', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame('phone', $field->icon());
+		$this->assertNull($field->placeholder());
+		$this->assertNull($field->counter());
+		$this->assertSame('tel', $field->autocomplete());
 		$this->assertTrue($field->save());
 	}
 }

--- a/tests/Form/Fields/TextFieldTest.php
+++ b/tests/Form/Fields/TextFieldTest.php
@@ -10,16 +10,16 @@ class TextFieldTest extends TestCase
 	{
 		$field = $this->field('text');
 
-		$this->assertEquals('text', $field->type());
-		$this->assertEquals('text', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->icon());
-		$this->assertEquals(null, $field->placeholder());
-		$this->assertEquals(true, $field->counter());
-		$this->assertEquals(null, $field->maxlength());
-		$this->assertEquals(null, $field->minlength());
-		$this->assertEquals(null, $field->pattern());
-		$this->assertEquals(false, $field->spellcheck());
+		$this->assertSame('text', $field->type());
+		$this->assertSame('text', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertNull($field->icon());
+		$this->assertNull($field->placeholder());
+		$this->assertTrue($field->counter());
+		$this->assertNull($field->maxlength());
+		$this->assertNull($field->minlength());
+		$this->assertNull($field->pattern());
+		$this->assertFalse($field->spellcheck());
 		$this->assertTrue($field->save());
 	}
 
@@ -46,8 +46,8 @@ class TextFieldTest extends TestCase
 			'default'   => $input
 		]);
 
-		$this->assertEquals($expected, $field->value());
-		$this->assertEquals($expected, $field->default());
+		$this->assertSame($expected, $field->value());
+		$this->assertSame($expected, $field->default());
 	}
 
 	public function testInvalidConverter()

--- a/tests/Form/Fields/TextareaFieldTest.php
+++ b/tests/Form/Fields/TextareaFieldTest.php
@@ -8,17 +8,17 @@ class TextareaFieldTest extends TestCase
 	{
 		$field = $this->field('textarea');
 
-		$this->assertEquals('textarea', $field->type());
-		$this->assertEquals('textarea', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->icon());
-		$this->assertEquals(null, $field->placeholder());
-		$this->assertEquals(true, $field->counter());
-		$this->assertEquals(null, $field->maxlength());
-		$this->assertEquals(null, $field->minlength());
-		$this->assertEquals(null, $field->size());
-		$this->assertEquals([], $field->files());
-		$this->assertEquals(['accept' => '*'], $field->uploads());
+		$this->assertSame('textarea', $field->type());
+		$this->assertSame('textarea', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertNull($field->icon());
+		$this->assertNull($field->placeholder());
+		$this->assertTrue($field->counter());
+		$this->assertNull($field->maxlength());
+		$this->assertNull($field->minlength());
+		$this->assertNull($field->size());
+		$this->assertSame([], $field->files());
+		$this->assertSame(['accept' => '*'], $field->uploads());
 		$this->assertTrue($field->save());
 	}
 
@@ -40,7 +40,7 @@ class TextareaFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['bold', 'italic'], $field->buttons());
+		$this->assertSame(['bold', 'italic'], $field->buttons());
 	}
 
 	public function testDefaultTrimmed()
@@ -49,7 +49,7 @@ class TextareaFieldTest extends TestCase
 			'default' => 'test '
 		]);
 
-		$this->assertEquals('test', $field->default());
+		$this->assertSame('test', $field->default());
 	}
 
 	public function testFiles()
@@ -61,7 +61,7 @@ class TextareaFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['query' => 'page.images'], $field->files());
+		$this->assertSame(['query' => 'page.images'], $field->files());
 	}
 
 	public function testFilesQuery()
@@ -71,7 +71,7 @@ class TextareaFieldTest extends TestCase
 			'files' => 'page.images'
 		]);
 
-		$this->assertEquals(['query' => 'page.images'], $field->files());
+		$this->assertSame(['query' => 'page.images'], $field->files());
 	}
 
 	public function testFilesWithInvalidInput()
@@ -80,7 +80,7 @@ class TextareaFieldTest extends TestCase
 			'files' => 1
 		]);
 
-		$this->assertEquals([], $field->files());
+		$this->assertSame([], $field->files());
 	}
 
 	public function testMaxLength()
@@ -114,7 +114,7 @@ class TextareaFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['template' => 'test', 'accept' => '*'], $field->uploads());
+		$this->assertSame(['template' => 'test', 'accept' => '*'], $field->uploads());
 	}
 
 	public function testUploadsDisabled()
@@ -136,7 +136,7 @@ class TextareaFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['parent' => 'page.parent', 'accept' => '*'], $field->uploads());
+		$this->assertSame(['parent' => 'page.parent', 'accept' => '*'], $field->uploads());
 	}
 
 	public function testUploadsTemplate()
@@ -146,7 +146,7 @@ class TextareaFieldTest extends TestCase
 			'uploads' => 'test'
 		]);
 
-		$this->assertEquals(['template' => 'test', 'accept' => '*'], $field->uploads());
+		$this->assertSame(['template' => 'test', 'accept' => '*'], $field->uploads());
 	}
 
 	public function testUploadsWithInvalidInput()
@@ -156,7 +156,7 @@ class TextareaFieldTest extends TestCase
 			'uploads' => 1,
 		]);
 
-		$this->assertEquals(['accept' => '*'], $field->uploads());
+		$this->assertSame(['accept' => '*'], $field->uploads());
 	}
 
 	public function testValueTrimmed()
@@ -165,6 +165,6 @@ class TextareaFieldTest extends TestCase
 			'value' => 'test '
 		]);
 
-		$this->assertEquals('test', $field->value());
+		$this->assertSame('test', $field->value());
 	}
 }

--- a/tests/Form/Fields/TimeFieldTest.php
+++ b/tests/Form/Fields/TimeFieldTest.php
@@ -8,14 +8,14 @@ class TimeFieldTest extends TestCase
 	{
 		$field = $this->field('time');
 
-		$this->assertEquals('time', $field->type());
-		$this->assertEquals('time', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals(null, $field->default());
-		$this->assertEquals('HH:mm', $field->display());
-		$this->assertEquals('clock', $field->icon());
-		$this->assertEquals(24, $field->notation());
-		$this->assertEquals(['size' => 5, 'unit' => 'minute'], $field->step());
+		$this->assertSame('time', $field->type());
+		$this->assertSame('time', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame('', $field->default());
+		$this->assertSame('HH:mm', $field->display());
+		$this->assertSame('clock', $field->icon());
+		$this->assertSame(24, $field->notation());
+		$this->assertSame(['size' => 5, 'unit' => 'minute'], $field->step());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/ToggleFieldTest.php
+++ b/tests/Form/Fields/ToggleFieldTest.php
@@ -10,9 +10,9 @@ class ToggleFieldTest extends TestCase
 	{
 		$field = $this->field('toggle');
 
-		$this->assertEquals('toggle', $field->type());
-		$this->assertEquals('toggle', $field->name());
-		$this->assertEquals(null, $field->value());
+		$this->assertSame('toggle', $field->type());
+		$this->assertSame('toggle', $field->name());
+		$this->assertFalse($field->value());
 		$this->assertTrue($field->save());
 	}
 
@@ -22,7 +22,7 @@ class ToggleFieldTest extends TestCase
 			'text' => 'Yay {{ page.slug }}'
 		]);
 
-		$this->assertEquals('Yay test', $field->text());
+		$this->assertSame('Yay test', $field->text());
 	}
 
 	public function testTextWithTranslation()
@@ -37,12 +37,12 @@ class ToggleFieldTest extends TestCase
 		I18n::$locale = 'en';
 
 		$field = $this->field('toggle', $props);
-		$this->assertEquals('Yay test', $field->text());
+		$this->assertSame('Yay test', $field->text());
 
 		I18n::$locale = 'de';
 
 		$field = $this->field('toggle', $props);
-		$this->assertEquals('Ja test', $field->text());
+		$this->assertSame('Ja test', $field->text());
 	}
 
 	public function testBooleanDefaultValue()
@@ -71,7 +71,7 @@ class ToggleFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['Yes test', 'No test'], $field->text());
+		$this->assertSame(['Yes test', 'No test'], $field->text());
 	}
 
 	public function testTextToggleWithTranslation()
@@ -86,11 +86,11 @@ class ToggleFieldTest extends TestCase
 		I18n::$locale = 'en';
 
 		$field = $this->field('toggle', $props);
-		$this->assertEquals(['Yes test', 'No test'], $field->text());
+		$this->assertSame(['Yes test', 'No test'], $field->text());
 
 		I18n::$locale = 'de';
 
 		$field = $this->field('toggle', $props);
-		$this->assertEquals(['Ja test', 'Nein test'], $field->text());
+		$this->assertSame(['Ja test', 'Nein test'], $field->text());
 	}
 }

--- a/tests/Form/Fields/TogglesFieldTest.php
+++ b/tests/Form/Fields/TogglesFieldTest.php
@@ -8,13 +8,13 @@ class TogglesFieldTest extends TestCase
 	{
 		$field = $this->field('toggles');
 
-		$this->assertEquals('toggles', $field->type());
-		$this->assertEquals('toggles', $field->name());
-		$this->assertEquals(null, $field->value());
+		$this->assertSame('toggles', $field->type());
+		$this->assertSame('toggles', $field->name());
+		$this->assertSame('', $field->value());
 		$this->assertTrue($field->grow());
 		$this->assertTrue($field->labels());
 		$this->assertTrue($field->reset());
-		$this->assertEquals([], $field->options());
+		$this->assertSame([], $field->options());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/UrlFieldTest.php
+++ b/tests/Form/Fields/UrlFieldTest.php
@@ -8,13 +8,13 @@ class UrlFieldTest extends TestCase
 	{
 		$field = $this->field('url');
 
-		$this->assertEquals('url', $field->type());
-		$this->assertEquals('url', $field->name());
-		$this->assertEquals(null, $field->value());
-		$this->assertEquals('url', $field->icon());
-		$this->assertEquals('https://example.com', $field->placeholder());
-		$this->assertEquals(null, $field->counter());
-		$this->assertEquals('url', $field->autocomplete());
+		$this->assertSame('url', $field->type());
+		$this->assertSame('url', $field->name());
+		$this->assertSame('', $field->value());
+		$this->assertSame('url', $field->icon());
+		$this->assertSame('https://example.com', $field->placeholder());
+		$this->assertNull($field->counter());
+		$this->assertSame('url', $field->autocomplete());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/Fields/UsersFieldTest.php
+++ b/tests/Form/Fields/UsersFieldTest.php
@@ -38,12 +38,12 @@ class UsersFieldTest extends TestCase
 			'model' => new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals('users', $field->type());
-		$this->assertEquals('users', $field->name());
-		$this->assertEquals([], $field->value());
-		$this->assertEquals([], $field->default());
-		$this->assertEquals(null, $field->max());
-		$this->assertEquals(true, $field->multiple());
+		$this->assertSame('users', $field->type());
+		$this->assertSame('users', $field->name());
+		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->default());
+		$this->assertNull($field->max());
+		$this->assertTrue($field->multiple());
 		$this->assertTrue($field->save());
 	}
 
@@ -55,7 +55,7 @@ class UsersFieldTest extends TestCase
 			'model' => new Page(['slug' => 'test'])
 		]);
 
-		$this->assertEquals('raphael@getkirby.com', $field->default()[0]['email']);
+		$this->assertSame('raphael@getkirby.com', $field->default()[0]['email']);
 	}
 
 	public function testMultipleDefaultUsers()
@@ -70,8 +70,8 @@ class UsersFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('raphael@getkirby.com', $field->default()[0]['email']);
-		$this->assertEquals('donatello@getkirby.com', $field->default()[1]['email']);
+		$this->assertSame('raphael@getkirby.com', $field->default()[0]['email']);
+		$this->assertSame('donatello@getkirby.com', $field->default()[1]['email']);
 	}
 
 	public function testDefaultUserDisabled()
@@ -83,7 +83,7 @@ class UsersFieldTest extends TestCase
 			'default' => false
 		]);
 
-		$this->assertEquals([], $field->default());
+		$this->assertSame([], $field->default());
 	}
 
 	public function testValue()
@@ -105,7 +105,7 @@ class UsersFieldTest extends TestCase
 			'raphael@getkirby.com'
 		];
 
-		$this->assertEquals($expected, $ids);
+		$this->assertSame($expected, $ids);
 	}
 
 	public function testMin()
@@ -120,7 +120,7 @@ class UsersFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(3, $field->min());
+		$this->assertSame(3, $field->min());
 		$this->assertTrue($field->required());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
@@ -137,7 +137,7 @@ class UsersFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
-		$this->assertEquals(1, $field->max());
+		$this->assertSame(1, $field->max());
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
@@ -148,7 +148,7 @@ class UsersFieldTest extends TestCase
 			'empty' => 'Test'
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testTranslatedEmpty()
@@ -158,7 +158,7 @@ class UsersFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 
-		$this->assertEquals('Test', $field->empty());
+		$this->assertSame('Test', $field->empty());
 	}
 
 	public function testRequiredProps()
@@ -169,7 +169,7 @@ class UsersFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->required());
-		$this->assertEquals(1, $field->min());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()

--- a/tests/Form/Fields/WriterFieldTest.php
+++ b/tests/Form/Fields/WriterFieldTest.php
@@ -10,9 +10,9 @@ class WriterFieldTest extends TestCase
 
 		$this->assertSame('writer', $field->type());
 		$this->assertSame('writer', $field->name());
-		$this->assertSame(false, $field->inline());
-		$this->assertSame(true, $field->marks());
-		$this->assertSame(null, $field->nodes());
+		$this->assertFalse($field->inline());
+		$this->assertTrue($field->marks());
+		$this->assertNull($field->nodes());
 		$this->assertTrue($field->save());
 	}
 

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -35,7 +35,7 @@ class FieldsTest extends TestCase
 			],
 		]);
 
-		$this->assertEquals('a', $fields->first()->name());
-		$this->assertEquals('b', $fields->last()->name());
+		$this->assertSame('a', $fields->first()->name());
+		$this->assertSame('b', $fields->last()->name());
 	}
 }

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -272,7 +272,7 @@ class FormTest extends TestCase
 		$this->assertArrayHasKey('a', $form->toArray()['fields']);
 		$this->assertArrayHasKey('b', $form->toArray()['fields']);
 		$this->assertCount(2, $form->toArray()['fields']);
-		$this->assertSame(false, $form->toArray()['invalid']);
+		$this->assertFalse($form->toArray()['invalid']);
 	}
 
 	public function testContent()

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -19,7 +19,7 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($values, $form->data());
+		$this->assertSame($values, $form->data());
 	}
 
 	public function testValuesWithoutFields()
@@ -32,7 +32,7 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($values, $form->values());
+		$this->assertSame($values, $form->values());
 	}
 
 	public function testDataFromUnsaveableFields()
@@ -90,7 +90,7 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('a, b', $form->data()['structure'][0]['tags']);
+		$this->assertSame('a, b', $form->data()['structure'][0]['tags']);
 	}
 
 	public function testInvalidFieldType()
@@ -113,10 +113,10 @@ class FormTest extends TestCase
 
 		$field = $form->fields()->first();
 
-		$this->assertEquals('info', $field->type());
-		$this->assertEquals('negative', $field->theme());
-		$this->assertEquals('Error in "test" field.', $field->label());
-		$this->assertEquals('<p>Field "test": The field type "does-not-exist" does not exist</p>', $field->text());
+		$this->assertSame('info', $field->type());
+		$this->assertSame('negative', $field->theme());
+		$this->assertSame('Error in "test" field.', $field->label());
+		$this->assertSame('<p>Field "test": The field type "does-not-exist" does not exist</p>', $field->text());
 	}
 
 	public function testFieldOrder()
@@ -234,10 +234,10 @@ class FormTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $form->errors());
+		$this->assertSame($expected, $form->errors());
 
 		// check for a correct cached array
-		$this->assertEquals($expected, $form->errors());
+		$this->assertSame($expected, $form->errors());
 	}
 
 	public function testToArray()
@@ -268,11 +268,11 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([], $form->toArray()['errors']);
+		$this->assertSame([], $form->toArray()['errors']);
 		$this->assertArrayHasKey('a', $form->toArray()['fields']);
 		$this->assertArrayHasKey('b', $form->toArray()['fields']);
 		$this->assertCount(2, $form->toArray()['fields']);
-		$this->assertEquals(false, $form->toArray()['invalid']);
+		$this->assertSame(false, $form->toArray()['invalid']);
 	}
 
 	public function testContent()
@@ -285,7 +285,7 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($values, $form->content());
+		$this->assertSame($values, $form->content());
 	}
 
 	public function testContentFromUnsaveableFields()
@@ -365,7 +365,7 @@ class FormTest extends TestCase
 		$values = $form->values();
 
 		// the title must always be transfered, even if not in the blueprint
-		$this->assertEquals('Updated Title', $values['title']);
+		$this->assertSame('Updated Title', $values['title']);
 
 		// empty fields should be actually empty
 		$this->assertSame('', $values['date']);
@@ -393,8 +393,8 @@ class FormTest extends TestCase
 
 		$values = $form->values();
 
-		$this->assertEquals('AA', $values['a']);
-		$this->assertEquals('B', $values['b']);
+		$this->assertSame('AA', $values['a']);
+		$this->assertSame('B', $values['b']);
 	}
 
 	public function testFileFormWithoutBlueprint()
@@ -419,7 +419,7 @@ class FormTest extends TestCase
 			'values' => ['a' => 'A', 'b' => 'B']
 		]);
 
-		$this->assertEquals(['a' => 'A', 'b' => 'B'], $form->data());
+		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->data());
 	}
 
 	public function testUntranslatedFields()
@@ -470,7 +470,7 @@ class FormTest extends TestCase
 			'b' => 'B'
 		];
 
-		$this->assertEquals($expected, $form->values());
+		$this->assertSame($expected, $form->values());
 
 		// secondary language
 		$form = Form::for($page, [
@@ -486,6 +486,6 @@ class FormTest extends TestCase
 			'b' => ''
 		];
 
-		$this->assertEquals($expected, $form->values());
+		$this->assertSame($expected, $form->values());
 	}
 }

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -88,18 +88,18 @@ class CookieTest extends TestCase
 
 		// separator missing
 		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85';
-		$this->assertSame(null, Cookie::get('foo'));
+		$this->assertNull(Cookie::get('foo'));
 		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// no hash
 		$_COOKIE['foo'] = '+bar';
-		$this->assertSame(null, Cookie::get('foo'));
+		$this->assertNull(Cookie::get('foo'));
 		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// wrong hash
 		$_COOKIE['foo'] = '040df854f89c9f9ca3490fb950c91ad9aa304c97+bar';
-		$this->assertSame(null, Cookie::get('foo'));
+		$this->assertNull(Cookie::get('foo'));
 	}
 }

--- a/tests/Http/Exceptions/NextRouteExceptionTest.php
+++ b/tests/Http/Exceptions/NextRouteExceptionTest.php
@@ -13,6 +13,6 @@ class NextRouteExceptionTest extends TestCase
 	{
 		$exception = new NextRouteException('test');
 		$this->assertInstanceOf(\Exception::class, $exception);
-		$this->assertEquals('test', $exception->getMessage());
+		$this->assertSame('test', $exception->getMessage());
 	}
 }

--- a/tests/Http/HeaderTest.php
+++ b/tests/Http/HeaderTest.php
@@ -30,7 +30,7 @@ class HeaderTest extends TestCase
 
 	public function testCreateSingle()
 	{
-		$this->assertEquals('Key: Value', Header::create('Key', 'Value'));
+		$this->assertSame('Key: Value', Header::create('Key', 'Value'));
 	}
 
 	public function testCreateMultiple()
@@ -45,22 +45,22 @@ class HeaderTest extends TestCase
 			'b: value b'
 		];
 
-		$this->assertEquals(implode("\r\n", $expected), Header::create($input));
+		$this->assertSame(implode("\r\n", $expected), Header::create($input));
 	}
 
 	public function testNamedStatuses()
 	{
 		$h = $this->statusHeaders;
-		$this->assertEquals($h[200], Header::success(false), 'success status should be 200');
-		$this->assertEquals($h[201], Header::created(false), 'created status should be 201');
-		$this->assertEquals($h[202], Header::accepted(false), 'accepted status should be 202');
-		$this->assertEquals($h[400], Header::error(false), 'error status should be 400');
-		$this->assertEquals($h[403], Header::forbidden(false), 'forbidden status should be 403');
-		$this->assertEquals($h[404], Header::notfound(false), 'notfound status should be 404');
-		$this->assertEquals($h[404], Header::missing(false), 'missing status should be 404');
-		$this->assertEquals($h[410], Header::gone(false), 'gone status should be 410');
-		$this->assertEquals($h[500], Header::panic(false), 'panic status should be 500');
-		$this->assertEquals($h[503], Header::unavailable(false), 'unavailable status should be 503');
+		$this->assertSame($h[200], Header::success(false), 'success status should be 200');
+		$this->assertSame($h[201], Header::created(false), 'created status should be 201');
+		$this->assertSame($h[202], Header::accepted(false), 'accepted status should be 202');
+		$this->assertSame($h[400], Header::error(false), 'error status should be 400');
+		$this->assertSame($h[403], Header::forbidden(false), 'forbidden status should be 403');
+		$this->assertSame($h[404], Header::notfound(false), 'notfound status should be 404');
+		$this->assertSame($h[404], Header::missing(false), 'missing status should be 404');
+		$this->assertSame($h[410], Header::gone(false), 'gone status should be 410');
+		$this->assertSame($h[500], Header::panic(false), 'panic status should be 500');
+		$this->assertSame($h[503], Header::unavailable(false), 'unavailable status should be 503');
 	}
 
 	public function testStatusCodeOnly()
@@ -68,44 +68,44 @@ class HeaderTest extends TestCase
 		$h = $this->statusHeaders;
 
 		// code only
-		$this->assertEquals(
+		$this->assertSame(
 			$h[200],
 			Header::status(200, false),
 			'Accepts integer status code'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$h[200],
 			Header::status('200', false),
 			'Accepts string status code'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$h[451],
 			Header::status('451', false),
 			'Can send HTTP 451 code (RFC 7725)'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$h[500],
 			Header::status(null, false),
 			'Null code results in 500'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			Header::status(500, false),
 			Header::status(999, false),
 			'Unknown code results in 500'
 		);
 
 		// with reason in code parameter
-		$this->assertEquals(
+		$this->assertSame(
 			$h[200],
 			Header::status('200 OK', false),
 			'Can send "200 OK"'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'HTTP/1.1 999 Custom Header',
 			Header::status('999 Custom Header', false),
 			'Can send a well-formed custom status code and reason'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$h[500],
 			Header::status("999 This is\nNOT OKAY", false),
 			'Newlines inside of reason results in a 500 code'
@@ -115,12 +115,12 @@ class HeaderTest extends TestCase
 	public function testRedirect()
 	{
 		$h = $this->statusHeaders;
-		$this->assertEquals(
+		$this->assertSame(
 			$h[301] . "\r\nLocation:/x",
 			Header::redirect('/x', 301, false),
 			'Can send a 301 redirect'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$h[302] . "\r\nLocation:/x",
 			Header::redirect('/x', 302, false),
 			'Can send a 302 redirect'
@@ -129,25 +129,25 @@ class HeaderTest extends TestCase
 
 	public function testContentType()
 	{
-		$this->assertEquals(
+		$this->assertSame(
 			'Content-type: video/webm',
 			Header::contentType('webm', '', false),
 			'Can send Content-type header with no encoding'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Content-type: video/webm',
 			Header::type('webm', '', false),
 			'Can send Content-type header with no encoding'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Content-type: application/json; charset=ISO-8859-1',
 			Header::contentType('json', 'ISO-8859-1', false),
 			'Can send Content-type header with custom charset'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Content-type: application/json; charset=ISO-8859-1',
 			Header::type('json', 'ISO-8859-1', false),
 			'Can send Content-type header with custom charset'

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -29,8 +29,8 @@ class ParamsTest extends TestCase
 	{
 		$params = new Params('a:/b:');
 
-		$this->assertSame(null, $params->a);
-		$this->assertSame(null, $params->b);
+		$this->assertNull($params->a);
+		$this->assertNull($params->b);
 	}
 
 	public function testConstructWithSpecialChars()

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -176,13 +176,13 @@ class RemoteTest extends TestCase
 	public function testContent()
 	{
 		$request = Remote::put('https://getkirby.com');
-		$this->assertSame(null, $request->content());
+		$this->assertNull($request->content());
 	}
 
 	public function testCode()
 	{
 		$request = Remote::put('https://getkirby.com');
-		$this->assertSame(null, $request->code());
+		$this->assertNull($request->code());
 	}
 
 	public function testDelete()

--- a/tests/Http/Request/BodyTest.php
+++ b/tests/Http/Request/BodyTest.php
@@ -77,13 +77,13 @@ class BodyTest extends TestCase
 		$body = new Body();
 		$this->assertSame('', $body->toString());
 		$this->assertSame('', $body->__toString());
-		$this->assertEquals('', $body);
+		$this->assertEquals('', $body); // cannot use strict assertion (string conversion)
 
 		// with data
 		$string = 'foo=bar';
 		$body   = new Body(['foo' => 'bar']);
 		$this->assertSame($string, $body->toString());
 		$this->assertSame($string, $body->__toString());
-		$this->assertEquals($string, $body);
+		$this->assertEquals($string, $body); // cannot use strict assertion (string conversion)
 	}
 }

--- a/tests/Http/Request/BodyTest.php
+++ b/tests/Http/Request/BodyTest.php
@@ -10,22 +10,22 @@ class BodyTest extends TestCase
 	{
 		// default contents
 		$body = new Body();
-		$this->assertEquals('', $body->contents());
+		$this->assertSame('', $body->contents());
 
 		// array content
 		$contents = ['a' => 'a'];
 		$body     = new Body($contents);
-		$this->assertEquals($contents, $body->contents());
+		$this->assertSame($contents, $body->contents());
 
 		// string
 		$contents = 'foo';
 		$body     = new Body($contents);
-		$this->assertEquals($contents, $body->contents());
+		$this->assertSame($contents, $body->contents());
 
 		// $_POST
 		$body = new Body();
 		$_POST = 'foo';
-		$this->assertEquals('foo', $body->contents());
+		$this->assertSame('foo', $body->contents());
 	}
 
 	public function testData()
@@ -33,57 +33,57 @@ class BodyTest extends TestCase
 		// default
 		$data = [];
 		$body = new Body();
-		$this->assertEquals($data, $body->data());
+		$this->assertSame($data, $body->data());
 
 		// array data
 		$data = ['a' => 'a'];
 		$body = new Body($data);
-		$this->assertEquals($data, $body->data());
+		$this->assertSame($data, $body->data());
 
 		// json data
 		$data = ['a' => 'a'];
 		$body = new Body(json_encode($data));
-		$this->assertEquals($data, $body->data());
+		$this->assertSame($data, $body->data());
 
 		// http query data
 		$data = ['a' => 'a'];
 		$body = new Body(http_build_query($data));
-		$this->assertEquals($data, $body->data());
+		$this->assertSame($data, $body->data());
 
 		// unparsable string
 		$data = 'foo';
 		$body = new Body($data);
-		$this->assertEquals([], $body->data());
+		$this->assertSame([], $body->data());
 	}
 
 	public function testToArrayAndDebuginfo()
 	{
 		$data = ['a' => 'a'];
 		$body = new Body($data);
-		$this->assertEquals($data, $body->toArray());
-		$this->assertEquals($data, $body->__debugInfo());
+		$this->assertSame($data, $body->toArray());
+		$this->assertSame($data, $body->__debugInfo());
 	}
 
 	public function testToJson()
 	{
 		$data = ['a' => 'a'];
 		$body = new Body($data);
-		$this->assertEquals(json_encode($data), $body->toJson());
+		$this->assertSame(json_encode($data), $body->toJson());
 	}
 
 	public function testToString()
 	{
 		// default
 		$body = new Body();
-		$this->assertEquals('', $body->toString());
-		$this->assertEquals('', $body->__toString());
+		$this->assertSame('', $body->toString());
+		$this->assertSame('', $body->__toString());
 		$this->assertEquals('', $body);
 
 		// with data
 		$string = 'foo=bar';
 		$body   = new Body(['foo' => 'bar']);
-		$this->assertEquals($string, $body->toString());
-		$this->assertEquals($string, $body->__toString());
+		$this->assertSame($string, $body->toString());
+		$this->assertSame($string, $body->__toString());
 		$this->assertEquals($string, $body);
 	}
 }

--- a/tests/Http/Request/FilesTest.php
+++ b/tests/Http/Request/FilesTest.php
@@ -19,22 +19,22 @@ class FilesTest extends TestCase
 
 		$files = new Files($upload);
 
-		$this->assertEquals('a.txt', $files->get('upload')[0]['name']);
-		$this->assertEquals('/tmp/a', $files->get('upload')[0]['tmp_name']);
-		$this->assertEquals(123, $files->get('upload')[0]['size']);
-		$this->assertEquals(0, $files->get('upload')[0]['error']);
+		$this->assertSame('a.txt', $files->get('upload')[0]['name']);
+		$this->assertSame('/tmp/a', $files->get('upload')[0]['tmp_name']);
+		$this->assertSame(123, $files->get('upload')[0]['size']);
+		$this->assertSame(0, $files->get('upload')[0]['error']);
 
-		$this->assertEquals('b.txt', $files->get('upload')[1]['name']);
-		$this->assertEquals('/tmp/b', $files->get('upload')[1]['tmp_name']);
-		$this->assertEquals(456, $files->get('upload')[1]['size']);
-		$this->assertEquals(0, $files->get('upload')[1]['error']);
+		$this->assertSame('b.txt', $files->get('upload')[1]['name']);
+		$this->assertSame('/tmp/b', $files->get('upload')[1]['tmp_name']);
+		$this->assertSame(456, $files->get('upload')[1]['size']);
+		$this->assertSame(0, $files->get('upload')[1]['error']);
 	}
 
 	public function testData()
 	{
 		// default
 		$files = new Files();
-		$this->assertEquals([], $files->data());
+		$this->assertSame([], $files->data());
 
 		// custom
 		$upload = [
@@ -47,7 +47,7 @@ class FilesTest extends TestCase
 		];
 
 		$files = new Files($upload);
-		$this->assertEquals($upload, $files->data());
+		$this->assertSame($upload, $files->data());
 	}
 
 	public function testGet()
@@ -66,7 +66,7 @@ class FilesTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(123, $files->get('upload')['size']);
+		$this->assertSame(123, $files->get('upload')['size']);
 	}
 
 	public function testToArrayAndDebuginfo()
@@ -81,8 +81,8 @@ class FilesTest extends TestCase
 		];
 
 		$files = new Files($data);
-		$this->assertEquals($data, $files->toArray());
-		$this->assertEquals($data, $files->__debugInfo());
+		$this->assertSame($data, $files->toArray());
+		$this->assertSame($data, $files->__debugInfo());
 	}
 
 	public function testToJson()
@@ -97,6 +97,6 @@ class FilesTest extends TestCase
 		];
 
 		$files = new Files($data);
-		$this->assertEquals(json_encode($data), $files->toJson());
+		$this->assertSame(json_encode($data), $files->toJson());
 	}
 }

--- a/tests/Http/Request/QueryTest.php
+++ b/tests/Http/Request/QueryTest.php
@@ -58,13 +58,13 @@ class QueryTest extends TestCase
 		$query = new Query();
 		$this->assertSame('', $query->toString());
 		$this->assertSame('', $query->__toString());
-		$this->assertEquals('', $query);
+		$this->assertEquals('', $query); // cannot use strict assertion (string conversion)
 
 		// custom
 		$query = new Query(['foo' => 'bar']);
 		$this->assertSame('foo=bar', $query->toString());
 		$this->assertSame('foo=bar', $query->__toString());
-		$this->assertEquals('foo=bar', $query);
+		$this->assertEquals('foo=bar', $query); // cannot use strict assertion (string conversion)
 	}
 
 	public function testToArrayAndDebuginfo()

--- a/tests/Http/Request/QueryTest.php
+++ b/tests/Http/Request/QueryTest.php
@@ -10,18 +10,18 @@ class QueryTest extends TestCase
 	{
 		// default
 		$query = new Query();
-		$this->assertEquals([], $query->data());
+		$this->assertSame([], $query->data());
 
 		// custom array
 		$data  = ['foo' => 'bar'];
 		$query = new Query($data);
-		$this->assertEquals($data, $query->data());
+		$this->assertSame($data, $query->data());
 
 		// custom string
 		$string = 'foo=bar&kirby[]=bastian&kirby[]=allgeier';
 		$data  = ['foo' => 'bar', 'kirby' => ['bastian', 'allgeier']];
 		$query = new Query($string);
-		$this->assertEquals($data, $query->data());
+		$this->assertSame($data, $query->data());
 	}
 
 	public function testIsEmpty()
@@ -45,25 +45,25 @@ class QueryTest extends TestCase
 
 		// single get
 		$query = new Query(['foo' => 'bar']);
-		$this->assertEquals('bar', $query->get('foo'));
+		$this->assertSame('bar', $query->get('foo'));
 
 		// multiple gets
 		$query = new Query(['a' => 'a', 'b' => 'b']);
-		$this->assertEquals(['a' => 'a', 'b' => 'b', 'c' => null], $query->get(['a', 'b', 'c']));
+		$this->assertSame(['a' => 'a', 'b' => 'b', 'c' => null], $query->get(['a', 'b', 'c']));
 	}
 
 	public function testToString()
 	{
 		// default
 		$query = new Query();
-		$this->assertEquals('', $query->toString());
-		$this->assertEquals('', $query->__toString());
+		$this->assertSame('', $query->toString());
+		$this->assertSame('', $query->__toString());
 		$this->assertEquals('', $query);
 
 		// custom
 		$query = new Query(['foo' => 'bar']);
-		$this->assertEquals('foo=bar', $query->toString());
-		$this->assertEquals('foo=bar', $query->__toString());
+		$this->assertSame('foo=bar', $query->toString());
+		$this->assertSame('foo=bar', $query->__toString());
 		$this->assertEquals('foo=bar', $query);
 	}
 
@@ -71,14 +71,14 @@ class QueryTest extends TestCase
 	{
 		$data  = ['a' => 'a'];
 		$query = new Query($data);
-		$this->assertEquals($data, $query->toArray());
-		$this->assertEquals($data, $query->__debugInfo());
+		$this->assertSame($data, $query->toArray());
+		$this->assertSame($data, $query->__debugInfo());
 	}
 
 	public function testToJson()
 	{
 		$data  = ['a' => 'a'];
 		$query = new Query($data);
-		$this->assertEquals(json_encode($data), $query->toJson());
+		$this->assertSame(json_encode($data), $query->toJson());
 	}
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -64,10 +64,10 @@ class RequestTest extends TestCase
 			'query'  => ['b' => 'b'],
 		]);
 
-		$this->assertEquals(['a' => 'a', 'b' => 'b'], $request->data());
-		$this->assertEquals('a', $request->get('a'));
-		$this->assertEquals('b', $request->get('b'));
-		$this->assertEquals(null, $request->get('c'));
+		$this->assertSame(['a' => 'a', 'b' => 'b'], $request->data());
+		$this->assertSame('a', $request->get('a'));
+		$this->assertSame('b', $request->get('b'));
+		$this->assertNull($request->get('c'));
 	}
 
 	public function test__debuginfo()
@@ -99,8 +99,8 @@ class RequestTest extends TestCase
 		$request = new Request();
 
 		$this->assertInstanceOf(BasicAuth::class, $request->auth());
-		$this->assertEquals('testuser', $request->auth()->username());
-		$this->assertEquals('testpass', $request->auth()->password());
+		$this->assertSame('testuser', $request->auth()->username());
+		$this->assertSame('testpass', $request->auth()->password());
 	}
 
 	public function testBearerAuth()
@@ -114,7 +114,7 @@ class RequestTest extends TestCase
 		$request = new Request();
 
 		$this->assertInstanceOf(BearerAuth::class, $request->auth());
-		$this->assertEquals('abcd', $request->auth()->token());
+		$this->assertSame('abcd', $request->auth()->token());
 	}
 
 	public function testCli()
@@ -275,6 +275,6 @@ class RequestTest extends TestCase
 			'url' => 'https://getkirby.com/a/b'
 		]);
 
-		$this->assertEquals('getkirby.com', $request->domain());
+		$this->assertSame('getkirby.com', $request->domain());
 	}
 }

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -20,16 +20,16 @@ class ResponseTest extends TestCase
 	public function testBody()
 	{
 		$response = new Response();
-		$this->assertEquals('', $response->body());
+		$this->assertSame('', $response->body());
 
 		$response = new Response('test');
-		$this->assertEquals('test', $response->body());
+		$this->assertSame('test', $response->body());
 
 		$response = new Response([
 			'body' => 'test'
 		]);
 
-		$this->assertEquals('test', $response->body());
+		$this->assertSame('test', $response->body());
 	}
 
 	public function testDownload()
@@ -134,7 +134,7 @@ class ResponseTest extends TestCase
 	public function testHeaders()
 	{
 		$response = new Response();
-		$this->assertEquals([], $response->headers());
+		$this->assertSame([], $response->headers());
 
 		$response = new Response([
 			'headers' => [
@@ -142,7 +142,7 @@ class ResponseTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['test' => 'test'], $response->headers());
+		$this->assertSame(['test' => 'test'], $response->headers());
 	}
 
 	public function testHeader()
@@ -156,16 +156,16 @@ class ResponseTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('test', $response->header('test'));
+		$this->assertSame('test', $response->header('test'));
 	}
 
 	public function testJson()
 	{
 		$response = Response::json();
 
-		$this->assertEquals('application/json', $response->type());
-		$this->assertEquals(200, $response->code());
-		$this->assertEquals('', $response->body());
+		$this->assertSame('application/json', $response->type());
+		$this->assertSame(200, $response->code());
+		$this->assertSame('', $response->body());
 	}
 
 	public function testJsonWithArray()
@@ -174,7 +174,7 @@ class ResponseTest extends TestCase
 		$expected = json_encode($data);
 		$response = Response::json($data);
 
-		$this->assertEquals($expected, $response->body());
+		$this->assertSame($expected, $response->body());
 	}
 
 	public function testJsonWithPrettyArray()
@@ -183,7 +183,7 @@ class ResponseTest extends TestCase
 		$expected = json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
 		$response = Response::json($data, 200, true);
 
-		$this->assertEquals($expected, $response->body());
+		$this->assertSame($expected, $response->body());
 	}
 
 	public function testFile()
@@ -214,46 +214,46 @@ class ResponseTest extends TestCase
 	public function testType()
 	{
 		$response = new Response();
-		$this->assertEquals('text/html', $response->type());
+		$this->assertSame('text/html', $response->type());
 
 		$response = new Response('', 'image/jpeg');
-		$this->assertEquals('image/jpeg', $response->type());
+		$this->assertSame('image/jpeg', $response->type());
 
 		$response = new Response([
 			'type' => 'image/jpeg'
 		]);
 
-		$this->assertEquals('image/jpeg', $response->type());
+		$this->assertSame('image/jpeg', $response->type());
 	}
 
 	public function testCharset()
 	{
 		$response = new Response();
-		$this->assertEquals('UTF-8', $response->charset());
+		$this->assertSame('UTF-8', $response->charset());
 
 		$response = new Response('', 'text/html', 200, [], 'test');
-		$this->assertEquals('test', $response->charset());
+		$this->assertSame('test', $response->charset());
 
 		$response = new Response([
 			'charset' => 'test'
 		]);
 
-		$this->assertEquals('test', $response->charset());
+		$this->assertSame('test', $response->charset());
 	}
 
 	public function testCode()
 	{
 		$response = new Response();
-		$this->assertEquals(200, $response->code());
+		$this->assertSame(200, $response->code());
 
 		$response = new Response('', 'text/html', 404);
-		$this->assertEquals(404, $response->code());
+		$this->assertSame(404, $response->code());
 
 		$response = new Response([
 			'code' => 404
 		]);
 
-		$this->assertEquals(404, $response->code());
+		$this->assertSame(404, $response->code());
 	}
 
 	public function testRedirect()
@@ -310,8 +310,8 @@ class ResponseTest extends TestCase
 
 		ob_end_clean();
 
-		$this->assertEquals($body, 'test');
-		$this->assertEquals($code, 200);
+		$this->assertSame($body, 'test');
+		$this->assertSame($code, 200);
 	}
 
 	/**
@@ -336,8 +336,8 @@ class ResponseTest extends TestCase
 
 		ob_end_clean();
 
-		$this->assertEquals($body, 'test');
-		$this->assertEquals($code, 200);
+		$this->assertSame($body, 'test');
+		$this->assertSame($code, 200);
 	}
 
 	public function testToArray()
@@ -352,6 +352,6 @@ class ResponseTest extends TestCase
 			'body'    => '',
 		];
 
-		$this->assertEquals($expected, $response->toArray());
+		$this->assertSame($expected, $response->toArray());
 	}
 }

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -261,7 +261,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect();
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => '/'], $response->headers());
+		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	public function testRedirectWithLocation()
@@ -269,7 +269,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('https://getkirby.com');
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers());
+		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	public function testRedirectWithInternationalLocation()
@@ -277,7 +277,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('https://täst.de');
 		$this->assertSame('', $response->body());
 		$this->assertSame(302, $response->code());
-		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers());
+		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	public function testRedirectWithResponseCode()
@@ -285,7 +285,7 @@ class ResponseTest extends TestCase
 		$response = Response::redirect('/', 301);
 		$this->assertSame('', $response->body());
 		$this->assertSame(301, $response->code());
-		$this->assertEquals(['Location' => '/'], $response->headers());
+		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
 	/**

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -19,10 +19,10 @@ class RouteTest extends TestCase
 			return 'test';
 		});
 
-		$this->assertEquals('', $route->pattern());
-		$this->assertEquals('POST', $route->method());
-		$this->assertEquals($func, $route->action());
-		$this->assertEquals('test', $route->action()->call($route));
+		$this->assertSame('', $route->pattern());
+		$this->assertSame('POST', $route->method());
+		$this->assertSame($func, $route->action());
+		$this->assertSame('test', $route->action()->call($route));
 	}
 
 	public function testName()
@@ -32,7 +32,7 @@ class RouteTest extends TestCase
 			'name' => 'test'
 		]);
 
-		$this->assertEquals('test', $route->name());
+		$this->assertSame('test', $route->name());
 	}
 
 	public function testAttributes()
@@ -43,7 +43,7 @@ class RouteTest extends TestCase
 			'b' => 'b'
 		]);
 
-		$this->assertEquals($attributes, $route->attributes());
+		$this->assertSame($attributes, $route->attributes());
 	}
 
 	public function testAttributesGetter()
@@ -53,35 +53,35 @@ class RouteTest extends TestCase
 			'a' => 'a'
 		]);
 
-		$this->assertEquals('a', $route->a());
-		$this->assertEquals(null, $route->b());
+		$this->assertSame('a', $route->a());
+		$this->assertNull($route->b());
 	}
 
 	public function testPattern()
 	{
 		$route = $this->_route();
-		$this->assertEquals('a', $route->pattern());
+		$this->assertSame('a', $route->pattern());
 	}
 
 	public function testMethod()
 	{
 		$route = $this->_route();
-		$this->assertEquals('GET', $route->method());
+		$this->assertSame('GET', $route->method());
 	}
 
 	public function testRegex()
 	{
 		$route = $this->_route();
-		$this->assertEquals('a/(-?[0-9]+)/b', $route->regex('a/(:num)/b'));
-		$this->assertEquals('a/([a-zA-Z]+)/b', $route->regex('a/(:alpha)/b'));
-		$this->assertEquals('a/([a-zA-Z0-9]+)/b', $route->regex('a/(:alphanum)/b'));
-		$this->assertEquals('a/([a-zA-Z0-9\.\-_%= \+\@\(\)]+)/b', $route->regex('a/(:any)/b'));
-		$this->assertEquals('a/(.*)', $route->regex('a/(:all)'));
-		$this->assertEquals('a(?:/(-?[0-9]+))?', $route->regex('a/(:num?)'));
-		$this->assertEquals('a(?:/([a-zA-Z]+))?', $route->regex('a/(:alpha?)'));
-		$this->assertEquals('a(?:/([a-zA-Z0-9]+))?', $route->regex('a/(:alphanum?)'));
-		$this->assertEquals('a(?:/([a-zA-Z0-9\.\-_%= \+\@\(\)]+))?', $route->regex('a/(:any?)'));
-		$this->assertEquals('a(?:/(.*))?', $route->regex('a/(:all?)'));
+		$this->assertSame('a/(-?[0-9]+)/b', $route->regex('a/(:num)/b'));
+		$this->assertSame('a/([a-zA-Z]+)/b', $route->regex('a/(:alpha)/b'));
+		$this->assertSame('a/([a-zA-Z0-9]+)/b', $route->regex('a/(:alphanum)/b'));
+		$this->assertSame('a/([a-zA-Z0-9\.\-_%= \+\@\(\)]+)/b', $route->regex('a/(:any)/b'));
+		$this->assertSame('a/(.*)', $route->regex('a/(:all)'));
+		$this->assertSame('a(?:/(-?[0-9]+))?', $route->regex('a/(:num?)'));
+		$this->assertSame('a(?:/([a-zA-Z]+))?', $route->regex('a/(:alpha?)'));
+		$this->assertSame('a(?:/([a-zA-Z0-9]+))?', $route->regex('a/(:alphanum?)'));
+		$this->assertSame('a(?:/([a-zA-Z0-9\.\-_%= \+\@\(\)]+))?', $route->regex('a/(:any?)'));
+		$this->assertSame('a(?:/(.*))?', $route->regex('a/(:all?)'));
 	}
 
 	public function patternProvider()
@@ -125,9 +125,9 @@ class RouteTest extends TestCase
 
 		if ($match === true) {
 			// required
-			$this->assertEquals([$input], $route->parse('(' . $pattern . ')', $input));
+			$this->assertSame([$input], $route->parse('(' . $pattern . ')', $input));
 			// optional
-			$this->assertEquals([$input], $route->parse('/(' . $pattern . '?)', '/' . $input));
+			$this->assertSame([$input], $route->parse('/(' . $pattern . '?)', '/' . $input));
 		} else {
 			// required
 			$this->assertFalse($route->parse('(' . $pattern . ')', $input));

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -20,8 +20,8 @@ class RouterTest extends TestCase
 		$result = $router->find('/', 'GET');
 
 		$this->assertInstanceOf(Route::class, $result);
-		$this->assertEquals('', $result->pattern());
-		$this->assertEquals('GET', $result->method());
+		$this->assertSame('', $result->pattern());
+		$this->assertSame('GET', $result->method());
 	}
 
 	public function testRegisterMultipleRoutes()
@@ -45,12 +45,12 @@ class RouterTest extends TestCase
 		$resultB = $router->find('b', 'POST');
 
 		$this->assertInstanceOf(Route::class, $resultA);
-		$this->assertEquals('a', $resultA->pattern());
-		$this->assertEquals('GET', $resultA->method());
+		$this->assertSame('a', $resultA->pattern());
+		$this->assertSame('GET', $resultA->method());
 
 		$this->assertInstanceOf(Route::class, $resultB);
-		$this->assertEquals('b', $resultB->pattern());
-		$this->assertEquals('POST', $resultB->method());
+		$this->assertSame('b', $resultB->pattern());
+		$this->assertSame('POST', $resultB->method());
 	}
 
 	public function testRegisterInvalidRoute()
@@ -95,8 +95,8 @@ class RouterTest extends TestCase
 		$hooks = [
 			'beforeEach' => function ($route, $path, $method) {
 				$this->assertInstanceOf(Route::class, $route);
-				$this->assertEquals('/', $path);
-				$this->assertEquals('GET', $method);
+				$this->assertSame('/', $path);
+				$this->assertSame('GET', $method);
 			}
 		];
 
@@ -119,9 +119,9 @@ class RouterTest extends TestCase
 		$hooks = [
 			'afterEach' => function ($route, $path, $method, $result, $final) {
 				$this->assertInstanceOf(Route::class, $route);
-				$this->assertEquals('/', $path);
-				$this->assertEquals('GET', $method);
-				$this->assertEquals('test', $result);
+				$this->assertSame('/', $path);
+				$this->assertSame('GET', $method);
+				$this->assertSame('test', $result);
 				$this->assertTrue($final);
 
 				return $result . ':after';
@@ -140,7 +140,7 @@ class RouterTest extends TestCase
 			$hooks
 		);
 
-		$this->assertEquals('test:after', $router->call('/', 'GET'));
+		$this->assertSame('test:after', $router->call('/', 'GET'));
 	}
 
 	public function testNext()
@@ -182,13 +182,13 @@ class RouterTest extends TestCase
 		]);
 
 		$result = $router->call('a');
-		$this->assertEquals('a', $result);
+		$this->assertSame('a', $result);
 
 		$result = $router->call('b');
-		$this->assertEquals('b', $result);
+		$this->assertSame('b', $result);
 
 		$result = $router->call('c');
-		$this->assertEquals('c', $result);
+		$this->assertSame('c', $result);
 
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('No route found for path: "d" and request method: "GET"');
@@ -231,8 +231,8 @@ class RouterTest extends TestCase
 		);
 
 		$router->call('a');
-		$this->assertEquals(2, $numTotal);
-		$this->assertEquals(1, $numFinal);
+		$this->assertSame(2, $numTotal);
+		$this->assertSame(1, $numFinal);
 	}
 
 	public function testCallWithCallback()
@@ -252,6 +252,6 @@ class RouterTest extends TestCase
 			return $route->arguments()[0];
 		});
 
-		$this->assertEquals('test', $result);
+		$this->assertSame('test', $result);
 	}
 }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -29,8 +29,8 @@ class UriTest extends TestCase
 			'query' => ['foo' => 'bar']
 		]);
 
-		$this->assertEquals('http://getkirby.com/test', $uri->toString());
-		$this->assertEquals('http://getkirby.com/yay?foo=bar', $clone->toString());
+		$this->assertSame('http://getkirby.com/test', $uri->toString());
+		$this->assertSame('http://getkirby.com/yay?foo=bar', $clone->toString());
 	}
 
 	public function testCurrent()
@@ -52,7 +52,7 @@ class UriTest extends TestCase
 	public function testCurrentInCli()
 	{
 		$uri = Uri::current();
-		$this->assertEquals('/', $uri->toString());
+		$this->assertSame('/', $uri->toString());
 	}
 
 	public function testCurrentWithCustomObject()
@@ -158,13 +158,13 @@ class UriTest extends TestCase
 		$url = new Uri();
 
 		$url->setHost('getkirby.com');
-		$this->assertEquals('getkirby.com', $url->host());
+		$this->assertSame('getkirby.com', $url->host());
 	}
 
 	public function testMissingHost()
 	{
 		$url = new Uri(['host' => false]);
-		$this->assertEquals(null, $url->host());
+		$this->assertSame('', $url->host());
 	}
 
 	public function testIsAbsolute()
@@ -182,16 +182,16 @@ class UriTest extends TestCase
 	public function testValidPort()
 	{
 		$url = new Uri(['port' => 1234]);
-		$this->assertEquals(1234, $url->port());
+		$this->assertSame(1234, $url->port());
 
 		$url = new Uri(['port' => null]);
-		$this->assertEquals(null, $url->port());
+		$this->assertSame(null, $url->port());
 	}
 
 	public function testZeroPort()
 	{
 		$url = new Uri(['port' => 0]);
-		$this->assertEquals(null, $url->port());
+		$this->assertSame(null, $url->port());
 	}
 
 	public function testInvalidPortFormat1()
@@ -212,28 +212,28 @@ class UriTest extends TestCase
 	public function testValidUsername()
 	{
 		$url = new Uri(['username' => 'testuser']);
-		$this->assertEquals('testuser', $url->username());
+		$this->assertSame('testuser', $url->username());
 
 		$url = new Uri(['username' => null]);
-		$this->assertEquals(null, $url->username());
+		$this->assertSame(null, $url->username());
 	}
 
 	public function testValidPassword()
 	{
 		$url = new Uri(['password' => 'weakpassword']);
-		$this->assertEquals('weakpassword', $url->password());
+		$this->assertSame('weakpassword', $url->password());
 
 		$url = new Uri(['password' => null]);
-		$this->assertEquals(null, $url->password());
+		$this->assertSame(null, $url->password());
 	}
 
 	public function testValidPath()
 	{
 		$url = new Uri(['path' => '/a/b/c']);
-		$this->assertEquals('a/b/c', $url->path()->toString());
+		$this->assertSame('a/b/c', $url->path()->toString());
 
 		$url = new Uri(['path' => ['a', 'b', 'c']]);
-		$this->assertEquals('a/b/c', $url->path()->toString());
+		$this->assertSame('a/b/c', $url->path()->toString());
 
 		$url = new Uri(['path' => null]);
 		$this->assertTrue($url->path()->isEmpty());
@@ -242,13 +242,13 @@ class UriTest extends TestCase
 	public function testValidQuery()
 	{
 		$url = new Uri(['query' => 'foo=bar']);
-		$this->assertEquals('foo=bar', $url->query()->toString());
+		$this->assertSame('foo=bar', $url->query()->toString());
 
 		$url = new Uri(['query' => '?foo=bar']);
-		$this->assertEquals('foo=bar', $url->query()->toString());
+		$this->assertSame('foo=bar', $url->query()->toString());
 
 		$url = new Uri(['query' => ['foo' => 'bar']]);
-		$this->assertEquals('foo=bar', $url->query()->toString());
+		$this->assertSame('foo=bar', $url->query()->toString());
 
 		$url = new Uri(['query' => null]);
 		$this->assertTrue($url->query()->isEmpty());
@@ -257,39 +257,39 @@ class UriTest extends TestCase
 	public function testValidFragment()
 	{
 		$url = new Uri(['fragment' => 'top']);
-		$this->assertEquals('top', $url->fragment());
+		$this->assertSame('top', $url->fragment());
 
 		$url = new Uri(['fragment' => '#top']);
-		$this->assertEquals('top', $url->fragment());
+		$this->assertSame('top', $url->fragment());
 
 		$url = new Uri(['fragment' => null]);
-		$this->assertEquals(null, $url->fragment());
+		$this->assertSame(null, $url->fragment());
 	}
 
 	public function testAuth()
 	{
 		$url = new Uri(['username' => 'testuser', 'password' => 'weakpassword']);
-		$this->assertEquals('testuser:weakpassword', $url->auth());
+		$this->assertSame('testuser:weakpassword', $url->auth());
 	}
 
 	public function testBase()
 	{
 		$url = new Uri(['scheme' => 'https', 'host' => 'getkirby.com']);
-		$this->assertEquals('https://getkirby.com', $url->base());
+		$this->assertSame('https://getkirby.com', $url->base());
 
 		$url->username = 'testuser';
 		$url->password = 'weakpassword';
 
-		$this->assertEquals('https://testuser:weakpassword@getkirby.com', $url->base());
+		$this->assertSame('https://testuser:weakpassword@getkirby.com', $url->base());
 
 		$url->port = 3000;
-		$this->assertEquals('https://testuser:weakpassword@getkirby.com:3000', $url->base());
+		$this->assertSame('https://testuser:weakpassword@getkirby.com:3000', $url->base());
 	}
 
 	public function testBaseWithoutHost()
 	{
 		$url = new Uri();
-		$this->assertEquals(null, $url->base());
+		$this->assertSame(null, $url->base());
 	}
 
 	public function testToArray()

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -185,13 +185,13 @@ class UriTest extends TestCase
 		$this->assertSame(1234, $url->port());
 
 		$url = new Uri(['port' => null]);
-		$this->assertSame(null, $url->port());
+		$this->assertNull($url->port());
 	}
 
 	public function testZeroPort()
 	{
 		$url = new Uri(['port' => 0]);
-		$this->assertSame(null, $url->port());
+		$this->assertNull($url->port());
 	}
 
 	public function testInvalidPortFormat1()
@@ -215,7 +215,7 @@ class UriTest extends TestCase
 		$this->assertSame('testuser', $url->username());
 
 		$url = new Uri(['username' => null]);
-		$this->assertSame(null, $url->username());
+		$this->assertNull($url->username());
 	}
 
 	public function testValidPassword()
@@ -224,7 +224,7 @@ class UriTest extends TestCase
 		$this->assertSame('weakpassword', $url->password());
 
 		$url = new Uri(['password' => null]);
-		$this->assertSame(null, $url->password());
+		$this->assertNull($url->password());
 	}
 
 	public function testValidPath()
@@ -263,7 +263,7 @@ class UriTest extends TestCase
 		$this->assertSame('top', $url->fragment());
 
 		$url = new Uri(['fragment' => null]);
-		$this->assertSame(null, $url->fragment());
+		$this->assertNull($url->fragment());
 	}
 
 	public function testAuth()
@@ -289,7 +289,7 @@ class UriTest extends TestCase
 	public function testBaseWithoutHost()
 	{
 		$url = new Uri();
-		$this->assertSame(null, $url->base());
+		$this->assertNull($url->base());
 	}
 
 	public function testToArray()

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -296,19 +296,19 @@ class UriTest extends TestCase
 	{
 		$url = new Uri($this->example2);
 
-		$this->assertEquals([
-			'scheme'   => 'https',
-			'host'     => 'getkirby.com',
-			'port'     => 3000,
-			'path'     => ['docs', 'getting-started'],
-			'username' => 'testuser',
-			'password' => 'weakpassword',
-			'query'    => ['q' => 'awesome'],
+		$this->assertSame([
 			'fragment' => 'top',
+			'host'     => 'getkirby.com',
+			'password' => 'weakpassword',
 			'params'   => [
 				'with' => 'kirby',
 			],
+			'path'     => ['docs', 'getting-started'],
+			'port'     => 3000,
+			'query'    => ['q' => 'awesome'],
+			'scheme'   => 'https',
 			'slash'    => true,
+			'username' => 'testuser',
 		], $url->toArray());
 	}
 

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -103,7 +103,7 @@ class UrlTest extends TestCase
 
 	public function testBase()
 	{
-		$this->assertSame(null, Url::base());
+		$this->assertNull(Url::base());
 		$this->assertSame('http://getkirby.com', Url::base('http://getkirby.com/docs/cheatsheet'));
 	}
 

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -21,48 +21,48 @@ class UrlTest extends TestCase
 
 	public function testCurrent()
 	{
-		$this->assertEquals('/', Url::current());
+		$this->assertSame('/', Url::current());
 
 		Url::$current = $this->_yts;
-		$this->assertEquals($this->_yts, Url::current());
+		$this->assertSame($this->_yts, Url::current());
 	}
 
 	public function testCurrentDir()
 	{
 		Url::$current = $this->_yts;
-		$this->assertEquals('https://www.youtube.com', Url::currentDir());
+		$this->assertSame('https://www.youtube.com', Url::currentDir());
 	}
 
 	public function testHome()
 	{
-		$this->assertEquals('/', Url::home());
+		$this->assertSame('/', Url::home());
 	}
 
 	public function testTo()
 	{
-		$this->assertEquals('/', Url::to());
-		$this->assertEquals($this->_yt, Url::to($this->_yt));
-		$this->assertEquals('/getkirby.com', Url::to('getkirby.com'));
-		$this->assertEquals('./something', Url::to('./something'));
-		$this->assertEquals('../something', Url::to('../something'));
+		$this->assertSame('/', Url::to());
+		$this->assertSame($this->_yt, Url::to($this->_yt));
+		$this->assertSame('/getkirby.com', Url::to('getkirby.com'));
+		$this->assertSame('./something', Url::to('./something'));
+		$this->assertSame('../something', Url::to('../something'));
 	}
 
 	public function testLast()
 	{
-		$this->assertEquals('', Url::last());
+		$this->assertSame('', Url::last());
 	}
 
 	public function testBuild()
 	{
-		$this->assertEquals('/', Url::build());
+		$this->assertSame('/', Url::build());
 
 		Url::$current = $this->_yts;
 
 		// build with defaults
-		$this->assertEquals('https://www.youtube.com/watch?v=9q_aXttJduk', Url::build());
+		$this->assertSame('https://www.youtube.com/watch?v=9q_aXttJduk', Url::build());
 
 		// build with different host
-		$this->assertEquals('https://kirbyvideo.com/watch?v=9q_aXttJduk', Url::build(['host' => 'kirbyvideo.com']));
+		$this->assertSame('https://kirbyvideo.com/watch?v=9q_aXttJduk', Url::build(['host' => 'kirbyvideo.com']));
 
 		// build from parts
 		$parts = [
@@ -71,7 +71,7 @@ class UrlTest extends TestCase
 			'fragment' => 'foo'
 		];
 		$result = 'http://getkirby.com/hello/kitty/mickey/mouse?get=kirby#foo';
-		$this->assertEquals($result, Url::build($parts, 'http://getkirby.com'));
+		$this->assertSame($result, Url::build($parts, 'http://getkirby.com'));
 	}
 
 	public function testIsAbsolute()
@@ -87,10 +87,10 @@ class UrlTest extends TestCase
 
 	public function testMakeAbsolute()
 	{
-		$this->assertEquals('http://getkirby.com', Url::makeAbsolute('http://getkirby.com'));
-		$this->assertEquals('/docs/cheatsheet', Url::makeAbsolute('docs/cheatsheet'));
-		$this->assertEquals('http://getkirby.com/docs/cheatsheet', Url::makeAbsolute('docs/cheatsheet', 'http://getkirby.com'));
-		$this->assertEquals('http://getkirby.com', Url::makeAbsolute('', 'http://getkirby.com'));
+		$this->assertSame('http://getkirby.com', Url::makeAbsolute('http://getkirby.com'));
+		$this->assertSame('/docs/cheatsheet', Url::makeAbsolute('docs/cheatsheet'));
+		$this->assertSame('http://getkirby.com/docs/cheatsheet', Url::makeAbsolute('docs/cheatsheet', 'http://getkirby.com'));
+		$this->assertSame('http://getkirby.com', Url::makeAbsolute('', 'http://getkirby.com'));
 	}
 
 	public function testFix()
@@ -103,74 +103,74 @@ class UrlTest extends TestCase
 
 	public function testBase()
 	{
-		$this->assertEquals(null, Url::base());
-		$this->assertEquals('http://getkirby.com', Url::base('http://getkirby.com/docs/cheatsheet'));
+		$this->assertSame(null, Url::base());
+		$this->assertSame('http://getkirby.com', Url::base('http://getkirby.com/docs/cheatsheet'));
 	}
 
 	public function testPath()
 	{
 		// stripped
-		$this->assertEquals('', Url::path('https://getkirby.com'));
-		$this->assertEquals('', Url::path('https://getkirby.com/'));
-		$this->assertEquals('a/b', Url::path('a/b'));
-		$this->assertEquals('a/b', Url::path('https://getkirby.com/a/b'));
-		$this->assertEquals('a/b', Url::path('https://getkirby.com/a/b/'));
+		$this->assertSame('', Url::path('https://getkirby.com'));
+		$this->assertSame('', Url::path('https://getkirby.com/'));
+		$this->assertSame('a/b', Url::path('a/b'));
+		$this->assertSame('a/b', Url::path('https://getkirby.com/a/b'));
+		$this->assertSame('a/b', Url::path('https://getkirby.com/a/b/'));
 
 		// leading slash
-		$this->assertEquals('', Url::path('https://getkirby.com', true));
-		$this->assertEquals('', Url::path('https://getkirby.com/', true));
-		$this->assertEquals('/a/b', Url::path('a/b', true));
-		$this->assertEquals('/a/b', Url::path('https://getkirby.com/a/b', true));
-		$this->assertEquals('/a/b', Url::path('https://getkirby.com/a/b/', true));
+		$this->assertSame('', Url::path('https://getkirby.com', true));
+		$this->assertSame('', Url::path('https://getkirby.com/', true));
+		$this->assertSame('/a/b', Url::path('a/b', true));
+		$this->assertSame('/a/b', Url::path('https://getkirby.com/a/b', true));
+		$this->assertSame('/a/b', Url::path('https://getkirby.com/a/b/', true));
 
 		// trailing slash
-		$this->assertEquals('', Url::path('https://getkirby.com', false, true));
-		$this->assertEquals('', Url::path('https://getkirby.com/', false, true));
-		$this->assertEquals('a/b/', Url::path('a/b', false, true));
-		$this->assertEquals('a/b/', Url::path('https://getkirby.com/a/b', false, true));
-		$this->assertEquals('a/b/', Url::path('https://getkirby.com/a/b/', false, true));
+		$this->assertSame('', Url::path('https://getkirby.com', false, true));
+		$this->assertSame('', Url::path('https://getkirby.com/', false, true));
+		$this->assertSame('a/b/', Url::path('a/b', false, true));
+		$this->assertSame('a/b/', Url::path('https://getkirby.com/a/b', false, true));
+		$this->assertSame('a/b/', Url::path('https://getkirby.com/a/b/', false, true));
 
 		// leading and trailing slash
-		$this->assertEquals('', Url::path('https://getkirby.com', true, true));
-		$this->assertEquals('', Url::path('https://getkirby.com/', true, true));
-		$this->assertEquals('/a/b/', Url::path('a/b', true, true));
-		$this->assertEquals('/a/b/', Url::path('https://getkirby.com/a/b', true, true));
-		$this->assertEquals('/a/b/', Url::path('https://getkirby.com/a/b/', true, true));
+		$this->assertSame('', Url::path('https://getkirby.com', true, true));
+		$this->assertSame('', Url::path('https://getkirby.com/', true, true));
+		$this->assertSame('/a/b/', Url::path('a/b', true, true));
+		$this->assertSame('/a/b/', Url::path('https://getkirby.com/a/b', true, true));
+		$this->assertSame('/a/b/', Url::path('https://getkirby.com/a/b/', true, true));
 	}
 
 	public function testStripPath()
 	{
-		$this->assertEquals('https://getkirby.com', Url::stripPath('https://getkirby.com/a/b'));
-		$this->assertEquals('https://getkirby.com/', Url::stripPath('https://getkirby.com/a/b/'));
+		$this->assertSame('https://getkirby.com', Url::stripPath('https://getkirby.com/a/b'));
+		$this->assertSame('https://getkirby.com/', Url::stripPath('https://getkirby.com/a/b/'));
 	}
 
 	public function testStripQuery()
 	{
-		$this->assertEquals('https://getkirby.com', Url::stripQuery('https://getkirby.com?a=b'));
-		$this->assertEquals('https://getkirby.com/', Url::stripQuery('https://getkirby.com/?a=b'));
+		$this->assertSame('https://getkirby.com', Url::stripQuery('https://getkirby.com?a=b'));
+		$this->assertSame('https://getkirby.com/', Url::stripQuery('https://getkirby.com/?a=b'));
 	}
 
 	public function testStripFragment()
 	{
-		$this->assertEquals('https://getkirby.com', Url::stripFragment('https://getkirby.com#a/b'));
-		$this->assertEquals('https://getkirby.com/', Url::stripFragment('https://getkirby.com/#a/b'));
+		$this->assertSame('https://getkirby.com', Url::stripFragment('https://getkirby.com#a/b'));
+		$this->assertSame('https://getkirby.com/', Url::stripFragment('https://getkirby.com/#a/b'));
 	}
 
 	public function testQuery()
 	{
-		$this->assertEquals('', Url::query('https://getkirby.com'));
-		$this->assertEquals('a=b', Url::query('?a=b'));
-		$this->assertEquals('a=b', Url::query('https://getkirby.com?a=b'));
-		$this->assertEquals('a=b', Url::query('https://getkirby.com/?a=b'));
+		$this->assertSame('', Url::query('https://getkirby.com'));
+		$this->assertSame('a=b', Url::query('?a=b'));
+		$this->assertSame('a=b', Url::query('https://getkirby.com?a=b'));
+		$this->assertSame('a=b', Url::query('https://getkirby.com/?a=b'));
 	}
 
 	public function testShort()
 	{
-		$this->assertEquals('getkirby.com/docs', Url::short($this->_docs));
-		$this->assertEquals('getkirby.com/docs', Url::short($this->_docs, 100));
-		$this->assertEquals('getkirby.com…', Url::short($this->_docs, 12));
-		$this->assertEquals('getkirby.com', Url::short($this->_docs, 20, true));
-		$this->assertEquals('getkirby.com###', Url::short($this->_docs, 12, false, '###'));
+		$this->assertSame('getkirby.com/docs', Url::short($this->_docs));
+		$this->assertSame('getkirby.com/docs', Url::short($this->_docs, 100));
+		$this->assertSame('getkirby.com…', Url::short($this->_docs, 12));
+		$this->assertSame('getkirby.com', Url::short($this->_docs, 20, true));
+		$this->assertSame('getkirby.com###', Url::short($this->_docs, 12, false, '###'));
 	}
 
 	public function testIdn()
@@ -219,6 +219,6 @@ class UrlTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, Url::index());
+		$this->assertSame($expected, Url::index());
 	}
 }

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -175,7 +175,9 @@ class UrlTest extends TestCase
 
 	public function testIdn()
 	{
-		$this->assertEquals('https://täst.de', Url::idn('https://xn--tst-qla.de'));
+		$object = Url::idn('https://xn--tst-qla.de');
+		$this->assertInstanceOf(Uri::class, $object);
+		$this->assertSame('https://täst.de', $object->toString());
 	}
 
 	public function scriptNameProvider()

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -12,11 +12,11 @@ class VisitorTest extends TestCase
 	{
 		$visitor = new Visitor();
 
-		$this->assertEquals('', $visitor->ip());
-		$this->assertEquals('', $visitor->userAgent());
-		$this->assertEquals(null, $visitor->acceptedLanguage());
+		$this->assertSame('', $visitor->ip());
+		$this->assertSame('', $visitor->userAgent());
+		$this->assertNull($visitor->acceptedLanguage());
 		$this->assertInstanceOf(Collection::class, $visitor->acceptedLanguages());
-		$this->assertEquals(null, $visitor->acceptedMimeType());
+		$this->assertNull($visitor->acceptedMimeType());
 		$this->assertInstanceOf(Collection::class, $visitor->acceptedMimeTypes());
 	}
 
@@ -29,27 +29,27 @@ class VisitorTest extends TestCase
 			'acceptedMimeType' => 'text/html'
 		]);
 
-		$this->assertEquals('192.168.1.1', $visitor->ip());
-		$this->assertEquals('Kirby', $visitor->userAgent());
+		$this->assertSame('192.168.1.1', $visitor->ip());
+		$this->assertSame('Kirby', $visitor->userAgent());
 		$this->assertInstanceOf(Obj::class, $visitor->acceptedLanguage());
-		$this->assertEquals('en_US', $visitor->acceptedLanguage()->locale());
+		$this->assertSame('en_US', $visitor->acceptedLanguage()->locale());
 		$this->assertInstanceOf(Obj::class, $visitor->acceptedMimeType());
-		$this->assertEquals('text/html', $visitor->acceptedMimeType()->type());
+		$this->assertSame('text/html', $visitor->acceptedMimeType()->type());
 	}
 
 	public function testIp()
 	{
 		$visitor = new Visitor();
-		$this->assertEquals(null, $visitor->ip());
+		$this->assertSame('', $visitor->ip());
 		$this->assertInstanceOf(Visitor::class, $visitor->ip('192.168.1.1'));
-		$this->assertEquals('192.168.1.1', $visitor->ip());
+		$this->assertSame('192.168.1.1', $visitor->ip());
 	}
 
 	public function testUserAgent()
 	{
 		$visitor = new Visitor();
 		$this->assertInstanceOf(Visitor::class, $visitor->userAgent('Kirby'));
-		$this->assertEquals('Kirby', $visitor->userAgent());
+		$this->assertSame('Kirby', $visitor->userAgent());
 	}
 
 	public function testAcceptsMimeType()

--- a/tests/Image/CameraTest.php
+++ b/tests/Image/CameraTest.php
@@ -34,6 +34,6 @@ class CameraTest extends TestCase
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);
-		$this->assertEquals('Kirby Kamera Inc. Deluxe Snap 3000', (string)$camera);
+		$this->assertSame('Kirby Kamera Inc. Deluxe Snap 3000', (string)$camera);
 	}
 }

--- a/tests/Image/CameraTest.php
+++ b/tests/Image/CameraTest.php
@@ -18,16 +18,16 @@ class CameraTest extends TestCase
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);
-		$this->assertEquals($exif['Make'], $camera->make());
-		$this->assertEquals($exif['Model'], $camera->model());
+		$this->assertSame($exif['Make'], $camera->make());
+		$this->assertSame($exif['Model'], $camera->model());
 	}
 
 	public function testToArray()
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);
-		$this->assertEquals(array_change_key_case($exif), $camera->toArray());
-		$this->assertEquals(array_change_key_case($exif), $camera->__debugInfo());
+		$this->assertSame(array_change_key_case($exif), $camera->toArray());
+		$this->assertSame(array_change_key_case($exif), $camera->__debugInfo());
 	}
 
 	public function testToString()

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -2,7 +2,7 @@
 
 namespace Kirby\Image\Darkroom;
 
-use Kirby\Toolkit\Dir;
+use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -2,7 +2,7 @@
 
 namespace Kirby\Image\Darkroom;
 
-use Kirby\Toolkit\Dir;
+use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\F;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -40,7 +40,7 @@ class DarkroomTest extends TestCase
 			'width' => 100
 		]);
 
-		$this->assertEquals('center', $options['crop']);
+		$this->assertSame('center', $options['crop']);
 	}
 
 	public function testBlurWithoutPosition()
@@ -50,7 +50,7 @@ class DarkroomTest extends TestCase
 			'blur' => true,
 		]);
 
-		$this->assertEquals(10, $options['blur']);
+		$this->assertSame(10, $options['blur']);
 	}
 
 	public function testQualityWithoutValue()
@@ -60,7 +60,7 @@ class DarkroomTest extends TestCase
 			'quality' => null,
 		]);
 
-		$this->assertEquals(90, $options['quality']);
+		$this->assertSame(90, $options['quality']);
 	}
 
 	public function testDefaults()
@@ -68,12 +68,12 @@ class DarkroomTest extends TestCase
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess('/dev/null');
 
-		$this->assertEquals(true, $options['autoOrient']);
-		$this->assertEquals(false, $options['crop']);
-		$this->assertEquals(false, $options['blur']);
-		$this->assertEquals(false, $options['grayscale']);
+		$this->assertTrue($options['autoOrient']);
+		$this->assertFalse($options['crop']);
+		$this->assertFalse($options['blur']);
+		$this->assertFalse($options['grayscale']);
 		$this->assertEquals(null, $options['height']);
-		$this->assertEquals(90, $options['quality']);
+		$this->assertSame(90, $options['quality']);
 		$this->assertEquals(null, $options['width']);
 	}
 
@@ -85,7 +85,7 @@ class DarkroomTest extends TestCase
 
 		$options = $darkroom->preprocess($this->file());
 
-		$this->assertEquals(20, $options['quality']);
+		$this->assertSame(20, $options['quality']);
 	}
 
 	public function testPassedOptions()
@@ -98,7 +98,7 @@ class DarkroomTest extends TestCase
 			'quality' => 30
 		]);
 
-		$this->assertEquals(30, $options['quality']);
+		$this->assertSame(30, $options['quality']);
 	}
 
 	public function testProcess()
@@ -111,7 +111,7 @@ class DarkroomTest extends TestCase
 			'quality' => 30
 		]);
 
-		$this->assertEquals(30, $options['quality']);
+		$this->assertSame(30, $options['quality']);
 	}
 
 	public function testGrayscaleFixes()
@@ -123,22 +123,22 @@ class DarkroomTest extends TestCase
 			'grayscale' => true
 		]);
 
-		$this->assertEquals(true, $options['grayscale']);
+		$this->assertSame(true, $options['grayscale']);
 
 		// greyscale
 		$options = $darkroom->preprocess($this->file(), [
 			'greyscale' => true
 		]);
 
-		$this->assertEquals(true, $options['grayscale']);
-		$this->assertEquals(false, isset($options['greyscale']));
+		$this->assertSame(true, $options['grayscale']);
+		$this->assertSame(false, isset($options['greyscale']));
 
 		// bw
 		$options = $darkroom->preprocess($this->file(), [
 			'bw' => true
 		]);
 
-		$this->assertEquals(true, $options['grayscale']);
-		$this->assertEquals(false, isset($options['bw']));
+		$this->assertSame(true, $options['grayscale']);
+		$this->assertSame(false, isset($options['bw']));
 	}
 }

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -123,22 +123,22 @@ class DarkroomTest extends TestCase
 			'grayscale' => true
 		]);
 
-		$this->assertSame(true, $options['grayscale']);
+		$this->assertTrue($options['grayscale']);
 
 		// greyscale
 		$options = $darkroom->preprocess($this->file(), [
 			'greyscale' => true
 		]);
 
-		$this->assertSame(true, $options['grayscale']);
-		$this->assertSame(false, isset($options['greyscale']));
+		$this->assertTrue($options['grayscale']);
+		$this->assertFalse(isset($options['greyscale']));
 
 		// bw
 		$options = $darkroom->preprocess($this->file(), [
 			'bw' => true
 		]);
 
-		$this->assertSame(true, $options['grayscale']);
-		$this->assertSame(false, isset($options['bw']));
+		$this->assertTrue($options['grayscale']);
+		$this->assertFalse(isset($options['bw']));
 	}
 }

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -72,9 +72,9 @@ class DarkroomTest extends TestCase
 		$this->assertFalse($options['crop']);
 		$this->assertFalse($options['blur']);
 		$this->assertFalse($options['grayscale']);
-		$this->assertEquals(null, $options['height']);
+		$this->assertSame(0, $options['height']);
 		$this->assertSame(90, $options['quality']);
-		$this->assertEquals(null, $options['width']);
+		$this->assertSame(0, $options['width']);
 	}
 
 	public function testGlobalOptions()

--- a/tests/Image/ExifTest.php
+++ b/tests/Image/ExifTest.php
@@ -15,7 +15,7 @@ class ExifTest extends TestCase
 	public function testData()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals([
+		$this->assertSame([
 			'FileName'      => 'cat.jpg',
 			'FileDateTime'  => exif_read_data(static::FIXTURES . '/image/cat.jpg')['FileDateTime'],
 			'FileSize'      => 23574,
@@ -52,7 +52,7 @@ class ExifTest extends TestCase
 	public function testTimestamp()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals(exif_read_data(static::FIXTURES . '/image/cat.jpg')['FileDateTime'], $exif->timestamp());
+		$this->assertSame((string)exif_read_data(static::FIXTURES . '/image/cat.jpg')['FileDateTime'], $exif->timestamp());
 	}
 
 	public function testExposure()
@@ -107,7 +107,7 @@ class ExifTest extends TestCase
 		$parse = $ref->getMethod('parseTimestamp');
 		$parse->setAccessible(true);
 
-		$this->assertEquals(strtotime('11.12.2016 11:13:14'), $parse->invoke($exif));
+		$this->assertSame((string)strtotime('11.12.2016 11:13:14'), $parse->invoke($exif));
 	}
 
 	public function testToArray()

--- a/tests/Image/ExifTest.php
+++ b/tests/Image/ExifTest.php
@@ -58,19 +58,19 @@ class ExifTest extends TestCase
 	public function testExposure()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals(null, $exif->exposure());
+		$this->assertNull($exif->exposure());
 	}
 
 	public function testAperture()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals(null, $exif->aperture());
+		$this->assertNull($exif->aperture());
 	}
 
 	public function testIso()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals(null, $exif->iso());
+		$this->assertNull($exif->iso());
 	}
 
 	public function testIsColor()
@@ -88,7 +88,7 @@ class ExifTest extends TestCase
 	public function testFocalLength()
 	{
 		$exif  = $this->_exif();
-		$this->assertEquals(null, $exif->focalLength());
+		$this->assertNull($exif->focalLength());
 	}
 
 	public function testParseTimestampDateTimeOriginal()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -32,23 +32,23 @@ class ImageTest extends TestCase
 
 		// svg with width and height
 		$file = $this->_image('square.svg');
-		$this->assertEquals(100, $file->dimensions()->width());
-		$this->assertEquals(100, $file->dimensions()->height());
+		$this->assertSame(100, $file->dimensions()->width());
+		$this->assertSame(100, $file->dimensions()->height());
 
 		// svg with viewBox
 		$file = $this->_image('circle.svg');
-		$this->assertEquals(50, $file->dimensions()->width());
-		$this->assertEquals(50, $file->dimensions()->height());
+		$this->assertSame(50, $file->dimensions()->width());
+		$this->assertSame(50, $file->dimensions()->height());
 
 		// webp
 		$file = $this->_image('valley.webp');
-		$this->assertEquals(550, $file->dimensions()->width());
-		$this->assertEquals(368, $file->dimensions()->height());
+		$this->assertSame(550, $file->dimensions()->width());
+		$this->assertSame(368, $file->dimensions()->height());
 
 		// non-image file
 		$file = $this->_image('blank.pdf');
-		$this->assertEquals(0, $file->dimensions()->width());
-		$this->assertEquals(0, $file->dimensions()->height());
+		$this->assertSame(0, $file->dimensions()->width());
+		$this->assertSame(0, $file->dimensions()->height());
 
 		// cached object
 		$this->assertInstanceOf(Dimensions::class, $file->dimensions());
@@ -219,7 +219,7 @@ class ImageTest extends TestCase
 	public function testRatio()
 	{
 		$image  = $this->_image();
-		$this->assertEquals(1.0, $image->ratio());
+		$this->assertSame(1.0, $image->ratio());
 	}
 
 	/**

--- a/tests/Image/LocationTest.php
+++ b/tests/Image/LocationTest.php
@@ -19,8 +19,8 @@ class LocationTest extends TestCase
 	public function testLatLng()
 	{
 		$camera = new Location($this->_exif());
-		$this->assertEquals(50.819053333333336, $camera->lat());
-		$this->assertEquals(-0.016666666666666666, $camera->lng());
+		$this->assertSame(50.819053333333336, $camera->lat());
+		$this->assertSame(-0.016666666666666666, $camera->lng());
 	}
 
 	public function testToArray()
@@ -30,8 +30,8 @@ class LocationTest extends TestCase
 			'lat' => 50.819053333333336,
 			'lng' => -0.016666666666666666
 		];
-		$this->assertEquals($array, $camera->toArray());
-		$this->assertEquals($array, $camera->__debugInfo());
+		$this->assertSame($array, $camera->toArray());
+		$this->assertSame($array, $camera->__debugInfo());
 	}
 
 	public function testToString()

--- a/tests/Panel/Areas/SiteDropdownsTest.php
+++ b/tests/Panel/Areas/SiteDropdownsTest.php
@@ -48,7 +48,7 @@ class SiteDropdownsTest extends AreaTestCase
 			]
 		];
 
-		$this->assertEquals($expected, $options);
+		$this->assertEquals($expected, $options); // cannot use strict assertion (array order)
 	}
 
 	public function testPageDropdown(): void

--- a/tests/Panel/Areas/UsersTest.php
+++ b/tests/Panel/Areas/UsersTest.php
@@ -26,7 +26,7 @@ class UsersTest extends AreaTestCase
 		$this->assertSame('k-users-view', $view['component']);
 		$this->assertSame('Users', $view['title']);
 
-		$this->assertSame(null, $props['role']);
+		$this->assertNull($props['role']);
 		$this->assertSame([
 			[
 				'id'    => 'admin',

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -106,7 +106,7 @@ class DropdownTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $options);
+		$this->assertEquals($expected, $options); // cannot use strict assertion (array order)
 	}
 
 	/**

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -141,7 +141,7 @@ class DropdownTest extends TestCase
 			]
 		];
 
-		$this->assertEquals($expected, $options);
+		$this->assertSame($expected, $options);
 	}
 
 	/**
@@ -185,7 +185,7 @@ class DropdownTest extends TestCase
 			],
 		];
 
-		$this->assertEquals($expected, $options);
+		$this->assertSame($expected, $options);
 	}
 
 	/**

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -345,7 +345,7 @@ class FileTest extends TestCase
 		$this->assertSame('orange-400', $image['color']);
 		$this->assertSame('3/2', $image['ratio']);
 		$this->assertSame('pattern', $image['back']);
-		$this->assertTrue(array_key_exists('url', $image));
+		$this->assertArrayHasKey('url', $image);
 	}
 
 	/**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -169,7 +169,7 @@ class ModelTest extends TestCase
 		// Custom function does not match and returns null, default case
 		$file  = $app->page('test')->file('test.jpg');
 		$panel = new CustomPanelModel($file);
-		$this->assertSame(null, $panel->dragTextFromCallback('markdown', $file, $file->filename()));
+		$this->assertNull($panel->dragTextFromCallback('markdown', $file, $file->filename()));
 
 		// Custom function should return image tag for heic
 		$file  = $app->page('test')->file('test.heic');
@@ -212,7 +212,7 @@ class ModelTest extends TestCase
 		// Custom function does not match and returns null, default case
 		$file  = $app->page('test')->file('test.jpg');
 		$panel = new CustomPanelModel($file);
-		$this->assertSame(null, $panel->dragTextFromCallback('kirbytext', $file, $file->filename()));
+		$this->assertNull($panel->dragTextFromCallback('kirbytext', $file, $file->filename()));
 
 		// Custom function should return image tag for heic
 		$file  = $app->page('test')->file('test.heic');
@@ -276,7 +276,7 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('cover', $image);
 		$this->assertArrayHasKey('icon', $image);
 		$this->assertArrayHasKey('ratio', $image);
-		$this->assertSame(false, $image['cover']);
+		$this->assertFalse($image['cover']);
 		$this->assertSame('page', $image['icon']);
 		$this->assertSame('3/2', $image['ratio']);
 

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -407,7 +407,7 @@ class UserTest extends TestCase
 		$panel = new User($user);
 		$translations = $panel->translation();
 		$this->assertSame('foo', $translations->code());
-		$this->assertSame(null, $translations->get('translation.name'));
+		$this->assertNull($translations->get('translation.name'));
 	}
 
 	/**

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -355,7 +355,7 @@ class ViewTest extends TestCase
 
 		$this->assertSame($expected, $data['$languages']);
 		$this->assertSame($expected[0], $data['$language']);
-		$this->assertSame(null, $data['$direction']);
+		$this->assertNull($data['$direction']);
 	}
 
 	/**

--- a/tests/Parsley/InlineTest.php
+++ b/tests/Parsley/InlineTest.php
@@ -95,7 +95,7 @@ class InlineTest extends TestCase
 		$comment = $dom->childNodes[1];
 		$html    = Inline::parseNode($comment);
 
-		$this->assertSame(null, $html);
+		$this->assertNull($html);
 	}
 
 	/**

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -27,7 +27,7 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
 
 		// arrays
 		$argument = Argument::factory('[1, "a", 3]');
-		$this->assertSame(3, $argument->value->count());
+		$this->assertCount(3, $argument->value);
 
 		// numbers
 		$argument = Argument::factory(' 23  ');

--- a/tests/Query/ArgumentsTest.php
+++ b/tests/Query/ArgumentsTest.php
@@ -13,19 +13,19 @@ class ArgumentsTest extends \PHPUnit\Framework\TestCase
 	public function testFactory()
 	{
 		$arguments = Arguments::factory('1, 2, 3');
-		$this->assertSame(3, $arguments->count());
+		$this->assertCount(3, $arguments);
 
 		$arguments = Arguments::factory('1, 2, [3, 4]');
-		$this->assertSame(3, $arguments->count());
+		$this->assertCount(3, $arguments);
 
 		$arguments = Arguments::factory('1, 2, \'3, 4\'');
-		$this->assertSame(3, $arguments->count());
+		$this->assertCount(3, $arguments);
 
 		$arguments = Arguments::factory('1, 2, "3, 4"');
-		$this->assertSame(3, $arguments->count());
+		$this->assertCount(3, $arguments);
 
 		$arguments = Arguments::factory('1, 2, (3, 4)');
-		$this->assertSame(3, $arguments->count());
+		$this->assertCount(3, $arguments);
 	}
 
 	/**

--- a/tests/Query/QueryDefaultFunctionsTest.php
+++ b/tests/Query/QueryDefaultFunctionsTest.php
@@ -42,7 +42,7 @@ class QueryDefaultFunctionsTest extends \PHPUnit\Framework\TestCase
 		$query = new Query('collection("test")');
 		$collection = $query->resolve();
 		$this->assertInstanceOf(Pages::class, $collection);
-		$this->assertSame(1, $collection->count());
+		$this->assertCount(1, $collection);
 	}
 
 	public function testFile()

--- a/tests/Query/SegmentTest.php
+++ b/tests/Query/SegmentTest.php
@@ -83,11 +83,11 @@ class SegmentTest extends \PHPUnit\Framework\TestCase
 
 		$segment = Segment::factory('foo(1, 2)');
 		$this->assertSame('foo', $segment->method);
-		$this->assertSame(2, $segment->arguments->count());
+		$this->assertCount(2, $segment->arguments);
 
 		$segment = Segment::factory('foo(1, bar(2))');
 		$this->assertSame('foo', $segment->method);
-		$this->assertSame(2, $segment->arguments->count());
+		$this->assertCount(2, $segment->arguments);
 	}
 
 	/**

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -17,16 +17,16 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testFactory()
 	{
 		$segments = Segments::factory('a.b.c');
-		$this->assertSame(5, $segments->count());
+		$this->assertCount(5, $segments);
 
 		$segments = Segments::factory('a().b(foo.bar).c(homer.simpson(2))');
-		$this->assertSame(5, $segments->count());
+		$this->assertCount(5, $segments);
 		$this->assertSame('c', $segments->nth(4)->method);
-		$this->assertSame(1, $segments->nth(2)->arguments->count());
+		$this->assertCount(1, $segments->nth(2)->arguments);
 		$this->assertSame(1, $segments->nth(2)->position);
 
 		$segments = Segments::factory('user0.profiles1.twitter');
-		$this->assertSame(5, $segments->count());
+		$this->assertCount(5, $segments);
 		$this->assertSame(2, $segments->nth(4)->position);
 	}
 

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -153,7 +153,7 @@ class AutoSessionTest extends TestCase
 		$session = $autoSession->get(['long' => true]);
 		$this->assertSame('awesome session', $session->data()->get('id'));
 		$this->assertSame(1209600, $session->duration());
-		$this->assertSame(false, $session->timeout());
+		$this->assertFalse($session->timeout());
 		Cookie::remove('kirby_session');
 
 		// custom duration and timeout (normal session)
@@ -211,21 +211,21 @@ class AutoSessionTest extends TestCase
 		$session = $autoSession->get();
 		$this->assertSame('awesome session', $session->data()->get('id'));
 		$this->assertSame(7300, $session->duration());
-		$this->assertSame(false, $session->timeout());
+		$this->assertFalse($session->timeout());
 		Cookie::remove('kirby_session');
 
 		// timeout for the first time: shouldn't change anything
 		$autoSession = new AutoSession($this->store);
 		$session = $autoSession->get(['long' => true]);
 		$this->assertSame(1209600, $session->duration());
-		$this->assertSame(false, $session->timeout());
+		$this->assertFalse($session->timeout());
 		$session->data()->set('id', 'awesome session');
 		$session->commit();
 		Cookie::set('kirby_session', $session->token());
 		$session = $autoSession->get();
 		$this->assertSame('awesome session', $session->data()->get('id'));
 		$this->assertSame(1209600, $session->duration());
-		$this->assertSame(false, $session->timeout());
+		$this->assertFalse($session->timeout());
 		$session->commit();
 	}
 

--- a/tests/Session/SessionDataTest.php
+++ b/tests/Session/SessionDataTest.php
@@ -191,7 +191,7 @@ class SessionDataTest extends TestCase
 	{
 		// string as key
 		$this->assertSame('someValue', $this->sessionData->get('someString', 'someDefault'));
-		$this->assertSame(null, $this->sessionData->get('someOtherString'));
+		$this->assertNull($this->sessionData->get('someOtherString'));
 		$this->assertSame('someDefault', $this->sessionData->get('someOtherString', 'someDefault'));
 		$this->assertSame(123, $this->sessionData->get('someInt', 456));
 
@@ -222,9 +222,9 @@ class SessionDataTest extends TestCase
 		$this->assertSame('someValue', $this->sessionData->pull('someString'));
 		$this->assertFalse($this->session->ensuredToken);
 		$this->assertTrue($this->session->preparedForWriting);
-		$this->assertSame(null, $this->sessionData->get('someString'));
+		$this->assertNull($this->sessionData->get('someString'));
 
-		$this->assertSame(null, $this->sessionData->pull('someOtherString'));
+		$this->assertNull($this->sessionData->pull('someOtherString'));
 		$this->assertSame('someDefault', $this->sessionData->pull('someOtherString', 'someDefault'));
 	}
 
@@ -239,7 +239,7 @@ class SessionDataTest extends TestCase
 		$this->sessionData->remove('someString');
 		$this->assertFalse($this->session->ensuredToken);
 		$this->assertTrue($this->session->preparedForWriting);
-		$this->assertSame(null, $this->sessionData->get('someString'));
+		$this->assertNull($this->sessionData->get('someString'));
 
 		// key-value array
 		$this->session->ensuredToken = false;

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -66,7 +66,7 @@ class SessionTest extends TestCase
 		$this->assertSame(7200, $session->duration());
 		$this->assertSame(1800, $session->timeout());
 		$this->assertSame(1337000000, $activityProperty->getValue($session)); // timestamp is from mock
-		$this->assertSame(true, $session->renewable());
+		$this->assertTrue($session->renewable());
 		$this->assertSame([], $session->data()->get());
 		$this->assertNull($session->token());
 		$this->assertWriteMode(false, $session);
@@ -82,8 +82,8 @@ class SessionTest extends TestCase
 		$this->assertSame(1337000000 + 3660, $session->expiryTime()); // timestamp is from mock
 		$this->assertSame(3600, $session->duration());
 		$this->assertFalse($session->timeout());
-		$this->assertSame(null, $activityProperty->getValue($session));
-		$this->assertSame(false, $session->renewable());
+		$this->assertNull($activityProperty->getValue($session));
+		$this->assertFalse($session->renewable());
 		$this->assertSame([], $session->data()->get());
 		$this->assertNull($session->token());
 		$this->assertWriteMode(false, $session);
@@ -367,7 +367,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 		$this->assertFalse($session->timeout(false));
 		$this->assertFalse($session->timeout());
-		$this->assertSame(null, $activityProperty->getValue($session));
+		$this->assertNull($activityProperty->getValue($session));
 		$this->assertWriteMode(true, $session);
 	}
 
@@ -566,7 +566,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 		$this->assertTrue(isset($this->store->isLocked['9999999999.valid']));
 		$this->assertSame(1234, $session->timeout());
-		$this->assertSame(false, $session->renewable());
+		$this->assertFalse($session->renewable());
 		$this->assertSame('aDifferentValue', $session->data()->get('someKey'));
 
 		$session->commit();
@@ -769,13 +769,13 @@ class SessionTest extends TestCase
 
 		$this->assertWriteMode(false, $session);
 		$this->assertFalse(isset($this->store->isLocked['9999999999.valid']));
-		$this->assertSame(null, $session->data()->get('someId'));
+		$this->assertNull($session->data()->get('someId'));
 
 		// manually overwrite some data like another thread would do
 		$this->store->sessions['9999999999.valid']['data']['someId'] = 123;
 		$this->assertWriteMode(false, $session);
 		$this->assertFalse(isset($this->store->isLocked['9999999999.valid']));
-		$this->assertSame(null, $session->data()->get('someId'));
+		$this->assertNull($session->data()->get('someId'));
 
 		// now trigger a reload of the session by setting a value
 		$session->data()->increment('someId', 1);

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -959,7 +959,7 @@ class SessionTest extends TestCase
 		$session = new Session($this->sessions, $token, []);
 		$this->assertSame('test-session', $session->data()->get('name'));
 		$this->assertInstanceOf(Obj::class, $session->data()->get('obj'));
-		$this->assertEquals($obj, $session->data()->get('obj')); // cannot use strict test
+		$this->assertEquals($obj, $session->data()->get('obj')); // cannot use strict assertion (serialized data)
 		$this->assertFalse($obj === $session->data()->get('obj'));
 	}
 

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -160,7 +160,7 @@ class SessionsTest extends TestCase
 		$this->assertSame(1337000000 + 3600, $session->startTime()); // timestamp is from mock
 		$this->assertSame(36000, $session->duration());
 		$this->assertSame(1337000000 + 39600, $session->expiryTime()); // timestamp is from mock
-		$this->assertSame(false, $session->timeout());
+		$this->assertFalse($session->timeout());
 		$this->assertFalse($session->renewable());
 	}
 

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -211,7 +211,7 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, $kirby->kirbytext($kirbytext));
+		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
 	/**
@@ -228,7 +228,7 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($expected, $kirby->kirbytext($kirbytext));
+		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
 	public function testImageWithoutFigure()
@@ -245,7 +245,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<img alt="" src="https://test.com/something.jpg">';
 
-		$this->assertEquals($expected, $kirby->kirbytext('(image: https://test.com/something.jpg)'));
+		$this->assertSame($expected, $kirby->kirbytext('(image: https://test.com/something.jpg)'));
 	}
 
 	public function testImageWithCaption()
@@ -253,7 +253,7 @@ class KirbyTagsTest extends TestCase
 		$kirby    = $this->app->clone();
 		$expected = '<figure><img alt="" src="/myimage.jpg"><figcaption>This is an <em>awesome</em> image and this a <a href="">link</a></figcaption></figure>';
 
-		$this->assertEquals($expected, $kirby->kirbytext('(image: myimage.jpg caption: This is an *awesome* image and this a <a href="">link</a>)'));
+		$this->assertSame($expected, $kirby->kirbytext('(image: myimage.jpg caption: This is an *awesome* image and this a <a href="">link</a>)'));
 	}
 
 	public function testImageWithFileLink()
@@ -285,7 +285,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<figure><a href="' . $doc->url() . '"><img alt="" src="' . $image->url() . '"></a></figure>';
 
-		$this->assertEquals($expected, $page->text()->kt()->value());
+		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
 	public function testImageWithFileUUID()
@@ -315,7 +315,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<figure><img alt="" src="' . $image->url() . '"></figure>';
 
-		$this->assertEquals($expected, $page->text()->kt()->value());
+		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
 	public function testFile()
@@ -343,7 +343,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<p><a download href="' . $file->url() . '">a.jpg</a></p>';
 
-		$this->assertEquals($expected, $page->text()->kt()->value());
+		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
 	public function testFileWithUUID()
@@ -373,7 +373,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<p><a download href="' . $file->url() . '">a.jpg</a></p>';
 
-		$this->assertEquals($expected, $page->text()->kt()->value());
+		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
 	public function testFileWithDisabledDownloadOption()
@@ -401,7 +401,7 @@ class KirbyTagsTest extends TestCase
 
 		$expected = '<p><a href="' . $file->url() . '">a.jpg</a></p>';
 
-		$this->assertEquals($expected, $page->text()->kt()->value());
+		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
 	public function testFileWithinFile()
@@ -431,7 +431,7 @@ class KirbyTagsTest extends TestCase
 		$b = $kirby->file('a/b.jpg');
 		$expected = '<p><a download href="' . $b->url() . '">b.jpg</a></p>';
 
-		$this->assertEquals($expected, $a->caption()->kt()->value());
+		$this->assertSame($expected, $a->caption()->kt()->value());
 	}
 
 	public function testLinkWithLangAttribute()
@@ -455,8 +455,8 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<a href="https://getkirby.com/en/a">getkirby.com/en/a</a>', $app->kirbytags('(link: a lang: en)'));
-		$this->assertEquals('<a href="https://getkirby.com/de/a">getkirby.com/de/a</a>', $app->kirbytags('(link: a lang: de)'));
+		$this->assertSame('<a href="https://getkirby.com/en/a">getkirby.com/en/a</a>', $app->kirbytags('(link: a lang: en)'));
+		$this->assertSame('<a href="https://getkirby.com/de/a">getkirby.com/de/a</a>', $app->kirbytags('(link: a lang: de)'));
 	}
 
 	public function testLinkWithHash()
@@ -480,10 +480,10 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('<a href="https://getkirby.com/en/a">getkirby.com/en/a</a>', $app->kirbytags('(link: a)'));
-		$this->assertEquals('<a href="https://getkirby.com/de/a">getkirby.com/de/a</a>', $app->kirbytags('(link: a lang: de)'));
-		$this->assertEquals('<a href="https://getkirby.com/en/a#anchor">getkirby.com/en/a</a>', $app->kirbytags('(link: a#anchor lang: en)'));
-		$this->assertEquals('<a href="https://getkirby.com/de/a#anchor">getkirby.com/de/a</a>', $app->kirbytags('(link: a#anchor lang: de)'));
+		$this->assertSame('<a href="https://getkirby.com/en/a">getkirby.com/en/a</a>', $app->kirbytags('(link: a)'));
+		$this->assertSame('<a href="https://getkirby.com/de/a">getkirby.com/de/a</a>', $app->kirbytags('(link: a lang: de)'));
+		$this->assertSame('<a href="https://getkirby.com/en/a#anchor">getkirby.com/en/a</a>', $app->kirbytags('(link: a#anchor lang: en)'));
+		$this->assertSame('<a href="https://getkirby.com/de/a#anchor">getkirby.com/de/a</a>', $app->kirbytags('(link: a#anchor lang: de)'));
 	}
 
 	public function testLinkWithUuid()
@@ -509,10 +509,10 @@ class KirbyTagsTest extends TestCase
 		]);
 
 		$result = $app->kirbytags('(link: page://page-uuid)');
-		$this->assertEquals('<a href="https://getkirby.com/a">getkirby.com/a</a>', $result);
+		$this->assertSame('<a href="https://getkirby.com/a">getkirby.com/a</a>', $result);
 
 		$result = $app->kirbytags('(link: file://file-uuid text: file)');
-		$this->assertEquals('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
+		$this->assertSame('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
 	}
 
 	public function testLinkWithUuidAndLang()
@@ -571,10 +571,10 @@ class KirbyTagsTest extends TestCase
 		]);
 
 		$result = $app->kirbytags('(link: page://page-uuid lang: de)');
-		$this->assertEquals('<a href="https://getkirby.com/de/ae">getkirby.com/de/ae</a>', $result);
+		$this->assertSame('<a href="https://getkirby.com/de/ae">getkirby.com/de/ae</a>', $result);
 
 		$result = $app->kirbytags('(link: file://file-uuid text: file lang: de)');
-		$this->assertEquals('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
+		$this->assertSame('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
 	}
 
 	public function testHooks()
@@ -587,7 +587,7 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('before', $app->kirbytags('test'));
+		$this->assertSame('before', $app->kirbytags('test'));
 
 		$app = $app->clone([
 			'hooks' => [
@@ -597,7 +597,7 @@ class KirbyTagsTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals('after', $app->kirbytags('test'));
+		$this->assertSame('after', $app->kirbytags('test'));
 	}
 
 	public function testVideoLocal()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -100,7 +100,7 @@ class ATest extends TestCase
 		$this->assertSame($array, A::get($array, null));
 
 		// fallback value
-		$this->assertSame(null, A::get($array, 'elephant'));
+		$this->assertNull(A::get($array, 'elephant'));
 		$this->assertSame('toot', A::get($array, 'elephant', 'toot'));
 
 		$this->assertSame([

--- a/tests/Toolkit/CollectionConverterTest.php
+++ b/tests/Toolkit/CollectionConverterTest.php
@@ -11,7 +11,7 @@ class CollectionConverterTest extends TestCase
 			'two'   => 'zwei'
 		];
 		$collection = new Collection($array);
-		$this->assertEquals($array, $collection->toArray());
+		$this->assertSame($array, $collection->toArray());
 	}
 
 	public function testToArrayMap()
@@ -20,7 +20,7 @@ class CollectionConverterTest extends TestCase
 			'one'   => 'eins',
 			'two'   => 'zwei'
 		]);
-		$this->assertEquals([
+		$this->assertSame([
 			'one'   => 'einsy',
 			'two'   => 'zweiy'
 		], $collection->toArray(function ($item) {
@@ -34,7 +34,7 @@ class CollectionConverterTest extends TestCase
 			'one'   => 'eins',
 			'two'   => 'zwei'
 		]);
-		$this->assertEquals('{"one":"eins","two":"zwei"}', $collection->toJson());
+		$this->assertSame('{"one":"eins","two":"zwei"}', $collection->toJson());
 	}
 
 	public function testToString()
@@ -44,7 +44,7 @@ class CollectionConverterTest extends TestCase
 			'two'   => 'zwei'
 		]);
 		$string = 'one<br />two';
-		$this->assertEquals($string, $collection->toString());
-		$this->assertEquals($string, (string)$collection);
+		$this->assertSame($string, $collection->toString());
+		$this->assertSame($string, (string)$collection);
 	}
 }

--- a/tests/Toolkit/CollectionFilterTest.php
+++ b/tests/Toolkit/CollectionFilterTest.php
@@ -39,22 +39,27 @@ class CollectionFilterTest extends TestCase
 			]
 		]);
 
-		$result = new Collection([
+		$expected = [
 			[
 				'name'  => 'Bastian',
 				'role'  => 'developer',
 				'color' => 'red'
 			]
-		]);
+		];
 
-		$this->assertEquals($result, $collection->filter([
+		$result = $collection->filter([
 			['role', '==', 'developer'],
 			['color', '==', 'red']
-		]));
-		$this->assertEquals($result, $collection->filterBy([
+		]);
+		$this->assertInstanceOf(Collection::class, $result);
+		$this->assertSame($expected, $result->data());
+
+		$result = $collection->filterBy([
 			['role', '==', 'developer'],
 			['color', '==', 'red']
-		]));
+		]);
+		$this->assertInstanceOf(Collection::class, $result);
+		$this->assertSame($expected, $result->data());
 	}
 
 	public function testFilterClosure()
@@ -70,21 +75,20 @@ class CollectionFilterTest extends TestCase
 			]
 		]);
 
-		$result = new Collection([
+		$expected = [
 			[
 				'name'  => 'Bastian',
 				'role'  => 'founder'
 			]
-		]);
+		];
 
-		$this->assertEquals(
-			$result,
-			$collection->filter(fn ($item) => $item['role'] === 'founder')
-		);
-		$this->assertEquals(
-			$result,
-			$collection->filterBy(fn ($item) => $item['role'] === 'founder')
-		);
+		$result = $collection->filter(fn ($item) => $item['role'] === 'founder');
+		$this->assertInstanceOf(Collection::class, $result);
+		$this->assertSame($expected, $result->data());
+
+		$result = $collection->filterBy(fn ($item) => $item['role'] === 'founder');
+		$this->assertInstanceOf(Collection::class, $result);
+		$this->assertSame($expected, $result->data());
 	}
 
 	public function filterDataProvider()
@@ -676,10 +680,12 @@ class CollectionFilterTest extends TestCase
 			'three' => 'drei'
 		]);
 
-		$result = new Collection([
+		$expected = [
 			'two' => 'zwei',
-		]);
+		];
 
-		$this->assertEquals($result, $collection->not('one', 'three'));
+		$result = $collection->not('one', 'three');
+		$this->assertInstanceOf(Collection::class, $result);
+		$this->assertSame($expected, $result->data());
 	}
 }

--- a/tests/Toolkit/CollectionFilterTest.php
+++ b/tests/Toolkit/CollectionFilterTest.php
@@ -77,12 +77,14 @@ class CollectionFilterTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals($result, $collection->filter(function ($item) {
-			return $item['role'] === 'founder';
-		}));
-		$this->assertEquals($result, $collection->filterBy(function ($item) {
-			return $item['role'] === 'founder';
-		}));
+		$this->assertEquals(
+			$result,
+			$collection->filter(fn ($item) => $item['role'] === 'founder')
+		);
+		$this->assertEquals(
+			$result,
+			$collection->filterBy(fn ($item) => $item['role'] === 'founder')
+		);
 	}
 
 	public function filterDataProvider()
@@ -663,7 +665,7 @@ class CollectionFilterTest extends TestCase
 		$collection = new Collection($data);
 		$result     = $collection->filter('attribute', $operator, $test, $split);
 
-		$this->assertEquals($expected, $result->keys(), $operator);
+		$this->assertSame($expected, $result->keys(), $operator);
 	}
 
 	public function testNot()

--- a/tests/Toolkit/CollectionFinderTest.php
+++ b/tests/Toolkit/CollectionFinderTest.php
@@ -17,7 +17,7 @@ class CollectionFinderTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			'name' => 'Bastian',
 			'email' => 'bastian@getkirby.com'
 		], $collection->findBy('email', 'bastian@getkirby.com'));
@@ -30,6 +30,6 @@ class CollectionFinderTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('zwei', $collection->find('two'));
+		$this->assertSame('zwei', $collection->find('two'));
 	}
 }

--- a/tests/Toolkit/CollectionGetterTest.php
+++ b/tests/Toolkit/CollectionGetterTest.php
@@ -13,7 +13,7 @@ class CollectionGetterTest extends TestCase
 
 		$this->assertSame('eins', $collection->one);
 		$this->assertSame('eins', $collection->ONE);
-		$this->assertSame(null, $collection->three);
+		$this->assertNull($collection->three);
 	}
 
 	public function testGet()
@@ -24,7 +24,7 @@ class CollectionGetterTest extends TestCase
 		]);
 
 		$this->assertSame('eins', $collection->get('one'));
-		$this->assertSame(null, $collection->get('three'));
+		$this->assertNull($collection->get('three'));
 		$this->assertSame('default', $collection->get('three', 'default'));
 	}
 
@@ -37,7 +37,7 @@ class CollectionGetterTest extends TestCase
 
 		$this->assertSame('eins', $collection->one());
 		$this->assertSame('zwei', $collection->two());
-		$this->assertSame(null, $collection->three());
+		$this->assertNull($collection->three());
 	}
 
 	public function testGetAttribute()
@@ -48,9 +48,9 @@ class CollectionGetterTest extends TestCase
 		]);
 
 		$this->assertSame('eins', $collection->getAttribute($collection->toArray(), 'one'));
-		$this->assertSame(null, $collection->getAttribute($collection->toArray(), 'three'));
+		$this->assertNull($collection->getAttribute($collection->toArray(), 'three'));
 
 		$this->assertSame('zwei', $collection->getAttribute($collection, 'two'));
-		$this->assertSame(null, $collection->getAttribute($collection, 'three'));
+		$this->assertNull($collection->getAttribute($collection, 'three'));
 	}
 }

--- a/tests/Toolkit/CollectionGetterTest.php
+++ b/tests/Toolkit/CollectionGetterTest.php
@@ -11,9 +11,9 @@ class CollectionGetterTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('eins', $collection->one);
-		$this->assertEquals('eins', $collection->ONE);
-		$this->assertEquals(null, $collection->three);
+		$this->assertSame('eins', $collection->one);
+		$this->assertSame('eins', $collection->ONE);
+		$this->assertSame(null, $collection->three);
 	}
 
 	public function testGet()
@@ -23,9 +23,9 @@ class CollectionGetterTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('eins', $collection->get('one'));
-		$this->assertEquals(null, $collection->get('three'));
-		$this->assertEquals('default', $collection->get('three', 'default'));
+		$this->assertSame('eins', $collection->get('one'));
+		$this->assertSame(null, $collection->get('three'));
+		$this->assertSame('default', $collection->get('three', 'default'));
 	}
 
 	public function testMagicMethods()
@@ -35,9 +35,9 @@ class CollectionGetterTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('eins', $collection->one());
-		$this->assertEquals('zwei', $collection->two());
-		$this->assertEquals(null, $collection->three());
+		$this->assertSame('eins', $collection->one());
+		$this->assertSame('zwei', $collection->two());
+		$this->assertSame(null, $collection->three());
 	}
 
 	public function testGetAttribute()
@@ -47,10 +47,10 @@ class CollectionGetterTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('eins', $collection->getAttribute($collection->toArray(), 'one'));
-		$this->assertEquals(null, $collection->getAttribute($collection->toArray(), 'three'));
+		$this->assertSame('eins', $collection->getAttribute($collection->toArray(), 'one'));
+		$this->assertSame(null, $collection->getAttribute($collection->toArray(), 'three'));
 
-		$this->assertEquals('zwei', $collection->getAttribute($collection, 'two'));
-		$this->assertEquals(null, $collection->getAttribute($collection, 'three'));
+		$this->assertSame('zwei', $collection->getAttribute($collection, 'two'));
+		$this->assertSame(null, $collection->getAttribute($collection, 'three'));
 	}
 }

--- a/tests/Toolkit/CollectionMutatorTest.php
+++ b/tests/Toolkit/CollectionMutatorTest.php
@@ -45,8 +45,8 @@ class CollectionMutatorTest extends TestCase
 	public function testSet()
 	{
 		$collection = new Collection();
-		$this->assertSame(null, $collection->one);
-		$this->assertSame(null, $collection->two);
+		$this->assertNull($collection->one);
+		$this->assertNull($collection->two);
 
 		$collection->one = 'eins';
 		$this->assertSame('eins', $collection->one);
@@ -107,7 +107,7 @@ class CollectionMutatorTest extends TestCase
 
 		$this->assertSame('zwei', $collection->two());
 		$collection->remove('two');
-		$this->assertSame(null, $collection->two());
+		$this->assertNull($collection->two());
 	}
 
 	public function testUnset()
@@ -119,7 +119,7 @@ class CollectionMutatorTest extends TestCase
 
 		$this->assertSame('zwei', $collection->two());
 		unset($collection->two);
-		$this->assertSame(null, $collection->two());
+		$this->assertNull($collection->two());
 	}
 
 	public function testMap()

--- a/tests/Toolkit/CollectionMutatorTest.php
+++ b/tests/Toolkit/CollectionMutatorTest.php
@@ -8,12 +8,12 @@ class CollectionMutatorTest extends TestCase
 	{
 		$collection = new Collection();
 
-		$this->assertEquals([], $collection->data());
+		$this->assertSame([], $collection->data());
 
 		$collection->data([
 			'three' => 'drei'
 		]);
-		$this->assertEquals([
+		$this->assertSame([
 			'three' => 'drei'
 		], $collection->data());
 
@@ -21,7 +21,7 @@ class CollectionMutatorTest extends TestCase
 			'one' => 'eins',
 			'two' => 'zwei'
 		]);
-		$this->assertEquals([
+		$this->assertSame([
 			'one' => 'eins',
 			'two' => 'zwei'
 		], $collection->data());
@@ -34,30 +34,30 @@ class CollectionMutatorTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals([
+		$this->assertSame([
 			'one' => 'eins',
 			'two' => 'zwei'
 		], $collection->data());
 
-		$this->assertEquals([], $collection->empty()->data());
+		$this->assertSame([], $collection->empty()->data());
 	}
 
 	public function testSet()
 	{
 		$collection = new Collection();
-		$this->assertEquals(null, $collection->one);
-		$this->assertEquals(null, $collection->two);
+		$this->assertSame(null, $collection->one);
+		$this->assertSame(null, $collection->two);
 
 		$collection->one = 'eins';
-		$this->assertEquals('eins', $collection->one);
+		$this->assertSame('eins', $collection->one);
 
 		$collection->set('two', 'zwei');
-		$this->assertEquals('zwei', $collection->two);
+		$this->assertSame('zwei', $collection->two);
 
 		$collection->set([
 			'three' => 'drei'
 		]);
-		$this->assertEquals('drei', $collection->three);
+		$this->assertSame('drei', $collection->three);
 	}
 
 	public function testAppend()
@@ -66,10 +66,10 @@ class CollectionMutatorTest extends TestCase
 			'one' => 'eins'
 		]);
 
-		$this->assertEquals('eins', $collection->last());
+		$this->assertSame('eins', $collection->last());
 
 		$collection->append('two', 'zwei');
-		$this->assertEquals('zwei', $collection->last());
+		$this->assertSame('zwei', $collection->last());
 	}
 
 	public function testPrepend()
@@ -78,10 +78,10 @@ class CollectionMutatorTest extends TestCase
 			'one' => 'eins'
 		]);
 
-		$this->assertEquals('eins', $collection->first());
+		$this->assertSame('eins', $collection->first());
 
 		$collection->prepend('zero', 'null');
-		$this->assertEquals('null', $collection->zero());
+		$this->assertSame('null', $collection->zero());
 	}
 
 	public function testExtend()
@@ -94,8 +94,8 @@ class CollectionMutatorTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('eins', $result->one());
-		$this->assertEquals('zwei', $result->two());
+		$this->assertSame('eins', $result->one());
+		$this->assertSame('zwei', $result->two());
 	}
 
 	public function testRemove()
@@ -105,9 +105,9 @@ class CollectionMutatorTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('zwei', $collection->two());
+		$this->assertSame('zwei', $collection->two());
 		$collection->remove('two');
-		$this->assertEquals(null, $collection->two());
+		$this->assertSame(null, $collection->two());
 	}
 
 	public function testUnset()
@@ -117,9 +117,9 @@ class CollectionMutatorTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('zwei', $collection->two());
+		$this->assertSame('zwei', $collection->two());
 		unset($collection->two);
-		$this->assertEquals(null, $collection->two());
+		$this->assertSame(null, $collection->two());
 	}
 
 	public function testMap()
@@ -129,11 +129,11 @@ class CollectionMutatorTest extends TestCase
 			'two' => 'zwei'
 		]);
 
-		$this->assertEquals('zwei', $collection->two());
+		$this->assertSame('zwei', $collection->two());
 		$collection->map(function ($item) {
 			return $item . '-ish';
 		});
-		$this->assertEquals('zwei-ish', $collection->two());
+		$this->assertSame('zwei-ish', $collection->two());
 	}
 
 	public function testPluck()
@@ -147,7 +147,7 @@ class CollectionMutatorTest extends TestCase
 			]
 		]);
 
-		$this->assertEquals(['homer', 'marge'], $collection->pluck('username'));
+		$this->assertSame(['homer', 'marge'], $collection->pluck('username'));
 	}
 
 	public function testPluckAndSplit()
@@ -165,7 +165,7 @@ class CollectionMutatorTest extends TestCase
 			'homer', 'marge', 'maggie', 'bart', 'lisa'
 		];
 
-		$this->assertEquals($expected, $collection->pluck('simpsons', ', '));
+		$this->assertSame($expected, $collection->pluck('simpsons', ', '));
 	}
 
 	public function testPluckUnique()
@@ -184,6 +184,6 @@ class CollectionMutatorTest extends TestCase
 
 		$expected = ['homer', 'marge'];
 
-		$this->assertEquals($expected, $collection->pluck('user', null, true));
+		$this->assertSame($expected, $collection->pluck('user', null, true));
 	}
 }

--- a/tests/Toolkit/CollectionNavigatorTest.php
+++ b/tests/Toolkit/CollectionNavigatorTest.php
@@ -13,8 +13,8 @@ class CollectionNavigatorTest extends TestCase
 			'four'  => 'vier'
 		]);
 
-		$this->assertEquals('eins', $collection->first());
-		$this->assertEquals('vier', $collection->last());
+		$this->assertSame('eins', $collection->first());
+		$this->assertSame('vier', $collection->last());
 	}
 
 	public function testNth()
@@ -26,9 +26,9 @@ class CollectionNavigatorTest extends TestCase
 			'four'  => 'vier'
 		]);
 
-		$this->assertEquals('eins', $collection->nth(0));
-		$this->assertEquals('zwei', $collection->nth(1));
-		$this->assertEquals('drei', $collection->nth(2));
-		$this->assertEquals('vier', $collection->nth(3));
+		$this->assertSame('eins', $collection->nth(0));
+		$this->assertSame('zwei', $collection->nth(1));
+		$this->assertSame('drei', $collection->nth(2));
+		$this->assertSame('vier', $collection->nth(3));
 	}
 }

--- a/tests/Toolkit/CollectionPaginatorTest.php
+++ b/tests/Toolkit/CollectionPaginatorTest.php
@@ -57,7 +57,7 @@ class CollectionPaginatorTest extends TestCase
 
 		$this->assertSame('drei', $collection->offset(2)->first());
 		$this->assertSame('vier', $collection->offset(3)->first());
-		$this->assertSame(null, $collection->offset(99)->first());
+		$this->assertNull($collection->offset(99)->first());
 	}
 
 	public function testPaginate()

--- a/tests/Toolkit/CollectionPaginatorTest.php
+++ b/tests/Toolkit/CollectionPaginatorTest.php
@@ -94,7 +94,7 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertSame(3, $collection->chunk(2)->count());
+		$this->assertCount(3, $collection->chunk(2));
 		$this->assertSame('eins', $collection->chunk(2)->first()->first());
 		$this->assertSame('fünf', $collection->chunk(2)->last()->first());
 	}

--- a/tests/Toolkit/CollectionPaginatorTest.php
+++ b/tests/Toolkit/CollectionPaginatorTest.php
@@ -14,8 +14,8 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals('drei', $collection->slice(2)->first());
-		$this->assertEquals('vier', $collection->slice(2, 2)->last());
+		$this->assertSame('drei', $collection->slice(2)->first());
+		$this->assertSame('vier', $collection->slice(2, 2)->last());
 	}
 
 	public function testSliceNotReally()
@@ -28,7 +28,7 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals($collection, $collection->slice());
+		$this->assertSame($collection, $collection->slice());
 	}
 
 	public function testLimit()
@@ -41,8 +41,8 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals('drei', $collection->limit(3)->last());
-		$this->assertEquals('fünf', $collection->limit(99)->last());
+		$this->assertSame('drei', $collection->limit(3)->last());
+		$this->assertSame('fünf', $collection->limit(99)->last());
 	}
 
 	public function testOffset()
@@ -55,9 +55,9 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals('drei', $collection->offset(2)->first());
-		$this->assertEquals('vier', $collection->offset(3)->first());
-		$this->assertEquals(null, $collection->offset(99)->first());
+		$this->assertSame('drei', $collection->offset(2)->first());
+		$this->assertSame('vier', $collection->offset(3)->first());
+		$this->assertSame(null, $collection->offset(99)->first());
 	}
 
 	public function testPaginate()
@@ -70,18 +70,18 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals('eins', $collection->paginate(2)->first());
-		$this->assertEquals('drei', $collection->paginate(2, 2)->first());
+		$this->assertSame('eins', $collection->paginate(2)->first());
+		$this->assertSame('drei', $collection->paginate(2, 2)->first());
 
-		$this->assertEquals('eins', $collection->paginate([
+		$this->assertSame('eins', $collection->paginate([
 			'foo' => 'bar'
 		])->first());
-		$this->assertEquals('fünf', $collection->paginate([
+		$this->assertSame('fünf', $collection->paginate([
 			'limit' => 2,
 			'page' => 3
 		])->first());
 
-		$this->assertEquals(3, $collection->pagination()->page());
+		$this->assertSame(3, $collection->pagination()->page());
 	}
 
 	public function testChunk()
@@ -94,8 +94,8 @@ class CollectionPaginatorTest extends TestCase
 			'five'  => 'fünf'
 		]);
 
-		$this->assertEquals(3, $collection->chunk(2)->count());
-		$this->assertEquals('eins', $collection->chunk(2)->first()->first());
-		$this->assertEquals('fünf', $collection->chunk(2)->last()->first());
+		$this->assertSame(3, $collection->chunk(2)->count());
+		$this->assertSame('eins', $collection->chunk(2)->first()->first());
+		$this->assertSame('fünf', $collection->chunk(2)->last()->first());
 	}
 }

--- a/tests/Toolkit/CollectionSorterTest.php
+++ b/tests/Toolkit/CollectionSorterTest.php
@@ -298,6 +298,6 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$shuffled = $collection->shuffle();
-		$this->assertSame(3, $shuffled->count());
+		$this->assertCount(3, $shuffled);
 	}
 }

--- a/tests/Toolkit/CollectionSorterTest.php
+++ b/tests/Toolkit/CollectionSorterTest.php
@@ -53,22 +53,22 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('name', 'asc');
-		$this->assertEquals('Bastian', $sorted->nth(0)['name']);
-		$this->assertEquals('green', $sorted->nth(1)['color']);
-		$this->assertEquals('blue', $sorted->nth(2)['color']);
-		$this->assertEquals('Sonja', $sorted->nth(3)['name']);
+		$this->assertSame('Bastian', $sorted->nth(0)['name']);
+		$this->assertSame('green', $sorted->nth(1)['color']);
+		$this->assertSame('blue', $sorted->nth(2)['color']);
+		$this->assertSame('Sonja', $sorted->nth(3)['name']);
 
 		$sorted = $collection->sort('name', 'desc');
-		$this->assertEquals('Bastian', $sorted->last()['name']);
-		$this->assertEquals('Sonja', $sorted->first()['name']);
+		$this->assertSame('Bastian', $sorted->last()['name']);
+		$this->assertSame('Sonja', $sorted->first()['name']);
 
 		$sorted = $collection->sort('name', 'asc', 'color', SORT_ASC);
-		$this->assertEquals('blue', $sorted->nth(1)['color']);
-		$this->assertEquals('green', $sorted->nth(2)['color']);
+		$this->assertSame('blue', $sorted->nth(1)['color']);
+		$this->assertSame('green', $sorted->nth(2)['color']);
 
 		$sorted = $collection->sort('name', 'asc', 'color', SORT_DESC);
-		$this->assertEquals('green', $sorted->nth(1)['color']);
-		$this->assertEquals('blue', $sorted->nth(2)['color']);
+		$this->assertSame('green', $sorted->nth(1)['color']);
+		$this->assertSame('blue', $sorted->nth(2)['color']);
 	}
 
 	public function testSortFlags()
@@ -81,22 +81,22 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('name', 'asc', SORT_REGULAR);
-		$this->assertEquals('img1.png', $sorted->nth(0)['name']);
-		$this->assertEquals('img10.png', $sorted->nth(1)['name']);
-		$this->assertEquals('img12.png', $sorted->nth(2)['name']);
-		$this->assertEquals('img2.png', $sorted->nth(3)['name']);
+		$this->assertSame('img1.png', $sorted->nth(0)['name']);
+		$this->assertSame('img10.png', $sorted->nth(1)['name']);
+		$this->assertSame('img12.png', $sorted->nth(2)['name']);
+		$this->assertSame('img2.png', $sorted->nth(3)['name']);
 
 		$sorted = $collection->sort('name', SORT_NATURAL);
-		$this->assertEquals('img1.png', $sorted->nth(0)['name']);
-		$this->assertEquals('img2.png', $sorted->nth(1)['name']);
-		$this->assertEquals('img10.png', $sorted->nth(2)['name']);
-		$this->assertEquals('img12.png', $sorted->nth(3)['name']);
+		$this->assertSame('img1.png', $sorted->nth(0)['name']);
+		$this->assertSame('img2.png', $sorted->nth(1)['name']);
+		$this->assertSame('img10.png', $sorted->nth(2)['name']);
+		$this->assertSame('img12.png', $sorted->nth(3)['name']);
 
 		$sorted = $collection->sort('name', SORT_NATURAL, 'desc');
-		$this->assertEquals('img12.png', $sorted->nth(0)['name']);
-		$this->assertEquals('img10.png', $sorted->nth(1)['name']);
-		$this->assertEquals('img2.png', $sorted->nth(2)['name']);
-		$this->assertEquals('img1.png', $sorted->nth(3)['name']);
+		$this->assertSame('img12.png', $sorted->nth(0)['name']);
+		$this->assertSame('img10.png', $sorted->nth(1)['name']);
+		$this->assertSame('img2.png', $sorted->nth(2)['name']);
+		$this->assertSame('img1.png', $sorted->nth(3)['name']);
 	}
 
 	public function testSortCases()
@@ -109,10 +109,10 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('name', 'asc');
-		$this->assertEquals('A', $sorted->nth(0)['name']);
-		$this->assertEquals('a', $sorted->nth(1)['name']);
-		$this->assertEquals('b', $sorted->nth(2)['name']);
-		$this->assertEquals('c', $sorted->nth(3)['name']);
+		$this->assertSame('A', $sorted->nth(0)['name']);
+		$this->assertSame('a', $sorted->nth(1)['name']);
+		$this->assertSame('b', $sorted->nth(2)['name']);
+		$this->assertSame('c', $sorted->nth(3)['name']);
 	}
 
 	public function testSortIntegers()
@@ -125,10 +125,10 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('number', 'asc');
-		$this->assertEquals(1, $sorted->nth(0)['number']);
-		$this->assertEquals(2, $sorted->nth(1)['number']);
-		$this->assertEquals(10, $sorted->nth(2)['number']);
-		$this->assertEquals(12, $sorted->nth(3)['number']);
+		$this->assertSame(1, $sorted->nth(0)['number']);
+		$this->assertSame(2, $sorted->nth(1)['number']);
+		$this->assertSame(10, $sorted->nth(2)['number']);
+		$this->assertSame(12, $sorted->nth(3)['number']);
 	}
 
 	public function testSortZeros()
@@ -153,10 +153,10 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('number', 'asc');
-		$this->assertEquals('1', $sorted->nth(0)['title']);
-		$this->assertEquals('2', $sorted->nth(1)['title']);
-		$this->assertEquals('3', $sorted->nth(2)['title']);
-		$this->assertEquals('4', $sorted->nth(3)['title']);
+		$this->assertSame('1', $sorted->nth(0)['title']);
+		$this->assertSame('2', $sorted->nth(1)['title']);
+		$this->assertSame('3', $sorted->nth(2)['title']);
+		$this->assertSame('4', $sorted->nth(3)['title']);
 	}
 
 	public function testSortCallable()
@@ -180,28 +180,28 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort(function ($value) {
-			$this->assertEquals('test', $value['tags']);
+			$this->assertSame('test', $value['tags']);
 
 			return strtotime($value['date']);
 		}, 'asc');
-		$this->assertEquals('First Article', $sorted->nth(0)['title']);
-		$this->assertEquals('Second Article', $sorted->nth(1)['title']);
-		$this->assertEquals('Third Article', $sorted->nth(2)['title']);
+		$this->assertSame('First Article', $sorted->nth(0)['title']);
+		$this->assertSame('Second Article', $sorted->nth(1)['title']);
+		$this->assertSame('Third Article', $sorted->nth(2)['title']);
 
 		$sorted = $collection->sort(function ($value) {
-			$this->assertEquals('test', $value['tags']);
+			$this->assertSame('test', $value['tags']);
 
 			return strtotime($value['date']);
 		}, 'desc');
-		$this->assertEquals('Third Article', $sorted->nth(0)['title']);
-		$this->assertEquals('Second Article', $sorted->nth(1)['title']);
-		$this->assertEquals('First Article', $sorted->nth(2)['title']);
+		$this->assertSame('Third Article', $sorted->nth(0)['title']);
+		$this->assertSame('Second Article', $sorted->nth(1)['title']);
+		$this->assertSame('First Article', $sorted->nth(2)['title']);
 	}
 
 	public function testSortEmpty()
 	{
 		$collection = new Collection();
-		$this->assertEquals($collection, $collection->sort());
+		$this->assertSame($collection, $collection->sort());
 	}
 
 	public function testSortObjects()
@@ -217,9 +217,9 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('name', 'asc');
-		$this->assertEquals($bastian, $sorted->nth(0)['name']);
-		$this->assertEquals($nico, $sorted->nth(1)['name']);
-		$this->assertEquals($sonja, $sorted->nth(2)['name']);
+		$this->assertSame($bastian, $sorted->nth(0)['name']);
+		$this->assertSame($nico, $sorted->nth(1)['name']);
+		$this->assertSame($sonja, $sorted->nth(2)['name']);
 	}
 
 	public function testSortNoRecursiveDependencyError()
@@ -232,9 +232,9 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$sorted = $collection->sort('name', 'asc');
-		$this->assertEquals('img1.png', $sorted->nth(0)['name']);
-		$this->assertEquals('img1.png', $sorted->nth(1)['name']);
-		$this->assertEquals('img2.png', $sorted->nth(2)['name']);
+		$this->assertSame('img1.png', $sorted->nth(0)['name']);
+		$this->assertSame('img1.png', $sorted->nth(1)['name']);
+		$this->assertSame('img2.png', $sorted->nth(2)['name']);
 
 		// objects with a __toString() method
 		$bastian = new MockObjectString('Bastian');
@@ -248,10 +248,10 @@ class CollectionSorterTest extends TestCase
 			'bastian2' => $bastian
 		]);
 		$sorted = $collection->sort('value', 'asc');
-		$this->assertEquals($bastian, $sorted->nth(0));
-		$this->assertEquals($bastian, $sorted->nth(1));
-		$this->assertEquals($nico, $sorted->nth(2));
-		$this->assertEquals($sonja, $sorted->nth(3));
+		$this->assertSame($bastian, $sorted->nth(0));
+		$this->assertSame($bastian, $sorted->nth(1));
+		$this->assertSame($nico, $sorted->nth(2));
+		$this->assertSame($sonja, $sorted->nth(3));
 
 		// objects without a __toString() method
 		$bastian = new MockObject('Bastian');
@@ -265,10 +265,10 @@ class CollectionSorterTest extends TestCase
 			'bastian2' => $bastian
 		]);
 		$sorted = $collection->sort('value', 'asc');
-		$this->assertEquals($bastian, $sorted->nth(0));
-		$this->assertEquals($bastian, $sorted->nth(1));
-		$this->assertEquals($nico, $sorted->nth(2));
-		$this->assertEquals($sonja, $sorted->nth(3));
+		$this->assertSame($bastian, $sorted->nth(0));
+		$this->assertSame($bastian, $sorted->nth(1));
+		$this->assertSame($nico, $sorted->nth(2));
+		$this->assertSame($sonja, $sorted->nth(3));
 	}
 
 	public function testFlip()
@@ -279,14 +279,14 @@ class CollectionSorterTest extends TestCase
 			['name' => 'img2.png']
 		]);
 
-		$this->assertEquals('img12.png', $collection->nth(0)['name']);
-		$this->assertEquals('img10.png', $collection->nth(1)['name']);
-		$this->assertEquals('img2.png', $collection->nth(2)['name']);
+		$this->assertSame('img12.png', $collection->nth(0)['name']);
+		$this->assertSame('img10.png', $collection->nth(1)['name']);
+		$this->assertSame('img2.png', $collection->nth(2)['name']);
 
 		$flipped = $collection->flip();
-		$this->assertEquals('img2.png', $flipped->nth(0)['name']);
-		$this->assertEquals('img10.png', $flipped->nth(1)['name']);
-		$this->assertEquals('img12.png', $flipped->nth(2)['name']);
+		$this->assertSame('img2.png', $flipped->nth(0)['name']);
+		$this->assertSame('img10.png', $flipped->nth(1)['name']);
+		$this->assertSame('img12.png', $flipped->nth(2)['name']);
 	}
 
 	public function testShuffle()
@@ -298,6 +298,6 @@ class CollectionSorterTest extends TestCase
 		]);
 
 		$shuffled = $collection->shuffle();
-		$this->assertEquals(3, $shuffled->count());
+		$this->assertSame(3, $shuffled->count());
 	}
 }

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -157,7 +157,7 @@ class CollectionTest extends TestCase
 
 		$this->assertSame('My second element', $filtered->first());
 		$this->assertSame('My second element', $filtered->last());
-		$this->assertSame(1, $filtered->count());
+		$this->assertCount(1, $filtered);
 		$this->assertIsUntouched();
 	}
 
@@ -267,8 +267,8 @@ class CollectionTest extends TestCase
 			return $item['group'];
 		});
 
-		$this->assertSame(2, $groups->admin()->count());
-		$this->assertSame(1, $groups->client()->count());
+		$this->assertCount(2, $groups->admin());
+		$this->assertCount(1, $groups->client());
 
 		$firstAdmin = $groups->admin()->first();
 		$this->assertSame('peter', $firstAdmin['username']);
@@ -345,8 +345,8 @@ class CollectionTest extends TestCase
 			return $item['group'];
 		});
 
-		$this->assertSame(2, $groups->admin()->count());
-		$this->assertSame(1, $groups->client()->count());
+		$this->assertCount(2, $groups->admin());
+		$this->assertCount(1, $groups->client());
 
 		$firstAdmin = $groups->admin()->first();
 		$this->assertSame('peter', $firstAdmin['username']);
@@ -376,8 +376,8 @@ class CollectionTest extends TestCase
 
 		$groups = $collection->group('group');
 
-		$this->assertSame(2, $groups->admin()->count());
-		$this->assertSame(1, $groups->client()->count());
+		$this->assertCount(2, $groups->admin());
+		$this->assertCount(1, $groups->client());
 
 		$firstAdmin = $groups->admin()->first();
 		$this->assertSame('peter', $firstAdmin['username']);
@@ -588,13 +588,13 @@ class CollectionTest extends TestCase
 	{
 		// remove elements
 		$this->assertSame('My second element', $this->collection->not('first')->first());
-		$this->assertSame(1, $this->collection->not('second')->not('third')->count());
-		$this->assertSame(0, $this->collection->not('first', 'second', 'third')->count());
+		$this->assertCount(1, $this->collection->not('second')->not('third'));
+		$this->assertCount(0, $this->collection->not('first', 'second', 'third'));
 
 		// also check the alternative
 		$this->assertSame('My second element', $this->collection->without('first')->first());
-		$this->assertSame(1, $this->collection->without('second')->not('third')->count());
-		$this->assertSame(0, $this->collection->without('first', 'second', 'third')->count());
+		$this->assertCount(1, $this->collection->without('second')->not('third'));
+		$this->assertCount(0, $this->collection->without('first', 'second', 'third'));
 
 		$this->assertIsUntouched();
 	}
@@ -855,9 +855,9 @@ class CollectionTest extends TestCase
 	public function testSlice()
 	{
 		$this->assertSame(array_slice($this->sampleData, 1), $this->collection->slice(1)->toArray());
-		$this->assertSame(2, $this->collection->slice(1)->count());
+		$this->assertCount(2, $this->collection->slice(1));
 		$this->assertSame(array_slice($this->sampleData, 0, 1), $this->collection->slice(0, 1)->toArray());
-		$this->assertSame(1, $this->collection->slice(0, 1)->count());
+		$this->assertCount(1, $this->collection->slice(0, 1));
 		$this->assertIsUntouched();
 	}
 

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -26,8 +26,8 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['prop' => 'prop value']);
 
-		$this->assertEquals('prop value', $component->prop());
-		$this->assertEquals('prop value', $component->prop);
+		$this->assertSame('prop value', $component->prop());
+		$this->assertSame('prop value', $component->prop);
 	}
 
 	public function testPropWithDefaultValue()
@@ -44,8 +44,8 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test');
 
-		$this->assertEquals('default value', $component->prop());
-		$this->assertEquals('default value', $component->prop);
+		$this->assertSame('default value', $component->prop());
+		$this->assertSame('default value', $component->prop);
 	}
 
 	public function testPropWithFixedValue()
@@ -60,8 +60,8 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test');
 
-		$this->assertEquals('test', $component->prop());
-		$this->assertEquals('test', $component->prop);
+		$this->assertSame('test', $component->prop());
+		$this->assertSame('test', $component->prop);
 	}
 
 	public function testAttrs()
@@ -72,8 +72,8 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['foo' => 'bar']);
 
-		$this->assertEquals('bar', $component->foo());
-		$this->assertEquals('bar', $component->foo);
+		$this->assertSame('bar', $component->foo());
+		$this->assertSame('bar', $component->foo);
 	}
 
 	public function testComputed()
@@ -90,8 +90,8 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test');
 
-		$this->assertEquals('computed prop', $component->prop());
-		$this->assertEquals('computed prop', $component->prop);
+		$this->assertSame('computed prop', $component->prop());
+		$this->assertSame('computed prop', $component->prop);
 	}
 
 	public function testComputedFromProp()
@@ -113,7 +113,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['prop' => 'prop value']);
 
-		$this->assertEquals('computed: prop value', $component->prop());
+		$this->assertSame('computed: prop value', $component->prop());
 	}
 
 	public function testMethod()
@@ -130,7 +130,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test');
 
-		$this->assertEquals('hello world', $component->say());
+		$this->assertSame('hello world', $component->say());
 	}
 
 	public function testPropsInMethods()
@@ -152,7 +152,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['message' => 'hello world']);
 
-		$this->assertEquals('hello world', $component->say());
+		$this->assertSame('hello world', $component->say());
 	}
 
 	public function testComputedPropsInMethods()
@@ -179,7 +179,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['message' => 'hello world']);
 
-		$this->assertEquals('HELLO WORLD', $component->say());
+		$this->assertSame('HELLO WORLD', $component->say());
 	}
 
 	public function testToArray()
@@ -206,7 +206,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['message' => 'hello world']);
 
-		$this->assertEquals(['message' => 'HELLO WORLD'], $component->toArray());
+		$this->assertSame(['message' => 'HELLO WORLD'], $component->toArray());
 	}
 
 	public function testCustomToArray()
@@ -223,7 +223,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test');
 
-		$this->assertEquals(['foo' => 'bar'], $component->toArray());
+		$this->assertSame(['foo' => 'bar'], $component->toArray());
 	}
 
 	public function testInvalidType()
@@ -259,7 +259,7 @@ class ComponentTest extends TestCase
 
 		$component = new Component('test', ['message' => 'hello world']);
 
-		$this->assertEquals('HELLO WORLD', $component->message());
-		$this->assertEquals('HELLO WORLD', $component->message);
+		$this->assertSame('HELLO WORLD', $component->message());
+		$this->assertSame('HELLO WORLD', $component->message);
 	}
 }

--- a/tests/Toolkit/ConfigTest.php
+++ b/tests/Toolkit/ConfigTest.php
@@ -16,8 +16,8 @@ class ConfigTest extends TestCase
 
 	public function testGet()
 	{
-		$this->assertEquals('testvalue', Config::get('testvar'));
-		$this->assertEquals('defaultvalue', Config::get('nonexistentvar', 'defaultvalue'));
+		$this->assertSame('testvalue', Config::get('testvar'));
+		$this->assertSame('defaultvalue', Config::get('nonexistentvar', 'defaultvalue'));
 	}
 
 	public function testSet()
@@ -25,15 +25,15 @@ class ConfigTest extends TestCase
 		Config::set('anothervar', 'anothervalue');
 		Config::set('testvar', 'overwrittenvalue');
 
-		$this->assertEquals('anothervalue', Config::get('anothervar'));
-		$this->assertEquals('overwrittenvalue', Config::get('testvar'));
+		$this->assertSame('anothervalue', Config::get('anothervar'));
+		$this->assertSame('overwrittenvalue', Config::get('testvar'));
 
 		Config::set([
 			'var1' => 'value1',
 			'var2' => 'value2'
 		]);
 
-		$this->assertEquals('value1', Config::get('var1'));
-		$this->assertEquals('value2', Config::get('var2'));
+		$this->assertSame('value1', Config::get('var1'));
+		$this->assertSame('value2', Config::get('var2'));
 	}
 }

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -66,7 +66,7 @@ class ControllerTest extends TestCase
 	{
 		$root       = __DIR__ . '/fixtures/controller/does-not-exist.php';
 		$controller = Controller::load($root);
-		$this->assertSame(null, $controller);
+		$this->assertNull($controller);
 	}
 
 	/**

--- a/tests/Toolkit/FacadeTest.php
+++ b/tests/Toolkit/FacadeTest.php
@@ -18,6 +18,6 @@ class FacadeTest extends TestCase
 {
 	public function testCall()
 	{
-		$this->assertEquals('Test', ObjFacade::test());
+		$this->assertSame('Test', ObjFacade::test());
 	}
 }

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -16,52 +16,52 @@ class PaginationTest extends TestCase
 	public function testDefaultPage()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->page());
+		$this->assertSame(0, $pagination->page());
 
 		$pagination = new Pagination(['total' => 1]);
-		$this->assertEquals(1, $pagination->page());
+		$this->assertSame(1, $pagination->page());
 	}
 
 	public function testPage()
 	{
 		$pagination = new Pagination(['total' => 100, 'page' => 2]);
-		$this->assertEquals(2, $pagination->page());
+		$this->assertSame(2, $pagination->page());
 	}
 
 	public function testPageString()
 	{
 		$pagination = new Pagination(['total' => 100, 'page' => '2']);
-		$this->assertEquals(2, $pagination->page());
+		$this->assertSame(2, $pagination->page());
 	}
 
 	public function testPageEmptyCollection()
 	{
 		$pagination = new Pagination(['total' => 0, 'page' => 1]);
-		$this->assertEquals(0, $pagination->page());
+		$this->assertSame(0, $pagination->page());
 	}
 
 	public function testTotalDefault()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->total());
+		$this->assertSame(0, $pagination->total());
 	}
 
 	public function testTotal()
 	{
 		$pagination = new Pagination(['total' => 12]);
-		$this->assertEquals(12, $pagination->total());
+		$this->assertSame(12, $pagination->total());
 	}
 
 	public function testLimitDefault()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(20, $pagination->limit());
+		$this->assertSame(20, $pagination->limit());
 	}
 
 	public function testLimit()
 	{
 		$pagination = new Pagination(['limit' => 100]);
-		$this->assertEquals(100, $pagination->limit());
+		$this->assertSame(100, $pagination->limit());
 	}
 
 	public function testStart()
@@ -70,15 +70,15 @@ class PaginationTest extends TestCase
 			'total' => 42
 		]);
 
-		$this->assertEquals(1, $pagination->start());
+		$this->assertSame(1, $pagination->start());
 
 		// go to the second page
 		$pagination = $pagination->clone(['page' => 2]);
-		$this->assertEquals(21, $pagination->start());
+		$this->assertSame(21, $pagination->start());
 
 		// set a different limit
 		$pagination = $pagination->clone(['limit' => 10]);
-		$this->assertEquals(11, $pagination->start());
+		$this->assertSame(11, $pagination->start());
 	}
 
 	public function testEnd()
@@ -87,15 +87,15 @@ class PaginationTest extends TestCase
 			'total' => 42
 		]);
 
-		$this->assertEquals(20, $pagination->end());
+		$this->assertSame(20, $pagination->end());
 
 		// go to the second page
 		$pagination = $pagination->clone(['page' => 2]);
-		$this->assertEquals(40, $pagination->end());
+		$this->assertSame(40, $pagination->end());
 
 		// set a different limit
 		$pagination = $pagination->clone(['limit' => 10]);
-		$this->assertEquals(20, $pagination->end());
+		$this->assertSame(20, $pagination->end());
 	}
 
 	public function testEndWithOneItem()
@@ -104,61 +104,61 @@ class PaginationTest extends TestCase
 			'total' => 1
 		]);
 
-		$this->assertEquals(1, $pagination->end());
+		$this->assertSame(1, $pagination->end());
 	}
 
 	public function testPages()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->pages());
+		$this->assertSame(0, $pagination->pages());
 
 		$pagination = new Pagination(['total' => 1]);
-		$this->assertEquals(1, $pagination->pages());
+		$this->assertSame(1, $pagination->pages());
 
 		$pagination = new Pagination(['total' => 10]);
-		$this->assertEquals(1, $pagination->pages());
+		$this->assertSame(1, $pagination->pages());
 
 		$pagination = new Pagination(['total' => 21]);
-		$this->assertEquals(2, $pagination->pages());
+		$this->assertSame(2, $pagination->pages());
 
 		$pagination = new Pagination(['total' => 11, 'limit' => 5]);
-		$this->assertEquals(3, $pagination->pages());
+		$this->assertSame(3, $pagination->pages());
 	}
 
 	public function testFirstPage()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->firstPage());
+		$this->assertSame(0, $pagination->firstPage());
 
 		$pagination = new Pagination(['total' => 1]);
-		$this->assertEquals(1, $pagination->firstPage());
+		$this->assertSame(1, $pagination->firstPage());
 
 		$pagination = new Pagination(['total' => 42]);
-		$this->assertEquals(1, $pagination->firstPage());
+		$this->assertSame(1, $pagination->firstPage());
 	}
 
 	public function testLastPage()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->lastPage());
+		$this->assertSame(0, $pagination->lastPage());
 
 		$pagination = new Pagination(['total' => 1]);
-		$this->assertEquals(1, $pagination->lastPage());
+		$this->assertSame(1, $pagination->lastPage());
 
 		$pagination = new Pagination(['total' => 42]);
-		$this->assertEquals(3, $pagination->lastPage());
+		$this->assertSame(3, $pagination->lastPage());
 	}
 
 	public function testOffset()
 	{
 		$pagination = new Pagination();
-		$this->assertEquals(0, $pagination->offset());
+		$this->assertSame(0, $pagination->offset());
 
 		$pagination = new Pagination(['total' => 42, 'page' => 2]);
-		$this->assertEquals(20, $pagination->offset());
+		$this->assertSame(20, $pagination->offset());
 
 		$pagination = new Pagination(['total' => 42, 'page' => 2, 'limit' => 10]);
-		$this->assertEquals(10, $pagination->offset());
+		$this->assertSame(10, $pagination->offset());
 	}
 
 	public function testHasPage()
@@ -200,10 +200,10 @@ class PaginationTest extends TestCase
 	public function testPrevPage()
 	{
 		$pagination = new Pagination(['page' => 2, 'total' => 42]);
-		$this->assertEquals(1, $pagination->prevPage());
+		$this->assertSame(1, $pagination->prevPage());
 
 		$pagination = new Pagination(['page' => 1, 'total' => 42]);
-		$this->assertEquals(null, $pagination->prevPage());
+		$this->assertSame(null, $pagination->prevPage());
 	}
 
 	public function testHasNextPage()
@@ -221,10 +221,10 @@ class PaginationTest extends TestCase
 	public function testNextPage()
 	{
 		$pagination = new Pagination(['page' => 1, 'total' => 30]);
-		$this->assertEquals(2, $pagination->nextPage());
+		$this->assertSame(2, $pagination->nextPage());
 
 		$pagination = new Pagination(['page' => 2, 'total' => 30]);
-		$this->assertEquals(null, $pagination->nextPage());
+		$this->assertSame(null, $pagination->nextPage());
 	}
 
 	public function testIsFirstPage()
@@ -355,9 +355,9 @@ class PaginationTest extends TestCase
 		$end   = A::last($case['expected']);
 
 		$this->assertCount($case['count'] ?? $case['range'], $range);
-		$this->assertEquals($case['expected'], $range);
-		$this->assertEquals($start, $pagination->rangeStart($case['range']));
-		$this->assertEquals($end, $pagination->rangeEnd($case['range']));
+		$this->assertSame($case['expected'], $range);
+		$this->assertSame($start, $pagination->rangeStart($case['range']));
+		$this->assertSame($end, $pagination->rangeEnd($case['range']));
 	}
 
 	public function testClone()
@@ -464,10 +464,10 @@ class PaginationTest extends TestCase
 		$collection = new Collection(['a', 'b', 'c']);
 		$pagination = Pagination::for($collection);
 
-		$this->assertEquals(1, $pagination->page());
-		$this->assertEquals(1, $pagination->pages());
-		$this->assertEquals(20, $pagination->limit());
-		$this->assertEquals(3, $pagination->total());
+		$this->assertSame(1, $pagination->page());
+		$this->assertSame(1, $pagination->pages());
+		$this->assertSame(20, $pagination->limit());
+		$this->assertSame(3, $pagination->total());
 	}
 
 	public function testForWithLimit()
@@ -475,9 +475,9 @@ class PaginationTest extends TestCase
 		$collection = new Collection(['a', 'b', 'c']);
 		$pagination = Pagination::for($collection, 1);
 
-		$this->assertEquals(1, $pagination->page());
-		$this->assertEquals(3, $pagination->pages());
-		$this->assertEquals(1, $pagination->limit());
+		$this->assertSame(1, $pagination->page());
+		$this->assertSame(3, $pagination->pages());
+		$this->assertSame(1, $pagination->limit());
 	}
 
 	public function testForWithLimitAndPage()
@@ -485,9 +485,9 @@ class PaginationTest extends TestCase
 		$collection = new Collection(['a', 'b', 'c']);
 		$pagination = Pagination::for($collection, 1, 2);
 
-		$this->assertEquals(2, $pagination->page());
-		$this->assertEquals(3, $pagination->pages());
-		$this->assertEquals(1, $pagination->limit());
+		$this->assertSame(2, $pagination->page());
+		$this->assertSame(3, $pagination->pages());
+		$this->assertSame(1, $pagination->limit());
 	}
 
 	public function testForWithOptionsArray()
@@ -498,9 +498,9 @@ class PaginationTest extends TestCase
 			'page'  => 2
 		]);
 
-		$this->assertEquals(2, $pagination->page());
-		$this->assertEquals(3, $pagination->pages());
-		$this->assertEquals(1, $pagination->limit());
+		$this->assertSame(2, $pagination->page());
+		$this->assertSame(3, $pagination->pages());
+		$this->assertSame(1, $pagination->limit());
 	}
 
 	public function testForWithLimitAndOptionsArray()
@@ -510,8 +510,8 @@ class PaginationTest extends TestCase
 			'page' => 2
 		]);
 
-		$this->assertEquals(2, $pagination->page());
-		$this->assertEquals(3, $pagination->pages());
-		$this->assertEquals(1, $pagination->limit());
+		$this->assertSame(2, $pagination->page());
+		$this->assertSame(3, $pagination->pages());
+		$this->assertSame(1, $pagination->limit());
 	}
 }

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -203,7 +203,7 @@ class PaginationTest extends TestCase
 		$this->assertSame(1, $pagination->prevPage());
 
 		$pagination = new Pagination(['page' => 1, 'total' => 42]);
-		$this->assertSame(null, $pagination->prevPage());
+		$this->assertNull($pagination->prevPage());
 	}
 
 	public function testHasNextPage()
@@ -224,7 +224,7 @@ class PaginationTest extends TestCase
 		$this->assertSame(2, $pagination->nextPage());
 
 		$pagination = new Pagination(['page' => 2, 'total' => 30]);
-		$this->assertSame(null, $pagination->nextPage());
+		$this->assertNull($pagination->nextPage());
 	}
 
 	public function testIsFirstPage()

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1262,12 +1262,12 @@ EOT;
 		$this->assertSame(['a'], Str::toType('a', []));
 
 		// string to bool
-		$this->assertSame(true, Str::toType(true, 'bool'));
-		$this->assertSame(true, Str::toType('true', 'bool'));
-		$this->assertSame(true, Str::toType('true', 'boolean'));
-		$this->assertSame(true, Str::toType(1, 'bool'));
-		$this->assertSame(true, Str::toType('1', 'bool'));
-		$this->assertSame(true, Str::toType('1', true));
+		$this->assertTrue(Str::toType(true, 'bool'));
+		$this->assertTrue(Str::toType('true', 'bool'));
+		$this->assertTrue(Str::toType('true', 'boolean'));
+		$this->assertTrue(Str::toType(1, 'bool'));
+		$this->assertTrue(Str::toType('1', 'bool'));
+		$this->assertTrue(Str::toType('1', true));
 		$this->assertFalse(Str::toType(false, 'bool'));
 		$this->assertFalse(Str::toType('false', 'bool'));
 		$this->assertFalse(Str::toType('false', 'boolean'));

--- a/tests/Toolkit/TplTest.php
+++ b/tests/Toolkit/TplTest.php
@@ -13,8 +13,7 @@ class TplTest extends TestCase
 	public function testLoadWithBadTemplate()
 	{
 		$this->expectException('Error');
-
-		$tpl = Tpl::load(__DIR__ . '/fixtures/tpl/bad.php');
+		Tpl::load(__DIR__ . '/fixtures/tpl/bad.php');
 	}
 
 	public function testLoadWithNonExistingFile()

--- a/tests/Toolkit/ViewTest.php
+++ b/tests/Toolkit/ViewTest.php
@@ -16,7 +16,7 @@ class ViewTest extends TestCase
 	public function testFile()
 	{
 		$view = $this->_view();
-		$this->assertEquals(static::FIXTURES . '/view.php', $view->file());
+		$this->assertSame(static::FIXTURES . '/view.php', $view->file());
 	}
 
 	public function testWithMissingFile()
@@ -31,18 +31,18 @@ class ViewTest extends TestCase
 	public function testData()
 	{
 		$view = $this->_view();
-		$this->assertEquals([], $view->data());
+		$this->assertSame([], $view->data());
 
 		$view = $this->_view(['test']);
-		$this->assertEquals(['test'], $view->data());
+		$this->assertSame(['test'], $view->data());
 	}
 
 	public function testToString()
 	{
 		$view = $this->_view(['name' => 'Tester']);
-		$this->assertEquals('Hello Tester', $view->toString());
-		$this->assertEquals('Hello Tester', $view->__toString());
-		$this->assertEquals('Hello Tester', (string)$view);
+		$this->assertSame('Hello Tester', $view->toString());
+		$this->assertSame('Hello Tester', $view->__toString());
+		$this->assertSame('Hello Tester', (string)$view);
 	}
 
 	public function testWithException()

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -69,15 +69,14 @@ class XmlTest extends TestCase
 		$this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '    ', 1));
 		$this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '  ', 2));
 
+		$fixtures = __DIR__ . '/fixtures/xml';
 		$data = [
-			'@name' => 'contact',
-			'@attributes' => [
-				'type' => 'husband'
-			],
-			'@value' => 'Homer'
+			'@name'       => 'contact',
+			'@attributes' => ['type' => 'husband'],
+			'@value'      => 'Homer'
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/contact.xml')));
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contact.xml', Xml::create($data, 'contact'));
+		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/contact.xml')));
+		$this->assertStringEqualsFile($fixtures . '/contact.xml', Xml::create($data, 'contact'));
 
 		$data = [
 			'@name' => 'contacts',
@@ -96,9 +95,9 @@ class XmlTest extends TestCase
 				]
 			]
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/contacts.xml')));
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contacts_nowrapper.xml', Xml::create($contacts, 'contact', false));
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/contacts.xml', Xml::create($data, 'contacts'));
+		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/contacts.xml')));
+		$this->assertStringEqualsFile($fixtures . '/contacts_nowrapper.xml', Xml::create($contacts, 'contact', false));
+		$this->assertStringEqualsFile($fixtures . '/contacts.xml', Xml::create($data, 'contacts'));
 
 		$data = [
 			'@name' => 'simpsons',
@@ -130,12 +129,12 @@ class XmlTest extends TestCase
 				]
 			]
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents(__DIR__ . '/fixtures/xml/simpsons.xml')));
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'invalid'));
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
+		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/simpsons.xml')));
+		$this->assertStringEqualsFile($fixtures . '/simpsons.xml', Xml::create($data, 'invalid'));
+		$this->assertStringEqualsFile($fixtures . '/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
 
 		unset($data['@name']);
-		$this->assertStringEqualsFile(__DIR__ . '/fixtures/xml/simpsons.xml', Xml::create($data, 'simpsons'));
+		$this->assertStringEqualsFile($fixtures . '/simpsons.xml', Xml::create($data, 'simpsons'));
 
 		$this->assertNull(Xml::parse('<this>is invalid</that>'));
 	}

--- a/tests/Uuid/PermalinksTest.php
+++ b/tests/Uuid/PermalinksTest.php
@@ -19,7 +19,7 @@ class PermalinksTest extends TestCase
 
 		// not cached, should fail (redirect to error)
 		$response = $app->call('/@/page/my-id');
-		$this->assertSame(false, $response);
+		$this->assertFalse($response);
 
 		// cached, should redirect to page A
 		$app->page('a')->uuid()->populate();
@@ -31,7 +31,7 @@ class PermalinksTest extends TestCase
 		$uuid = $app->page('a')->uuid();
 		$uuid->clear();
 		$response = $app->call('/@/page/my-id');
-		$this->assertSame(false, $response);
+		$this->assertFalse($response);
 		$uuid->url();
 		$response = $app->call('/@/page/my-id')->send();
 		$this->assertSame(302, $response->code());

--- a/tests/Uuid/SiteUuidTest.php
+++ b/tests/Uuid/SiteUuidTest.php
@@ -36,7 +36,7 @@ class SiteUuidTest extends TestCase
 	public function testPopulate()
 	{
 		$uuid = $this->app->site()->uuid();
-		$this->assertSame(true, $uuid->populate());
+		$this->assertTrue($uuid->populate());
 	}
 
 	/**

--- a/tests/Uuid/UserUuidTest.php
+++ b/tests/Uuid/UserUuidTest.php
@@ -36,6 +36,6 @@ class UserUuidTest extends TestCase
 	public function testPopulate()
 	{
 		$uuid = $this->app->user('my-user')->uuid();
-		$this->assertSame(true, $uuid->populate());
+		$this->assertTrue($uuid->populate());
 	}
 }


### PR DESCRIPTION
## Refactoring

- Our PHPUnit tests consistently use `assertSame` instead of `assertEquals` where possible
- Our PHPUnit tests use more specific assertions (e.g. `assertTrue`, `assertNull`, `assertFileExists`, `assertArrayHasKey`, `assertFileExists`) instead of `assertSame`