### PR TITLE
Fix for nested drawers

### DIFF
--- a/panel/src/components/Drawers/FiberDrawer.vue
+++ b/panel/src/components/Drawers/FiberDrawer.vue
@@ -8,7 +8,7 @@
 			:disabled="isCurrent(drawer.id) === false"
 			:visible="true"
 			v-bind="drawer.props"
-			v-on="isCurrent(drawer.id) ? $panel.drawer.listeners() : {}"
+			v-on="isCurrent(drawer.id) ? $panel.drawer.listeners() : drawer.on"
 		/>
 	</div>
 </template>

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -203,7 +203,7 @@ export default {
 	},
 	methods: {
 		close() {
-			this.$panel.drawer.close();
+			this.$panel.drawer.close(this.id);
 		},
 		focus() {
 			if (typeof this.$refs.editor?.focus === "function") {
@@ -289,10 +289,6 @@ export default {
 				},
 				on: {
 					submit: () => {
-						if (this.$panel.drawer.id === this.id) {
-							this.$panel.drawer.close();
-						}
-
 						this.$panel.dialog.close();
 						this.$emit("remove", this.id);
 					}

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -94,6 +94,7 @@ export default {
 	methods: {
 		add() {
 			this.object = this.$helper.field.form(this.fields);
+			this.save();
 			this.open();
 		},
 		cell(name, value) {

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -304,9 +304,7 @@ export default {
 	},
 	watch: {
 		value(value) {
-			if (value != this.items) {
-				this.items = this.toItems(value);
-			}
+			this.items = this.toItems(value);
 		}
 	},
 	methods: {
@@ -331,11 +329,10 @@ export default {
 				index = this.items.length - 1;
 			}
 
-			this.save();
 			this.open(index);
 		},
 		close() {
-			this.$panel.drawer.close();
+			this.$panel.drawer.close(this._uid);
 		},
 
 		/**
@@ -369,6 +366,7 @@ export default {
 
 			this.$panel.drawer.open({
 				component: "k-structure-drawer",
+				id: this._uid,
 				props: {
 					icon: this.icon ?? "list-bullet",
 					next: this.items[index + 1],

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -329,6 +329,7 @@ export default {
 				index = this.items.length - 1;
 			}
 
+			this.save();
 			this.open(index);
 		},
 		close() {

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -28,8 +28,15 @@ export default (panel) => {
 		 * Closes the drawer and goes back to the
 		 * parent one if it has been stored
 		 */
-		async close() {
+		async close(id) {
 			if (this.isOpen === false) {
+				return;
+			}
+
+			// Compare the drawer id to avoid closing
+			// the wrong drawer. This is particularly useful
+			// in nested drawers.
+			if (id !== undefined && id !== this.id) {
 				return;
 			}
 


### PR DESCRIPTION
This is a complicated beast. Let me try to break it down: 

- Nested drawers all get rendered but layered on top of each other. Only the top-most drawer is visible.
- The top-most drawer gets all the event listeners that would submit, close, update or cancel the drawer
- So far none of the underlying drawers did get any event listeners. But this would mean that the top most drawer could not send its input event to the parent drawer above and thus the input event does not propagate. This leads to incorrect values. 

My first reflex was to add the event listeners to all drawers, but this leads to infinite loops. When only the custom event listeners are added, the fields can still receive input calls, but those don't interfere with other drawer logic. 

It feels pretty clean to me now, but the nested drawers remain a really tricky case. 

I fixed and refactored a few more things along the way to get object and structure fields as similar as possible. 

## Fixes

- https://github.com/getkirby/kirby/issues/5385
- https://github.com/getkirby/kirby/issues/5427
- https://github.com/getkirby/kirby/issues/5411