### PR TITLE
Remove `noopener` where not needed

### DIFF
--- a/panel/src/components/Forms/Writer/Marks/Link.js
+++ b/panel/src/components/Forms/Writer/Marks/Link.js
@@ -100,7 +100,7 @@ export default class Link extends Mark {
 				"a",
 				{
 					...node.attrs,
-					rel: "noopener noreferrer"
+					rel: "noreferrer"
 				},
 				0
 			]

--- a/src/Parsley/Schema/Blocks.php
+++ b/src/Parsley/Schema/Blocks.php
@@ -224,7 +224,7 @@ class Blocks extends Plain
 				'tag' => 'a',
 				'attrs' => ['href', 'rel', 'target', 'title'],
 				'defaults' => [
-					'rel' => 'noopener noreferrer'
+					'rel' => 'noreferrer'
 				]
 			],
 			[

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -358,7 +358,7 @@ class Html extends Xml
 	}
 
 	/**
-	 * Add noopener & noreferrer to rels when target is `_blank`
+	 * Add noreferrer to rels when target is `_blank`
 	 *
 	 * @param string|null $rel Current `rel` value
 	 * @param string|null $target Current `target` value

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -373,7 +373,7 @@ class Html extends Xml
 				return $rel;
 			}
 
-			return trim($rel . ' noopener noreferrer', ' ');
+			return trim($rel . ' noreferrer', ' ');
 		}
 
 		return $rel ?: null;

--- a/tests/Parsley/fixtures/link-with-nested-div.php
+++ b/tests/Parsley/fixtures/link-with-nested-div.php
@@ -3,7 +3,7 @@
 return [
 	[
 		'content' => [
-			'text' => '<p><a href="/test" rel="noopener noreferrer">A B</a></p>'
+			'text' => '<p><a href="/test" rel="noreferrer">A B</a></p>'
 		],
 		'type' => 'text',
 	]

--- a/tests/Sane/fixtures/html/allowed/sandbox-blocks.html
+++ b/tests/Sane/fixtures/html/allowed/sandbox-blocks.html
@@ -1,9 +1,9 @@
 <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts. Separated they live in Bookmarksgrove right at the coast of the Semantics, a large language ocean. A small river named Duden flows by <strong>their</strong> place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth. Even the all-powerful Pointing has no control about the blind texts it is an almost unorthographic life One day however a small line of blind text by the name of Lorem Ipsum decided to leave for the far World of Grammar.</p>
-<p><strong>The Big Oxmox</strong> advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic <a href="https://getkirby.com" rel="noopener noreferrer nofollow">Mountains</a>, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. Pityful a rethoric question ran over her cheek, then she continued her way. On her way she met a copy.</p>
+<p><strong>The Big Oxmox</strong> advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic <a href="https://getkirby.com" rel="noreferrer nofollow">Mountains</a>, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. Pityful a rethoric question ran over her cheek, then she continued her way. On her way she met a copy.</p>
 <blockquote>
     Time flies like an arrow; fruit flies like a banana
     <footer>
-        <a href="https://en.wikipedia.org/wiki/Anthony_Oettinger" rel="noopener noreferrer nofollow">Anthony Oettinger</a>
+        <a href="https://en.wikipedia.org/wiki/Anthony_Oettinger" rel="noreferrer nofollow">Anthony Oettinger</a>
     </footer>
 </blockquote>
 <h2>Let's put a heading here</h2>

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -832,7 +832,7 @@ class KirbyTagsTest extends TestCase
 			],
 			[
 				'(link: http://wikipedia.org text: Wikipedia)',
-				'<p><a class="link-class" href="http://wikipedia.org" rel="noopener noreferrer" target="_blank">Wikipedia</a></p>'
+				'<p><a class="link-class" href="http://wikipedia.org" rel="noreferrer" target="_blank">Wikipedia</a></p>'
 			],
 			[
 				'(tel: +49123456789)',

--- a/tests/Text/fixtures/kirbytext/link-with-target/expected.html
+++ b/tests/Text/fixtures/kirbytext/link-with-target/expected.html
@@ -1,1 +1,1 @@
-<p><a href="http://getkirby.com" rel="noopener noreferrer" target="_blank">Kirby</a></p>
+<p><a href="http://getkirby.com" rel="noreferrer" target="_blank">Kirby</a></p>

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -90,7 +90,7 @@ class HtmlTest extends TestCase
 	public function testAWithTarget()
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby', ['target' => '_blank']);
-		$expected = '<a href="https://getkirby.com" rel="noopener noreferrer" target="_blank">Kirby</a>';
+		$expected = '<a href="https://getkirby.com" rel="noreferrer" target="_blank">Kirby</a>';
 		$this->assertSame($expected, $html);
 	}
 
@@ -250,7 +250,7 @@ class HtmlTest extends TestCase
 	public function testEmailWithTarget()
 	{
 		$html = Html::email('mail@company.com', 'Email', ['target' => '_blank']);
-		$expected = '!^<a href="mailto:(.*?)" rel="noopener noreferrer" target="_blank">Email</a>$!';
+		$expected = '!^<a href="mailto:(.*?)" rel="noreferrer" target="_blank">Email</a>$!';
 		$this->assertMatchesRegularExpression($expected, $html);
 		preg_match($expected, $html, $matches);
 		$this->assertSame('mail@company.com', Html::decode($matches[1]));
@@ -373,7 +373,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 
 		$html = Html::rel(null, '_blank');
-		$expected = 'noopener noreferrer';
+		$expected = 'noreferrer';
 		$this->assertSame($expected, $html);
 
 		$html = Html::rel('noopener', '_blank');


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- Removed `noopener` where it's already implied by `noreferrer` #5134


### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
