### PR TITLE
Plugin `assets` extension

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -230,7 +230,7 @@ return [
 					$scoring['score'] += 16 * $score;
 					$scoring['hits']  += 1;
 
-					// check for exact beginning matches
+				// check for exact beginning matches
 				} elseif (
 					$options['words'] === false &&
 					Str::startsWith($lowerValue, $query) === true
@@ -238,7 +238,7 @@ return [
 					$scoring['score'] += 8 * $score;
 					$scoring['hits']  += 1;
 
-					// check for exact query matches
+				// check for exact query matches
 				} elseif ($matches = preg_match_all('!' . $exact . '!i', $value, $r)) {
 					$scoring['score'] += 2 * $score;
 					$scoring['hits']  += $matches;

--- a/config/components.php
+++ b/config/components.php
@@ -230,7 +230,7 @@ return [
 					$scoring['score'] += 16 * $score;
 					$scoring['hits']  += 1;
 
-				// check for exact beginning matches
+					// check for exact beginning matches
 				} elseif (
 					$options['words'] === false &&
 					Str::startsWith($lowerValue, $query) === true
@@ -238,7 +238,7 @@ return [
 					$scoring['score'] += 8 * $score;
 					$scoring['hits']  += 1;
 
-				// check for exact query matches
+					// check for exact query matches
 				} elseif ($matches = preg_match_all('!' . $exact . '!i', $value, $r)) {
 					$scoring['score'] += 2 * $score;
 					$scoring['hits']  += $matches;

--- a/config/routes.php
+++ b/config/routes.php
@@ -61,17 +61,16 @@ return function (App $kirby) {
 			}
 		],
 		[
-			'pattern' => $media . '/plugins/(:any)/(:any)/(:all)\.(css|map|gif|js|mjs|jpg|png|svg|webp|avif|woff2|woff|json)',
+			'pattern' => $media . '/plugins/(:any)/(:any)/(:all)',
 			'env'     => 'media',
 			'action'  => function (
 				string $provider,
 				string $pluginName,
-				string $filename,
-				string $extension
+				string $path
 			) {
 				return PluginAssets::resolve(
 					$provider . '/' . $pluginName,
-					$filename . '.' . $extension
+					$path
 				);
 			}
 		],

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -2,11 +2,13 @@
 
 namespace Kirby\Cms;
 
+use Closure;
 use Composer\InstalledVersions;
 use Exception;
 use Kirby\Cms\System\UpdateStatus;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\V;
@@ -57,6 +59,24 @@ class Plugin
 	public function __call(string $key, array $arguments = null): mixed
 	{
 		return $this->info()[$key] ?? null;
+	}
+
+	public function assets(): array
+	{
+		if ($assets = $this->extends['assets'] ?? null) {
+			if ($assets instanceof Closure) {
+				$assets = $assets();
+			}
+
+			return $assets;
+		}
+
+		$assets = $this->root() . '/assets';
+
+		return A::map(
+			Dir::index($this->root() . '/assets', true),
+			fn ($filename) => 'assets/' . $filename
+		);
 	}
 
 	/**

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -63,10 +63,7 @@ class Plugin
 	}
 
 	/**
-	 * Returns a specific
-	 *
-	 * @param string $name
-	 * @return string|null
+	 * Returns the absolute path to a specific asset
 	 */
 	public function asset(string $path): string|null
 	{
@@ -92,13 +89,11 @@ class Plugin
 			// normalize array: use relative path as
 			// key when no key is defined
 			foreach ($assets as $key => $asset) {
-				unset($assets[$key]);
-
 				if (is_int($key) === true) {
+					unset($assets[$key]);
 					$key = Str::after($asset, $this->root() . '/');
+					$assets[$key] = $asset;
 				}
-
-				$assets[$key] = $asset;
 			}
 		}
 
@@ -109,7 +104,10 @@ class Plugin
 			$root   = $this->root() . '/assets';
 
 			foreach (Dir::index($root, true) as $asset) {
-				$assets['assets/' . $asset] = $root . '/' . $asset;
+				$path = $root . '/' . $asset;
+				if (is_file($path) === true) {
+					$assets['assets/' . $asset] = $path;
+				}
 			}
 		}
 

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
-use Kirby\Toolkit\Str;
 
 /**
  * Plugin assets are automatically copied/linked

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -56,19 +56,20 @@ class PluginAssets
 		if ($plugin = App::instance()->plugin($pluginName)) {
 			$assets = $plugin->assets();
 
-			if ($asset = $assets[$path] ?? null) {
-				if (F::exists($asset, $plugin->root()) === true) {
-					// do some spring cleaning for older files
-					static::clean($pluginName);
+			if (
+				($asset = $assets[$path] ?? null) &&
+				F::exists($asset, $plugin->root()) === true
+			) {
+				// do some spring cleaning for older files
+				static::clean($pluginName);
 
-					$target = $plugin->mediaRoot() . '/' . $path;
+				$target = $plugin->mediaRoot() . '/' . $path;
 
-					// create a symlink if possible
-					F::link($asset, $target, 'symlink');
+				// create a symlink if possible
+				F::link($asset, $target, 'symlink');
 
-					// return the file response
-					return Response::file($asset);
-				}
+				// return the file response
+				return Response::file($asset);
 			}
 		}
 

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
+use Kirby\Toolkit\Str;
 
 /**
  * Plugin assets are automatically copied/linked
@@ -25,21 +26,18 @@ class PluginAssets
 	public static function clean(string $pluginName): void
 	{
 		if ($plugin = App::instance()->plugin($pluginName)) {
-			$root   = $plugin->root();
 			$media  = $plugin->mediaRoot();
-			$assets = Dir::index($media, true);
+			$assets = $plugin->assets();
+			$files  = Dir::index($media, true);
+			$files  = array_diff($files, array_keys($assets));
 
-			foreach ($assets as $asset) {
-				$original = $root . '/' . $asset;
+			foreach ($files as $file) {
+				$root = $media . '/' . $file;
 
-				if (file_exists($original) === false) {
-					$assetRoot = $media . '/' . $asset;
-
-					if (is_file($assetRoot) === true) {
-						F::remove($assetRoot);
-					} else {
-						Dir::remove($assetRoot);
-					}
+				if (is_file($root) === true) {
+					F::remove($root);
+				} else {
+					Dir::remove($root);
 				}
 			}
 		}
@@ -54,10 +52,8 @@ class PluginAssets
 		string $path
 	): Response|null {
 		if ($plugin = App::instance()->plugin($pluginName)) {
-			$assets = $plugin->assets();
-
 			if (
-				($asset = $assets[$path] ?? null) &&
+				($asset = $plugin->asset($path)) &&
 				F::exists($asset, $plugin->root()) === true
 			) {
 				// do some spring cleaning for older files

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -56,23 +56,19 @@ class PluginAssets
 		if ($plugin = App::instance()->plugin($pluginName)) {
 			$assets = $plugin->assets();
 
-			if (in_array($path, $assets) === false) {
-				return null;
-			}
+			if ($asset = $assets[$path] ?? null) {
+				if (F::exists($asset, $plugin->root()) === true) {
+					// do some spring cleaning for older files
+					static::clean($pluginName);
 
-			$source = $plugin->root() . '/' . $path;
+					$target = $plugin->mediaRoot() . '/' . $path;
 
-			if (F::exists($source, $plugin->root()) === true) {
-				// do some spring cleaning for older files
-				static::clean($pluginName);
+					// create a symlink if possible
+					F::link($asset, $target, 'symlink');
 
-				$target = $plugin->mediaRoot() . '/' . $path;
-
-				// create a symlink if possible
-				F::link($source, $target, 'symlink');
-
-				// return the file response
-				return Response::file($source);
+					// return the file response
+					return Response::file($asset);
+				}
 			}
 		}
 

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -25,7 +25,7 @@ class PluginAssets
 	public static function clean(string $pluginName): void
 	{
 		if ($plugin = App::instance()->plugin($pluginName)) {
-			$root   = $plugin->root() . '/assets';
+			$root   = $plugin->root();
 			$media  = $plugin->mediaRoot();
 			$assets = Dir::index($media, true);
 
@@ -51,16 +51,22 @@ class PluginAssets
 	 */
 	public static function resolve(
 		string $pluginName,
-		string $filename
+		string $path
 	): Response|null {
 		if ($plugin = App::instance()->plugin($pluginName)) {
-			$source = $plugin->root() . '/assets/' . $filename;
+			$assets = $plugin->assets();
+
+			if (in_array($path, $assets) === false) {
+				return null;
+			}
+
+			$source = $plugin->root() . '/' . $path;
 
 			if (F::exists($source, $plugin->root()) === true) {
 				// do some spring cleaning for older files
 				static::clean($pluginName);
 
-				$target = $plugin->mediaRoot() . '/' . $filename;
+				$target = $plugin->mediaRoot() . '/' . $path;
 
 				// create a symlink if possible
 				F::link($source, $target, 'symlink');

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -9,60 +9,79 @@ use PHPUnit\Framework\TestCase;
 class PluginAssetsTest extends TestCase
 {
 	protected $app;
-	protected $fixtures;
+	protected $tmp = __DIR__ . '/tmp/PluginAssetsTest';
 
 	public function setUp(): void
 	{
-		$this->fixtures = __DIR__ . '/fixtures/PluginAssetsTest';
+		$a = $this->tmp . '/site/plugins/a';
+		F::write($a . '/index.php', '<?php Kirby::plugin("getkirby/a", []);');
+		F::write($a . '/assets/test.css', 'test');
 
-		Dir::remove($this->fixtures);
-
-		$plugin = $this->fixtures . '/site/plugins/test';
-
-		F::write($plugin . '/index.php', '<?php Kirby::plugin("test/test", []);');
-		F::write($plugin . '/assets/test.css', 'test');
-		F::write($plugin . '/assets/test.mjs', 'test');
+		$b = $this->tmp . '/site/plugins/b';
+		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["foo/bar.css"]]);' );
+		F::write($b . '/foo/bar.css', 'test');
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures
+				'index' => $this->tmp
 			]
 		]);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove($this->tmp);
 	}
 
 	public function testClean()
 	{
-		// create orphan
-		F::write($orphan = $this->fixtures . '/media/plugins/test/test/orphan.css', 'test');
+		// create orphans
+		F::write(
+			$a = $this->tmp . '/media/plugins/getkirby/a/orphan.css',
+			'test'
+		);
+		F::write(
+			$b= $this->tmp . '/media/plugins/getkirby/a/assets/orphan.css',
+			'test'
+		);
 
-		$this->assertFileExists($orphan);
+		$this->assertFileExists($a);
+		$this->assertFileExists($b);
 
-		PluginAssets::clean('test/test');
+		PluginAssets::clean('getkirby/a');
 
-		$this->assertFileDoesNotExist($orphan);
+		$this->assertFileDoesNotExist($a);
+		$this->assertFileDoesNotExist($b);
 	}
 
 	public function testResolve()
 	{
-		$response = PluginAssets::resolve('test/test', 'test.css');
+		$response = PluginAssets::resolve('getkirby/b', 'foo/bar.css');
+		$media    = $this->tmp . '/media/plugins/getkirby/b/foo/bar.css';
 
-		$this->assertTrue(is_link($this->fixtures . '/media/plugins/test/test/test.css'));
+		$this->assertTrue(is_link($media));
 		$this->assertSame(200, $response->code());
 		$this->assertSame('text/css', $response->type());
+
+		$response = PluginAssets::resolve('getkirby/b', 'assets/foo.css');
+		$media    = $this->tmp . '/media/plugins/getkirby/b/assets/foo.css';
+		$this->assertNull($response);
+		$this->assertFalse(is_link($media));
 	}
 
-	public function testCallPluginAsset()
+	public function testResolveAutomaticFromAssetsFolder()
 	{
-		$response = App::instance()->call('media/plugins/test/test/test.mjs');
+		$response = PluginAssets::resolve('getkirby/a', 'assets/test.css');
+		$media    = $this->tmp . '/media/plugins/getkirby/a/assets/test.css';
 
+		$this->assertTrue(is_link($media));
 		$this->assertSame(200, $response->code());
-		$this->assertSame('text/javascript', $response->type());
-		$this->assertSame('test', $response->body());
+		$this->assertSame('text/css', $response->type());
+
+		$response = PluginAssets::resolve('getkirby/a', 'assets/foo.css');
+		$media    = $this->tmp . '/media/plugins/getkirby/a/assets/foo.css';
+		$this->assertNull($response);
+		$this->assertFalse(is_link($media));
 	}
 
 	public function testCallPluginAssetInvalid()

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -18,11 +18,11 @@ class PluginAssetsTest extends TestCase
 		F::write($a . '/assets/test.css', 'test');
 
 		$b = $this->tmp . '/site/plugins/b';
-		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["'. $b .'/foo/bar.css"]]);' );
+		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["' . $b . '/foo/bar.css"]]);');
 		F::write($b . '/foo/bar.css', 'test');
 
 		$c = $this->tmp . '/site/plugins/c';
