### PR TITLE
Refactor `I18n::translate()`

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -77,7 +77,8 @@ class Blueprint
 		$props['name'] ??= 'default';
 
 		// normalize and translate the title
-		$props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
+		$props['title'] ??= ucfirst($props['name']);
+		$props['title']   = $this->i18n($props['title']);
 
 		// convert all shortcuts
 		$props = $this->convertFieldsToSections('main', $props);
@@ -221,14 +222,12 @@ class Blueprint
 
 	/**
 	 * Create a new blueprint for a model
-	 *
-	 * @param string $name
-	 * @param string|null $fallback
-	 * @param \Kirby\Cms\Model $model
-	 * @return static|null
 	 */
-	public static function factory(string $name, string $fallback = null, Model $model)
-	{
+	public static function factory(
+		string $name,
+		string $fallback = null,
+		Model $model
+	): static|null {
 		try {
 			$props = static::load($name);
 		} catch (Exception) {
@@ -318,7 +317,7 @@ class Blueprint
 	 */
 	protected function i18n($value, $fallback = null)
 	{
-		return I18n::translate($value, $fallback ?? $value);
+		return I18n::translate($value, $fallback) ?? $value;
 	}
 
 	/**
@@ -333,28 +332,21 @@ class Blueprint
 
 	/**
 	 * Loads a blueprint from file or array
-	 *
-	 * @param string $name
-	 * @return array
 	 */
 	public static function load(string $name): array
 	{
 		$props = static::find($name);
 
-		$normalize = function ($props) use ($name) {
-			// inject the filename as name if no name is set
-			$props['name'] ??= $name;
+		// inject the filename as name if no name is set
+		$props['name'] ??= $name;
 
-			// normalize the title
-			$title = $props['title'] ?? ucfirst($props['name']);
+		// normalize the title
+		$title = $props['title'] ?? ucfirst($props['name']);
 
-			// translate the title
-			$props['title'] = I18n::translate($title, $title);
+		// translate the title
+		$props['title'] = I18n::translate($title) ?? $title;
 
-			return $props;
-		};
-
-		return $normalize($props);
+		return $props;
 	}
 
 	/**

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -171,7 +171,7 @@ class Role extends Model
 	 */
 	protected function setDescription($description = null)
 	{
-		$this->description = I18n::translate($description, $description);
+		$this->description = I18n::translate($description) ?? $description;
 		return $this;
 	}
 
@@ -201,7 +201,7 @@ class Role extends Model
 	 */
 	protected function setTitle($title = null)
 	{
-		$this->title = I18n::translate($title, $title);
+		$this->title = I18n::translate($title) ?? $title;
 		return $this;
 	}
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -25,55 +25,46 @@ class I18n
 
 	/**
 	 * Current locale
-	 *
-	 * @var string|\Closure
 	 */
-	public static $locale = 'en';
+	public static string|Closure|null $locale = 'en';
 
 	/**
 	 * All registered translations
-	 *
-	 * @var array
 	 */
-	public static $translations = [];
+	public static array $translations = [];
 
 	/**
-	 * The fallback locale or a
-	 * list of fallback locales
-	 *
-	 * @var string|array|\Closure|null
+	 * The fallback locale or a list of fallback locales
 	 */
-	public static $fallback = ['en'];
+	public static string|array|Closure|null $fallback = ['en'];
 
 	/**
 	 * Cache of `NumberFormatter` objects by locale
-	 *
-	 * @var array
 	 */
-	protected static $decimalsFormatters = [];
+	protected static array $decimalsFormatters = [];
 
 	/**
 	 * Returns the list of fallback locales
 	 */
 	public static function fallbacks(): array
 	{
-		if (
-			is_array(static::$fallback) === true ||
-			is_string(static::$fallback) === true
-		) {
-			return A::wrap(static::$fallback);
+		if (is_callable(static::$fallback) === true) {
+			static::$fallback = (static::$fallback)();
 		}
 
-		if (is_callable(static::$fallback) === true) {
-			return static::$fallback = A::wrap((static::$fallback)());
+		if (is_array(static::$fallback) === true) {
+			return static::$fallback;
+		}
+
+		if (is_string(static::$fallback) === true) {
+			return A::wrap(static::$fallback);
 		}
 
 		return static::$fallback = ['en'];
 	}
 
 	/**
-	 * Returns singular or plural
-	 * depending on the given number
+	 * Returns singular or plural depending on the given number
 	 *
 	 * @param bool $none If true, 'none' will be returned if the count is 0
 	 */
@@ -98,88 +89,24 @@ class I18n
 	}
 
 	/**
-	 * Returns the locale code
+	 * Returns thecurrent locale code
 	 */
 	public static function locale(): string
 	{
-		if (is_string(static::$locale) === true) {
-			return static::$locale;
+		if (is_callable(static::$locale) === true) {
+			static::$locale = (static::$locale)();
 		}
 
-		if (is_callable(static::$locale) === true) {
-			return static::$locale = (static::$locale)();
+		if (is_string(static::$locale) === true) {
+			return static::$locale;
 		}
 
 		return static::$locale = 'en';
 	}
 
 	/**
-	 * Translates a given message
-	 * according to the currently set locale
-	 */
-	public static function translate(
-		string|array|null $key,
-		string|array $fallback = null,
-		string $locale = null
-	): string|array|Closure|null {
-		$locale ??= static::locale();
-
-		if (is_array($key) === true) {
-			// try to use actual locale
-			if ($result = $key[$locale] ?? null) {
-				return $result;
-			}
-			// try to use language code, e.g. `es` when locale is `es_ES`
-			if ($result = $key[Str::before($locale, '_')] ?? null) {
-				return $result;
-			}
-			// use global wildcard as i18n key
-			if (isset($key['*']) === true) {
-				return static::translate($key['*'], $key['*']);
-			}
-			// use fallback
-			if (is_array($fallback) === true) {
-				return
-					$fallback[$locale] ??
-					$fallback['en'] ??
-					reset($fallback);
-			}
-
-			return $fallback;
-		}
-
-		// $key is a string
-		if ($result = static::translation($locale)[$key] ?? null) {
-			return $result;
-		}
-
-		if ($fallback !== null) {
-			return $fallback;
-		}
-
-		foreach (static::fallbacks() as $fallback) {
-			// skip locales we have already tried
-			if ($locale === $fallback) {
-				continue;
-			}
-
-			if ($result = static::translation($fallback)[$key] ?? null) {
-				return $result;
-			}
-		}
-
-		return null;
-	}
-
-	/**
 	 * Translate by key and then replace
 	 * placeholders in the text
-	 *
-	 * @param string $key
-	 * @param string|array|null $fallback
-	 * @param array|null $replace
-	 * @param string|null $locale
-	 * @return string
 	 */
 	public static function template(
 		string $key,
@@ -194,11 +121,126 @@ class I18n
 		}
 
 		$template = static::translate($key, $fallback, $locale);
+
 		return Str::template($template, $replace, [
 			'fallback' => '-',
 			'start'    => '{',
 			'end'      => '}'
 		]);
+	}
+
+	/**
+	 * Translates either a given i18n key from global translations
+	 * or chooses correct entry from array of translations
+	 * according to the currently set locale
+	 */
+	public static function translate(
+		string|array|null $key,
+		string|array $fallback = null,
+		string $locale = null
+	): string|array|Closure|null {
+		// use current locale if no specific is passed
+		$locale ??= static::locale();
+		// create shorter locale code, e.g. `es` for `es_ES` locale
+		$shortLocale = Str::before($locale, '_');
+
+		// There are two main use cases that we will treat separately:
+		// (1) with a string representing an i18n key to be looked up
+		// (2) an array with entries per locale
+		//
+		// Both with various ways of handling fallbacks, provided
+		// explicitly via the parameter and/or from global defaults.
+
+		// (1) string $key: look up i18n string from global translations
+		if (is_string($key) === true) {
+			// look up locale in global translations list,
+			if ($result = static::translation($locale)[$key] ?? null) {
+				return $result;
+			}
+
+			// prefer any direct provided $fallback
+			// over further fallback alternatives
+			if ($fallback !== null) {
+				if (is_array($fallback) === true) {
+					return static::translate($fallback, null, $locale);
+				}
+
+				return $fallback;
+			}
+
+			// last resort: try using the fallback locales
+			foreach (static::fallbacks() as $fallback) {
+				// skip locale if we have already tried to save performance
+				if ($locale === $fallback) {
+					continue;
+				}
+
+				if ($result = static::translation($fallback)[$key] ?? null) {
+					return $result;
+				}
+			}
+
+			return null;
+		}
+
+		// --------
+		// (2) array|null $key with entries per locale
+
+		// try entry for long and short locale
+		if ($result = $key[$locale] ?? null) {
+			return $result;
+		}
+		if ($result = $key[$shortLocale] ?? null) {
+			return $result;
+		}
+
+		// if the array as a global wildcard entry,
+		// use this one as i18n key and try to resolve
+		// this via part (1) of this method
+		if ($wildcard = $key['*'] ?? null) {
+			if ($result = static::translate($wildcard, $wildcard, $locale)) {
+				return $result;
+			}
+		}
+
+		// if the $fallback parameter is an array, we can assume
+		// that it's also an array with entries per locale:
+		// check with long and short locale if we find a matching entry
+		if ($result = $fallback[$locale] ?? null) {
+			return $result;
+		}
+		if ($result = $fallback[$shortLocale] ?? null) {
+			return $result;
+		}
+
+		// all options for long/short actual locale have been exhausted,
+		// revert to the list of fallback locales and try with each of them
+		foreach (static::fallbacks() as $locale) {
+			// first on the original input
+			if ($result = $key[$locale] ?? null) {
+				return $result;
+			}
+			// then on the fallback
+			if ($result = $fallback[$locale] ?? null) {
+				return $result;
+			}
+		}
+
+		// if a string was provided as fallback, use that one
+		if (is_string($fallback) === true) {
+			return $fallback;
+		}
+
+		// otherwise the first array element of the input
+		// or the first array element of the fallback
+		if (is_array($key) === true) {
+			return reset($key);
+		}
+		if (is_array($fallback) === true) {
+			return reset($fallback);
+		}
+
+		return null;
 	}
 
 	/**
@@ -210,8 +252,8 @@ class I18n
 	{
 		$locale ??= static::locale();
 
-		if (isset(static::$translations[$locale]) === true) {
-			return static::$translations[$locale];
+		if ($translation = static::$translations[$locale] ?? null) {
+			return $translation;
 		}
 
 		if (static::$load instanceof Closure) {
@@ -219,9 +261,8 @@ class I18n
 		}
 
 		// try to use language code, e.g. `es` when locale is `es_ES`
-		$lang = Str::before($locale, '_');
-		if (isset(static::$translations[$lang]) === true) {
-			return static::$translations[$lang];
+		if ($translation = static::$translations[Str::before($locale, '_')] ?? null) {
+			return $translation;
 		}
 
 		return static::$translations[$locale] = [];
@@ -240,8 +281,8 @@ class I18n
 	 */
 	protected static function decimalNumberFormatter(string $locale): NumberFormatter|null
 	{
-		if (isset(static::$decimalsFormatters[$locale]) === true) {
-			return static::$decimalsFormatters[$locale];
+		if ($formatter = static::$decimalsFormatters[$locale] ?? null) {
+			return $formatter;
 		}
 
 		if (
@@ -266,8 +307,12 @@ class I18n
 	 *
 	 * @param bool $formatNumber If set to `false`, the count is not formatted
 	 */
-	public static function translateCount(string $key, int $count, string $locale = null, bool $formatNumber = true)
-	{
+	public static function translateCount(
+		string $key,
+		int $count,
+		string $locale = null,
+		bool $formatNumber = true
+	) {
 		$locale    ??= static::locale();
 		$translation = static::translate($key, null, $locale);
 

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -89,7 +89,7 @@ class I18n
 	}
 
 	/**
-	 * Returns thecurrent locale code
+	 * Returns the current locale code
 	 */
 	public static function locale(): string
 	{

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -230,6 +231,56 @@ class BlueprintTest extends TestCase
 		]);
 
 		$this->assertSame('Test', $blueprint->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleTranslatedFallback()
+	{
+		I18n::$locale       = 'de';
+		I18n::$translations = ['en' => ['my.i18n.string' => 'success']];
+
+		$blueprint = new Blueprint([
+			'title' => 'my.i18n.string',
+			'model' => $this->model
+		]);
+
+		$this->assertSame('success', $blueprint->title());
+	}
+
+	public function testTitleTranslatedFallbackForRoles()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true,
+					'translations' => [
+						'my.custom.role' => 'My custom role'
+					]
+				],
+				[
+					'code' => 'de',
+					'translations' => []
+				]
+			],
+			'blueprints' => [
+				'users/editor' => [
+					'name' => 'editor',
+					'title' => 'my.custom.role'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('de');
+		$app->setCurrentLanguage('de');
+
+		$role = $app->roles()->get('editor')->title();
+		$this->assertSame('My custom role', $role);
 	}
 
 	/**

--- a/tests/Cms/Users/UserBlueprintTest.php
+++ b/tests/Cms/Users/UserBlueprintTest.php
@@ -6,6 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 class UserBlueprintTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		Blueprint::$loaded = [];
+	}
+
 	public function testTranslatedDescription()
 	{
 		$blueprint = new UserBlueprint([
@@ -37,5 +42,168 @@ class UserBlueprintTest extends TestCase
 		];
 
 		$this->assertSame($expected, $blueprint->options());
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function testTitleI18n()
+	{
+		$app = new App([
+			'blueprints' => [
+				'users/editor' => [
+					'name'  => 'editor',
+					'title' => 'role.editor'
+				]
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true,
+					'translations' => [
+						'role.editor' => 'Editor role'
+					]
+				],
+				[
+					'code' => 'de',
+					'translations' => [
+						'role.editor' => 'Editor-Rolle'
+					],
+				]
+			],
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('de');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor-Rolle', $user->role()->title());
+
+		// clone app to test other language
+		// since $user object has not `->purge()` method
+		$app = $app->clone();
+		$app->setCurrentTranslation('en');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor role', $user->role()->title());
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function testTitleI18nWithFallbackLanguage()
+	{
+		$app = new App([
+			'blueprints' => [
+				'users/editor' => [
+					'name'  => 'editor',
+					'title' => 'role.editor'
+				]
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true,
+					'translations' => [
+						'role.editor' => 'Editor role'
+					]
+				],
+				[
+					'code' => 'de',
+					'translations' => [],
+				]
+			],
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('fr');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor role', $user->role()->title());
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function testTitleI18nArray()
+	{
+		$app = new App([
+			'blueprints' => [
+				'users/editor' => [
+					'name'  => 'editor',
+					'title' => [
+						'en' => 'Editor role',
+						'de' => 'Editor-Rolle'
+					]
+				]
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('de');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor-Rolle', $user->role()->title());
+
+		// clone app to test other language
+		// since $user object has not `->purge()` method
+		$app = $app->clone();
+		$app->setCurrentTranslation('en');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor role', $user->role()->title());
+	}
+
+	public function testTitleI18nArrayFallBack()
+	{
+		$app = new App([
+			'blueprints' => [
+				'users/editor' => [
+					'name'  => 'editor',
+					'title' => [
+						'en' => 'Editor role',
+						'de' => 'Editor-Rolle'
+					]
+				]
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			]
+		]);
+
+		$app->setCurrentTranslation('fr');
+		$user = $app->user('editor@getkirby.com');
+		$this->assertSame('Editor role', $user->role()->title());
 	}
 }

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -22,11 +22,11 @@ class I18nTest extends TestCase
 	 */
 	public function testFallbacks()
 	{
-		I18n::$fallback = 'en';
-		$this->assertSame(['en'], I18n::fallbacks());
+		I18n::$fallback = 'de';
+		$this->assertSame(['de'], I18n::fallbacks());
 
-		I18n::$fallback = ['en'];
-		$this->assertSame(['en'], I18n::fallbacks());
+		I18n::$fallback = ['de'];
+		$this->assertSame(['de'], I18n::fallbacks());
 
 		I18n::$fallback = ['en-us', 'en'];
 		$this->assertSame(['en-us', 'en'], I18n::fallbacks());
@@ -34,19 +34,13 @@ class I18nTest extends TestCase
 		I18n::$fallback = null;
 		$this->assertSame(['en'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return 'de';
-		};
+		I18n::$fallback = fn () => 'de';
 		$this->assertSame(['de'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return ['de'];
-		};
+		I18n::$fallback = fn () => ['de'];
 		$this->assertSame(['de'], I18n::fallbacks());
 
-		I18n::$fallback = function () {
-			return ['de', 'en'];
-		};
+		I18n::$fallback = fn () => ['de', 'en'];
 		$this->assertSame(['de', 'en'], I18n::fallbacks());
 	}
 
@@ -92,9 +86,7 @@ class I18nTest extends TestCase
 		I18n::$locale = 'de';
 		$this->assertSame('de', I18n::locale());
 
-		I18n::$locale = function () {
-			return 'de';
-		};
+		I18n::$locale = fn () => 'de';
 		$this->assertSame('de', I18n::locale());
 
 		I18n::$locale = null;
@@ -111,9 +103,10 @@ class I18nTest extends TestCase
 				'template' => 'This is a {test}'
 			]
 		];
-		$this->assertSame('This is a test template', I18n::template('template', [
-			'test' => 'test template'
-		]));
+		$this->assertSame(
+			'This is a test template',
+			I18n::template('template', ['test' => 'test template'])
+		);
 
 		// with fallback
 		I18n::$translations = [
@@ -121,12 +114,14 @@ class I18nTest extends TestCase
 				'template' => 'This is a {test}'
 			]
 		];
-		$this->assertSame('This is a fallback', I18n::template('does-not-exist', 'This is a fallback', [
-			'test' => 'test template'
-		]));
-		$this->assertSame('This is a test fallback', I18n::template('does-not-exist', 'This is a {test}', [
-			'test' => 'test fallback'
-		]));
+		$this->assertSame(
+			'This is a fallback',
+			I18n::template('does-not-exist', 'This is a fallback', ['test' => 'test template'])
+		);
+		$this->assertSame(
+			'This is a test fallback',
+			I18n::template('does-not-exist', 'This is a {test}', ['test' => 'test fallback'])
+		);
 
 		// with locale
 		I18n::$translations = [
@@ -138,20 +133,19 @@ class I18nTest extends TestCase
 			]
 		];
 
-		$this->assertSame('Das ist ein test template', I18n::template('template', null, [
-			'test' => 'test template'
-		], 'de'));
+		$this->assertSame(
+			'Das ist ein test template',
+			I18n::template('template', null, ['test' => 'test template'], 'de')
+		);
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslate()
+	public function testTranslateI18nKey()
 	{
 		I18n::$translations = [
-			'en' => [
-				'save' => 'Speichern'
-			]
+			'en' => ['save' => 'Speichern']
 		];
 
 		$this->assertSame('Speichern', I18n::translate('save'));
@@ -161,17 +155,40 @@ class I18nTest extends TestCase
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateWithLanguageCode()
+	public function testTranslateI18nKeyShortLocale()
 	{
-		I18n::$locale = 'es_ES';
+		I18n::$translations = [
+			'en' => ['go' => 'Let\'s go'],
+			'es' => ['go' => 'Vamos']
+		];
 
-		$this->assertSame('vamos', I18n::translate(['es' => 'vamos']));
+		I18n::$locale = 'es_ES';
+		$this->assertSame('Vamos', I18n::translate('go'));
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateWithFallback()
+	public function testTranslateI18nKeyWithFallbackStringArgument()
+	{
+		$this->assertSame('My fallback', I18n::translate('not.exist', 'My fallback'));
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateI18nKeyWithFallbackArrayArgument()
+	{
+		$this->assertSame('My fallback in array', I18n::translate('not.exist', [
+			'de' => 'Notfalllösung',
+			'en' => 'My fallback in array'
+		]));
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateI18nKeyWithFallbackLocales()
 	{
 		I18n::$translations = [
 			'en' => [
@@ -197,78 +214,24 @@ class I18nTest extends TestCase
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateWithFallbackArgument()
-	{
-		$this->assertSame('Save', I18n::translate('save', 'Save'));
-	}
-
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslateWithArrayFallback()
-	{
-		I18n::$locale = 'de';
-
-		$input = [
-		];
-
-		$fallback = [
-			'en' => 'Save',
-			'de' => 'Speichern'
-		];
-
-		$this->assertSame('Speichern', I18n::translate($input, $fallback));
-	}
-
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArray()
 	{
-		$this->assertSame('Save', I18n::translate([
-			'en' => 'Save',
-		]));
+		$this->assertSame('Save', I18n::translate(['en' => 'Save']));
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateArrayWithFallback()
+	public function testTranslateArrayShortLocale()
 	{
-		$this->assertSame('fallback', I18n::translate([
-			'de' => 'Save',
-		], 'fallback'));
+		I18n::$locale = 'es_ES';
+		$this->assertSame('Vamos', I18n::translate(['es' => 'Vamos']));
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateArrayWithArrayFallback()
-	{
-		// use the english translation as fallback if available
-		$this->assertSame('Save', I18n::translate(['de' => 'Speichern'], ['en' => 'Save']));
-
-		// use the first value if there's no english translation
-		$this->assertSame('Fallback', I18n::translate(['de' => 'Speichern'], ['first' => 'Fallback']));
-	}
-
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslateArrayWithDifferentLocale()
-	{
-		I18n::$locale = 'de';
-
-		$this->assertSame('Speichern', I18n::translate([
-			'en' => 'Save',
-			'de' => 'Speichern'
-		]));
-	}
-
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslateArrayWithI18nKey()
+	public function testTranslateArrayWildcard()
 	{
 		I18n::$locale = 'de';
 
@@ -276,39 +239,115 @@ class I18nTest extends TestCase
 			'de' => ['save' => 'Speichern']
 		];
 
-		$this->assertSame('Speichern', I18n::translate([
-			'*' => 'save'
-		]));
+		$this->assertSame('Speichern', I18n::translate(['*' => 'save']));
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateArrayWithFallbackEnglish()
+	public function testTranslateArrayWithFallbackArray()
 	{
-		I18n::$locale = 'de';
-
-		$translations = [
-			'en' => 'Some',
-			'es' => 'Algunos'
-		];
-
-		$this->assertSame('Some', I18n::translate($translations, $translations));
+		// English is current locale, not in first array,
+		// but in fallback array
+		$this->assertSame(
+			'Save',
+			I18n::translate(['de' => 'Speichern'], ['en' => 'Save'])
+		);
 	}
 
 	/**
 	 * @covers ::translate
 	 */
-	public function testTranslateArrayWithFallbackFirstLanguage()
+	public function testTranslateArrayWithFallbackArrayShortLocale()
 	{
-		I18n::$locale = 'en';
+		I18n::$locale = 'es_ES';
+		$this->assertSame(
+			'Vamos',
+			I18n::translate(['de' => 'Speichern'], ['es' => 'Vamos'])
+		);
+	}
 
-		$translations = [
-			'es' => 'Algunos',
-			'de' => 'Einige',
-		];
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayFallbackLocales()
+	{
+		I18n::$locale = 'fr';
+		I18n::$fallback = 'de';
+		$this->assertSame(
+			'Speichern',
+			I18n::translate(
+				['es' => 'Vamos', 'de' => 'Speichern'],
+				['en' => 'Save']
+			)
+		);
 
-		$this->assertSame('Algunos', I18n::translate($translations, $translations));
+		I18n::$fallback = ['es', 'de'];
+		$this->assertSame(
+			'Vamos',
+			I18n::translate(
+				['es' => 'Vamos', 'de' => 'Speichern'],
+				['en' => 'Save']
+			)
+		);
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayFallbackLocalesFromFallbackArray()
+	{
+		I18n::$locale = 'fr';
+		I18n::$fallback = 'en';
+		$this->assertSame(
+			'Save',
+			I18n::translate(
+				['es' => 'Vamos', 'de' => 'Speichern'],
+				['en' => 'Save']
+			)
+		);
+
+		I18n::$fallback = ['de', 'en'];
+		$this->assertSame(
+			'Speichern',
+			I18n::translate(
+				['es' => 'Vamos'],
+				['en' => 'Save', 'de' => 'Speichern']
+			)
+		);
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayWithFallbackString()
+	{
+		$this->assertSame(
+			'fallback',
+			I18n::translate(['de' => 'Save'], 'fallback')
+		);
+	}
+
+	/**
+	 * @covers ::translate
+	 */
+	public function testTranslateArrayWithFallbackFirstKey()
+	{
+		$this->assertSame(
+			'Algunos',
+			I18n::translate(
+				['es' => 'Algunos', 'de' => 'Einige'],
+				['es' => 'Alguna', 'de' => 'Einzige']
+			)
+		);
+
+		$this->assertSame(
+			'Alguna',
+			I18n::translate(
+				null,
+				['es' => 'Alguna', 'de' => 'Einzige']
+			)
+		);
 	}
 
 	/**
@@ -415,15 +454,9 @@ class I18nTest extends TestCase
 	public function testTranslation()
 	{
 		I18n::$translations = [
-			'en' => [
-				'test' => 'yay'
-			],
-			'de' => [
-				'test' => 'juhu'
-			],
-			'es' => [
-				'test' => 'vamos'
-			]
+			'en' => ['test' => 'yay'],
+			'de' => ['test' => 'juhu'],
+			'es' => ['test' => 'vamos']
 		];
 
 		I18n::$locale = 'en';
@@ -446,17 +479,11 @@ class I18nTest extends TestCase
 	public function testTranslationLoad()
 	{
 		$translations = [
-			'en' => [
-				'test' => 'yay'
-			],
-			'de' => [
-				'test' => 'juhu'
-			]
+			'en' => ['test' => 'yay'],
+			'de' => ['test' => 'juhu']
 		];
 
-		I18n::$load = function ($locale) use ($translations) {
-			return $translations[$locale] ?? [];
-		};
+		I18n::$load = fn ($locale) => $translations[$locale] ?? [];
 
 		I18n::$locale = 'en';
 		$this->assertSame('yay', I18n::translate('test'));
@@ -477,9 +504,7 @@ class I18nTest extends TestCase
 		$this->assertSame([], I18n::translations());
 
 		I18n::$translations = $translations = [
-			'en' => [
-				'foo' => 'bar'
-			]
+			'en' => ['foo' => 'bar']
 		];
 
 		$this->assertSame($translations, I18n::translations());


### PR DESCRIPTION
- [x] Revert https://github.com/getkirby/kirby/pull/5072 which will solve #5086
- [x] Rebase PR
- [x] Unit tests all the way for each and every branch of `I18n::translate()`

This PR then should fix properly https://github.com/getkirby/kirby/issues/4869

### Breaking change
- If $fallback is an array and neither array $key nor array $fallback have an entry for the locale, the first $key array element will now be returned not the one from $fallback. If $fallback is a string, it will be considered with priority over both of these.