### PR TITLE
Fix snippets with `null` argument 

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -280,7 +280,7 @@ return [
 	 * @param string|array $name Snippet name
 	 * @param array $data Data array for the snippet
 	 */
-	'snippet' => function (App $kirby, string|array $name, array $data = [], bool $slots = false): Snippet|string {
+	'snippet' => function (App $kirby, string|array|null $name, array $data = [], bool $slots = false): Snippet|string {
 		return Snippet::factory($name, $data, $slots);
 	},
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1612,12 +1612,11 @@ class App
 	 * Uses the snippet component to create
 	 * and return a template snippet
 	 *
-	 * @param mixed $name
 	 * @param array|object $data Variables or an object that becomes `$item`
 	 * @param bool $return On `false`, directly echo the snippet
 	 * @psalm-return ($return is true ? string : null)
 	 */
-	public function snippet($name, $data = [], bool $return = true, bool $slots = false): Snippet|string|null
+	public function snippet(string|array|null $name, $data = [], bool $return = true, bool $slots = false): Snippet|string|null
 	{
 		if (is_object($data) === true) {
 			$data = ['item' => $data];

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1615,7 +1615,6 @@ class App
 	 * @param mixed $name
 	 * @param array|object $data Variables or an object that becomes `$item`
 	 * @param bool $return On `false`, directly echo the snippet
-	 * @return string|null
 	 * @psalm-return ($return is true ? string : null)
 	 */
 	public function snippet($name, $data = [], bool $return = true, bool $slots = false): Snippet|string|null

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -157,11 +157,10 @@ class Snippet extends Tpl
 		array $data = [],
 		bool $slots = false
 	): static|string {
-		if ($name === null) {
-			return '';
-		}
-
-		$file = static::file($name);
+		// instead of returning empty string when `$name` is null
+		// allow rest of code to run, otherwise the wrong snippet would be closed
+		// and potential issues for nested snippets may occur
+		$file = $name !== null ? static::file($name) : null;
 
 		// for snippets with slots, make sure to open a new
 		// snippet and start capturing slots

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -153,10 +153,14 @@ class Snippet extends Tpl
 	 * or the template string for self-enclosed snippets
 	 */
 	public static function factory(
-		string|array $name,
+		string|array|null $name,
 		array $data = [],
 		bool $slots = false
 	): static|string {
+		if ($name === null) {
+			return '';
+		}
+
 		$file = static::file($name);
 
 		// for snippets with slots, make sure to open a new

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -732,6 +732,32 @@ class HelperFunctionsTest extends TestCase
 		$this->assertSame('Hello world', $result);
 	}
 
+	public function testSnippetNullArgument()
+	{
+		$this->kirby->clone([
+			'roots' => [
+				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
+				'snippets'  => $index,
+			]
+		]);
+
+		$result = snippet(null, ['message' => 'world'], true);
+		$this->assertSame('', $result);
+	}
+
+	public function testSnippetNotExists()
+	{
+		$this->kirby->clone([
+			'roots' => [
+				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
+				'snippets'  => $index
+			]
+		]);
+
+		$result = snippet('not-exist', ['message' => 'world'], true);
+		$this->assertSame('', $result);
+	}
+
 	public function testSnippetAlternatives()
 	{
 		$this->kirby->clone([
@@ -741,7 +767,11 @@ class HelperFunctionsTest extends TestCase
 			]
 		]);
 
-		$result = snippet(['does-not-exist', 'does-not-exist-either', 'snippet'], ['message' => 'world'], true);
+		$result = snippet(
+			[null, 'does-not-exist', 'does-not-exist-either', 'snippet'],
+			['message' => 'world'],
+			true
+		);
 		$this->assertSame('Hello world', $result);
 	}
 

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -58,7 +58,7 @@ class SnippetTest extends TestCase
 		$this->assertInstanceOf(Snippet::class, $snippet);
 
 		$snippet = Snippet::factory(null, ['message' => 'hello'], slots: true);
-		$this->assertSame('', $snippet);
+		$this->assertInstanceOf(Snippet::class, $snippet);
 	}
 
 	/**

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -56,6 +56,9 @@ class SnippetTest extends TestCase
 
 		$snippet = Snippet::factory('missin', ['message' => 'hello'], slots: true);
 		$this->assertInstanceOf(Snippet::class, $snippet);
+
+		$snippet = Snippet::factory(null, ['message' => 'hello'], slots: true);
+		$this->assertSame('', $snippet);
 	}
 
 	/**

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -48,6 +48,9 @@ class SnippetTest extends TestCase
 		$openProp->setAccessible(true);
 		$this->assertTrue($openProp->getValue($snippet));
 
+		$snippet = Snippet::factory(null, ['message' => 'hello']);
+		$this->assertSame('', $snippet);
+
 		$snippet = Snippet::factory('missin', ['message' => 'hello']);
 		$this->assertSame('', $snippet);
 


### PR DESCRIPTION
## This PR …

I've implement @lukasbestle idea in https://github.com/getkirby/kirby/issues/5004#issuecomment-1399274649. But IMHO this is not bug, an enhancement.

### Enhancements
- Passing the snippet name argument as `null` is now handled gracefully #5004

### Breaking changes
None so far.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
