### PR TITLE
Query language support for pages section `create` and `templates` and files section `template` props

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\File;
 use Kirby\Cms\Files;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\I18n;
 
 return [

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -39,6 +39,23 @@ return [
 		}
 	],
 	'computed' => [
+		/**
+		 * Do not change the order of this alphabetically.
+		 * It must be processed before other computed calls to work correctly.
+		 */
+		'template' => function () {
+			$template = $this->template;
+
+			if ($query = $this->model->query($template)) {
+				if (is_string($query) === false) {
+					throw new InvalidArgumentException('Invalid `template` prop: query must return a string.');
+				}
+
+				$template = $query;
+			}
+
+			return $template;
+		},
 		'accept' => function () {
 			if ($this->template) {
 				$file = new File([

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -51,13 +51,59 @@ return [
 			return $status;
 		},
 		/**
+		 * Filters the list by single template.
+		 */
+		'template' => function (string $template = null) {
+			return $template;
+		},
+		/**
 		 * Filters the list by templates and sets template options when adding new pages to the section.
 		 */
 		'templates' => function ($templates = null) {
-			return A::wrap($templates ?? $this->template);
+			return $templates;
 		}
 	],
 	'computed' => [
+		'create' => function () {
+			$create = $this->create;
+
+			if (is_string($create) === true) {
+				if ($query = $this->model->query($create)) {
+					if (
+						is_string($query) === false &&
+						is_array($query) === false
+					) {
+						throw new InvalidArgumentException('Invalid `create` prop: query must return string or array.');
+					}
+
+					$create = $query;
+				}
+			}
+
+			return $create;
+		},
+		/**
+		 * Do not change the order of this alphabetically.
+		 * It must be processed before other computed calls to work correctly.
+		 */
+		'templates' => function () {
+			$templates = $this->templates ?? $this->template;
+
+			if (is_string($templates) === true) {
+				if ($query = $this->model->query($templates)) {
+					if (
+						is_string($query) === false &&
+						is_array($query) === false
+					) {
+						throw new InvalidArgumentException('Invalid `templates` prop: query must return string or array.');
+					}
+
+					$templates = $query;
+				}
+			}
+
+			return A::wrap($templates);
+		},
 		'parent' => function () {
 			$parent = $this->parentModel();
 

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -738,4 +738,38 @@ class FilesSectionTest extends TestCase
 
 		$this->assertSame(4, $section->upload()['attributes']['sort']);
 	}
+
+	public function testQueryTemplate()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'template' => 'foo'
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$model = new Page([
+			'slug'  => 'test',
+			'files' => [
+				['filename' => 'a.jpg'],
+				['filename' => 'b.jpg'],
+				[
+					'filename' => 'c.jpg',
+					'content' => [
+						'template' => 'foo'
+					]
+				],
+			]
+		]);
+
+		$section = new Section('files', [
+			'name'     => 'test',
+			'model'    => $model,
+			'template' => 'kirby.option("template")'
+		]);
+
+		$this->assertSame('foo', $section->template());
+		$this->assertCount(1, $section->files());
+	}
 }

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
@@ -771,5 +772,41 @@ class FilesSectionTest extends TestCase
 
 		$this->assertSame('foo', $section->template());
 		$this->assertCount(1, $section->files());
+	}
+
+	public function testQueryTemplateInvalid()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid `template` prop: query must return a string.');
+
+		$app = $this->app->clone([
+			'options' => [
+				'template' => new \stdClass()
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$model = new Page([
+			'slug'  => 'test',
+			'files' => [
+				['filename' => 'a.jpg'],
+				['filename' => 'b.jpg'],
+				[
+					'filename' => 'c.jpg',
+					'content' => [
+						'template' => 'foo'
+					]
+				],
+			]
+		]);
+
+		$section = new Section('files', [
+			'name'     => 'test',
+			'model'    => $model,
+			'template' => 'kirby.option("template")'
+		]);
+
+		$section->template();
 	}
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -849,4 +849,97 @@ class PagesSectionTest extends TestCase
 
 		$this->assertCount(1, $section->pages());
 	}
+
+	public function testQueryCreate()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'create' => $expected = [
+					'foo',
+					'bar'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parent = new Page([
+			'slug' => 'test',
+			'children' => [
+				['slug' => 'a'],
+				['slug' => 'b'],
+				['slug' => 'c']
+			]
+		]);
+
+		$section = new Section('pages', [
+			'create' => 'kirby.option("create")',
+			'model'  => $parent,
+			'name'   => 'test'
+		]);
+
+		$this->assertSame($expected, $section->create());
+		$this->assertCount(3, $section->pages());
+	}
+
+	public function testQueryTemplate()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'template' => 'bar'
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parent = new Page([
+			'slug' => 'test',
+			'children' => [
+				['slug' => 'a', 'template' => 'foo'],
+				['slug' => 'b', 'template' => 'bar'],
+				['slug' => 'c', 'template' => 'baz']
+			]
+		]);
+
+		$section = new Section('pages', [
+			'name'      => 'test',
+			'model'     => $parent,
+			'template'  => 'kirby.option("template")'
+		]);
+
+		$this->assertSame(['bar'], $section->templates());
+		$this->assertCount(1, $section->pages());
+	}
+
+	public function testQueryTemplates()
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'templates' => $expected = [
+					'foo',
+					'bar'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parent = new Page([
+			'slug' => 'test',
+			'children' => [
+				['slug' => 'a', 'template' => 'foo'],
+				['slug' => 'b', 'template' => 'bar'],
+				['slug' => 'c', 'template' => 'baz']
+			]
+		]);
+
+		$section = new Section('pages', [
+			'name'      => 'test',
+			'model'     => $parent,
+			'templates' => 'kirby.option("templates")'
+		]);
+
+		$this->assertSame($expected, $section->templates());
+		$this->assertCount(2, $section->pages());
+	}
 }

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -882,6 +882,37 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(3, $section->pages());
 	}
 
