### PR TITLE
Support but deprecate 16x16 viewbox for icons

### DIFF
--- a/panel/src/components/Misc/Icons.vue
+++ b/panel/src/components/Misc/Icons.vue
@@ -11,7 +11,7 @@
 				v-for="(icon, type) in $options.icons"
 				:key="type"
 				:id="'icon-' + type"
-				viewBox="0 0 16 16"
+				:viewBox="viewbox(type, icon)"
 				v-html="icon"
 			/>
 		</defs>
@@ -24,7 +24,35 @@
  * @internal
  */
 export default {
-	icons: window.panel.plugins.icons
+	icons: window.panel.plugins.icons,
+	methods: {
+		/**
+		 * @deprecated 4.0.0
+		 * @todo switch to only supporting `0 0 24 24` viewbox in v5
+		 */
+		viewbox(name, path) {
+			const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+			svg.innerHTML = path;
+			document.body.appendChild(svg);
+			const bbox = svg.getBBox();
+			const width = bbox.width + bbox.x * 2;
+			const height = bbox.height + bbox.y * 2;
+			const average = (width + height) / 2;
+			const distanceTo16 = Math.abs(average - 16);
+			const distanceTo24 = Math.abs(average - 24);
+			document.body.removeChild(svg);
+
+			if (distanceTo16 < distanceTo24) {
+				window.panel.deprecated(
+					`Custom icon "${name}" seems to use a 16x16 viewbox which has been deprecated. In an upcoming version, Kirby will only support custom icons with a 24x24 viewbox by default. If you want to continue using icons with a different viewport, please wrap them in an <svg> element with the corresponding viewBox attribute.`
+				);
+
+				return "0 0 16 16";
+			}
+
+			return "0 0 24 24";
+		}
+	}
 };
 </script>
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Custom icons with 24x24 viewbox are supported now
#5492

### Deprecated
- Custom icons using a 16x16 viewbox have been deprecated. In an upcoming version, Kirby will only support custom icons with a 24x24 viewbox by default. If you want to continue using icons with a different viewport, please wrap them in an `<svg>` element with the corresponding `viewBox` attribute
