### PR TITLE
Reverts #5072 blueprint i18n issue

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -77,8 +77,7 @@ class Blueprint
 		$props['name'] ??= 'default';
 
 		// normalize and translate the title
-		$props['title'] ??= ucfirst($props['name']);
-		$props['title']   = $this->i18n($props['title']);
+		$props['title'] = $this->i18n($props['title'] ?? ucfirst($props['name']));
 
 		// convert all shortcuts
 		$props = $this->convertFieldsToSections('main', $props);
@@ -312,14 +311,14 @@ class Blueprint
 
 	/**
 	 * Used to translate any label, heading, etc.
+	 *
+	 * @param mixed $value
+	 * @param mixed $fallback
+	 * @return mixed
 	 */
-	protected function i18n(
-		string|array|null $value,
-		string|array $fallback = null
-	): string|null {
-		// use $value as final fallback to show i18n strings
-		// (e.g. my.editor.title) when no actual translation is found
-		return I18n::translate($value, $fallback) ?? $value;
+	protected function i18n($value, $fallback = null)
+	{
+		return I18n::translate($value, $fallback ?? $value);
 	}
 
 	/**
@@ -342,10 +341,20 @@ class Blueprint
 	{
 		$props = static::find($name);
 
-		// inject the filename as name if no name is set
-		$props['name'] ??= $name;
+		$normalize = function ($props) use ($name) {
+			// inject the filename as name if no name is set
+			$props['name'] ??= $name;
 
-		return $props;
+			// normalize the title
+			$title = $props['title'] ?? ucfirst($props['name']);
+
+			// translate the title
+			$props['title'] = I18n::translate($title, $title);
+
+			return $props;
+		};
+
+		return $normalize($props);
 	}
 
 	/**

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -171,7 +171,7 @@ class Role extends Model
 	 */
 	protected function setDescription($description = null)
 	{
-		$this->description = I18n::translate($description) ?? $description;
+		$this->description = I18n::translate($description, $description);
 		return $this;
 	}
 
@@ -201,7 +201,7 @@ class Role extends Model
 	 */
 	protected function setTitle($title = null)
 	{
-		$this->title = I18n::translate($title) ?? $title;
+		$this->title = I18n::translate($title, $title);
 		return $this;
 	}
 

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
-use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -231,56 +230,6 @@ class BlueprintTest extends TestCase
 		]);
 
 		$this->assertSame('Test', $blueprint->title());
-	}
-
-	/**
-	 * @covers ::title
-	 */
-	public function testTitleTranslatedFallback()
-	{
-		I18n::$locale       = 'de';
-		I18n::$translations = ['en' => ['my.i18n.string' => 'success']];
-
-		$blueprint = new Blueprint([
-			'title' => 'my.i18n.string',
-			'model' => $this->model
-		]);
-
-		$this->assertSame('success', $blueprint->title());
-	}
-
-	public function testTitleTranslatedFallbackForRoles()
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'languages' => [
-				[
-					'code' => 'en',
-					'default' => true,
-					'translations' => [
-						'my.custom.role' => 'My custom role'
-					]
-				],
-				[
-					'code' => 'de',
-					'translations' => []
-				]
-			],
-			'blueprints' => [
-				'users/editor' => [
-					'name' => 'editor',
-					'title' => 'my.custom.role'
-				]
-			]
-		]);
-
-		$app->setCurrentTranslation('de');
-		$app->setCurrentLanguage('de');
-
-		$role = $app->roles()->get('editor')->title();
-		$this->assertSame('My custom role', $role);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

Reverts #5072 and fixes #5086 blueprint i18n issue. Considering refactor with #5090 PR

### Fixes (not for release page)
- Translation doesn't working in page blueprints title prop #5086

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
