### PR TITLE
Fix rendering pages inside snippet's slot

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -146,13 +146,19 @@ class Template
 	 */
 	public function render(array $data = []): string
 	{
+		// if the template is rendered inside a snippet,
+		// we need to keep the "outside" snippet object
+		// to compare it later
+		$snippet = Snippet::$current;
+
 		// load the template
 		$template = Tpl::load($this->file(), $data);
 
-		// if last `endsnippet()` has been ommitted,
-		// take the buffer output as default slot and
-		// render the snippets as final template output
-		if (Snippet::$current !== null) {
+		// if last `endsnippet()` inside the current template
+		// has been omitted, take the buffer output as default
+		// slot and render the snippet as final template output
+		// (snippet was used as layout snippet)
+		if (Snippet::$current !== $snippet) {
 			$template = Snippet::$current->render($data, [
 				'default' => $template
 			]);

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -222,7 +222,7 @@ class SnippetTest extends TestCase
 		$snippet->open();
 		echo 'content';
 
-		$this->assertSame("<h1>Layout</h1>\ncontent", $snippet->render());
+		$this->assertSame("<h1>Layout</h1>\ncontent<footer>with other stuff</footer>\n", $snippet->render());
 	}
 
 	/**

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -132,7 +132,7 @@ class TemplateTest extends TestCase
 	/**
 	 * @covers ::render
 	 */
-	public function testRenderOpenSnippets()
+	public function testRenderOpenLayoutSnippet()
 	{
 		new App([
 			'roots' => [
@@ -142,8 +142,72 @@ class TemplateTest extends TestCase
 		]);
 
 		$template = new Template('with-layout');
-		$this->assertSame('<h1>Layout</h1>
-My content
-', $template->render());
+		$this->assertSame("<h1>Layout</h1>\nMy content\n<footer>with other stuff</footer>\n", $template->render());
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderOpenParentSnippet1()
+	{
+		$app = new App([
+			'roots' => [
+				'snippets'  => __DIR__ . '/fixtures',
+				'templates' => __DIR__ . '/fixtures'
+			]
+		]);
+
+		$this->assertSame(
+			"Before rendering\n" .
+			"Simple output\n" .
+			"After rendering\n",
+			$app->snippet('render')
+		);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderOpenParentSnippet2()
+	{
+		$app = new App([
+			'roots' => [
+				'snippets'  => __DIR__ . '/fixtures',
+				'templates' => __DIR__ . '/fixtures'
+			]
+		]);
+
+		$template = new Template('render-in-slot');
+		$this->assertSame(
+			"Before snippet\n" .
+			"Before rendering\n" .
+			"Simple output\n" .
+			"After rendering\n" .
+			"After snippet\n",
+			$template->render()
+		);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderOpenParentSnippet3()
+	{
+		$app = new App([
+			'roots' => [
+				'snippets'  => __DIR__ . '/fixtures',
+				'templates' => __DIR__ . '/fixtures'
+			]
+		]);
+
+		$template = new Template('render-in-slot-layout');
+		$this->assertSame(
+			"Before snippet\n" .
+			"Before rendering\n" .
+			"<h1>Layout</h1>\nMy content\n<footer>with other stuff</footer>\n" .
+			"After rendering\n" .
+			"After snippet\n",
+			$template->render()
+		);
 	}
 }

--- a/tests/Template/fixtures/layout.php
+++ b/tests/Template/fixtures/layout.php
@@ -1,2 +1,3 @@
 <h1>Layout</h1>
 <?= $slot ?>
+<footer>with other stuff</footer>

--- a/tests/Template/fixtures/plain.php
+++ b/tests/Template/fixtures/plain.php
@@ -1,0 +1,1 @@
+Simple output

--- a/tests/Template/fixtures/render-in-slot-layout.php
+++ b/tests/Template/fixtures/render-in-slot-layout.php
@@ -1,0 +1,7 @@
+Before snippet
+<?php snippet('simple', slots: true) ?>
+Before rendering
+<?= (new Kirby\Template\Template('with-layout'))->render() ?>
+After rendering
+<?php endsnippet() ?>
+After snippet

--- a/tests/Template/fixtures/render-in-slot.php
+++ b/tests/Template/fixtures/render-in-slot.php
@@ -1,0 +1,7 @@
+Before snippet
+<?php snippet('simple', slots: true) ?>
+Before rendering
+<?= (new Kirby\Template\Template('plain'))->render() ?>
+After rendering
+<?php endsnippet() ?>
+After snippet

--- a/tests/Template/fixtures/render.php
+++ b/tests/Template/fixtures/render.php
@@ -1,0 +1,3 @@
+Before rendering
+<?= (new Kirby\Template\Template('plain'))->render() ?>
+After rendering


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes (bug introduced in 3.9)

- Rendering a page inside a snippet's slot no longer breaks the slot output #4997

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] ~Add changes to release notes draft in Notion~
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
