### PR TITLE
Fix panel url redirect issue when running on subfolder

### DIFF
--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -153,6 +153,15 @@ class Home
 	}
 
 	/**
+	 * Returns the path after /panel/ for the home url
+	 */
+	public static function path(): string|null
+	{
+		$url = Home::url();
+		return Home::panelPath($url);
+	}
+
+	/**
 	 * Returns the Url that has been stored in the session
 	 * before the last logout. We take this Url if possible
 	 * to redirect the user back to the last point where they

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -354,7 +354,7 @@ class Panel
 				'installation',
 				'login',
 			],
-			'action' => fn () => Panel::go(Home::url()),
+			'action' => fn () => Panel::go(Home::path()),
 			'auth' => false
 		];
 

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -289,6 +289,22 @@ class HomeTest extends TestCase
 	}
 
 	/**
+	 * @covers ::path
+	 */
+	public function testPath()
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				['email' => 'test@getkirby.com', 'role' => 'admin']
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		$this->assertSame('site', Home::path());
+	}
+
+	/**
 	 * @covers ::remembered
 	 */
 	public function testRemembered()


### PR DESCRIPTION
## This PR …
`Panel::go` uses the `Url::to()` method to redirect. Since this method already includes the root directory, don't need to include the root directory again and used `::panelPath` for this case. What do you think @bastianallgeier ?

### Fixes
- Fix panel url redirect issue when running on subfolder #5266

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
