### PR TITLE
Fix drag’n’drop between blocks fields

### DIFF
--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -17,7 +17,6 @@
 
 <script>
 import SectionMixin from "@/mixins/section.js";
-import debounce from "@/helpers/debounce.js";
 
 export default {
 	mixins: [SectionMixin],
@@ -42,7 +41,6 @@ export default {
 		}
 	},
 	created() {
-		this.input = debounce(this.input, 50);
 		this.fetch();
 	},
 	methods: {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Debouncing the input handler is a bad idea for situations where two fields' value change at once (e.g. dragging one block from one field to another, both blocks simultaneously will emit an input event).

If we think certain fields would be emitting their input way too often, we should debounce this on the emitter, not on the receiving fields section.

### Fixes
- Drag'n'drop between blocks fields works agaiN
#5290


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
