### PR TITLE
Date field: fix tabbing behavior

### DIFF
--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -280,9 +280,9 @@ export default {
 		 * c. cursor selection covers more than one part
 		 *    => select the last affected part
 		 * d. cursor selection cover last part
-		 *    => tab should blur the input, focus on next tabbale element
+		 *    => tab should blur the input, focus on next tabable element
 		 * e. cursor is at the end of the pattern
-		 *    => tab should blur the input, focus on next tabbale element
+		 *    => tab should blur the input, focus on next tabable element
 		 *
 		 * @param {Event} event
 		 */

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -281,6 +281,8 @@ export default {
 		 *    => select the last affected part
 		 * d. cursor selection cover last part
 		 *    => tab should blur the input, focus on next tabbale element
+		 * e. cursor is at the end of the pattern
+		 *    => tab should blur the input, focus on next tabbale element
 		 *
 		 * @param {Event} event
 		 */
@@ -322,8 +324,33 @@ export default {
 						this.selectNext(selection.index);
 					}
 				} else {
-					// select default part (step unit)
-					event.shiftKey ? this.selectLast() : this.selectFirst();
+					// nothing or no part fully selected
+					if (
+						this.$refs.input &&
+						this.$refs.input.selectionStart == selection.end + 1 &&
+						selection.index == this.pattern.parts.length - 1
+					) {
+						// cursor at the end of the pattern, jump out
+						return;
+					}
+
+					// more than one part selected, select last affected part
+					else if (
+						this.$refs.input &&
+						this.$refs.input.selectionEnd - 1 > selection.end
+					) {
+						const last = this.pattern.at(
+							this.$refs.input.selectionEnd,
+							this.$refs.input.selectionEnd
+						);
+
+						this.select(this.pattern.parts[last.index]);
+					}
+
+					// select part where the cursor is located
+					else {
+						this.select(this.pattern.parts[selection.index]);
+					}
 				}
 
 				event.preventDefault();


### PR DESCRIPTION
## This PR fixes the tabbing behavior of date fields

While typing in dates in the panel I realized that the tabbing behavior is slowing me down: when I press tab after typing in a full date, instead of going to the next field, the cursor jumps back to the beginning of the date and I have to jump through day, month and year before I can continue:

https://user-images.githubusercontent.com/60777/214268473-553f08c3-1e5b-4503-b599-b6123d07baf3.mp4

I looked into `DateInput.vue` and found this inline documentation:

<pre>
/**
* Handle tab key in input
*
* a. cursor is somewhere in the input, no selection
*    => select the part where the cursor is located
* b. cursor selection already covers a part fully
*    => select the next part
* c. cursor selection covers more than one part
*    => select the last affected part
* d. cursor selection cover last part
*    => tab should blur the input, focus on next tabable element
*/
</pre>

So there is no intended behavior yet to jump out of the input when the cursor is at the end of the pattern.
While working on that behavior I realized that the behaviors **a** and **c** didn't work.

### Fixes

This PR:
1. adds the new tab-behavior **e** to jump out of the input when the cursor is at the end of the pattern.
2. makes behavior **a** and **c** work.

<pre>
/**
* Handle tab key in input
*
* a. cursor is somewhere in the input, no selection
*    <b>=> select the part where the cursor is located</b>
* b. cursor selection already covers a part fully
*    => select the next part
* c. cursor selection covers more than one part
*    <b>=> select the last affected part</b>
* d. cursor selection cover last part
*    => tab should blur the input, focus on next tabable element
* <b>e. cursor is at the end of the pattern
*    => tab should blur the input, focus on next tabable element</b>
*/
</pre>

For the jump out at the end behavior **e** I check if the cursor is at the end of the pattern part and if the pattern part is the last part:

https://user-images.githubusercontent.com/60777/214273081-0d2df92e-c819-4ecf-85f8-846a86ab9463.mp4

For the more than one part selected behavior **c** I check if the end of the selection in the input is greater than the matched pattern-part end (when more than one part is selected, dayjs.pattern returns the first):

https://user-images.githubusercontent.com/60777/214273456-f60381eb-5e32-4aa3-8d30-f55eb9eb885f.mp4

The select current part behavior **a** selects the part at the current matched pattern index:

https://user-images.githubusercontent.com/60777/214274051-9286791f-3a57-4153-a807-a7b41c0af330.mp4

### Breaking changes

I think there are no breaking changes. All logic is based on the dayjs.pattern. I developed with `display: DD.MM.YYYY` and tested it successfully with the default `YYYY-MM-DD`.

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
