### PR TITLE
Never escape Unicode characters in blocks/layout fields

### DIFF
--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -838,11 +838,13 @@ abstract class FieldClass
 	 */
 	protected function valueToJson(array $value = null, bool $pretty = false): string
 	{
+		$constants = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
 		if ($pretty === true) {
-			return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+			$constants |= JSON_PRETTY_PRINT;
 		}
 
-		return json_encode($value);
+		return json_encode($value, $constants);
 	}
 
 	/**

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -106,7 +106,7 @@ class BlocksFieldTest extends TestCase
 			[
 				'type'    => 'heading',
 				'content' => [
-					'text' => 'A nice heading'
+					'text' => 'A nice block/heäding'
 				]
 			],
 		];
@@ -116,7 +116,7 @@ class BlocksFieldTest extends TestCase
 				'type'    => 'heading',
 				'content' => [
 					'level' => '',
-					'text'  => 'A nice heading'
+					'text'  => 'A nice block/heäding'
 				]
 			],
 		];
@@ -261,7 +261,7 @@ class BlocksFieldTest extends TestCase
 			[
 				'type'    => 'heading',
 				'content' => [
-					'text' => 'A nice heading'
+					'text' => 'A nice block/heäding'
 				]
 			],
 		];
@@ -271,7 +271,7 @@ class BlocksFieldTest extends TestCase
 				'type'    => 'heading',
 				'content' => [
 					'level' => '',
-					'text'  => 'A nice heading'
+					'text'  => 'A nice block/heäding'
 				]
 			],
 		];
@@ -280,7 +280,10 @@ class BlocksFieldTest extends TestCase
 			'value' => $value
 		]);
 
-		$this->assertSame(json_encode($expected), $field->store($value));
+		$this->assertSame(
+			json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+			$field->store($value)
+		);
 
 		// empty tests
 		$this->assertSame('', $field->store(null));

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -138,7 +138,7 @@ class LayoutFieldTest extends TestCase
 							[
 								'type'    => 'heading',
 								'content' => [
-									'text' => 'A nice heading',
+									'text' => 'A nice block/heäding',
 								]
 							]
 						]
@@ -164,14 +164,17 @@ class LayoutFieldTest extends TestCase
 		$store = $field->store($value);
 		$this->assertIsString($store);
 
-		$expected = json_decode($store, true);
+		// ensure that the Unicode characters and slashes are not encoded
+		$this->assertStringContainsString('A nice block/heäding', $store);
 
-		$this->assertSame(['url' => 'https://getkirby.com/'], $expected[0]['attrs']);
-		$this->assertArrayHasKey('id', $expected[0]);
-		$this->assertArrayHasKey('columns', $expected[0]);
-		$this->assertIsArray($expected[0]['columns']);
-		$this->assertSame('heading', $expected[0]['columns'][0]['blocks'][0]['type']);
-		$this->assertSame('A nice heading', $expected[0]['columns'][0]['blocks'][0]['content']['text']);
+		$result = json_decode($store, true);
+
+		$this->assertSame(['url' => 'https://getkirby.com/'], $result[0]['attrs']);
+		$this->assertArrayHasKey('id', $result[0]);
+		$this->assertArrayHasKey('columns', $result[0]);
+		$this->assertIsArray($result[0]['columns']);
+		$this->assertSame('heading', $result[0]['columns'][0]['blocks'][0]['type']);
+		$this->assertSame('A nice block/heäding', $result[0]['columns'][0]['blocks'][0]['content']['text']);
 
 		// empty tests
 		$this->assertSame('', $field->store(null));


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- Unicode characters and slashes are no longer escaped in blocks and layout fields, even if the `pretty: true` mode is not used https://kirby.nolt.io/518

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature (will add if accepted)
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
