### PR TITLE
[v4] Customizable layout selector

### DIFF
--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -97,6 +97,12 @@ export default {
 	}
 }
 
+@media screen and (min-width: 60rem) {
+	.k-dialog[data-size="huge"] {
+		--dialog-width: 60rem;
+	}
+}
+
 /** Pagination **/
 .k-dialog .k-pagination {
 	margin-bottom: -1.5rem;

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -56,6 +56,7 @@ export default {
 			type: Array,
 			default: () => [["1/1"]]
 		},
+		selector: Object,
 		settings: Object,
 		value: {
 			type: Array,

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -2,11 +2,16 @@
 	<k-dialog
 		v-bind="$props"
 		class="k-layout-selector"
+		:size="selector?.size ?? 'medium'"
 		@cancel="$emit('cancel')"
 		@submit="$emit('submit', value)"
 	>
 		<h3 class="k-label">{{ label }}</h3>
-		<k-navigate axis="x" class="k-layout-selector-options">
+		<k-navigate
+			:style="'--columns:' + Number(selector?.columns ?? 3)"
+			axis="x"
+			class="k-layout-selector-options"
+		>
 			<button
 				v-for="(columns, layoutIndex) in layouts"
 				:key="layoutIndex"
@@ -51,10 +56,7 @@ export default {
 		layouts: {
 			type: Array
 		},
-		// eslint-disable-next-line vue/require-prop-types
-		size: {
-			default: "medium"
-		},
+		selector: Object,
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
 			default: false
@@ -71,13 +73,16 @@ export default {
 	margin-top: -0.5rem;
 	margin-bottom: var(--spacing-3);
 }
-
 .k-layout-selector-options {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	gap: var(--spacing-6);
 }
-
+@media screen and (min-width: 65em) {
+	.k-layout-selector-options {
+		grid-template-columns: repeat(var(--columns), 1fr);
+	}
+}
 .k-layout-selector-option {
 	--color-border: hsla(var(--color-gray-hs), 0%, 6%);
 	--color-back: var(--color-white);

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -101,11 +101,12 @@ export default {
 	border-radius: var(--rounded);
 	overflow: hidden;
 	box-shadow: var(--shadow);
+	height: 5rem;
 }
 .k-layout-selector-option .k-column {
 	grid-column: span var(--span);
 	background: var(--color-back);
-	height: 5rem;
+	height: 100%;
 }
 .k-layout-selector-option[aria-current] {
 	--color-border: var(--color-focus);

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -108,6 +108,10 @@ export default {
 	background: var(--color-back);
 	height: 100%;
 }
+.k-layout-selector-option:hover {
+	--color-border: var(--color-gray-500);
+	--color-back: var(--color-gray-100);
+}
 .k-layout-selector-option[aria-current] {
 	--color-border: var(--color-focus);
 	--color-back: var(--color-blue-300);

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -62,6 +62,7 @@ export default {
 		fieldsets: Object,
 		layouts: Array,
 		max: Number,
+		selector: Object,
 		settings: Object,
 		value: Array
 	},
@@ -113,6 +114,7 @@ export default {
 				props: {
 					label: this.$t("field.layout.change"),
 					layouts: this.layouts,
+					selector: this.selector,
 					value: this.layouts[layoutIndex]
 				},
 				on: {
@@ -277,6 +279,7 @@ export default {
 				component: "k-layout-selector",
 				props: {
 					layouts: this.layouts,
+					selector: this.selector,
 					value: null
 				},
 				on: {

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -15,12 +15,14 @@ use Throwable;
 class LayoutField extends BlocksField
 {
 	protected array|null $layouts;
+	protected array|null $selector;
 	protected Fieldset|null $settings;
 
 	public function __construct(array $params)
 	{
 		$this->setModel($params['model'] ?? App::instance()->site());
 		$this->setLayouts($params['layouts'] ?? ['1/1']);
+		$this->setSelector($params['selector'] ?? null);
 		$this->setSettings($params['settings'] ?? null);
 
 		parent::__construct($params);
@@ -123,8 +125,9 @@ class LayoutField extends BlocksField
 		$settings = $this->settings();
 
 		return array_merge(parent::props(), [
-			'settings' => $settings?->toArray(),
-			'layouts'  => $this->layouts()
+			'layouts'  => $this->layouts(),
+			'selector' => $this->selector(),
+			'settings' => $settings?->toArray()
 		]);
 	}
 
@@ -195,6 +198,11 @@ class LayoutField extends BlocksField
 		return $routes;
 	}
 
+	public function selector(): array|null
+	{
+		return $this->selector;
+	}
+
 	protected function setDefault(mixed $default = null): void
 	{
 		// set id for layouts, columns and blocks within layout if not exists
@@ -227,6 +235,14 @@ class LayoutField extends BlocksField
 			fn ($layout) => Str::split($layout),
 			$layouts
 		);
+	}
+
+	/**
+	 * Layout selector's styles such as size (`small`, `medium`, `large` or `huge`) and columns
+	 */
+	protected function setSelector(array|null $selector = null): void
+	{
+		$this->selector = $selector;
 	}
 
 	protected function setSettings(array|string|null $settings = null): void


### PR DESCRIPTION
## This PR …

### Current
![screen-capture-1633-Drawer expand - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/31a3c583-9bf1-4199-911b-7639103725b8)

### Large
![screen-capture-1634-Drawer expand - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/aba0d1e7-1fdd-4a04-a58d-9a5f16b2ed77)

### Huge
![screen-capture-1635-Drawer expand - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/1c9b13ae-822b-43ea-b852-4881f7b050c0)


### Enhancement
- Layout selector customizable `size` (small, medium, large, huge) and `columns` via new `selector` prop

### Fixes
- Fix layout selector column heights #5382

### Usage
````yaml
fields:    
   layout:
    type: layout
    layouts:
      ...
    selector:
      # `small`, `medium`, `large` or `huge`
      size: huge
      columns: 6
````

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
