### PR TITLE
Fix `Database::lastError()`

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -62,7 +62,7 @@ class Database
 	/**
 	 * The last error
 	 */
-	protected Exception|null $lastError = null;
+	protected Throwable|null $lastError = null;
 
 	/**
 	 * The last insert id
@@ -280,7 +280,7 @@ class Database
 	/**
 	 * Returns the last db error
 	 */
-	public function lastError(): Throwable
+	public function lastError(): Throwable|null
 	{
 		return $this->lastError;
 	}

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -111,6 +111,7 @@ class DatabaseTest extends TestCase
 	 */
 	public function testLastError()
 	{
+		$this->assertNull($this->database->lastError());
 		$this->database->table('users')->select('nonexisting')->all();
 		$this->assertInstanceOf(PDOException::class, $this->database->lastError());
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `Database::lastError()` doesn't crash anymore when no error occurred 
#5165


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
