### PR TITLE
k-coloroptions-input

### DIFF
--- a/panel/src/components/Forms/Field/ColorField.vue
+++ b/panel/src/components/Forms/Field/ColorField.vue
@@ -1,22 +1,13 @@
 <template>
 	<k-field v-bind="$props" :input="_uid" class="k-color-field">
 		<!-- Mode: options -->
-		<div
+		<k-coloroptions-input
 			v-if="mode === 'options'"
-			style="--preview-width: var(--field-input-height)"
+			:options="convertedOptions"
+			:value="value"
 			class="k-color-field-options"
-		>
-			<button
-				v-for="color in convertedOptions"
-				:key="color.value"
-				:aria-current="color.value === currentOption?.value"
-				:style="'color: ' + color.value"
-				:title="color.text ?? color.value"
-				class="k-color-frame k-frame"
-				type="button"
-				@click="onOption(color)"
-			/>
-		</div>
+			@input="$emit('input', $event)"
+		/>
 
 		<!-- Mode: picker/input -->
 		<k-input
@@ -26,7 +17,7 @@
 			ref="input"
 			theme="field"
 			type="color"
-			@input="onInput"
+			@input="$emit('input', $event)"
 			@invalid="isInvalid = $event ?? false"
 			@submit="$emit('submit')"
 		>
@@ -44,22 +35,11 @@
 						<k-colorpicker-input
 							ref="color"
 							:alpha="alpha"
+							:options="convertedOptions"
 							:required="required"
 							:value="value"
 							@input="onPicker"
 						/>
-						<div v-if="convertedOptions.length" class="k-color-field-options">
-							<button
-								v-for="color in convertedOptions"
-								:key="color.value"
-								:aria-current="color.value === currentOption?.value"
-								:style="'color: ' + color.value"
-								:title="color.text ?? color.value"
-								type="button"
-								class="k-color-frame k-frame"
-								@click="$refs.input.$refs.input.onPaste(color.value)"
-							/>
-						</div>
 					</k-dropdown-content>
 				</template>
 				<k-color-frame v-else :color="!isInvalid ? value : null" />
