### PR TITLE
Fix block collapsing inside layouts

### DIFF
--- a/panel/src/components/Forms/Blocks/Types/Text.vue
+++ b/panel/src/components/Forms/Blocks/Types/Text.vue
@@ -88,9 +88,4 @@ export default {
 	line-height: 1.5em;
 	height: 100%;
 }
-.k-block-type-text,
-.k-block-container-type-text,
-.k-block-type-text .k-writer .ProseMirror {
-	height: 100%;
-}
 </style>

--- a/panel/src/components/Forms/Layouts/LayoutColumn.vue
+++ b/panel/src/components/Forms/Layouts/LayoutColumn.vue
@@ -65,9 +65,6 @@ export default {
 	flex-direction: column;
 	height: 100%;
 }
-.k-layout-column .k-blocks .k-block-container:last-of-type {
-	flex-grow: 1;
-}
 .k-layout-column .k-blocks-empty {
 	position: absolute;
 	inset: 0;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

@bastianallgeier did these CSS lines have any other purpose than blowing up the last block in a layout to fill the full layout? And to make text blocks demand the most space?

If there aren't any other side effects, I think the benefit of collapsible blocks is a better choice.

### Fixes
- #5289
