### PR TITLE
Fix `alt` attribute issue for `asset()` helper

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Image;
 
+use Kirby\Cms\Content;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\File;
 use Kirby\Toolkit\Html;
@@ -114,8 +115,13 @@ class Image extends File
 	{
 		// if no alt text explicitly provided,
 		// try to infer from model content file
-		if ($alt = $this->model?->alt()) {
-			$attr['alt'] ??= $alt;
+		if (
+			$this->model !== null &&
+			method_exists($this->model, 'content') === true &&
+			$this->model->content() instanceof Content &&
+			$this->model->content()->get('alt')->isNotEmpty() === true
+		) {
+			$attr['alt'] ??= $this->model->content()->get('alt')->value();
 		}
 
 		if ($url = $this->url()) {

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -84,6 +84,12 @@ class AssetTest extends TestCase
 		$this->assertSame($this->app->url('media') . '/' . $mediaPath, $asset->mediaUrl());
 	}
 
+	public function testToString()
+	{
+		$asset = $this->_asset();
+		$this->assertSame('<img alt="" src="https://getkirby.com/images/logo.svg">', $asset->__toString());
+	}
+
 	public function testNonExistingMethod()
 	{
 		$asset = $this->_asset();


### PR DESCRIPTION
## This PR …

Fixes #4915 regression with implementing the solution in https://github.com/getkirby/kirby/issues/5065#issuecomment-1442282214 of @lukasbestle 

### Fixes
- Fix `alt` attribute issue for `asset()` helper #5065

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
