### PR TITLE
a11y fixes

### DIFF
--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -1,5 +1,5 @@
 <template>
-	<fieldset class="k-fieldset">
+	<div class="k-fieldset">
 		<k-grid variant="fields">
 			<template v-for="(field, fieldName) in fields">
 				<k-column
@@ -43,7 +43,7 @@
 				</k-column>
 			</template>
 		</k-grid>
-	</fieldset>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -96,7 +96,7 @@ export default {
 }
 
 .k-header-title-icon {
-	--icon-color: var(--color-gray-500);
+	--icon-color: var(--color-text-dimmed);
 	border-radius: var(--rounded);
 	transition: opacity 0.2s;
 	display: grid;

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -7,6 +7,7 @@
 			<button
 				v-if="editable"
 				class="k-header-title-button"
+				type="button"
 				@click="$emit('edit')"
 			>
 				<span class="k-header-title-text"><slot /></span>

--- a/panel/src/components/View/Inside.vue
+++ b/panel/src/components/View/Inside.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-panel class="k-panel-inside" tabindex="0">
+	<k-panel class="k-panel-inside">
 		<k-panel-menu />
 		<main class="k-panel-main">
 			<k-topbar :breadcrumb="$panel.view.breadcrumb" :view="$panel.view">

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -34,6 +34,7 @@
 		<!-- Collapse/expand toggle -->
 		<k-button
 			:icon="$panel.menu.isOpen ? 'angle-left' : 'angle-right'"
+			:title="$panel.menu.isOpen ? $t('collapse') : $t('expand')"
 			size="xs"
 			class="k-panel-menu-toggle"
 			@click="$panel.menu.toggle()"

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -1,6 +1,7 @@
 <template>
 	<nav
 		class="k-panel-menu"
+		:aria-label="$t('menu')"
 		:data-hover="$panel.menu.hover"
 		@mouseenter="$panel.menu.hover = true"
 		@mouseleave="$panel.menu.hover = false"


### PR DESCRIPTION
## Fixes 

- Removed unnecessary tabindex on main element
- Label for the menu toggle and the menu element
- Add type=button to the header button
- Turn up contrast for the edit icon in the header
- Use a div instead of a meaningless fieldset without legend in k-fieldset