### PR TITLE
Fix failing first/one/row queries when using fetch closure

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -391,7 +391,7 @@ class Database
 				foreach ($results as $key => $result) {
 					$results[$key] = $options['fetch']($result, $key);
 				}
-			} else if ($options['method'] === 'fetch' && $results !== false) {
+			} elseif ($options['method'] === 'fetch' && $results !== false) {
 				// fetching a single record
 				$results = $options['fetch']($results);
 			}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3,9 +3,10 @@
 namespace Kirby\Database;
 
 use Closure;
-use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\Collection;
+use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 use PDO;
 use PDOStatement;
@@ -337,13 +338,16 @@ class Database
 	/**
 	 * Executes a sql query, which is expected to return a set of results
 	 */
-	public function query(string $query, array $bindings = [], array $params = [])
-	{
+	public function query(
+		string $query,
+		array $bindings = [],
+		array $params = []
+	) {
 		$defaults = [
 			'flag'     => null,
 			'method'   => 'fetchAll',
-			'fetch'    => 'Kirby\Toolkit\Obj',
-			'iterator' => 'Kirby\Toolkit\Collection',
+			'fetch'    => Obj::class,
+			'iterator' => Collection::class,
 		];
 
 		$options = array_merge($defaults, $params);
@@ -359,7 +363,7 @@ class Database
 		) {
 			$flags = PDO::FETCH_ASSOC;
 		} else {
-			$flags = PDO::FETCH_CLASS|PDO::FETCH_PROPS_LATE;
+			$flags = PDO::FETCH_CLASS | PDO::FETCH_PROPS_LATE;
 		}
 
 		// add optional flags
@@ -368,7 +372,10 @@ class Database
 		}
 
 		// set the fetch mode
