### PR TITLE
Allow individual isDraft in props to work

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -175,7 +175,7 @@ class Pages extends Collection
 			$props['kirby']   = $kirby;
 			$props['parent']  = $parent;
 			$props['site']    = $site;
-			$props['isDraft'] = $draft ?? $props['isDraft'] ?? false;
+			$props['isDraft'] = $draft ?? $props['isDraft'] ?? $props['draft'] ?? false;
 
 			$page = Page::factory($props);
 

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -175,7 +175,7 @@ class Pages extends Collection
 			$props['kirby']   = $kirby;
 			$props['parent']  = $parent;
 			$props['site']    = $site;
-			$props['isDraft'] = $draft;
+			$props['isDraft'] ??= $draft;
 
 			$page = Page::factory($props);
 

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -154,7 +154,7 @@ class Pages extends Collection
 	 *
 	 * @param array $pages
 	 * @param \Kirby\Cms\Model|null $model
-	 * @param bool $draft
+	 * @param bool|null $draft
 	 * @return static
 	 */
 	public static function factory(array $pages, Model $model = null, bool $draft = null)
@@ -175,7 +175,7 @@ class Pages extends Collection
 			$props['kirby']   = $kirby;
 			$props['parent']  = $parent;
 			$props['site']    = $site;
-			$props['isDraft'] = $draft ?? ($props['isDraft'] ?? false);
+			$props['isDraft'] = $draft ?? $props['isDraft'] ?? false;
 
 			$page = Page::factory($props);
 

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -157,7 +157,7 @@ class Pages extends Collection
 	 * @param bool $draft
 	 * @return static
 	 */
-	public static function factory(array $pages, Model $model = null, bool $draft = false)
+	public static function factory(array $pages, Model $model = null, bool $draft = null)
 	{
 		$model  ??= App::instance()->site();
 		$children = new static([], $model);
@@ -175,7 +175,7 @@ class Pages extends Collection
 			$props['kirby']   = $kirby;
 			$props['parent']  = $parent;
 			$props['site']    = $site;
-			$props['isDraft'] ??= $draft;
+			$props['isDraft'] = $draft ?? ($props['isDraft'] ?? false);
 
 			$page = Page::factory($props);
 

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -1021,4 +1021,42 @@ class PagesTest extends TestCase
 
 		$this->assertSame(['a.mov', 'b.mp4'], $pages->videos()->pluck('filename'));
 	}
+
+	public function testFactoryIsDraftProp()
+	{
+		$pages = Pages::factory([
+			[
+				'slug'    => 'a',
+				'isDraft' => true,
+			],
+			[
+				'slug'    => 'b',
+				'isDraft' => false,
+			],
+			[
+				'slug'    => 'c',
+			]
+		]);
+
+		$this->assertSame([true, false, false], $pages->pluck('isDraft'));
+	}
+
+	public function testFactoryDraftParameter()
+	{
+		$pages = Pages::factory([
+			[
+				'slug'    => 'a',
+				'isDraft' => true,
+			],
+			[
+				'slug'    => 'b',
+				'isDraft' => false,
+			],
+			[
+				'slug'    => 'c',
+			],
+		], null, true);
+
+		$this->assertSame([true, true, true], $pages->pluck('isDraft'));
+	}
 }


### PR DESCRIPTION
Fix to allow individual isDraft to override the factory default if set in the array of props (issue https://github.com/getkirby/kirby/issues/5041)

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
Issue https://github.com/getkirby/kirby/issues/5041

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
