### PR TITLE
Fix sticky header offset in drawer

### DIFF
--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -60,6 +60,7 @@ export default {
 
 <style>
 :root {
+	--drawer-body-padding: 1.5rem;
 	--drawer-color-back: var(--color-light);
 	--drawer-header-height: 2.5rem;
 	--drawer-header-padding: 1rem;
@@ -76,6 +77,7 @@ export default {
 }
 
 .k-drawer {
+	--header-sticky-offset: calc(var(--drawer-body-padding) * -1);
 	z-index: var(--z-toolbar);
 	display: flex;
 	flex-basis: var(--drawer-width);

--- a/panel/src/components/Drawers/Elements/Body.vue
+++ b/panel/src/components/Drawers/Elements/Body.vue
@@ -6,7 +6,7 @@
 
 <style>
 .k-drawer-body {
-	padding: 1.5rem;
+	padding: var(--drawer-body-padding);
 	flex-grow: 1;
 	background: var(--color-background);
 }


### PR DESCRIPTION
## Fixes 

- Fixes the sticky header offset in the drawer and stops the toolbar from jumping in writers and textarea fields https://github.com/getkirby/kirby/issues/5501