### PR TITLE
Fix translated blueprint title

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -77,7 +77,8 @@ class Blueprint
 		$props['name'] ??= 'default';
 
 		// normalize and translate the title
-		$props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
+		$props['title'] ??= ucfirst($props['name']);
+		$props['title']   = $this->i18n($props['title']);
 
 		// convert all shortcuts
 		$props = $this->convertFieldsToSections('main', $props);
@@ -311,14 +312,14 @@ class Blueprint
 
 	/**
 	 * Used to translate any label, heading, etc.
-	 *
-	 * @param mixed $value
-	 * @param mixed $fallback
-	 * @return mixed
 	 */
-	protected function i18n($value, $fallback = null)
-	{
-		return I18n::translate($value, $fallback ?? $value);
+	protected function i18n(
+		string|array|null $value,
+		string|array $fallback = null
+	): string|null {
+		// use $value as final fallback to show i18n strings
+		// (e.g. my.editor.title) when no actual translation is found
+		return I18n::translate($value, $fallback) ?? $value;
 	}
 
 	/**
@@ -341,20 +342,10 @@ class Blueprint
 	{
 		$props = static::find($name);
 
-		$normalize = function ($props) use ($name) {
-			// inject the filename as name if no name is set
-			$props['name'] ??= $name;
+		// inject the filename as name if no name is set
+		$props['name'] ??= $name;
 
-			// normalize the title
-			$title = $props['title'] ?? ucfirst($props['name']);
-
-			// translate the title
-			$props['title'] = I18n::translate($title, $title);
-
-			return $props;
-		};
-
-		return $normalize($props);
+		return $props;
 	}
 
 	/**

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -171,7 +171,7 @@ class Role extends Model
 	 */
 	protected function setDescription($description = null)
 	{
-		$this->description = I18n::translate($description, $description);
+		$this->description = I18n::translate($description) ?? $description;
 		return $this;
 	}
 
@@ -201,7 +201,7 @@ class Role extends Model
 	 */
 	protected function setTitle($title = null)
 	{
-		$this->title = I18n::translate($title, $title);
+		$this->title = I18n::translate($title) ?? $title;
 		return $this;
 	}
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -25,55 +25,46 @@ class I18n
 
 	/**
 	 * Current locale
-	 *
-	 * @var string|\Closure
 	 */
-	public static $locale = 'en';
+	public static string|Closure|null $locale = 'en';
 
 	/**
 	 * All registered translations
-	 *
-	 * @var array
 	 */
-	public static $translations = [];
+	public static array $translations = [];
 
 	/**
-	 * The fallback locale or a
-	 * list of fallback locales
-	 *
-	 * @var string|array|\Closure|null
+	 * The fallback locale or a list of fallback locales
 	 */
-	public static $fallback = ['en'];
+	public static string|array|Closure|null $fallback = ['en'];
 
 	/**
 	 * Cache of `NumberFormatter` objects by locale
-	 *
-	 * @var array
 	 */
-	protected static $decimalsFormatters = [];
+	protected static array $decimalsFormatters = [];
 
 	/**
 	 * Returns the list of fallback locales
 	 */
 	public static function fallbacks(): array
 	{
-		if (
-			is_array(static::$fallback) === true ||
-			is_string(static::$fallback) === true
-		) {
-			return A::wrap(static::$fallback);
+		if (is_callable(static::$fallback) === true) {
+			static::$fallback = (static::$fallback)();
 		}
 
-		if (is_callable(static::$fallback) === true) {
-			return static::$fallback = A::wrap((static::$fallback)());
+		if (is_array(static::$fallback) === true) {
+			return static::$fallback;
+		}
+
+		if (is_string(static::$fallback) === true) {
+			return A::wrap(static::$fallback);
 		}
 
 		return static::$fallback = ['en'];
 	}
 
 	/**
-	 * Returns singular or plural
-	 * depending on the given number
+	 * Returns singular or plural depending on the given number
 	 *
 	 * @param bool $none If true, 'none' will be returned if the count is 0
 	 */
@@ -98,16 +89,16 @@ class I18n
 	}
 
 	/**
-	 * Returns the locale code
+	 * Returns thecurrent locale code
 	 */
 	public static function locale(): string
 	{
-		if (is_string(static::$locale) === true) {
-			return static::$locale;
+		if (is_callable(static::$locale) === true) {
+			static::$locale = (static::$locale)();
 		}
 
-		if (is_callable(static::$locale) === true) {
-			return static::$locale = (static::$locale)();
+		if (is_string(static::$locale) === true) {
+			return static::$locale;
 		}
 
 		return static::$locale = 'en';
@@ -122,43 +113,27 @@ class I18n
 		string|array $fallback = null,
 		string $locale = null
 	): string|array|Closure|null {
+		// use current locale if no specific is passed
 		$locale ??= static::locale();
 
+		// array of translated strings ['en' => 'house', 'de' => 'Haus', …]
 		if (is_array($key) === true) {
-			// try to use actual locale
-			if ($result = $key[$locale] ?? null) {
-				return $result;
-			}
-			// try to use language code, e.g. `es` when locale is `es_ES`
-			if ($result = $key[Str::before($locale, '_')] ?? null) {
-				return $result;
-			}
-			// use global wildcard as i18n key
-			if (isset($key['*']) === true) {
-				return static::translate($key['*'], $key['*']);
-			}
-			// use fallback
-			if (is_array($fallback) === true) {
-				return
-					$fallback[$locale] ??
-					$fallback['en'] ??
-					reset($fallback);
-			}
-
-			return $fallback;
+			return static::translateFromTranslations($locale, $key, $fallback);
 		}
 
-		// $key is a string
+		// $key is a string, look up as key in translations table
 		if ($result = static::translation($locale)[$key] ?? null) {
 			return $result;
 		}
 
+		// if an explicit fallback has been passed
 		if ($fallback !== null) {
 			return $fallback;
 		}
 
+		// last resort: use translations for fallback locales
 		foreach (static::fallbacks() as $fallback) {
-			// skip locales we have already tried
+			// skip locale if we have already tried
 			if ($locale === $fallback) {
 				continue;
 			}
@@ -172,14 +147,45 @@ class I18n
 	}
 
 	/**
+	 * Choose translation from array based on the provided locale
+	 *
+	 * @param array $translations e.g. ['en' => 'house', 'de' => 'Haus', …]
+	 */
+	protected static function translateFromTranslations(
+		string $locale,
+		array $translations,
+		string|array $fallback = null
+	): string {
+		// try to use actual locale or
+		// shorter language code, e.g. `es` for `es_ES` locale
+		$result   = $translations[$locale] ?? null;
+		$result ??= $translations[Str::before($locale, '_')] ?? null;
+
+		if ($result) {
+			return $result;
+		}
+
+		// use global wildcard as i18n key
+		if ($wildcard = $translations['*'] ?? null) {
+			return static::translate($wildcard, $wildcard);
+		}
+
+		// use fallback
+		if (is_array($fallback) === false) {
+			return $fallback;
+		}
+
+		// try first fallback for locale, fallback for English as
+		// global default or, lastly, just go with the first entry
+		return
+			$fallback[$locale] ??
+			$fallback['en'] ??
+			reset($fallback);
+	}
+
+	/**
 	 * Translate by key and then replace
 	 * placeholders in the text
-	 *
-	 * @param string $key
-	 * @param string|array|null $fallback
-	 * @param array|null $replace
-	 * @param string|null $locale
-	 * @return string
 	 */
 	public static function template(
 		string $key,
@@ -194,6 +200,7 @@ class I18n
 		}
 
 		$template = static::translate($key, $fallback, $locale);
+
 		return Str::template($template, $replace, [
 			'fallback' => '-',
 			'start'    => '{',
@@ -210,8 +217,8 @@ class I18n
 	{
 		$locale ??= static::locale();
 
-		if (isset(static::$translations[$locale]) === true) {
-			return static::$translations[$locale];
+		if ($translation = static::$translations[$locale] ?? null) {
+			return $translation;
 		}
 
 		if (static::$load instanceof Closure) {
@@ -219,9 +226,8 @@ class I18n
 		}
 
 		// try to use language code, e.g. `es` when locale is `es_ES`
-		$lang = Str::before($locale, '_');
-		if (isset(static::$translations[$lang]) === true) {
-			return static::$translations[$lang];
+		if ($translation = static::$translations[Str::before($locale, '_')] ?? null) {
+			return $translation;
 		}
 
 		return static::$translations[$locale] = [];
@@ -240,8 +246,8 @@ class I18n
 	 */
 	protected static function decimalNumberFormatter(string $locale): NumberFormatter|null
 	{
-		if (isset(static::$decimalsFormatters[$locale]) === true) {
-			return static::$decimalsFormatters[$locale];
+		if ($formatter = static::$decimalsFormatters[$locale] ?? null) {
+			return $formatter;
 		}
 
 		if (
@@ -266,8 +272,12 @@ class I18n
 	 *
 	 * @param bool $formatNumber If set to `false`, the count is not formatted
 	 */
-	public static function translateCount(string $key, int $count, string $locale = null, bool $formatNumber = true)
-	{
+	public static function translateCount(
+		string $key,
+		int $count,
+		string $locale = null,
+		bool $formatNumber = true
+	) {
 		$locale    ??= static::locale();
 		$translation = static::translate($key, null, $locale);
 

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -249,6 +249,40 @@ class BlueprintTest extends TestCase
 		$this->assertSame('success', $blueprint->title());
 	}
 
+	public function testTitleTranslatedFallbackForRoles()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true,
+					'translations' => [
+						'my.custom.role' => 'My custom role'
+					]
+				],
+				[
+					'code' => 'de',
+					'translations' => []
+				]
+			],
+			'blueprints' => [
+				'users/editor' => [
+					'name' => 'editor',
+					'title' => 'my.custom.role'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('de');
+		$app->setCurrentLanguage('de');
+
+		$role = $app->roles()->get('editor')->title();
+		$this->assertSame('My custom role', $role);
+	}
+
 	/**
 	 * @covers ::title
 	 */

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -230,6 +231,22 @@ class BlueprintTest extends TestCase
 		]);
 
 		$this->assertSame('Test', $blueprint->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleTranslatedFallback()
+	{
+		I18n::$locale       = 'de';
+		I18n::$translations = ['en' => ['my.i18n.string' => 'success']];
+
+		$blueprint = new Blueprint([
+			'title' => 'my.i18n.string',
+			'model' => $this->model
+		]);
+
+		$this->assertSame('success', $blueprint->title());
 	}
 
 	/**

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -34,19 +34,13 @@ class I18nTest extends TestCase
 		I18n::$fallback = null;
 		$this->assertSame(['en'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return 'de';
-		};
+		I18n::$fallback = fn () => 'de';
 		$this->assertSame(['de'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return ['de'];
-		};
+		I18n::$fallback = fn () => ['de'];
 		$this->assertSame(['de'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return ['de', 'en'];
-		};
+		I18n::$fallback = fn () => ['de', 'en'];
 		$this->assertSame(['de', 'en'], I18n::fallbacks());
 	}
 
@@ -92,9 +86,7 @@ class I18nTest extends TestCase
 		I18n::$locale = 'de';
 		$this->assertSame('de', I18n::locale());
 
-		I18n::$locale = function () {
-			return 'de';
-		};
+		I18n::$locale = fn () => 'de';
 		$this->assertSame('de', I18n::locale());
 
 		I18n::$locale = null;
@@ -111,9 +103,10 @@ class I18nTest extends TestCase
 				'template' => 'This is a {test}'
 			]
 		];
-		$this->assertSame('This is a test template', I18n::template('template', [
-			'test' => 'test template'
-		]));
+		$this->assertSame(
+			'This is a test template',
+			I18n::template('template', ['test' => 'test template'])
+		);
 
 		// with fallback
 		I18n::$translations = [
@@ -121,12 +114,14 @@ class I18nTest extends TestCase
 				'template' => 'This is a {test}'
 			]
 		];
-		$this->assertSame('This is a fallback', I18n::template('does-not-exist', 'This is a fallback', [
-			'test' => 'test template'
-		]));
-		$this->assertSame('This is a test fallback', I18n::template('does-not-exist', 'This is a {test}', [
-			'test' => 'test fallback'
-		]));
+		$this->assertSame(
+			'This is a fallback',
+			I18n::template('does-not-exist', 'This is a fallback', ['test' => 'test template'])
+		);
+		$this->assertSame(
+			'This is a test fallback',
+			I18n::template('does-not-exist', 'This is a {test}', ['test' => 'test fallback'])
+		);
 
 		// with locale
 		I18n::$translations = [
@@ -138,9 +133,10 @@ class I18nTest extends TestCase
 			]
 		];
 
-		$this->assertSame('Das ist ein test template', I18n::template('template', null, [
-			'test' => 'test template'
-		], 'de'));
+		$this->assertSame(
+			'Das ist ein test template',
+			I18n::template('template', null, ['test' => 'test template'], 'de')
+		);
 	}
 
 	/**
@@ -149,23 +145,11 @@ class I18nTest extends TestCase
 	public function testTranslate()
 	{
 		I18n::$translations = [
-			'en' => [
-				'save' => 'Speichern'
-			]
+			'en' => ['save' => 'Speichern']
 		];
 
 		$this->assertSame('Speichern', I18n::translate('save'));
 		$this->assertNull(I18n::translate('invalid'));
-	}
-
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslateWithLanguageCode()
-	{
-		I18n::$locale = 'es_ES';
-
-		$this->assertSame('vamos', I18n::translate(['es' => 'vamos']));
 	}
 
 	/**
@@ -204,58 +188,61 @@ class I18nTest extends TestCase
 
 	/**
 	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateWithArrayFallback()
+	public function testTranslateWithLanguageCode()
 	{
-		I18n::$locale = 'de';
-
-		$input = [
+		I18n::$translations = [
+			'en' => ['go' => 'Let\'s go'],
+			'es' => ['go' => 'vamos']
 		];
 
-		$fallback = [
-			'en' => 'Save',
-			'de' => 'Speichern'
-		];
-
-		$this->assertSame('Speichern', I18n::translate($input, $fallback));
+		I18n::$locale = 'es_ES';
+		$this->assertSame('vamos', I18n::translate('go'));
 	}
 
 	/**
 	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArray()
+	public function testTranslateFromTranslations()
 	{
-		$this->assertSame('Save', I18n::translate([
-			'en' => 'Save',
-		]));
+		$this->assertSame('Save', I18n::translate(['en' => 'Save']));
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithFallback()
+	public function testTranslateFromTranslationsWithFallback()
 	{
-		$this->assertSame('fallback', I18n::translate([
-			'de' => 'Save',
-		], 'fallback'));
+		$this->assertSame(
+			'fallback',
+			I18n::translate(['de' => 'Save'], 'fallback')
+		);
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithArrayFallback()
+	public function testTranslateFromTranslationsWithArrayFallback()
 	{
 		// use the english translation as fallback if available
-		$this->assertSame('Save', I18n::translate(['de' => 'Speichern'], ['en' => 'Save']));
+		$this->assertSame(
+			'Save',
+			I18n::translate(['de' => 'Speichern'], ['en' => 'Save'])
+		);
 
 		// use the first value if there's no english translation
-		$this->assertSame('Fallback', I18n::translate(['de' => 'Speichern'], ['first' => 'Fallback']));
+		$this->assertSame(
+			'Fallback',
+			I18n::translate(['de' => 'Speichern'], ['first' => 'Fallback'])
+		);
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithDifferentLocale()
+	public function testTranslateFromTranslationsWithDifferentLocale()
 	{
 		I18n::$locale = 'de';
 
@@ -266,9 +253,9 @@ class I18nTest extends TestCase
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithI18nKey()
+	public function testTranslateFromTranslationsWithI18nKey()
 	{
 		I18n::$locale = 'de';
 
@@ -276,15 +263,13 @@ class I18nTest extends TestCase
 			'de' => ['save' => 'Speichern']
 		];
 
-		$this->assertSame('Speichern', I18n::translate([
-			'*' => 'save'
-		]));
+		$this->assertSame('Speichern', I18n::translate(['*' => 'save']));
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithFallbackEnglish()
+	public function testTranslateFromTranslationsWithFallbackEnglish()
 	{
 		I18n::$locale = 'de';
 
@@ -293,13 +278,16 @@ class I18nTest extends TestCase
 			'es' => 'Algunos'
 		];
 
-		$this->assertSame('Some', I18n::translate($translations, $translations));
+		$this->assertSame(
+			'Some',
+			I18n::translate($translations, $translations)
+		);
 	}
 
 	/**
-	 * @covers ::translate
+	 * @covers ::translateFromTranslations
 	 */
-	public function testTranslateArrayWithFallbackFirstLanguage()
+	public function testTranslateFromTranslationsWithFallbackFirstLanguage()
 	{
 		I18n::$locale = 'en';
 
@@ -308,7 +296,10 @@ class I18nTest extends TestCase
 			'de' => 'Einige',
 		];
 
-		$this->assertSame('Algunos', I18n::translate($translations, $translations));
+		$this->assertSame(
+			'Algunos',
+			I18n::translate($translations, $translations)
+		);
 	}
 
 	/**
@@ -415,15 +406,9 @@ class I18nTest extends TestCase
 	public function testTranslation()
 	{
 		I18n::$translations = [
-			'en' => [
-				'test' => 'yay'
-			],
-			'de' => [
-				'test' => 'juhu'
-			],
-			'es' => [
-				'test' => 'vamos'
-			]
+			'en' => ['test' => 'yay'],
+			'de' => ['test' => 'juhu'],
+			'es' => ['test' => 'vamos']
 		];
 
 		I18n::$locale = 'en';
@@ -446,17 +431,11 @@ class I18nTest extends TestCase
 	public function testTranslationLoad()
 	{
 		$translations = [
-			'en' => [
-				'test' => 'yay'
-			],
-			'de' => [
-				'test' => 'juhu'
-			]
+			'en' => ['test' => 'yay'],
+			'de' => ['test' => 'juhu']
 		];
 
-		I18n::$load = function ($locale) use ($translations) {
-			return $translations[$locale] ?? [];
-		};
+		I18n::$load = fn ($locale) => $translations[$locale] ?? [];
 
 		I18n::$locale = 'en';
 		$this->assertSame('yay', I18n::translate('test'));
@@ -477,9 +456,7 @@ class I18nTest extends TestCase
 		$this->assertSame([], I18n::translations());
 
 		I18n::$translations = $translations = [
-			'en' => [
-				'foo' => 'bar'
-			]
+			'en' => ['foo' => 'bar']
 		];
 
 		$this->assertSame($translations, I18n::translations());


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

The main change is here: https://github.com/getkirby/kirby/pull/5072/files#diff-b52d06f8dd9e8c5cfc7e124ef31d4654d293561b8ab1a75b65a4efad5b24dd28R322
Moving `?? $value` outside the method call.
The rest is cleaning up, so I could even understand our code :D

### Fixes
- Blueprints: when looking up i18n strings, fallback locales now take precedences over the i18n key as fallback
#4869 

### Breaking changes
None known


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
