### PR TITLE
Fix wrong sort number when using limit in files section

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -178,6 +178,9 @@ return [
 				'max'        => $max,
 				'api'        => $this->parent->apiUrl(true) . '/files',
 				'attributes' => array_filter([
+					// TODO: an edge issue that needs to be solved:
+					//		 if multiple users load the same section at the same time
+					// 		 and upload a file, uploaded files have the same sort number
 					'sort'     => $this->sortable === true ? $this->total + 1 : null,
 					'template' => $template
 				])

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -162,10 +162,9 @@ return [
 			}
 
 			// count all uploaded files
-			$total = count($this->data);
-			$max   = $this->max ? $this->max - $total : null;
+			$max = $this->max ? $this->max - $this->total : null;
 
-			if ($this->max && $total === $this->max - 1) {
+			if ($this->max && $this->total === $this->max - 1) {
 				$multiple = false;
 			} else {
 				$multiple = true;
@@ -179,7 +178,7 @@ return [
 				'max'        => $max,
 				'api'        => $this->parent->apiUrl(true) . '/files',
 				'attributes' => array_filter([
-					'sort'     => $this->sortable === true ? $total + 1 : null,
+					'sort'     => $this->sortable === true ? $this->total + 1 : null,
 					'template' => $template
 				])
 			];

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -708,4 +708,34 @@ class FilesSectionTest extends TestCase
 		$this->assertSame([], $options['columns']);
 		$this->assertNull($options['link']);
 	}
+
+	public function testSort()
+	{
+		$model = new Page([
+			'slug'  => 'test',
+			'files' => [
+				['filename' => 'a.jpg'],
+				['filename' => 'b.jpg'],
+				['filename' => 'c.jpg'],
+			]
+		]);
+
+		// fewer files than limit
+		$section = new Section('files', [
+			'name'  => 'test',
+			'model' => $model,
+			'limit'   => 5
+		]);
+
+		$this->assertSame(4, $section->upload()['attributes']['sort']);
+
+		// more files than limit
+		$section = new Section('files', [
+			'name'  => 'test',
+			'model' => $model,
+			'limit'   => 2
+		]);
+
+		$this->assertSame(4, $section->upload()['attributes']['sort']);
+	}
 }


### PR DESCRIPTION
## This PR …

This issue is fixed with using `total` computed data instead counting paginated data.

### Fixes
- Fix wrong sort number when using limit in files section #5101

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~Unit tests for fixed bug/feature~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
