### PR TITLE
Upload dialog: fix error overflow

### DIFF
--- a/panel/src/components/Dialogs/UploadDialog.vue
+++ b/panel/src/components/Dialogs/UploadDialog.vue
@@ -138,11 +138,11 @@ export default {
 	border-radius: var(--rounded);
 	background: var(--color-white);
 	box-shadow: var(--shadow);
-	height: 6rem;
+	min-height: 6rem;
 }
 .k-upload-item-preview {
 	grid-area: preview;
-	display: block;
+	display: flex;
 	width: 100%;
 	height: 100%;
 	overflow: hidden;
@@ -161,6 +161,7 @@ export default {
 	flex-direction: column;
 	justify-content: space-between;
 	padding: var(--spacing-2) var(--spacing-3);
+	min-width: 0;
 }
 .k-upload-item-input.k-input {
 	--input-color-border: transparent;

--- a/panel/src/components/Dialogs/UploadDialog.vue
+++ b/panel/src/components/Dialogs/UploadDialog.vue
@@ -52,12 +52,13 @@
 									- {{ file.progress }}%
 								</template>
 							</p>
-							<p class="k-upload-item-error">{{ file.error }}</p>
-						</div>
-						<div class="k-upload-item-progress">
+							<p v-if="file.error" class="k-upload-item-error">
+								{{ file.error }}
+							</p>
 							<k-progress
-								v-if="file.progress > 0 && !file.error"
+								v-else-if="file.progress"
 								:value="file.progress"
+								class="k-upload-item-progress"
 							/>
 						</div>
 						<div class="k-upload-item-toggle">
@@ -131,10 +132,9 @@ export default {
 	display: grid;
 	grid-template-areas:
 		"preview input input"
-		"preview body toggle"
-		"preview progress toggle";
+		"preview body toggle";
 	grid-template-columns: 6rem 1fr auto;
-	grid-template-rows: 1fr 1fr 1fr;
+	grid-template-rows: var(--input-height) 1fr;
 	border-radius: var(--rounded);
 	background: var(--color-white);
 	box-shadow: var(--shadow);
@@ -157,7 +157,10 @@ export default {
 
 .k-upload-item-body {
 	grid-area: body;
-	padding: var(--spacing-2) var(--spacing-3) 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding: var(--spacing-2) var(--spacing-3);
 }
 .k-upload-item-input.k-input {
 	--input-color-border: transparent;
@@ -185,10 +188,6 @@ export default {
 	color: var(--color-red-700);
 }
 .k-upload-item-progress {
-	padding-inline: var(--spacing-3);
-	align-self: end;
-	height: 1.375rem;
-	grid-area: progress;
 	--progress-height: 0.25rem;
 	--progress-color-back: var(--color-light);
 }


### PR DESCRIPTION
@bastianallgeier I feel like it's the right direction to merge the two grid rows - but if the error text gets really long, it'll still break the layout.