### PR TITLE
Various input fixes

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -277,7 +277,7 @@
 	"field.blocks.delete.confirm.all": "Do you really want to delete all blocks?",
 	"field.blocks.delete.confirm.selected": "Do you really want to delete the selected blocks?",
 	"field.blocks.empty": "No blocks yet",
-	"field.blocks.fieldsets.empy": "No fieldsets yet",
+	"field.blocks.fieldsets.empty": "No fieldsets yet",
 	"field.blocks.fieldsets.label": "Please select a block type …",
 	"field.blocks.fieldsets.paste": "Press <kbd>{{ shortcut }}</kbd> to import layouts/blocks from your clipboard <small>Only those allowed in the current field will get inserted.</small>",
 	"field.blocks.gallery.name": "Gallery",

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -211,7 +211,7 @@ export default {
 			};
 		},
 		activeTypes() {
-			if (!this.options) {
+			if (!this.options?.length) {
 				return this.availableTypes;
 			}
 


### PR DESCRIPTION
This PR is coming from the inputbox refactoring and moves over a couple of the fixes

## Fixes
- Fixed translation string for the blocks field
- The link field shows up correctly if no options are defined