### PR TITLE
`Dir::index()`: fix `$ignore` parameter

### DIFF
--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -143,7 +143,7 @@ class Dir
 	public static function index(
 		string $dir,
 		bool $recursive = false,
-		array|null $ignore = null,
+		array|null $ignore = [],
 		string $path = null
 	): array {
 		$result = [];
@@ -151,6 +151,10 @@ class Dir
 		$items  = static::read($dir);
 
 		foreach ($items as $item) {
+			if (in_array($item, $ignore) === true) {
+				continue;
+			}
+
 			$root     = $dir . '/' . $item;
 			$entry    = $path !== null ? $path . '/' . $item : $item;
 			$result[] = $entry;

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -169,10 +169,10 @@ class DirTest extends TestCase
 	public function testIndex()
 	{
 		Dir::make($dir = $this->tmp);
-		Dir::make($sub = $this->tmp . '/sub');
+		Dir::make($this->tmp . '/sub');
 
-		F::write($a = $this->tmp . '/a.txt', 'test');
-		F::write($b = $this->tmp . '/b.txt', 'test');
+		F::write($this->tmp . '/a.txt', 'test');
+		F::write($this->tmp . '/b.txt', 'test');
 
 		$expected = [
 			'a.txt',
@@ -189,12 +189,12 @@ class DirTest extends TestCase
 	public function testIndexRecursive()
 	{
 		Dir::make($dir = $this->tmp);
-		Dir::make($sub = $this->tmp . '/sub');
-		Dir::make($subsub = $this->tmp . '/sub/sub');
+		Dir::make($this->tmp . '/sub');
+		Dir::make($this->tmp . '/sub/sub');
 
-		F::write($a = $this->tmp . '/a.txt', 'test');
-		F::write($b = $this->tmp . '/sub/b.txt', 'test');
-		F::write($c = $this->tmp . '/sub/sub/c.txt', 'test');
+		F::write($this->tmp . '/a.txt', 'test');
+		F::write($this->tmp . '/sub/b.txt', 'test');
+		F::write($this->tmp . '/sub/sub/c.txt', 'test');
 
 		$expected = [
 			'a.txt',
@@ -205,6 +205,33 @@ class DirTest extends TestCase
 		];
 
 		$this->assertSame($expected, Dir::index($dir, true));
+	}
+
+	/**
+	 * @covers ::index
+	 */
+	public function testIndexIgnore()
+	{
+		Dir::make($dir = $this->tmp);
+		Dir::make($this->tmp . '/sub');
+		Dir::make($this->tmp . '/sub/sub');
+
+		F::write($this->tmp . '/a.txt', 'test');
+		F::write($this->tmp . '/d.txt', 'test');
+		F::write($this->tmp . '/sub/a.txt', 'test');
+		F::write($this->tmp . '/sub/b.txt', 'test');
+		F::write($this->tmp . '/sub/sub/a.txt', 'test');
+		F::write($this->tmp . '/sub/sub/c.txt', 'test');
+
+		$expected = [
+			'd.txt',
+			'sub',
+			'sub/b.txt',
+			'sub/sub',
+			'sub/sub/c.txt'
+		];
+
+		$this->assertSame($expected, Dir::index($dir, true, ['a.txt']));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `Dir::index()`: `$ignore` parameter works now 
 #5010

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
