### PR TITLE
A::keyBy()

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -4,6 +4,7 @@ namespace Kirby\Toolkit;
 
 use Closure;
 use Exception;
+use InvalidArgumentException;
 
 /**
  * The `A` class provides a set of handy methods
@@ -159,6 +160,33 @@ class A
 		}
 
 		return implode($separator, $value);
+	}
+
+	/**
+	 * Takes an array and makes it associative by an argument.
+	 * If the argument is a callable, it will be used to map the array.
+	 * If it is a string, it will be used as a key to pluck from the array.
+	 *
+	 * <code>
+	 * $array = [['id'=>1], ['id'=>2], ['id'=>3]];
+	 * $keyed = A::keyBy($array, 'id');
+	 *
+	 * // Now you can access the array by the id
+	 * </code>
+	 *
+	 * @param array $array
+	 * @param string|callable $keyBy
+	 * @return array
+	 */
+	public static function keyBy(array $array, string|callable $keyBy): array
+	{
+		$keys = is_callable($keyBy) ? static::map($array, $keyBy) : static::pluck($array, $keyBy);
+
+		if (count($keys) !== count($array)) {
+			throw new InvalidArgumentException('The "key by" argument must be a valid key or a callable');
+		}
+
+		return array_combine($keys, $array);
 	}
 
 	public const MERGE_OVERWRITE = 0;

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -820,6 +820,62 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::keyBy
+	 */
+	public function testKeyBy()
+	{
+		$array = [
+			[ 'id' => 1, 'username' => 'bastian'],
+			[ 'id' => 2, 'username' => 'sonja'],
+			[ 'id' => 3, 'username' => 'lukas']
+		];
+
+		$array_by_id = [
+			1 => [ 'id' => 1, 'username' => 'bastian'],
+			2 => [ 'id' => 2, 'username' => 'sonja'],
+			3 => [ 'id' => 3, 'username' => 'lukas']
+		];
+
+		$array_by_name = [
+			'bastian' => [ 'id' => 1, 'username' => 'bastian'],
+			'sonja' => [ 'id' => 2, 'username' => 'sonja'],
+			'lukas' => [ 'id' => 3, 'username' => 'lukas']
+		];
+
+		$array_by_cb = [
+			'bastian-1' => [ 'id' => 1, 'username' => 'bastian'],
+			'sonja-2' => [ 'id' => 2, 'username' => 'sonja'],
+			'lukas-3' => [ 'id' => 3, 'username' => 'lukas']
+		];
+
+		$this->assertSame($array_by_id, A::keyBy($array, 'id'));
+		$this->assertSame($array_by_name, A::keyBy($array, 'username'));
+		$this->assertSame($array_by_cb, A::keyBy($array, function ($item) {
+			return $item['username'] . '-' . $item['id'];
+		}));
+
+		// test with associative array
+		$this->assertSame($array_by_id, A::keyBy($array_by_cb, 'id'));
+	}
+
+	/**
+	 * @covers ::keyBy
+	 */
+	public function testKeyByWithNonexistentKeys()
+	{
+		$this->expectException('InvalidArgumentException');
+		$this->expectExceptionMessage('The "key by" argument must be a valid key or a callable');
+
+		$array = [
+			[ 'id' => 1, 'username' => 'bastian'],
+			[ 'id' => 2, 'username' => 'sonja'],
+			[ 'id' => 3, 'username' => 'lukas']
+		];
+
+		A::keyBy($array, 'nonexistent');
+	}
+
+	/**
 	 * @covers ::update
 	 */
 	public function testUpdate()


### PR DESCRIPTION
## This PR …
A key by function adds a key to an array without one (or replaces the existing one). This, also known as hash table, is useful when you combine your data from multiple sources, as it lowers the execution cost from searching for a value in an unkeyed array.

```php
$companies = A::keyBy([
  ['id' => 'msft', name => 'Microsoft'],
  ['id' => 'appl', name => 'Apple']
], 'id');

// later in your template, for instance
$company = $companies[$product->company_id()];
```

### Fixes
Missing keyBy function.

### Breaking changes
None.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
