### PR TITLE
Deprecate `Collection::$caseSensitive`

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -5,6 +5,7 @@ namespace Kirby\Toolkit;
 use Closure;
 use Countable;
 use Exception;
+use Kirby\Cms\Helpers;
 
 /**
  * The collection class provides a nicer
@@ -29,6 +30,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Whether the collection keys should be
 	 * treated as case-sensitive
+	 * @deprecated 4.0.0
 	 *
 	 * @var bool
 	 */
@@ -61,8 +63,13 @@ class Collection extends Iterator implements Countable
 	 */
 	public function __construct(array $data = [], bool $caseSensitive = false)
 	{
-		$this->caseSensitive = $caseSensitive;
 		$this->set($data);
+
+		/** TODO: remove in v5 */
+		if ($caseSensitive === true) {
+			Helpers::deprecated('The `$caseSensitive` prop in `' . static::class . '` class has been deprecated and will be removed in a future version.', 'collection-caseSensitive-prop');
+			$this->caseSensitive = $caseSensitive;
+		}
 	}
 
 	/**
@@ -82,10 +89,11 @@ class Collection extends Iterator implements Countable
 	 */
 	public function __get($key)
 	{
+		/** @codeCoverageIgnoreStart */
 		if ($this->caseSensitive === true) {
 			return $this->data[$key] ?? null;
 		}
-
+		/** @codeCoverageIgnoreEnd */
 		return $this->data[$key] ?? $this->data[strtolower($key)] ?? null;
 	}
 
@@ -98,10 +106,11 @@ class Collection extends Iterator implements Countable
 	 */
 	public function __set(string $key, $value): void
 	{
+		/** @codeCoverageIgnoreStart */
 		if ($this->caseSensitive !== true) {
 			$key = strtolower($key);
 		}
-
+		/** @codeCoverageIgnoreEnd */
 		$this->data[$key] = $value;
 	}
 

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -88,7 +88,7 @@ class CollectionTest extends TestCase
 	 * @covers ::get
 	 * @covers ::set
 	 */
-	public function testCaseSensitive()
+	public function testCaseInsensitive()
 	{
 		$normalCollection = new Collection([
 			'lowercase' => 'test1',
@@ -111,28 +111,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('test2', $normalCollection->get('uppercase'));
 		$this->assertSame('test3', $normalCollection->get('mIxEd'));
 		$this->assertSame('test4', $normalCollection->get('another'));
-
-		$sensitiveCollection = new Collection([
-			'lowercase' => 'test1',
-			'UPPERCASE' => 'test2',
-			'MiXeD'     => 'test3'
-		], true);
-		$sensitiveCollection->set('AnOtHeR', 'test4');
-
-		$this->assertSame([
-			'lowercase' => 'test1',
-			'UPPERCASE' => 'test2',
-			'MiXeD'     => 'test3',
-			'AnOtHeR'   => 'test4'
-		], $sensitiveCollection->data());
-		$this->assertSame('test1', $sensitiveCollection->get('lowercase'));
-		$this->assertSame('test2', $sensitiveCollection->get('UPPERCASE'));
-		$this->assertSame('test3', $sensitiveCollection->get('MiXeD'));
-		$this->assertSame('test4', $sensitiveCollection->get('AnOtHeR'));
-		$this->assertNull($sensitiveCollection->get('Lowercase'));
-		$this->assertNull($sensitiveCollection->get('uppercase'));
-		$this->assertNull($sensitiveCollection->get('mixed'));
-		$this->assertNull($sensitiveCollection->get('another'));
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Deprecated
- `Collection::$caseSensitive` has been deprecated and will be removed in a future version.
