### PR TITLE
Stale bot only for when actions needed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
           stale-issue-message: "This issue has been marked as stale because it requires further input but has not seen activity in the past months. This is for us to prioritize issues that are still relevant and actionable. It will be closed if no further activity occurs within the next 15 days. If this issue is still relevant to you, please help us in gathering the necessary input."
 
           # Comment on the staled PRs
-          stale-pr-message: "This PR has been marked as stale because it requires further changes but has not seen activity in the past months. This is for us to prioritize PRs that can be reviewed and merged. It will be closed if no further activity occurs within the next 15 days. If you still have interest in this PR, please help us finalizing it."
+          stale-pr-message: "This PR has been marked as stale because it requires further changes but has not seen activity in the past months. This is for us to prioritize PRs that can be reviewed and merged. It will be closed if no further activity occurs within the next 15 days. If you still have interest in this PR, please help us finalizing it. Please let us know in case you are stuck on the required changes."
 
           # Label to apply on staled issues
           stale-issue-label: "type: stale 💤"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,22 +14,31 @@ jobs:
       - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # pin@v7
         with:
           # Idle number of days before marking issues stale, set `-1` to disable
-          days-before-issue-stale: 180
+          days-before-issue-stale: 75
 
           # Idle number of days before marking issues stale, set `-1` to disable
-          days-before-pr-stale: -1
+          days-before-pr-stale: 75
 
           # Idle number of days before closing stale issues/PRs
-          days-before-close: 14
+          days-before-close: 21
 
           # Comment on the staled issues
-          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. This is for us to prioritize issues that are still relevant to our community. It will be closed if no further activity occurs within the next 14 days. If this issue is still relevant to you, please leave a comment."
+          stale-issue-message: "This issue has been marked as stale because it requires further input but has not seen activity in the past months. This is for us to prioritize issues that are still relevant and actionable. It will be closed if no further activity occurs within the next 21 days. If this issue is still relevant to you, please help us in gathering the necessary input."
+
+          # Comment on the staled PRs
+          stale-pr-message: "This PR has been marked as stale because it requires further changes but has not seen activity in the past months. This is for us to prioritize PRs that can be reviewed and merged. It will be closed if no further activity occurs within the next 21 days. If you still have interest in this PR, please help us finalizing it."
 
           # Label to apply on staled issues
           stale-issue-label: "type: stale 💤"
 
+          # Label to apply on staled PRs
+          stale-pr-label: "type: stale 💤"
+
           # Reason to use when closing issues
           close-issue-reason: not_planned
+
+          # Labels to check for stale issues/PRs
+          any-of-labels: "needs: changes 🔁,"
 
           # Labels on issues exempted from stale
           exempt-issue-labels: "critical: roadblock 🚧,type: regression 🚨"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,19 +14,19 @@ jobs:
       - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # pin@v7
         with:
           # Idle number of days before marking issues stale, set `-1` to disable
-          days-before-issue-stale: 75
+          days-before-issue-stale: 60
 
           # Idle number of days before marking issues stale, set `-1` to disable
-          days-before-pr-stale: 75
+          days-before-pr-stale: 60
 
           # Idle number of days before closing stale issues/PRs
-          days-before-close: 21
+          days-before-close: 15
 
           # Comment on the staled issues
-          stale-issue-message: "This issue has been marked as stale because it requires further input but has not seen activity in the past months. This is for us to prioritize issues that are still relevant and actionable. It will be closed if no further activity occurs within the next 21 days. If this issue is still relevant to you, please help us in gathering the necessary input."
+          stale-issue-message: "This issue has been marked as stale because it requires further input but has not seen activity in the past months. This is for us to prioritize issues that are still relevant and actionable. It will be closed if no further activity occurs within the next 15 days. If this issue is still relevant to you, please help us in gathering the necessary input."
 
           # Comment on the staled PRs
-          stale-pr-message: "This PR has been marked as stale because it requires further changes but has not seen activity in the past months. This is for us to prioritize PRs that can be reviewed and merged. It will be closed if no further activity occurs within the next 21 days. If you still have interest in this PR, please help us finalizing it."
+          stale-pr-message: "This PR has been marked as stale because it requires further changes but has not seen activity in the past months. This is for us to prioritize PRs that can be reviewed and merged. It will be closed if no further activity occurs within the next 15 days. If you still have interest in this PR, please help us finalizing it."
 
           # Label to apply on staled issues
           stale-issue-label: "type: stale 💤"
@@ -38,7 +38,9 @@ jobs:
           close-issue-reason: not_planned
 
           # Labels to check for stale issues/PRs
-          any-of-labels: "needs: changes 🔁,"
+          any-of-pr-labels: "needs: changes 🔁,needs: docs 📝,needs: tests  🧪"
+          any-of-issue-labels: "needs: information ❓,needs: replication 🔬"
 
-          # Labels on issues exempted from stale
+          # PRs/issues exempted from stale
+          exempt-all-milestones: true
           exempt-issue-labels: "critical: roadblock 🚧,type: regression 🚨"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,7 +38,7 @@ jobs:
           close-issue-reason: not_planned
 
           # Labels to check for stale issues/PRs
-          any-of-pr-labels: "needs: changes 🔁,needs: docs 📝,needs: tests  🧪"
+          any-of-pr-labels: "needs: changes 🔁"
           any-of-issue-labels: "needs: information ❓,needs: replication 🔬"
 
           # PRs/issues exempted from stale


### PR DESCRIPTION
Apply stale bot on issues and PRs only when certain input/actions are needed from the user.
If they don't happen for 60 days, gets marked as stale and after 15 additional days closed.