### PR TITLE
`Structure` to extend `Item` classes

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -262,12 +262,15 @@ return function (App $app) {
 		 */
 		'toStructure' => function (Field $field) {
 			try {
-				return new Structure(Data::decode($field->value, 'yaml'), $field->parent());
+				return Structure::factory(
+					Data::decode($field->value, 'yaml'),
+					['parent' => $field->parent()]
+				);
 			} catch (Exception) {
 				$message = 'Invalid structure data for "' . $field->key() . '" field';
 
 				if ($parent = $field->parent()) {
-					$message .= ' on parent "' . $parent->title() . '"';
+					$message .= ' on parent "' . $parent->id() . '"';
 				}
 
 				throw new InvalidArgumentException($message);

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -73,6 +73,8 @@ trait AppPlugins
 		'sections' => [],
 		'siteMethods' => [],
 		'snippets' => [],
+		'structureMethods' => [],
+		'structureObjectMethods' => [],
 		'tags' => [],
 		'templates' => [],
 		'thirdParty' => [],
@@ -477,6 +479,22 @@ trait AppPlugins
 	protected function extendSnippets(array $snippets): array
 	{
 		return $this->extensions['snippets'] = array_merge($this->extensions['snippets'], $snippets);
+	}
+
+	/**
+	 * Registers additional structure methods
+	 */
+	protected function extendStructureMethods(array $methods): array
+	{
+		return $this->extensions['structureMethods'] = Structure::$methods = array_merge(Structure::$methods, $methods);
+	}
+
+	/**
+	 * Registers additional structure object methods
+	 */
+	protected function extendStructureObjectMethods(array $methods): array
+	{
+		return $this->extensions['structureObjectMethods'] = StructureObject::$methods = array_merge(StructureObject::$methods, $methods);
 	}
 
 	/**

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -232,7 +232,6 @@ class Block extends Item
 				$this->controller(),
 				true
 			);
-
 		} catch (Throwable $e) {
 			if ($kirby->option('debug') === true) {
 				return '<p>Block error: "' . $e->getMessage() . '" in block type: "' . $this->type() . '"</p>';

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -25,35 +25,18 @@ class Block extends Item
 	public const ITEMS_CLASS = Blocks::class;
 
 	/**
-	 * @var \Kirby\Cms\Content
-	 */
-	protected $content;
-
-	/**
-	 * @var bool
-	 */
-	protected $isHidden;
-
-	/**
 	 * Registry with all block models
-	 *
-	 * @var array
 	 */
-	public static $models = [];
+	public static array $models = [];
 
-	/**
-	 * @var string
-	 */
-	protected $type;
+	protected Content $content;
+	protected bool $isHidden;
+	protected string $type;
 
 	/**
 	 * Proxy for content fields
-	 *
-	 * @param string $method
-	 * @param array $args
-	 * @return \Kirby\Cms\Field
 	 */
-	public function __call(string $method, array $args = [])
+	public function __call(string $method, array $args = []): mixed
 	{
 		// block methods
 		if ($this->hasMethod($method)) {
@@ -66,7 +49,6 @@ class Block extends Item
 	/**
 	 * Creates a new block object
 	 *
-	 * @param array $params
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public function __construct(array $params)
@@ -90,18 +72,15 @@ class Block extends Item
 			$params['content'] = [];
 		}
 
-		$this->content  = $params['content'];
 		$this->isHidden = $params['isHidden'] ?? false;
 		$this->type     = $params['type'];
 
 		// create the content object
-		$this->content = new Content($this->content, $this->parent);
+		$this->content = new Content($params['content'], $this->parent);
 	}
 
 	/**
 	 * Converts the object to a string
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{
@@ -110,18 +89,14 @@ class Block extends Item
 
 	/**
 	 * Returns the content object
-	 *
-	 * @return \Kirby\Cms\Content
 	 */
-	public function content()
+	public function content(): Content
 	{
 		return $this->content;
 	}
 
 	/**
 	 * Controller for the block snippet
-	 *
-	 * @return array
 	 */
 	public function controller(): array
 	{
@@ -140,28 +115,26 @@ class Block extends Item
 	 * Converts the block to HTML and then
 	 * uses the Str::excerpt method to create
 	 * a non-formatted, shortened excerpt from it
-	 *
-	 * @param mixed ...$args
-	 * @return string
 	 */
-	public function excerpt(...$args)
+	public function excerpt(mixed ...$args): string
 	{
 		return Str::excerpt($this->toHtml(), ...$args);
 	}
 
 	/**
 	 * Constructs a block object with registering blocks models
-	 *
-	 * @param array $params
-	 * @return static
-	 * @throws \Kirby\Exception\InvalidArgumentException
 	 * @internal
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public static function factory(array $params)
+	public static function factory(array $params): static
 	{
 		$type = $params['type'] ?? null;
 
-		if (empty($type) === false && $class = (static::$models[$type] ?? null)) {
+		if (
+			empty($type) === false &&
+			$class = (static::$models[$type] ?? null)
+		) {
 			$object = new $class($params);
 
 			if ($object instanceof self) {
@@ -183,8 +156,6 @@ class Block extends Item
 
 	/**
 	 * Checks if the block is empty
-	 *
-	 * @return bool
 	 */
 	public function isEmpty(): bool
 	{
@@ -194,8 +165,6 @@ class Block extends Item
 	/**
 	 * Checks if the block is hidden
 	 * from being rendered in the frontend
-	 *
-	 * @return bool
 	 */
 	public function isHidden(): bool
 	{
@@ -204,8 +173,6 @@ class Block extends Item
 
 	/**
 	 * Checks if the block is not empty
-	 *
-	 * @return bool
 	 */
 	public function isNotEmpty(): bool
 	{
@@ -214,18 +181,14 @@ class Block extends Item
 
 	/**
 	 * Returns the sibling collection that filtered by block status
-	 *
-	 * @return \Kirby\Cms\Collection
 	 */
-	protected function siblingsCollection()
+	protected function siblingsCollection(): Blocks
 	{
 		return $this->siblings->filter('isHidden', $this->isHidden());
 	}
 
 	/**
 	 * Returns the block type
-	 *
-	 * @return string
 	 */
 	public function type(): string
 	{
@@ -235,8 +198,6 @@ class Block extends Item
 	/**
 	 * The result is being sent to the editor
 	 * via the API in the panel
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -253,24 +214,25 @@ class Block extends Item
 	 * and then places that inside a field
 	 * object. This can be used further
 	 * with all available field methods
-	 *
-	 * @return \Kirby\Cms\Field
 	 */
-	public function toField()
+	public function toField(): Field
 	{
 		return new Field($this->parent(), $this->id(), $this->toHtml());
 	}
 
 	/**
 	 * Converts the block to HTML
-	 *
-	 * @return string
 	 */
 	public function toHtml(): string
 	{
 		try {
 			$kirby = $this->parent()->kirby();
-			return (string)$kirby->snippet('blocks/' . $this->type(), $this->controller(), true);
+			return (string)$kirby->snippet(
+				'blocks/' . $this->type(),
+				$this->controller(),
+				true
+			);
+
 		} catch (Throwable $e) {
 			if ($kirby->option('debug') === true) {
 				return '<p>Block error: "' . $e->getMessage() . '" in block type: "' . $this->type() . '"</p>';

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -33,8 +33,6 @@ class Blocks extends Items
 	/**
 	 * Return HTML when the collection is
 	 * converted to a string
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{
@@ -45,11 +43,8 @@ class Blocks extends Items
 	 * Converts the blocks to HTML and then
 	 * uses the Str::excerpt method to create
 	 * a non-formatted, shortened excerpt from it
-	 *
-	 * @param mixed ...$args
-	 * @return string
 	 */
-	public function excerpt(...$args)
+	public function excerpt(mixed ...$args): string
 	{
 		return Str::excerpt($this->toHtml(), ...$args);
 	}
@@ -57,13 +52,11 @@ class Blocks extends Items
 	/**
 	 * Wrapper around the factory to
 	 * catch blocks from layouts
-	 *
-	 * @param array $items
-	 * @param array $params
-	 * @return \Kirby\Cms\Blocks
 	 */
-	public static function factory(array $items = null, array $params = [])
-	{
+	public static function factory(
+		array $items = null,
+		array $params = []
+	): static {
 		$items = static::extractFromLayouts($items);
 
 		// @deprecated old editor format
@@ -77,9 +70,6 @@ class Blocks extends Items
 
 	/**
 	 * Pull out blocks from layouts
-	 *
-	 * @param array $input
-	 * @return array
 	 */
 	protected static function extractFromLayouts(array $input): array
 	{
@@ -113,9 +103,6 @@ class Blocks extends Items
 	/**
 	 * Checks if a given block type exists in the collection
 	 * @since 3.6.0
-	 *
-	 * @param string $type
-	 * @return bool
 	 */
 	public function hasType(string $type): bool
 	{
@@ -124,11 +111,8 @@ class Blocks extends Items
 
 	/**
 	 * Parse and sanitize various block formats
-	 *
-	 * @param array|string $input
-	 * @return array
 	 */
-	public static function parse($input): array
+	public static function parse(array|string|null $input): array
 	{
 		if (empty($input) === false && is_array($input) === false) {
 			try {
@@ -173,16 +157,10 @@ class Blocks extends Items
 
 	/**
 	 * Convert all blocks to HTML
-	 *
-	 * @return string
 	 */
 	public function toHtml(): string
 	{
-		$html = [];
-
-		foreach ($this->data as $block) {
-			$html[] = $block->toHtml();
-		}
+		$html = A::map($this->data, fn ($block) => $block->toHtml());
 
 		return implode($html);
 	}

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -21,24 +21,21 @@ class Fieldset extends Item
 {
 	public const ITEMS_CLASS = Fieldsets::class;
 
-	protected $disabled;
-	protected $editable;
-	protected $fields = [];
-	protected $icon;
-	protected $label;
-	protected $model;
-	protected $name;
-	protected $preview;
-	protected $tabs;
-	protected $translate;
-	protected $type;
-	protected $unset;
-	protected $wysiwyg;
+	protected bool $disabled;
+	protected bool $editable;
+	protected array $fields = [];
+	protected string|null $icon;
+	protected string|null $label;
+	protected string|null $name;
+	protected string|bool|null $preview;
+	protected array $tabs;
+	protected bool $translate;
+	protected string $type;
+	protected bool $unset;
+	protected bool $wysiwyg;
 
 	/**
 	 * Creates a new Fieldset object
-	 *
-	 * @param array $params
 	 */
 	public function __construct(array $params = [])
 	{
@@ -50,17 +47,17 @@ class Fieldset extends Item
 
 		parent::__construct($params);
 
-		$this->disabled  = $params['disabled'] ?? false;
-		$this->editable  = $params['editable'] ?? true;
-		$this->icon      = $params['icon'] ?? null;
-		$this->model     = $this->parent;
-		$this->name      = $this->createName($params['title'] ?? $params['name'] ?? Str::ucfirst($this->type));
-		$this->label     = $this->createLabel($params['label'] ?? null);
-		$this->preview   = $params['preview'] ?? null;
-		$this->tabs      = $this->createTabs($params);
-		$this->translate = $params['translate'] ?? true;
-		$this->unset     = $params['unset'] ?? false;
-		$this->wysiwyg   = $params['wysiwyg'] ?? false;
+		$this->disabled    = $params['disabled'] ?? false;
+		$this->editable    = $params['editable'] ?? true;
+		$this->icon        = $params['icon'] ?? null;
+		$params['title'] ??= $params['name'] ?? Str::ucfirst($this->type);
+		$this->name        = $this->createName($params['title']);
+		$this->label       = $this->createLabel($params['label'] ?? null);
+		$this->preview     = $params['preview'] ?? null;
+		$this->tabs        = $this->createTabs($params);
+		$this->translate   = $params['translate'] ?? true;
+		$this->unset       = $params['unset'] ?? false;
+		$this->wysiwyg     = $params['wysiwyg'] ?? false;
 
 		if (
 			$this->translate === false &&
@@ -73,10 +70,6 @@ class Fieldset extends Item
 		}
 	}
 
-	/**
-	 * @param array $fields
-	 * @return array
-	 */
 	protected function createFields(array $fields = []): array
 	{
 		$fields = Blueprint::fieldsProps($fields);
@@ -88,28 +81,16 @@ class Fieldset extends Item
 		return $fields;
 	}
 
-	/**
-	 * @param array|string $name
-	 * @return string|null
-	 */
-	protected function createName($name): string|null
+	protected function createName(array|string $name): string|null
 	{
 		return I18n::translate($name, $name);
 	}
 
-	/**
-	 * @param array|string $label
-	 * @return string|null
-	 */
-	protected function createLabel($label = null): string|null
+	protected function createLabel(array|string|null $label = null): string|null
 	{
 		return I18n::translate($label, $label);
 	}
 
-	/**
-	 * @param array $params
-	 * @return array
-	 */
 	protected function createTabs(array $params = []): array
 	{
 		$tabs = $params['tabs'] ?? [];
@@ -133,9 +114,10 @@ class Fieldset extends Item
 
 			$tab = Blueprint::extend($tab);
 
-			$tab['fields'] = $this->createFields($tab['fields'] ?? []);
-			$tab['label']  = $this->createLabel($tab['label'] ?? Str::ucfirst($name));
-			$tab['name']   = $name;
+			$tab['fields']  = $this->createFields($tab['fields'] ?? []);
+			$tab['label'] ??= Str::ucfirst($name);
+			$tab['label']   = $this->createLabel($tab['label']);
+			$tab['name']    = $name;
 
 			$tabs[$name] = $tab;
 		}
@@ -143,17 +125,11 @@ class Fieldset extends Item
 		return $tabs;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function disabled(): bool
 	{
 		return $this->disabled;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function editable(): bool
 	{
 		if ($this->editable === false) {
@@ -167,9 +143,6 @@ class Fieldset extends Item
 		return true;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function fields(): array
 	{
 		return $this->fields;
@@ -177,88 +150,57 @@ class Fieldset extends Item
 
 	/**
 	 * Creates a form for the given fields
-	 *
-	 * @param array $fields
-	 * @param array $input
-	 * @return \Kirby\Form\Form
 	 */
-	public function form(array $fields, array $input = [])
+	public function form(array $fields, array $input = []): Form
 	{
 		return new Form([
 			'fields' => $fields,
-			'model'  => $this->model,
+			'model'  => $this->parent,
 			'strict' => true,
 			'values' => $input,
 		]);
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function icon(): string|null
 	{
 		return $this->icon;
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function label(): string|null
 	{
 		return $this->label;
 	}
 
-	/**
-	 * @return \Kirby\Cms\ModelWithContent
-	 */
-	public function model()
+	public function model(): ModelWithContent
 	{
-		return $this->model;
+		return $this->parent;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function name(): string
 	{
 		return $this->name;
 	}
 
-	/**
-	 * @return string|bool
-	 */
-	public function preview()
+	public function preview(): string|bool|null
 	{
 		return $this->preview;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function tabs(): array
 	{
 		return $this->tabs;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function translate(): bool
 	{
 		return $this->translate;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function type(): string
 	{
 		return $this->type;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -276,17 +218,11 @@ class Fieldset extends Item
 		];
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function unset(): bool
 	{
 		return $this->unset;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function wysiwyg(): bool
 	{
 		return $this->wysiwyg;

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -26,7 +26,7 @@ class Fieldsets extends Items
 	 */
 	public static array $methods = [];
 
-	protected static function createFieldsets($params)
+	protected static function createFieldsets(array $params): array
 	{
 		$fieldsets = [];
 		$groups    = [];
@@ -73,8 +73,10 @@ class Fieldsets extends Items
 		];
 	}
 
-	public static function factory(array $items = null, array $params = [])
-	{
+	public static function factory(
+		array $items = null,
+		array $params = []
+	): static {
 		$items ??= App::instance()->option('blocks.fieldsets', [
 			'code'     => 'blocks/code',
 			'gallery'  => 'blocks/gallery',
@@ -90,7 +92,10 @@ class Fieldsets extends Items
 
 		$result = static::createFieldsets($items);
 
-		return parent::factory($result['fieldsets'], ['groups' => $result['groups']] + $params);
+		return parent::factory(
+			$result['fieldsets'],
+			['groups' => $result['groups']] + $params
+		);
 	}
 
 	public function groups(): array

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -28,49 +28,27 @@ class Item
 
 	protected Field|null $field;
 
-	/**
-	 * @var string
-	 */
-	protected $id;
-
-	/**
-	 * @var array
-	 */
-	protected $params;
-
-	/**
-	 * @var \Kirby\Cms\Page|\Kirby\Cms\Site|\Kirby\Cms\File|\Kirby\Cms\User
-	 */
-	protected $parent;
-
-	/**
-	 * @var \Kirby\Cms\Items
-	 */
-	protected $siblings;
+	protected string $id;
+	protected array $params;
+	protected ModelWithContent $parent;
+	protected Items $siblings;
 
 	/**
 	 * Creates a new item
-	 *
-	 * @param array $params
 	 */
 	public function __construct(array $params = [])
 	{
-		$siblingsClass = static::ITEMS_CLASS;
-
 		$this->id       = $params['id']       ?? Str::uuid();
 		$this->params   = $params;
 		$this->field    = $params['field']    ?? null;
 		$this->parent   = $params['parent']   ?? App::instance()->site();
-		$this->siblings = $params['siblings'] ?? new $siblingsClass();
+		$this->siblings = $params['siblings'] ?? new (static::ITEMS_CLASS)();
 	}
 
 	/**
 	 * Static Item factory
-	 *
-	 * @param array $params
-	 * @return \Kirby\Cms\Item
 	 */
-	public static function factory(array $params)
+	public static function factory(array $params): static
 	{
 		return new static($params);
 	}
@@ -85,8 +63,6 @@ class Item
 
 	/**
 	 * Returns the unique item id (UUID v4)
-	 *
-	 * @return string
 	 */
 	public function id(): string
 	{
@@ -95,9 +71,6 @@ class Item
 
 	/**
 	 * Compares the item to another one
-	 *
-	 * @param \Kirby\Cms\Item $item
-	 * @return bool
 	 */
 	public function is(Item $item): bool
 	{
@@ -106,20 +79,16 @@ class Item
 
 	/**
 	 * Returns the Kirby instance
-	 *
-	 * @return \Kirby\Cms\App
 	 */
-	public function kirby()
+	public function kirby(): App
 	{
 		return $this->parent()->kirby();
 	}
 
 	/**
 	 * Returns the parent model
-	 *
-	 * @return \Kirby\Cms\Page|\Kirby\Cms\Site|\Kirby\Cms\File|\Kirby\Cms\User
 	 */
-	public function parent()
+	public function parent(): ModelWithContent
 	{
 		return $this->parent;
 	}
@@ -128,18 +97,15 @@ class Item
 	 * Returns the sibling collection
 	 * This is required by the HasSiblings trait
 	 *
-	 * @return \Kirby\Cms\Items
 	 * @psalm-return self::ITEMS_CLASS
 	 */
-	protected function siblingsCollection()
+	protected function siblingsCollection(): Items
 	{
 		return $this->siblings;
 	}
 
 	/**
 	 * Converts the item to an array
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -38,11 +38,12 @@ class Item
 	 */
 	public function __construct(array $params = [])
 	{
+		$class          = static::ITEMS_CLASS;
 		$this->id       = $params['id']       ?? Str::uuid();
 		$this->params   = $params;
 		$this->field    = $params['field']    ?? null;
 		$this->parent   = $params['parent']   ?? App::instance()->site();
-		$this->siblings = $params['siblings'] ?? new (static::ITEMS_CLASS)();
+		$this->siblings = $params['siblings'] ?? new $class();
 	}
 
 	/**

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -63,13 +63,16 @@ class Items extends Collection
 
 		foreach ($items as $item) {
 			if (is_array($item) === false) {
-				continue;
+				throw new InvalidArgumentException('Invalid data for ' . static::ITEM_CLASS);
 			}
 
+			// inject properties from the parent
 			$item['field']    = $collection->field();
 			$item['options']  = $params['options'] ?? [];
 			$item['parent']   = $collection->parent();
 			$item['siblings'] = $collection;
+			$item['params']   = $item;
+
 			$item = (static::ITEM_CLASS)::factory($item);
 			$collection->append($item->id(), $item);
 		}

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -73,7 +73,8 @@ class Items extends Collection
 			$item['siblings'] = $collection;
 			$item['params']   = $item;
 
-			$item = (static::ITEM_CLASS)::factory($item);
+			$class = static::ITEM_CLASS;
+			$item  = $class::factory($item);
 			$collection->append($item->id(), $item);
 		}
 

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -3,7 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
-use Exception;
+use Kirby\Exception\InvalidArgumentException;
 
 /**
  * A collection of items
@@ -26,22 +26,13 @@ class Items extends Collection
 	 */
 	public static array $methods = [];
 
-	/**
-	 * @var array
-	 */
-	protected $options;
+	protected array $options;
 
 	/**
 	 * @var \Kirby\Cms\ModelWithContent
 	 */
 	protected $parent;
 
-	/**
-	 * Constructor
-	 *
-	 * @param array $objects
-	 * @param array $options
-	 */
 	public function __construct($objects = [], array $options = [])
 	{
 		$this->options = $options;
@@ -54,41 +45,32 @@ class Items extends Collection
 	/**
 	 * Creates a new item collection from a
 	 * an array of item props
-	 *
-	 * @param array $items
-	 * @param array $params
-	 * @return \Kirby\Cms\Items
 	 */
-	public static function factory(array $items = null, array $params = [])
-	{
-		$options = array_merge([
-			'field'   => null,
-			'options' => [],
-			'parent'  => App::instance()->site(),
-		], $params);
-
+	public static function factory(
+		array $items = null,
+		array $params = []
+	): static {
 		if (empty($items) === true || is_array($items) === false) {
 			return new static();
 		}
 
-		if (is_array($options) === false) {
-			throw new Exception('Invalid item options');
+		if (is_array($params) === false) {
+			throw new InvalidArgumentException('Invalid item options');
 		}
 
 		// create a new collection of blocks
-		$collection = new static([], $options);
+		$collection = new static([], $params);
 
-		foreach ($items as $params) {
-			if (is_array($params) === false) {
+		foreach ($items as $item) {
+			if (is_array($item) === false) {
 				continue;
 			}
 
-			$params['field']    = $options['field'];
-			$params['options']  = $options['options'];
-			$params['parent']   = $options['parent'];
-			$params['siblings'] = $collection;
-			$class = static::ITEM_CLASS;
-			$item  = $class::factory($params);
+			$item['field']    = $collection->field();
+			$item['options']  = $params['options'] ?? [];
+			$item['parent']   = $collection->parent();
+			$item['siblings'] = $collection;
+			$item = (static::ITEM_CLASS)::factory($item);
 			$collection->append($item->id(), $item);
 		}
 
@@ -105,8 +87,6 @@ class Items extends Collection
 
 	/**
 	 * Convert the items to an array
-	 *
-	 * @return array
 	 */
 	public function toArray(Closure $map = null): array
 	{

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -19,24 +19,13 @@ class Layout extends Item
 
 	public const ITEMS_CLASS = Layouts::class;
 
-	/**
-	 * @var \Kirby\Cms\Content
-	 */
-	protected $attrs;
-
-	/**
-	 * @var \Kirby\Cms\LayoutColumns
-	 */
-	protected $columns;
+	protected Content $attrs;
+	protected LayoutColumns $columns;
 
 	/**
 	 * Proxy for attrs
-	 *
-	 * @param string $method
-	 * @param array $args
-	 * @return \Kirby\Cms\Field
 	 */
-	public function __call(string $method, array $args = [])
+	public function __call(string $method, array $args = []): mixed
 	{
 		// layout methods
 		if ($this->hasMethod($method) === true) {
@@ -48,8 +37,6 @@ class Layout extends Item
 
 	/**
 	 * Creates a new Layout object
-	 *
-	 * @param array $params
 	 */
 	public function __construct(array $params = [])
 	{
@@ -66,20 +53,16 @@ class Layout extends Item
 
 	/**
 	 * Returns the attrs object
-	 *
-	 * @return \Kirby\Cms\Content
 	 */
-	public function attrs()
+	public function attrs(): Content
 	{
 		return $this->attrs;
 	}
 
 	/**
 	 * Returns the columns in this layout
-	 *
-	 * @return \Kirby\Cms\LayoutColumns
 	 */
-	public function columns()
+	public function columns(): LayoutColumns
 	{
 		return $this->columns;
 	}
@@ -87,24 +70,18 @@ class Layout extends Item
 	/**
 	 * Checks if the layout is empty
 	 * @since 3.5.2
-	 *
-	 * @return bool
 	 */
 	public function isEmpty(): bool
 	{
 		return $this
 			->columns()
-			->filter(function ($column) {
-				return $column->isNotEmpty();
-			})
+			->filter('isEmpty', false)
 			->count() === 0;
 	}
 
 	/**
 	 * Checks if the layout is not empty
 	 * @since 3.5.2
-	 *
-	 * @return bool
 	 */
 	public function isNotEmpty(): bool
 	{
@@ -114,8 +91,6 @@ class Layout extends Item
 	/**
 	 * The result is being sent to the editor
 	 * via the API in the panel
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -21,20 +21,11 @@ class LayoutColumn extends Item
 
 	public const ITEMS_CLASS = LayoutColumns::class;
 
-	/**
-	 * @var \Kirby\Cms\Blocks
-	 */
-	protected $blocks;
-
-	/**
-	 * @var string
-	 */
-	protected $width;
+	protected Blocks $blocks;
+	protected string $width;
 
 	/**
 	 * Creates a new LayoutColumn object
-	 *
-	 * @param array $params
 	 */
 	public function __construct(array $params = [])
 	{
@@ -50,12 +41,8 @@ class LayoutColumn extends Item
 
 	/**
 	 * Magic getter function
-	 *
-	 * @param string $method
-	 * @param mixed $args
-	 * @return mixed
 	 */
-	public function __call(string $method, $args)
+	public function __call(string $method, mixed $args): mixed
 	{
 		// layout column methods
 		if ($this->hasMethod($method) === true) {
@@ -67,9 +54,8 @@ class LayoutColumn extends Item
 	 * Returns the blocks collection
 	 *
 	 * @param bool $includeHidden Sets whether to include hidden blocks
-	 * @return \Kirby\Cms\Blocks
 	 */
-	public function blocks(bool $includeHidden = false)
+	public function blocks(bool $includeHidden = false): Blocks
 	{
 		if ($includeHidden === false) {
 			return $this->blocks->filter('isHidden', false);
@@ -81,8 +67,6 @@ class LayoutColumn extends Item
 	/**
 	 * Checks if the column is empty
 	 * @since 3.5.2
-	 *
-	 * @return bool
 	 */
 	public function isEmpty(): bool
 	{
@@ -95,8 +79,6 @@ class LayoutColumn extends Item
 	/**
 	 * Checks if the column is not empty
 	 * @since 3.5.2
-	 *
-	 * @return bool
 	 */
 	public function isNotEmpty(): bool
 	{
@@ -105,9 +87,6 @@ class LayoutColumn extends Item
 
 	/**
 	 * Returns the number of columns this column spans
-	 *
-	 * @param int $columns
-	 * @return int
 	 */
 	public function span(int $columns = 12): int
 	{
@@ -121,8 +100,6 @@ class LayoutColumn extends Item
 	/**
 	 * The result is being sent to the editor
 	 * via the API in the panel
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -135,8 +112,6 @@ class LayoutColumn extends Item
 
 	/**
 	 * Returns the width of the column
-	 *
-	 * @return string
 	 */
 	public function width(): string
 	{

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -25,8 +25,10 @@ class Layouts extends Items
 	 */
 	public static array $methods = [];
 
-	public static function factory(array $items = null, array $params = [])
-	{
+	public static function factory(
+		array $items = null,
+		array $params = []
+	): static {
 		// convert single layout to layouts array
 		if (
 			isset($items['columns']) === true ||
@@ -61,9 +63,6 @@ class Layouts extends Items
 	/**
 	 * Checks if a given block type exists in the layouts collection
 	 * @since 3.6.0
-	 *
-	 * @param string $type
-	 * @return bool
 	 */
 	public function hasBlockType(string $type): bool
 	{
@@ -72,13 +71,13 @@ class Layouts extends Items
 
 	/**
 	 * Parse layouts data
-	 *
-	 * @param array|string $input
-	 * @return array
 	 */
-	public static function parse($input): array
+	public static function parse(array|string|null $input): array
 	{
-		if (empty($input) === false && is_array($input) === false) {
+		if (
+			empty($input) === false &&
+			is_array($input) === false
+		) {
 			try {
 				$input = Json::decode((string)$input);
 			} catch (Throwable) {
@@ -98,9 +97,8 @@ class Layouts extends Items
 	 * @since 3.6.0
 	 *
 	 * @param bool $includeHidden Sets whether to include hidden blocks
-	 * @return \Kirby\Cms\Blocks
 	 */
-	public function toBlocks(bool $includeHidden = false)
+	public function toBlocks(bool $includeHidden = false): Blocks
 	{
 		$blocks = [];
 

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\InvalidArgumentException;
-
 /**
  * The Structure class wraps
  * array data into a nicely chainable

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -18,54 +18,12 @@ use Kirby\Exception\InvalidArgumentException;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class Structure extends Collection
+class Structure extends Items
 {
+	public const ITEM_CLASS = StructureObject::class;
+
 	/**
 	 * All registered structure methods
 	 */
 	public static array $methods = [];
-
-	/**
-	 * Creates a new Collection with the given objects
-	 *
-	 * @param array $objects Kirby\Cms\StructureObject` objects or props arrays
-	 * @param object|null $parent
-	 */
-	public function __construct($objects = [], $parent = null)
-	{
-		$this->parent = $parent;
-		$this->set($objects);
-	}
-
-	/**
-	 * The internal setter for collection items.
-	 * This makes sure that nothing unexpected ends
-	 * up in the collection. You can pass arrays or
-	 * StructureObjects
-	 *
-	 * @param string $id
-	 * @param array|StructureObject $props
-	 * @return void
-	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
-	 */
-	public function __set(string $id, $props): void
-	{
-		if ($props instanceof StructureObject) {
-			$object = $props;
-		} else {
-			if (is_array($props) === false) {
-				throw new InvalidArgumentException('Invalid structure data');
-			}
-
-			$object = new StructureObject([
-				'content'    => $props,
-				'id'         => $props['id'] ?? $id,
-				'parent'     => $this->parent,
-				'structure'  => $this
-			]);
-		}
-
-		parent::__set($object->id(), $object);
-	}
 }

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\InvalidArgumentException;
-
 /**
  * The StructureObject represents each item
  * in a Structure collection. StructureObjects

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -20,45 +20,38 @@ use Kirby\Exception\InvalidArgumentException;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class StructureObject
+class StructureObject extends Item
 {
-	use HasSiblings;
+	use HasMethods;
 
-	/**
-	 * The content
-	 */
-	protected Content|array $content;
-	protected string $id;
-	protected ModelWithContent|null $parent;
+	public const ITEMS_CLASS = Structure::class;
 
-	/**
-	 * The parent Structure collection
-	 */
-	protected Structure|null $structure;
+	protected Content $content;
 
 	/**
 	 * Creates a new StructureObject with the given props
-	 *
-	 * @param array $props
 	 */
-	public function __construct(array $props)
+	public function __construct(array $params = [])
 	{
-		if (isset($props['id']) === false) {
-			throw new InvalidArgumentException('The property "id" is required');
-		}
+		parent::__construct($params);
 
-		$this->id        = $props['id'];
-		$this->parent    = $props['parent'] ?? App::instance()->site();
-		$this->structure = $props['structure'] ?? null;
-		$this->content   = $props['content'] ?? [];
+		$this->content = new Content(
+			$params['content'] ?? $params['params'] ?? [],
+			$this->parent
+		);
 	}
 
 	/**
 	 * Modified getter to also return fields
 	 * from the object's content
 	 */
-	public function __call(string $method, array $arguments = []): mixed
+	public function __call(string $method, array $args = []): mixed
 	{
+		// structure object methods
+		if ($this->hasMethod($method) === true) {
+			return $this->callMethod($method, $args);
+		}
+
 		// public property access
 		if (isset($this->$method) === true) {
 			return $this->$method;
@@ -72,67 +65,21 @@ class StructureObject
 	 */
 	public function content(): Content
 	{
-		if ($this->content instanceof Content) {
-			return $this->content;
-		}
-
-		if (is_array($this->content) !== true) {
-			$this->content = [];
-		}
-
-		return $this->content = new Content($this->content, $this->parent());
-	}
-
-	/**
-	 * Returns the required id
-	 */
-	public function id(): string
-	{
-		return $this->id;
-	}
-
-	/**
-	 * Compares the current object with the given structure object
-	 */
-	public function is(mixed $structure): bool
-	{
-		if ($structure instanceof self === false) {
-			return false;
-		}
-
-		return $this === $structure;
-	}
-
-	/**
-	 * Returns the parent object
-	 */
-	public function parent(): ModelWithContent|null
-	{
-		return $this->parent;
-	}
-
-	/**
-	 * Returns the parent Structure collection as siblings
-	 */
-	protected function siblingsCollection(): Structure|null
-	{
-		return $this->structure;
+		return $this->content;
 	}
 
 	/**
 	 * Converts all fields in the object to a
 	 * plain associative array. The id is
-	 * injected into the array afterwards
+	 * injected from the parent into the array
 	 * to make sure it's always present and
-	 * not overloaded in the content.
+	 * not overloaded by the content.
 	 */
 	public function toArray(): array
 	{
-		$array = $this->content()->toArray();
-		$array['id'] = $this->id();
-
-		ksort($array);
-
-		return $array;
+		return array_merge(
+			$this->content()->toArray(),
+			parent::toArray()
+		);
 	}
 }

--- a/tests/Cms/Structures/StructureMethodsTest.php
+++ b/tests/Cms/Structures/StructureMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class StructureMethodsTest extends TestCase
+{
+	protected $app;
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'structureMethods' => [
+				'test' => function () {
+					return 'structure method';
+				}
+			]
+		]);
+	}
+
+	public function testBlocksMethod()
+	{
+		$blocks = Structure::factory([]);
+		$this->assertSame('structure method', $blocks->test());
+	}
+}

--- a/tests/Cms/Structures/StructureObjectMethodsTest.php
+++ b/tests/Cms/Structures/StructureObjectMethodsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class StructureObjectMethodsTest extends TestCase
+{
+	protected $app;
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'structureObjectMethods' => [
+				'test' => function () {
+					return 'structure object method';
+				}
+			]
+		]);
+	}
+
+	public function testBlockMethod()
+	{
+		$structure = new StructureObject();
+		$this->assertSame('structure object method', $structure->test());
+	}
+}

--- a/tests/Cms/Structures/StructureObjectTest.php
+++ b/tests/Cms/Structures/StructureObjectTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\InvalidArgumentException;
 use TypeError;
 
 class StructureObjectTest extends TestCase
@@ -106,7 +105,7 @@ class StructureObjectTest extends TestCase
 
 	public function testInvalidParent()
 	{
-		$this->expectException('TypeError');
+		$this->expectException(TypeError::class);
 
 		$object = new StructureObject([
 			'id'     => 'test',

--- a/tests/Cms/Structures/StructureObjectTest.php
+++ b/tests/Cms/Structures/StructureObjectTest.php
@@ -3,33 +3,20 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use TypeError;
 
 class StructureObjectTest extends TestCase
 {
 	public function testId()
 	{
-		$object = new StructureObject([
-			'id' => 'test'
-		]);
-
+		$object = new StructureObject(['id' => 'test']);
 		$this->assertSame('test', $object->id());
 	}
 
 	public function testInvalidId()
 	{
-		$this->expectException('TypeError');
-
-		$object = new StructureObject([
-			'id' => []
-		]);
-	}
-
-	public function testMissingId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('The property "id" is required');
-
-		new StructureObject(['foo' => 'bar']);
+		$this->expectException(TypeError::class);
+		new StructureObject(['id' => []]);
 	}
 
 	public function testContent()
@@ -135,9 +122,9 @@ class StructureObjectTest extends TestCase
 		];
 
 		$expected = [
-			'id'    => 'test',
-			'text'  => 'Text',
 			'title' => 'Title',
+			'text'  => 'Text',
+			'id'    => 'test',
 		];
 
 		$object = new StructureObject([

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -8,20 +8,20 @@ class StructureTest extends TestCase
 {
 	public function testCreate()
 	{
-		$structure = new Structure([
+		$structure = Structure::factory([
 			['test' => 'Test']
 		]);
 
 		$this->assertInstanceOf(StructureObject::class, $structure->first());
-		$this->assertSame('0', $structure->first()->id());
+		$this->assertSame(1, $structure->count());
 	}
 
 	public function testParent()
 	{
 		$parent    = new Page(['slug' => 'test']);
-		$structure = new Structure([
+		$structure = Structure::factory([
 			['test' => 'Test']
-		], $parent);
+		], ['parent' => $parent]);
 
 		$this->assertSame($parent, $structure->first()->parent());
 	}
@@ -32,20 +32,17 @@ class StructureTest extends TestCase
 			['name' => 'A'],
 			['name' => 'B']
 		];
+		$structure = Structure::factory($data)->toArray();
 
-		$expected = [
-			['id' => '0', 'name' => 'A'],
-			['id' => '1', 'name' => 'B'],
-		];
-
-		$structure = new Structure($data);
-
-		$this->assertSame($expected, $structure->toArray());
+		$this->assertSame('A', $structure[0]['name']);
+		$this->assertArrayHasKey('id', $structure[0]);
+		$this->assertSame('B', $structure[1]['name']);
+		$this->assertArrayHasKey('id', $structure[1]);
 	}
 
 	public function testGroup()
 	{
-		$structure = new Structure([
+		$structure = Structure::factory([
 			[
 				'name' => 'A',
 				'category' => 'cat-a'
@@ -77,7 +74,7 @@ class StructureTest extends TestCase
 
 	public function testSiblings()
 	{
-		$structure = new Structure([
+		$structure = Structure::factory([
 			['name' => 'A'],
 			['name' => 'B'],
 			['name' => 'C']
@@ -103,9 +100,9 @@ class StructureTest extends TestCase
 	public function testWithInvalidData()
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid structure data');
+		$this->expectExceptionMessage('Invalid data for Kirby\Cms\StructureObject');
 
-		$structure = new Structure([
+		Structure::factory([
 			[
 				'name' => 'A',
 				'category' => 'cat-a'


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

- Align the structure classes to be built on top of `Cms\Item`, same as blocks, layouts etc.
- I think this will help to have consistent support for UUIDs for blocks and structure objects

### Feature
- Custom methods for structure and structure object

### Refactored
- `Kirby\Cms\Structure` extends `Kirby\Cms\Items` and `Kirby\Cms\StructureObject` extends `Kirby\Cms\Item`


### Breaking changes
- `new Structure()`/`new StructureObject()` don't work anymore as before. Use `Structure::factory()`/`StructureObject::factory()` instead
- Structure object IDs aren't simply their collection index numbers anymore but receive a `Str::uuid()` as blocks do
- `Items::factory()` and all inheriting classes throw an exception now if malformed data is passed


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