+	public function testQueryCreateInvalid()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid `create` prop: query must return string or array.');
+
+		$app = $this->app->clone([
+			'options' => [
+				'create' => new \stdClass()
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parent = new Page([
+			'slug' => 'test',
+			'children' => [
+				['slug' => 'a'],
+				['slug' => 'b'],
+				['slug' => 'c']
+			]
+		]);
+
+		$section = new Section('pages', [
+			'create' => 'kirby.option("create")',
+			'model'  => $parent,
+			'name'   => 'test'
+		]);
+
+		$section->create();
+	}
+
 	public function testQueryTemplate()
 	{
 		$app = $this->app->clone([
@@ -941,5 +972,36 @@ class PagesSectionTest extends TestCase
 
 		$this->assertSame($expected, $section->templates());
 		$this->assertCount(2, $section->pages());
+	}
+
+	public function testQueryTemplatesInvalid()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid `templates` prop: query must return string or array.');
+
+		$app = $this->app->clone([
+			'options' => [
+				'templates' => new \stdClass()
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parent = new Page([
+			'slug' => 'test',
+			'children' => [
+				['slug' => 'a', 'template' => 'foo'],
+				['slug' => 'b', 'template' => 'bar'],
+				['slug' => 'c', 'template' => 'baz']
+			]
+		]);
+
+		$section = new Section('pages', [
+			'name'      => 'test',
+			'model'     => $parent,
+			'templates' => 'kirby.option("templates")'
+		]);
+
+		$section->templates();
 	}
 }


### PR DESCRIPTION
## This PR …

Implements https://kirby.nolt.io/130 (59 upvotes)

By providing query language support, it was made to cover the this nolt idea and to make it a more flexible structure. 

````yaml
sections:
  pages:
    type: pages
    create: page.createTemplates()
    templates: site.availableTemplates()
  files:
    type: files
    template: site.availableTemplate()
````

### Features

- Query language support for pages section `create` and `templates` and files section `template` props https://kirby.nolt.io/130

### Breaking changes

- Pages and files sections won't allow anymore templates named `page`, `site`, `kirby`, `model` as value for the `create` and `template`/`templates` options

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
