### PR TITLE
PageCreateDialog: fix supported field types

### DIFF
--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -30,19 +30,21 @@ class PageCreateDialog
 		'date',
 		'email',
 		'info',
-		'multiselect',
-		'number',
+		'line',
+		'link',
 		'list',
+		'number',
+		'multiselect',
 		'radio',
+		'range',
 		'select',
+		'slug',
 		'tags',
 		'tel',
 		'text',
-		'textarea',
 		'toggles',
 		'time',
-		'url',
-		'writer'
+		'url'
 	];
 
 	public function __construct(


### PR DESCRIPTION
Excluding `textarea` and `writer` for now until we have a better idea how to handle them.