### PR TITLE
Fix `->inline()`, `->nl2br()` and `->toTimestamp()` field methods when field is empty or not exists

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -278,10 +278,10 @@ return function (App $app) {
 		 * Converts the field value to a Unix timestamp
 		 *
 		 * @param \Kirby\Cms\Field $field
-		 * @return int
+		 * @return int|false
 		 */
-		'toTimestamp' => function (Field $field): int {
-			return strtotime($field->value);
+		'toTimestamp' => function (Field $field): int|false {
+			return strtotime($field->value ?? '');
 		},
 
 		/**

--- a/config/methods.php
+++ b/config/methods.php
@@ -483,7 +483,7 @@ return function (App $app) {
 		 * @return \Kirby\Cms\Field
 		 */
 		'nl2br' => function (Field $field) {
-			$field->value = nl2br($field->value, false);
+			$field->value = nl2br($field->value ?? '', false);
 			return $field;
 		},
 

--- a/config/methods.php
+++ b/config/methods.php
@@ -396,7 +396,7 @@ return function (App $app) {
 			// Obsolete elements, script tags, image maps and form elements have
 			// been excluded for safety reasons and as they are most likely not
 			// needed in most cases.
-			$field->value = strip_tags($field->value, Html::$inlineList);
+			$field->value = strip_tags($field->value ?? '', Html::$inlineList);
 			return $field;
 		},
 

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -540,6 +540,7 @@ class FieldMethodsTest extends TestCase
 		$expected = 'Multiline<br>' . PHP_EOL . 'test<br>' . PHP_EOL . 'string';
 
 		$this->assertSame($expected, $this->field($input)->nl2br()->value());
+		$this->assertSame('', $this->field(null)->nl2br()->value());
 	}
 
 	public function testKirbytext()

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -406,6 +406,15 @@ class FieldMethodsTest extends TestCase
 		$field->toStructure();
 	}
 
+	public function testToTimestamp()
+	{
+		$field = $this->field('2012-12-12');
+		$ts    = strtotime('2012-12-12');
+
+		$this->assertSame($ts, $field->toTimestamp());
+		$this->assertFalse($this->field(null)->toTimestamp());
+	}
+
 	public function testToDefaultUrl()
 	{
 		$field    = $this->field('super/cool');

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -531,6 +531,7 @@ class FieldMethodsTest extends TestCase
 		$expected = 'Headline Subtitle with <a href="#">link</a>.';
 
 		$this->assertSame($expected, $this->field($html)->inline()->value());
+		$this->assertSame('', $this->field(null)->inline()->value());
 	}
 
 	public function testNl2br()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fixes `->inline()`, `->nl2br()` and `->toTimestamp()` field methods when field is empty or not exists

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
