### PR TITLE
Add CLI specific config file 

### DIFF
--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -772,7 +772,7 @@ class Environment
 
 	/**
 	 * Loads and returns options from environment-specific
-	 * PHP files (by cli, host name and server IP address)
+	 * PHP files (by host name and server IP address or CLI)
 	 *
 	 * @param string $root Root directory to load configs from
 	 */

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -772,12 +772,21 @@ class Environment
 
 	/**
 	 * Loads and returns options from environment-specific
-	 * PHP files (by host name and server IP address)
+	 * PHP files (by cli, host name and server IP address)
 	 *
 	 * @param string $root Root directory to load configs from
 	 */
 	public function options(string $root): array
 	{
+		// load the config for the cli
+		if ($this->cli() === true) {
+			return F::load(
+				file: $root . '/config.cli.php',
+				fallback: [],
+				allowOutput: false
+			);
+		}
+
 		$configHost = [];
 		$configAddr = [];
 

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -778,20 +778,21 @@ class Environment
 	 */
 	public function options(string $root): array
 	{
-		// load the config for the cli
-		if ($this->cli() === true) {
-			return F::load(
-				file: $root . '/config.cli.php',
-				fallback: [],
-				allowOutput: false
-			);
-		}
-
+		$configCli  = [];
 		$configHost = [];
 		$configAddr = [];
 
 		$host = $this->host();
 		$addr = $this->ip();
+
+		// load the config for the cli
+		if ($this->cli() === true) {
+			$configCli = F::load(
+				file: $root . '/config.cli.php',
+				fallback: [],
+				allowOutput: false
+			);
+		}
 
 		// load the config for the host
 		if (empty($host) === false) {
@@ -811,7 +812,7 @@ class Environment
 			);
 		}
 
-		return array_replace_recursive($configHost, $configAddr);
+		return array_replace_recursive($configCli, $configHost, $configAddr);
 	}
 
 	/**

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -51,9 +51,7 @@ class EnvironmentTest extends TestCase
 	{
 		$env = new Environment([
 			'allowed' => '/'
-		], [
-
-		]);
+		], []);
 
 		$this->assertSame('/', $env->baseUrl());
 		$this->assertNull($env->host());
@@ -63,9 +61,7 @@ class EnvironmentTest extends TestCase
 	{
 		$env = new Environment([
 			'allowed' => '/subfolder'
-		], [
-
-		]);
+		], []);
 
 		$this->assertSame('/subfolder', $env->baseUrl());
 		$this->assertNull($env->host());
@@ -1103,6 +1099,15 @@ class EnvironmentTest extends TestCase
 		$this->assertSame([], $env->options($this->config));
 	}
 
+	public function testOptionsFromCLI()
+	{
+		$env = new Environment([
+			'cli' => true
+		]);
+
+		$this->assertSame('test cli option', $env->options($this->config)['test']);
+	}
+
 	/**
 	 * @covers ::path
 	 */
@@ -1570,7 +1575,7 @@ class EnvironmentTest extends TestCase
 		$expected = [];
 
 		foreach ($this->providerForSanitize() as $row) {
-			$input   [$row[0]] = $row[1];
+			$input[$row[0]] = $row[1];
 			$expected[$row[0]] = $row[2];
 		}
 

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -1089,6 +1089,7 @@ class EnvironmentTest extends TestCase
 	public function testOptionsFromInvalidHost()
 	{
 		$env = new Environment([
+			'cli' => false,
 			'allowed' => [
 				'http://example.de'
 			]

--- a/tests/Http/fixtures/EnvironmentTest/config.cli.php
+++ b/tests/Http/fixtures/EnvironmentTest/config.cli.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'test' => 'test cli option'
+];


### PR DESCRIPTION
## This PR …
Adds the option to define a CLI specific config file `config.cli.php`. You can already do something like this by using the `ready` callback and define your CLI specific options in there. Probably only for edge cases but when you need CLI specific options I think this would fit in quite nicely with the current system of environment (host name or ip address) specific options.

```php
// config.php
return [
    'ready' => function (App $kirby) {
        $options = [
            //
        ];

        if ($kirby->environment()->cli()) {
            $options = array_merge($options, [
                'option.one' => 1,
                'option.two' => 2,
            ]);
        }

        return $options;
    }
];

// config.cli.php
return [
    'option.one' => 1,
    'option.two' => 2,
];
```

Related: https://discord.com/channels/525634039965679616/525641819854471168/1149657559746224188

### Breaking changes
Hopefully none.

## Ready?
- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
