### PR TITLE
Clean up k-choice-input and remove k-choice

### DIFF
--- a/panel/src/components/Forms/Element/index.js
+++ b/panel/src/components/Forms/Element/index.js
@@ -1,7 +1,0 @@
-import Choice from "./Choice.vue";
-
-export default {
-	install(app) {
-		app.component("k-choice", Choice);
-	}
-};

--- a/panel/src/components/Forms/Input/CheckboxesInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxesInput.vue
@@ -57,7 +57,6 @@ export default {
 					info: option.info,
 					label: option.text,
 					name: this.name ?? this.id,
-					theme: this.theme,
 					type: "checkbox",
 					value: option.value
 				};

--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -1,68 +1,73 @@
 <template>
-	<label
-		class="k-choice-input"
-		:aria-disabled="disabled"
-		:data-has-info="Boolean(info)"
-		:data-theme="theme"
-	>
-		<k-choice
-			ref="input"
-			v-bind="$props"
-			@input="$emit('input', $event)"
-			@invalid="$emit('invalid', $event)"
+	<label class="k-choice-input" :aria-disabled="disabled">
+		<input
+			v-bind="{
+				autofocus,
+				id,
+				checked,
+				disabled,
+				name,
+				required,
+				type,
+				value
+			}"
+			:data-variant="variant"
+			@input="$emit('input', $event.target.checked)"
 		/>
-		<span class="k-choice-input-label">
+		<span v-if="label || info" class="k-choice-input-label">
 			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span class="k-choice-input-text" v-html="label" />
+			<span class="k-choice-input-label-text" v-html="label" />
 			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span v-if="info" class="k-choice-input-info" v-html="info" />
+			<span v-if="info" class="k-choice-input-label-info" v-html="info" />
 		</span>
 	</label>
 </template>
 
 <script>
