### PR TITLE
Writer: preserve whitespace

### DIFF
--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -145,6 +145,9 @@ export default {
 			editable: !this.disabled,
 			element: this.$el,
 			emptyDocument: this.emptyDocument,
+			parseOptions: {
+				preserveWhitespace: true
+			},
 			events: {
 				link: (editor) => {
 					this.$refs.linkDialog.open(editor.getMarkAttrs("link"));


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Through a reactive loop between both writer instances (in preview and in drawer), it seemed to have triggered the writers whitespace removal/collapsing. Adding the option seems to fix it, but I'm worried whether it could have any side effects.

### Fixes
- #5295

