### PR TITLE
Some missing A::functions

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -161,7 +161,7 @@ class A
 	}
 
 	/**
-	 * Checks in array has a value
+	 * Checks if array has a value
 	 *
 	 * @param array $array
 	 * @param mixed $value

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -53,7 +53,7 @@ class A
 	 * @param array $array
 	 * @return int
 	 */
-	public static function count(array $array = []): int
+	public static function count(array $array): int
 	{
 		return count($array);
 	}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -48,6 +48,21 @@ class A
 	}
 
 	/**
+	 * Counts the number of elements in an array
+	 *
+	 * @param array $array
+	 * @return int
+	 */
+	public static function count(array $array = []): int
+	{
+		if (!is_array($array)) {
+			throw new Exception('Invalid argument type: ' . gettype($array));
+		}
+
+		return count($array);
+	}
+
+	/**
 	 * Gets an element of an array by key
 	 *
 	 * <code>
@@ -198,7 +213,7 @@ class A
 				) {
 					$merged[] = $value;
 
-				// recursively merge the two array values
+					// recursively merge the two array values
 				} elseif (
 					is_array($value) === true &&
 					isset($merged[$key]) === true &&
@@ -206,7 +221,7 @@ class A
 				) {
 					$merged[$key] = static::merge($merged[$key], $value, $mode);
 
-				// simply overwrite with the value from the second array
+					// simply overwrite with the value from the second array
 				} else {
 					$merged[$key] = $value;
 				}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -165,6 +165,28 @@ class A
 	}
 
 	/**
+	 * Checks in array has a value
+	 *
+	 * @param array $array
+	 * @return bool
+	 */
+	public static function has(array $array, $value): bool
+	{
+		return in_array($value, $array);
+	}
+
+	/**
+	 * Checks in array includes a value (alias for A::has)
+	 *
+	 * @param array $array
+	 * @return bool
+	 */
+	public static function includes(array $array, mixed $value): bool
+	{
+		return A::has($array, $value);
+	}
+
+	/**
 	 * Joins the elements of an array to a string
 	 */
 	public static function join(array|string $value, string $separator = ', '): string

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -363,6 +363,18 @@ class A
 	): array {
 		return array_slice($array, $offset, $length, $preserveKeys);
 	}
+
+	/**
+	 * Sums an array
+	 *
+	 * @param array $array
+	 * @return int|float
+	 */
+	public static function sum(array $array): int|float
+	{
+		return array_sum($array);
+	}
+
 	/**
 	 * Returns the first element of an array
 	 *

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -235,7 +235,7 @@ class A
 				) {
 					$merged[] = $value;
 
-					// recursively merge the two array values
+				// recursively merge the two array values
 				} elseif (
 					is_array($value) === true &&
 					isset($merged[$key]) === true &&
@@ -243,7 +243,7 @@ class A
 				) {
 					$merged[$key] = static::merge($merged[$key], $value, $mode);
 
-					// simply overwrite with the value from the second array
+				// simply overwrite with the value from the second array
 				} else {
 					$merged[$key] = $value;
 				}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -345,6 +345,24 @@ class A
 		return $new;
 	}
 
+
+	/**
+	 * Returns a slice of an array
+	 *
+	 * @param array $array
+	 * @param int $offset
+	 * @param int|null $length
+	 * @param bool $preserveKeys
+	 * @return array
+	 */
+	public static function slice(
+		array $array,
+		int $offset,
+		int $length = null,
+		bool $preserveKeys = false
+	): array {
+		return array_slice($array, $offset, $length, $preserveKeys);
+	}
 	/**
 	 * Returns the first element of an array
 	 *

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -297,6 +297,19 @@ class A
 	}
 
 	/**
+	 * Reduce an array to a single value
+	 *
+	 * @param array $array
+	 * @param callable $callback
+	 * @param mixed $initial
+	 * @return mixed
+	 */
+	public static function reduce(array $array, callable $callback, $initial = null): mixed
+	{
+		return array_reduce($array, $callback, $initial);
+	}
+
+	/**
 	 * Shuffles an array and keeps the keys
 	 *
 	 * <code>

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -55,10 +55,6 @@ class A
 	 */
 	public static function count(array $array = []): int
 	{
-		if (!is_array($array)) {
-			throw new Exception('Invalid argument type: ' . gettype($array));
-		}
-
 		return count($array);
 	}
 
@@ -168,22 +164,13 @@ class A
 	 * Checks in array has a value
 	 *
 	 * @param array $array
+	 * @param mixed $value
+	 * @param bool $strict
 	 * @return bool
 	 */
