### PR TITLE
Provide `$field` prop to block/layout objects

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -66,7 +66,8 @@ return function (App $app) {
 			try {
 				$blocks = Blocks::parse($field->value());
 				$blocks = Blocks::factory($blocks, [
-					'parent' => $field->parent()
+					'parent' => $field->parent(),
+					'field'  => $field,
 				]);
 				return $blocks->filter('isHidden', false);
 			} catch (Throwable) {
@@ -192,7 +193,8 @@ return function (App $app) {
 		 */
 		'toLayouts' => function (Field $field) {
 			return Layouts::factory(Layouts::parse($field->value()), [
-				'parent' => $field->parent()
+				'parent' => $field->parent(),
+				'field'  => $field,
 			]);
 		},
 

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -27,6 +27,11 @@ class Item
 	public const ITEMS_CLASS = Items::class;
 
 	/**
+	 * @var \Kirby\Cms\Field|null
+	 */
+	protected $field;
+
+	/**
 	 * @var string
 	 */
 	protected $id;
@@ -57,6 +62,7 @@ class Item
 
 		$this->id       = $params['id']       ?? Str::uuid();
 		$this->params   = $params;
+		$this->field    = $params['field']    ?? null;
 		$this->parent   = $params['parent']   ?? App::instance()->site();
 		$this->siblings = $params['siblings'] ?? new $siblingsClass();
 	}
@@ -70,6 +76,14 @@ class Item
 	public static function factory(array $params)
 	{
 		return new static($params);
+	}
+
+	/**
+	 * Returns the parent field if known
+	 */
+	public function field(): Field|null
+	{
+		return $this->field;
 	}
 
 	/**

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -26,10 +26,7 @@ class Item
 
 	public const ITEMS_CLASS = Items::class;
 
-	/**
-	 * @var \Kirby\Cms\Field|null
-	 */
-	protected $field;
+	protected Field|null $field;
 
 	/**
 	 * @var string

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -20,6 +20,11 @@ class Items extends Collection
 	public const ITEM_CLASS = Item::class;
 
 	/**
+	 * @var \Kirby\Cms\Field|null
+	 */
+	protected $field;
+
+	/**
 	 * @var array
 	 */
 	protected $options;
@@ -39,6 +44,7 @@ class Items extends Collection
 	{
 		$this->options = $options;
 		$this->parent  = $options['parent'] ?? App::instance()->site();
+		$this->field   = $options['field']  ?? null;
 
 		parent::__construct($objects, $this->parent);
 	}
@@ -54,6 +60,7 @@ class Items extends Collection
 	public static function factory(array $items = null, array $params = [])
 	{
 		$options = array_merge([
+			'field'   => null,
 			'options' => [],
 			'parent'  => App::instance()->site(),
 		], $params);
@@ -74,6 +81,7 @@ class Items extends Collection
 				continue;
 			}
 
+			$params['field']    = $options['field'];
 			$params['options']  = $options['options'];
 			$params['parent']   = $options['parent'];
 			$params['siblings'] = $collection;
@@ -83,6 +91,14 @@ class Items extends Collection
 		}
 
 		return $collection;
+	}
+
+	/**
+	 * Returns the parent field if known
+	 */
+	public function field(): Field|null
+	{
+		return $this->field;
 	}
 
 	/**

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -19,10 +19,7 @@ class Items extends Collection
 {
 	public const ITEM_CLASS = Item::class;
 
-	/**
-	 * @var \Kirby\Cms\Field|null
-	 */
-	protected $field;
+	protected Field|null $field;
 
 	/**
 	 * @var array

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -56,6 +56,7 @@ class Layout extends Item
 		parent::__construct($params);
 
 		$this->columns = LayoutColumns::factory($params['columns'] ?? [], [
+			'field'  => $this->field,
 			'parent' => $this->parent
 		]);
 

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -41,6 +41,7 @@ class LayoutColumn extends Item
 		parent::__construct($params);
 
 		$this->blocks = Blocks::factory($params['blocks'] ?? [], [
+			'field'  => $this->field,
 			'parent' => $this->parent
 		]);
 

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -98,6 +98,9 @@ class Layouts extends Items
 			}
 		}
 
-		return Blocks::factory($blocks);
+		return Blocks::factory($blocks, [
+			'field'  => $this->field,
+			'parent' => $this->parent
+		]);
 	}
 }

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -880,6 +880,7 @@ class FieldMethodsTest extends TestCase
 		$page    = kirby()->page('files');
 		$field   = new Field($page, 'test', json_encode($data));
 		$layouts = $field->toLayouts();
+		$blocks  = $layouts->toBlocks();
 
 		$this->assertInstanceOf(Layouts::class, $layouts);
 		$this->assertSame($page, $layouts->parent());
@@ -893,6 +894,10 @@ class FieldMethodsTest extends TestCase
 		$this->assertArrayHasKey('attrs', $array);
 		$this->assertArrayHasKey('columns', $array);
 		$this->assertArrayHasKey('id', $array);
+
+		$block = $blocks->first();
+		$this->assertSame($page, $block->parent());
+		$this->assertEquals($field, $block->field());
 	}
 
 	public function testToObject()

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -825,7 +825,8 @@ class FieldMethodsTest extends TestCase
 		];
 
 		$json   = Json::encode($data);
-		$field  = new Field(kirby()->page('files'), 'test', $json);
+		$page   = kirby()->page('files');
+		$field  = new Field($page, 'test', $json);
 		$blocks = $field->toBlocks();
 
 		$this->assertInstanceOf(Blocks::class, $blocks);
@@ -836,6 +837,8 @@ class FieldMethodsTest extends TestCase
 		foreach ($data as $index => $row) {
 			$block = $blocks->nth($index);
 
+			$this->assertSame($page, $block->parent());
+			$this->assertEquals($field, $block->field()); // cannot use strict assertion (cloned object)
 			$this->assertSame($row['type'], $block->type());
 			$this->assertSame($row['content'], $block->content()->data());
 			$this->assertNotEmpty($block->toHtml());
@@ -874,17 +877,22 @@ class FieldMethodsTest extends TestCase
 			]
 		];
 
-		$field = $this->field(json_encode($data));
+		$page    = kirby()->page('files');
+		$field   = new Field($page, 'test', json_encode($data));
 		$layouts = $field->toLayouts();
 
 		$this->assertInstanceOf(Layouts::class, $layouts);
-		$this->assertInstanceOf(Site::class, $layouts->parent());
+		$this->assertSame($page, $layouts->parent());
 		$this->assertCount(1, $layouts->data());
 
-		$layout = $layouts->first()->toArray();
-		$this->assertArrayHasKey('attrs', $layout);
-		$this->assertArrayHasKey('columns', $layout);
-		$this->assertArrayHasKey('id', $layout);
+		$layout = $layouts->first();
+		$this->assertSame($page, $layout->parent());
+		$this->assertEquals($field, $layout->field()); // cannot use strict assertion (cloned object)
+
+		$array = $layout->toArray();
+		$this->assertArrayHasKey('attrs', $array);
+		$this->assertArrayHasKey('columns', $array);
+		$this->assertArrayHasKey('id', $array);
 	}
 
 	public function testToObject()

--- a/tests/Cms/Items/ItemTest.php
+++ b/tests/Cms/Items/ItemTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class ItemTest extends TestCase
 {
 	protected $app;
+	protected $field;
 	protected $page;
 
 	public function setUp(): void
@@ -17,7 +18,8 @@ class ItemTest extends TestCase
 			],
 		]);
 
-		$this->page = new Page(['slug' => 'test']);
+		$this->page  = new Page(['slug' => 'test']);
+		$this->field = new Field($this->page, 'test', 'abcde');
 	}
 
 	public function testConstruct()
@@ -28,6 +30,16 @@ class ItemTest extends TestCase
 		$this->assertSame($this->app, $item->kirby());
 		$this->assertInstanceOf(Site::class, $item->parent());
 		$this->assertInstanceOf(Items::class, $item->siblings());
+	}
+
+	public function testField()
+	{
+		$item = new Item([
+			'parent' => $this->page,
+			'field'  => $this->field
+		]);
+
+		$this->assertSame($this->field, $item->field());
 	}
 
 	public function testIs()

--- a/tests/Cms/Items/ItemsTest.php
+++ b/tests/Cms/Items/ItemsTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class ItemsTest extends TestCase
 {
 	protected $app;
+	protected $field;
 	protected $page;
 
 	public function setUp(): void
@@ -17,7 +18,8 @@ class ItemsTest extends TestCase
 			],
 		]);
 
-		$this->page = new Page(['slug' => 'test']);
+		$this->page  = new Page(['slug' => 'test']);
+		$this->field = new Field($this->page, 'test', 'abcde');
 	}
 
 	public function testConstruct()
@@ -37,19 +39,41 @@ class ItemsTest extends TestCase
 
 	public function testFactoryFromArray()
 	{
-		$items = Items::factory([
+		$items = Items::factory(
 			[
-				'id' => 'a',
+				[
+					'id' => 'a',
+				],
+				[
+					'id' => 'b',
+				]
 			],
 			[
-				'id' => 'b',
+				'parent' => $this->page,
+				'field'  => $this->field
 			]
-		]);
+		);
 
 		$this->assertCount(2, $items);
 		$this->assertSame($items, $items->first()->siblings());
 		$this->assertSame('a', $items->first()->id());
 		$this->assertSame('b', $items->last()->id());
+		$this->assertSame($this->page, $items->first()->parent());
+		$this->assertSame($this->field, $items->first()->field());
+	}
+
+	public function testField()
+	{
+		$items = new Items([]);
+
+		$this->assertNull($items->field());
+
+		$items = new Blocks([], [
+			'parent' => $this->page,
+			'field'  => $this->field
+		]);
+
+		$this->assertSame($this->field, $items->field());
 	}
 
 	public function testParent()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- Block and layout objects for the blocks and layout fields now allow access to the parent field object with `$block->field()`, `$layout->field()` and `$layoutColumn->field()`.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
