### PR TITLE
Page move dialog: disable invalid page options

### DIFF
--- a/config/api/models/Page.php
+++ b/config/api/models/Page.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\Page;
+use Kirby\Cms\PageRules;
 use Kirby\Form\Form;
 
 /**
@@ -10,6 +11,17 @@ return [
 	'fields' => [
 		'blueprint'   => fn (Page $page) => $page->blueprint(),
 		'blueprints'  => fn (Page $page) => $page->blueprints(),
+		'canBeMovedTo' => function (Page $page) {
+			$target = $this->page($this->requestQuery('target'));
+
+			try {
+				PageRules::move($target, $page);
+				return true;
+
+			} catch (Throwable) {
+				return false;
+			}
+		},
 		'children'    => fn (Page $page) => $page->children(),
 		'content'     => fn (Page $page) => Form::for($page)->values(),
 		'drafts'      => fn (Page $page) => $page->drafts(),

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -510,6 +510,7 @@ return [
 				'component' => 'k-page-move-dialog',
 				'props' => [
 					'value' => [
+						'page'   => $page->panel()->id(),
 						'parent' => $page->parent()?->panel()->url(true) ?? '/site'
 					]
 				]

--- a/panel/src/components/Dialogs/PageMoveDialog.vue
+++ b/panel/src/components/Dialogs/PageMoveDialog.vue
@@ -13,7 +13,12 @@
 	>
 		<k-headline>{{ $t("page.move") }}</k-headline>
 		<div class="k-page-move-parent" tabindex="0" data-autofocus>
-			<k-page-tree :current="value.parent" identifier="id" @select="select" />
+			<k-page-move-tree
+				:current="value.parent"
+				:target="value.page"
+				identifier="id"
+				@select="select"
+			/>
 		</div>
 	</k-dialog>
 </template>
@@ -25,16 +30,14 @@ export default {
 	mixins: [Dialog],
 	props: {
 		value: {
-			default() {
-				return {};
-			},
+			default: () => ({}),
 			type: Object
 		}
 	},
 	emits: ["cancel", "input", "submit"],
 	methods: {
 		select(page) {
-			this.$emit("input", { parent: page.id });
+			this.$emit("input", { ...this.value, parent: page.id });
 		}
 	}
 };

--- a/panel/src/components/Navigation/PageMoveTree.vue
+++ b/panel/src/components/Navigation/PageMoveTree.vue
@@ -1,0 +1,47 @@
+<script>
+import PageTree from "./PageTree.vue";
+
+export default {
+	name: "k-page-move-tree",
+	extends: PageTree,
+	props: {
+		target: {
+			required: true,
+			type: String
+		}
+	},
+	methods: {
+		async load(path) {
+			const { data } = await this.$api.get(path + "/children", {
+				target: this.target,
+				select: "canBeMovedTo,hasChildren,hasDrafts,id,panelImage,title,uuid",
+				status: "all"
+			});
+
+			const pages = {};
+
+			data.forEach((page) => {
+				const id = page[this.identifier];
+
+				pages[id] = {
+					id,
+					disabled: !page.canBeMovedTo,
+					icon: page.panelImage.icon,
+					label: page.title,
+					hasChildren: page.hasChildren || page.hasDrafts,
+					children: "/pages/" + this.$api.pages.id(page.id),
+					open: false
+				};
+			});
+
+			return pages;
+		}
+	}
+};
+</script>
+
+<style>
+.k-tree-folder[disabled] {
+	--tree-color-text: var(--color-gray-600);
+}
+</style>

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -19,6 +19,7 @@
 					<k-icon :type="item.open ? 'angle-down' : 'angle-right'" />
 				</button>
 				<button
+					:disabled="item.disabled"
 					class="k-tree-folder"
 					type="button"
 					@click="select(item)"
@@ -84,7 +85,7 @@ export default {
 	--tree-color-hover-back: var(--color-gray-300);
 	--tree-color-selected-back: var(--color-blue-300);
 	--tree-color-selected-text: var(--color-black);
-	--tree-color-text: var(--color-text-dimmed);
+	--tree-color-text: var(--color-gray-900);
 	--tree-level: 0;
 	--tree-indentation: 0.6rem;
 }

--- a/panel/src/components/Navigation/index.js
+++ b/panel/src/components/Navigation/index.js
@@ -7,6 +7,7 @@ import Link from "./Link.vue";
 import ModelTabs from "./ModelTabs.vue";
 import Navigate from "./Navigate.js";
 import PageTree from "./PageTree.vue";
+import PageMoveTree from "./PageMoveTree.vue";
 import Pagination from "./Pagination.vue";
 import PrevNext from "./PrevNext.vue";
 import Tag from "./Tag.vue";
@@ -30,6 +31,7 @@ export default {
 		app.component("k-link", Link);
 		app.component("k-model-tabs", ModelTabs);
 		app.component("k-page-tree", PageTree);
+		app.component("k-page-move-tree", PageMoveTree);
 		app.component("k-pagination", Pagination);
 		app.component("k-prev-next", PrevNext);
 		app.component("k-tag", Tag);

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -345,7 +345,13 @@ class PageRules
 		}
 
 		// the page cannot be moved into itself
-		if ($parent instanceof Page && ($page->is($parent) === true || $page->isAncestorOf($parent) === true)) {
+		if (
+			$parent instanceof Page &&
+			(
+				$page->is($parent) === true ||
+				$page->isAncestorOf($parent) === true
+			)
+		) {
 			throw new LogicException([
 				'key' => 'page.move.ancestor',
 			]);


### PR DESCRIPTION
First experiment to improve the UX of the page move dialog:
Pages that are invalid as new parent are disabled for selection.

Seemed to me the best solution, e.g. vs. completely hiding them (cause what about invalid parent page that has valid subpages).

I am not super happy with adding this `canBeMovedTo` field to the regular API. IMO we should have also Fiber `data` endpoints and instead of calling the regular API, the page tree would get its data from such a Fiber endpoint. Instead of creating a new `k-page-move-tree` component, we could then allow simply specifying which Fiber endpoint `k-page-tree` should use and point this to a more specific one for the page move dialog. Would maybe also allow wrapping all the logic in a small `PageMoveDialog` class.

But curious to first hear your thoughts, @bastianallgeier 