-import { props as ChoiceProps } from "@/components/Forms/Element/Choice.vue";
-import { label } from "@/mixins/props.js";
+import { props as InputProps } from "@/mixins/input.js";
+import Input from "@/mixins/input.js";
 
 export const props = {
-	mixins: [ChoiceProps, label],
+	mixins: [InputProps],
 	props: {
+		checked: {
+			type: Boolean
+		},
 		info: {
 			type: String
 		},
-		theme: {
+		label: {
+			type: String
+		},
+		type: {
+			default: "checkbox",
+			type: String
+		},
+		value: {
+			type: [Boolean, Number, String]
+		},
+		variant: {
 			type: String
 		}
 	}
 };
 
+/**
+ * @example <k-choice-input :value="value" @input="value = $event" />
+ * @public
+ */
 export default {
-	mixins: [props],
-	emits: ["input", "invalid"],
-	methods: {
-		focus() {
-			this.$refs.input.focus();
-		},
-		select() {
-			this.focus();
-		}
-	}
+	mixins: [Input, props]
 };
 </script>
 
 <style>
-:root {
-	--choice-input-color-back: var(--color-white);
-	--choice-input-color-info: var(--color-text-dimmed);
-	--choice-input-color-text: var(--color-text);
-}
-
 .k-choice-input {
 	display: flex;
 	gap: var(--spacing-3);
 	min-width: 0;
 }
-.k-choice-input .k-choice {
+.k-choice-input input {
 	top: 2px;
 }
 .k-choice-input-label {
@@ -70,31 +75,26 @@ export default {
 	line-height: 1.25rem;
 	flex-direction: column;
 	min-width: 0;
-	color: var(--choice-input-color-text);
+	color: var(--choice-color-text);
 }
 .k-choice-input-label > * {
 	display: block;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
-.k-choice-input-info {
-	color: var(--choice-input-color-info);
+.k-choice-input-label-info {
+	color: var(--choice-color-info);
 }
-
 .k-choice-input[aria-disabled] {
 	cursor: not-allowed;
-	--choice-input-color-back: var(--color-light);
-	--choice-input-color-info: var(--color-gray-400);
-	--choice-input-color-text: var(--color-text-dimmed);
-	--shadow: none;
 }
 
 .k-field .k-choice-input {
-	background: var(--choice-input-color-back);
+	background: var(--input-color-back);
 	min-height: var(--input-height);
 	padding-block: var(--spacing-2);
 	padding-inline: var(--spacing-3);
-	border-radius: var(--rounded);
+	border-radius: var(--input-rounded);
 	box-shadow: var(--shadow);
 }
 </style>

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -36,7 +36,6 @@ export default {
 					info: option.info,
 					label: option.text,
 					name: this.name ?? this.id,
-					theme: this.theme,
 					type: "radio",
 					value: option.value
 				};

--- a/panel/src/components/Forms/index.js
+++ b/panel/src/components/Forms/index.js
@@ -27,7 +27,6 @@ import ToolbarLinkDialog from "./Toolbar/LinkDialog.vue";
 
 /* Form parts */
 import Blocks from "./Blocks/index.js";
-import Elements from "./Element/index.js";
 import Fields from "./Field/index.js";
 import Inputs from "./Input/index.js";
 import Layouts from "./Layouts/index.js";
@@ -60,7 +59,6 @@ export default {
 		app.component("k-toolbar-link-dialog", ToolbarLinkDialog);
 
 		app.use(Blocks);
-		app.use(Elements);
 		app.use(Inputs);
 		app.use(Fields);
 		app.use(Layouts);

--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -1,3 +1,4 @@
+@import url("./reset/choice.css");
 @import url("./reset/range.css");
 
 *,

--- a/panel/src/styles/reset/choice.css
+++ b/panel/src/styles/reset/choice.css
@@ -1,86 +1,11 @@
-<template>
-	<input
-		:id="id"
-		ref="input"
-		:autofocus="autofocus"
-		:checked="checked"
-		:data-variant="variant"
-		:disabled="disabled"
-		:name="name"
-		:required="required"
-		:type="type"
-		:value="value"
-		class="k-choice"
-		@change="$emit('input', $event.target.checked)"
-	/>
-</template>
-
-<script>
-import { autofocus, disabled, id, name, required } from "@/mixins/props.js";
-import { required as validateRequired } from "vuelidate/lib/validators";
-
-export const props = {
-	mixins: [autofocus, disabled, id, name, required],
-	inheritAttrs: false,
-	props: {
-		checked: {
-			type: Boolean
-		},
-		type: {
-			default: "checkbox",
-			type: String
-		},
-		variant: {
-			type: String
-		},
-		value: {
-			type: [Boolean, Number, String]
-		}
-	}
-};
-
-export default {
-	mixins: [props],
-	watch: {
-		value: {
-			handler() {
-				this.validate();
-			},
-			immediate: true
-		}
-	},
-	methods: {
-		focus() {
-			this.$refs.input.focus();
-		},
-		select() {
-			this.focus();
-		},
-		validate() {
-			/**
-			 * The invalid event is triggered when the input validation fails. This can be used to react on errors immediately.
-			 * @event invalid
-			 */
-			this.$emit("invalid", this.$v.$invalid, this.$v);
-		}
-	},
-	validations() {
-		return {
-			value: {
-				required: this.required ? validateRequired : true
-			}
-		};
-	}
-};
-</script>
-
-<style>
 :root {
 	--choice-color-back: var(--color-white);
 	--choice-color-border: var(--color-gray-500);
 	--choice-color-checked: var(--color-black);
 	--choice-color-disabled: var(--color-gray-400);
 	--choice-color-icon: var(--color-light);
+	--choice-color-info: var(--color-text-dimmed);
+	--choice-color-text: var(--color-text);
 	--choice-color-toggle: var(--choice-color-border);
 	--choice-height: 1rem;
 	--choice-rounded: var(--rounded-sm);
@@ -132,11 +57,9 @@ input:where([type="checkbox"], [type="radio"]):checked:focus {
 
 /** Disabled state **/
 input:where([type="checkbox"], [type="radio"])[disabled] {
-	--choice-color-checked: var(--choice-color-disabled);
+	--choice-color-back: none;
 	--choice-color-border: var(--color-gray-300);
-	box-shadow: none;
-	cursor: default;
-	background: none;
+	--choice-color-checked: var(--choice-color-disabled);
 	box-shadow: none;
 }
 
@@ -168,4 +91,3 @@ input[type="checkbox"][data-variant="toggle"]:checked::after {
 	background: var(--choice-color-checked);
 	margin-inline-start: auto;
 }
-</style>


### PR DESCRIPTION
## Refactoring

- `k-choice` has been removed. Use `k-choice-input` instead
- The basic choice styles have been moved to `styles/reset/choice.css`
- The unused theme prop has been removed from `k-choice-input`