### PR TITLE
Fix for issue #5042 Page::create ignores isDraft prop 

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -523,7 +523,7 @@ trait PageActions
 		// clean up the slug
 		$props['slug']     = Str::slug($props['slug'] ?? $props['content']['title'] ?? null);
 		$props['template'] = $props['model'] = strtolower($props['template'] ?? 'default');
-		$props['isDraft']  = ($props['draft'] ?? true);
+		$props['isDraft']  ??= true;
 
 		// make sure that a UUID gets generated and
 		// added to content right away

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -521,9 +521,9 @@ trait PageActions
 	public static function create(array $props)
 	{
 		// clean up the slug
-		$props['slug']     = Str::slug($props['slug'] ?? $props['content']['title'] ?? null);
-		$props['template'] = $props['model'] = strtolower($props['template'] ?? 'default');
-		$props['isDraft']  ??= ($props['draft'] ?? true);
+		$props['slug']      = Str::slug($props['slug'] ?? $props['content']['title'] ?? null);
+		$props['template']  = $props['model'] = strtolower($props['template'] ?? 'default');
+		$props['isDraft'] ??= $props['draft'] ?? true;
 
 		// make sure that a UUID gets generated and
 		// added to content right away

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -523,7 +523,7 @@ trait PageActions
 		// clean up the slug
 		$props['slug']     = Str::slug($props['slug'] ?? $props['content']['title'] ?? null);
 		$props['template'] = $props['model'] = strtolower($props['template'] ?? 'default');
-		$props['isDraft']  ??= true;
+		$props['isDraft']  ??= ($props['draft'] ?? true);
 
 		// make sure that a UUID gets generated and
 		// added to content right away

--- a/tests/Cms/Pages/PageCreateTest.php
+++ b/tests/Cms/Pages/PageCreateTest.php
@@ -124,6 +124,22 @@ class PageCreateTest extends TestCase
 		$this->assertTrue($site->children()->has($page));
 	}
 
+	public function testCreateUnlistedPage()
+	{
+		$site = $this->app->site();
+		$page = Page::create([
+			'slug'    => 'new-page',
+			'isDraft' => false,
+		]);
+
+		$this->assertTrue($page->exists());
+		$this->assertInstanceOf(Page::class, $page);
+		$this->assertFalse($page->isDraft());
+		$this->assertFalse($page->isListed());
+		$this->assertTrue($page->parentModel()->children()->has($page));
+		$this->assertTrue($site->children()->has($page));
+	}
+
 	public function testCreateDuplicate()
 	{
 		$this->expectException(DuplicateException::class);

--- a/tests/Cms/Pages/PageCreateTest.php
+++ b/tests/Cms/Pages/PageCreateTest.php
@@ -124,11 +124,28 @@ class PageCreateTest extends TestCase
 		$this->assertTrue($site->children()->has($page));
 	}
 
-	public function testCreateUnlistedPage()
+	public function testCreateUnlistedPageDraftProp()
+	{
+		$site = $this->app->site();
+		$page = Page::create([
+			'slug'  => 'new-page',
+			'draft' => false,
+		]);
+
+		$this->assertTrue($page->exists());
+		$this->assertInstanceOf(Page::class, $page);
+		$this->assertFalse($page->isDraft());
+		$this->assertFalse($page->isListed());
+		$this->assertTrue($page->parentModel()->children()->has($page));
+		$this->assertTrue($site->children()->has($page));
+	}
+
+	public function testCreateUnlistedPageIsDraftProp()
 	{
 		$site = $this->app->site();
 		$page = Page::create([
 			'slug'    => 'new-page',
+			'draft'   => true,
 			'isDraft' => false,
 		]);
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->
Fixes code to match documentation for props array, also allows creation of unlisted pages by setting `isDraft` prop to true and leaving `num` empty (this currently doesn't work). Fixes issue https://github.com/getkirby/kirby/issues/5042

### Fixes
Issue https://github.com/getkirby/kirby/issues/5042

### Breaking changes
Should not introduce breaking change


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
