### PR TITLE
Fix `$page->isUnlisted()`

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -733,7 +733,7 @@ class Page extends ModelWithContent
 	 */
 	public function isListed(): bool
 	{
-		return $this->num() !== null;
+		return $this->isPublished() && $this->num() !== null;
 	}
 
 	/**
@@ -797,7 +797,7 @@ class Page extends ModelWithContent
 	 */
 	public function isUnlisted(): bool
 	{
-		return $this->isListed() === false;
+		return $this->isPublished() && $this->num() === null;
 	}
 
 	/**
@@ -811,7 +811,7 @@ class Page extends ModelWithContent
 	public function isVerified(string $token = null)
 	{
 		if (
-			$this->isDraft() === false &&
+			$this->isPublished() === true &&
 			$this->parents()->findBy('status', 'draft') === null
 		) {
 			return true;

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -197,6 +197,87 @@ class PageTest extends TestCase
 		]);
 	}
 
+	/**
+	 * @covers ::isDraft
+	 */
+	public function testIsDraft()
+	{
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => 1
+		]);
+
+		$this->assertFalse($page->isDraft());
+
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => null
+		]);
+
+		$this->assertFalse($page->isDraft());
+
+		$page = new Page([
+			'slug'    => 'test',
+			'isDraft' => true
+		]);
+
+		$this->assertTrue($page->isDraft());
+	}
+
+	/**
+	 * @covers ::isListed
+	 */
+	public function testIsListed()
+	{
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => 1
+		]);
+
+		$this->assertTrue($page->isListed());
+
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => null
+		]);
+
+		$this->assertFalse($page->isListed());
+
+		$page = new Page([
+			'slug'    => 'test',
+			'isDraft' => true
+		]);
+
+		$this->assertFalse($page->isListed());
+	}
+
+	/**
+	 * @covers ::isUnlisted
+	 */
+	public function testIsUnlisted()
+	{
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => 1
+		]);
+
+		$this->assertFalse($page->isUnlisted());
+
+		$page = new Page([
+			'slug'  => 'test',
+			'num'   => null
+		]);
+
+		$this->assertTrue($page->isUnlisted());
+
+		$page = new Page([
+			'slug'    => 'test',
+			'isDraft' => true
+		]);
+
+		$this->assertFalse($page->isUnlisted());
+	}
+
 	public function testNum()
 	{
 		$page = new Page([


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fixed `$page->isUnlisted()` which falsely would return `true` for drafts



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
