### PR TITLE
`Query` package: remove strict types again

### DIFF
--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Closure;

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Kirby\Toolkit\A;

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Kirby\Exception\LogicException;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Closure;

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Closure;
@@ -87,7 +85,7 @@ class Segment
 
 		// 1st segment, start from $data array
 		if ($this->position === 0) {
-			if (is_array($data) == true) {
+			if (is_array($data) === true) {
 				return $this->resolveArray($data, $args);
 			}
 
@@ -129,8 +127,8 @@ class Segment
 	}
 
 	/**
-	 * Resolves segment by calling the method/accessing the property
-	 * on the base object
+	 * Resolves segment by calling the method/
+	 * accessing the property on the base object
 	 */
 	protected function resolveObject(object $object, array $args): mixed
 	{
@@ -142,7 +140,8 @@ class Segment
 		}
 
 		if (
-			$args === [] && (
+			$args === [] &&
+			(
 				property_exists($object, $this->method) === true ||
 				method_exists($object, '__get') === true
 			)

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Kirby\Query;
 
 use Kirby\Toolkit\A;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Strict types are causing issues when we want to support passing a `Field` object which gets casted to a string (the field value). I currently see the benefits of stricter types not outweighing the issues we would have to add checks for `Field` objects all over. That's why I suggest that we just revert the strict types for now again.

### Fixes
- #5185
