### PR TITLE
`Panel\Menu::link()` helper for custom menu links

### DIFF
--- a/config/areas/site.php
+++ b/config/areas/site.php
@@ -1,6 +1,9 @@
 <?php
 
+use Kirby\Cms\App;
+use Kirby\Panel\Menu;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 return function ($kirby) {
 	return [
@@ -10,6 +13,23 @@ return function ($kirby) {
 		'icon'      => 'home',
 		'label'     => $kirby->site()->blueprint()->title() ?? I18n::translate('view.site'),
 		'menu'      => true,
+		'current'   => function (string|null $id = null) {
+			if ($id !== 'site') {
+				return false;
+			}
+
+			// ensure that site menu entry is not shown as current
+			// when a custom Panel menu link is active
+			$path = App::instance()->request()->path()->toString();
+
+			foreach (Menu::$links as $page) {
+				if (Str::contains($path, $page['link']) === true) {
+					return false;
+				}
+			}
+
+			return true;
+		},
 		'dialogs'   => require __DIR__ . '/site/dialogs.php',
 		'drawers'   => require __DIR__ . '/site/drawers.php',
 		'dropdowns' => require __DIR__ . '/site/dropdowns.php',

--- a/src/Panel/Menu.php
+++ b/src/Panel/Menu.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel;
 use Closure;
 use Kirby\Cms\App;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 /**
  * The Menu class takes care of gathering
@@ -19,6 +20,8 @@ use Kirby\Toolkit\I18n;
  */
 class Menu
 {
+	public static array $links = [];
+
 	public function __construct(
 		protected array $areas = [],
 		protected array $permissions = [],
@@ -184,6 +187,27 @@ class Menu
 		}
 
 		return $this->current === $id;
+	}
+
+	/**
+	 * Helper method to create the menu entry data
+	 * and register a custom link for the Panel menu
+	 */
+	public static function link(
+		string $link,
+		string $label,
+		string|null $icon = null,
+		Closure|bool|null $current = null
+	): array {
+		return static::$links[] = [
+			'label'   => I18n::translate($label, $label),
+			'link'    => $link,
+			'icon'    => $icon,
+			'current' => $current ?? fn () => Str::contains(
+				App::instance()->request()->path()->toString(),
+				$link
+			)
+		];
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Credits to @lukaskleinschmidt 

- [ ] @bastianallgeier do you think this makes sense to include in the core?
- [ ] Unit tests

### Enhancement
- New `Panel\Menu::link()` helper method to generate custom Panel menu links:

```php
'panel' => [
	'menu' => [
		'site',
		'-',
		'fields' => Menu::link('pages/fields', 'Fields', 'pen'),
		'sections' => Menu::link('pages/sections', 'Sections', 'grid'),
	]
]
```

Registering those links with the helper will also ensure that the `site` menu entry is not shown as current when one of the custom links is active/current (even though the linked target likely will lie within the site area).
