### PR TITLE
Fix missing node selector in writer

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -150,7 +150,7 @@ export default {
 
 			const buttons = {};
 
-			for (const node of this.nodes.entries()) {
+			for (const node of this.nodes) {
 				if (available[node]) {
 					buttons[node] = available[node];
 				}


### PR DESCRIPTION
## Fixes 

- When choosing to show only some nodes in the toolbar, the node selector is now correctly displayed again. https://github.com/getkirby/kirby/issues/5482