### PR TITLE
Set select background and text color

### DIFF
--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -41,6 +41,8 @@
 
 :where(select) {
 	appearance: none;
+	background: var(--color-white);
+	color: var(--color-black);
 }
 
 :where(


### PR DESCRIPTION
## Fixes 

- Select dropdowns now always have a white background and black text on Windows, which make them readable again everywhere https://github.com/getkirby/kirby/issues/5469