### PR TITLE
Page move: consider section parent in rules

### DIFF
--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -396,7 +396,14 @@ class PageRules
 				continue;
 			}
 
-			// go through all allowed blueprints and add the name to the allow list
+			// only consider page sections that list pages
+			// of the targeted new parent page
+			if ($section->parent() !== $parent) {
+				continue;
+			}
+
+			// go through all allowed blueprints and
+			// add the name to the allow list
 			foreach ($section->blueprints() as $blueprint) {
 				$allowed[] = $blueprint['name'];
 			}
@@ -408,7 +415,7 @@ class PageRules
 				'key'  => 'page.move.template',
 				'data' => [
 					'template' => $page->intendedTemplate()->name(),
-					'parent'   => $parent->id()
+					'parent'   => $parent->id() ?? '/',
 				]
 			]);
 		}

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -864,7 +864,7 @@ class PageRulesTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => '/dev/null',
+				'index' => $this->tmp,
 			],
 			'site' => [
 				'children' => [
@@ -890,6 +890,11 @@ class PageRulesTest extends TestCase
 						'albums' => [
 							'type'      => 'pages',
 							'templates' => ['album']
+						],
+						'related' => [
+							'type'      => 'pages',
+							'parent'    => 'site.find("parent-a")',
+							'templates' => ['article']
 						]
 					]
 				]


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `PageRules::move()` considers whether a pages section actually refers to subpages of the current page when collecting allowed blueprints
- #5218
