### PR TITLE
Bring back the old font size for help text

### DIFF
--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -75,8 +75,7 @@ export default {
 .k-field:focus-within > .k-field-header > .k-field-counter {
 	display: block;
 }
-/** TODO: .k-field > :has(+ footer) { margin-bottom: var(--spacing-1);} */
-.k-field > footer {
+.k-field-footer {
 	margin-top: var(--spacing-2);
 }
 </style>

--- a/panel/src/components/Text/Text.vue
+++ b/panel/src/components/Text/Text.vue
@@ -159,7 +159,5 @@ export default {
 /** Help */
 .k-help {
 	color: var(--color-text-dimmed);
-	font-size: var(--text-xs);
-	line-height: 1.25;
 }
 </style>


### PR DESCRIPTION
## Enhancements

- Increase the font size for help text in sections and fields

## Comment

I agree with the feedback in various parts that the help text is too small in xs