-		if ($options['fetch'] instanceof Closure || $options['fetch'] === 'array') {
+		if (
+			$options['fetch'] instanceof Closure ||
+			$options['fetch'] === 'array'
+		) {
 			$this->statement->setFetchMode($flags);
 		} else {
 			$this->statement->setFetchMode($flags, $options['fetch']);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -393,7 +393,7 @@ class Database
 				}
 			} elseif ($options['method'] === 'fetch' && $results !== false) {
 				// fetching a single record
-				$results = $options['fetch']($results);
+				$results = $options['fetch']($results, null);
 			}
 		}
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -386,8 +386,14 @@ class Database
 
 		// apply the fetch closure to all results if given
 		if ($options['fetch'] instanceof Closure) {
-			foreach ($results as $key => $result) {
-				$results[$key] = $options['fetch']($result, $key);
+			if ($options['method'] === 'fetchAll') {
+				// fetching multiple records
+				foreach ($results as $key => $result) {
+					$results[$key] = $options['fetch']($result, $key);
+				}
+			} else if ($options['method'] === 'fetch' && $results !== false) {
+				// fetching a single record
+				$results = $options['fetch']($results);
 			}
 		}
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -821,13 +821,13 @@ class Query
 				if ($args[0] === null) {
 					return $current;
 
-					// ->where('username like "myuser"');
+				// ->where('username like "myuser"');
 				} elseif (is_string($args[0]) === true) {
 					// simply add the entire string to the where clause
 					// escaping or using bindings has to be done before calling this method
 					$result = $args[0];
 
-					// ->where(['username' => 'myuser']);
+				// ->where(['username' => 'myuser']);
 				} elseif (is_array($args[0]) === true) {
 					// simple array mode (AND operator)
 					$sql = $this->database->sql()->values($this->table, $args[0], ' AND ', true, true);
@@ -861,7 +861,7 @@ class Query
 					// store the bindings
 					$this->bindings($args[1]);
 
-					// ->where('username like ?', 'myuser')
+				// ->where('username like ?', 'myuser')
 				} elseif (is_string($args[0]) === true && is_string($args[1]) === true) {
 					// prepared where clause
 					$result = $args[0];
@@ -899,7 +899,7 @@ class Query
 						// add that to the where clause in parenthesis
 						$result = $key . ' ' . $predicate . ' (' . implode(', ', $values) . ')';
 
-						// ->where('username', 'like', 'myuser');
+					// ->where('username', 'like', 'myuser');
 					} else {
 						$predicates = [
 							'=', '>=', '>', '<=', '<', '<>', '!=', '<=>',

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -623,7 +623,7 @@ class Query
 	/**
 	 * Selects only one row from a table
 	 */
-	public function first(): object|array|false
+	public function first(): mixed
 	{
 		return $this->query($this->offset(0)->limit(1)->build('select'), [
 			'fetch'    => $this->fetch,
@@ -635,7 +635,7 @@ class Query
 	/**
 	 * Selects only one row from a table
 	 */
-	public function row(): object|array|false
+	public function row(): mixed
 	{
 		return $this->first();
 	}
@@ -643,7 +643,7 @@ class Query
 	/**
 	 * Selects only one row from a table
 	 */
-	public function one(): object|array|false
+	public function one(): mixed
 	{
 		return $this->first();
 	}
@@ -821,13 +821,13 @@ class Query
 				if ($args[0] === null) {
 					return $current;
 
-				// ->where('username like "myuser"');
+					// ->where('username like "myuser"');
 				} elseif (is_string($args[0]) === true) {
 					// simply add the entire string to the where clause
 					// escaping or using bindings has to be done before calling this method
 					$result = $args[0];
 
-				// ->where(['username' => 'myuser']);
+					// ->where(['username' => 'myuser']);
 				} elseif (is_array($args[0]) === true) {
 					// simple array mode (AND operator)
 					$sql = $this->database->sql()->values($this->table, $args[0], ' AND ', true, true);
@@ -861,7 +861,7 @@ class Query
 					// store the bindings
 					$this->bindings($args[1]);
 
-				// ->where('username like ?', 'myuser')
+					// ->where('username like ?', 'myuser')
 				} elseif (is_string($args[0]) === true && is_string($args[1]) === true) {
 					// prepared where clause
 					$result = $args[0];
@@ -899,7 +899,7 @@ class Query
 						// add that to the where clause in parenthesis
 						$result = $key . ' ' . $predicate . ' (' . implode(', ', $values) . ')';
 
-					// ->where('username', 'like', 'myuser');
+						// ->where('username', 'like', 'myuser');
 					} else {
 						$predicates = [
 							'=', '>=', '>', '<=', '<', '<>', '!=', '<=>',

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -301,6 +301,31 @@ class QueryTest extends TestCase
 			->one();
 	}
 
+	public function testFetch()
+	{
+		$query = $this->database
+			->table('users')
+			->where([
+				'username' => 'john'
+			])
+			->fetch(fn ($row) => $row['fname']);
+
+		$this->assertSame('John', (clone $query)->limit(1)->all()->first());
+		$this->assertSame('John', (clone $query)->first());
+		$this->assertSame('John', (clone $query)->row());
+
+		$falseQuery = $this->database
+			->table('users')
+			->where([
+				'username' => 'john-lennon-and-beatles'
+			])
+			->fetch(fn ($row) => $row['fname']);
+
+		$this->assertNull((clone $falseQuery)->limit(1)->all()->first());
+		$this->assertSame(false, (clone $falseQuery)->first());
+		$this->assertSame(false, (clone $falseQuery)->row());
+	}
+
 	public function testFind()
 	{
 		$user = $this->database


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- #5615 

This PR replaces #5639 so I can work on it instead Nico. I also added his reformatting from that PR, and added a unit test. 

Note: I had to change function descriptions on first/one/row, because since `->fetch()->first()` now works, it can return absolutely anything (in tests, I use the fetch function to return string)

cc @lukasbestle @distantnative 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
