### PR TITLE
Keep the language selector in sync

### DIFF
--- a/panel/src/fiber/app.js
+++ b/panel/src/fiber/app.js
@@ -96,7 +96,7 @@ export default {
 
 				this.component = state.$view.component;
 				this.state = state;
-				this.key = options.replace === true ? this.key : state.$view.timestamp;
+				this.key = state.$view.timestamp;
 
 				if (options.navigate === true) {
 					this.navigate();


### PR DESCRIPTION
## This PR …

This PR always uses the timestamp from the server as key for the View component to make sure it always gets rerendered correctly. This broke the language toggle so far when hitting the back button. 

### Fixes

- Keep the language selector in sync when pressing the back button https://github.com/getkirby/kirby/issues/5007

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