-		F::write($c . '/index.php', '<?php Kirby::plugin("getkirby/c", ["assets" => ["test.css" => "'. $c .'/foo/bar.css"]]);' );
+		F::write($c . '/index.php', '<?php Kirby::plugin("getkirby/c", ["assets" => ["test.css" => "' . $c . '/foo/bar.css"]]);');
 		F::write($c . '/foo/bar.css', 'test');
 
 		$this->app = new App([
@@ -77,7 +77,7 @@ class PluginAssetsTest extends TestCase
 
 		$this->assertTrue(is_link($media));
 		$this->assertSame(200, $response->code());
-		$this->assertSame('text/css', $response->type());;
+		$this->assertSame('text/css', $response->type());
 	}
 
 	public function testResolveAutomaticFromAssetsFolder()

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -18,8 +18,12 @@ class PluginAssetsTest extends TestCase
 		F::write($a . '/assets/test.css', 'test');
 
 		$b = $this->tmp . '/site/plugins/b';
-		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["foo/bar.css"]]);' );
+		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["'. $b .'/foo/bar.css"]]);' );
 		F::write($b . '/foo/bar.css', 'test');
+
+		$c = $this->tmp . '/site/plugins/c';
+		F::write($c . '/index.php', '<?php Kirby::plugin("getkirby/c", ["assets" => ["test.css" => "'. $c .'/foo/bar.css"]]);' );
+		F::write($c . '/foo/bar.css', 'test');
 
 		$this->app = new App([
 			'roots' => [
@@ -67,6 +71,13 @@ class PluginAssetsTest extends TestCase
 		$media    = $this->tmp . '/media/plugins/getkirby/b/assets/foo.css';
 		$this->assertNull($response);
 		$this->assertFalse(is_link($media));
+
+		$response = PluginAssets::resolve('getkirby/c', 'test.css');
+		$media    = $this->tmp . '/media/plugins/getkirby/c/test.css';
+
+		$this->assertTrue(is_link($media));
+		$this->assertSame(200, $response->code());
+		$this->assertSame('text/css', $response->type());;
 	}
 
 	public function testResolveAutomaticFromAssetsFolder()

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -67,38 +67,80 @@ class PluginTest extends TestCase
 	}
 
 	/**
+	 * @covers ::asset
+	 */
+	public function testAsset()
+	{
+		$root = __DIR__ . '/fixtures/plugin-assets';
+		$plugin = new Plugin('getkirby/test-plugin', [
+			'assets' => [
+				'c.css' => $a = $root . '/a.css',
+				'd.css' => $b = $root . '/foo/b.css'
+			]
+		]);
+
+		$this->assertSame($a, $plugin->asset('c.css'));
+		$this->assertSame($b, $plugin->asset('d.css'));
+	}
+
+	/**
 	 * @covers ::assets
 	 */
 	public function testAssets()
 	{
-		// assets defined in the plugin config
+		$root = __DIR__ . '/fixtures/plugin-assets';
+
+		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => __DIR__ . '/fixtures/plugin-assets',
-			'assets' => $assets = [
-				'a.css',
-				'b.css'
+			'root'   => $root,
+			'assets' => [
+				'c.css' => $root . '/a.css',
+				'd.css' => $root . '/foo/b.css'
 			]
 		]);
 
-		$this->assertSame($assets, $plugin->assets());
+		$expected = [
+			'c.css' => $root . '/a.css',
+			'd.css' =>	$root . '/foo/b.css'
+		];
+
+		$this->assertSame($expected, $plugin->assets());
+
+		// assets defined as non-associative array in the plugin config
+		$plugin = new Plugin('getkirby/test-plugin', [
+			'root'   => $root,
+			'assets' => [
+				$root . '/a.css',
+				$root . '/foo/b.css'
+			]
+		]);
+
+		$expected = [
+			'a.css'     => $root . '/a.css',
+			'foo/b.css' =>	$root . '/foo/b.css'
+		];
+
+		$this->assertSame($expected, $plugin->assets());
 
 		// assets defined als closure in the plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'root'   => __DIR__ . '/fixtures/plugin-assets',
 			'assets' => fn () => [
-				'a.css',
-				'b.css'
+				$root . '/a.css',
+				$root . '/foo/b.css'
 			]
 		]);
 
