### PR TITLE
Panel: Fix `field.isVisible` helper 

### DIFF
--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -93,16 +93,7 @@ export default {
 	},
 	methods: {
 		onAdd() {
-			this.object = {};
-
-			for (const fieldName in this.fields) {
-				const field = this.fields[fieldName];
-
-				if (field.default) {
-					this.object[fieldName] = this.$helper.clone(field.default);
-				}
-			}
-
+			this.object = this.$helper.field.form(this.fields);
 			this.$emit("input", this.object);
 			this.open();
 		},

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -369,15 +369,8 @@ export default {
 				return false;
 			}
 
-			// create entry data from field defaults
-			let data = {};
-
-			for (const fieldName in this.fields) {
-				data[fieldName] = this.$helper.clone(this.fields[fieldName].default);
-			}
-
 			this.currentIndex = "new";
-			this.currentModel = data;
+			this.currentModel = this.$helper.field.form(this.fields);
 
 			this.onFormOpen();
 		},

--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -1,3 +1,20 @@
+import { clone } from "./object.js";
+
+/**
+ * Creates form values for provided fields
+ * @param {Object} fields
+ * @returns {Object}
+ */
+export function form(fields) {
+	const form = {};
+
+	for (const fieldName in fields) {
+		form[fieldName] = clone(fields[fieldName].default);
+	}
+
+	return form;
+}
+
 /**
  * Evaluates the when option and field
  * type to check if a field should be
@@ -15,18 +32,21 @@ export function isVisible(field, values) {
 		return true;
 	}
 
-	let result = true;
-
-	Object.keys(field.when).forEach((key) => {
+	for (const key in field.when) {
 		const value = values[key.toLowerCase()];
 		const condition = field.when[key];
 
-		if (value !== condition) {
-			result = false;
+		// if condition is checking for empty field
+		if (value === undefined && (condition === "" || condition === [])) {
+			continue;
 		}
-	});
 
-	return result;
+		if (value !== condition) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**
@@ -57,6 +77,7 @@ export function subfields(field, fields) {
 }
 
 export default {
+	form,
 	isVisible,
 	subfields
 };

--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -21,7 +21,8 @@ export function form(fields) {
  * visible. Also works for sections.
  *
  * @param {object} field
- * @returns {object}
+ * @param {array} values
+ * @returns {boolean}
  */
 export function isVisible(field, values) {
 	if (field.type === "hidden") {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

- We cannot simply add an empty string as fallback here https://github.com/getkirby/kirby/pull/5076/files#diff-04e8dc6763a997696e500ceeb03a7f770ea1c14df821298111e13dbecaaeef5eR12 - this will screw with all fields that don't expect a string as value prop (e.g. blocks). They rely on `undefined` to have their prop default kick in.
- Instead we check in the `inVisible` helper if the `when` condition is set to an empty string that `undefined` will be just as fine

### Fixes
- Fix displaying conditional fields for empty `when` condition
#4838

### Enhancements
- New `$helper.field.form(fields)` function to set up values for an empty form

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
