### PR TITLE
Fix `$collection->group()` for case-sensitive

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -168,9 +168,7 @@ class Collection extends BaseCollection
 				}
 
 				// ignore upper/lowercase for group names
-				if ($i) {
-					$value = Str::lower($value);
-				}
+				$value = $i === true ? Str::lower($value) : (string)$value;
 
 				if (isset($groups->data[$value]) === false) {
 					// create a new entry for the group if it does not exist yet

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -531,7 +531,7 @@ class Collection extends Iterator implements Countable
 				$value = $this->getAttribute($item, $field);
 
 				// ignore upper/lowercase for group names
-				return $i === true ? Str::lower($value) : $value;
+				return $i === true ? Str::lower($value) : (string)$value;
 			});
 		}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fix `$collection->group()` for case-sensitive
#5628


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
