### PR TITLE
Fix users field default

### DIFF
--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -24,18 +24,8 @@ return [
 		/**
 		 * Default selected user(s) when a new page/file/user is created
 		 */
-		'default' => function ($default = null) {
-			if ($default === false) {
-				return [];
-			}
-
-			if ($default === null && $user = $this->kirby()->user()) {
-				return [
-					$this->userResponse($user)
-				];
-			}
-
-			return $this->toUsers($default);
+		'default' => function (string|array|bool $default = null) {
+			return $default;
 		},
 
 		'value' => function ($value = null) {
@@ -43,10 +33,22 @@ return [
 		},
 	],
 	'computed' => [
-		/**
-		 * Unset inherited computed
-		 */
-		'default' => null
+		'default' => function (): array {
+			if ($this->default === false) {
+				return [];
+			}
+
+			if (
+				$this->default === true &&
+				$user = $this->kirby()->user()
+			) {
+				return [
+					$this->userResponse($user)
+				];
+			}
+
+			return $this->toUsers($this->default);
+		}
 	],
 	'methods' => [
 		'userResponse' => function ($user) {
@@ -57,7 +59,7 @@ return [
 				'text'   => $this->text,
 			]);
 		},
-		'toUsers' => function ($value = null) {
+		'toUsers' => function ($value = null): array {
 			$users = [];
 			$kirby = App::instance();
 

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -24,7 +24,7 @@ return [
 		/**
 		 * Default selected user(s) when a new page/file/user is created
 		 */
-		'default' => function (string|array|bool $default = null) {
+		'default' => function (string|array|bool|null $default = null) {
 			return $default;
 		},
 

--- a/tests/Form/Fields/UsersFieldTest.php
+++ b/tests/Form/Fields/UsersFieldTest.php
@@ -55,6 +55,18 @@ class UsersFieldTest extends TestCase
 			'model' => new Page(['slug' => 'test'])
 		]);
 
+		$this->assertSame([], $field->default());
+	}
+
+	public function testCurrentDefaultUser()
+	{
+		$this->app->impersonate('raphael@getkirby.com');
+
+		$field = $this->field('users', [
+			'model'   => new Page(['slug' => 'test']),
+			'default' => true
+		]);
+
 		$this->assertSame('raphael@getkirby.com', $field->default()[0]['email']);
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

@texnixe since query support pose the question again what happens if `username === query entry` (e.g. page, site...), I didn't pursue that option. Instead, now it needs to be `$default === true` and not `$default === null` to automatically set the current user. Do you think that works?

### Fixes
- Users field does not anymore use a default if none set #5284

### Enhancement
- Users field: set `default: true` to always use the currently logged in user as default

### Breaking changes
- Users field doesn't automatically uses the current user as default, add `default: true` to keep this functionality


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
