### PR TITLE
Fix paste blocks with max option

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -228,6 +228,10 @@ export default {
 			}
 		},
 		isSplitable() {
+			if (this.isFull === true) {
+				return false;
+			}
+
 			if (this.$refs.editor) {
 				return (
 					(this.$refs.editor.isSplitable ?? true) &&

--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -88,7 +88,11 @@
 				<k-dropdown-item icon="template" @click="$emit('copy')">
 					{{ $t("copy") }}
 				</k-dropdown-item>
-				<k-dropdown-item icon="download" @click="$emit('paste')">
+				<k-dropdown-item
+					:disabled="isFull"
+					icon="download"
+					@click="$emit('paste')"
+				>
 					{{ $t("paste.after") }}
 				</k-dropdown-item>
 				<hr />

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -543,7 +543,7 @@ export default {
 			const html = this.$helper.clipboard.read(e);
 
 			// pass html or plain text to the paste endpoint to convert it to blocks
-			const blocks = await this.$api.post(this.endpoints.field + "/paste", {
+			let blocks = await this.$api.post(this.endpoints.field + "/paste", {
 				html: html
 			});
 
@@ -553,6 +553,12 @@ export default {
 
 			if (lastIndex === -1) {
 				lastIndex = this.blocks.length;
+			}
+
+			// don't add blocks that exceed the maximum limit
+			if (this.max) {
+				const max = this.max - this.blocks.length;
+				blocks = blocks.slice(0, max);
 			}
 
 			this.blocks.splice(lastIndex + 1, 0, ...blocks);

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -157,11 +157,6 @@ class BlocksField extends FieldClass
 			}
 		}
 
-		// don't add blocks that exceed the maximum limit
-		if ($max = $this->max()) {
-			$blocks = array_slice($blocks, 0, $max);
-		}
-
 		return $blocks;
 	}
 


### PR DESCRIPTION
## This PR fixes
- paste blocks with max option
- disabled `paste after` button when full
- disabled `split` button when full

### Fixes
- Blocks field: max option ignored when pasting blocks #5670

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
