### PR TITLE
Fix user blueprint home option and running on subfolder

### DIFF
--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -153,15 +153,6 @@ class Home
 	}
 
 	/**
-	 * Returns the path after /panel/ for the home url
-	 */
-	public static function path(): string|null
-	{
-		$url = Home::url();
-		return Home::panelPath($url);
-	}
-
-	/**
 	 * Returns the Url that has been stored in the session
 	 * before the last logout. We take this Url if possible
 	 * to redirect the user back to the last point where they

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -11,6 +11,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Http\Response;
 use Kirby\Http\Router;
+use Kirby\Http\Uri;
 use Kirby\Http\Url;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\Tpl;
@@ -354,7 +355,7 @@ class Panel
 				'installation',
 				'login',
 			],
-			'action' => fn () => Panel::go(Home::path()),
+			'action' => fn () => Panel::go(Home::url()),
 			'auth' => false
 		];
 
@@ -538,15 +539,22 @@ class Panel
 	 */
 	public static function url(string|null $url = null): string
 	{
-		$slug = App::instance()->option('panel.slug', 'panel');
-
 		// only touch relative paths
 		if (Url::isAbsolute($url) === false) {
-			$path = trim($url, '/');
+			$kirby = App::instance();
+			$slug  = $kirby->option('panel.slug', 'panel');
+			$path  = trim($url, '/');
 
+			$baseUri  = new Uri($kirby->url());
+			$basePath = trim($baseUri->path()->toString(), '/');
+
+			// removes base path if relative path contains it
+			if (empty($basePath) === false && Str::startsWith($path, $basePath) === true) {
+				$path = Str::after($path, $basePath);
+			}
 			// add the panel slug prefix if it it's not
 			// included in the path yet
-			if (Str::startsWith($path, $slug . '/') === false) {
+			elseif (Str::startsWith($path, $slug . '/') === false) {
 				$path = $slug . '/' . $path;
 			}
 

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -289,22 +289,6 @@ class HomeTest extends TestCase
 	}
 
 	/**
-	 * @covers ::path
-	 */
-	public function testPath()
-	{
-		$this->app = $this->app->clone([
-			'users' => [
-				['email' => 'test@getkirby.com', 'role' => 'admin']
-			]
-		]);
-
-		$this->app->impersonate('test@getkirby.com');
-
-		$this->assertSame('site', Home::path());
-	}
-
-	/**
 	 * @covers ::remembered
 	 */
 	public function testRemembered()


### PR DESCRIPTION
## This PR …

After much debugging and testing I finally found a clue to the solution. I hope it's acceptable.

Since there are too many cases, we broke one while fixing the other. Now I think I have fixed both cases, but the HTTP class is too complicated for me. @bastianallgeier will decide how good and stable the fix is 😅 

The critical part of this fix is that if the relative path contains the root directory of the application, it removes it to avoid duplication.

### Fixes
- Fix user blueprint home option #5359 (regression)
- Fix panel url redirect issue when running on subfolder #5266

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
