### PR TITLE
Inherit `when` for field groups

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -463,7 +463,7 @@ class Blueprint
 
 			if (isset($props['when']) === true) {
 				$fields = array_map(
-					fn ($field) => array_merge_recursive(['when' => $props['when']], $field),
+					fn ($field) => array_replace_recursive(['when' => $props['when']], $field),
 					$fields
 				);
 			}

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -459,10 +459,19 @@ class Blueprint
 
 		// groups don't need all the crap
 		if ($type === 'group') {
+			$fields = $props['fields'];
+
+			if (isset($props['when']) === true) {
+				$fields = array_map(
+					fn ($field) => array_merge_recursive(['when' => $props['when']], $field),
+					$fields
+				);
+			}
+
 			return [
-				'fields' => $props['fields'],
+				'fields' => $fields,
 				'name'   => $name,
-				'type'   => $type,
+				'type'   => $type
 			];
 		}
 

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -224,4 +224,45 @@ class BlueprintFieldTest extends TestCase
 
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
+
+	public function testFieldGroupWhenMerge()
+	{
+		$props = Blueprint::fieldProps([
+			'name'   => 'test',
+			'type'   => 'group',
+			'when'	 => [
+				'category' => 'value',
+				'another'  => 'value',
+			],
+			'fields' => [
+				'headline' => [
+					'type' => 'text',
+					'when' => [
+						'category'  => 'different-value',
+						'different' => 'field'
+					]
+				]
+			]
+		]);
+
+		$expected = [
+			'fields' => [
+				'headline' => [
+					'label' => 'Headline',
+					'name'  => 'headline',
+					'type'  => 'text',
+					'width' => '1/1',
+					'when'	 => [
+						'category'  => 'different-value',
+						'another'   => 'value',
+						'different' => 'field'
+					],
+				]
+			],
+			'name' => 'test',
+			'type' => 'group'
+		];
+
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
+	}
 }

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -190,4 +190,38 @@ class BlueprintFieldTest extends TestCase
 
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
+
+	public function testFieldGroupWhen()
+	{
+		$props = Blueprint::fieldProps([
+			'name'   => 'test',
+			'type'   => 'group',
+			'when'	 => [
+				'category' => 'value'
+			],
+			'fields' => [
+				'headline' => [
+					'type' => 'text'
+				]
+			]
+		]);
+
+		$expected = [
+			'fields' => [
+				'headline' => [
+					'label' => 'Headline',
+					'name'  => 'headline',
+					'type'  => 'text',
+					'width' => '1/1',
+					'when'	 => [
+						'category' => 'value'
+					],
+				]
+			],
+			'name' => 'test',
+			'type' => 'group'
+		];
+
+		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
+	}
 }


### PR DESCRIPTION
## This PR …

Implements https://github.com/getkirby/kirby/pull/5097 PR

This PR gives the ability to set `when` props to a group of fields.

It will be inherit to his child fields. Use it like this:
```yml
fields:
  showit:
    type: toggle

  my_group:
    type: group
    when:
      showit: true
    fields:
      my_field1:
        type: text
      my_field2:
        type: text

```

### Enhancements

- Inherit `when` for field groups

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
