### PR TITLE
`F::move()`: Support non-atomic moves

### DIFF
--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -521,12 +521,26 @@ class F
 			Dir::make($directory, true);
 		}
 
-		// actually move the file
-		if (rename($oldRoot, $newRoot) !== true) {
-			return false;
+		// atomically moving the file will only work if
+		// source and target are on the same filesystem
+		if (stat($oldRoot)['dev'] === stat($directory)['dev']) {
+			// same filesystem, we can move the file
+			return rename($oldRoot, $newRoot) === true;
 		}
 
-		return true;
+		// not the same filesystem; we need to copy
+		// the file and unlink the source afterwards
+		if (copy($oldRoot, $newRoot) === true) {
+			return unlink($oldRoot) === true;
+		}
+
+		// copying failed, ensure the new root isn't there
+		// (e.g. if the file could be created but there's no
+		// more remaining disk space to write its contents)
+		// @codeCoverageIgnoreStart
+		static::remove($newRoot);
+		return false;
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Uploading files no longer fails with the error "Operation not permitted" when the temporary directory is on another filesystem #5024
- `F::move()` now detects if the source and target are on different filesystems; it then copies the file and deletes the source on success instead of atomically moving the file #5124

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature (test added, but skipped in CI because tests are run inside a container; this is why code coverage only displays 50%)
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
