### PR TITLE
Fix permissions for almighty `kirby`

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -390,6 +390,13 @@ class Auth
 
 		// validate the user and log in to the session
 		$user = $this->validatePassword($email, $password);
+
+		// @codeCoverageIgnoreStart
+		if ($user->id() === 'kirby') {
+			throw new PermissionException('The almighty user "kirby" cannot be used for login, only for raising permissions in code via `$kirby->impersonate()`');
+		}
+		// @codeCoverageIgnoreEnd
+
 		$user->loginPasswordless($options);
 
 		// clear the status cache

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -390,13 +390,6 @@ class Auth
 
 		// validate the user and log in to the session
 		$user = $this->validatePassword($email, $password);
-
-		// @codeCoverageIgnoreStart
-		if ($user->id() === 'kirby') {
-			throw new PermissionException('The almighty user "kirby" cannot be used for login, only for raising permissions in code via `$kirby->impersonate()`');
-		}
-		// @codeCoverageIgnoreEnd
-
 		$user->loginPasswordless($options);
 
 		// clear the status cache

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -45,8 +45,16 @@ abstract class ModelPermissions
 
 	public function can(string $action): bool
 	{
+		$user = $this->user->id();
 		$role = $this->user->role()->id();
 
+		// the almighty `kirby` user can do anything
+		if ($user === 'kirby' && $role === 'admin') {
+			return true;
+		}
+
+		// users with the `nobody` role can do nothing
+		// that needs a permission check
 		if ($role === 'nobody') {
 			return false;
 		}

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -48,23 +48,25 @@ abstract class ModelPermissions
 		$user = $this->user->id();
 		$role = $this->user->role()->id();
 
-		// the almighty `kirby` user can do anything
-		if ($user === 'kirby' && $role === 'admin') {
-			return true;
-		}
-
 		// users with the `nobody` role can do nothing
 		// that needs a permission check
 		if ($role === 'nobody') {
 			return false;
 		}
 
-		// check for a custom overall can method
+		// check for a custom `can` method
+		// which would take priority over any other
+		// role-based permission rules
 		if (
 			method_exists($this, 'can' . $action) === true &&
 			$this->{'can' . $action}() === false
 		) {
 			return false;
+		}
+
+		// the almighty `kirby` user can do anything
+		if ($user === 'kirby' && $role === 'admin') {
+			return true;
 		}
 
 		// evaluate the blueprint options block

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -7,6 +7,7 @@ use Exception;
 use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\User as Panel;
@@ -373,20 +374,31 @@ class User extends ModelWithContent
 	public function loginPasswordless(
 		Session|array|null $session = null
 	): void {
-		$kirby = $this->kirby();
+		if ($this->id() === 'kirby') {
+			throw new PermissionException('The almighty user "kirby" cannot be used for login, only for raising permissions in code via `$kirby->impersonate()`');
+		}
 
+		$kirby   = $this->kirby();
 		$session = $this->sessionFromOptions($session);
 
-		$kirby->trigger('user.login:before', ['user' => $this, 'session' => $session]);
+		$kirby->trigger(
+			'user.login:before',
+			['user' => $this, 'session' => $session]
+		);
 
 		$session->regenerateToken(); // privilege change
 		$session->data()->set('kirby.userId', $this->id());
+
 		if ($this->passwordTimestamp() !== null) {
 			$session->data()->set('kirby.loginTimestamp', time());
 		}
-		$this->kirby()->auth()->setUser($this);
 
-		$kirby->trigger('user.login:after', ['user' => $this, 'session' => $session]);
+		$kirby->auth()->setUser($this);
+
+		$kirby->trigger(
+			'user.login:after',
+			['user' => $this, 'session' => $session]
+		);
 	}
 
 	/**

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -399,9 +399,13 @@ class ApiTest extends TestCase
 						'slug' 	   => 'c'
 					]
 				]
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
-		$app->impersonate('kirby');
+
+		$app->impersonate('bastian');
 
 		$this->assertSame(['a', 'c'], $app->api()->pages()->keys());
 	}

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -16,6 +16,9 @@ class PagePermissionsTest extends TestCase
 		$this->app = new App([
 			'roots' => [
 				'index' => '/dev/null'
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
 	}
@@ -42,7 +45,7 @@ class PagePermissionsTest extends TestCase
 	 */
 	public function testWithAdmin($action)
 	{
-		$this->app->impersonate('kirby');
+		$this->app->impersonate('bastian');
 
 		$page = new Page([
 			'slug' => 'test',
@@ -58,7 +61,7 @@ class PagePermissionsTest extends TestCase
 	 */
 	public function testWithAdminButDisabledOption($action)
 	{
-		$this->app->impersonate('kirby');
+		$this->app->impersonate('bastian');
 
 		$page = new Page([
 			'slug' => 'test',

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -1088,10 +1088,13 @@ class PagesTest extends TestCase
 						'template' => 'readable-baz'
 					]
 				]
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
 
-		$app->impersonate('kirby');
+		$app->impersonate('bastian');
 
 		$page = $app->page('foo');
 		$this->assertTrue($page->isReadable());
@@ -1138,10 +1141,13 @@ class PagesTest extends TestCase
 						'template' => 'visible-baz'
 					]
 				]
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
 
-		$app->impersonate('kirby');
+		$app->impersonate('bastian');
 
 		$page = $app->page('default');
 		$this->assertTrue($page->isListable());
@@ -1201,10 +1207,13 @@ class PagesTest extends TestCase
 						'template' => 'accessible-baz'
 					]
 				]
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
 
-		$app->impersonate('kirby');
+		$app->impersonate('bastian');
 
 		$page = $app->page('default');
 		$this->assertTrue($page->isAccessible());

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -551,9 +551,13 @@ class PagesSectionTest extends TestCase
 				'pages/unreadable' => [
 					'options' => ['read' => false]
 				]
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
-		$app->impersonate('kirby');
+
+		$app->impersonate('bastian');
 
 		$page = new Page([
 			'slug' => 'test',

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -4,8 +4,10 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use TypeError;
 
 class UserTestModel extends User
 {
@@ -43,7 +45,7 @@ class UserTest extends TestCase
 
 	public function testInvalidContent()
 	{
-		$this->expectException('TypeError');
+		$this->expectException(TypeError::class);
 
 		$user = new User(['email' => 'user@domain.com', 'content' => 'something']);
 	}
@@ -65,9 +67,8 @@ class UserTest extends TestCase
 
 	public function testInvalidEmail()
 	{
-		$this->expectException('TypeError');
-
-		$user = new User(['email' => []]);
+		$this->expectException(TypeError::class);
+		new User(['email' => []]);
 	}
 
 	/**
@@ -170,6 +171,14 @@ class UserTest extends TestCase
 		]);
 		$this->assertTrue($user->isNobody());
 	}
+
+	public function testLoginPasswordlessKirby()
+	{
+		$user = new User(['id' => 'kirby']);
+		$this->expectException(PermissionException::class);
+		$user->loginPasswordless();
+	}
+
 
 	public function testName()
 	{


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Currently, if a blueprint option disables a permission also for admins, event he almighty `kirby` user with fail at the permission because it is treated as just an admin.

This PR elevates its position as now the almighty `kirby` user will really be almighty and supersede any permissions settings etc.

This is needed, e.g. so that developers can disable changing the page status via the UI even for admins, but still allow the page create dialog to create a page directly as listed (which involves changing the status, which is done by impersonating `kirby`).

- [x] Merge first https://github.com/getkirby/kirby/pull/5514

### Fixes
-  #5365


### Breaking change
- When impersonating the almighty `kirby` user, any permission check will succeed even if permission has been disabled for regular admins

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
