### PR TITLE
Deprecate `k-dropdown`

### DIFF
--- a/panel/src/components/Dialogs/SearchDialog.vue
+++ b/panel/src/components/Dialogs/SearchDialog.vue
@@ -11,28 +11,27 @@
 	>
 		<div class="k-search-dialog-input">
 			<!-- Type select -->
-			<k-dropdown class="k-search-dialog-types">
-				<k-button
-					:dropdown="true"
-					:icon="currentType.icon"
-					:text="currentType.label"
-					variant="dimmed"
-					@click="$refs.types.toggle()"
-				/>
-				<k-dropdown-content ref="types">
-					<k-dropdown-item
-						v-for="(typeItem, typeIndex) in $panel.searches"
-						:key="typeIndex"
-						:icon="typeItem.icon"
-						@click="
-							type = typeIndex;
-							focus();
-						"
-					>
-						{{ typeItem.label }}
-					</k-dropdown-item>
-				</k-dropdown-content>
-			</k-dropdown>
+			<k-button
+				:dropdown="true"
+				:icon="currentType.icon"
+				:text="currentType.label"
+				variant="dimmed"
+				class="k-search-dialog-types"
+				@click="$refs.types.toggle()"
+			/>
+			<k-dropdown-content ref="types">
+				<k-dropdown-item
+					v-for="(typeItem, typeIndex) in $panel.searches"
+					:key="typeIndex"
+					:icon="typeItem.icon"
+					@click="
+						type = typeIndex;
+						focus();
+					"
+				>
+					{{ typeItem.label }}
+				</k-dropdown-item>
+			</k-dropdown-content>
 
 			<!-- Input -->
 			<input

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -18,19 +18,19 @@
 				<slot name="options">
 					<template v-for="(option, index) in options">
 						<template v-if="option.dropdown">
-							<k-dropdown :key="index">
-								<k-button
-									v-bind="option"
-									class="k-drawer-option"
-									@click="$refs['dropdown-' + index][0].toggle()"
-								/>
-								<k-dropdown-content
-									:ref="'dropdown-' + index"
-									:options="option.dropdown"
-									align-x="end"
-									theme="light"
-								/>
-							</k-dropdown>
+							<k-button
+								:key="'btn-' + index"
+								v-bind="option"
+								class="k-drawer-option"
+								@click="$refs['dropdown-' + index][0].toggle()"
+							/>
+							<k-dropdown-content
+								:ref="'dropdown-' + index"
+								:key="'dropdown-' + index"
+								:options="option.dropdown"
+								align-x="end"
+								theme="light"
+							/>
 						</template>
 
 						<k-button

--- a/panel/src/components/Dropdowns/Dropdown.vue
+++ b/panel/src/components/Dropdowns/Dropdown.vue
@@ -6,9 +6,15 @@
 
 <script>
 /**
- * Dropdowns are constructed with two elements: `<k-dropdown>` is used as wrapper to position the dropdown relatively to the button (or any other element) that serves as toggle. `<k-dropdown-content>` holds any content shown when opening the dropdown: any number of `<k-dropdown-item>` elements or any other HTML.
+ * @deprecated 4.0.0 Use `<k-dropdown-content>` as standalone.
  */
-export default {};
+export default {
+	created() {
+		window.panel.deprecated(
+			"<k-dropdown> will be removed in a future version. Since Kirby 4.0, you don't need it anymore as wrapper element. Use `<k-dropdown-content>` as standalone instead."
+		);
+	}
+};
 </script>
 
 <style>

