### PR TITLE
Block default model: change key to `default`

### DIFF
--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -170,7 +170,7 @@ class Block extends Item
 		}
 
 		// default model for blocks
-		if ($class = (static::$models['Kirby\Cms\Block'] ?? null)) {
+		if ($class = (static::$models['default'] ?? null)) {
 			$object = new $class($params);
 
 			if ($object instanceof self) {

--- a/tests/Cms/Blocks/BlockModelsTest.php
+++ b/tests/Cms/Blocks/BlockModelsTest.php
@@ -80,7 +80,7 @@ class BlockModelsTest extends TestCase
 				'index' => '/dev/null',
 			],
 			'blockModels' => [
-				'Kirby\Cms\Block' => DefaultBlock::class
+				'default' => DefaultBlock::class
 			]
 		]);
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

I've been wondering why we ask people to register the default block model with `Kirby\Cms\Block` and not with a simple `default` as key like we do it in most other cases: https://getkirby.com/docs/reference/plugins/extensions/block-models#overwriting-the-default-block-class

It's an added breaking change, but I think it would be good to remove the tech-term for the more common one.

### Breaking changes
- Registering a default block model now needs to be done with the key `default`, not `Kirby\Cms\Block`


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
