### PR TITLE
Adding Variadic Controller Arguments

### DIFF
--- a/src/Toolkit/Controller.php
+++ b/src/Toolkit/Controller.php
@@ -31,7 +31,7 @@ class Controller
 		foreach ($info->getParameters() as $param) {
 			$name = $param->getName();
 
-			if ($param->isVariadic()) {
+			if ($param->isVariadic() === true) {
 				$args += $data;
 			} else {
 				$args[$name] = $data[$name] ?? null;

--- a/src/Toolkit/Controller.php
+++ b/src/Toolkit/Controller.php
@@ -26,11 +26,19 @@ class Controller
 	public function arguments(array $data = []): array
 	{
 		$info = new ReflectionFunction($this->function);
+		$args = [];
 
-		return A::map(
-			$info->getParameters(),
-			fn ($parameter) => $data[$parameter->getName()] ?? null
-		);
+		foreach ($info->getParameters() as $param) {
+			$name = $param->getName();
+
+			if ($param->isVariadic()) {
+				$args += $data;
+			} else {
+				$args[$name] = $data[$name] ?? null;
+			}
+		}
+
+		return $args;
 	}
 
 	public function call($bind = null, $data = [])

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -32,6 +32,19 @@ class ControllerTest extends TestCase
 	/**
 	 * @covers ::arguments
 	 */
+	public function testArgumentsOrder()
+	{
+		$controller = new Controller(fn ($b, $a) => $b . $a);
+
+		$this->assertSame('BA', $controller->call(null, [
+			'a' => 'A',
+			'b' => 'B'
+		]));
+	}
+
+	/**
+	 * @covers ::arguments
+	 */
 	public function testVariadicArguments()
 	{
 		$controller = new Controller(fn ($c, ...$args) => $c . '/' . implode('', $args));

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -30,6 +30,20 @@ class ControllerTest extends TestCase
 	}
 
 	/**
+	 * @covers ::arguments
+	 */
+	public function testVariadicArguments()
+	{
+		$controller = new Controller(fn ($c, ...$args) => $c . implode('', $args));
+
+		$this->assertSame('CAB', $controller->call(null, [
+			'a' => 'A',
+			'b' => 'B',
+			'c' => 'C'
+		]));
+	}
+
+	/**
 	 * @covers ::call
 	 */
 	public function testCallBind()

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -36,7 +36,7 @@ class ControllerTest extends TestCase
 	{
 		$controller = new Controller(fn ($c, ...$args) => $c . '/' . implode('', $args));
 
-		$this->assertSame('CAB', $controller->call(null, [
+		$this->assertSame('C/AB', $controller->call(null, [
 			'a' => 'A',
 			'b' => 'B',
 			'c' => 'C'

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -34,7 +34,7 @@ class ControllerTest extends TestCase
 	 */
 	public function testVariadicArguments()
 	{
-		$controller = new Controller(fn ($c, ...$args) => $c . implode('', $args));
+		$controller = new Controller(fn ($c, ...$args) => $c . '/' . implode('', $args));
 
 		$this->assertSame('CAB', $controller->call(null, [
 			'a' => 'A',


### PR DESCRIPTION
## This PR …
Currently working on an update for a plugin where I previously used the `Kirby\Toolkit\Controller` to pass in arguments.
Thought this might be something for the core as well, as it does not break anything and allows for some advanced implementations without adding (🤞) any extra complexity. 

Edit:
On second thought this actually fixes some edge cases:

```php
$controller = new Controller(function ($c, ...$b) {
	// Current implementation
	// $c = 'C'
	// $b = ['B']

	// Should be
	// $c = 'C'
	// $b = ['A', 'B']
});

$controller->call(null, [
	'a' => 'A',
	'b' => 'B',
	'c' => 'C'
]);
```

## Ready?
- [x] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
