### PR TITLE
Fix filling default values while creating new page

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -536,29 +536,43 @@ trait PageActions
 		// create a temporary page object
 		$page = Page::factory($props);
 
+		// always create pages in the default language
+		if ($page->kirby()->multilang() === true) {
+			$languageCode = $page->kirby()->defaultLanguage()->code();
+		} else {
+			$languageCode = null;
+		}
+
 		// create a form for the page
-		$form = Form::for($page, ['values' => $props['content']]);
+		// use always default language to fill form with default values
+		$form = Form::for(
+			$page,
+			[
+				'language' => $languageCode,
+				'values'   => $props['content']
+			]
+		);
 
 		// inject the content
 		$page = $page->clone(['content' => $form->strings(true)]);
 
 		// run the hooks and creation action
-		$page = $page->commit('create', ['page' => $page, 'input' => $props], function ($page, $props) {
-			// always create pages in the default language
-			if ($page->kirby()->multilang() === true) {
-				$languageCode = $page->kirby()->defaultLanguage()->code();
-			} else {
-				$languageCode = null;
+		$page = $page->commit(
+			'create',
+			[
+				'page'  => $page,
+				'input' => $props
+			],
+			function ($page, $props) use ($languageCode) {
+				// write the content file
+				$page = $page->save($page->content()->toArray(), $languageCode);
+
+				// flush the parent cache to get children and drafts right
+				static::updateParentCollections($page, 'append');
+
+				return $page;
 			}
-
-			// write the content file
-			$page = $page->save($page->content()->toArray(), $languageCode);
-
-			// flush the parent cache to get children and drafts right
-			static::updateParentCollections($page, 'append');
-
-			return $page;
-		});
+		);
 
 		// publish the new page if a number is given
 		if (isset($props['num']) === true) {

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -1177,4 +1177,187 @@ class PageActionsTest extends TestCase
 
 		$this->assertSame(2, $calls);
 	}
+
+	public function testCreateDefaultLanguage()
+	{
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$value = [
+			'title'    => 'Test page',
+			'headline' => 'A headline',
+			'text'     => 'Any text'
+		];
+
+		$page = Page::create([
+			'slug'      => 'test',
+			'content'   => $value,
+			'blueprint' => [
+				'title'  => 'Default',
+				'fields' => [
+					'headline' => ['type' => 'text'],
+					'text'     => ['type' => 'textarea']
+				]
+			],
+		]);
+
+		$value['uuid'] = $page->content()->get('uuid')->value();
+
+		$this->assertSame($value, $page->content('en')->toArray());
+		$this->assertSame($value, $page->content('de')->toArray());
+	}
+
+	public function testCreateSecondaryLanguage()
+	{
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+		$app->setCurrentLanguage('de');
+
+		$value = [
+			'title'    => 'Test page',
+			'headline' => 'A headline',
+			'text'     => 'Any text'
+		];
+
+		$page = Page::create([
+			'slug'      => 'test',
+			'content'   => $value,
+			'blueprint' => [
+				'title'  => 'Default',
+				'fields' => [
+					'headline' => ['type' => 'text'],
+					'text'     => ['type' => 'textarea']
+				]
+			]
+		]);
+
+		$value['uuid'] = $page->content()->get('uuid')->value();
+
+		$this->assertSame('de', $app->language()->code());
+		$this->assertSame($value, $page->content('en')->toArray());
+		$this->assertSame($value, $page->content('de')->toArray());
+	}
+
+	public function testCreateSecondaryLanguageUntranslatable()
+	{
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+		$app->setCurrentLanguage('de');
+
+		$value = [
+			'title'    => 'Test page',
+			'headline' => 'A headline',
+			'text'     => 'Any text'
+		];
+
+		$page = Page::create([
+			'slug'      => 'test',
+			'content'   => $value,
+			'blueprint' => [
+				'title'  => 'Default',
+				'fields' => [
+					'headline' => [
+						'type'      => 'text',
+						'translate' => false
+					],
+					'text'     => ['type' => 'textarea']
+				]
+			]
+		]);
+
+		$value['uuid'] = $page->content()->get('uuid')->value();
+
+		$this->assertSame('de', $app->language()->code());
+		$this->assertSame($value, $page->content('en')->toArray());
+		$this->assertSame($value, $page->content('de')->toArray());
+	}
+
+	public function testCreateSecondaryLanguageDefaultValues()
+	{
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+		$app->setCurrentLanguage('de');
+
+		$page = Page::create([
+			'slug'       => 'test',
+			'content'    => ['title' => 'Test page'],
+			'blueprint'  => [
+				'title'  => 'test',
+				'fields' => [
+					'headline' => [
+						'type'      => 'text',
+						'translate' => false,
+						'default'   => 'A headline'
+					],
+					'text'     => [
+						'type'    => 'textarea',
+						'default' => 'Any text'
+					]
+				]
+			]
+		]);
+
+		$expected = [
+			'title'    => 'Test page',
+			'uuid'     =>  $page->content()->get('uuid')->value(),
+			'headline' => 'A headline',
+			'text'     => 'Any text',
+		];
+
+		$this->assertSame('de', $app->language()->code());
+		$this->assertSame($expected, $page->content('en')->toArray());
+		$this->assertSame($expected, $page->content('de')->toArray());
+	}
 }


### PR DESCRIPTION
## This PR …

Solved this issue by [always sending the default language as an argument](https://github.com/getkirby/kirby/pull/5144/files#diff-8e8501f5cf24c63dea196abff40bfb44322604ba3a244561300db2c053d2242aR551) to get the default values since [we do this in the default language when creating a multilingual page](https://github.com/getkirby/kirby/pull/5144/files#diff-8e8501f5cf24c63dea196abff40bfb44322604ba3a244561300db2c053d2242aR568).

### Fixes
- Fix filling default values while creating new page on secondary language #5140

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
