### PR TITLE
Clean some of `Form` package

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -54,13 +54,13 @@ class Field extends Component
 	/**
 	 * Field constructor
 	 *
-	 * @param string $type
-	 * @param array $attrs
-	 * @param \Kirby\Form\Fields|null $formFields
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public function __construct(string $type, array $attrs = [], ?Fields $formFields = null)
-	{
+	public function __construct(
+		string $type,
+		array $attrs = [],
+		Fields|null $formFields = null
+	) {
 		if (isset(static::$types[$type]) === false) {
 			throw new InvalidArgumentException([
 				'key'  => 'field.type.missing',
@@ -99,7 +99,6 @@ class Field extends Component
 	/**
 	 * Returns field data
 	 *
-	 * @param bool $default
 	 * @return mixed
 	 */
 	public function data(bool $default = false)
@@ -125,8 +124,6 @@ class Field extends Component
 
 	/**
 	 * Default props and computed of the field
-	 *
-	 * @return array
 	 */
 	public static function defaults(): array
 	{
@@ -265,8 +262,6 @@ class Field extends Component
 
 	/**
 	 * Returns optional dialog routes for the field
-	 *
-	 * @return array
 	 */
 	public function dialogs(): array
 	{
@@ -282,8 +277,6 @@ class Field extends Component
 
 	/**
 	 * Returns optional drawer routes for the field
-	 *
-	 * @return array
 	 */
 	public function drawers(): array
 	{
@@ -300,13 +293,13 @@ class Field extends Component
 	/**
 	 * Creates a new field instance
 	 *
-	 * @param string $type
-	 * @param array $attrs
-	 * @param Fields|null $formFields
 	 * @return static
 	 */
-	public static function factory(string $type, array $attrs = [], ?Fields $formFields = null)
-	{
+	public static function factory(
+		string $type,
+		array $attrs = [],
+		Fields|null $formFields = null
+	) {
 		$field = static::$types[$type] ?? null;
 
 		if (is_string($field) && class_exists($field) === true) {
@@ -319,18 +312,14 @@ class Field extends Component
 
 	/**
 	 * Parent collection with all fields of the current form
-	 *
-	 * @return \Kirby\Form\Fields|null
 	 */
-	public function formFields(): ?Fields
+	public function formFields(): Fields|null
 	{
 		return $this->formFields;
 	}
 
 	/**
 	 * Validates when run for the first time and returns any errors
-	 *
-	 * @return array
 	 */
 	public function errors(): array
 	{
@@ -345,7 +334,6 @@ class Field extends Component
 	 * Checks if the field is empty
 	 *
 	 * @param mixed ...$args
-	 * @return bool
 	 */
 	public function isEmpty(...$args): bool
 	{
@@ -372,8 +360,6 @@ class Field extends Component
 
 	/**
 	 * Checks if the field is invalid
-	 *
-	 * @return bool
 	 */
 	public function isInvalid(): bool
 	{
@@ -382,8 +368,6 @@ class Field extends Component
 
 	/**
 	 * Checks if the field is required
-	 *
-	 * @return bool
 	 */
 	public function isRequired(): bool
 	{
@@ -392,8 +376,6 @@ class Field extends Component
 
 	/**
 	 * Checks if the field is valid
-	 *
-	 * @return bool
 	 */
 	public function isValid(): bool
 	{
@@ -427,8 +409,6 @@ class Field extends Component
 	 * - The field is required
 	 * - The field is currently empty
 	 * - The field is not currently inactive because of a `when` rule
-	 *
-	 * @return bool
 	 */
 	protected function needsValue(): bool
 	{
@@ -462,8 +442,6 @@ class Field extends Component
 
 	/**
 	 * Checks if the field is saveable
-	 *
-	 * @return bool
 	 */
 	public function save(): bool
 	{
@@ -472,8 +450,6 @@ class Field extends Component
 
 	/**
 	 * Converts the field to a plain array
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -495,8 +471,6 @@ class Field extends Component
 
 	/**
 	 * Runs the validations defined for the field
-	 *
-	 * @return void
 	 */
 	protected function validate(): void
 	{

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -96,7 +96,7 @@ class BlocksField extends FieldClass
 		return empty($fieldsetGroups) === true ? null : $fieldsetGroups;
 	}
 
-	public function fill($value = null)
+	public function fill($value = null): void
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value);
@@ -234,7 +234,7 @@ class BlocksField extends FieldClass
 		return $this->valueToJson($blocks, $this->pretty());
 	}
 
-	protected function setDefault($default = null)
+	protected function setDefault($default = null): void
 	{
 		// set id for blocks if not exists
 		if (is_array($default) === true) {
@@ -246,7 +246,7 @@ class BlocksField extends FieldClass
 		parent::setDefault($default);
 	}
 
-	protected function setFieldsets($fieldsets, $model)
+	protected function setFieldsets($fieldsets, $model): void
 	{
 		if (is_string($fieldsets) === true) {
 			$fieldsets = [];
@@ -257,12 +257,12 @@ class BlocksField extends FieldClass
 		]);
 	}
 
-	protected function setGroup(string $group = null)
+	protected function setGroup(string $group = null): void
 	{
 		$this->group = $group;
 	}
 
-	protected function setPretty(bool $pretty = false)
+	protected function setPretty(bool $pretty = false): void
 	{
 		$this->pretty = $pretty;
 	}

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -26,7 +26,7 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	public function fill($value = null)
+	public function fill($value = null): void
 	{
 		$value   = $this->valueFromJson($value);
 		$layouts = Layouts::factory($value, ['parent' => $this->model])->toArray();
@@ -185,7 +185,7 @@ class LayoutField extends BlocksField
 		return $routes;
 	}
 
-	protected function setDefault($default = null)
+	protected function setDefault($default = null): void
 	{
 		// set id for layouts, columns and blocks within layout if not exists
 		if (is_array($default) === true) {
@@ -211,7 +211,7 @@ class LayoutField extends BlocksField
 		parent::setDefault($default);
 	}
 
-	protected function setLayouts(array $layouts = [])
+	protected function setLayouts(array $layouts = []): void
 	{
 		$this->layouts = array_map(
 			fn ($layout) => Str::split($layout),
@@ -219,7 +219,7 @@ class LayoutField extends BlocksField
 		);
 	}
 
-	protected function setSettings($settings = null)
+	protected function setSettings($settings = null): void
 	{
 		if (empty($settings) === true) {
 			$this->settings = null;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -118,8 +118,6 @@ abstract class FieldClass
 	protected $width;
 
 	/**
-	 * @param string $param
-	 * @param array $args
 	 * @return mixed
 	 */
 	public function __call(string $param, array $args)
@@ -131,9 +129,6 @@ abstract class FieldClass
 		return $this->params[$param] ?? null;
 	}
 
-	/**
-	 * @param array $params
-	 */
 	public function __construct(array $params = [])
 	{
 		$this->params = $params;
@@ -160,33 +155,21 @@ abstract class FieldClass
 		}
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function after(): string|null
 	{
 		return $this->stringTemplate($this->after);
 	}
 
-	/**
-	 * @return array
-	 */
 	public function api(): array
 	{
 		return $this->routes();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function autofocus(): bool
 	{
 		return $this->autofocus;
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function before(): string|null
 	{
 		return $this->stringTemplate($this->before);
@@ -200,7 +183,6 @@ abstract class FieldClass
 	 * in a format to be stored
 	 * in Kirby's content fields
 	 *
-	 * @param bool $default
 	 * @return mixed
 	 */
 	public function data(bool $default = false)
@@ -225,8 +207,6 @@ abstract class FieldClass
 
 	/**
 	 * Returns optional dialog routes for the field
-	 *
-	 * @return array
 	 */
 	public function dialogs(): array
 	{
@@ -235,8 +215,6 @@ abstract class FieldClass
 
 	/**
 	 * If `true`, the field is no longer editable and will not be saved
-	 *
-	 * @return bool
 	 */
 	public function disabled(): bool
 	{
@@ -245,8 +223,6 @@ abstract class FieldClass
 
 	/**
 	 * Returns optional drawer routes for the field
-	 *
-	 * @return array
 	 */
 	public function drawers(): array
 	{
@@ -256,8 +232,6 @@ abstract class FieldClass
 	/**
 	 * Runs all validations and returns an array of
 	 * error messages
-	 *
-	 * @return array
 	 */
 	public function errors(): array
 	{
@@ -268,17 +242,14 @@ abstract class FieldClass
 	 * Setter for the value
 	 *
 	 * @param mixed $value
-	 * @return void
 	 */
-	public function fill($value = null)
+	public function fill($value = null): void
 	{
 		$this->value = $value;
 	}
 
 	/**
 	 * Optional help text below the field
-	 *
-	 * @return string|null
 	 */
 	public function help(): string|null
 	{
@@ -293,7 +264,6 @@ abstract class FieldClass
 
 	/**
 	 * @param string|array|null $param
-	 * @return string|null
 	 */
 	protected function i18n($param = null): string|null
 	{
@@ -302,33 +272,22 @@ abstract class FieldClass
 
 	/**
 	 * Optional icon that will be shown at the end of the field
-	 *
-	 * @return string|null
 	 */
 	public function icon(): string|null
 	{
 		return $this->icon;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function id(): string
 	{
 		return $this->name();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isDisabled(): bool
 	{
 		return $this->disabled;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isEmpty(): bool
 	{
 		return $this->isEmptyValue($this->value());
@@ -336,7 +295,6 @@ abstract class FieldClass
 
 	/**
 	 * @param mixed $value
-	 * @return bool
 	 */
 	public function isEmptyValue($value = null): bool
 	{
@@ -350,25 +308,17 @@ abstract class FieldClass
 
 	/**
 	 * Checks if the field is invalid
-	 *
-	 * @return bool
 	 */
 	public function isInvalid(): bool
 	{
 		return $this->isValid() === false;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isRequired(): bool
 	{
 		return $this->required;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isSaveable(): bool
 	{
 		return true;
@@ -376,8 +326,6 @@ abstract class FieldClass
 
 	/**
 	 * Checks if the field is valid
-	 *
-	 * @return bool
 	 */
 	public function isValid(): bool
 	{
@@ -396,12 +344,12 @@ abstract class FieldClass
 
 	/**
 	 * The field label can be set as string or associative array with translations
-	 *
-	 * @return string
 	 */
 	public function label(): string
 	{
-		return $this->stringTemplate($this->label ?? Str::ucfirst($this->name()));
+		return $this->stringTemplate(
+			$this->label ?? Str::ucfirst($this->name())
+		);
 	}
 
 	/**
@@ -416,8 +364,6 @@ abstract class FieldClass
 
 	/**
 	 * Returns the field name
-	 *
-	 * @return string
 	 */
 	public function name(): string
 	{
@@ -431,8 +377,6 @@ abstract class FieldClass
 	 * - The field is required
 	 * - The field is currently empty
 	 * - The field is not currently inactive because of a `when` rule
-	 *
-	 * @return bool
 	 */
 	protected function needsValue(): bool
 	{
@@ -470,8 +414,6 @@ abstract class FieldClass
 
 	/**
 	 * Returns all original params for the field
-	 *
-	 * @return array
 	 */
 	public function params(): array
 	{
@@ -480,8 +422,6 @@ abstract class FieldClass
 
 	/**
 	 * Optional placeholder value that will be shown when the field is empty
-	 *
-	 * @return string|null
 	 */
 	public function placeholder(): string|null
 	{
@@ -491,8 +431,6 @@ abstract class FieldClass
 	/**
 	 * Define the props that will be sent to
 	 * the Vue component
-	 *
-	 * @return array
 	 */
 	public function props(): array
 	{
@@ -519,8 +457,6 @@ abstract class FieldClass
 
 	/**
 	 * If `true`, the field has to be filled in correctly to be saved.
-	 *
-	 * @return bool
 	 */
 	public function required(): bool
 	{
@@ -529,8 +465,6 @@ abstract class FieldClass
 
 	/**
 	 * Routes for the field API
-	 *
-	 * @return array
 	 */
 	public function routes(): array
 	{
@@ -549,126 +483,85 @@ abstract class FieldClass
 
 	/**
 	 * @param array|string|null $after
-	 * @return void
 	 */
-	protected function setAfter($after = null)
+	protected function setAfter($after = null): void
 	{
 		$this->after = $this->i18n($after);
 	}
 
-	/**
-	 * @param bool $autofocus
-	 * @return void
-	 */
-	protected function setAutofocus(bool $autofocus = false)
+	protected function setAutofocus(bool $autofocus = false): void
 	{
 		$this->autofocus = $autofocus;
 	}
 
 	/**
 	 * @param array|string|null $before
-	 * @return void
 	 */
-	protected function setBefore($before = null)
+	protected function setBefore($before = null): void
 	{
 		$this->before = $this->i18n($before);
 	}
 
 	/**
 	 * @param mixed $default
-	 * @return void
 	 */
-	protected function setDefault($default = null)
+	protected function setDefault($default = null): void
 	{
 		$this->default = $default;
 	}
 
-	/**
-	 * @param bool $disabled
-	 * @return void
-	 */
-	protected function setDisabled(bool $disabled = false)
+	protected function setDisabled(bool $disabled = false): void
 	{
 		$this->disabled = $disabled;
 	}
 
 	/**
 	 * @param array|string|null $help
-	 * @return void
 	 */
-	protected function setHelp($help = null)
+	protected function setHelp($help = null): void
 	{
 		$this->help = $this->i18n($help);
 	}
 
-	/**
-	 * @param string|null $icon
-	 * @return void
-	 */
-	protected function setIcon(string|null $icon = null)
+	protected function setIcon(string|null $icon = null): void
 	{
 		$this->icon = $icon;
 	}
 
 	/**
 	 * @param array|string|null $label
-	 * @return void
 	 */
-	protected function setLabel($label = null)
+	protected function setLabel($label = null): void
 	{
 		$this->label = $this->i18n($label);
 	}
 
-	/**
-	 * @param \Kirby\Cms\ModelWithContent $model
-	 * @return void
-	 */
-	protected function setModel(ModelWithContent $model)
+	protected function setModel(ModelWithContent $model): void
 	{
 		$this->model = $model;
 	}
 
-	/**
-	 * @param string|null $name
-	 * @return void
-	 */
-	protected function setName(string $name = null)
+	protected function setName(string|null $name = null): void
 	{
 		$this->name = $name;
 	}
 
-	/**
-	 * @param array|string|null $placeholder
-	 * @return void
-	 */
-	protected function setPlaceholder($placeholder = null)
+	protected function setPlaceholder($placeholder = null): void
 	{
 		$this->placeholder = $this->i18n($placeholder);
 	}
 
-	/**
-	 * @param bool $required
-	 * @return void
-	 */
-	protected function setRequired(bool $required = false)
+	protected function setRequired(bool $required = false): void
 	{
 		$this->required = $required;
 	}
 
-	/**
-	 * @param \Kirby\Form\Fields|null $siblings
-	 * @return void
-	 */
-	protected function setSiblings(?Fields $siblings = null)
+	protected function setSiblings(Fields|null $siblings = null): void
 	{
 		$this->siblings = $siblings ?? new Fields([$this]);
 	}
 
-	/**
-	 * @param bool $translate
-	 * @return void
-	 */
-	protected function setTranslate(bool $translate = true)
+	protected function setTranslate(bool $translate = true): void
 	{
 		$this->translate = $translate;
 	}
@@ -677,20 +570,16 @@ abstract class FieldClass
 	 * Setter for the when condition
 	 *
 	 * @param mixed $when
-	 * @return void
 	 */
-	protected function setWhen($when = null)
+	protected function setWhen($when = null): void
 	{
 		$this->when = $when;
 	}
 
 	/**
 	 * Setter for the field width
-	 *
-	 * @param string|null $width
-	 * @return void
 	 */
-	protected function setWidth(string $width = null)
+	protected function setWidth(string|null $width = null): void
 	{
 		$this->width = $width;
 	}
@@ -707,9 +596,6 @@ abstract class FieldClass
 
 	/**
 	 * Parses a string template in the given value
-	 *
-	 * @param string|null $string
-	 * @return string|null
 	 */
 	protected function stringTemplate(string|null $string = null): string|null
 	{
@@ -734,8 +620,6 @@ abstract class FieldClass
 
 	/**
 	 * Should the field be translatable?
-	 *
-	 * @return bool
 	 */
 	public function translate(): bool
 	{
@@ -744,8 +628,6 @@ abstract class FieldClass
 
 	/**
 	 * Converts the field to a plain array
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -759,8 +641,6 @@ abstract class FieldClass
 
 	/**
 	 * Returns the field type
-	 *
-	 * @return string
 	 */
 	public function type(): string
 	{
@@ -769,8 +649,6 @@ abstract class FieldClass
 
 	/**
 	 * Runs the validations defined for the field
-	 *
-	 * @return array
 	 */
 	protected function validate(): array
 	{
@@ -808,8 +686,6 @@ abstract class FieldClass
 
 	/**
 	 * Defines all validation rules
-	 *
-	 * @return array
 	 */
 	protected function validations(): array
 	{
@@ -837,7 +713,6 @@ abstract class FieldClass
 
 	/**
 	 * @param mixed $value
-	 * @return array
 	 */
 	protected function valueFromJson($value): array
 	{
@@ -850,20 +725,16 @@ abstract class FieldClass
 
 	/**
 	 * @param mixed $value
-	 * @return array
 	 */
 	protected function valueFromYaml($value): array
 	{
 		return Data::decode($value, 'yaml');
 	}
 
-	/**
-	 * @param array|null $value
-	 * @param bool $pretty
-	 * @return string
-	 */
-	protected function valueToJson(array $value = null, bool $pretty = false): string
-	{
+	protected function valueToJson(
+		array $value = null,
+		bool $pretty = false
+	): string {
 		$constants = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
 		if ($pretty === true) {
@@ -873,10 +744,6 @@ abstract class FieldClass
 		return json_encode($value, $constants);
 	}
 
-	/**
-	 * @param array|null $value
-	 * @return string
-	 */
 	protected function valueToYaml(array $value = null): string
 	{
 		return Data::encode($value, 'yaml');
@@ -884,8 +751,6 @@ abstract class FieldClass
 
 	/**
 	 * Conditions when the field will be shown
-	 *
-	 * @return array|null
 	 */
 	public function when(): array|null
 	{
@@ -895,8 +760,6 @@ abstract class FieldClass
 	/**
 	 * Returns the width of the field in
 	 * the Panel grid
-	 *
-	 * @return string
 	 */
 	public function width(): string
 	{

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -21,9 +21,7 @@ class Fields extends Collection
 	 * This takes care of validation and of setting
 	 * the collection prop on each object correctly.
 	 *
-	 * @param string $name
 	 * @param object|array $field
-	 * @return void
 	 */
 	public function __set(string $name, $field): void
 	{
@@ -40,9 +38,6 @@ class Fields extends Collection
 	 * Converts the fields collection to an
 	 * array and also does that for every
 	 * included field.
-	 *
-	 * @param \Closure|null $map
-	 * @return array
 	 */
 	public function toArray(Closure $map = null): array
 	{

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -48,8 +48,6 @@ class Form
 
 	/**
 	 * Form constructor
-	 *
-	 * @param array $props
 	 */
 	public function __construct(array $props)
 	{
@@ -118,8 +116,6 @@ class Form
 	/**
 	 * Returns the data required to write to the content file
 	 * Doesn't include default and null values
-	 *
-	 * @return array
 	 */
 	public function content(): array
 	{
@@ -130,8 +126,6 @@ class Form
 	 * Returns data for all fields in the form
 	 *
 	 * @param false $defaults
-	 * @param bool $includeNulls
-	 * @return array
 	 */
 	public function data($defaults = false, bool $includeNulls = true): array
 	{
@@ -154,8 +148,6 @@ class Form
 
 	/**
 	 * An array of all found errors
-	 *
-	 * @return array
 	 */
 	public function errors(): array
 	{
@@ -180,12 +172,12 @@ class Form
 	/**
 	 * Shows the error with the field
 	 *
-	 * @param \Throwable $exception
-	 * @param array $props
 	 * @return \Kirby\Form\Field
 	 */
-	public static function exceptionField(Throwable $exception, array $props = [])
-	{
+	public static function exceptionField(
+		Throwable $exception,
+		array $props = []
+	) {
 		$message = $exception->getMessage();
 
 		if (App::instance()->option('debug') === true) {
@@ -285,8 +277,6 @@ class Form
 
 	/**
 	 * Checks if the form is invalid
-	 *
-	 * @return bool
 	 */
 	public function isInvalid(): bool
 	{
@@ -295,8 +285,6 @@ class Form
 
 	/**
 	 * Checks if the form is valid
-	 *
-	 * @return bool
 	 */
 	public function isValid(): bool
 	{
@@ -306,13 +294,11 @@ class Form
 	/**
 	 * Disables fields in secondary languages when
 	 * they are configured to be untranslatable
-	 *
-	 * @param array $fields
-	 * @param string|null $language
-	 * @return array
 	 */
-	protected static function prepareFieldsForLanguage(array $fields, string|null $language = null): array
-	{
+	protected static function prepareFieldsForLanguage(
+		array $fields,
+		string|null $language = null
+	): array {
 		$kirby = App::instance(null, true);
 
 		// only modify the fields if we have a valid Kirby multilang instance
@@ -339,7 +325,6 @@ class Form
 	 * Converts the data of fields to strings
 	 *
 	 * @param false $defaults
-	 * @return array
 	 */
 	public function strings($defaults = false): array
 	{
@@ -360,8 +345,6 @@ class Form
 
 	/**
 	 * Converts the form to a plain array
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -376,8 +359,6 @@ class Form
 
 	/**
 	 * Returns form values
-	 *
-	 * @return array
 	 */
 	public function values(): array
 	{

--- a/src/Form/Validations.php
+++ b/src/Form/Validations.php
@@ -20,8 +20,6 @@ class Validations
 	 * Validates if the field value is boolean
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function boolean($field, $value): bool
@@ -41,8 +39,6 @@ class Validations
 	 * Validates if the field value is valid date
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function date($field, $value): bool
@@ -62,8 +58,6 @@ class Validations
 	 * Validates if the field value is valid email
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function email($field, $value): bool
@@ -83,8 +77,6 @@ class Validations
 	 * Validates if the field value is maximum
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function max($field, $value): bool
@@ -104,8 +96,6 @@ class Validations
 	 * Validates if the field value is max length
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function maxlength($field, $value): bool
@@ -125,8 +115,6 @@ class Validations
 	 * Validates if the field value is minimum
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function min($field, $value): bool
@@ -146,8 +134,6 @@ class Validations
 	 * Validates if the field value is min length
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function minlength($field, $value): bool
@@ -167,8 +153,6 @@ class Validations
 	 * Validates if the field value matches defined pattern
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function pattern($field, $value): bool
@@ -188,8 +172,6 @@ class Validations
 	 * Validates if the field value is required
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function required($field, $value): bool
@@ -207,8 +189,6 @@ class Validations
 	 * Validates if the field value is in defined options
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function option($field, $value): bool
@@ -230,8 +210,6 @@ class Validations
 	 * Validates if the field values is in defined options
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function options($field, $value): bool
@@ -254,8 +232,6 @@ class Validations
 	 * Validates if the field value is valid time
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function time($field, $value): bool
@@ -275,8 +251,6 @@ class Validations
 	 * Validates if the field value is valid url
 	 *
 	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass $field
-	 * @param $value
-	 * @return bool
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public static function url($field, $value): bool

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -28,7 +28,7 @@ class UnsaveableField extends FieldClass
 
 class JsonField extends FieldClass
 {
-	public function fill($value = null)
+	public function fill($value = null): void
 	{
 		$this->value = $this->valueFromJson($value);
 	}
@@ -36,7 +36,7 @@ class JsonField extends FieldClass
 
 class YamlField extends FieldClass
 {
-	public function fill($value = null)
+	public function fill($value = null): void
 	{
 		$this->value = $this->valueFromYaml($value);
 	}


### PR DESCRIPTION
I've tried to only make formatting changes or removing docblocks where a native type hint already exists. This should help reviewing the PR, making it not too hard. Only exception is a few `: void` native type hints added.