### PR TITLE
Fix blocks and layout field default values

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -202,6 +202,19 @@ class BlocksField extends FieldClass
 		return $this->valueToJson($blocks, $this->pretty());
 	}
 
+	protected function setDefault($default = null)
+	{
+		// set id for blocks if not exists
+		if (is_array($default) === true) {
+			$default = array_map(function ($block) {
+				$block['id'] ??= Str::uuid();
+				return $block;
+			}, $default);
+		}
+
+		parent::setDefault($default);
+	}
+
 	protected function setFieldsets($fieldsets, $model)
 	{
 		if (is_string($fieldsets) === true) {

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -206,10 +206,9 @@ class BlocksField extends FieldClass
 	{
 		// set id for blocks if not exists
 		if (is_array($default) === true) {
-			$default = array_map(function ($block) {
+			array_walk($default, function (&$block) {
 				$block['id'] ??= Str::uuid();
-				return $block;
-			}, $default);
+			});
 		}
 
 		parent::setDefault($default);

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -119,24 +119,23 @@ class LayoutField extends BlocksField
 	{
 		// set id for layouts, columns and blocks within layout if not exists
 		if (is_array($default) === true) {
-			$default = array_map(function ($layout) {
+			array_walk($default, function (&$layout) {
 				$layout['id'] ??= Str::uuid();
 
 				// set columns id within layout
-				$layout['columns'] = array_map(function ($column) {
-					$column['id'] ??= Str::uuid();
+				if (isset($layout['columns']) === true) {
+					array_walk($layout['columns'], function (&$column) {
+						$column['id'] ??= Str::uuid();
 
-					// set blocks id within column
-					$column['blocks'] = array_map(function ($block) {
-						$block['id'] ??= Str::uuid();
-						return $block;
-					}, $column['blocks'] ?? []);
-
-					return $column;
-				}, $layout['columns'] ?? []);
-
-				return $layout;
-			}, $default);
+						// set blocks id within column
+						if (isset($column['blocks']) === true) {
+							array_walk($column['blocks'], function (&$block) {
+								$block['id'] ??= Str::uuid();
+							});
+						}
+					});
+				}
+			});
 		}
 
 		parent::setDefault($default);

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -115,6 +115,33 @@ class LayoutField extends BlocksField
 		return $routes;
 	}
 
+	protected function setDefault($default = null)
+	{
+		// set id for layouts, columns and blocks within layout if not exists
+		if (is_array($default) === true) {
+			$default = array_map(function ($layout) {
+				$layout['id'] ??= Str::uuid();
+
+				// set columns id within layout
+				$layout['columns'] = array_map(function ($column) {
+					$column['id'] ??= Str::uuid();
+
+					// set blocks id within column
+					$column['blocks'] = array_map(function ($block) {
+						$block['id'] ??= Str::uuid();
+						return $block;
+					}, $column['blocks'] ?? []);
+
+					return $column;
+				}, $layout['columns'] ?? []);
+
+				return $layout;
+			}, $default);
+		}
+
+		parent::setDefault($default);
+	}
+
 	protected function setLayouts(array $layouts = [])
 	{
 		$this->layouts = array_map(

--- a/tests/Form/Fields/BlocksFieldTest.php
+++ b/tests/Form/Fields/BlocksFieldTest.php
@@ -502,4 +502,23 @@ class BlocksFieldTest extends TestCase
 
 		$this->assertSame($expected, $field->errors());
 	}
+
+	public function testDefault()
+	{
+		$field = $this->field('blocks', [
+			'default' => [
+				[
+					'type' => 'heading',
+					'text' => 'Some title'
+				]
+			]
+		]);
+
+		$default = $field->default();
+
+		$this->assertCount(1, $default);
+		$this->assertSame('heading', $default[0]['type']);
+		$this->assertSame('Some title', $default[0]['text']);
+		$this->assertArrayHasKey('id', $default[0]);
+	}
 }

--- a/tests/Form/Fields/LayoutFieldTest.php
+++ b/tests/Form/Fields/LayoutFieldTest.php
@@ -264,4 +264,38 @@ class LayoutFieldTest extends TestCase
 
 		$this->assertSame($value, $field->empty());
 	}
+
+	public function testDefault()
+	{
+		$field = $this->field('layout', [
+			'default' => [
+				[
+					'columns' => [
+						[
+							'width' => '1/2',
+							'blocks' => [
+								[
+									'type' => 'heading',
+									'text' => 'Some title'
+								]
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$default = $field->default();
+
+		$layout = $default[0];
+		$column = $layout['columns'][0];
+		$block = $column['blocks'][0];
+
+		$this->assertCount(1, $default);
+		$this->assertArrayHasKey('id', $layout);
+		$this->assertArrayHasKey('id', $column);
+		$this->assertArrayHasKey('id', $block);
+		$this->assertSame('heading', $block['type']);
+		$this->assertSame('Some title', $block['text']);
+	}
 }


### PR DESCRIPTION
## This PR …
The source of the issue was that there was a conflict in the block and layout field default value because did not have a unique ID. I solved the issue by assigning new ID while setting the default value.

### Fixes
- Fix blocks and layout field ids for default values #5111

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
