### PR TITLE
Close drawers when opening new view

### DIFF
--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -51,6 +51,12 @@ export default (panel) => {
 			return this.open(this.history.last());
 		},
 
+		async closeAll() {
+			while (this.history.isEmpty() === false) {
+				await this.close();
+			}
+		},
+
 		goTo(id) {
 			const state = this.history.goto(id);
 

--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -100,7 +100,7 @@ export default (panel, key, defaults) => {
 		 * passing a state object
 		 *
 		 * @example
-		 * panel.dialog.view({
+		 * panel.dialog.view.open({
 		 *   component: "k-page-view",
 		 *	 props: {},
 		 *   on: {

--- a/panel/src/panel/view.js
+++ b/panel/src/panel/view.js
@@ -20,6 +20,31 @@ export default (panel) => {
 		...parent,
 
 		/**
+		 * Opens the feature either by URL or by
+		 * passing a state object
+		 *
+		 * @example
+		 * panel.dialog.view.open({
+		 *   component: "k-page-view",
+		 *	 props: {},
+		 *   on: {
+		 *     submit: () => {}
+		 * 	 }
+		 * });
+		 *
+		 * See load for more examples
+		 *
+		 * @param {String|URL|Object} feature
+		 * @param {Object|Function} options
+		 * @returns {Object} Returns the current state
+		 */
+		async open(feature, options = {}) {
+			panel.dialog.close();
+			panel.drawer.closeAll();
+			return await parent.open.call(this, feature, options);
+		},
+
+		/**
 		 * Setting the active view state
 		 * will also change the document title
 		 * and the browser URL


### PR DESCRIPTION
Not sure if this is the right solution for https://github.com/getkirby/kirby/issues/5497 or whether we should just close them in the `$go` helper function.

Also if you have a better idea for closing all drawers, @bastianallgeier.

So far untested, just thought concept how/where to solve this.