### PR TITLE
Page tree: use blueprint icons

### DIFF
--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -52,7 +52,7 @@ export default {
 	methods: {
 		async load(path) {
 			const { data } = await this.$api.get(path + "/children", {
-				select: "hasChildren,id,title,uuid",
+				select: "hasChildren,id,panelImage,title,uuid",
 				status: "all"
 			});
 
@@ -63,6 +63,7 @@ export default {
 
 				pages[id] = {
 					id,
+					icon: page.panelImage.icon,
 					label: page.title,
 					hasChildren: page.hasChildren,
 					children: "/pages/" + this.$api.pages.id(page.id),


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- Page tree now uses the icon defined in each page's blueprint
- 
<img width="707" alt="Screenshot 2023-06-03 at 13 07 34" src="https://github.com/getkirby/kirby/assets/3788865/e85cc7c1-baba-4295-a6f4-46eb48f5d1dc">

