### PR TITLE
Custom method inheritance

### DIFF
--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -26,6 +26,13 @@ class Blocks extends Items
 	public const ITEM_CLASS = Block::class;
 
 	/**
+	 * All registered blocks methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * Return HTML when the collection is
 	 * converted to a string
 	 *

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -21,6 +21,13 @@ class Fieldsets extends Items
 {
 	public const ITEM_CLASS = Fieldset::class;
 
+	/**
+	 * All registered fieldsets methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
 	protected static function createFieldsets($params)
 	{
 		$fieldsets = [];

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -22,6 +22,13 @@ class Items extends Collection
 	protected Field|null $field;
 
 	/**
+	 * All registered items methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * @var array
 	 */
 	protected $options;

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -17,6 +17,13 @@ use Kirby\Filesystem\F;
 class Languages extends Collection
 {
 	/**
+	 * All registered languages methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * Creates a new collection with the given language objects
 	 *
 	 * @param array $objects `Kirby\Cms\Language` objects

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -15,4 +15,11 @@ namespace Kirby\Cms;
 class LayoutColumns extends Items
 {
 	public const ITEM_CLASS = LayoutColumn::class;
+
+	/**
+	 * All registered layout columns methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
 }

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -20,6 +20,13 @@ class Layouts extends Items
 {
 	public const ITEM_CLASS = Layout::class;
 
+	/**
+	 * All registered layouts methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
 	public static function factory(array $items = null, array $params = [])
 	{
 		$first = $items[0] ?? [];

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -19,6 +19,13 @@ namespace Kirby\Cms;
 class Roles extends Collection
 {
 	/**
+	 * All registered roles methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * Returns a filtered list of all
 	 * roles that can be created by the
 	 * current user

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -21,6 +21,13 @@ use Kirby\Exception\InvalidArgumentException;
 class Structure extends Collection
 {
 	/**
+	 * All registered structure methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * Creates a new Collection with the given objects
 	 *
 	 * @param array $objects Kirby\Cms\StructureObject` objects or props arrays

--- a/src/Cms/Translations.php
+++ b/src/Cms/Translations.php
@@ -20,6 +20,13 @@ use Kirby\Filesystem\F;
 class Translations extends Collection
 {
 	/**
+	 * All registered translations methods
+	 *
+	 * @var array
+	 */
+	public static $methods = [];
+
+	/**
 	 * @param string $code
 	 * @return void
 	 */


### PR DESCRIPTION
## This PR fixes the problems outlined here #5120 

I had another look and the trait already does something like this in the [getMethod()](https://github.com/getkirby/kirby/blob/main/src/Cms/HasMethods.php#L66) method.
Nevertheless the method "bleeding" is still a problem for some classes.

I added two commits to this PR.
1. Addresses the classes that can/should be extended using a plugin.
2. Adds the `public static $methods = [];` to classes that are also affected by this.
  These classes cannot be extended by a plugin, but a developer might want to extend these for one reason or another.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
