### PR TITLE
Page create dialog: fix custom fields

### DIFF
--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -29,6 +29,7 @@ class PageCreateDialog
 		'checkboxes',
 		'date',
 		'email',
+		'info',
 		'multiselect',
 		'number',
 		'list',
@@ -122,7 +123,7 @@ class PageCreateDialog
 
 		foreach ($blueprint->create()['fields'] ?? [] as $name) {
 			if (!$field = ($fields[$name] ?? null)) {
-				continue;
+				throw new InvalidArgumentException('Unknown field  "' . $name . '" in create dialog');
 			}
 
 			if (in_array($field['type'], static::$fieldTypes) === false) {
@@ -130,7 +131,7 @@ class PageCreateDialog
 			}
 
 			if (in_array($name, $ignore) === true) {
-				throw new InvalidArgumentException('Field "' . $name . '" not allowed as custom field in create dialog');
+				throw new InvalidArgumentException('Field name "' . $name . '" not allowed as custom field in create dialog');
 			}
 
 			// switch all fields to 1/1

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -201,7 +201,7 @@ class PageCreateDialog
 			'slug'     => 'new',
 			'template' => $this->template,
 			'model'    => $this->template,
-			'parent'   => $this->parent
+			'parent'   => $this->parent instanceof Page ? $this->parent : null
 		]);
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Page create dialog needs to resolve custom fields via `Form` class to get all props, options etc. properly resolved.

### Fixes
- #5231
- https://github.com/getkirby/kirby/issues/5235

### Enhancements
- Page create dialog throws proper exceptions if a field type is not supported
- Add custom field types to the list of allowed fields for the page create dialog via `\Kirby\Panel\PageCreateDialog::$fieldTypes[] = 'yourFieldType'`
