### PR TITLE
give `when` property of field access to parent fieldsets

### DIFF
--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -3,7 +3,7 @@
 		<k-grid>
 			<template v-for="(field, fieldName) in fields">
 				<k-column
-					v-if="$helper.field.isVisible(field, value)"
+					v-if="$helper.field.isVisible(field, context)"
 					:key="field.signature"
 					:width="field.width"
 				>
@@ -47,10 +47,23 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+
 /**
  * The Fieldset component is a wrapper around manual field component creation. You simply pass it an fields object and all field components will automatically be created including a nice field grid. This is the ideal starting point if you want an easy way to create fields without having to deal with a full form element.
  */
 export default {
+	provide() {
+		return {
+			context: computed(() => this.context)
+		};
+	},
+	inject: {
+		injectedContext: {
+			from: "context",
+			default: {}
+		}
+	},
 	props: {
 		config: Object,
 		disabled: Boolean,
@@ -78,6 +91,14 @@ export default {
 		return {
 			errors: {}
 		};
+	},
+	computed: {
+		context() {
+			return {
+				...this.injectedContext,
+				...this.value
+			}
+		}
 	},
 	methods: {
 		/**

--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script>
-import { computed } from 'vue';
+import { computed } from "vue";
 
 /**
  * The Fieldset component is a wrapper around manual field component creation. You simply pass it an fields object and all field components will automatically be created including a nice field grid. This is the ideal starting point if you want an easy way to create fields without having to deal with a full form element.
@@ -97,7 +97,7 @@ export default {
 			return {
 				...this.injectedContext,
 				...this.value
-			}
+			};
 		}
 	},
 	methods: {


### PR DESCRIPTION
## This PR …
The `when` property of fields currently only has access to the fields of the fieldset to which it belongs to. 
This PR gives the query also access to fields in "parent" fieldsets (think nested structure fields, for example).

This happens by providing / injecting a reactive `context` object from fieldset to fieldset. Each of them merging the injected context with its own value. 

This behaviour mirrors the concepts of scoping and shadowing present in many programming languages. 

This is a draft because the current implementation lacks the serverside counterpart (about handling required hidden fields). But before proceeding I wanted to get some feedback on whether this could ever be merged or not. 

Thank you for your consideration :)

### Example
```yml
title: Default Page

fields:
  outer:
    type: structure
    fields:
      toggle:
        type: toggle
      
      inner:
        type: structure
        fields:
          info2:
            type: info
            text: >
              A nested info field that is always visible.
              There is also a second info field that shows when the outer toggle is yes
          info3:
            type: info
            text: A nested info field that is only visible when outer toggle is yes
            when:
              toggle: true
```

### Fixes
https://forum.getkirby.com/t/conditional-field-in-structure-not-working-what-am-i-doing-wrong/27552

### Breaking changes
Not sure. I think not. 

## Ready?
- [ ] Server side code
- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
