### PR TITLE
Blueprints: fix name for system default files

### DIFF
--- a/config/blueprints/blocks/code.yml
+++ b/config/blueprints/blocks/code.yml
@@ -1,4 +1,4 @@
-name: Code
+title: Code
 icon: code
 fields:
   code:

--- a/config/blueprints/blocks/heading.yml
+++ b/config/blueprints/blocks/heading.yml
@@ -1,3 +1,4 @@
+title: Heading
 icon: title
 fields:
   text:

--- a/config/blueprints/blocks/image.yml
+++ b/config/blueprints/blocks/image.yml
@@ -1,4 +1,4 @@
-name: Image
+title: Image
 icon: image
 fields:
   image:

--- a/config/blueprints/blocks/quote.yml
+++ b/config/blueprints/blocks/quote.yml
@@ -1,4 +1,4 @@
-name: Quote
+title: Quote
 icon: quote
 fields:
   text:

--- a/config/blueprints/blocks/table.yml
+++ b/config/blueprints/blocks/table.yml
@@ -1,4 +1,4 @@
-name: Table
+title: Table
 icon: menu
 fields:
   rows:

--- a/config/blueprints/blocks/text.yml
+++ b/config/blueprints/blocks/text.yml
@@ -1,4 +1,4 @@
-name: Text
+title: Text
 icon: text
 fields:
   text:

--- a/config/blueprints/blocks/video.yml
+++ b/config/blueprints/blocks/video.yml
@@ -1,4 +1,4 @@
-name: Video
+title: Video
 icon: video
 label: "{{ url }}"
 fields:

--- a/config/blueprints/files/default.yml
+++ b/config/blueprints/files/default.yml
@@ -1,2 +1,1 @@
-name: File
-title: file
+title: File

--- a/config/blueprints/pages/default.yml
+++ b/config/blueprints/pages/default.yml
@@ -1,3 +1,1 @@
-name: Page
 title: Page
-

--- a/config/blueprints/site.yml
+++ b/config/blueprints/site.yml
@@ -1,7 +1,5 @@
-name: Site
 title: Site
 sections:
   pages:
     headline: Pages
     type: pages
-

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -284,8 +284,12 @@ class Blueprint
 		$root  = $kirby->root('blueprints');
 		$file  = $root . '/' . $name . '.yml';
 
-		// first try to find a site blueprint,
-		// then check in the plugin extensions
+		// if blueprint does not exist in the
+		// site directory (blueprint root),
+		// also check the plugin extension
+		// (this includes not only blueprints from
+		// plugins but also system default blueprints
+		// stored in `kirby/config/blueprints`)
 		if (F::exists($file, $root) !== true) {
 			$file = $kirby->extension('blueprints', $name);
 		}

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -249,7 +249,7 @@ class ModelWithContentTest extends TestCase
 				'title' => 'Home'
 			],
 			[
-				'name' => 'Page',
+				'name' => 'default',
 				'title' => 'Page'
 			]
 		], $model->blueprints());
@@ -260,7 +260,7 @@ class ModelWithContentTest extends TestCase
 				'title' => 'Home'
 			],
 			[
-				'name' => 'Page',
+				'name' => 'default',
 				'title' => 'Page'
 			]
 		], $model->blueprints('menu'));

--- a/tests/Panel/Areas/PageDialogsTest.php
+++ b/tests/Panel/Areas/PageDialogsTest.php
@@ -533,7 +533,7 @@ class PageDialogsTest extends AreaTestCase
 
 		$this->assertSame('site', $props['value']['parent']);
 		$this->assertSame('', $props['value']['slug']);
-		$this->assertSame('Page', $props['value']['template']);
+		$this->assertSame('default', $props['value']['template']);
 		$this->assertSame('', $props['value']['title']);
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Default blueprints for pages and files that are bundled with Kirby now correctly provide their names as `default`



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
