### PR TITLE
Remove deprecated `DS`

### DIFF
--- a/config/setup.php
+++ b/config/setup.php
@@ -1,12 +1,6 @@
 <?php
 
 /**
- * Constants
- * @deprecated 3.8.0 Use `/` instead
- */
-define('DS', '/');
-
-/**
  * Class aliases
  */
 $aliases = require_once __DIR__ . '/aliases.php';


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Breaking changes
- Removed deprecated `DS` constant. Use `/` instead.