-		$this->assertSame($assets, $plugin->assets());
+		$this->assertSame($expected, $plugin->assets());
 
 		// assets gathered from `assets` folder inside plugin root
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'root' => __DIR__ . '/fixtures/plugin-assets'
 		]);
 
-		$this->assertSame(['assets/test.css'], $plugin->assets());
+		$this->assertSame([
+			'assets/test.css' => $root . '/assets/test.css',
+		], $plugin->assets());
 	}
 
 	/**

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -67,6 +67,41 @@ class PluginTest extends TestCase
 	}
 
 	/**
+	 * @covers ::assets
+	 */
+	public function testAssets()
+	{
+		// assets defined in the plugin config
+		$plugin = new Plugin('getkirby/test-plugin', [
+			'root'   => __DIR__ . '/fixtures/plugin-assets',
+			'assets' => $assets = [
+				'a.css',
+				'b.css'
+			]
+		]);
+
+		$this->assertSame($assets, $plugin->assets());
+
+		// assets defined als closure in the plugin config
+		$plugin = new Plugin('getkirby/test-plugin', [
+			'root'   => __DIR__ . '/fixtures/plugin-assets',
+			'assets' => fn () => [
+				'a.css',
+				'b.css'
+			]
+		]);
+
+		$this->assertSame($assets, $plugin->assets());
+
+		// assets gathered from `assets` folder inside plugin root
+		$plugin = new Plugin('getkirby/test-plugin', [
+			'root' => __DIR__ . '/fixtures/plugin-assets'
+		]);
+
+		$this->assertSame(['assets/test.css'], $plugin->assets());
+	}
+
+	/**
 	 * @covers ::authors
 	 */
 	public function testAuthors()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features
- New `assets` extension that allows plugins to specify assets from custom paths and with a wider range of extensions than previously supported. https://github.com/getkirby/kirby/issues/5247

### Breaking changes
- Files in a plugin's `assets` directory are now always assumed to be public, independent of their file extension. If your plugin needs to store other files in the assets directory, please use the new `assets` extension to explicitly define the public assets.