### PR TITLE
`->toUrl()` to return `null` on empty fields

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -372,7 +372,13 @@ return [
 		}
 
 		// support UUIDs
-		if ($path !== null && (Uuid::is($path, 'page') === true || Uuid::is($path, 'file') === true)) {
+		if (
+			$path !== null &&
+			(
+				Uuid::is($path, 'page') === true ||
+				Uuid::is($path, 'file') === true
+			)
+		) {
 			$path = Uuid::for($path)->model()->url();
 		}
 

--- a/config/methods.php
+++ b/config/methods.php
@@ -286,12 +286,9 @@ return function (App $app) {
 
 		/**
 		 * Turns the field value into an absolute Url
-		 *
-		 * @param \Kirby\Cms\Field $field
-		 * @return string
 		 */
-		'toUrl' => function (Field $field): string {
-			return Url::to($field->value);
+		'toUrl' => function (Field $field): string|null {
+			return $field->value ? Url::to($field->value) : null;
 		},
 
 		/**

--- a/config/methods.php
+++ b/config/methods.php
@@ -288,7 +288,7 @@ return function (App $app) {
 		 * Turns the field value into an absolute Url
 		 */
 		'toUrl' => function (Field $field): string|null {
-			return $field->value ? Url::to($field->value) : null;
+			return $field->isNotEmpty() ? Url::to($field->value) : null;
 		},
 
 		/**

--- a/tests/Cms/Fields/FieldMethodsTest.php
+++ b/tests/Cms/Fields/FieldMethodsTest.php
@@ -440,6 +440,12 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $field->toUrl());
 	}
 
+	public function testToUrlEmpty()
+	{
+		$field = $this->field();
+		$this->assertNull($field->toUrl());
+	}
+
 	public function testToUser()
 	{
 		$app = new App([


### PR DESCRIPTION
- `->toUrl()` to return `null` on empty fields
#5258
