### PR TITLE
Add asset methods for plugins

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Exception\DuplicateException;
+use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\Mime;
@@ -45,6 +46,7 @@ trait AppPlugins
 		// other plugin types
 		'api' => [],
 		'areas' => [],
+		'assetMethods' => [],
 		'authChallenges' => [],
 		'blockMethods' => [],
 		'blockModels' => [],
@@ -145,6 +147,17 @@ trait AppPlugins
 		}
 
 		return $this->extensions['areas'];
+	}
+
+	/**
+	 * Registers additional asset methods
+	 *
+	 * @param array $methods
+	 * @return array
+	 */
+	protected function extendAssetMethods(array $methods): array
+	{
+		return $this->extensions['assetMethods'] = Asset::$methods = array_merge(Asset::$methods, $methods);
 	}
 
 	/**

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -3,6 +3,8 @@
 namespace Kirby\Filesystem;
 
 use Kirby\Cms\FileModifications;
+use Kirby\Cms\HasMethods;
+use Kirby\Exception\BadMethodCallException;
 
 /**
  * Anything in your public path can be converted
@@ -20,6 +22,7 @@ class Asset
 {
 	use IsFile;
 	use FileModifications;
+	use HasMethods;
 
 	/**
 	 * Relative file path
@@ -36,6 +39,31 @@ class Asset
 			'root' => $this->kirby()->root('index') . '/' . $path,
 			'url'  => $this->kirby()->url('base') . '/' . $path
 		]);
+	}
+
+	/**
+	 * Magic caller for asset methods
+	 *
+	 * @throws \Kirby\Exception\BadMethodCallException
+	 */
+	public function __call(string $method, array $arguments = [])
+	{
+		// public property access
+		if (isset($this->$method) === true) {
+			return $this->$method;
+		}
+
+		// asset methods
+		if ($this->hasMethod($method)) {
+			return $this->callMethod($method, $arguments);
+		}
+
+		// asset method proxy
+		if (method_exists($this->asset(), $method)) {
+			return $this->asset()->$method(...$arguments);
+		}
+
+		throw new BadMethodCallException('The method: "' . $method . '" does not exist');
 	}
 
 	/**

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -53,16 +53,16 @@ class Asset
 			return $this->$method;
 		}
 
-		// asset methods
-		if ($this->hasMethod($method)) {
-			return $this->callMethod($method, $arguments);
-		}
-
 		// asset method proxy
 		if (method_exists($this->asset(), $method)) {
 			return $this->asset()->$method(...$arguments);
 		}
 
+		// asset methods
+		if ($this->hasMethod($method)) {
+			return $this->callMethod($method, $arguments);
+		}
+		
 		throw new BadMethodCallException('The method: "' . $method . '" does not exist');
 	}
 

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -62,7 +62,7 @@ class Asset
 		if ($this->hasMethod($method)) {
 			return $this->callMethod($method, $arguments);
 		}
-		
+
 		throw new BadMethodCallException('The method: "' . $method . '" does not exist');
 	}
 

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -22,6 +22,11 @@ class AssetTest extends TestCase
 			'urls' => [
 				'index' => 'https://getkirby.com'
 			],
+			'assetMethods' => [
+				'test' => function () {
+					return 'asset method';
+				}
+			]
 		]);
 	}
 
@@ -85,5 +90,11 @@ class AssetTest extends TestCase
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('The method: "nonexists" does not exist');
 		$asset->nonexists();
+	}
+
+	public function testAssetMethod()
+	{
+		$asset = $this->_asset();
+		$this->assertSame('asset method', $asset->test());
 	}
 }


### PR DESCRIPTION
## This PR …
Adds asset methods that work similar to file methods or page methods, just for use with the `Kirby/Filesystem/Asset` class that's e.g. used by the `asset()` helper.

### Why is this important?
There are many plugins out there that can e.g. apply image transforms such as [johannschopplich/kirby-blurry-placeholder](https://github.com/johannschopplich/kirby-blurry-placeholder) or my own [kirby-blurhash](https://github.com/tobimori/kirby-blurhash) that one might want to use on a static image, but they only work conveniently with Kirby files itself due to file methods not being supported for simple assets.

See also: https://github.com/johannschopplich/kirby-blurry-placeholder/issues/15

This should also be in favor of Kirby, as the docs state: "Anything in your public path can be converted to an Asset object to use the same handy file methods as for any other Kirby files."
They obviously can't be allowed access to regular custom file methods, as those might access properties only available on the `File` object.

### What else to consider?

An alternative to this could be to allow `imageMethods` which extend the `Kirby/Image/Image` class. They would automatically inherit to assets and image files, but thus also allow less customization due to the lack of access to e.g.`media` path info.

### Breaking changes
None.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
