### PR TITLE
Inherit 'when' for fieldgroups

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -448,6 +448,7 @@ class Blueprint
 		$name = $props['name'];
 		$type = $props['type'] ?? $name;
 
+
 		if ($type !== 'group' && isset(Field::$types[$type]) === false) {
 			throw new InvalidArgumentException('Invalid field type ("' . $type . '")');
 		}
@@ -459,10 +460,23 @@ class Blueprint
 
 		// groups don't need all the crap
 		if ($type === 'group') {
+
+			$fields = $props['fields'];
+
+			if (array_key_exists('when', $props)) {
+
+				$fields = array_map(function($field) use ($props) {
+					
+					return array_merge($field, ['when' => $props['when']]);
+
+				}, $fields);
+
+			};
+
 			return [
-				'fields' => $props['fields'],
+				'fields' => $fields,
 				'name'   => $name,
-				'type'   => $type,
+				'type'   => $type
 			];
 		}
 
@@ -471,8 +485,9 @@ class Blueprint
 			'label' => $props['label'] ?? ucfirst($name),
 			'name'  => $name,
 			'type'  => $type,
-			'width' => $props['width'] ?? '1/1',
+			'width' => $props['width'] ?? '1/1'
 		]);
+
 	}
 
 	/**


### PR DESCRIPTION
## This PR gives the ability to set `when` props to a group of fields.

It will be inherit to his child fields. Use it like this:
```yml
fields:
  showit:
    type: toggle
  my_group:
    type: group
    when:
      showit: true
    fields:
      my_field1:
        type: text
      my_field2:
        type: text

```

<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes


### Breaking changes



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
