### PR TITLE
Fix custom marks and nodes

### DIFF
--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -45,7 +45,7 @@ export default class Editor extends Emitter {
 	}
 
 	get builtInExtensions() {
-		if (!this.options.useBuiltInExtensions) {
+		if (this.options.useBuiltInExtensions !== true) {
 			return [];
 		}
 
@@ -110,11 +110,11 @@ export default class Editor extends Emitter {
 	}
 
 	createEvents() {
-		const events = this.options.events || {};
+		const events = this.options.events ?? {};
 
-		Object.entries(events).forEach(([eventName, eventCallback]) => {
-			this.on(eventName, eventCallback);
-		});
+		for (const [name, callback] of Object.entries(events)) {
+			this.on(name, callback);
+		}
 
 		return events;
 	}
@@ -145,12 +145,8 @@ export default class Editor extends Emitter {
 					tabindex: 0
 				},
 				handleDOMEvents: {
-					focus: (view, event) => {
-						toggleFocus(view, event, true);
-					},
-					blur: (view, event) => {
-						toggleFocus(view, event, false);
-					}
+					focus: (view, event) => toggleFocus(view, event, true),
+					blur: (view, event) => toggleFocus(view, event, false)
 				}
 			}
 		});
@@ -504,7 +500,7 @@ export default class Editor extends Emitter {
 	}
 
 	get state() {
-		return this.view ? this.view.state : null;
+		return this.view?.state;
 	}
 
 	toggleMark(mark) {

--- a/panel/src/components/Forms/Writer/Extensions.js
+++ b/panel/src/components/Forms/Writer/Extensions.js
@@ -4,10 +4,11 @@ import utils from "./Utils";
 
 export default class Extensions {
 	constructor(extensions = [], editor) {
-		extensions.forEach((extension) => {
+		for (const extension of extensions) {
 			extension.bindEditor(editor);
 			extension.init();
-		});
+		}
+
 		this.extensions = extensions;
 	}
 
@@ -38,15 +39,15 @@ export default class Extensions {
 				 * logic to stop commands for disabled editors
 				 * or focus the view before the command is executed
 				 */
-				const createCommand = (commandName, commandCallback) => {
-					commands[commandName] = (attrs) => {
-						if (typeof commandCallback !== "function" || !view.editable) {
+				const createCommand = (name, callback) => {
+					commands[name] = (attrs) => {
+						if (typeof callback !== "function" || !view.editable) {
 							return false;
 						}
 
 						view.focus();
 
-						const result = commandCallback(attrs);
+						const result = callback(attrs);
 
 						if (typeof result === "function") {
 							return result(view.state, view.dispatch, view);
@@ -56,19 +57,18 @@ export default class Extensions {
 					};
 				};
 
-				/**
-				 * extensions can return an object with multiple
-				 * commands. The object key is the command name.
-				 */
 				if (typeof value === "object") {
-					Object.entries(value).forEach(([commandName, commandCallback]) => {
-						createCommand(commandName, commandCallback);
-					});
-
+					/**
+					 * extensions can return an object with multiple
+					 * commands. The object key is the command name.
+					 */
+					for (const [name, callback] of Object.entries(value)) {
+						createCommand(name, callback);
+					}
+				} else {
 					/**
 					 * the extension name will be used as command name
 					 */
-				} else {
 					createCommand(name, value);
 				}
 

--- a/panel/src/components/Forms/Writer/Mark.js
+++ b/panel/src/components/Forms/Writer/Mark.js
@@ -1,10 +1,6 @@
 import Extension from "./Extension.js";
 
 export default class Mark extends Extension {
-	constructor(options = {}) {
-		super(options);
-	}
-
 	command() {
 		return () => {};
 	}

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -239,15 +239,19 @@ export default {
 			);
 		},
 		createMarksFromPanelPlugins() {
-			const customs = window.panel.plugins.writerMarks ?? {};
+			const plugins = window.panel.plugins.writerMarks ?? {};
+			const marks = {};
 
 			// take each extenstion object and turn
 			// it into an instance that extends the Mark class
-			for (const markName in customs) {
-				Object.setPrototypeOf(customs[markName], new Mark());
+			for (const name in plugins) {
+				marks[name] = Object.create(
+					Mark.prototype,
+					Object.getOwnPropertyDescriptors(plugins[name])
+				);
 			}
 
-			return customs;
+			return marks;
 		},
 		createNodes() {
 			const hardBreak = new HardBreak({
@@ -288,15 +292,19 @@ export default {
 			);
 		},
 		createNodesFromPanelPlugins() {
-			const customs = window.panel.plugins.writerNodes ?? {};
+			const plugins = window.panel.plugins.writerNodes ?? {};
+			const nodes = {};
 
 			// take each extenstion object and turn
 			// it into an instance that extends the Node class
-			for (const nodeName in customs) {
-				Object.setPrototypeOf(customs[nodeName], new Node());
+			for (const name in plugins) {
+				nodes[name] = Object.create(
+					Node.prototype,
+					Object.getOwnPropertyDescriptors(plugins[name])
+				);
 			}
 
-			return customs;
+			return nodes;
 		},
 		getHTML() {
 			return this.editor.getHTML();


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Turns out 

```js
Object.setPrototypeOf(customs[markName], new Mark());
```

isn't the right way to do it. It for one modifies `window.panel.plugins.writerMarks` in place which isn't good when having multiple writer fields. And also there is some weird behavior introduced.

But turns out

```js
marks[name] = Object.create(
  Mark.prototype,
  Object.getOwnPropertyDescriptors(plugins[name])
);
```

seems to do what we want without the bad side effects.

Changes that fixed the problem in `components/Forms/Writer/Writer.vue`, the rest is just code cleaning to help me understand during debugging.
 
### Fixes
- Custom marks and nodes receive the right editor instance
#5456
