### PR TITLE
Fix conflicting block keyboard shortcuts

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -11,21 +11,11 @@
 		:data-translate="fieldset.translate"
 		class="k-block-container"
 		tabindex="0"
-		@keydown.meta.j.prevent.stop="$emit('merge')"
 		@keydown.ctrl.j.prevent.stop="$emit('merge')"
-		@keydown.meta.up.exact.prevent.stop="$emit('focusPrev')"
-		@keydown.ctrl.up.exact.prevent.stop="$emit('focusPrev')"
-		@keydown.meta.down.exact.prevent.stop="$emit('focusNext')"
-		@keydown.ctrl.down.exact.prevent.stop="$emit('focusNext')"
-		@keydown.meta.alt.down.prevent.stop="$emit('selectDown')"
 		@keydown.ctrl.alt.down.prevent.stop="$emit('selectDown')"
-		@keydown.meta.alt.up.prevent.stop="$emit('selectUp')"
 		@keydown.ctrl.alt.up.prevent.stop="$emit('selectUp')"
-		@keydown.meta.shift.down.prevent.stop="$emit('sortDown')"
 		@keydown.ctrl.shift.down.prevent.stop="$emit('sortDown')"
-		@keydown.meta.shift.up.prevent.stop="$emit('sortUp')"
 		@keydown.ctrl.shift.up.prevent.stop="$emit('sortUp')"
-		@keydown.meta.backspace.prevent.stop="remove"
 		@keydown.ctrl.backspace.prevent.stop="remove"
 		@focus.stop="$emit('focus')"
 		@focusin.stop="onFocusIn"
@@ -125,8 +115,6 @@ export default {
 		"copy",
 		"duplicate",
 		"focus",
-		"focusPrev",
-		"focusNext",
 		"hide",
 		"merge",
 		"open",

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -30,8 +30,6 @@
 					@copy="copy()"
 					@duplicate="duplicate(block, index)"
 					@focus="onFocus(block)"
-					@focusPrev="focusPrev(index)"
-					@focusNext="focusNext(index)"
 					@hide="hide(block)"
 					@merge="merge()"
 					@open="isEditing = true"
@@ -339,14 +337,6 @@ export default {
 			this.selected = [block?.id ?? this.blocks[0]];
 			ref?.focus();
 			ref?.$el.scrollIntoView({ block: "nearest" });
-		},
-		focusNext(index) {
-			const block = this.blocks[Math.min(index + 1, this.blocks.length - 1)];
-			this.focus(block);
-		},
-		focusPrev(index) {
-			const block = this.blocks[Math.max(0, index - 1)];
-			this.focus(block);
 		},
 		focusOrOpen(block) {
 			if (this.fieldsets[block.type].wysiwyg) {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Removes conflicting block keyboard shortcuts with `Cmd` key (instead use variants with `Ctrl` key)
#5268

### Breaking changes
- Removes keyboard shortcut to move block focus up/down