### PR TITLE
[v4] Fix setting new root when change num

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -129,7 +129,7 @@ trait PageActions
 				if (Dir::move($oldPage->root(), $newPage->root()) === true) {
 					// Updates the root path of the old page with the root path
 					// of the moved new page to use fly actions on old page in loop
-					$oldPage->setRoot($newPage->root());
+					$oldPage->root = $newPage->root();
 				} else {
 					throw new LogicException('The page directory cannot be moved');
 				}

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -1424,4 +1424,69 @@ class PageActionsTest extends TestCase
 		$this->assertSame($expected, $page->content('en')->toArray());
 		$this->assertSame($expected, $page->content('de')->toArray());
 	}
+
+	public function testUnpublish()
+	{
+		$page = Page::create([
+			'slug' => 'test',
+			'draft' => false
+		]);
+
+		Page::create([
+			'slug' => 'child-a',
+			'draft' => false,
+			'num' => 1,
+			'parent' => $page
+		]);
+
+		Page::create([
+			'slug' => 'child-b',
+			'draft' => false,
+			'num' => 2,
+			'parent' => $page
+		]);
+
+		Page::create([
+			'slug' => 'child-c',
+			'draft' => false,
+			'parent' => $page
+		]);
+
+		Page::create([
+			'slug' => 'child-d',
+			'draft' => true,
+			'parent' => $page
+		]);
+
+		$listed = $page->children()->listed();
+		$unlisted = $page->children()->unlisted();
+		$drafts = $page->drafts();
+
+		$this->assertCount(2, $listed);
+		foreach ($listed as $child) {
+			$this->assertSame('listed', $child->status());
+		}
+
+		$this->assertCount(1, $unlisted);
+		foreach ($unlisted as $child) {
+			$this->assertSame('unlisted', $child->status());
+		}
+
+		$this->assertCount(1, $drafts);
+		foreach ($drafts as $child) {
+			$this->assertSame('draft', $child->status());
+		}
+
+		// unpublish all
+		foreach ($page->children() as $child) {
+			$child->unpublish();
+		}
+
+		// make sure that not cached children
+		$clone = $page->clone();
+
+		$this->assertCount(0, $clone->children()->listed());
+		$this->assertCount(0, $clone->children()->unlisted());
+		$this->assertCount(4, $clone->drafts());
+	}
 }


### PR DESCRIPTION
## This PR …

It is both nice and annoying that after hours of debugging the issue is so simple 😅 

This issue is caused by the fact that the `->setRoot()` method is still used after the removal of `Properties` trait.

https://github.com/getkirby/kirby/commit/99187924602a3cf41842788536d774f4ca9483d9#diff-3b700032469a1feb9c9a9eab21e85c3b799a16b107327bc5173c1e375e962f06L657-L661

### Fixes
- not possible to unpublish multiple children #5396


### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
