### PR TITLE
Allow deactivating deprecation notices

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -20,7 +20,7 @@ class Helpers
 {
 	public static $deprecations = [
 		// Passing the $slot or $slots variables to snippets is
-		// deprecated and will break in Kirby 3.10.
+		// deprecated and will break in a future version.
 		'snippet-pass-slots'    => true,
 
 		// The `Toolkit\Query` class has been deprecated and will

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -18,6 +18,16 @@ use Kirby\Toolkit\Str;
  */
 class Helpers
 {
+	/**
+	 * Allows to disable specific deprecation warnings
+	 * by setting them to `false`.
+	 * You can do this by putting the following code in
+	 * `site/config/config.php`:
+	 *
+	 * ```php
+	 * Helpers::$deprecations['<deprecation-key>'] = false;
+	 * ```
+	 */
 	public static $deprecations = [
 		// Passing the $slot or $slots variables to snippets is
 		// deprecated and will break in a future version.
@@ -39,9 +49,10 @@ class Helpers
 	 * Triggers a deprecation warning if debug mode is active
 	 * and warning has not been surpressed via `Helpers::$deprecations`
 	 *
+	 * @param string|null $key If given, the key will be checked against the static array
 	 * @return bool Whether the warning was triggered
 	 */
-	public static function deprecated(string $message, string $key = null): bool
+	public static function deprecated(string $message, string|null $key = null): bool
 	{
 		if (
 			App::instance()->option('debug') === true ||

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -54,16 +54,22 @@ class Helpers
 	 */
 	public static function deprecated(string $message, string|null $key = null): bool
 	{
+		// only trigger warning in debug mode or when running PHPUnit tests
+		// @codeCoverageIgnoreStart
 		if (
-			App::instance()->option('debug') === true ||
-			(defined('KIRBY_TESTING') === true && KIRBY_TESTING === true)
+			App::instance()->option('debug') !== true &&
+			(defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true)
 		) {
-			if ((static::$deprecations[$key] ?? true) !== false) {
-				return trigger_error($message, E_USER_DEPRECATED) === true;
-			}
+			return false;
+		}
+		// @codeCoverageIgnoreEnd
+
+		// don't trigger the warning if disabled by default or by the dev
+		if ($key !== null && (static::$deprecations[$key] ?? true) === false) {
+			return false;
 		}
 
-		return false;
+		return trigger_error($message, E_USER_DEPRECATED) === true;
 	}
 
 	/**

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -18,19 +18,23 @@ use Kirby\Toolkit\Str;
  */
 class Helpers
 {
+	public static $deprecations = [];
+
 	/**
 	 * Triggers a deprecation warning if debug mode is active
+	 * and warning has not been surpressed via `Helpers::$deprecations`
 	 *
-	 * @param string $message
 	 * @return bool Whether the warning was triggered
 	 */
-	public static function deprecated(string $message): bool
+	public static function deprecated(string $message, string $key = null): bool
 	{
 		if (
 			App::instance()->option('debug') === true ||
 			(defined('KIRBY_TESTING') === true && KIRBY_TESTING === true)
 		) {
-			return trigger_error($message, E_USER_DEPRECATED) === true;
+			if ((static::$deprecations[$key] ?? true) !== false) {
+				return trigger_error($message, E_USER_DEPRECATED) === true;
+			}
 		}
 
 		return false;

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -18,7 +18,22 @@ use Kirby\Toolkit\Str;
  */
 class Helpers
 {
-	public static $deprecations = [];
+	public static $deprecations = [
+		// Passing the $slot or $slots variables to snippets is
+		// deprecated and will break in Kirby 3.10.
+		'snippet-pass-slots'    => true,
+
+		// The `Toolkit\Query` class has been deprecated and will
+		// be removed in a future version. Use `Query\Query` instead:
+		// Kirby\Query\Query::factory($query)->resolve($data).
+		'toolkit-query-class'   => true,
+
+		// Passing an empty string as value to `Xml::attr()` has been
+		// deprecated. In a future version, passing an empty string won't
+		// omit the attribute anymore but render it with an empty value.
+		// To omit the attribute, please pass `null`.
+		'xml-attr-empty-string' => false,
+	];
 
 	/**
 	 * Triggers a deprecation warning if debug mode is active

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -309,7 +309,7 @@ class Snippet extends Tpl
 			array_key_exists('slot', $data) === true ||
 			array_key_exists('slots', $data) === true
 		) {
-			Helpers::deprecated('Passing the $slot or $slots variables to snippets is deprecated and will break in Kirby 3.10.', 'snippet-pass-slots');
+			Helpers::deprecated('Passing the $slot or $slots variables to snippets is deprecated and will break in a future version.', 'snippet-pass-slots');
 		}
 		// @codeCoverageIgnoreEnd
 

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -309,7 +309,7 @@ class Snippet extends Tpl
 			array_key_exists('slot', $data) === true ||
 			array_key_exists('slots', $data) === true
 		) {
-			Helpers::deprecated('Passing the $slot or $slots variables to snippets is deprecated and will break in Kirby 3.10.');
+			Helpers::deprecated('Passing the $slot or $slots variables to snippets is deprecated and will break in Kirby 3.10.', 'snippet-pass-slots');
 		}
 		// @codeCoverageIgnoreEnd
 

--- a/src/Toolkit/Query.php
+++ b/src/Toolkit/Query.php
@@ -58,7 +58,7 @@ class Query
 		$this->query = $query;
 		$this->data  = $data;
 
-		Helpers::deprecated('The `Toolkit\Query` class has been deprecated and will be removed in a future version. Use `Query\Query` instead: Kirby\Query\Query::factory($query)->resolve($data).');
+		Helpers::deprecated('The `Toolkit\Query` class has been deprecated and will be removed in a future version. Use `Query\Query` instead: Kirby\Query\Query::factory($query)->resolve($data).', 'toolkit-query-class');
 	}
 
 	/**

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -97,7 +97,7 @@ class Xml
 			// TODO: Remove in 3.10
 			// @codeCoverageIgnoreStart
 			if ($value === '') {
-				Helpers::deprecated('Passing an empty string as value to `Xml::attr()` has been deprecated. In a future version, passing an empty string won\'t omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`.');
+				Helpers::deprecated('Passing an empty string as value to `Xml::attr()` has been deprecated. In a future version, passing an empty string won\'t omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`.', 'xml-attr-empty-string');
 			}
 			// @codeCoverageIgnoreEnd
 

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -34,6 +34,27 @@ class HelpersTest extends TestCase
 	}
 
 	/**
+	 * @covers ::deprecated
+	 */
+	public function testDeprecatedKeyUndefined()
+	{
+		$this->expectException('Whoops\Exception\ErrorException');
+		$this->expectExceptionMessage('The xyz method is deprecated.');
+
+		$this->assertFalse(Helpers::deprecated('The xyz method is deprecated.', 'my-key'));
+	}
+
+	/**
+	 * @covers ::deprecated
+	 */
+	public function testDeprecatedKeyDeactivated()
+	{
+		Helpers::$deprecations = ['my-key' => false];
+		$this->assertFalse(Helpers::deprecated('The xyz method is deprecated.', 'my-key'));
+		Helpers::$deprecations = [];
+	}
+
+	/**
 	 * @covers ::dump
 	 */
 	public function testDumpOnCli()

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -15,11 +15,15 @@ class HelpersTest extends TestCase
 
 	public function setUp(): void
 	{
+		parent::setUp();
+
 		$this->deprecations = Helpers::$deprecations;
 	}
 
 	public function tearDown(): void
 	{
+		parent::tearDown();
+
 		Helpers::$deprecations = $this->deprecations;
 
 		if ($this->hasErrorHandler === true) {

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -49,7 +49,19 @@ class HelpersTest extends TestCase
 		$this->expectException('Whoops\Exception\ErrorException');
 		$this->expectExceptionMessage('The xyz method is deprecated.');
 
-		$this->assertFalse(Helpers::deprecated('The xyz method is deprecated.', 'my-key'));
+		Helpers::deprecated('The xyz method is deprecated.', 'my-key');
+	}
+
+	/**
+	 * @covers ::deprecated
+	 */
+	public function testDeprecatedActivated()
+	{
+		$this->expectException('Whoops\Exception\ErrorException');
+		$this->expectExceptionMessage('The xyz method is deprecated.');
+
+		Helpers::$deprecations = ['my-key' => true];
+		Helpers::deprecated('The xyz method is deprecated.', 'my-key');
 	}
 
 	/**

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -10,10 +10,18 @@ use Kirby\Toolkit\Obj;
  */
 class HelpersTest extends TestCase
 {
+	protected $deprecations = [];
 	protected $hasErrorHandler = false;
+
+	public function setUp(): void
+	{
+		$this->deprecations = Helpers::$deprecations;
+	}
 
 	public function tearDown(): void
 	{
+		Helpers::$deprecations = $this->deprecations;
+
 		if ($this->hasErrorHandler === true) {
 			restore_error_handler();
 			$this->hasErrorHandler = false;
@@ -51,7 +59,6 @@ class HelpersTest extends TestCase
 	{
 		Helpers::$deprecations = ['my-key' => false];
 		$this->assertFalse(Helpers::deprecated('The xyz method is deprecated.', 'my-key'));
-		Helpers::$deprecations = [];
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- Deprecation warnings can now be disabled granularly by setting `Helpers::$deprecations['<deprecation-key>'] = false` in your `site/config/config.php`. You can find the possible deprecation keys in `kirby/src/Cms/Helpers.php`.
- The deprecation warning for passing an empty string as the value to `Xml::attr()` (introduced in 3.9.0) is no longer displayed by default because there are use cases where both the old and new behavior are fine. If you still want to check your code, you can enable the deprecation warning with `Helpers::$deprecations['xml-attr-empty-string'] = true`.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
