### PR TITLE
Fix scroll bar issues in drawers and dialogs

### DIFF
--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -176,7 +176,10 @@ export default {
 }
 
 /* Scroll lock */
-html:has(.k-overlay[open]) {
+html[data-overlay] {
 	overflow: hidden;
+}
+html[data-overlay] body {
+	overflow: scroll;
 }
 </style>

--- a/panel/src/components/View/Panel.vue
+++ b/panel/src/components/View/Panel.vue
@@ -54,8 +54,8 @@
 
 <style>
 html {
-	scrollbar-gutter: stable;
 	overflow-x: hidden;
+	overflow-y: scroll;
 }
 
 body {

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -44,9 +44,7 @@ export default (panel) => {
 
 			// no more items in the history
 			if (this.history.isEmpty() === true) {
-				this.reset();
-				this.isOpen = false;
-				this.emit("close");
+				parent.close.call(this);
 				return;
 			}
 

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -55,6 +55,11 @@ export default (panel, key, defaults) => {
 			this.isOpen = false;
 			this.emit("close");
 			this.reset();
+
+			if (panel.overlays().length === 0) {
+				// unblock the overflow until we can use :has for this.
+				document.documentElement.removeAttribute("data-overlay");
+			}
 		},
 
 		/**
@@ -118,6 +123,9 @@ export default (panel, key, defaults) => {
 			if (this.isOpen === false) {
 				panel.notification.close();
 			}
+
+			// block the overflow until we can use :has for this.
+			document.documentElement.setAttribute("data-overlay", "true");
 
 			// open the modal feature via url or with a state object
 			await parent.open.call(this, modal, options);

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -225,6 +225,20 @@ export default {
 		}
 	},
 
+	overlays() {
+		const overlays = [];
+
+		if (this.drawer.isOpen === true) {
+			overlays.push("drawer");
+		}
+
+		if (this.dialog.isOpen === true) {
+			overlays.push("dialog");
+		}
+
+		return overlays;
+	},
+
 	/**
 	 * Sends a POST request
 	 *


### PR DESCRIPTION
I think I have a solid solution for scroll bars on the body and in the drawer. This no longer relies on the new scrollbar-gutter rule, but will always force a scrollbar on the document and still hide it properly once an overlay is opened. 

Since we cannot use :has so far, the modal.js module will now add the data-overlay attribute to the html element in JS. This needs a bit more work and I had to introduce a new `panel.overlays()` method to count the number of open overlays. Otherwise it could happen that a drawer and a dialog is open, but once the dialog is closed the scroll lock is incorrectly disabled already. 

I've tested it all in Firefox, Safari and Chrome and with enabled and disabled scroll bars on macOS and it feels very nice to me. @afbora it would be awesome if you could give it another look on Windows. 

## Fixes

https://github.com/getkirby/kirby/issues/5393