### PR TITLE
Remove return type for `collection()` helper

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kirby\Cms\App;
-use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Html;
@@ -50,8 +49,11 @@ if (Helpers::hasOverride('attr') === false) { // @codeCoverageIgnore
 if (Helpers::hasOverride('collection') === false) { // @codeCoverageIgnore
 	/**
 	 * Returns the result of a collection by name
+	 *
+	 * @return \Kirby\Toolkit\Collection|null
+	 * @todo 5.0 Add return type declaration
 	 */
-	function collection(string $name): Collection|null
+	function collection(string $name)
 	{
 		return App::instance()->collection($name);
 	}

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -364,8 +364,8 @@ class App
 	 * by name. All relevant dependencies are
 	 * automatically injected
 	 *
-	 * @param string $name
-	 * @return \Kirby\Cms\Collection|null
+	 * @return \Kirby\Toolkit\Collection|null
+	 * @todo 5.0 Add return type declaration
 	 */
 	public function collection(string $name)
 	{
@@ -379,10 +379,8 @@ class App
 
 	/**
 	 * Returns all user-defined collections
-	 *
-	 * @return \Kirby\Cms\Collections
 	 */
-	public function collections()
+	public function collections(): Collections
 	{
 		return $this->collections ??= new Collections();
 	}

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -28,25 +28,20 @@ class Collections
 	 * has been called, to avoid further
 	 * processing on sequential calls to
 	 * the same collection.
-	 *
-	 * @var array
 	 */
-	protected $cache = [];
+	protected array $cache = [];
 
 	/**
 	 * Store of all collections
-	 *
-	 * @var array
 	 */
-	protected $collections = [];
+	protected array $collections = [];
 
 	/**
 	 * Magic caller to enable something like
 	 * `$collections->myCollection()`
 	 *
-	 * @param string $name
-	 * @param array $arguments
-	 * @return \Kirby\Cms\Collection|null
+	 * @return \Kirby\Toolkit\Collection|null
+	 * @todo 5.0 Add return type declaration
 	 */
 	public function __call(string $name, array $arguments = [])
 	{
@@ -56,9 +51,9 @@ class Collections
 	/**
 	 * Loads a collection by name if registered
 	 *
-	 * @param string $name
-	 * @param array $data
-	 * @return \Kirby\Cms\Collection|null
+	 * @return \Kirby\Toolkit\Collection|null
+	 * @todo 4.0 Add deprecation warning when anything else than a Collection is returned
+	 * @todo 5.0 Add return type declaration
 	 */
 	public function get(string $name, array $data = [])
 	{


### PR DESCRIPTION
## This PR …
Applies @lukasbestle [ideas in here](https://github.com/getkirby/kirby/issues/5169#issuecomment-1555083893)

### Fixes
Remove return type for `collection()` helper #5169

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
