### PR TITLE
CI: Only enable Whoops when it is tested

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 
 	bootstrap="tests/bootstrap.php"
+	convertDeprecationsToExceptions="true"
 	colors="true"
 	verbose="true"
 	stderr="true"

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -27,6 +27,15 @@ use Whoops\Run as Whoops;
 trait AppErrors
 {
 	/**
+	 * Allows to disable Whoops globally in CI;
+	 * can be overridden by explicitly setting
+	 * the `whoops` option to `true` or `false`
+	 *
+	 * @internal
+	 */
+	public static bool $enableWhoops = true;
+
+	/**
 	 * Whoops instance cache
 	 */
 	protected Whoops $whoops;
@@ -45,6 +54,17 @@ trait AppErrors
 	 */
 	protected function handleErrors(): void
 	{
+		// no matter the environment, exit early if
+		// Whoops was disabled globally
+		// (but continue if the option was explicitly
+		// set to `true` in the config)
+		if (
+			static::$enableWhoops === false &&
+			$this->option('whoops') !== true
+		) {
+			return;
+		}
+
 		if ($this->environment()->cli() === true) {
 			$this->handleCliErrors();
 			return;

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -15,6 +15,22 @@ require_once dirname(__DIR__) . '/mocks.php';
  */
 class AppErrorsTest extends TestCase
 {
+	protected App|null $originalApp;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Whoops is normally enabled by default, but disabled in CI
+		// to reduce memory leaks; in this test class we need it!
+		$this->originalApp = $this->app;
+		$this->app = $this->originalApp->clone([
+			'options' => [
+				'whoops' => true
+			]
+		]);
+	}
+
 	public function tearDown(): void
 	{
 		$unsetMethod = new ReflectionMethod(App::class, 'unsetWhoopsHandler');
@@ -22,8 +38,14 @@ class AppErrorsTest extends TestCase
 
 		$app = App::instance();
 		$unsetMethod->invoke($app);
+		$unsetMethod->invoke($this->app);
+		$unsetMethod->invoke($this->originalApp);
 
 		parent::tearDown();
+		$this->originalApp = null;
+
+		// reset to the value set by tests/bootstrap.php
+		App::$enableWhoops = false;
 	}
 
 	/**
@@ -164,6 +186,39 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(2, $handlers);
 		$this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
+	}
+
+	/**
+	 * @covers ::handleErrors
+	 */
+	public function testHandleErrorsGlobalSetting()
+	{
+		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+		$whoopsMethod->setAccessible(true);
+
+		$testMethod = new ReflectionMethod(App::class, 'handleErrors');
+		$testMethod->setAccessible(true);
+
+		$whoopsEnabled  = $whoopsMethod->invoke($this->app);
+		$whoopsDisabled = $whoopsMethod->invoke($this->originalApp);
+
+		$testMethod->invoke($this->app);
+		$handlers = $whoopsEnabled->getHandlers();
+		$this->assertCount(2, $handlers);
+
+		$testMethod->invoke($this->originalApp);
+		$handlers = $whoopsDisabled->getHandlers();
+		$this->assertCount(0, $handlers);
+
+		App::$enableWhoops = true;
+
+		$testMethod->invoke($this->app);
+		$handlers = $whoopsEnabled->getHandlers();
+		$this->assertCount(2, $handlers);
+
+		$testMethod->invoke($this->originalApp);
+		$handlers = $whoopsDisabled->getHandlers();
+		$this->assertCount(2, $handlers);
 	}
 
 	/**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -727,12 +727,14 @@ class AppTest extends TestCase
 						'error'        => $kirby->site()->content()->error()->value(),
 						'slugs'        => 'de'
 					];
-				}
+				},
+				'whoops' => true
 			]
 		]);
 
 		$this->assertSame([
 			'ready' => $ready,
+			'whoops' => true,
 			'test' => '/dev/null',
 			'another.test' => 'foo',
 			'debug' => true,

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -7,6 +7,8 @@ use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Obj;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Error\Deprecated;
 
 class HelperFunctionsTest extends TestCase
 {
@@ -188,10 +190,15 @@ class HelperFunctionsTest extends TestCase
 	{
 		// the deprecation warnings are always triggered in testing mode,
 		// so we cannot test it with disabled debug mode
-		$this->expectException('Whoops\Exception\ErrorException');
-		$this->expectExceptionMessage('The xyz method is deprecated.');
 
-		deprecated('The xyz method is deprecated.');
+		try {
+			deprecated('The xyz method is deprecated.');
+		} catch (Deprecated $e) {
+			$this->assertSame('The xyz method is deprecated.', $e->getMessage());
+			return;
+		}
+
+		Assert::fail('Expected deprecation warning was not generated');
 	}
 
 	public function testDumpOnCli()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Cms\App;
+
 error_reporting(E_ALL);
 ini_set('display_errors', 'on');
 ini_set('display_startup_errors', 'on');
@@ -7,3 +9,7 @@ ini_set('display_startup_errors', 'on');
 require_once __DIR__ . '/../vendor/autoload.php';
 
 define('KIRBY_TESTING', true);
+
+// disable Whoops for all tests that don't need it
+// to reduce the impact of memory leaks
+App::$enableWhoops = false;


### PR DESCRIPTION
This first step already helps us to make CI succeed on PHP 8.0. I'll still work on the other quick fix as we discussed, but that may take a little longer.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactoring

- Whoops is now generally disabled during PHPUnit test runs to reduce memory usage during tests

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
