### PR TITLE
[v4] Panel: add pagination to search results

### DIFF
--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -8,16 +8,13 @@ return [
 	'pages' => [
 		'label' => I18n::translate('pages'),
 		'icon'  => 'page',
-		'query' => function (string $query = null) {
+		'query' => function (string $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$pages = $kirby->site()
 				->index(true)
 				->search($query)
 				->filter('isListable', true)
-				->paginate(
-					(int)$kirby->request()->get('limit', 10),
-					(int)$kirby->request()->get('page', 1)
-				);
+				->paginate($limit, $page);
 
 			return [
 				'results' => $pages->values(fn ($page) => [
@@ -34,17 +31,14 @@ return [
 	'files' => [
 		'label' => I18n::translate('files'),
 		'icon'  => 'image',
-		'query' => function (string $query = null) {
+		'query' => function (string $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$files = $kirby->site()
 				->index(true)
 				->filter('isListable', true)
 				->files()
 				->search($query)
-				->paginate(
-					(int)$kirby->request()->get('limit', 10),
-					(int)$kirby->request()->get('page', 1)
-				);
+				->paginate($limit, $page);
 
 			return [
 				'results' => $files->values(fn ($file) => [

--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -9,49 +9,53 @@ return [
 		'label' => I18n::translate('pages'),
 		'icon'  => 'page',
 		'query' => function (string $query = null) {
-			$pages = App::instance()->site()
+			$kirby = App::instance();
+			$pages = $kirby->site()
 				->index(true)
 				->search($query)
-				->filter('isListable', true);
+				->filter('isListable', true)
+				->paginate(
+					(int)$kirby->request()->get('limit', 10),
+					(int)$kirby->request()->get('page', 1)
+				);
 
-			$results = [];
-
-			foreach ($pages as $page) {
-				$results[] = [
+			return [
+				'results' => $pages->values(fn ($page) => [
 					'image' => $page->panel()->image(),
 					'text' => Escape::html($page->title()->value()),
 					'link' => $page->panel()->url(true),
 					'info' => Escape::html($page->id()),
 					'uuid' => $page->uuid()->toString(),
-				];
-			}
-
-			return $results;
+				]),
+				'pagination' => $pages->pagination()->toArray()
+			];
 		}
 	],
 	'files' => [
 		'label' => I18n::translate('files'),
 		'icon'  => 'image',
 		'query' => function (string $query = null) {
-			$files = App::instance()->site()
+			$kirby = App::instance();
+			$files = $kirby->site()
 				->index(true)
 				->filter('isListable', true)
 				->files()
-				->search($query);
+				->search($query)
+				->paginate(
+					(int)$kirby->request()->get('limit', 10),
+					(int)$kirby->request()->get('page', 1)
+				);
 
-			$results = [];
-
-			foreach ($files as $file) {
-				$results[] = [
+			return [
+				'results' => $files->values(fn ($file) => [
 					'image' => $file->panel()->image(),
 					'text'  => Escape::html($file->filename()),
 					'link'  => $file->panel()->url(true),
 					'info'  => Escape::html($file->id()),
 					'uuid'  => $file->uuid()->toString(),
-				];
-			}
-
-			return $results;
+				]),
+				'pagination' => $files->pagination()->toArray()
+			];
 		}
 	]
 ];

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -8,14 +8,11 @@ return [
 	'users' => [
 		'label' => I18n::translate('users'),
 		'icon'  => 'users',
-		'query' => function (string $query = null) {
+		'query' => function (string $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$users = $kirby->users()
 				->search($query)
-				->paginate(
-					(int)$kirby->request()->get('limit', 10),
-					(int)$kirby->request()->get('page', 1)
-				);
+				->paginate($limit, $page);
 
 			return [
 				'results' => $users->values(fn ($user) => [

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -9,20 +9,24 @@ return [
 		'label' => I18n::translate('users'),
 		'icon'  => 'users',
 		'query' => function (string $query = null) {
-			$users   = App::instance()->users()->search($query);
-			$results = [];
+			$kirby = App::instance();
+			$users = $kirby->users()
+				->search($query)
+				->paginate(
+					(int)$kirby->request()->get('limit', 10),
+					(int)$kirby->request()->get('page', 1)
+				);
 
-			foreach ($users as $user) {
-				$results[] = [
+			return [
+				'results' => $users->values(fn ($user) => [
 					'image' => $user->panel()->image(),
 					'text'  => Escape::html($user->username()),
 					'link'  => $user->panel()->url(true),
 					'info'  => Escape::html($user->role()->title()),
 					'uuid'  => $user->uuid()->toString(),
-				];
-			}
-
-			return $results;
+				]),
+				'pagination' => $users->pagination()->toArray()
+			];
 		}
 	]
 ];

--- a/panel/src/components/Dialogs/SearchDialog.vue
+++ b/panel/src/components/Dialogs/SearchDialog.vue
@@ -68,7 +68,7 @@
 				<k-collection
 					v-if="items.length"
 					ref="items"
-					:items="items.slice(0, 10)"
+					:items="items"
 					@mouseout.native="select(-1)"
 				/>
 
@@ -79,7 +79,7 @@
 					</p>
 
 					<k-button
-						v-else-if="items.length > 10"
+						v-else-if="items.length < pagination.total"
 						icon="search"
 						@click="
 							$go('search', {
@@ -90,7 +90,7 @@
 							})
 						"
 					>
-						All {{ items.length }} results
+						All {{ pagination.total }} results
 					</k-button>
 				</footer>
 			</div>
@@ -108,6 +108,7 @@ export default {
 		return {
 			isLoading: false,
 			items: [],
+			pagination: {},
 			q: null,
 			selected: -1,
 			type: this.$panel.view.search
@@ -173,8 +174,10 @@ export default {
 
 				const response = await this.$search(this.type, query);
 				this.items = response.results;
+				this.pagination = response.pagination;
 			} catch (error) {
 				this.items = [];
+				this.pagination = {};
 			} finally {
 				this.isLoading = false;
 			}

--- a/panel/src/components/Views/SearchView.vue
+++ b/panel/src/components/Views/SearchView.vue
@@ -39,6 +39,8 @@
 							icon: 'search',
 							text: $t('search.results.none')
 						}"
+						:pagination="pagination"
+						@paginate="onPaginate"
 					/>
 				</div>
 			</div>
@@ -56,8 +58,9 @@ export default {
 	},
 	data() {
 		return {
+			items: [],
 			query: this.getQuery(),
-			items: []
+			pagination: {}
 		};
 	},
 	watch: {
@@ -82,12 +85,20 @@ export default {
 		getQuery() {
 			return new URLSearchParams(window.location.search).get("query");
 		},
-		async search(query) {
+		onPaginate(pagination) {
+			this.search(this.query, pagination.page);
+		},
+		async search(query, page) {
 			this.$panel.isLoading = true;
+
+			if (!page) {
+				page = new URLSearchParams(window.location.search).get("page") ?? 1;
+			}
 
 			const url = this.$panel.url(window.location, {
 				type: this.type,
-				query: this.query
+				query: this.query,
+				page: page > 1 ? page : null
 			});
 
 			window.history.pushState("", "", url.toString());
@@ -98,10 +109,15 @@ export default {
 					throw Error("Empty query");
 				}
 
-				const response = await this.$search(this.type, query);
+				const response = await this.$search(this.type, query, {
+					page,
+					limit: 15
+				});
 				this.items = response.results;
+				this.pagination = response.pagination;
 			} catch (error) {
 				this.items = [];
+				this.pagination = {};
 			} finally {
 				this.$panel.isLoading = false;
 			}

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -249,9 +249,10 @@ export default {
 	 *
 	 * @param {String} type
 	 * @param {Object} query
+	 * @param {Object} options { limit, page }
 	 * @returns {Object} { code, path, referrer, results, timestamp }
 	 */
-	async search(type, query) {
+	async search(type, query, options) {
 		// open the search dialog
 		if (!type && !query) {
 			return this.dialog.open({
@@ -260,7 +261,7 @@ export default {
 		}
 
 		const { $search } = await this.get(`/search/${type}`, {
-			query: { query }
+			query: { query, ...options }
 		});
 
 		return $search;

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -449,8 +449,7 @@ class Panel
 					$kirby   = App::instance();
 					$request = $kirby->request();
 					$query   = $request->get('query');
-					$limit   = (int)$request->get('limit', 10);
-					$limit ??= $kirby->option('panel.search.limit', 10);
+					$limit   = (int)$request->get('limit', $kirby->option('panel.search.limit', 10));
 					$page    = (int)$request->get('page', 1);
 
 					return $params['query']($query, $limit, $page);

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -198,7 +198,7 @@ class Panel
 		$request = App::instance()->request();
 
 		return Response::json($data, $code, $request->get('_pretty'), [
-			'X-Fiber' => 'true',
+			'X-Fiber'       => 'true',
 			'Cache-Control' => 'no-store, private'
 		]);
 	}
@@ -446,9 +446,14 @@ class Panel
 				'type'    => 'search',
 				'area'    => $areaId,
 				'action'  => function () use ($params) {
-					$request = App::instance()->request();
+					$kirby   = App::instance();
+					$request = $kirby->request();
+					$query   = $request->get('query');
+					$limit   = (int)$request->get('limit', 10);
+					$limit ??= $kirby->option('panel.search.limit', 10);
+					$page    = (int)$request->get('page', 1);
 
-					return $params['query']($request->get('query'));
+					return $params['query']($query, $limit, $page);
 				}
 			];
 		}

--- a/src/Panel/Search.php
+++ b/src/Panel/Search.php
@@ -19,15 +19,4 @@ use Kirby\Http\Response;
 class Search extends Json
 {
 	protected static string $key = '$search';
-
-	public static function response($data, array $options = []): Response
-	{
-		if (is_array($data) === true) {
-			$data = [
-				'results' => $data
-			];
-		}
-
-		return parent::response($data, $options);
-	}
 }

--- a/src/Panel/Search.php
+++ b/src/Panel/Search.php
@@ -19,4 +19,23 @@ use Kirby\Http\Response;
 class Search extends Json
 {
 	protected static string $key = '$search';
+
+	public static function response($data, array $options = []): Response
+	{
+		if (
+			is_array($data) === true &&
+			array_key_exists('results', $data) === false
+		) {
+			$data = [
+				'results'    => $data,
+				'pagination' => [
+					'page'      => 1,
+					'limit'     => $total = count($data),
+					'total'     => $total
+				]
+			];
+		}
+
+		return parent::response($data, $options);
+	}
 }

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -213,7 +213,11 @@ class View
 					'timestamp'  => (int)(microtime(true) * 1000),
 				];
 
-				$view = array_replace_recursive($defaults, $options['area'] ?? [], $view);
+				$view = array_replace_recursive(
+					$defaults,
+					$options['area'] ?? [],
+					$view
+				);
 
 				// make sure that views and dialogs are gone
 				unset(
@@ -262,12 +266,8 @@ class View
 		return [
 			'$config' => function () use ($kirby) {
 				return [
-					'debug'     => $kirby->option('debug', false),
-					'kirbytext' => $kirby->option('panel.kirbytext', true),
-					'search'    => [
-						'limit' => $kirby->option('panel.search.limit', 10),
-						'type'  => $kirby->option('panel.search.type', 'pages')
-					],
+					'debug'       => $kirby->option('debug', false),
+					'kirbytext'   => $kirby->option('panel.kirbytext', true),
 					'translation' => $kirby->option('panel.language', 'en'),
 				];
 			},

--- a/tests/Panel/Areas/PluginSearchesTest.php
+++ b/tests/Panel/Areas/PluginSearchesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kirby\Panel\Areas;
+
+use Kirby\Cms\App;
+
+class PluginSearchesTest extends AreaTestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->install();
+		$this->login();
+		App::destroy();
+	}
+
+	public function testLegacyPluginSearch(): void
+	{
+		App::plugin('test/a', [
+			'areas' => [
+				'test' => [
+					'search' => 'test',
+					'searches' => [
+						'test' => [
+							'query' => function (string $query = null) {
+								return [['a'], ['b'], ['c']];
+							},
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app([
+			'request' => [
+				'query' => [
+					'query' => 'test'
+				]
+			]
+		]);
+
+		$this->login();
+
+		$search = $this->search('test');
+
+		$this->assertCount(3, $search['results']);
+		$this->assertSame(1, $search['pagination']['page']);
+		$this->assertSame(3, $search['pagination']['limit']);
+		$this->assertSame(3, $search['pagination']['total']);
+	}
+}

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -484,7 +484,6 @@ class ViewTest extends TestCase
 		// $config
 		$this->assertFalse($config['debug']);
 		$this->assertTrue($config['kirbytext']);
-		$this->assertSame(['limit' => 10, 'type'  => 'pages'], $config['search']);
 		$this->assertSame('en', $config['translation']);
 
 		// $system


### PR DESCRIPTION
# Breaking changes
- Removed `this.$config.search` from Panel
- Area `search` plugins receive two additional arguments for their `query` callback: `$limit` and `$page` to be used to paginate the results. They should then return an array with entries `results` and `pagination`.