### PR TITLE
Fixed link field when UUIDs are switched off

### DIFF
--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -17,6 +17,9 @@ return [
 			if ($parent === null) {
 				$site  = $kirby->site();
 				$panel = $site->panel();
+			 	$uuid  = $site->uuid()?->toString();
+			 	$url   = $site->url();
+				$value = $uuid ?? $url;
 
 				return [
 					[
@@ -27,8 +30,9 @@ return [
 						'id'          => '/',
 						'label'       => I18n::translate('view.site'),
 						'open'        => false,
-						'url'         => $site->url(),
-						'uuid'        => $site->uuid()?->toString(),
+						'url'         => $url,
+						'uuid'        => $uuid,
+						'value'       => $value
 					]
 				];
 			}
@@ -38,6 +42,9 @@ return [
 
 			foreach ($parent->childrenAndDrafts()->filterBy('isListable', true) as $child) {
 				$panel = $child->panel();
+			 	$uuid  = $child->uuid()?->toString();
+			 	$url   = $child->url();
+				$value = $uuid ?? $url;
 
 				$pages[] = [
 					'children'    => $panel->url(true),
@@ -47,8 +54,9 @@ return [
 					'id'          => $child->id(),
 					'open'        => false,
 					'label'       => $child->title()->value(),
-					'url'         => $child->url(),
-					'uuid'        => $child->uuid()?->toString(),
+					'url'         => $url,
+					'uuid'        => $uuid,
+					'value'       => $value
 				];
 			}
 

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -24,10 +24,9 @@ return [
 						'disabled'    => $move?->isMovableTo($site) === false,
 						'hasChildren' => true,
 						'icon'        => 'home',
-						'id'          => $site->id(),
+						'id'          => $site->uuid()?->toString() ?? '/',
 						'open'        => false,
 						'label'       => I18n::translate('view.site'),
-						'uuid'        => $site->uuid()->toString(),
 					]
 				];
 			}
@@ -43,10 +42,9 @@ return [
 					'disabled'    => $move?->isMovableTo($child) === false,
 					'hasChildren' => $child->hasChildren() === true || $child->hasDrafts() === true,
 					'icon'        => $panel->image()['icon'] ?? null,
-					'id'          => $child->id(),
+					'id'          => $child->uuid()?->toString() ?? '/' . $child->id(),
 					'open'        => false,
 					'label'       => $child->title()->value(),
-					'uuid'        => $child->uuid()->toString(),
 				];
 			}
 

--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -24,9 +24,11 @@ return [
 						'disabled'    => $move?->isMovableTo($site) === false,
 						'hasChildren' => true,
 						'icon'        => 'home',
-						'id'          => $site->uuid()?->toString() ?? '/',
-						'open'        => false,
+						'id'          => '/',
 						'label'       => I18n::translate('view.site'),
+						'open'        => false,
+						'url'         => $site->url(),
+						'uuid'        => $site->uuid()?->toString(),
 					]
 				];
 			}
@@ -42,9 +44,11 @@ return [
 					'disabled'    => $move?->isMovableTo($child) === false,
 					'hasChildren' => $child->hasChildren() === true || $child->hasDrafts() === true,
 					'icon'        => $panel->image()['icon'] ?? null,
-					'id'          => $child->uuid()?->toString() ?? '/' . $child->id(),
+					'id'          => $child->id(),
 					'open'        => false,
 					'label'       => $child->title()->value(),
+					'url'         => $child->url(),
+					'uuid'        => $child->uuid()?->toString(),
 				];
 			}
 

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -77,7 +77,7 @@
 					<k-page-tree
 						:current="getPageUUID(value)"
 						:root="false"
-						@select="selectPage($event)"
+						@select="selectModel($event)"
 					/>
 				</div>
 			</div>
@@ -89,7 +89,7 @@
 			>
 				<k-file-browser
 					:selected="getFileUUID(value)"
-					@select="selectFile($event)"
+					@select="selectModel($event)"
 				/>
 			</div>
 		</k-input>
