### PR TITLE
Allow string for `$page->search(params: )` again

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1067,7 +1067,7 @@ class Page extends ModelWithContent
 	/**
 	 * Search all pages within the current page
 	 */
-	public function search(string|null $query = null, array $params = []): Pages
+	public function search(string|null $query = null, string|array $params = []): Pages
 	{
 		return $this->index()->search($query, $params);
 	}

--- a/tests/Cms/Pages/PageChildrenTest.php
+++ b/tests/Cms/Pages/PageChildrenTest.php
@@ -121,4 +121,85 @@ class PageChildrenTest extends TestCase
 
 		$this->assertFalse($page->hasDrafts());
 	}
+
+	public function testSearch()
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'children' => [
+				[
+					'slug'    => 'mtb',
+					'content' => [
+						'title' => 'Mountainbike'
+					]
+				],
+				[
+					'slug'    => 'mountains',
+					'content' => [
+						'title' => 'Mountains'
+					]
+				],
+				[
+					'slug'    => 'lakes',
+					'content' => [
+						'title' => 'Lakes'
+					]
+				]
+			]
+		]);
+
+		$result = $page->search('mountain');
+		$this->assertCount(2, $result);
+
+		$result = $page->search('mountain', 'title|text');
+		$this->assertCount(2, $result);
+
+		$result = $page->search('mountain', 'text');
+		$this->assertCount(0, $result);
+	}
+
+	public function testSearchWords()
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'children' => [
+				[
+					'slug'    => 'mtb',
+					'content' => [
+						'title' => 'Mountainbike'
+					]
+				],
+				[
+					'slug'    => 'mountain',
+					'content' => [
+						'title' => 'Mountain'
+					]
+				],
+				[
+					'slug'    => 'everest-mountain',
+					'content' => [
+						'title' => 'Everest Mountain'
+					]
+				],
+				[
+					'slug'    => 'mount',
+					'content' => [
+						'title' => 'Mount'
+					]
+				],
+				[
+					'slug'    => 'lakes',
+					'content' => [
+						'title' => 'Lakes'
+					]
+				]
+			]
+		]);
+
+		$result = $page->search('mountain', ['words' => true]);
+		$this->assertCount(2, $result);
+
+		$result = $page->search('mount', ['words' => false]);
+		$this->assertCount(4, $result);
+	}
 }

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -907,6 +907,12 @@ class PagesTest extends TestCase
 
 		$result = $pages->search('mountain');
 		$this->assertCount(2, $result);
+
+		$result = $pages->search('mountain', 'title|text');
+		$this->assertCount(2, $result);
+
+		$result = $pages->search('mountain', 'text');
+		$this->assertCount(0, $result);
 	}
 
 	public function testSearchWords()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- `$page->search()` allows to provide a string with field names as `$params` again https://github.com/getkirby/getkirby.com/pull/2094

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