@@ -129,9 +109,6 @@ export default {
 		convert(value) {
 			return this.$library.colors.toString(value, this.format, this.alpha);
 		},
-		onInput(input) {
-			this.$emit("input", input);
-		},
 		onPicker(hsv) {
 			if (!hsv) {
 				return this.$emit("input", "");
@@ -139,15 +116,6 @@ export default {
 
 			const input = this.convert(hsv);
 			this.$emit("input", input);
-		},
-		onOption(option) {
-			const value = this.convert(option.value);
-
-			if (value !== this.value || this.required) {
-				this.$emit("input", value);
-			} else {
-				this.$emit("input", "");
-			}
 		}
 	}
 };
@@ -162,35 +130,17 @@ export default {
 	padding-inline: var(--spacing-1);
 }
 
+/* Mode: options */
+.k-color-field-options {
+	--color-frame-size: var(--input-height);
+}
+
+/* Mode: picker */
 .k-color-field-picker {
 	padding: var(--spacing-3);
 }
 .k-color-field-picker-toggle {
 	--color-frame-rounded: var(--rounded-sm);
 	border-radius: var(--color-frame-rounded);
-}
-
-.k-color-field-options {
-	--color-frame-size: var(--input-height);
-	display: grid;
-	grid-template-columns: repeat(auto-fill, var(--color-frame-size));
-	gap: var(--spacing-2);
-}
-.k-color-field-picker .k-color-field-options {
-	--color-frame-size: 100%;
-	--color-frame-darkness: 100%;
-	grid-template-columns: repeat(6, 1fr);
-	margin-top: var(--spacing-3);
-}
-
-.k-color-field .k-color-frame[aria-current] {
-	outline: var(--outline);
-}
-.k-color-field[data-disabled="true"] .k-color-field-options {
-	opacity: var(--opacity-disabled);
-}
-
-.k-color-field .k-input-after {
-	font-size: var(--text-xs);
 }
 </style>

--- a/panel/src/components/Forms/Field/ColorField.vue
+++ b/panel/src/components/Forms/Field/ColorField.vue
@@ -3,6 +3,7 @@
 		<!-- Mode: options -->
 		<k-coloroptions-input
 			v-if="mode === 'options'"
+			:name="name"
 			:options="convertedOptions"
 			:value="value"
 			class="k-color-field-options"

--- a/panel/src/components/Forms/Input/ColoroptionsInput.vue
+++ b/panel/src/components/Forms/Input/ColoroptionsInput.vue
@@ -12,7 +12,7 @@
 						:autofocus="autofocus && index === 0"
 						:checked="choice.value === value"
 						:disabled="disabled"
-						:name="name"
+						:name="name ?? _uid"
 						:required="required"
 						:value="choice.value"
 						class="input-hidden"

--- a/panel/src/components/Forms/Input/ColoroptionsInput.vue
+++ b/panel/src/components/Forms/Input/ColoroptionsInput.vue
@@ -9,11 +9,11 @@
 			<li v-for="(choice, index) in choices" :key="index">
 				<label :title="choice.title">
 					<input
-						:autofocus="choice.autofocus"
-						:checked="choice.checked"
-						:disabled="choice.disabled"
-						:name="choice.name"
-						:required="choice.required"
+						:autofocus="autofocus && index === 0"
+						:checked="choice.value === value"
+						:disabled="disabled"
+						:name="name"
+						:required="required"
 						:value="choice.value"
 						class="input-hidden"
 						type="radio"
@@ -52,20 +52,11 @@ export default {
 	mixins: [RadioInput, props],
 	computed: {
 		choices() {
-			return this.options.map((color, index) => {
-				const value = this.colorToString(color.value);
-
-				return {
-					...color,
-					autofocus: this.autofocus && index === 0,
-					checked: value === this.value,
-					disabled: this.disabled,
-					name: this.name,
-					required: this.required,
-					title: color.text ?? color.value,
-					value: value
-				};
-			});
+			return this.options.map((color) => ({
+				...color,
+				title: color.text ?? color.value,
+				value: this.colorToString(color.value)
+			}));
 		}
 	},
 	methods: {

--- a/panel/src/components/Forms/Input/ColoroptionsInput.vue
+++ b/panel/src/components/Forms/Input/ColoroptionsInput.vue
@@ -1,0 +1,104 @@
+<template>
+	<fieldset
+		v-if="choices.length"
+		:disabled="disabled"
+		class="k-coloroptions-input"
+	>
+		<legend class="sr-only">{{ $t("options") }}</legend>
+		<ul>
+			<li v-for="(choice, index) in choices" :key="index">
+				<label :title="choice.title">
+					<input
+						:autofocus="choice.autofocus"
+						:checked="choice.checked"
+						:disabled="choice.disabled"
+						:name="choice.name"
+						:required="choice.required"
+						:value="choice.value"
+						class="input-hidden"
+						type="radio"
+						@click="toggle(choice.value)"
+						@input="$emit('input', choice.value)"
+					/>
+					<k-color-frame :color="choice.value" />
+				</label>
+			</li>
+		</ul>
+	</fieldset>
+</template>
+
+<script>
+import RadioInput, { props as RadioInputProps } from "./RadioInput.vue";
+
+export const props = {
+	mixins: [RadioInputProps],
+	props: {
+		format: {
+			type: String,
+			default: "hex",
+			validator: (format) => ["hex", "rgb", "hsl"].includes(format)
+		},
+		value: {
+			type: String
+		}
+	}
+};
+
+/**
+ * @example <k-coloroptions-input :options="options" :value="value" @input="value = $event" />
+ * @public
+ */
+export default {
+	mixins: [RadioInput, props],
+	computed: {
+		choices() {
+			return this.options.map((color, index) => {
+				const value = this.colorToString(color.value);
+
+				return {
+					...color,
+					autofocus: this.autofocus && index === 0,
+					checked: value === this.value,
+					disabled: this.disabled,
+					name: this.name,
+					required: this.required,
+					title: color.text ?? color.value,
+					value: value
+				};
+			});
+		}
+	},
+	methods: {
+		colorToString(value) {
+			try {
+				return this.$library.colors.toString(value, this.format);
+			} catch {
+				return value;
+			}
+		}
+	}
+};
+</script>
+
+<style>
+.k-coloroptions-input {
+	--color-preview-size: var(--input-height);
+}
+.k-coloroptions-input ul {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, var(--color-preview-size));
+	gap: var(--spacing-2);
+}
+
+.k-coloroptions-input input:focus-visible + .k-color-frame {
+	outline: var(--outline);
+}
+.k-coloroptions-input[disabled] label {
+	opacity: var(--opacity-disabled);
+	cursor: not-allowed;
+}
+.k-coloroptions-input input:checked + .k-color-frame {
+	outline: 2px solid currentColor;
+	outline-offset: 2px;
+}
+</style>

--- a/panel/src/components/Forms/Input/ColoroptionsInput.vue
+++ b/panel/src/components/Forms/Input/ColoroptionsInput.vue
@@ -81,7 +81,7 @@ export default {
 	gap: var(--spacing-2);
 }
 
-.k-coloroptions-input input:focus-visible + .k-color-frame {
+.k-coloroptions-input input:focus + .k-color-frame {
 	outline: var(--outline);
 }
 .k-coloroptions-input[disabled] label {

--- a/panel/src/components/Forms/Input/ColorpickerInput.vue
+++ b/panel/src/components/Forms/Input/ColorpickerInput.vue
@@ -17,7 +17,6 @@
 			:value="coords"
 			@input="setCoords($event)"
 		/>
-
 		<label :aria-label="$t('hue')">
 			<k-hue-input
 				:disabled="disabled"
@@ -26,7 +25,6 @@
 				@input="setHue($event)"
 			/>
 		</label>
-
 		<label v-if="alpha" :aria-label="$t('alpha')">
 			<k-alpha-input
 				:disabled="disabled"
@@ -35,7 +33,14 @@
 				@input="setAlpha($event)"
 			/>
 		</label>
-
+		<k-coloroptions-input
+			:disabled="disabled"
+			:format="format"
+			:options="options"
+			:required="required"
+			:value="value"
+			@input="$emit('input', $event)"
+		/>
 		<input
 			:name="name"
 			:required="required"
@@ -49,9 +54,10 @@
 
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
+import { options } from "@/mixins/props.js";
 
 export const props = {
-	mixins: [InputProps],
+	mixins: [InputProps, options],
 	props: {
 		alpha: {
 			default: true,
@@ -61,9 +67,6 @@ export const props = {
 			default: "hex",
 			type: String,
 			validator: (format) => ["hex", "rgb", "hsl"].includes(format)
-		},
-		options: {
-			type: Array
 		},
 		value: {
 			type: [Object, String]

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -5,7 +5,11 @@
 		data-variant="choices"
 	>
 		<li v-for="(choice, index) in choices" :key="index">
-			<k-choice-input v-bind="choice" @input="$emit('input', choice.value)" />
+			<k-choice-input
+				v-bind="choice"
+				@click.native.stop="toggle(choice.value)"
+				@input="$emit('input', choice.value)"
+			/>
 		</li>
 	</ul>
 </template>
@@ -19,6 +23,10 @@ export const props = {
 	mixins: [InputProps, options],
 	props: {
 		columns: Number,
+		reset: {
+			default: true,
+			type: Boolean
+		},
 		theme: String,
 		value: [String, Number, Boolean]
 	}
@@ -56,6 +64,11 @@ export default {
 		},
 		select() {
 			this.focus();
+		},
+		toggle(value) {
+			if (value === this.value && this.reset && !this.required) {
+				this.$emit("input", "");
+			}
 		},
 		validate() {
 			this.$emit("invalid", this.$v.$invalid, this.$v);

--- a/panel/src/components/Forms/Input/index.js
+++ b/panel/src/components/Forms/Input/index.js
@@ -4,6 +4,7 @@ import CheckboxInput from "./CheckboxInput.vue";
 import CheckboxesInput from "./CheckboxesInput.vue";
 import ChoiceInput from "./ChoiceInput.vue";
 import ColorInput from "./ColorInput.vue";
+import ColoroptionsInput from "./ColoroptionsInput.vue";
 import ColorpickerInput from "./ColorpickerInput.vue";
 import CoordsInput from "./CoordsInput.vue";
 import DateInput from "./DateInput.vue";
@@ -35,6 +36,7 @@ export default {
 		app.component("k-checkboxes-input", CheckboxesInput);
 		app.component("k-choice-input", ChoiceInput);
 		app.component("k-color-input", ColorInput);
+		app.component("k-coloroptions-input", ColoroptionsInput);
 		app.component("k-colorpicker-input", ColorpickerInput);
 		app.component("k-coords-input", CoordsInput);
 		app.component("k-date-input", DateInput);


### PR DESCRIPTION
## Features

- New `k-coloroptions-input`

![Screenshot 2023-09-25 at 16 46 43](https://github.com/getkirby/kirby/assets/24532/86256687-e430-41d2-8407-11848796d136)

The new input is used as foundation for the color field and the k-colorpicker-input, but can now also be used on its own. 

```html
<k-coloroptions-input :options="options" :value="value=" @input="value = $event" />
```