### PR TITLE
Minor query refactoring; fix handling of quote escaping

### DIFF
--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -38,18 +38,23 @@ class Argument
 			$argument = trim(substr($argument, 1, -1));
 		}
 
-		// string with single or double quotes
+		// string with single quotes
 		if (
-			(
-				Str::startsWith($argument, '"') &&
-				Str::endsWith($argument, '"')
-			) || (
-				Str::startsWith($argument, "'") &&
-				Str::endsWith($argument, "'")
-			)
+			Str::startsWith($argument, "'") &&
+			Str::endsWith($argument, "'")
 		) {
 			$string = substr($argument, 1, -1);
-			$string = str_replace(['\"', "\'"], ['"', "'"], $string);
+			$string = str_replace("\'", "'", $string);
+			return new static($string);
+		}
+
+		// string with double quotes
+		if (
+			Str::startsWith($argument, '"') &&
+			Str::endsWith($argument, '"')
+		) {
+			$string = substr($argument, 1, -1);
+			$string = str_replace('\"', '"', $string);
 			return new static($string);
 		}
 

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -6,8 +6,8 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 
 /**
- * The Argument class represents a single
- * parameter passed to a method in a chained query
+ * The Arguments class helps splitting a
+ * parameter string into processable arguments
  *
  * @package   Kirby Query
  * @author    Nico Hoffmann <nico@getkirby.com>

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -22,6 +22,9 @@ class Expression
 	) {
 	}
 
+	/**
+	 * Parses an expression string into its parts
+	 */
 	public static function factory(string $expression, Query $parent = null): static|Segments
 	{
 		// split into different expression parts and operators

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -124,7 +124,6 @@ Query::$entries['site'] = function (): Site {
 	return App::instance()->site();
 };
 
-
 Query::$entries['t'] = function (
 	string $key,
 	string|array $fallback = null,

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -51,6 +51,11 @@ class Segment
 		throw new BadMethodCallException($error);
 	}
 
+	/**
+	 * Parses a segment into the property/method name and its arguments
+	 *
+	 * @param int $position String position of the segment inside the full query
+	 */
 	public static function factory(
 		string $segment,
 		int $position = 0
@@ -69,6 +74,10 @@ class Segment
 		);
 	}
 
+	/**
+	 * Automatically resolves the segment depending on the
+	 * segment position and the type of the base
+	 */
 	public function resolve(mixed $base = null, array|object $data = []): mixed
 	{
 		// resolve arguments to array

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -19,11 +19,23 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
 		$argument = Argument::factory(" ' 23 '  ");
 		$this->assertSame(' 23 ', $argument->value);
 
+		$argument = Argument::factory("'2\"3'");
+		$this->assertSame('2"3', $argument->value);
+
+		$argument = Argument::factory("'2\\\"3'");
+		$this->assertSame('2\\"3', $argument->value);
+
+		$argument = Argument::factory("'2\\'3'");
+		$this->assertSame("2'3", $argument->value);
+
 		$argument = Argument::factory('"2\'3"');
-		$this->assertSame('2\'3', $argument->value);
+		$this->assertSame("2'3", $argument->value);
 
 		$argument = Argument::factory('"2\\\'3"');
-		$this->assertSame('2\'3', $argument->value);
+		$this->assertSame("2\\'3", $argument->value);
+
+		$argument = Argument::factory('"2\\"3"');
+		$this->assertSame('2"3', $argument->value);
 
 		// arrays
 		$argument = Argument::factory('[1, "a", 3]');


### PR DESCRIPTION
Sorry for the mixed PR, wanted to avoid merge conflicts; I recommend to review the two commits separately.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Escaping quotes inside query arguments with `\"` and `\'` now behaves like it does in PHP (only the same type of quote used for the string can be escaped).

### Refactoring

- Minor code improvements to the `Query` classes

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
