### PR TITLE
Revert `Str::short(appendix: false)`

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -980,7 +980,7 @@ class Str
 	public static function short(
 		string $string = null,
 		int $length = 0,
-		string|false $appendix = '…'
+		string $appendix = '…'
 	): string {
 		if ($string === null) {
 			return '';
@@ -994,12 +994,7 @@ class Str
 			return $string;
 		}
 
-		$string = static::substr($string, 0, $length);
-
-		return match ($appendix) {
-			false   => $string,
-			default => $string . $appendix
-		};
+		return static::substr($string, 0, $length) . $appendix;
 	}
 
 	/**
@@ -1124,7 +1119,7 @@ class Str
 		$string = preg_replace('![^a-z0-9]+$!', '', $string);
 
 		// cut the string after the given maxlength
-		return static::short($string, $maxlength, false);
+		return static::short($string, $maxlength, '');
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -984,6 +984,9 @@ class StrTest extends TestCase
 		// with different ellipsis character
 		$this->assertSame('Super---', Str::short($string, 5, '---'));
 
+		// without ellipsis
+		$this->assertSame('Super', Str::short($string, 5, ''));
+
 		// with null
 		$this->assertSame('', Str::short(null, 5));
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactoring

- Clean up type hints for `Str::short()` https://github.com/getkirby/kirby/pull/5495#pullrequestreview-1585955894

### Breaking changes

None (the `false` type hint was introduced in 4.0.0-beta.1)

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
