### PR TITLE
`Str::template`: support single/double curly brace

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -116,11 +116,7 @@ class Exception extends \Exception
 			}
 
 			// format message with passed data
-			$message = Str::template($message, $this->data, [
-				'fallback' => '-',
-				'start'    => '{',
-				'end'      => '}'
-			]);
+			$message = Str::template($message, $this->data, ['fallback' => '-']);
 
 			// handover to Exception parent class constructor
 			parent::__construct($message, 0, $args['previous'] ?? null);

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -120,11 +120,7 @@ class I18n
 
 		$template = static::translate($key, $fallback, $locale);
 
-		return Str::template($template, $replace, [
-			'fallback' => '-',
-			'start'    => '{',
-			'end'      => '}'
-		]);
+		return Str::template($template, $replace, ['fallback' => '-']);
 	}
 
 	/**
@@ -332,6 +328,6 @@ class I18n
 			$count = static::formatNumber($count, $locale);
 		}
 
-		return str_replace('{{ count }}', (string)$count, $message);
+		return Str::template($message, compact('count'));
 	}
 }

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1246,8 +1246,8 @@ class Str
 		array $data = [],
 		array $options = []
 	): string {
-		$start    = $options['start'] ?? '{{';
-		$end      = $options['end'] ?? '}}';
+		$start    = $options['start'] ?? '{{1,2}';
+		$end      = $options['end'] ?? '}{1,2}';
 		$fallback = $options['fallback'] ?? null;
 		$callback = $options['callback'] ?? null;
 

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -412,12 +412,15 @@ class I18nTest extends TestCase
 	{
 		I18n::$translations = [
 			'en' => [
-				'car' => '{{ count }} car(s)'
+				'car'  => '{{ count }} car(s)',
+				'bike' => '{ count } bike(s)'
 			]
 		];
 
 		$this->assertSame('1 car(s)', I18n::translateCount('car', 1));
 		$this->assertSame('2 car(s)', I18n::translateCount('car', 2));
+		$this->assertSame('1 bike(s)', I18n::translateCount('bike', 1));
+		$this->assertSame('2 bike(s)', I18n::translateCount('bike', 2));
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1282,6 +1282,25 @@ EOT;
 	}
 
 	/**
+	 * @covers ::template
+	 */
+	public function testTemplateStartEnd()
+	{
+		$this->assertSame(
+			'From a to b',
+			Str::template('From {{ b }} to {{ a }}', ['a' => 'b', 'b' => 'a'])
+		);
+		$this->assertSame(
+			'From a to b',
+			Str::template('From { b } to { a }', ['a' => 'b', 'b' => 'a'])
+		);
+		$this->assertSame(
+			'From a to b',
+			Str::template('From dbf to daf', ['a' => 'b', 'b' => 'a'], ['start' => 'd', 'end' => 'f'])
+		);
+	}
+
+	/**
 	 * @covers ::toBytes
 	 */
 	public function testToBytes()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- `Str::template()` support single and double curly braces as start/end delimiters by default

### Breaking changes



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
