### PR TITLE
File blueprint `focus` option

### DIFF
--- a/panel/src/components/Layout/FilePreview.vue
+++ b/panel/src/components/Layout/FilePreview.vue
@@ -6,7 +6,7 @@
 				<!-- Image with focus picker -->
 				<template v-if="image.src">
 					<k-coords
-						:aria-disabled="!focusable"
+						:aria-disabled="!canFocus"
 						:x="focus?.x"
 						:y="focus?.y"
 						@input="setFocus($event.detail)"
@@ -62,7 +62,7 @@
 						<dt>{{ $t("file.focus.title") }}</dt>
 						<dd>
 							<k-button
-								v-if="focusable"
+								v-if="canFocus"
 								:icon="hasFocus ? 'cancel-small' : 'preview'"
 								:title="hasFocus ? $t('file.focus.reset') : undefined"
 								size="xs"
@@ -72,7 +72,7 @@
 								<template v-if="hasFocus">
 									{{ focus.x }}% {{ focus.y }}%
 								</template>
-								<template v-else-if="focusable">
+								<template v-else-if="canFocus">
 									{{ $t("file.focus.placeholder") }}
 								</template>
 							</k-button>
@@ -94,6 +94,7 @@ export default {
 		details: Array,
 		focusable: Boolean,
 		image: Object,
+		isLocked: Boolean,
 		url: String
 	},
 	computed: {
@@ -106,6 +107,9 @@ export default {
 
 			const [x, y] = focus.replaceAll("%", "").split(" ");
 			return { x: parseFloat(x), y: parseFloat(y) };
+		},
+		canFocus() {
+			return this.focusable && this.image.src && this.isLocked === false;
 		},
 		hasFocus() {
 			return this.focus?.x !== undefined && this.focus?.y !== undefined;
@@ -120,7 +124,7 @@ export default {
 				}
 			];
 
-			if (this.focusable && this.image.src) {
+			if (this.canFocus) {
 				if (this.hasFocus) {
 					options.push({
 						icon: "cancel",

--- a/panel/src/components/Views/FileView.vue
+++ b/panel/src/components/Views/FileView.vue
@@ -6,7 +6,7 @@
 			:data-template="blueprint"
 			class="k-file-view"
 		>
-			<k-file-preview v-bind="preview" :focusable="isFocusable" />
+			<k-file-preview v-bind="preview" :is-locked="isLocked" />
 			<k-view class="k-file-content">
 				<k-header
 					:editable="permissions.changeName && !isLocked"
@@ -63,17 +63,6 @@ export default {
 	extends: ModelView,
 	props: {
 		preview: Object
-	},
-	computed: {
-		isFocusable() {
-			return (
-				!this.isLocked &&
-				this.permissions.update &&
-				(!window.panel.multilang ||
-					window.panel.languages.length === 0 ||
-					window.panel.language.default)
-			);
-		}
 	},
 	methods: {
 		action(action) {

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -411,6 +411,85 @@ class FileTest extends TestCase
 	}
 
 	/**
+	 * @covers ::isFocusable
+	 */
+	public function testIsFocusable()
+	{
+		$this->app->clone([
+			'blueprints' => [
+				'files/foo' => [
+					'focus' => false
+				]
+			]
+		]);
+
+
+		$page = new ModelPage(['slug' => 'test']);
+
+		// no update permission
+		$file = new ModelFile([
+			'filename' => 'test.jpg',
+			'parent'   => $page,
+		]);
+
+		$this->assertFalse((new File($file))->isFocusable());
+
+		// default for images (viewable)
+		$file = new ModelFile([
+			'filename' => 'test.jpg',
+			'parent'   => $page,
+		]);
+		$file->kirby()->impersonate('kirby');
+
+		$this->assertTrue((new File($file))->isFocusable());
+
+		// default for others (not viewable)
+		$file = new ModelFile([
+			'filename' => 'test.mp4',
+			'parent'   => $page,
+		]);
+		$file->kirby()->impersonate('kirby');
+
+		$this->assertFalse((new File($file))->isFocusable());
+
+		// blueprint option: false
+		$file = new ModelFile([
+			'filename' => 'test.jpg',
+			'parent'   => $page,
+			'template' => 'foo',
+		]);
+		$file->kirby()->impersonate('kirby');
+
+		$this->assertFalse((new File($file))->isFocusable());
+
+		// editing secondary language
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$app->setCurrentLanguage('de');
+
+
+		$file = new ModelFile([
+			'filename' => 'test.jpg',
+			'parent'   => $page,
+		]);
+		$file->kirby()->impersonate('kirby');
+
+		$this->assertFalse((new File($file))->isFocusable());
+	}
+
+	/**
 	 * @covers ::options
 	 */
 	public function testOptions()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- New `focus` option for file blueprints to enable/disable setting focus point in the Panel (defaults to true for all viewable images, false for all other files)
#5316


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
