### PR TITLE
Fix prev/next navigation for users view 

### DIFF
--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -143,12 +143,28 @@ class User extends Model
 	}
 
 	/**
+	 * Checks whether the user is on their own account page
+	 * by checking the session and the last part of the URL
+	 *
+	 * For examples:
+	 * /panel/users/*** > FALSE
+	 * /custom-panel-address/account > TRUE
+	 *
+	 * @internal
+	 */
+	protected function isAccountView(): bool
+	{
+		return $this->model->isLoggedIn() === true
+			&& $this->model->kirby()->request()->path()->last() === 'account';
+	}
+
+	/**
 	 * Returns the full path without leading slash
 	 */
 	public function path(): string
 	{
 		// path to your own account
-		if ($this->model->isLoggedIn() === true) {
+		if ($this->isAccountView() === true) {
 			return 'account';
 		}
 
@@ -193,7 +209,7 @@ class User extends Model
 	public function props(): array
 	{
 		$user    = $this->model;
-		$account = $user->isLoggedIn();
+		$account = $this->isAccountView();
 		$avatar  = $user->avatar();
 
 		return array_merge(


### PR DESCRIPTION
## This PR …

I came up with a simple solution. By checking the last part of the URL, I can tell if the user is on their own page or not, so I can dynamically send different dynamic props to the fiber.

It might be a very stupid idea 🙈, so I created the PR as a draft. If it makes sense to you, I'll keep working on it.

### Fixes
- Fix prev/next navigation for users view #4225

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
