### PR TITLE
New `panel.frameAncestors` option

### DIFF
--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -278,8 +278,16 @@ class Document
 			'panelUrl' => $uri->path()->toString(true) . '/',
 		]);
 
+		$frameAncestors = $kirby->option('panel.frameAncestors');
+		$frameAncestors = match (true) {
+			$frameAncestors === true   => "'self'",
+			is_array($frameAncestors)  => "'self' " . implode(' ', $frameAncestors),
+			is_string($frameAncestors) => $frameAncestors,
+			default                    => "'none'"
+		};
+
 		return new Response($body, 'text/html', $code, [
-			'Content-Security-Policy' => "frame-ancestors 'none'"
+			'Content-Security-Policy' => 'frame-ancestors ' . $frameAncestors
 		]);
 	}
 }

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -361,4 +361,97 @@ class DocumentTest extends TestCase
 		$this->assertSame("frame-ancestors 'none'", $response->header('Content-Security-Policy'));
 		$this->assertNotNull($response->body());
 	}
+
+	/**
+	 * @covers ::response
+	 */
+	public function testResponseFrameAncestorsSelf(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'panel' => [
+					'frameAncestors' => true
+				]
+			]
+		]);
+
+		// create panel dist files first to avoid redirect
+		Document::link($this->app);
+
+		// get panel response
+		$response = Document::response([
+			'test' => 'Test'
+		]);
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(200, $response->code());
+		$this->assertSame('text/html', $response->type());
+		$this->assertSame('UTF-8', $response->charset());
+		$this->assertSame("frame-ancestors 'self'", $response->header('Content-Security-Policy'));
+		$this->assertNotNull($response->body());
+	}
+
+	/**
+	 * @covers ::response
+	 */
+	public function testResponseFrameAncestorsArray(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'panel' => [
+					'frameAncestors' => ['*.example.com', 'https://example.com']
+				]
+			]
+		]);
+
+		// create panel dist files first to avoid redirect
+		Document::link($this->app);
+
+		// get panel response
+		$response = Document::response([
+			'test' => 'Test'
+		]);
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(200, $response->code());
+		$this->assertSame('text/html', $response->type());
+		$this->assertSame('UTF-8', $response->charset());
+		$this->assertSame(
+			"frame-ancestors 'self' *.example.com https://example.com",
+			$response->header('Content-Security-Policy')
+		);
+		$this->assertNotNull($response->body());
+	}
+
+	/**
+	 * @covers ::response
+	 */
+	public function testResponseFrameAncestorsString(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'panel' => [
+					'frameAncestors' => '*.example.com https://example.com'
+				]
+			]
+		]);
+
+		// create panel dist files first to avoid redirect
+		Document::link($this->app);
+
+		// get panel response
+		$response = Document::response([
+			'test' => 'Test'
+		]);
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(200, $response->code());
+		$this->assertSame('text/html', $response->type());
+		$this->assertSame('UTF-8', $response->charset());
+		$this->assertSame(
+			'frame-ancestors *.example.com https://example.com',
+			$response->header('Content-Security-Policy')
+		);
+		$this->assertNotNull($response->body());
+	}
 }


### PR DESCRIPTION
According to the [OWASP clickjacking cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html), the `'self'` value should only be used if necessary, `'none'` should be the default. So I've added an option like proposed by @afbora that allows to override the default behavior.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- The `Content-Security-Policy: frame-ancestors` header sent by the Panel (introduced in 3.9.6) can now be customized with an option if needed:
  ```php
  <?php
  
  return [
    'panel' => [
      // allow frame embedding from the same domain
      'frameAncestors' => true,
      
      // allow frame embedding from the same *and* from the specified domains
      'frameAncestors' => ['*.example.com', 'https://example.com'],
      
      // allow frame embedding on any domain (not recommended)
      'frameAncestors' => '*',
    ]
  ];
  ```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
