### PR TITLE
`FileActions`: consistent multi-lang handling

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -230,14 +230,12 @@ trait FileActions
 				throw new LogicException('The file could not be created');
 			}
 
-			// always create files in the default language
-			$languageCode =
-				$file->kirby()->multilang() ?
-				$file->kirby()->defaultLanguage()->code() :
-				null;
-
 			// store the content if necessary
-			$file->save($file->content()->toArray(), $languageCode);
+			// (always create files in the default language)
+			$file->save(
+				$file->content()->toArray(),
+				$file->kirby()->defaultLanguage()?->code()
+			);
 
 			// add the file to the list of siblings
 			$file->siblings()->append($file->id(), $file);

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -57,18 +57,11 @@ trait FileActions
 			// rename the main file
 			F::move($oldFile->root(), $newFile->root());
 
-			$translations =
-				$newFile->kirby()->multilang() ?
-				$newFile->translations()->values(
-					fn ($translation) => $translation->code()
-				) :
-				['default'];
-
-			foreach ($translations as $translation) {
+			foreach ($newFile->kirby()->languages()->codes() as $lang) {
 				// rename the content file
 				F::move(
-					$oldFile->contentFile($translation),
-					$newFile->contentFile($translation)
+					$oldFile->contentFile($lang),
+					$newFile->contentFile($lang)
 				);
 			}
 
@@ -166,14 +159,9 @@ trait FileActions
 	{
 		F::copy($this->root(), $page->root() . '/' . $this->filename());
 
-		$languages =
-			$this->kirby()->multilang() ?
-			$this->kirby()->languages()->values(fn ($lang) => $lang->code()) :
-			['default'];
-
-		foreach ($languages as $language) {
+		foreach ($this->kirby()->languages()->codes() as $lang) {
 			F::copy(
-				$contentFile = $this->contentFile($language),
+				$contentFile = $this->contentFile($lang),
 				$page->root() . '/' . basename($contentFile)
 			);
 		}
@@ -272,13 +260,8 @@ trait FileActions
 			// remove all public versions, lock and clear UUID cache
 			$file->unpublish();
 
-			$translations =
-				$file->kirby()->multilang() ?
-				$file->translations()->values(fn ($lang) => $lang->code()) :
-				['default'];
-
-			foreach ($translations as $translation) {
-				F::remove($file->contentFile($translation));
+			foreach ($file->kirby()->languages()->codes() as $lang) {
+				F::remove($file->contentFile($lang));
 			}
 
 			F::remove($file->root());

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -44,12 +44,10 @@ class Languages extends Collection
 
 	/**
 	 * Returns all language codes as array
-	 *
-	 * @return array
 	 */
 	public function codes(): array
 	{
-		return $this->keys();
+		return App::instance()->multilang() ? $this->keys() : ['default'];
 	}
 
 	/**

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -44,6 +44,43 @@ class LanguagesTest extends TestCase
 		Dir::remove($this->tmp);
 	}
 
+	/**
+	 * @covers ::codes
+	 */
+	public function testCodes()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => $this->tmp = __DIR__ . '/tmp/LanguagesTest',
+			],
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true,
+					'locale'  => 'en_US',
+					'url'     => '/',
+				],
+				[
+					'code'    => 'de',
+					'name'    => 'Deutsch',
+					'locale'  => 'de_DE',
+					'url'     => '/de',
+				],
+			]
+		]);
+
+		$this->assertSame(['en', 'de'], $app->languages()->codes());
+
+		$app = new App([
+			'roots' => [
+				'index' => $this->tmp = __DIR__ . '/tmp/LanguagesTest',
+			]
+		]);
+
+		$this->assertSame(['default'], $app->languages()->codes());
+	}
+
 	public function testLoad()
 	{
 		$this->assertCount(2, $this->languages);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Isolated improvement that will help us in the changes refactoring.

Makes the multi-lang handling consistent between the FileActions methods and prepares the code to easier adapt to a setup where single-lang is just multilane with lang count = 1.

### Breaking changes
- `$languages->codes()` now returns`['default']` for single language installations

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
