### PR TITLE
`Find::parent()`: fix for file with `files` parent

### DIFF
--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -121,7 +121,10 @@ class Find
 			'site'    => $kirby->site(),
 			'account' => static::user(),
 			'page'    => static::page(basename($path)),
-			'file'    => static::file(...explode('/files/', $path)),
+			// regular expression to split the path at the last
+			// occurrence of /files/ which separates parent path
+			// and filename
+			'file'    => static::file(...preg_split('$.*\K(/files/)$', $path)),
 			'user'    => $kirby->user(basename($path)),
 			default   => throw new InvalidArgumentException('Invalid model type: ' . $modelType)
 		};

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -245,6 +245,12 @@ class FindTest extends TestCase
 						'files' => [
 							['filename' => 'a-regular-file.jpg']
 						]
+					],
+					[
+						'slug' => 'files',
+						'files' => [
+							['filename' => 'file-in-files-page.jpg']
+						]
 					]
 				],
 				'files' => [
@@ -279,6 +285,7 @@ class FindTest extends TestCase
 		$this->assertInstanceOf(Page::class, Find::parent('pages/a aa'));
 		$this->assertInstanceOf(File::class, Find::parent('site/files/sitefile.jpg'));
 		$this->assertInstanceOf(File::class, Find::parent('pages/a/files/a-regular-file.jpg'));
+		$this->assertInstanceOf(File::class, Find::parent('pages/files/files/file-in-files-page.jpg'));
 		$this->assertInstanceOf(File::class, Find::parent('users/test@getkirby.com/files/userfile.jpg'));
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Exploding the path at `/files/` separator created issues when that segment was multiple times present (due to page's name). Added a regular expression that splits the string only at the last occurrence of `/files/`.

### Fixes
- Fixed `lock` API routes for files that are ancestors of a page called `files`
#5273


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
