### PR TITLE
Fix overwriting of `Query::$entries`

### DIFF
--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -70,6 +70,10 @@ class Argument
 
 		// numeric
 		if (is_numeric($argument) === true) {
+			if (strpos($argument, '.') === false) {
+				return new static((int)$argument);
+			}
+
 			return new static((float)$argument);
 		}
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -117,7 +117,7 @@ Query::$entries['file'] = function (string $id): File|null {
 };
 
 Query::$entries['page'] = function (string $id): Page|null {
-	return App::instance()->site()->find($id);
+	return App::instance()->page($id);
 };
 
 Query::$entries['site'] = function (): Site {

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -77,19 +77,17 @@ class Segment
 	/**
 	 * Automatically resolves the segment depending on the
 	 * segment position and the type of the base
+	 *
+	 * @param mixed $base Current value of the query chain
 	 */
 	public function resolve(mixed $base = null, array|object $data = []): mixed
 	{
 		// resolve arguments to array
 		$args = $this->arguments?->resolve($data) ?? [];
 
-		// 1st segment, start from $data array
+		// 1st segment, use $data as base
 		if ($this->position === 0) {
-			if (is_array($data) == true) {
-				return $this->resolveArray($data, $args);
-			}
-
-			return $this->resolveObject($data, $args);
+			$base = $data;
 		}
 
 		if (is_array($base) === true) {
@@ -109,26 +107,55 @@ class Segment
 	 */
 	protected function resolveArray(array $array, array $args): mixed
 	{
-		if (array_key_exists($this->method, $array) === false) {
-			static::error($array, $this->method, 'property');
+		// the directly provided array takes precedence
+		// to look up a matching entry
+		if (array_key_exists($this->method, $array) === true) {
+			$value = $array[$this->method];
+
+			// if this is a Closure we can directly use it, as
+			// Closures from the $array should always have priority
+			// over the Query::$entries Closures
+			if ($value instanceof Closure) {
+				return $value(...$args);
+			}
+
+			// if we have no arguments to pass, we also can directly
+			// use the value from the $array as it must not be different
+			// to the one from Query::$entries with the same name
+			if ($args === []) {
+				return $value;
+			}
 		}
 
-		$value = $array[$this->method];
-
-		if ($value instanceof Closure) {
-			return $value(...$args);
+		// fallback time: only if we are handling the first segment,
+		// we can also try to resolve the segment with an entry from the
+		// default Query::$entries
+		if ($this->position === 0) {
+			if (array_key_exists($this->method, Query::$entries) === true) {
+				return Query::$entries[$this->method](...$args);
+			}
 		}
 
-		if ($args !== []) {
+		// if we have not been able to return anything so far,
+		// we just need to differntiate between two different error messages
+
+		// this one is in case the original array contained the key,
+		// but was not a Closure while the segment had arguments
+		if (
+			array_key_exists($this->method, $array) &&
+			$args !== []
+		) {
 			throw new InvalidArgumentException('Cannot access array element "' . $this->method . '" with arguments');
 		}
 
-		return $value;
+		// last, the standard error for trying to access something
+		// that does not exist
+		static::error($array, $this->method, 'property');
 	}
 
 	/**
-	 * Resolves segment by calling the method/accessing the property
-	 * on the base object
+	 * Resolves segment by calling the method/
+	 * accessing the property on the base object
 	 */
 	protected function resolveObject(object $object, array $args): mixed
 	{
@@ -140,7 +167,8 @@ class Segment
 		}
 
 		if (
-			$args === [] && (
+			$args === [] &&
+			(
 				property_exists($object, $this->method) === true ||
 				method_exists($object, '__get') === true
 			)

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -43,7 +43,9 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
 
 		// numbers
 		$argument = Argument::factory(' 23  ');
-		$this->assertSame(23.0, $argument->value);
+		$this->assertSame(23, $argument->value);
+		$argument = Argument::factory(' 23.3  ');
+		$this->assertSame(23.3, $argument->value);
 
 		// null
 		$argument = Argument::factory(' null ');
@@ -70,8 +72,8 @@ class ArgumentTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame(' 23 ', $argument);
 
 		// arrays
-		$argument = Argument::factory('[1, "a", 3]')->resolve();
-		$this->assertSame([1.0, 'a', 3.0], $argument);
+		$argument = Argument::factory('[1, "a", 3.3]')->resolve();
+		$this->assertSame([1, 'a', 3.3], $argument);
 
 		// nested query
 		$argument = Argument::factory('foo')->resolve(['foo' => 'bar']);

--- a/tests/Query/ArgumentsTest.php
+++ b/tests/Query/ArgumentsTest.php
@@ -33,19 +33,19 @@ class ArgumentsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testResolve()
 	{
-		$arguments = Arguments::factory('1, 2, 3');
-		$this->assertSame([1.0 , 2.0, 3.0], $arguments->resolve());
+		$arguments = Arguments::factory('1, 2.3, 3');
+		$this->assertSame([1, 2.3, 3], $arguments->resolve());
 
-		$arguments = Arguments::factory('1, 2, [3, 4]');
-		$this->assertSame([1.0 , 2.0, [3.0, 4.0]], $arguments->resolve());
+		$arguments = Arguments::factory('1, 2, [3.3, 4]');
+		$this->assertSame([1, 2, [3.3, 4]], $arguments->resolve());
 
 		$arguments = Arguments::factory('1, 2, \'3, 4\'');
-		$this->assertSame([1.0 , 2.0, '3, 4'], $arguments->resolve());
+		$this->assertSame([1, 2, '3, 4'], $arguments->resolve());
 
 		$arguments = Arguments::factory('1, 2, "3, 4"');
-		$this->assertSame([1.0 , 2.0, '3, 4'], $arguments->resolve());
+		$this->assertSame([1, 2, '3, 4'], $arguments->resolve());
 
 		$arguments = Arguments::factory('1, 2, \'(3, 4)\'');
-		$this->assertSame([1.0 , 2.0, '(3, 4)'], $arguments->resolve());
+		$this->assertSame([1, 2, '(3, 4)'], $arguments->resolve());
 	}
 }

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -91,7 +91,7 @@ class ExpressionTest extends \PHPUnit\Framework\TestCase
 			['0 ?: "no"', 'no'],
 			['null ?? null ?? null ?? "yes"', 'yes'],
 			['"yes" ?? "no"', 'yes'],
-			['null ?? (null ?? null ?? (false ? "what" : 42)) ?? "no"', 42.0],
+			['null ?? (null ?? null ?? (false ? "what" : 42)) ?? "no"', 42],
 		];
 	}
 

--- a/tests/Query/QueryDefaultFunctionsTest.php
+++ b/tests/Query/QueryDefaultFunctionsTest.php
@@ -75,20 +75,33 @@ class QueryDefaultFunctionsTest extends \PHPUnit\Framework\TestCase
 
 	public function testPage()
 	{
-		new App([
+		$app = new App([
 			'site' => [
 				'children' => [
 					[
 						'slug' => 'a',
+					],
+					[
+						'slug'    => 'b',
+						'content' => ['uuid' => 'test']
 					]
 				]
 			]
 		]);
 
-		$query = new Query('page("a")');
-		$this->assertInstanceOf(Page::class, $query->resolve());
+		$a = $app->page('a');
+		$b = $app->page('b');
 
-		$query = new Query('page("b")');
+		$query = new Query('page("a")');
+		$this->assertSame($a, $query->resolve());
+
+		$query = new Query('page("a").slug');
+		$this->assertSame('a', $query->resolve(['slug' => 'foo']));
+
+		$query = new Query('page("page://test")');
+		$this->assertSame($b, $query->resolve(['page' => $b]));
+
+		$query = new Query('page("c")');
 		$this->assertNull($query->resolve());
 	}
 

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -220,10 +220,10 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayCallError()
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Cannot access array element "user" with arguments');
+		$this->expectExceptionMessage('Cannot access array element "editor" with arguments');
 
-		$segments = Segments::factory('user("test")');
-		$data     = ['user' => new TestUser()];
+		$segments = Segments::factory('editor("test")');
+		$data     = ['editor' => new TestUser()];
 		$segments->resolve($data);
 	}
 
@@ -233,9 +233,9 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayMissingKey1()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing property "user" on array');
+		$this->expectExceptionMessage('Access to non-existing property "editor" on array');
 
-		$segments = Segments::factory('user');
+		$segments = Segments::factory('editor');
 		$segments->resolve();
 	}
 
@@ -245,9 +245,9 @@ class SegmentsTest extends \PHPUnit\Framework\TestCase
 	public function testResolveWithArrayMissingKey2()
 	{
 		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Access to non-existing property "user" on array');
+		$this->expectExceptionMessage('Access to non-existing property "editor" on array');
 
-		$segments = Segments::factory('user.username');
+		$segments = Segments::factory('editor.username');
 		$segments->resolve();
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

For most queries, we pass along a few objects (`kirby`, `site` as well as `file`, `page` etc.). However, in doing so, we would overwrite the default entry helpers, such as `page()` or `file()`.

This PR fixes it by:
- still given the data precedence that was passed along
- but falling back to the entry helpers if
  - no matching data was passed along
  - the matching data doesn't fit to the query (e.g. it's an object, but query tries to call it with arguments)

It also backports a fix from v4 regarding integer/float arguments. This commit could be skipped in the review.

### Fixes
- Kirby queries can handle integers and floats as arguments currently now
- Fixed using Query helpers, such as `page()` alongside provided  objects with the same name
#5276


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
