### PR TITLE
Disable structure options btn when form open

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -1,8 +1,12 @@
 <template>
 	<k-field v-bind="$props" class="k-structure-field" @click.native.stop>
 		<template #options>
-			<k-dropdown v-if="!currentIndex">
-				<k-button icon="dots" @click="$refs.options.toggle()" />
+			<k-dropdown>
+				<k-button
+					:disabled="currentIndex !== null"
+					icon="dots"
+					@click="$refs.options.toggle()"
+				/>
 				<k-dropdown-content ref="options" align="right">
 					<k-dropdown-item :disabled="!more" icon="add" @click="onAdd">
 						{{ $t("add") }}


### PR DESCRIPTION

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Structure form options button doesn't disappear anymore when form open, but is disabeld 
#5302