### PR TITLE
Items: expose options slot for table layout

### DIFF
--- a/panel/src/components/Collection/Collection.vue
+++ b/panel/src/components/Collection/Collection.vue
@@ -20,7 +20,7 @@
 			@option="onOption"
 			@sort="$emit('sort', $event)"
 		>
-			<template #options="{ item, itemIndex: index }">
+			<template #options="{ item, index }">
 				<slot name="options" v-bind="{ item, index }" />
 			</template>
 		</k-items>

--- a/panel/src/components/Collection/Items.vue
+++ b/panel/src/components/Collection/Items.vue
@@ -6,7 +6,11 @@
 		@change="$emit('change', $event)"
 		@sort="$emit('sort', $event)"
 		@option="onOption"
-	/>
+	>
+		<template #options="{ row: item, rowIndex: index }">
+			<slot name="options" v-bind="{ item, index }" />
+		</template>
+	</k-table>
 
 	<!-- Layout: cards, cardlets, list -->
 	<k-draggable
@@ -38,7 +42,7 @@
 					@option="onOption($event, item, itemIndex)"
 				>
 					<template #options>
-						<slot name="options" v-bind="{ item, itemIndex }" />
+						<slot name="options" v-bind="{ item, itemIndex: index }" />
 					</template>
 				</k-item>
 			</slot>

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -54,69 +54,71 @@
 				</tr>
 
 				<!-- Rows -->
-				<tr v-for="(row, rowIndex) in values" v-else :key="rowIndex">
-					<!-- Index & drag handle -->
-					<td
-						v-if="hasIndexColumn"
-						:data-sortable="sortable && row.sortable !== false"
-						data-mobile
-						class="k-table-index-column"
-					>
-						<slot
-							name="index"
-							v-bind="{
-								row,
-								rowIndex
-							}"
+				<template v-else>
+					<tr v-for="(row, rowIndex) in values" :key="rowIndex">
+						<!-- Index & drag handle -->
+						<td
+							v-if="hasIndexColumn"
+							:data-sortable="sortable && row.sortable !== false"
+							data-mobile
+							class="k-table-index-column"
 						>
-							<div class="k-table-index" v-text="index + rowIndex" />
-						</slot>
+							<slot
+								name="index"
+								v-bind="{
+									row,
+									rowIndex
+								}"
+							>
+								<div class="k-table-index" v-text="index + rowIndex" />
+							</slot>
 
-						<k-sort-handle
-							v-if="sortable && row.sortable !== false"
-							class="k-table-sort-handle"
-						/>
-					</td>
-
-					<!-- Cell -->
-					<k-table-cell
-						v-for="(column, columnIndex) in columns"
-						:key="rowIndex + '-' + columnIndex"
-						:column="column"
-						:field="fields[columnIndex]"
-						:row="row"
-						:mobile="column.mobile"
-						:value="row[columnIndex]"
-						:style="'width:' + width(column.width)"
-						class="k-table-column"
-						@click.native="
-							onCell({
-								row,
-								rowIndex,
-								column,
-								columnIndex
-							})
-						"
-						@input="
-							onCellUpdate({
-								columnIndex,
-								rowIndex,
-								value: $event
-							})
-						"
-					/>
-
-					<!-- Options -->
-					<td v-if="hasOptions" data-mobile class="k-table-options-column">
-						<slot name="options" v-bind="{ row, rowIndex, options }">
-							<k-options-dropdown
-								:options="row.options ?? options"
-								:text="(row.options ?? options).length > 1"
-								@option="onOption($event, row, rowIndex)"
+							<k-sort-handle
+								v-if="sortable && row.sortable !== false"
+								class="k-table-sort-handle"
 							/>
-						</slot>
-					</td>
-				</tr>
+						</td>
+
+						<!-- Cell -->
+						<k-table-cell
+							v-for="(column, columnIndex) in columns"
+							:key="rowIndex + '-' + columnIndex"
+							:column="column"
+							:field="fields[columnIndex]"
+							:row="row"
+							:mobile="column.mobile"
+							:value="row[columnIndex]"
+							:style="'width:' + width(column.width)"
+							class="k-table-column"
+							@click.native="
+								onCell({
+									row,
+									rowIndex,
+									column,
+									columnIndex
+								})
+							"
+							@input="
+								onCellUpdate({
+									columnIndex,
+									rowIndex,
+									value: $event
+								})
+							"
+						/>
+
+						<!-- Options -->
+						<td v-if="hasOptions" data-mobile class="k-table-options-column">
+							<slot name="options" v-bind="{ row, rowIndex }">
+								<k-options-dropdown
+									:options="row.options ?? options"
+									:text="(row.options ?? options).length > 1"
+									@option="onOption($event, row, rowIndex)"
+								/>
+							</slot>
+						</td>
+					</tr>
+				</template>
 			</k-draggable>
 		</table>
 
@@ -237,6 +239,7 @@ export default {
 		 */
 		hasOptions() {
 			return (
+				this.$scopedSlots.options ||
 				this.options?.length > 0 ||
 				Object.values(this.values).filter((row) => row.options).length > 0
 			);

--- a/panel/src/components/Navigation/ButtonGroup.vue
+++ b/panel/src/components/Navigation/ButtonGroup.vue
@@ -1,18 +1,19 @@
 <template>
 	<div :data-layout="layout" class="k-button-group">
 		<slot v-if="$slots.default" />
-		<k-button
-			v-for="(button, index) in buttons"
-			v-else
-			:key="index"
-			v-bind="{
-				variant,
-				theme,
-				size,
-				responsive,
-				...button
-			}"
-		/>
+		<template v-else>
+			<k-button
+				v-for="(button, index) in buttons"
+				:key="index"
+				v-bind="{
+					variant,
+					theme,
+					size,
+					responsive,
+					...button
+				}"
+			/>
+		</template>
 	</div>
 </template>
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `k-collection` and `k-items`: `options` slot gets properly exposed also for table layout