@@ -288,6 +288,7 @@ export default {
 		},
 		isPageUUID(value) {
 			return (
+				value === "site://" ||
 				value.startsWith("page://") === true ||
 				value.startsWith("/@/page/") === true
 			);
@@ -337,6 +338,12 @@ export default {
 			}
 		},
 		async previewForPage(id) {
+			if (id === "site://") {
+				return {
+					label: this.$t("view.site")
+				};
+			}
+
 			try {
 				const page = await this.$api.pages.get(id, {
 					select: "title"
@@ -349,23 +356,14 @@ export default {
 				return null;
 			}
 		},
-		selectPage(page) {
-			if (page.uuid) {
-				this.onInput(page.uuid);
+		selectModel(model) {
+			if (model.uuid) {
+				this.onInput(model.uuid);
 				return;
 			}
 
 			this.switchType("url");
-			this.onInput(page.url);
-		},
-		selectFile(file) {
-			if (file.uuid) {
-				this.onInput(file.uuid);
-				return;
-			}
-
-			this.switchType("url");
-			this.onInput(file.url);
+			this.onInput(model.url);
 		},
 		switchType(type) {
 			if (type === this.linkType) {

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -77,7 +77,7 @@
 					<k-page-tree
 						:current="getPageUUID(value)"
 						:root="false"
-						@select="onInput($event.id)"
+						@select="selectPage($event)"
 					/>
 				</div>
 			</div>
@@ -89,7 +89,7 @@
 			>
 				<k-file-browser
 					:selected="getFileUUID(value)"
-					@select="onInput($event.id)"
+					@select="selectFile($event)"
 				/>
 			</div>
 		</k-input>
@@ -235,7 +235,7 @@ export default {
 				this.linkValue = parts.link;
 
 				if (value !== old) {
-					this.preview();
+					this.preview(parts);
 				}
 			},
 			immediate: true
@@ -309,11 +309,15 @@ export default {
 				this.expanded = false;
 			}
 		},
-		async preview() {
-			if (this.linkType === "page" && this.linkValue) {
-				this.model = await this.previewForPage(this.linkValue);
-			} else if (this.linkType === "file" && this.linkValue) {
-				this.model = await this.previewForFile(this.linkValue);
+		async preview({ type, link }) {
+			if (type === "page" && link) {
+				this.model = await this.previewForPage(link);
+			} else if (type === "file" && link) {
+				this.model = await this.previewForFile(link);
+			} else if (link) {
+				this.model = {
+					label: link
+				};
 			} else {
 				this.model = null;
 			}
@@ -344,6 +348,24 @@ export default {
 			} catch (e) {
 				return null;
 			}
+		},
+		selectPage(page) {
+			if (page.uuid) {
+				this.onInput(page.uuid);
+				return;
+			}
+
+			this.switchType("url");
+			this.onInput(page.url);
+		},
+		selectFile(file) {
+			if (file.uuid) {
+				this.onInput(file.uuid);
+				return;
+			}
+
+			this.switchType("url");
+			this.onInput(file.url);
 		},
 		switchType(type) {
 			if (type === this.linkType) {

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -293,7 +293,7 @@ export default {
 			);
 		},
 		onInput(link) {
-			const value = link.trim();
+			const value = link?.trim() ?? "";
 
 			if (!value.length) {
 				return this.$emit("input", "");

--- a/panel/src/components/Navigation/Browser.vue
+++ b/panel/src/components/Navigation/Browser.vue
@@ -1,7 +1,12 @@
 <template>
 	<nav class="k-browser">
 		<div class="k-browser-items">
-			<label v-for="item in items" :key="item.value" class="k-browser-item">
+			<label
+				v-for="item in items"
+				:key="item.value"
+				:aria-selected="selected === item.value"
+				class="k-browser-item"
+			>
 				<input
 					:checked="selected === item.value"
 					:name="name"
@@ -98,8 +103,7 @@ export default {
 	opacity: 0;
 	width: 0;
 }
-.k-browser-item:has(input:checked) {
-	color: var(--color-blue-700);
-	background: var(--color-blue-200);
+.k-browser-item[aria-selected] {
+	background: var(--color-blue-300);
 }
 </style>

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -3,7 +3,7 @@
 		<div class="k-file-browser-layout">
 			<aside ref="tree" class="k-file-browser-tree">
 				<k-page-tree
-					:current="page?.id"
+					:current="page?.value"
 					@select="selectPage"
 					@toggleBranch="togglePage"
 				/>

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -48,22 +48,22 @@ export default {
 			this.page = page;
 
 			const parent =
-				page.id === "site://"
+				page.id === "/"
 					? "/site/files"
 					: "/pages/" + this.$api.pages.id(page.id) + "/files";
 
 			const { data } = await this.$api.get(parent, {
-				select: "filename,panelImage,uuid,id"
+				select: "filename,id,panelImage,url,uuid"
 			});
 
 			this.files = data.map((file) => {
-				const id = file.uuid ?? "/" + file.id;
-
 				return {
 					label: file.filename,
 					image: file.panelImage,
-					id: id,
-					value: id
+					id: file.id,
+					url: file.url,
+					uuid: file.uuid,
+					value: file.uuid ?? file.url
 				};
 			});
 

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -53,15 +53,17 @@ export default {
 					: "/pages/" + this.$api.pages.id(page.id) + "/files";
 
 			const { data } = await this.$api.get(parent, {
-				select: "filename,panelImage,uuid"
+				select: "filename,panelImage,uuid,id"
 			});
 
 			this.files = data.map((file) => {
+				const id = file.uuid ?? "/" + file.id;
+
 				return {
 					label: file.filename,
 					image: file.panelImage,
-					id: file.uuid,
-					value: file.uuid
+					id: id,
+					value: id
 				};
 			});
 

--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -14,14 +14,6 @@ export default {
 			default: "/site",
 			type: String
 		},
-		/**
-		 * @values `id`, `uuid`
-		 */
-		identifier: {
-			default: "uuid",
-			type: String,
-			validator: (value) => ["id", "uuid"].includes(value)
-		},
 		move: {
 			type: String
 		}

--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -11,7 +11,6 @@ export default {
 			type: Boolean
 		},
 		current: {
-			default: "/site",
 			type: String
 		},
 		move: {

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -4,7 +4,7 @@
 			v-for="(item, index) in state"
 			:key="index"
 			:aria-expanded="item.open"
-			:aria-current="item.id === current"
+			:aria-current="item.value === current"
 		>
 			<p
 				class="k-tree-branch"


### PR DESCRIPTION
## Fixes 

- The link field is now usable when UUIDs are switched off. The page and file browsers will insert the absolute URL instead of the UUID https://github.com/getkirby/kirby/issues/5489