-	public static function has(array $array, $value): bool
+	public static function has(array $array, $value, bool $strict = false): bool
 	{
-		return in_array($value, $array);
-	}
-
-	/**
-	 * Checks in array includes a value (alias for A::has)
-	 *
-	 * @param array $array
-	 * @return bool
-	 */
-	public static function includes(array $array, mixed $value): bool
-	{
-		return A::has($array, $value);
+		return in_array($value, $array, $strict);
 	}
 
 	/**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -426,6 +426,19 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::sum
+	 */
+	public function testSum()
+	{
+		$array = $this->_array();
+
+		$this->assertSame(0, A::sum([]));
+		$this->assertSame(6, A::sum([1, 2, 3]));
+		$this->assertSame(6, A::sum([1, -1, 6]));
+		$this->assertSame(6.0, A::sum([1.2, 2.4, 2.4]));
+	}
+
+	/**
 	 * @covers ::first
 	 */
 	public function testFirst()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -412,6 +412,20 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::slice
+	 */
+	public function testSlice()
+	{
+		$array = $this->_array();
+
+		$this->assertSame(['cat' => 'miao'], A::slice($array, 0, 1));
+		$this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::slice($array, 1));
+		$this->assertSame(['bird' => 'tweet'], A::slice($array, -1));
+		$this->assertSame(['dog' => 'wuff'], A::slice($array, -2, 1));
+		$this->assertSame($array, A::slice($array, 0));
+	}
+
+	/**
 	 * @covers ::first
 	 */
 	public function testFirst()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -180,6 +180,22 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::has
+	 */
+	public function testHas()
+	{
+		$array = $this->_array();
+
+		$this->assertTrue(A::has($array, 'miao'));
+		$this->assertFalse(A::has($array, 'cat'));
+		$this->assertFalse(A::has($array, 4));
+		$this->assertFalse(A::has($array, ['miao']));
+
+		// test alias
+		$this->assertTrue(A::includes($array, 'miao'));
+	}
+
+	/**
 	 * @covers ::map
 	 */
 	public function testMap()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -389,6 +389,29 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::reduce
+	 */
+	public function testReduce()
+	{
+		$array = $this->_array();
+
+		$reduced = A::reduce($array, function ($carry, $item) {
+			return $carry . $item;
+		}, '');
+		$this->assertSame('miaowufftweet', $reduced);
+
+		$reduced = A::reduce([1, 2, 3], function ($carry, $item) {
+			return $carry + $item;
+		}, 0);
+		$this->assertSame(6, $reduced);
+
+		$reduced = A::reduce([], function ($carry, $item) {
+			return $carry + $item;
+		});
+		$this->assertSame(null, $reduced);
+	}
+
+	/**
 	 * @covers ::first
 	 */
 	public function testFirst()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -415,8 +415,8 @@ class ATest extends TestCase
 
 		$reduced = A::reduce([1, 2, 3], function ($carry, $item) {
 			return $carry + $item;
-		}, 0);
-		$this->assertSame(6, $reduced);
+		}, 42);
+		$this->assertSame(48, $reduced);
 
 		$reduced = A::reduce([], function ($carry, $item) {
 			return $carry + $item;

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -78,6 +78,18 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::count
+	 */
+	public function testCount()
+	{
+		$array = $this->_array();
+
+		$this->assertSame(3, A::count($array));
+		$this->assertSame(2, A::count(['cat', 'dog']));
+		$this->assertSame(0, A::count([]));
+	}
+
+	/**
 	 * @covers ::get
 	 */
 	public function testGet()
@@ -351,9 +363,9 @@ class ATest extends TestCase
 	public function testPluck()
 	{
 		$array = [
-			[ 'id' => 1, 'username' => 'bastian'],
-			[ 'id' => 2, 'username' => 'sonja'],
-			[ 'id' => 3, 'username' => 'lukas']
+			['id' => 1, 'username' => 'bastian'],
+			['id' => 2, 'username' => 'sonja'],
+			['id' => 3, 'username' => 'lukas']
 		];
 
 		$this->assertSame([
@@ -696,9 +708,9 @@ class ATest extends TestCase
 	public function testSort()
 	{
 		$array = [
-			[ 'id' => 1, 'username' => 'bastian'],
-			[ 'id' => 2, 'username' => 'sonja'],
-			[ 'id' => 3, 'username' => 'lukas']
+			['id' => 1, 'username' => 'bastian'],
+			['id' => 2, 'username' => 'sonja'],
+			['id' => 3, 'username' => 'lukas']
 		];
 
 		// ASC
@@ -899,7 +911,7 @@ class ATest extends TestCase
 		$this->assertSame(['dog' => 'wuff', 'bird' => 'tweet'], A::without($associativeArray, ['this', 'cat', 'doesnt', 'exist']));
 
 		$this->assertSame([0 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, range(1, 3)));
-		$this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4=> 'dog', 5 => 'bird'], A::without($indexedArray, 0));
+		$this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, 0));
 		$this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($indexedArray, -1));
 	}
 }

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -190,9 +190,6 @@ class ATest extends TestCase
 		$this->assertFalse(A::has($array, 'cat'));
 		$this->assertFalse(A::has($array, 4));
 		$this->assertFalse(A::has($array, ['miao']));
-
-		// test alias
-		$this->assertTrue(A::includes($array, 'miao'));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
Adds some additional `A::` methods; These are basically just wrappers around matching `array_*` functions, but I often reach for them only to realise they are not there, and have to mix `array_thing(A::other($array))`.

### Breaking changes
None

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
