### PR TITLE
Add callable support to $query->fetch()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -189,8 +189,12 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function fetch(string|Closure $fetch): static
+	public function fetch(string|callable|Closure $fetch): static
 	{
+		if (is_callable($fetch) === true) {
+			$fetch = Closure::fromCallable($fetch);
+		}
+
 		$this->fetch = $fetch;
 		return $this;
 	}

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -339,14 +339,17 @@ class QueryTest extends TestCase
 		$this->assertSame('John Lennon', (clone $query)->fetch([$this, 'fetchTestCallable'])->first());
 		$this->assertInstanceOf(
 			MockClassWithCallable::class,
-			(clone $query)->fetch([MockClassWithCallable::class, 'from_db'])->first()
+			(clone $query)->fetch([MockClassWithCallable::class, 'fromDb'])->first()
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'John Lennon',
-			(clone $query)->fetch('\Kirby\Database\MockClassWithCallable::from_db')->first()->name()
+			(clone $query)->fetch('\Kirby\Database\MockClassWithCallable::fromDb')->first()->name()
 		);
 	}
-	// Helper function for testFetch()
+	
+	/**
+	 * Helper function for testFetch()
+	 */
 	public function fetchTestCallable(array $row, $key = null)
 	{
 		return $row['fname'] . ' ' . $row['lname'];

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -7,6 +7,8 @@ use Kirby\Toolkit\Collection;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/mocks.php';
+
 /**
  * @coversDefaultClass \Kirby\Database\Database
  */
@@ -324,6 +326,30 @@ class QueryTest extends TestCase
 		$this->assertNull((clone $falseQuery)->limit(1)->all()->first());
 		$this->assertSame(false, (clone $falseQuery)->first());
 		$this->assertSame(false, (clone $falseQuery)->row());
+
+		$query = $this->database
+			->table('users')
+			->where(['username' => 'john']);
+
+		$x = function ($row, $key) {
+			return $row['fname'] . ' ' . $row['lname'];
+		};
+
+		$this->assertSame('John Lennon', (clone $query)->fetch($x)->first());
+		$this->assertSame('John Lennon', (clone $query)->fetch([$this, 'fetchTestCallable'])->first());
+		$this->assertInstanceOf(
+			MockClassWithCallable::class,
+			(clone $query)->fetch([MockClassWithCallable::class, 'from_db'])->first()
+		);
+		$this->assertEquals(
+			'John Lennon',
+			(clone $query)->fetch('\Kirby\Database\MockClassWithCallable::from_db')->first()->name()
+		);
+	}
+	// Helper function for testFetch()
+	public function fetchTestCallable(array $row, $key = null)
+	{
+		return $row['fname'] . ' ' . $row['lname'];
 	}
 
 	public function testFind()

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -346,7 +346,7 @@ class QueryTest extends TestCase
 			(clone $query)->fetch('\Kirby\Database\MockClassWithCallable::fromDb')->first()->name()
 		);
 	}
-	
+
 	/**
 	 * Helper function for testFetch()
 	 */

--- a/tests/Database/mocks.php
+++ b/tests/Database/mocks.php
@@ -26,7 +26,7 @@ class MockClassWithCallable
 		return $this->fname . ' ' . $this->lname;
 	}
 
-	public static function from_db(array $row, $key = null): MockClassWithCallable
+	public static function fromDb(array $row, $key = null): MockClassWithCallable
 	{
 		return new MockClassWithCallable($row['fname'], $row['lname']);
 	}

--- a/tests/Database/mocks.php
+++ b/tests/Database/mocks.php
@@ -12,3 +12,22 @@ class MockSql extends Sql
 	{
 	}
 }
+
+class MockClassWithCallable
+{
+	public function __construct(
+		public string $fname,
+		public string $lname
+	) {
+	}
+
+	public function name(): string
+	{
+		return $this->fname . ' ' . $this->lname;
+	}
+
+	public static function from_db(array $row, $key = null): MockClassWithCallable
+	{
+		return new MockClassWithCallable($row['fname'], $row['lname']);
+	}
+}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

This PR adds a support for type `callable` in the `$database->fetch()` method. This allows using existing functions/methods without having to rewrap them in a Closure.

```php
// while having a class/function to render a database row
$query->fetch([SomeClass::class, 'renderRow'])->all();
$query->fetch('SomeClass::renderRow')->all()
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
