### PR TITLE
Set autofocus in structure field drawers

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -3,6 +3,7 @@
 		<template #options>
 			<k-button-group layout="collapsed">
 				<k-button
+					:autofocus="autofocus"
 					:disabled="isFull"
 					:responsive="true"
 					:text="$t('add')"

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -3,6 +3,7 @@
 		<template #options>
 			<k-button-group layout="collapsed">
 				<k-button
+					:autofocus="autofocus"
 					:text="$t('add')"
 					icon="add"
 					variant="filled"
@@ -49,6 +50,7 @@ export default {
 	mixins: [Field],
 	inheritAttrs: false,
 	props: {
+		autofocus: Boolean,
 		empty: String,
 		fieldsetGroups: Object,
 		fieldsets: Object,

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -4,6 +4,7 @@
 			<k-button-group class="k-field-options">
 				<k-button
 					v-if="more && !disabled"
+					:autofocus="autofocus"
 					:icon="btnIcon"
 					:text="btnLabel"
 					size="xs"

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -1,7 +1,17 @@
 <template>
 	<k-field v-bind="$props" class="k-structure-field" @click.native.stop>
 		<template v-if="hasFields && !disabled" #options>
-			<k-dropdown>
+			<k-button-group layout="collapsed">
+				<k-button
+					:autofocus="autofocus"
+					:disabled="!more"
+					:responsive="true"
+					:text="$t('add')"
+					icon="add"
+					variant="filled"
+					size="xs"
+					@click="add()"
+				/>
 				<k-button
 					icon="dots"
 					size="xs"
@@ -20,7 +30,7 @@
 						{{ $t("delete.all") }}
 					</k-dropdown-item>
 				</k-dropdown-content>
-			</k-dropdown>
+			</k-button-group>
 		</template>
 
 		<template v-if="hasFields">
@@ -77,6 +87,7 @@ export default {
 	mixins: [Field],
 	inheritAttrs: false,
 	props: {
+		autofocus: Boolean,
 		/**
 		 * What columns to show in the table
 		 */
@@ -134,7 +145,6 @@ export default {
 	},
 	data() {
 		return {
-			autofocus: null,
 			items: this.toItems(this.value),
 			page: 1
 		};
@@ -149,13 +159,6 @@ export default {
 				disabled: !this.isSortable,
 				fallbackClass: "k-sortable-row-fallback"
 			};
-		},
-		/**
-		 * Config for the structure form
-		 * @returns {Object}
-		 */
-		form() {
-			return this.$helper.field.subfields(this, this.fields);
 		},
 		/**
 		 * Index of first row that is displayed
@@ -346,6 +349,22 @@ export default {
 			this.$refs.add?.focus?.();
 		},
 		/**
+		 * Config for the structure form
+		 * @returns {Object}
+		 */
+		form(autofocus) {
+			const fields = this.$helper.field.subfields(this, this.fields);
+
+			// set the autofocus to the matching field in the form
+			if (autofocus) {
+				for (const field in fields) {
+					fields[field].autofocus = field === autofocus;
+				}
+			}
+
+			return fields;
+		},
+		/**
 		 * Opens form for a specific row at index
 		 * with field focussed
 		 * @param {number} index
@@ -376,7 +395,7 @@ export default {
 					prev: this.items[index - 1],
 					tabs: {
 						content: {
-							fields: this.form
+							fields: this.form(field)
 						}
 					},
 					title: this.label,

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -4,6 +4,7 @@
 			<k-button-group class="k-field-options">
 				<k-button
 					v-if="more && !disabled"
+					:autofocus="autofocus"
 					:icon="btnIcon"
 					:text="btnLabel"
 					variant="filled"

--- a/panel/src/mixins/forms/picker.js
+++ b/panel/src/mixins/forms/picker.js
@@ -4,6 +4,7 @@ export default {
 	mixins: [Field],
 	inheritAttrs: false,
 	props: {
+		autofocus: Boolean,
 		empty: String,
 		info: String,
 		link: Boolean,


### PR DESCRIPTION
## Enhancements

- Correct autofocus handling for blocks, layout, structure and picker fields. 

## Fixes 

- Sets the focus correctly when the structure field drawer is opened