### PR TITLE
Fix extending Vue components

### DIFF
--- a/panel/src/config/errorhandling.js
+++ b/panel/src/config/errorhandling.js
@@ -1,5 +1,5 @@
 export default {
-	install(app, panel) {
+	install(app) {
 		/**
 		 * Handles promise rejections that have
 		 * not been caught
@@ -9,11 +9,11 @@ export default {
 		window.onunhandledrejection = (event) => {
 			event.preventDefault();
 
-			if (panel.debug) {
+			if (window.panel.debug) {
 				console.error(event.reason);
 			}
 
-			panel.notification.error(event.reason);
+			window.panel.notification.error(event.reason);
 		};
 
 		/**
@@ -22,11 +22,11 @@ export default {
 		 * @param {Error} error
 		 */
 		app.config.errorHandler = (error) => {
-			if (panel.debug) {
+			if (window.panel.debug) {
 				console.error(error);
 			}
 
-			panel.notification.error(error);
+			window.panel.notification.error(error);
 		};
 	}
 };

--- a/panel/src/index.js
+++ b/panel/src/index.js
@@ -15,15 +15,29 @@ Vue.config.productionTip = false;
 Vue.config.devtools = true;
 
 /**
- * Create the Panel instance
+ * Global styles need to be loaded before
+ * components
  */
-window.panel = Panel.create(window.panel.plugins);
+import "./styles/variables.css";
+import "./styles/reset.css";
+import "./styles/animations.css";
 
 /**
+ * Load all relevant Vue plugins
+ * that do not depend on the Panel instance
+ */
+Vue.use(Helpers);
+Vue.use(Libraries);
+Vue.use(Vuelidate);
+Vue.use(Components);
+
+/**
+ * Create the Panel instance
+ *
  * This is the single source of truth
  * for all Vue components.
  */
-Vue.prototype.$panel = window.panel;
+window.panel = Vue.prototype.$panel = Panel.create(window.panel.plugins);
 
 /**
  * Some shortcuts to the Panel's features
@@ -40,23 +54,11 @@ window.panel.app = new Vue({
 });
 
 /**
- * Global styles need to be loaded before
- * components
- */
-import "./styles/variables.css";
-import "./styles/reset.css";
-import "./styles/animations.css";
-
-/**
  * Additional functionalities and app configuration
  */
-Vue.use(ErrorHandling, window.panel);
-Vue.use(Legacy, window.panel);
-Vue.use(Helpers);
-Vue.use(Libraries);
 Vue.use(I18n);
-Vue.use(Vuelidate);
-Vue.use(Components);
+Vue.use(ErrorHandling);
+Vue.use(Legacy);
 
 /**
  * Load CSS utilities after components

--- a/panel/src/legacy/index.js
+++ b/panel/src/legacy/index.js
@@ -7,20 +7,22 @@ import dropdown from "./dropdown.js";
  * in future major releases to clean up.
  */
 export default {
-	install(app, panel) {
+	install(app) {
 		/**
 		 * @deprecated Deprecated Panel Methods
 		 */
-		panel.error = app.config.errorHandler;
-		panel.deprecated = panel.notification.deprecated.bind(panel.notification);
+		window.panel.error = app.config.errorHandler;
+		window.panel.deprecated = window.panel.notification.deprecated.bind(
+			window.panel.notification
+		);
 
 		/**
 		 * Method object binding for the polyfills below
 		 */
-		panel.redirect = panel.redirect.bind(panel);
-		panel.reload = panel.reload.bind(panel);
-		panel.request = panel.request.bind(panel);
-		panel.search = panel.search.bind(panel);
+		window.panel.redirect = window.panel.redirect.bind(window.panel);
+		window.panel.reload = window.panel.reload.bind(window.panel);
+		window.panel.request = window.panel.request.bind(window.panel);
+		window.panel.search = window.panel.search.bind(window.panel);
 
 		/**
 		 * @deprecated Dollar Sign Shortcuts
@@ -62,7 +64,7 @@ export default {
 
 		for (const polyfill of polyfills) {
 			const key = `$${polyfill}`;
-			app.prototype[key] = panel[key] = panel[polyfill];
+			app.prototype[key] = window.panel[key] = window.panel[polyfill];
 		}
 
 		/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

`window.Vue.options.components` inside the `isComponent` helper would not yet have access to core components if plugins registry runs before the core components are registered (which now the plugin registry got run directly then creating the new `Panel` instance)

### Fixes
- #5183
- #5182
- https://github.com/getkirby/kirby/issues/5201

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
