### PR TITLE
Fix zero number in param

### DIFF
--- a/src/Http/Params.php
+++ b/src/Http/Params.php
@@ -66,7 +66,7 @@ class Params extends Obj
 				$paramValue = $paramParts[1] ?? null;
 
 				if ($paramKey !== null) {
-					$params[rawurldecode($paramKey)] = $paramValue ? rawurldecode($paramValue) : null;
+					$params[rawurldecode($paramKey)] = $paramValue !== null ? rawurldecode($paramValue) : null;
 				}
 
 				unset($path[$index]);

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -68,6 +68,14 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params);
 	}
 
+	public function testExtractFromZeroString()
+	{
+		$params   = Params::extract('price:0');
+		$expected = ['price' => '0'];
+
+		$this->assertSame($expected, $params['params']);
+	}
+
 	public function testExtractFromSeparator()
 	{
 		$params   = Params::extract(Params::separator());


### PR DESCRIPTION
## This PR …

This issue is reported @owzim from discord: https://discord.com/channels/525634039965679616/525641819854471168/1085883628426383450

Thanks @texnixe for found the bug line.

### Fixes
- Using zero number in params now returns the correct result

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
