### PR TITLE
Files `upload`: use `upload.parent` for mime check

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -25,9 +25,12 @@ return [
 			$uploads['accept'] = '*';
 
 			if ($template = $uploads['template'] ?? null) {
-				$file = new File([
+				// get parent object for upload target
+				$parent = $this->uploadParent($uploads['parent'] ?? null);
+
+				$file   = new File([
 					'filename' => 'tmp',
-					'parent'   => $this->model(),
+					'parent'   => $parent,
 					'template' => $template
 				]);
 
@@ -43,15 +46,7 @@ return [
 				throw new Exception('Uploads are disabled for this field');
 			}
 
-			$parent = $this->model();
-
-			if ($parentQuery = ($params['parent'] ?? null)) {
-				$parent = $parent->query($parentQuery);
-			}
-
-			if ($parent instanceof File) {
-				$parent = $parent->parent();
-			}
+			$parent = $this->uploadParent($params['parent'] ?? null);
 
 			return $api->upload(function ($source, $filename) use ($parent, $params, $map) {
 				$props = [
@@ -69,6 +64,19 @@ return [
 
 				return $map($file, $parent);
 			});
+		},
+		'uploadParent' => function (string $parentQuery = null) {
+			$parent = $this->model();
+
+			if ($parentQuery) {
+				$parent = $parent->query($parentQuery);
+			}
+
+			if ($parent instanceof File) {
+				$parent = $parent->parent();
+			}
+
+			return $parent;
 		}
 	]
 ];


### PR DESCRIPTION
Files field on a file blueprint would throw an error now as using `$this->model()` would pass a `File` object as `File` to create a new `File`. Which our native type hints now prevent. Instead, we need to use `upload.parent` for the check, not the field parent.