### PR TITLE
Improvements to `k-button`

### DIFF
--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -8,10 +8,12 @@
 	>
 		<k-icon v-if="icon" :type="icon" :alt="tooltip" class="k-button-icon" />
 
-		<template v-if="text">
-			{{ text }}
-		</template>
-		<span v-else-if="$slots.default" class="k-button-text"><slot /></span>
+		<span v-if="text || $slots.default" class="k-button-text">
+			<template v-if="text">
+				{{ text }}
+			</template>
+			<slot />
+		</span>
 	</component>
 </template>
 
@@ -86,7 +88,7 @@ export default {
 	},
 	computed: {
 		attributes() {
-			const attributes = {
+			const common = {
 				class: "k-button",
 				"data-responsive": this.responsive,
 				"data-theme": this.theme,
@@ -94,33 +96,44 @@ export default {
 				title: this.tooltip
 			};
 
-			// button only
+			const disabled = {
+				"data-disabled": this.disabled,
+				"aria-disabled": this.disabled
+			};
+
+			const focus = {
+				"aria-current": this.current,
+				autofocus: this.autofocus,
+				role: this.role,
+				tabindex: this.tabindex
+			};
+
+			// Button (enabled + disabled)
 			if (this.component === "button") {
-				attributes["type"] = this.type;
-				attributes["data-disabled"] = this.disabled;
-				attributes["aria-disabled"] = this.disabled;
+				return {
+					...common,
+					...disabled,
+					...focus,
+					type: this.type
+				};
 			}
 
-			// link only
+			// Link (enabled)
 			if (this.component === "k-link") {
-				attributes["rel"] = this.rel;
-				attributes["target"] = this.target;
-				attributes["to"] = this.link;
+				return {
+					...common,
+					...focus,
+					rel: this.rel,
+					target: this.target,
+					to: this.link
+				};
 			}
 
-			if (this.component === "span") {
-				attributes["data-disabled"] = true;
-			}
-
-			// for buttons and enabled links
-			if (this.component === "button" || this.component === "k-link") {
-				attributes["aria-current"] = this.current;
-				attributes["autofocus"] = this.autofocus;
-				attributes["role"] = this.role;
-				attributes["tabindex"] = this.tabindex;
-			}
-
-			return attributes;
+			// Text (= disabled link)
+			return {
+				...common,
+				...disabled
+			};
 		},
 		component() {
 			if (!this.link) {

--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -13,6 +13,9 @@
 </template>
 
 <script>
+/**
+ * @deprecated will be removed in v3.10. Use `k-button` directly
+ */
 export default {
 	inheritAttrs: false,
 	props: {
@@ -24,14 +27,3 @@ export default {
 	}
 };
 </script>
-
-<style>
-.k-button[data-disabled="true"] {
-	opacity: 0.5;
-	pointer-events: none;
-	cursor: default;
-}
-.k-card-options > .k-button[data-disabled="true"] {
-	display: inline-flex;
-}
-</style>

--- a/panel/src/components/Navigation/ButtonLink.vue
+++ b/panel/src/components/Navigation/ButtonLink.vue
@@ -20,6 +20,9 @@
 </template>
 
 <script>
+/**
+ * @deprecated will be removed in v3.10. Use `k-button` directly
+ */
 export default {
 	inheritAttrs: false,
 	props: {

--- a/panel/src/components/Navigation/ButtonNative.vue
+++ b/panel/src/components/Navigation/ButtonNative.vue
@@ -21,6 +21,9 @@
 <script>
 import tab from "@/mixins/tab.js";
 
+/**
+ * @deprecated will be removed in v3.10. Use `k-button` directly
+ */
 export default {
 	mixins: [tab],
 	inheritAttrs: false,

--- a/panel/src/components/Navigation/index.js
+++ b/panel/src/components/Navigation/index.js
@@ -20,10 +20,7 @@ export default {
 	install(app) {
 		app.component("k-breadcrumb", Breadcrumb);
 		app.component("k-button", Button);
-		app.component("k-button-disabled", ButtonDisabled);
 		app.component("k-button-group", ButtonGroup);
-		app.component("k-button-link", ButtonLink);
-		app.component("k-button-native", ButtonNative);
 		app.component("k-dropdown", Dropdown);
 		app.component("k-dropdown-content", DropdownContent);
 		app.component("k-dropdown-item", DropdownItem);
@@ -35,5 +32,12 @@ export default {
 		app.component("k-search", Search);
 		app.component("k-tag", Tag);
 		app.component("k-topbar", Topbar);
+
+		/**
+		 * @deprecated will be removed in v3.10. Use `k-button` directly
+		 */
+		app.component("k-button-disabled", ButtonDisabled);
+		app.component("k-button-link", ButtonLink);
+		app.component("k-button-native", ButtonNative);
 	}
 };


### PR DESCRIPTION
## TODOs

- [ ]  listeners must not be applied to disabled elements
- [ ] Focus style is currently handled with the data-tabbed implementation, but it has some quirks in the CSS. We should solve this with focus-visible instead, which is now widely supported.
- [ ] status-icon button component has its own styling rules, which don't place nicely with just improving the focus state for the button component.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- Improved accessibility for disabled native buttons 

### Refactoring
- Merged `k-button-disabled`, `k-button-native` and `k-button-link` into `k-button`

### Deprecated
-  `k-button-disabled`, `k-button-native` and `k-button-link` have been deprecated and will be removed in Kirby 3.10. Use `k-button` directly




## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
