### PR TITLE
Customizable layout selector

### DIFF
--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -97,6 +97,12 @@ export default {
 	}
 }
 
+@media screen and (min-width: 60rem) {
+	.k-dialog[data-size="huge"] {
+		--dialog-width: 60rem;
+	}
+}
+
 /** Pagination **/
 .k-dialog .k-pagination {
 	margin-bottom: -1.5rem;

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -95,6 +95,12 @@ export default {
 	}
 }
 
+@media screen and (min-width: 60rem) {
+	.k-dialog[data-size="huge"] {
+		--dialog-width: 60rem;
+	}
+}
+
 /** Pagination **/
 .k-dialog .k-pagination {
 	margin-bottom: -1.5rem;

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -56,6 +56,7 @@ export default {
 			type: Array,
 			default: () => [["1/1"]]
 		},
+		selector: Object,
 		settings: Object,
 		value: {
 			type: Array,

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -50,6 +50,13 @@ export default {
 			default: () => [["1/1"]]
 		},
 		settings: Object,
+		/**
+		 * @values small, medium, large, huge
+		 */
+		size: {
+			type: String,
+			default: "medium"
+		},
 		value: {
 			type: Array,
 			default: () => []

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -49,14 +49,8 @@ export default {
 			type: Array,
 			default: () => [["1/1"]]
 		},
+		selector: Object,
 		settings: Object,
-		/**
-		 * @values small, medium, large, huge
-		 */
-		size: {
-			type: String,
-			default: "medium"
-		},
 		value: {
 			type: Array,
 			default: () => []

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -2,11 +2,16 @@
 	<k-dialog
 		v-bind="$props"
 		class="k-layout-selector"
+		:size="selector?.size ?? 'medium'"
 		@cancel="$emit('cancel')"
 		@submit="$emit('submit', value)"
 	>
 		<h3 class="k-label">{{ label }}</h3>
-		<k-navigate axis="x" class="k-layout-selector-options">
+		<k-navigate
+			:style="'--columns:' + Number(selector?.columns ?? 3)"
+			axis="x"
+			class="k-layout-selector-options"
+		>
 			<button
 				v-for="(columns, layoutIndex) in layouts"
 				:key="layoutIndex"
@@ -51,10 +56,7 @@ export default {
 		layouts: {
 			type: Array
 		},
-		// eslint-disable-next-line vue/require-prop-types
-		size: {
-			default: "medium"
-		},
+		selector: Object,
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
 			default: false
@@ -71,13 +73,16 @@ export default {
 	margin-top: -0.5rem;
 	margin-bottom: var(--spacing-3);
 }
-
 .k-layout-selector-options {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	gap: var(--spacing-6);
 }
-
+@media screen and (min-width: 65em) {
+	.k-layout-selector-options {
+		grid-template-columns: repeat(var(--columns), 1fr);
+	}
+}
 .k-layout-selector-option {
 	--color-border: hsla(var(--color-gray-hs), 0%, 6%);
 	--color-back: var(--color-white);

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -3,7 +3,7 @@
 		ref="dialog"
 		:cancel-button="false"
 		:submit-button="false"
-		size="medium"
+		:size="size"
 		class="k-layout-selector"
 	>
 		<k-headline>{{ $t("field.layout.select") }}</k-headline>
@@ -33,7 +33,11 @@
 export default {
 	inheritAttrs: false,
 	props: {
-		layouts: Array
+		layouts: Array,
+		size: {
+			type: String,
+			default: "medium"
+		}
 	},
 	data() {
 		return {
@@ -73,7 +77,16 @@ export default {
 	grid-template-columns: repeat(3, 1fr);
 	grid-gap: 1.5rem;
 }
-
+@media screen and (min-width: 40em) {
+	.k-layout-selector[data-size="large"] ul {
+		grid-template-columns: repeat(4, 1fr);
+	}
+}
+@media screen and (min-width: 60em) {
+	.k-layout-selector[data-size="huge"] ul {
+		grid-template-columns: repeat(5, 1fr);
+	}
+}
 .k-layout-selector-option {
 	outline: 2px solid var(--option-outline, transparent);
 	outline-offset: 2px;

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -101,11 +101,12 @@ export default {
 	border-radius: var(--rounded);
 	overflow: hidden;
 	box-shadow: var(--shadow);
+	height: 5rem;
 }
 .k-layout-selector-option .k-column {
 	grid-column: span var(--span);
 	background: var(--color-back);
-	height: 5rem;
+	height: 100%;
 }
 .k-layout-selector-option[aria-current] {
 	--color-border: var(--color-focus);

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -3,11 +3,11 @@
 		ref="dialog"
 		:cancel-button="false"
 		:submit-button="false"
-		:size="size"
+		:size="selector?.size ?? 'medium'"
 		class="k-layout-selector"
 	>
 		<k-headline>{{ $t("field.layout.select") }}</k-headline>
-		<ul>
+		<ul :style="'--columns:' + Number(selector?.columns ?? 3)">
 			<li
 				v-for="(columns, layoutIndex) in layouts"
 				:key="layoutIndex"
@@ -34,10 +34,7 @@ export default {
 	inheritAttrs: false,
 	props: {
 		layouts: Array,
-		size: {
-			type: String,
-			default: "medium"
-		}
+		selector: Object
 	},
 	data() {
 		return {
@@ -77,14 +74,9 @@ export default {
 	grid-template-columns: repeat(3, 1fr);
 	grid-gap: 1.5rem;
 }
-@media screen and (min-width: 40em) {
-	.k-layout-selector[data-size="large"] ul {
-		grid-template-columns: repeat(4, 1fr);
-	}
-}
-@media screen and (min-width: 60em) {
-	.k-layout-selector[data-size="huge"] ul {
-		grid-template-columns: repeat(5, 1fr);
+@media screen and (min-width: 65em) {
+	.k-layout-selector ul {
+		grid-template-columns: repeat(var(--columns), 1fr);
 	}
 }
 .k-layout-selector-option {

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -62,6 +62,7 @@ export default {
 		fieldsets: Object,
 		layouts: Array,
 		max: Number,
+		selector: Object,
 		settings: Object,
 		value: Array
 	},
@@ -113,6 +114,7 @@ export default {
 				props: {
 					label: this.$t("field.layout.change"),
 					layouts: this.layouts,
+					selector: this.selector,
 					value: this.layouts[layoutIndex]
 				},
 				on: {
@@ -277,6 +279,7 @@ export default {
 				component: "k-layout-selector",
 				props: {
 					layouts: this.layouts,
+					selector: this.selector,
 					value: null
 				},
 				on: {

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -40,7 +40,7 @@
 			</k-empty>
 		</template>
 
-		<k-layout-selector ref="selector" :layouts="layouts" :size="size" @select="onSelect" />
+		<k-layout-selector ref="selector" :layouts="layouts" :selector="selector" @select="onSelect" />
 		<k-block-pasteboard ref="pasteboard" @paste="onPaste" />
 	</div>
 </template>
@@ -58,11 +58,8 @@ export default {
 		fieldsets: Object,
 		layouts: Array,
 		max: Number,
+		selector: Object,
 		settings: Object,
-		size: {
-			type: String,
-			default: "medium"
-		},
 		value: Array
 	},
 	data() {

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -40,7 +40,7 @@
 			</k-empty>
 		</template>
 
-		<k-layout-selector ref="selector" :layouts="layouts" @select="onSelect" />
+		<k-layout-selector ref="selector" :layouts="layouts" :size="size" @select="onSelect" />
 		<k-block-pasteboard ref="pasteboard" @paste="onPaste" />
 	</div>
 </template>
@@ -59,6 +59,10 @@ export default {
 		layouts: Array,
 		max: Number,
 		settings: Object,
+		size: {
+			type: String,
+			default: "medium"
+		},
 		value: Array
 	},
 	data() {

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -15,12 +15,14 @@ use Throwable;
 class LayoutField extends BlocksField
 {
 	protected array|null $layouts;
+	protected array|null $selector;
 	protected Fieldset|null $settings;
 
 	public function __construct(array $params)
 	{
 		$this->setModel($params['model'] ?? App::instance()->site());
 		$this->setLayouts($params['layouts'] ?? ['1/1']);
+		$this->setSelector($params['selector'] ?? null);
 		$this->setSettings($params['settings'] ?? null);
 
 		parent::__construct($params);
@@ -123,8 +125,9 @@ class LayoutField extends BlocksField
 		$settings = $this->settings();
 
 		return array_merge(parent::props(), [
-			'settings' => $settings?->toArray(),
-			'layouts'  => $this->layouts()
+			'layouts'  => $this->layouts(),
+			'selector' => $this->selector(),
+			'settings' => $settings?->toArray()
 		]);
 	}
 
@@ -195,6 +198,11 @@ class LayoutField extends BlocksField
 		return $routes;
 	}
 
+	public function selector(): array|null
+	{
+		return $this->selector;
+	}
+
 	protected function setDefault(mixed $default = null): void
 	{
 		// set id for layouts, columns and blocks within layout if not exists
@@ -227,6 +235,14 @@ class LayoutField extends BlocksField
 			fn ($layout) => Str::split($layout),
 			$layouts
 		);
+	}
+
+	/**
+	 * Layout selector's styles such as size (`small`, `medium`, `large` or `huge`) and columns
+	 */
+	protected function setSelector(array|null $selector = null): void
+	{
+		$this->selector = $selector;
 	}
 
 	protected function setSettings(array|string|null $settings = null): void

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -16,12 +16,14 @@ class LayoutField extends BlocksField
 {
 	protected $layouts;
 	protected $settings;
+	protected $size;
 
 	public function __construct(array $params)
 	{
 		$this->setModel($params['model'] ?? App::instance()->site());
 		$this->setLayouts($params['layouts'] ?? ['1/1']);
 		$this->setSettings($params['settings'] ?? null);
+		$this->setSize($params['size'] ?? 'medium');
 
 		parent::__construct($params);
 	}
@@ -123,8 +125,9 @@ class LayoutField extends BlocksField
 		$settings = $this->settings();
 
 		return array_merge(parent::props(), [
+			'layouts'  => $this->layouts(),
 			'settings' => $settings?->toArray(),
-			'layouts'  => $this->layouts()
+			'size'     => $this->size(),
 		]);
 	}
 
@@ -235,9 +238,22 @@ class LayoutField extends BlocksField
 		$this->settings = Fieldset::factory($settings);
 	}
 
+	/**
+	 * Size for layout selector: `small`, `medium`, `large` or `huge`
+	 */
+	protected function setSize(string $size = 'medium'): void
+	{
+		$this->size = $size;
+	}
+
 	public function settings()
 	{
 		return $this->settings;
+	}
+
+	public function size(): string
+	{
+		return $this->size;
 	}
 
 	public function store($value)

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -16,14 +16,14 @@ class LayoutField extends BlocksField
 {
 	protected $layouts;
 	protected $settings;
-	protected $size;
+	protected $selector;
 
 	public function __construct(array $params)
 	{
 		$this->setModel($params['model'] ?? App::instance()->site());
 		$this->setLayouts($params['layouts'] ?? ['1/1']);
+		$this->setSelector($params['selector'] ?? null);
 		$this->setSettings($params['settings'] ?? null);
-		$this->setSize($params['size'] ?? 'medium');
 
 		parent::__construct($params);
 	}
@@ -126,8 +126,8 @@ class LayoutField extends BlocksField
 
 		return array_merge(parent::props(), [
 			'layouts'  => $this->layouts(),
+			'selector' => $this->selector(),
 			'settings' => $settings?->toArray(),
-			'size'     => $this->size(),
 		]);
 	}
 
@@ -239,11 +239,11 @@ class LayoutField extends BlocksField
 	}
 
 	/**
-	 * Size for layout selector: `small`, `medium`, `large` or `huge`
+	 * Layout selector's styles such as size (`small`, `medium`, `large` or `huge`) and columns
 	 */
-	protected function setSize(string $size = 'medium'): void
+	protected function setSelector(array|null $selector = null): void
 	{
-		$this->size = $size;
+		$this->selector = $selector;
 	}
 
 	public function settings()
@@ -251,9 +251,9 @@ class LayoutField extends BlocksField
 		return $this->settings;
 	}
 
-	public function size(): string
+	public function selector(): array|null
 	{
-		return $this->size;
+		return $this->selector;
 	}
 
 	public function store($value)


### PR DESCRIPTION
## This PR …

A little snack enhancement suggestion. We can also add a `fullwidth` dialog if you wish. That would be great.

### Current
![screen-capture-1629-Layout selector - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/46e1198c-1e23-4acb-8c80-fa6c837ece02)

### Large
![screen-capture-1628-Layout selector - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/5b7bf9ac-9c59-4feb-9d11-89b155d0e9de)


### Huge
![screen-capture-1627-Layout selector - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/3ad849eb-ba40-4acc-8cd4-9a43a4b398ac)


### Enhancement
- Layout selector customizable `size` (small, medium, large, huge) and `columns` via new `selector` prop

### Fixes

- Fix layout selector column heights #5382

````yaml
fields:    
   layout:
    type: layout
    layouts:
      ...
    selector:
      # `small`, `medium`, `large` or `huge`
      size: huge
      columns: 5
````

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
