### PR TITLE
Plugin assets: allow any file type for media route

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -60,10 +60,18 @@ return function ($kirby) {
 			}
 		],
 		[
-			'pattern' => $media . '/plugins/(:any)/(:any)/(:all).(css|map|gif|js|mjs|jpg|png|svg|webp|avif|woff2|woff|json)',
+			'pattern' => $media . '/plugins/(:any)/(:any)/(:all).(:any)',
 			'env'     => 'media',
-			'action'  => function (string $provider, string $pluginName, string $filename, string $extension) {
-				return PluginAssets::resolve($provider . '/' . $pluginName, $filename . '.' . $extension);
+			'action'  => function (
+				string $provider,
+				string $pluginName,
+				string $filename,
+				string $extension
+			) {
+				return PluginAssets::resolve(
+					$provider . '/' . $pluginName,
+					$filename . '.' . $extension
+				);
 			}
 		],
 		[


### PR DESCRIPTION
Fixes 

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- Plugin files from the plugin's `assets` folder can now be accessed via its media url no matter what file extension they have
#5247