### PR TITLE
[v4] `$model->file()`: adhere to sort order

### DIFF
--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -90,7 +90,10 @@ trait HasFiles
 	public function file(string $filename = null, string $in = 'files')
 	{
 		if ($filename === null) {
-			return $this->$in()->first();
+			return $this
+				->$in()
+				->sortBy('sort', 'asc', 'filename', 'asc')
+				->first();
 		}
 
 		// find by global UUID


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Especially in the Panel, it currently seems odd that the default preview image is not the first image as shown not he Panel page

### Enhancement
- `$model->file()`, `$model->image()` etc. return the first file/image considering the `sort` field (and not just the filename).


### Breaking changes
- `$model->file()`, `$model->image()` etc. return a different file now, if the lowest `sort` field value is not also the first alphabetical filename


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
