### PR TITLE
Correct "Logout" menu label to "Log out"

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -388,7 +388,7 @@
 	"login.toggleText.password-reset.email": "Forgot your password?",
 	"login.toggleText.password-reset.email-password": "← Back to login",
 
-	"logout": "Logout",
+	"logout": "Log out",
 
 	"menu": "Menu",
 	"meridiem": "AM/PM",

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -568,7 +568,7 @@ class ViewTest extends TestCase
 			'icon' => 'logout',
 			'id'   => 'logout',
 			'link' => 'logout',
-			'text' => 'Logout'
+			'text' => 'Log out'
 		];
 
 		$this->assertCount(4, $menu);


### PR DESCRIPTION
Corrected the menu label from "Logout" (noun) to "Log out" (verb).

<img width="164" alt="Screenshot 2023-02-08 at 10 45 55@2x" src="https://user-images.githubusercontent.com/329880/217508168-fe5555e8-93c9-40c5-adda-ddd452e053d0.png">

(I should have picked this up in #4482 !)