### PR TITLE
Fix slug input

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -51,7 +51,9 @@ export default {
 	data() {
 		return {
 			slug: this.sluggify(this.value),
-			slugs: this.$language ? this.$language.rules : this.$panel.system.slugs,
+			slugs: this.$panel.language.code
+				? this.$panel.language.rules
+				: this.$panel.system.slugs,
 			syncValue: null
 		};
 	},

--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -51,7 +51,7 @@ export default {
 	data() {
 		return {
 			slug: this.sluggify(this.value),
-			slugs: this.$panel.language.code
+			slugs: this.$panel.multilang
 				? this.$panel.language.rules
 				: this.$panel.system.slugs,
 			syncValue: null

--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -51,9 +51,7 @@ export default {
 	data() {
 		return {
 			slug: this.sluggify(this.value),
-			slugs: this.$panel.multilang
-				? this.$panel.language.rules
-				: this.$panel.system.slugs,
+			slugs: this.$panel.language.rules ?? this.$panel.system.slugs,
 			syncValue: null
 		};
 	},

--- a/panel/src/panel/language.js
+++ b/panel/src/panel/language.js
@@ -6,7 +6,7 @@ export const defaults = () => {
 		default: false,
 		direction: "ltr",
 		name: null,
-		rules: []
+		rules: null
 	};
 };
 

--- a/panel/src/panel/language.test.js
+++ b/panel/src/panel/language.test.js
@@ -14,7 +14,7 @@ describe.concurrent("panel.language", () => {
 			default: false,
 			direction: "ltr",
 			name: null,
-			rules: []
+			rules: null,
 		};
 
 		expect(language.key()).toStrictEqual("language");


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Since `this.$language`/`this.$panel.language` now always is an object, we need to check for `this.$panel.language.code` to check if an actual language object was loaded.

### Fixes regression
- https://github.com/getkirby/kirby/issues/5423
