### PR TITLE
New k-calendar-input to replace k-calendar

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -33,7 +33,7 @@
 					/>
 					<k-dropdown-content ref="calendar" align-x="end">
 						<k-calendar
-							:value="value"
+							:value="iso.date"
 							:min="min"
 							:max="max"
 							@input="onCalendarInput"

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -25,7 +25,7 @@
 			</span>
 			<k-button :title="$t('next')" icon="angle-right" @click="onNext" />
 		</nav>
-		<table class="k-calendar-table" :key="year + '-' + month">
+		<table :key="year + '-' + month" class="k-calendar-table">
 			<!-- Weekdays -->
 			<thead>
 				<tr>
@@ -67,8 +67,8 @@
 			</tfoot>
 		</table>
 		<input
-			:disabled="disabled"
 			:id="id"
+			:disabled="disabled"
 			:min="min"
 			:max="max"
 			:name="name"
@@ -186,9 +186,6 @@ export default {
 			var options = [];
 
 			this.monthnames.forEach((item, index) => {
-				// get date object for 1st of the month
-				const date = this.toDate(1, index);
-
 				options.push({
 					value: index,
 					text: item

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -1,28 +1,31 @@
 <template>
-	<div class="k-calendar-input">
+	<fieldset class="k-calendar-input">
+		<legend class="sr-only">{{ $t("date.select") }}</legend>
 		<!-- Month + year selects -->
 		<nav>
-			<k-button icon="angle-left" @click="onPrev" />
+			<k-button :title="$t('prev')" icon="angle-left" @click="onPrev" />
 			<span class="k-calendar-selects">
 				<k-select-input
+					:aria-label="$t('month')"
+					:autofocus="autofocus"
 					:options="months"
-					:disabled="disabled"
+					:empty="false"
 					:required="true"
-					:value="current.month"
-					@input="current.month = Number($event)"
+					:value="month"
+					@input="month = Number($event)"
 				/>
 				<k-select-input
+					:aria-label="$t('year')"
 					:options="years"
-					:disabled="disabled"
+					:empty="false"
 					:required="true"
-					:value="current.year"
-					@input="current.year = Number($event)"
+					:value="year"
+					@input="year = Number($event)"
 				/>
 			</span>
-			<k-button icon="angle-right" @click="onNext" />
+			<k-button :title="$t('next')" icon="angle-right" @click="onNext" />
 		</nav>
-
-		<table class="k-calendar-table">
+		<table class="k-calendar-table" :key="year + '-' + month">
 			<!-- Weekdays -->
 			<thead>
 				<tr>
@@ -45,7 +48,7 @@
 							v-if="day"
 							:disabled="isDisabled(day)"
 							:text="day"
-							@click="select(day)"
+							@click="select(toDate(day))"
 						/>
 					</td>
 				</tr>
@@ -54,27 +57,42 @@
 				<!-- Today button -->
 				<tr>
 					<td class="k-calendar-today" colspan="7">
-						<k-button :text="$t('today')" @click="select('today')" />
+						<k-button
+							:disabled="disabled"
+							:text="$t('today')"
+							@click="select(today)"
+						/>
 					</td>
 				</tr>
 			</tfoot>
 		</table>
-	</div>
+		<input
+			:disabled="disabled"
+			:id="id"
+			:min="min"
+			:max="max"
+			:name="name"
+			:required="required"
+			:value="value"
+			class="sr-only"
+			tabindex="-1"
+			type="date"
+		/>
+	</fieldset>
 </template>
 
 <script>
+import { props as InputProps } from "@/mixins/input.js";
+
 /**
  * The Calendar component is mainly used for our `DateInput` component, but it could be used as stand-alone calendar as well with a little CSS love.
- * @public
  *
- * @example <k-calendar value="2012-12-12" @input="onInput" />
+ * @example <k-calendar-input :value="value" @input="value = $event" />
+ * @public
  */
 export default {
+	mixins: [InputProps],
 	props: {
-		/**
-		 * Disables whole calendar
-		 */
-		disabled: Boolean,
 		/**
 		 * The last allowed date
 		 * @example `2020-12-31`
@@ -89,10 +107,20 @@ export default {
 		 * ISO date/datetime string
 		 * @example `2020-03-05`
 		 */
-		value: String
+		value: {
+			default: "",
+			type: String
+		}
 	},
 	data() {
-		return this.data(this.value);
+		return {
+			maxdate: null,
+			mindate: null,
+			month: null,
+			selected: null,
+			today: this.$library.dayjs(),
+			year: null
+		};
 	},
 	computed: {
 		/**
@@ -163,10 +191,7 @@ export default {
 
 				options.push({
 					value: index,
-					text: item,
-					disabled:
-						date.isBefore(this.current.min, "month") ||
-						date.isAfter(this.current.max, "month")
+					text: item
 				});
 			});
 
@@ -178,41 +203,46 @@ export default {
 		 * @returns {array}
 		 */
 		years() {
-			const min = this.current.min?.get("year") ?? this.current.year - 20;
-			const max = this.current.max?.get("year") ?? this.current.year + 20;
+			const min = this.year - 20;
+			const max = this.year + 20;
 			return this.toOptions(min, max);
 		}
 	},
 	watch: {
-		value(value) {
-			const data = this.data(value);
-			this.dt = data.dt;
-			this.current = data.current;
+		max: {
+			handler(newValue, oldValue) {
+				if (newValue === oldValue) {
+					return;
+				}
+
+				this.maxdate = this.$library.dayjs.interpret(newValue, "date");
+			},
+			immediate: true
+		},
+		min: {
+			handler(newValue, oldValue) {
+				if (newValue === oldValue) {
+					return;
+				}
+
+				this.mindate = this.$library.dayjs.interpret(newValue, "date");
+			},
+			immediate: true
+		},
+		value: {
+			handler(newValue, oldValue) {
+				if (newValue === oldValue) {
+					return;
+				}
+
+				// set the selected date
+				this.selected = this.$library.dayjs.interpret(newValue, "date");
+				this.show(this.selected);
+			},
+			immediate: true
 		}
 	},
 	methods: {
-		/**
-		 * Internal method to set and update the
-		 * data object on initialization and when
-		 * the `value` prop changes
-		 * @param {string} value
-		 */
-		data(value) {
-			const dt = this.$library.dayjs.iso(value);
-			const now = this.$library.dayjs();
-
-			return {
-				// datetime object of selection
-				dt: dt,
-				// current calendar view
-				current: {
-					month: (dt ?? now).month(),
-					year: (dt ?? now).year(),
-					min: this.$library.dayjs.iso(this.min),
-					max: this.$library.dayjs.iso(this.max)
-				}
-			};
-		},
 		/**
 		 * Dates for a specific week in the current view (month + year)
 		 * @param {number} week number of week in the current month
@@ -242,8 +272,8 @@ export default {
 			const date = this.toDate(day);
 			return (
 				this.disabled ||
-				date.isBefore(this.current.min, "day") ||
-				date.isAfter(this.current.max, "day")
+				date.isBefore(this.mindate, "day") ||
+				date.isAfter(this.maxdate, "day")
 			);
 		},
 		/**
@@ -253,7 +283,7 @@ export default {
 		 * @returns {boolean}
 		 */
 		isSelected(day) {
-			return this.toDate(day).isSame(this.dt, "day");
+			return this.toDate(day).isSame(this.selected, "day");
 		},
 		/**
 		 * Whether a specified day in the current view (month + year)
@@ -262,18 +292,7 @@ export default {
 		 * @returns {boolean}
 		 */
 		isToday(day) {
-			const now = this.$library.dayjs();
-			return this.toDate(day).isSame(now, "day");
-		},
-		/**
-		 * Emits the current datetime as ISO string
-		 */
-		onInput() {
-			/**
-			 * The input event is fired when a date is selected.
-			 * @property {string} iso data as ISO date string
-			 */
-			this.$emit("input", this.dt?.toISO("date") ?? null);
+			return this.toDate(day).isSame(this.today, "day");
 		},
 		/**
 		 * Shows the following month
@@ -293,24 +312,13 @@ export default {
 		 * Selects a day and updates datetime object
 		 * based on current view (month + year)
 		 */
-		select(day) {
-			// when selecting today, make sure to merge in current time selects
-			const date =
-				day === "today"
-					? this.$library.dayjs().merge(this.toDate(), "time")
-					: this.toDate(day);
-			this.dt = date;
-			this.show(date);
-			this.onInput();
+		select(date) {
+			this.$emit("input", date?.toISO("date") ?? null);
 		},
-		/**
-		 * Updates the calendar to display the
-		 * month of the provided dayjs object
-		 * @param {Object} dt
-		 */
-		show(dt) {
-			this.current.year = dt.year();
-			this.current.month = dt.month();
+		show(date) {
+			// set the view
+			this.month = (date ?? this.today).month();
+			this.year = (date ?? this.today).year();
 		},
 		/**
 		 * Creates a dayjs object for a specified day and
@@ -318,8 +326,8 @@ export default {
 		 * @param {number} day
 		 * @param {number} month
 		 */
-		toDate(day = 1, month = this.current.month) {
-			return this.$library.dayjs(`${this.current.year}-${month + 1}-${day}`);
+		toDate(day = 1, month = this.month) {
+			return this.$library.dayjs(`${this.year}-${month + 1}-${day}`);
 		},
 		/**
 		 * Generates select options between min and max
@@ -379,8 +387,10 @@ export default {
 .k-calendar-selects .k-select-input {
 	display: flex;
 	align-items: center;
+	text-align: center;
 	height: var(--button-height);
 	padding: 0 0.5rem;
+	border-radius: var(--input-rounded);
 }
 .k-calendar-selects .k-select-input:focus-within {
 	outline: var(--outline);
@@ -397,13 +407,13 @@ export default {
 .k-calendar-day[aria-current="date"] .k-button {
 	text-decoration: underline;
 }
-.k-calendar-day[aria-selected="date"] .k-button {
-	--button-color-text: var(--color-text);
-	--button-color-back: var(--color-focus);
-}
+.k-calendar-day[aria-selected="date"] .k-button,
 .k-calendar-day[aria-selected="date"] .k-button:focus {
-	--button-color-text: initial;
-	--button-color-back: transparent;
+	--button-color-text: var(--color-text);
+	--button-color-back: var(--color-blue-500);
+}
+.k-calendar-day[aria-selected="date"] .k-button:focus-visible {
+	outline-offset: 2px;
 }
 .k-calendar-today {
 	padding-top: var(--spacing-2);

--- a/panel/src/components/Forms/Input/index.js
+++ b/panel/src/components/Forms/Input/index.js
@@ -1,3 +1,4 @@
+import CalendarInput from "./CalendarInput.vue";
 import CheckboxInput from "./CheckboxInput.vue";
 import CheckboxesInput from "./CheckboxesInput.vue";
 import ChoiceInput from "./ChoiceInput.vue";
@@ -26,6 +27,7 @@ import WriterInput from "./WriterInput.vue";
 
 export default {
 	install(app) {
+		app.component("k-calendar-input", CalendarInput);
 		app.component("k-checkbox-input", CheckboxInput);
 		app.component("k-checkboxes-input", CheckboxesInput);
 		app.component("k-choice-input", ChoiceInput);
@@ -51,5 +53,8 @@ export default {
 		app.component("k-toggles-input", TogglesInput);
 		app.component("k-url-input", UrlInput);
 		app.component("k-writer-input", WriterInput);
+
+		/** Keep k-calendar as legacy alias */
+		app.component("k-calendar", CalendarInput);
 	}
 };

--- a/panel/src/components/Forms/index.js
+++ b/panel/src/components/Forms/index.js
@@ -2,7 +2,6 @@ import Autosize from "./Autosize.js";
 
 /* Form */
 import Autocomplete from "./Autocomplete.vue";
-import Calendar from "./Calendar.vue";
 import Counter from "./Counter.vue";
 import Form from "./Form.vue";
 import FormButtons from "./FormButtons.vue";
@@ -39,7 +38,6 @@ export default {
 	install(app) {
 		customElements.define("k-autosize", Autosize);
 
-		app.component("k-calendar", Calendar);
 		app.component("k-counter", Counter);
 		app.component("k-autocomplete", Autocomplete);
 		app.component("k-form", Form);


### PR DESCRIPTION
## Enhancements
- `k-calendar-input` is now set up as a proper fieldset with legend and additional aria labels for improved accessibility. 

## Refactoring
- `k-calendar-input` replaces `k-calendar`. `k-calendar` is still available but only as deprecated alias.

## Fixes
- `k-calendar-input` can now receive a regular iso date as value.