### PR TITLE
Pages field preview: fix escaping

### DIFF
--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -1,14 +1,15 @@
 <template>
 	<div class="k-bubbles-field-preview" :class="$options.class">
-		<k-bubbles :bubbles="bubbles" />
+		<k-bubbles :bubbles="bubbles" :html="html" />
 	</div>
 </template>
 
 <script>
 import FieldPreview from "@/mixins/forms/fieldPreview.js";
+import { props as Bubbles } from "@/components/Layout/Bubbles.vue";
 
 export default {
-	mixins: [FieldPreview],
+	mixins: [FieldPreview, Bubbles],
 	inheritAttrs: false,
 	props: {
 		value: [Array, String]
@@ -37,10 +38,6 @@ export default {
 						bubble.text = option.text;
 					}
 				}
-
-				// we can unescape the text here, as Vue will
-				// take care of escaping only the relevant parts
-				bubble.text = this.$helper.string.unescapeHTML(bubble.text);
 
 				return bubble;
 			});

--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -38,6 +38,10 @@ export default {
 					}
 				}
 
+				// we can unescape the text here, as Vue will
+				// take care of escaping only the relevant parts
+				bubble.text = this.$helper.string.unescapeHTML(bubble.text);
+
 				return bubble;
 			});
 		}

--- a/panel/src/components/Forms/Previews/FilesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FilesFieldPreview.vue
@@ -5,15 +5,19 @@ export default {
 	extends: BubblesFieldPreview,
 	inheritAttrs: false,
 	class: "k-files-field-preview",
+	props: {
+		html: {
+			type: Boolean,
+			default: true
+		}
+	},
 	computed: {
 		bubbles() {
-			return this.value.map((file) => {
-				return {
-					text: file.filename,
-					link: file.link,
-					image: file.image
-				};
-			});
+			return this.value.map((file) => ({
+				text: file.filename,
+				link: file.link,
+				image: file.image
+			}));
 		}
 	}
 };

--- a/panel/src/components/Forms/Previews/PagesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/PagesFieldPreview.vue
@@ -4,6 +4,12 @@ import BubblesFieldPreview from "./BubblesFieldPreview.vue";
 export default {
 	extends: BubblesFieldPreview,
 	inheritAttrs: false,
-	class: "k-pages-field-preview"
+	class: "k-pages-field-preview",
+	props: {
+		html: {
+			type: Boolean,
+			default: true
+		}
+	}
 };
 </script>

--- a/panel/src/components/Layout/Bubble.vue
+++ b/panel/src/components/Layout/Bubble.vue
@@ -16,7 +16,11 @@
 			<k-icon-frame v-else-if="image" v-bind="image" />
 			<span v-else></span>
 		</slot>
-		<span v-if="text" class="k-bubble-text">{{ text }}</span>
+		<template v-if="text">
+			<!-- eslint-disable-next-line vue/no-v-html -->
+			<span v-if="html" class="k-bubble-text" v-html="text" />
+			<span v-else class="k-bubble-text">{{ text }}</span>
+		</template>
 	</component>
 </template>
 
@@ -49,6 +53,13 @@ export default {
 		element: {
 			type: String,
 			default: "li"
+		},
+		/**
+		 * If set to `true`, the `text` is rendered as HTML code,
+		 * otherwise as plain text
+		 */
+		html: {
+			type: Boolean
 		},
 		/**
 		 * Optional image to display in the bubble. Used for <k-image-frame>, see for available props

--- a/panel/src/components/Layout/Bubbles.vue
+++ b/panel/src/components/Layout/Bubbles.vue
@@ -1,12 +1,24 @@
 <template>
 	<ul class="k-bubbles">
 		<li v-for="(bubble, id) in items" :key="id">
-			<k-bubble v-bind="bubble" />
+			<k-bubble v-bind="bubble" :html="html" />
 		</li>
 	</ul>
 </template>
 
 <script>
+export const props = {
+	props: {
+		/**
+		 * If set to `true`, the `text` is rendered as HTML code,
+		 * otherwise as plain text
+		 */
+		html: {
+			type: Boolean
+		}
+	}
+};
+
 /**
  * Display a list of <k-bubble>
  * @public
@@ -15,6 +27,7 @@
  * @example <k-bubbles :bubbles="['Hello', 'World']" />
  */
 export default {
+	mixins: [props],
 	inheritAttrs: false,
 	props: {
 		/**
@@ -31,7 +44,7 @@ export default {
 			}
 
 			return bubbles.map((bubble) =>
-				 bubble === "string" ? { text: bubble } : bubble
+				bubble === "string" ? { text: bubble } : bubble
 			);
 		}
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements
- New `html` prop for `k-bubble`, `k-bubbles` and `k-bubbles-field-preview`

### Fixes
- Page preview field: fixed escaping
 #4041