### PR TITLE
Re-populate uuid when invalid model id cached

### DIFF
--- a/src/Uuid/SiteUuid.php
+++ b/src/Uuid/SiteUuid.php
@@ -46,7 +46,7 @@ class SiteUuid extends Uuid
 	/**
 	 * Pretends to fill cache - we don't need it in cache
 	 */
-	public function populate(): bool
+	public function populate(bool $force = false): bool
 	{
 		return true;
 	}

--- a/src/Uuid/UserUuid.php
+++ b/src/Uuid/UserUuid.php
@@ -46,7 +46,7 @@ class UserUuid extends Uuid
 	/**
 	 * Pretends to fill cache - we don't need it in cache
 	 */
-	public function populate(): bool
+	public function populate(bool $force = false): bool
 	{
 		return true;
 	}

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -309,7 +309,8 @@ class Uuid
 				// lazily fill cache by writing to cache
 				// whenever looked up from index to speed
 				// up future lookups of the same UUID
-				$this->populate();
+				// also force to update value again if it is already cached
+				$this->populate($this->isCached());
 
 				return $this->model;
 			}
@@ -320,12 +321,10 @@ class Uuid
 
 	/**
 	 * Feeds the UUID into the cache
-	 *
-	 * @return bool
 	 */
-	public function populate(): bool
+	public function populate(bool $force = false): bool
 	{
-		if ($this->isCached() === true) {
+		if ($force === false && $this->isCached() === true) {
 			return true;
 		}
 


### PR DESCRIPTION
## This PR …

If a cached model cannot be found in the caches, it will force it to update its new value. 

### Fixes
- Uuid not corrected when cached #5430

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
