### PR TITLE
Regular expressions for `Str`

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -522,6 +522,20 @@ class Str
 		return preg_replace('!^(' . preg_quote($trim) . ')+!', '', $string);
 	}
 
+	/**
+	 * Match string against a regular expression and return matches
+	 *
+	 * @param string $string The string to match
+	 * @param string $pattern The regular expression
+	 * @param int $flags Optional flags for the match
+	 * @param int $offset Optional offset for the match
+	 * @return array|null The matches or null if no match was found
+	 */
+	public static function match(string $string, string $pattern, int $flags = 0, int $offset = 0): ?array
+	{
+		$result = preg_match($pattern, $string, $matches, $flags, $offset);
+		return ($result > 0) ? $matches : null;
+	}
 
 	/**
 	 * Get a character pool with various possible combinations

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -527,23 +527,23 @@ class Str
 	 *
 	 * @param string $string The string to match
 	 * @param string $pattern The regular expression
-	 * @param int $flags Optional flags for the match
-	 * @param int $offset Optional offset for the match
+	 * @param int $flags Optional flags for PHP `preg_match()`
+	 * @param int $offset Positional offset in the string to start the search
 	 * @return array|null The matches or null if no match was found
 	 */
 	public static function match(string $string, string $pattern, int $flags = 0, int $offset = 0): ?array
 	{
 		$result = preg_match($pattern, $string, $matches, $flags, $offset);
-		return ($result > 0) ? $matches : null;
+		return ($result === 1) ? $matches : null;
 	}
 
 	/**
-	 * Syntax sugar for boolean string matching
+	 * Check whether a string matches a regular expression
 	 *
 	 * @param string $string The string to match
 	 * @param string $pattern The regular expression
-	 * @param int $flags Optional flags for the match
-	 * @param int $offset Optional offset for the match
+	 * @param int $flags Optional flags for PHP `preg_match()`
+	 * @param int $offset Positional offset in the string to start the search
 	 * @return bool True if the string matches the pattern
 	 */
 	public static function matches(string $string, string $pattern, int $flags = 0, int $offset = 0): bool
@@ -556,14 +556,14 @@ class Str
 	 *
 	 * @param string $string The string to match
 	 * @param string $pattern The regular expression
-	 * @param int $flags Optional flags for the match
-	 * @param int $offset Optional offset for the match
+	 * @param int $flags Optional flags for PHP `preg_match_all()`
+	 * @param int $offset Positional offset in the string to start the search
 	 * @return array|null The matches or null if no match was found
 	 */
 	public static function matchAll(string $string, string $pattern, int $flags = 0, int $offset = 0): ?array
 	{
 		$result = preg_match_all($pattern, $string, $matches, $flags, $offset);
-		return ($result > 0) ? $matches : null;
+		return ($result === 1) ? $matches : null;
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -538,6 +538,21 @@ class Str
 	}
 
 	/**
+	 * Match string against a regular expression and return all matches
+	 *
+	 * @param string $string The string to match
+	 * @param string $pattern The regular expression
+	 * @param int $flags Optional flags for the match
+	 * @param int $offset Optional offset for the match
+	 * @return array|null The matches or null if no match was found
+	 */
+	public static function matchAll(string $string, string $pattern, int $flags = 0, int $offset = 0): ?array
+	{
+		$result = preg_match_all($pattern, $string, $matches, $flags, $offset);
+		return ($result > 0) ? $matches : null;
+	}
+
+	/**
 	 * Get a character pool with various possible combinations
 	 */
 	public static function pool(string|array $type, bool $array = true): string|array

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -563,7 +563,7 @@ class Str
 	public static function matchAll(string $string, string $pattern, int $flags = 0, int $offset = 0): ?array
 	{
 		$result = preg_match_all($pattern, $string, $matches, $flags, $offset);
-		return ($result === 1) ? $matches : null;
+		return ($result > 0) ? $matches : null;
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -538,6 +538,20 @@ class Str
 	}
 
 	/**
+	 * Syntax sugar for boolean string matching
+	 *
+	 * @param string $string The string to match
+	 * @param string $pattern The regular expression
+	 * @param int $flags Optional flags for the match
+	 * @param int $offset Optional offset for the match
+	 * @return bool True if the string matches the pattern
+	 */
+	public static function matches(string $string, string $pattern, int $flags = 0, int $offset = 0): bool
+	{
+		return static::match($string, $pattern, $flags, $offset) !== null;
+	}
+
+	/**
 	 * Match string against a regular expression and return all matches
 	 *
 	 * @param string $string The string to match

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -527,6 +527,15 @@ class StrTest extends TestCase
 	}
 
 	/**
+	 * @covers ::match
+	 */
+	public function testMatch()
+	{
+		$this->assertSame(['test', 'es'], Str::match('test', '/t(es)t/'));
+		$this->assertNull(Str::match('one two three', '/(four)/'));
+	}
+
+	/**
 	 * @covers ::pool
 	 */
 	public function testPool()

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -536,6 +536,25 @@ class StrTest extends TestCase
 	}
 
 	/**
+	 * @covers ::matchAll
+	 */
+	public function testMatchAll()
+	{
+		$longText = <<<TEXT
+		This is line with "one" and something else to match.
+		This is line with "two" and another thing to match.
+		This is line with "three" and yet another match.
+		TEXT;
+
+		$matches = Str::matchAll($longText, '/"(.*)" and (.*).$/m');
+
+		$this->assertSame(['one', 'two', 'three'], $matches[1]);
+		$this->assertSame(['something else to match', 'another thing to match', 'yet another match'], $matches[2]);
+		$this->assertNull(Str::matchAll($longText, '/(miao)/'));
+		$this->assertNull(Str::matchAll('one two three', '/(four)/'));
+	}
+
+	/**
 	 * @covers ::pool
 	 */
 	public function testPool()

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -536,6 +536,15 @@ class StrTest extends TestCase
 	}
 
 	/**
+	 * @covers ::matches
+	 */
+	public function testMatches()
+	{
+		$this->assertTrue(Str::matches('test', '/t(es)t/'));
+		$this->assertFalse(Str::matches('one two three', '/(four)/'));
+	}
+
+	/**
 	 * @covers ::matchAll
 	 */
 	public function testMatchAll()


### PR DESCRIPTION
## This PR …
introduces three new functions to `Str` Toolkit class - match and matchAll.

These are wrappers around default PHP with:
- default Str method order (string to with on first, arguments later)
- simplified working with result

with default `preg_match` (and all), you have to capture the matches (which is what I usually want/need) in a temporary value, while often just throwing away the return value of the original function.

This also includes `Str::matches($string, $pattern)` which is a simple syntactic sugar for simple matching string against a regular expression

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
