### PR TITLE
Page move dialog: disable invalid page options (Volume 2)

### DIFF
--- a/config/areas/site.php
+++ b/config/areas/site.php
@@ -13,6 +13,7 @@ return function ($kirby) {
 		'dialogs'   => require __DIR__ . '/site/dialogs.php',
 		'drawers'   => require __DIR__ . '/site/drawers.php',
 		'dropdowns' => require __DIR__ . '/site/dropdowns.php',
+		'requests'  => require __DIR__ . '/site/requests.php',
 		'searches'  => require __DIR__ . '/site/searches.php',
 		'views'     => require __DIR__ . '/site/views.php',
 	];

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -510,6 +510,7 @@ return [
 				'component' => 'k-page-move-dialog',
 				'props' => [
 					'value' => [
+						'move'   => $page->panel()->url(true),
 						'parent' => $page->parent()?->panel()->url(true) ?? '/site'
 					]
 				]

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cms\App;
 use Kirby\Cms\Find;
 
 return [

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -6,8 +6,10 @@ return [
 	'tree' => [
 		'pattern' => 'site/tree',
 		'action'  => function () {
-			$parent = Find::parent(get('parent', 'site'));
-			$move   = get('move') ? Find::parent(get('move')) : null;
+			$request = App::instance()->request();
+			$parent  = Find::parent($request->get('parent', 'site'));
+			$move    = $request->get('move');
+			$move    = $move ? Find::parent($move) : null;
 			$pages  = [];
 
 			foreach ($parent->childrenAndDrafts() as $child) {

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -1,0 +1,31 @@
+<?php
+
+use Kirby\Cms\Find;
+
+return [
+	'tree' => [
+		'pattern' => 'site/tree',
+		'action'  => function () {
+			$parent = Find::parent(get('parent', 'site'));
+			$move   = get('move') ? Find::parent(get('move')) : null;
+			$pages  = [];
+
+			foreach ($parent->childrenAndDrafts() as $child) {
+				$panel = $child->panel();
+
+				$pages[] = [
+					'children'    => $panel->url(true),
+					'disabled'    => $move !== null && $move->isMovableTo($child) === false,
+					'hasChildren' => $child->hasChildren() === true || $child->hasDrafts() === true,
+					'icon'        => $panel->image()['icon'] ?? null,
+					'id'          => $child->id(),
+					'open'        => false,
+					'label'       => $child->title()->value(),
+					'uuid'        => $child->uuid()->toString(),
+				];
+			}
+
+			return $pages;
+		},
+	],
+];

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -17,7 +17,7 @@ return [
 
 				$pages[] = [
 					'children'    => $panel->url(true),
-					'disabled'    => $move !== null && $move->isMovableTo($child) === false,
+					'disabled'    => $move?->isMovableTo($child) === false,
 					'hasChildren' => $child->hasChildren() === true || $child->hasDrafts() === true,
 					'icon'        => $panel->image()['icon'] ?? null,
 					'id'          => $child->id(),

--- a/panel/src/components/Dialogs/PageMoveDialog.vue
+++ b/panel/src/components/Dialogs/PageMoveDialog.vue
@@ -13,7 +13,12 @@
 	>
 		<k-headline>{{ $t("page.move") }}</k-headline>
 		<div class="k-page-move-parent" tabindex="0" data-autofocus>
-			<k-page-tree :current="value.parent" identifier="id" @select="select" />
+			<k-page-tree
+				:current="value.parent"
+				:move="value.move"
+				identifier="id"
+				@select="select"
+			/>
 		</div>
 	</k-dialog>
 </template>
@@ -34,7 +39,7 @@ export default {
 	emits: ["cancel", "input", "submit"],
 	methods: {
 		select(page) {
-			this.$emit("input", { parent: page.id });
+			this.$emit("input", { ...this.value, parent: page.id });
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -125,7 +125,9 @@ export default {
 	},
 	computed: {
 		currentType() {
-			return this.activeTypes[this.linkType] ?? Object.values(this.activeTypes)[0];
+			return (
+				this.activeTypes[this.linkType] ?? Object.values(this.activeTypes)[0]
+			);
 		},
 		availableTypes() {
 			return {

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -16,16 +16,17 @@
 					type="button"
 					@click="toggle(item)"
 				>
-					<k-icon :type="item.open ? 'angle-down' : 'angle-right'" />
+					<k-icon :type="arrow(item)" />
 				</button>
 				<button
+					:disabled="item.disabled"
 					class="k-tree-folder"
 					type="button"
 					@click="select(item)"
 					@dblclick="toggle(item)"
 				>
 					<k-icon-frame :icon="item.icon ?? 'folder'" />
-					<span>{{ item.label }}</span>
+					<span class="k-tree-folder-label">{{ item.label }}</span>
 				</button>
 			</p>
 			<template v-if="item.hasChildren && item.open">
@@ -34,8 +35,7 @@
 					v-bind="$props"
 					:items="item.children"
 					:level="level + 1"
-					@select="select"
-					@toggle="toggle"
+					v-on="$listeners"
 				/>
 			</template>
 		</li>
@@ -68,11 +68,32 @@ export default {
 		};
 	},
 	methods: {
+		arrow(item) {
+			if (item.loading === true) {
+				return "loader";
+			}
+
+			return item.open ? "angle-down" : "angle-right";
+		},
+		close(item) {
+			this.$set(item, "open", false);
+			this.$emit("close", item);
+		},
+		open(item) {
+			this.$set(item, "open", true);
+			this.$emit("open", item);
+		},
 		select(item) {
 			this.$emit("select", item);
 		},
 		toggle(item) {
 			this.$emit("toggle", item);
+
+			if (item.open === true) {
+				this.close(item);
+			} else {
+				this.open(item);
+			}
 		}
 	}
 };
@@ -84,7 +105,7 @@ export default {
 	--tree-color-hover-back: var(--color-gray-300);
 	--tree-color-selected-back: var(--color-blue-300);
 	--tree-color-selected-text: var(--color-black);
-	--tree-color-text: var(--color-text-dimmed);
+	--tree-color-text: var(--color-gray-dimmed);
 	--tree-level: 0;
 	--tree-indentation: 0.6rem;
 }
@@ -154,10 +175,14 @@ li[aria-current] > .k-tree-branch {
 .k-tree-folder > .k-frame {
 	flex-shrink: 0;
 }
-.k-tree-folder > span {
+.k-tree-folder-label {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--tree-color-text);
+	color: currentColor;
+}
+
+.k-tree-folder[disabled] {
+	opacity: var(--opacity-disabled);
 }
 </style>

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -35,7 +35,10 @@
 					v-bind="$props"
 					:items="item.children"
 					:level="level + 1"
-					v-on="$listeners"
+					@close="$emit('close', $event)"
+					@open="$emit('open', $event)"
+					@select="$emit('select', $event)"
+					@toggle="$emit('toggle', $event)"
 				/>
 			</template>
 		</li>

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -13,6 +13,7 @@ use Kirby\Panel\Page as Panel;
 use Kirby\Template\Template;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * The `$page` object is the heart and
@@ -689,6 +690,15 @@ class Page extends ModelWithContent
 	public function isListed(): bool
 	{
 		return $this->isPublished() && $this->num() !== null;
+	}
+
+	public function isMovableTo(Page|Site $parent): bool
+	{
+		try {
+			return PageRules::move($this, $parent);
+		} catch (Throwable $e) {
+			return false;
+		}
 	}
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -696,7 +696,7 @@ class Page extends ModelWithContent
 	{
 		try {
 			return PageRules::move($this, $parent);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -335,6 +335,11 @@ class PageRules
 	 */
 	public static function move(Page $page, Site|Page $parent): bool
 	{
+		// if nothing changes, there's no need for checks
+		if ($parent->is($page->parent()) === true) {
+			return true;
+		}
+
 		if ($page->permissions()->move() !== true) {
 			throw new PermissionException([
 				'key' => 'page.move.permission',

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -40,29 +40,7 @@ abstract class Json
 	 */
 	public static function response($data, array $options = []): Response
 	{
-		// handle redirects
-		if ($data instanceof Redirect) {
-			$data = [
-				'redirect' => $data->location(),
-				'code'     => $data->code()
-			];
-
-		// handle Kirby exceptions
-		} elseif ($data instanceof Exception) {
-			$data = static::error($data->getMessage(), $data->getHttpCode());
-
-		// handle exceptions
-		} elseif ($data instanceof Throwable) {
-			$data = static::error($data->getMessage(), 500);
-
-		// only expect arrays from here on
-		} elseif (is_array($data) === false) {
-			$data = static::error('Invalid response', 500);
-		}
-
-		if (empty($data) === true) {
-			$data = static::error('The response is empty', 404);
-		}
+		$data = static::responseData($data);
 
 		// always inject the response code
 		$data['code']   ??= 200;
@@ -72,4 +50,37 @@ abstract class Json
 
 		return Panel::json([static::$key => $data], $data['code']);
 	}
+
+	public static function responseData(mixed $data): array
+	{
+		// handle redirects
+		if ($data instanceof Redirect) {
+			return [
+				'redirect' => $data->location(),
+				'code'     => $data->code()
+			];
+		}
+
+		// handle Kirby exceptions
+		if ($data instanceof Exception) {
+			return static::error($data->getMessage(), $data->getHttpCode());
+		}
+
+		// handle exceptions
+		if ($data instanceof Throwable) {
+			return static::error($data->getMessage(), 500);
+		}
+
+		// only expect arrays from here on
+		if (is_array($data) === false) {
+			return static::error('Invalid response', 500);
+		}
+
+		if (empty($data) === true) {
+			return static::error('The response is empty', 404);
+		}
+
+		return $data;
+	}
+
 }

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -245,6 +245,7 @@ class Panel
 			'dialog'   => Dialog::response($result, $options),
 			'drawer'   => Drawer::response($result, $options),
 			'dropdown' => Dropdown::response($result, $options),
+			'request'  => Request::response($result, $options),
 			'search'   => Search::response($result, $options),
 			default    => View::response($result, $options)
 		};
@@ -343,6 +344,7 @@ class Panel
 				static::routesForDialogs($areaId, $area),
 				static::routesForDrawers($areaId, $area),
 				static::routesForDropdowns($areaId, $area),
+				static::routesForRequests($areaId, $area),
 			);
 		}
 
@@ -424,6 +426,21 @@ class Panel
 				prefix: 'dropdowns',
 				options: $dropdown
 			));
+		}
+
+		return $routes;
+	}
+
+	/**
+	 * Extract all routes from an area
+	 */
+	public static function routesForRequests(string $areaId, array $area): array
+	{
+		$routes = $area['requests'] ?? [];
+
+		foreach ($routes as $key => $route) {
+			$routes[$key]['area'] = $areaId;
+			$routes[$key]['type'] = 'request';
 		}
 
 		return $routes;

--- a/src/Panel/Request.php
+++ b/src/Panel/Request.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kirby\Panel;
+
+use Kirby\Http\Response;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Request
+{
+	/**
+	 * Renders request responses
+	 */
+	public static function response($data, array $options = []): Response
+	{
+		$data = Json::responseData($data);
+
+		return Panel::json(Json::responseData($data), $data['code'] ?? 200);
+	}
+}

--- a/src/Panel/Request.php
+++ b/src/Panel/Request.php
@@ -19,7 +19,6 @@ class Request
 	public static function response($data, array $options = []): Response
 	{
 		$data = Json::responseData($data);
-
-		return Panel::json(Json::responseData($data), $data['code'] ?? 200);
+		return Panel::json($data, $data['code'] ?? 200);
 	}
 }


### PR DESCRIPTION
## Enhancements

- The page move dialog now disables all pages that are invalid new parents for the page 

## Features

- Each Fiber area can now define additional requests for simple data endpoints or actions. 