--- a/panel/src/components/Dropdowns/DropdownContent.vue
+++ b/panel/src/components/Dropdowns/DropdownContent.vue
@@ -38,8 +38,7 @@ import Vue from "vue";
 let OpenDropdown = null;
 
 /**
- * See `<k-dropdown>` for how to use these components together.
- * @internal
+ * Dropdowns are constructed with two elements: `<k-dropdown-content>` holds any content shown when opening the dropdown: any number of `<k-dropdown-item>` elements or any other HTML; typically a `<k-button>` then is used to call the `toggle()` method on `<k-dropdown-content>`.
  */
 export default {
 	props: {

--- a/panel/src/components/Dropdowns/LanguagesDropdown.vue
+++ b/panel/src/components/Dropdowns/LanguagesDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown v-if="languages.length > 1" class="k-languages-dropdown">
+	<div v-if="languages.length > 1" class="k-languages-dropdown">
 		<k-button
 			:dropdown="true"
 			:text="code"
@@ -9,8 +9,8 @@
 			variant="filled"
 			@click="$refs.languages.toggle()"
 		/>
-		<k-dropdown-content v-if="languages" ref="languages" :options="options" />
-	</k-dropdown>
+		<k-dropdown-content ref="languages" :options="options" />
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Dropdowns/OptionsDropdown.vue
+++ b/panel/src/components/Dropdowns/OptionsDropdown.vue
@@ -18,7 +18,7 @@
 	</k-button>
 
 	<!-- Multiple options = dropdown -->
-	<k-dropdown v-else-if="options.length" class="k-options-dropdown">
+	<div v-else-if="options.length" class="k-options-dropdown">
 		<k-button
 			:dropdown="true"
 			:icon="icon"
@@ -36,7 +36,7 @@
 			class="k-options-dropdown-content"
 			@action="onAction"
 		/>
-	</k-dropdown>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Dropdowns/SelectorDropdown.vue
+++ b/panel/src/components/Dropdowns/SelectorDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown class="k-selector-dropdown">
+	<div class="k-selector-dropdown">
 		<slot />
 		<k-dropdown-content
 			ref="dropdown"
@@ -18,7 +18,7 @@
 				@select="select"
 			/>
 		</k-dropdown-content>
-	</k-dropdown>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Forms/Autocomplete.vue
+++ b/panel/src/components/Forms/Autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown class="k-autocomplete">
+	<div class="k-autocomplete">
 		<!-- @slot Use to insert your input -->
 		<slot />
 		<k-dropdown-content
@@ -23,7 +23,7 @@
 			</k-dropdown-item>
 		</k-dropdown-content>
 		{{ query }}
-	</k-dropdown>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown class="k-block-options">
+	<div class="k-block-options">
 		<template v-if="isBatched">
 			<k-button
 				:title="$t('copy')"
@@ -115,7 +115,7 @@
 				</k-dropdown-item>
 			</k-dropdown-content>
 		</template>
-	</k-dropdown>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Forms/Field/ColorField.vue
+++ b/panel/src/components/Forms/Field/ColorField.vue
@@ -32,35 +32,20 @@
 		>
 			<template #before>
 				<template v-if="mode === 'picker'">
-					<k-dropdown>
-						<button
-							:style="!isInvalid ? 'color: ' + value : null"
-							class="k-color-field-preview k-color-preview"
-							type="button"
-							@click="$refs.picker.toggle()"
+					<button
+						:style="!isInvalid ? 'color: ' + value : null"
+						class="k-color-field-preview k-color-preview"
+						type="button"
+						@click="$refs.picker.toggle()"
+					/>
+					<k-dropdown-content ref="picker" class="k-color-field-picker">
+						<k-colorpicker-input
+							ref="color"
+							:alpha="alpha"
+							:value="value"
+							@input="onPicker"
 						/>
-						<k-dropdown-content ref="picker" class="k-color-field-picker">
-							<k-colorpicker-input
-								ref="color"
-								:alpha="alpha"
-								:value="value"
-								@input="onPicker"
-							/>
-
-							<div class="k-color-field-options">
-								<button
-									v-for="color in convertedOptions"
-									:key="color.value"
-									:aria-current="color.value === currentOption?.value"
-									:style="'color: ' + color.value"
-									:title="color.text ?? color.value"
-									type="button"
-									class="k-color-preview"
-									@click="$refs.input.$refs.input.onPaste(color.value)"
-								/>
-							</div>
-						</k-dropdown-content>
-					</k-dropdown>
+					</k-dropdown-content>
 				</template>
 				<div
 					v-else

--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -25,22 +25,20 @@
 				@submit="$emit('submit')"
 			>
 				<template v-if="calendar" #icon>
-					<k-dropdown>
-						<k-button
-							:icon="icon"
-							:title="$t('date.select')"
-							class="k-input-icon-button"
-							@click="$refs.calendar.toggle()"
+					<k-button
+						:icon="icon"
+						:title="$t('date.select')"
+						class="k-input-icon-button"
+						@click="$refs.calendar.toggle()"
+					/>
+					<k-dropdown-content ref="calendar" align-x="end">
+						<k-calendar
+							:value="value"
+							:min="min"
+							:max="max"
+							@input="onCalendarInput"
 						/>
-						<k-dropdown-content ref="calendar" align-x="end">
-							<k-calendar
-								:value="value"
-								:min="min"
-								:max="max"
-								@input="onCalendarInput"
-							/>
-						</k-dropdown-content>
-					</k-dropdown>
+					</k-dropdown-content>
 				</template>
 			</k-input>
 
@@ -60,21 +58,19 @@
 				@submit="$emit('submit')"
 			>
 				<template v-if="times" #icon>
-					<k-dropdown>
-						<k-button
-							:icon="time.icon ?? 'clock'"
-							:title="$t('time.select')"
-							class="k-input-icon-button"
-							@click="$refs.times.toggle()"
+					<k-button
+						:icon="time.icon ?? 'clock'"
+						:title="$t('time.select')"
+						class="k-input-icon-button"
+						@click="$refs.times.toggle()"
+					/>
+					<k-dropdown-content ref="times" align-x="end">
+						<k-times
+							:display="time.display"
+							:value="value"
+							@input="onTimesInput"
 						/>
-						<k-dropdown-content ref="times" align-x="end">
-							<k-times
-								:display="time.display"
-								:value="value"
-								@input="onTimesInput"
-							/>
-						</k-dropdown-content>
-					</k-dropdown>
+					</k-dropdown-content>
 				</template>
 			</k-input>
 		</div>

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -3,29 +3,27 @@
 		<k-input v-bind="$props" :invalid="isInvalid" :icon="false" theme="field">
 			<div class="k-link-input-header">
 				<!-- Type selector -->
-				<k-dropdown>
-					<k-button
-						class="k-link-input-toggle"
-						:disabled="disabled"
-						:dropdown="true"
-						:icon="currentType.icon"
-						variant="filled"
-						@click="$refs.types.toggle()"
+				<k-button
+					class="k-link-input-toggle"
+					:disabled="disabled"
+					:dropdown="true"
+					:icon="currentType.icon"
+					variant="filled"
+					@click="$refs.types.toggle()"
+				>
+					{{ currentType.label }}
+				</k-button>
+				<k-dropdown-content ref="types">
+					<k-dropdown-item
+						v-for="(type, key) in activeTypes"
+						:key="key"
+						:current="key === linkType"
+						:icon="type.icon"
+						@click="switchType(key)"
 					>
-						{{ currentType.label }}
-					</k-button>
-					<k-dropdown-content ref="types">
-						<k-dropdown-item
-							v-for="(type, key) in activeTypes"
-							:key="key"
-							:current="key === linkType"
-							:icon="type.icon"
-							@click="switchType(key)"
-						>
-							{{ type.label }}
-						</k-dropdown-item>
-					</k-dropdown-content>
-				</k-dropdown>
+						{{ type.label }}
+					</k-dropdown-item>
+				</k-dropdown-content>
 
 				<!-- Input -->
 				<div

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -9,17 +9,15 @@
 			@input="$emit('input', $event ?? '')"
 		>
 			<template v-if="times" #icon>
-				<k-dropdown>
-					<k-button
-						:icon="icon ?? 'clock'"
-						:title="$t('time.select')"
-						class="k-input-icon-button"
-						@click="$refs.times.toggle()"
-					/>
-					<k-dropdown-content ref="times" align-x="end">
-						<k-times :display="display" :value="value" @input="select" />
-					</k-dropdown-content>
-				</k-dropdown>
+				<k-button
+					:icon="icon ?? 'clock'"
+					:title="$t('time.select')"
+					class="k-input-icon-button"
+					@click="$refs.times.toggle()"
+				/>
+				<k-dropdown-content ref="times" align-x="end">
+					<k-times :display="display" :value="value" @input="select" />
+				</k-dropdown-content>
 			</template>
 		</k-input>
 	</k-field>

--- a/panel/src/components/Forms/Layouts/Layout.vue
+++ b/panel/src/components/Forms/Layouts/Layout.vue
@@ -31,50 +31,45 @@
 				@click="openSettings"
 			/>
 
-			<k-dropdown>
-				<k-button
-					class="k-layout-toolbar-button"
-					icon="angle-down"
-					@click="$refs.options.toggle()"
-				/>
-				<k-dropdown-content ref="options" align-x="end">
-					<k-dropdown-item icon="angle-up" @click="$emit('prepend')">
-						{{ $t("insert.before") }}
-					</k-dropdown-item>
-					<k-dropdown-item icon="angle-down" @click="$emit('append')">
-						{{ $t("insert.after") }}
-					</k-dropdown-item>
-					<hr />
-					<k-dropdown-item
-						v-if="settings"
-						icon="settings"
-						@click="openSettings"
-					>
-						{{ $t("settings") }}
-					</k-dropdown-item>
-					<k-dropdown-item icon="copy" @click="$emit('duplicate')">
-						{{ $t("duplicate") }}
-					</k-dropdown-item>
-					<k-dropdown-item
-						:disabled="layouts.length === 1"
-						icon="dashboard"
-						@click="$emit('change')"
-					>
-						{{ $t("field.layout.change") }}
-					</k-dropdown-item>
-					<hr />
-					<k-dropdown-item icon="template" @click="$emit('copy')">
-						{{ $t("copy") }}
-					</k-dropdown-item>
-					<k-dropdown-item icon="download" @click="$emit('paste')">
-						{{ $t("paste.after") }}
-					</k-dropdown-item>
-					<hr />
-					<k-dropdown-item icon="trash" @click="remove">
-						{{ $t("field.layout.delete") }}
-					</k-dropdown-item>
-				</k-dropdown-content>
-			</k-dropdown>
+			<k-button
+				class="k-layout-toolbar-button"
+				icon="angle-down"
+				@click="$refs.options.toggle()"
+			/>
+			<k-dropdown-content ref="options" align-x="end">
+				<k-dropdown-item icon="angle-up" @click="$emit('prepend')">
+					{{ $t("insert.before") }}
+				</k-dropdown-item>
+				<k-dropdown-item icon="angle-down" @click="$emit('append')">
+					{{ $t("insert.after") }}
+				</k-dropdown-item>
+				<hr />
+				<k-dropdown-item v-if="settings" icon="settings" @click="openSettings">
+					{{ $t("settings") }}
+				</k-dropdown-item>
+				<k-dropdown-item icon="copy" @click="$emit('duplicate')">
+					{{ $t("duplicate") }}
+				</k-dropdown-item>
+				<k-dropdown-item
+					:disabled="layouts.length === 1"
+					icon="dashboard"
+					@click="$emit('change')"
+				>
+					{{ $t("field.layout.change") }}
+				</k-dropdown-item>
+				<hr />
+				<k-dropdown-item icon="template" @click="$emit('copy')">
+					{{ $t("copy") }}
+				</k-dropdown-item>
+				<k-dropdown-item icon="download" @click="$emit('paste')">
+					{{ $t("paste.after") }}
+				</k-dropdown-item>
+				<hr />
+				<k-dropdown-item icon="trash" @click="remove">
+					{{ $t("field.layout.delete") }}
+				</k-dropdown-item>
+			</k-dropdown-content>
+
 			<k-sort-handle />
 		</nav>
 	</section>

--- a/panel/src/components/Forms/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar.vue
@@ -9,16 +9,19 @@
 			/>
 
 			<!-- dropdown -->
-			<k-dropdown v-else-if="button.dropdown" :key="buttonIndex + '-dropdown'">
+			<template v-else-if="button.dropdown">
 				<k-button
-					:key="buttonIndex"
+					:key="buttonIndex + '-dropdown-btn'"
 					:icon="button.icon"
 					:title="button.label"
 					tabindex="-1"
 					class="k-toolbar-button"
 					@click="$refs[buttonIndex + '-dropdown'][0].toggle()"
 				/>
-				<k-dropdown-content :ref="buttonIndex + '-dropdown'">
+				<k-dropdown-content
+					:key="buttonIndex + '-dropdown'"
+					:ref="buttonIndex + '-dropdown'"
+				>
 					<k-dropdown-item
 						v-for="(dropdownItem, dropdownItemIndex) in button.dropdown"
 						:key="dropdownItemIndex"
@@ -28,7 +31,7 @@
 						{{ dropdownItem.label }}
 					</k-dropdown-item>
 				</k-dropdown-content>
-			</k-dropdown>
+			</template>
 
 			<!-- single button -->
 			<k-button

--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -9,7 +9,7 @@
 		}"
 	>
 		<!-- Nodes -->
-		<k-dropdown v-if="hasNodes" @mousedown.native.prevent>
+		<div v-if="hasNodes" @mousedown.native.prevent>
 			<k-button
 				:current="Boolean(activeNode)"
 				:icon="activeNode.icon ?? 'title'"
@@ -36,7 +36,7 @@
 					/>
 				</template>
 			</k-dropdown-content>
-		</k-dropdown>
+		</div>
 
 		<!-- Divider -->
 		<div v-if="hasNodes && hasMarks" class="k-toolbar-divider" />

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -1,9 +1,9 @@
 <template>
 	<nav :aria-label="label" class="k-breadcrumb">
-		<k-dropdown v-if="segments.length > 1" class="k-breadcrumb-dropdown">
+		<div v-if="segments.length > 1" class="k-breadcrumb-dropdown">
 			<k-button icon="home" @click="$refs.dropdown.toggle()" />
 			<k-dropdown-content ref="dropdown" :options="dropdown" />
-		</k-dropdown>
+		</div>
 
 		<ol>
 			<li v-for="(crumb, index) in segments" :key="index">

--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -162,7 +162,7 @@ export default {
 	max-width: 100cqw;
 	max-height: 100cqh;
 }
-.k-file-preview-thumb .k-dropdown {
+.k-file-preview-thumb > .k-button {
 	position: absolute;
 	top: var(--spacing-2);
 	inset-inline-start: var(--spacing-2);

--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -12,15 +12,13 @@
 					<img v-bind="image" @dragstart.prevent />
 				</k-coords-input>
 
-				<k-dropdown>
-					<k-button
-						icon="dots"
-						size="xs"
-						style="color: var(--color-gray-500)"
-						@click="$refs.dropdown.toggle()"
-					/>
-					<k-dropdown-content ref="dropdown" :options="options" theme="light" />
-				</k-dropdown>
+				<k-button
+					icon="dots"
+					size="xs"
+					style="color: var(--color-gray-500)"
+					@click="$refs.dropdown.toggle()"
+				/>
+				<k-dropdown-content ref="dropdown" :options="options" theme="light" />
 			</template>
 
 			<!-- Icon -->

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -28,23 +28,24 @@
 						target="_blank"
 						variant="filled"
 					/>
-					<k-dropdown class="k-file-view-options">
-						<k-button
-							:disabled="isLocked"
-							:dropdown="true"
-							:title="$t('settings')"
-							icon="cog"
-							size="sm"
-							variant="filled"
-							@click="$refs.settings.toggle()"
-						/>
-						<k-dropdown-content
-							ref="settings"
-							:options="$dropdown(id)"
-							align-x="end"
-							@action="action"
-						/>
-					</k-dropdown>
+
+					<k-button
+						:disabled="isLocked"
+						:dropdown="true"
+						:title="$t('settings')"
+						icon="cog"
+						size="sm"
+						variant="filled"
+						class="k-file-view-options"
+						@click="$refs.settings.toggle()"
+					/>
+					<k-dropdown-content
+						ref="settings"
+						:options="$dropdown(id)"
+						align-x="end"
+						@action="action"
+					/>
+
 					<k-languages-dropdown />
 				</k-button-group>
 

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -28,22 +28,22 @@
 						size="sm"
 						class="k-page-view-preview"
 					/>
-					<k-dropdown class="k-page-view-options">
-						<k-button
-							:disabled="isLocked === true"
-							:dropdown="true"
-							:title="$t('settings')"
-							icon="cog"
-							variant="filled"
-							size="sm"
-							@click="$refs.settings.toggle()"
-						/>
-						<k-dropdown-content
-							ref="settings"
-							:options="$dropdown(id)"
-							align-x="end"
-						/>
-					</k-dropdown>
+
+					<k-button
+						:disabled="isLocked === true"
+						:dropdown="true"
+						:title="$t('settings')"
+						icon="cog"
+						variant="filled"
+						size="sm"
+						class="k-page-view-options"
+						@click="$refs.settings.toggle()"
+					/>
+					<k-dropdown-content
+						ref="settings"
+						:options="$dropdown(id)"
+						align-x="end"
+					/>
 
 					<k-languages-dropdown />
 

--- a/panel/src/components/Views/System/TableUpdateStatusCell.vue
+++ b/panel/src/components/Views/System/TableUpdateStatusCell.vue
@@ -6,7 +6,7 @@
 		>
 			{{ value }}
 		</span>
-		<k-dropdown v-else>
+		<template v-else>
 			<k-button
 				class="k-table-update-status-cell-button"
 				:dropdown="true"
@@ -36,7 +36,7 @@
 					</k-button>
 				</template>
 			</k-dropdown-content>
-		</k-dropdown>
+		</template>
 	</div>
 </template>
 

--- a/panel/src/components/Views/Users/UserAvatar.vue
+++ b/panel/src/components/Views/Users/UserAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown>
+	<div>
 		<k-button
 			:title="$t('avatar')"
 			variant="filled"
@@ -25,7 +25,7 @@
 				}
 			]"
 		/>
-	</k-dropdown>
+	</div>
 </template>
 
 <script>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -27,22 +27,21 @@
 
 			<template #buttons>
 				<k-button-group>
-					<k-dropdown class="k-user-view-options">
-						<k-button
-							:disabled="isLocked"
-							:dropdown="true"
-							:title="$t('settings')"
-							icon="cog"
-							size="sm"
-							variant="filled"
-							@click="$refs.settings.toggle()"
-						/>
-						<k-dropdown-content
-							ref="settings"
-							align-x="end"
-							:options="$dropdown(id)"
-						/>
-					</k-dropdown>
+					<k-button
+						:disabled="isLocked"
+						:dropdown="true"
+						:title="$t('settings')"
+						icon="cog"
+						size="sm"
+						variant="filled"
+						class="k-user-view-options"
+						@click="$refs.settings.toggle()"
+					/>
+					<k-dropdown-content
+						ref="settings"
+						align-x="end"
+						:options="$dropdown(id)"
+					/>
 					<k-languages-dropdown />
 				</k-button-group>
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Deprecated
- `<k-dropdown>` was deprecated. Use `<k-dropdown-content>` as standalone instead.
