### PR TITLE
`$collection->group()`: rename parameter to `$caseInsensitive`

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -147,11 +147,11 @@ class Collection extends BaseCollection
 	 * with an item for each group and a collection for each group.
 	 *
 	 * @param string|Closure $field
-	 * @param bool $i Ignore upper/lowercase for group names
+	 * @param bool $caseInsensitive Ignore upper/lowercase for group names
 	 * @return \Kirby\Cms\Collection
 	 * @throws \Kirby\Exception\Exception
 	 */
-	public function group($field, bool $i = true)
+	public function group($field, bool $caseInsensitive = true)
 	{
 		if (is_string($field) === true) {
 			$groups = new Collection([], $this->parent());
@@ -164,8 +164,12 @@ class Collection extends BaseCollection
 					throw new InvalidArgumentException('Invalid grouping value for key: ' . $key);
 				}
 
+				$value = (string)$value;
+
 				// ignore upper/lowercase for group names
-				$value = $i === true ? Str::lower($value) : (string)$value;
+				if ($caseInsensitive === true) {
+					$value = Str::lower($value);
+				}
 
 				if (isset($groups->data[$value]) === false) {
 					// create a new entry for the group if it does not exist yet
@@ -179,7 +183,7 @@ class Collection extends BaseCollection
 			return $groups;
 		}
 
-		return parent::group($field, $i);
+		return parent::group($field, $caseInsensitive);
 	}
 
 	/**

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -530,7 +530,7 @@ class Collection extends Iterator implements Countable
 
 				// ignore upper/lowercase for group names
 				if ($caseInsensitive === true) {
-					$value = Str::lower($value);
+					return Str::lower($value);
 				}
 
 				return (string)$value;

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -516,21 +516,24 @@ class Collection extends Iterator implements Countable
 	 * Groups the elements by a given field or callback function
 	 *
 	 * @param string|Closure $field
-	 * @param bool $i
 	 * @return \Kirby\Toolkit\Collection A new collection with an element for
 	 *                                   each group and a subcollection in
 	 *                                   each group
 	 * @throws \Exception if $field is not a string nor a callback function
 	 */
-	public function group($field, bool $i = true)
+	public function group($field, bool $caseInsensitive = true)
 	{
 		// group by field name
 		if (is_string($field) === true) {
-			return $this->group(function ($item) use ($field, $i) {
+			return $this->group(function ($item) use ($field, $caseInsensitive) {
 				$value = $this->getAttribute($item, $field);
 
 				// ignore upper/lowercase for group names
-				return $i === true ? Str::lower($value) : (string)$value;
+				if ($caseInsensitive === true) {
+					$value = Str::lower($value);
+				}
+
+				return (string)$value;
 			});
 		}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge https://github.com/getkirby/kirby/pull/5631 first

### Breaking changes
- Renamed parameter of  `::group()` method of all collection classes to `$caseInsensitive`
