### PR TITLE
`A::fill()` accept callable as fill value

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -410,11 +410,8 @@ class A
 	 */
 	public static function fill(array $array, int $limit, $fill = 'placeholder'): array
 	{
-		$diff = $limit - count($array);
-		$original = count($array);
-
-		for ($x = 0; $x < $diff; $x++) {
-			$array[] = is_callable($fill) ? $fill($original + $x) : $fill;
+		for ($x = count($array); $x < $limit; $x++) {
+			$array[] = is_callable($fill) ? $fill($x) : $fill;
 		}
 
 		return $array;

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -404,15 +404,17 @@ class A
 	 * @param int $limit The number of elements the array should
 	 *                   contain after filling it up.
 	 * @param mixed $fill The element, which should be used to
-	 *                    fill the array
+	 *                    fill the array. If it's a callable, it
+	 *                    will be called with the current index
 	 * @return array The filled-up result array
 	 */
 	public static function fill(array $array, int $limit, $fill = 'placeholder'): array
 	{
 		$diff = $limit - count($array);
+		$original = count($array);
 
 		for ($x = 0; $x < $diff; $x++) {
-			$array[] = $fill;
+			$array[] = is_callable($fill) ? $fill($original + $x) : $fill;
 		}
 
 		return $array;

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Toolkit;
 
-use Kirby\Toolkit\V;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -457,10 +456,10 @@ class ATest extends TestCase
 			'elephant',
 			'elephant',
 			'elephant'
-		], A::fill($array, 6, fn() => 'elephant'));
+		], A::fill($array, 6, fn () => 'elephant'));
 
 		// Callable with Closure
-		$this->assertSame([1, 2, 3], A::fill([], 3, fn(int $i) => $i + 1));
+		$this->assertSame([1, 2, 3], A::fill([], 3, fn (int $i) => $i + 1));
 
 		// callable with callable
 		$this->assertSame([false, true, false], A::fill([], 3, [V::class, 'accepted']));

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -447,6 +447,24 @@ class ATest extends TestCase
 			'elephant',
 			'elephant'
 		], A::fill($array, 5, 'elephant'));
+
+		// Callable
+		$this->assertSame([
+			'miao',
+			'wuff',
+			'tweet',
+			'elephant',
+			'elephant',
+			'elephant'
+		], A::fill($array, 6, function () {
+			return 'elephant';
+		}));
+
+		// Callable with Closure
+		$this->assertSame([1, 2, 3], A::fill([], 3, function(int $i) { return $i + 1; }));
+
+		// callable with callable
+		$this->assertSame([false, true, false], A::fill([], 3, [\Kirby\Toolkit\V::class, 'accepted']));
 	}
 
 	/**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Kirby\Toolkit\V;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -456,17 +457,13 @@ class ATest extends TestCase
 			'elephant',
 			'elephant',
 			'elephant'
-		], A::fill($array, 6, function () {
-			return 'elephant';
-		}));
+		], A::fill($array, 6, fn() => 'elephant'));
 
 		// Callable with Closure
-		$this->assertSame([1, 2, 3], A::fill([], 3, function (int $i) {
-			return $i + 1;
-		}));
+		$this->assertSame([1, 2, 3], A::fill([], 3, fn(int $i) => $i + 1));
 
 		// callable with callable
-		$this->assertSame([false, true, false], A::fill([], 3, [\Kirby\Toolkit\V::class, 'accepted']));
+		$this->assertSame([false, true, false], A::fill([], 3, [V::class, 'accepted']));
 	}
 
 	/**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -461,7 +461,9 @@ class ATest extends TestCase
 		}));
 
 		// Callable with Closure
-		$this->assertSame([1, 2, 3], A::fill([], 3, function(int $i) { return $i + 1; }));
+		$this->assertSame([1, 2, 3], A::fill([], 3, function (int $i) {
+			return $i + 1;
+		}));
 
 		// callable with callable
 		$this->assertSame([false, true, false], A::fill([], 3, [\Kirby\Toolkit\V::class, 'accepted']));


### PR DESCRIPTION
## This PR …
Sometimes, when doing parametric stuff, it's nice to create an array with some default values - which are not the same.

Small change to `A::fill` makes it accept a closure/callable, so it can be used to create new arrays with useful values:

```php
$new = A::fill([], 10, fn($i) => $i); // [0, 1, 2, 3, …]
$new2 = A::fill($new, 15, fn($i) => $i); // correctly adds [10, 11, …]
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
