### PR TITLE
Fix type hints for `HasSiblings`; fix behavior of `$collection->indexOf()`

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -209,9 +209,9 @@ class Collection extends BaseCollection
 	 * or ids and then search accordingly.
 	 *
 	 * @param string|object $needle
-	 * @return int
+	 * @return int|false
 	 */
-	public function indexOf($needle): int
+	public function indexOf($needle): int|false
 	{
 		if (is_string($needle) === true) {
 			return array_search($needle, $this->keys());

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -19,9 +19,9 @@ trait HasSiblings
 	 *
 	 * @param \Kirby\Cms\Collection|null $collection
 	 *
-	 * @return int
+	 * @return int|false
 	 */
-	public function indexOf($collection = null): int
+	public function indexOf($collection = null): int|false
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->indexOf($this);

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -29,6 +29,9 @@ trait HasSiblings
 
 	/**
 	 * Returns the next item in the collection if available
+	 * @todo `static` return type hint is not 100% accurate because of
+	 *       quirks in the `Form` classes; would break if enforced
+	 *       (https://github.com/getkirby/kirby/pull/5175)
 	 *
 	 * @param \Kirby\Cms\Collection|null $collection
 	 *
@@ -55,6 +58,9 @@ trait HasSiblings
 
 	/**
 	 * Returns the previous item in the collection if available
+	 * @todo `static` return type hint is not 100% accurate because of
+	 *       quirks in the `Form` classes; would break if enforced
+	 *       (https://github.com/getkirby/kirby/pull/5175)
 	 *
 	 * @param \Kirby\Cms\Collection|null $collection
 	 *

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -32,7 +32,7 @@ trait HasSiblings
 	 *
 	 * @param \Kirby\Cms\Collection|null $collection
 	 *
-	 * @return \Kirby\Cms\Model|null
+	 * @return static|null
 	 */
 	public function next($collection = null)
 	{
@@ -58,7 +58,7 @@ trait HasSiblings
 	 *
 	 * @param \Kirby\Cms\Collection|null $collection
 	 *
-	 * @return \Kirby\Cms\Model|null
+	 * @return static|null
 	 */
 	public function prev($collection = null)
 	{

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -206,9 +206,12 @@ class CollectionTest extends TestCase
 			$c = new MockObject(['id' => 'c'])
 		]);
 
+		$d = new MockObject(['id' => 'd']);
+
 		$this->assertSame(0, $collection->indexOf($a));
 		$this->assertSame(1, $collection->indexOf($b));
 		$this->assertSame(2, $collection->indexOf($c));
+		$this->assertFalse($collection->indexOf($d));
 	}
 
 	public function testIndexOfWithString()
@@ -222,6 +225,7 @@ class CollectionTest extends TestCase
 		$this->assertSame(0, $collection->indexOf('a'));
 		$this->assertSame(1, $collection->indexOf('b'));
 		$this->assertSame(2, $collection->indexOf('c'));
+		$this->assertFalse($collection->indexOf('d'));
 	}
 
 	public function testNotWithObjects()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- `$collection->indexOf()` returns `false` instead of the index `0` when the passed element was not found in the collection #5175
- The collection `next()` and `prev()` methods are now type-hinted to return `static` for improved IDE support #5039

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
