### PR TITLE
Field preview refactoring

### DIFF
--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -10,8 +10,8 @@ import { props as BubblesProps } from "@/components/Layout/Bubbles.vue";
 
 export default {
 	mixins: [FieldPreview, BubblesProps],
-	inheritAttrs: false,
 	props: {
+		default: () => [],
 		value: [Array, String]
 	},
 	computed: {
@@ -19,13 +19,13 @@ export default {
 			let bubbles = this.value;
 
 			// predefined options
-			const options = this.column?.options ?? this.field?.options ?? [];
+			const options = this.column.options ?? this.field.options ?? [];
 
 			if (typeof bubbles === "string") {
 				bubbles = bubbles.split(",");
 			}
 
-			return bubbles.map((bubble) => {
+			return (bubbles ?? []).map((bubble) => {
 				if (typeof bubble === "string") {
 					bubble = {
 						value: bubble,

--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -54,5 +54,6 @@ export default {
 	--bubble-text: var(--color-black);
 
 	padding: 0.325rem 0.75rem;
+	overflow: hidden;
 }
 </style>

--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -11,8 +11,10 @@ import { props as BubblesProps } from "@/components/Layout/Bubbles.vue";
 export default {
 	mixins: [FieldPreview, BubblesProps],
 	props: {
-		default: () => [],
-		value: [Array, String]
+		value: {
+			default: () => [],
+			type: [Array, String]
+		}
 	},
 	computed: {
 		bubbles() {

--- a/panel/src/components/Forms/Previews/ColorFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ColorFieldPreview.vue
@@ -1,13 +1,9 @@
 <template>
-	<div :data-has-text="Boolean(text)" class="k-color-field-preview">
-		<k-tag>
-			<template #image>
-				<k-color-frame :color="value" />
-			</template>
-			<template v-if="text">
-				{{ text }}
-			</template>
-		</k-tag>
+	<div class="k-color-field-preview">
+		<k-color-frame :color="value" />
+		<template v-if="text">
+			{{ text }}
+		</template>
 	</div>
 </template>
 
@@ -16,20 +12,27 @@ import FieldPreview from "@/mixins/forms/fieldPreview.js";
 
 export default {
 	mixins: [FieldPreview],
-	inheritAttrs: false,
 	props: {
-		field: Object,
 		value: String
 	},
 	computed: {
 		text() {
-			const option = this.field.options.find(
+			if (!this.value) {
+				return;
+			}
+
+			const value = this.$library.colors.toString(
+				this.value,
+				this.field.format,
+				this.field.alpha
+			);
+			const option = this.field.options?.find(
 				(option) =>
 					this.$library.colors.toString(
 						option.value,
 						this.field.format,
 						this.field.alpha
-					) === this.value
+					) === value
 			);
 
 			if (option) {
@@ -44,22 +47,11 @@ export default {
 
 <style>
 .k-color-field-preview {
-	--tag-height: var(--height-sm);
-	--tag-color-back: var(--color-gray-200);
-	--tag-color-text: var(--color-black);
-	--tag-color-focus-back: var(--tag-color-back);
-	--tag-color-focus-text: var(--tag-color-text);
-	--tag-rounded: var(--rounded);
-
 	--color-frame-rounded: var(--tag-rounded);
 	--color-frame-size: var(--tag-height);
-
 	padding: 0.325rem 0.75rem;
-}
-/** TODO: .k-color-field-preview .k-color-frame:has(+ .k-tag-text) */
-.k-color-field-preview[data-has-text="true"]
-	:where(.k-color-frame, .k-color-frame::after) {
-	border-start-end-radius: 0;
-	border-end-end-radius: 0;
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-2);
 }
 </style>

--- a/panel/src/components/Forms/Previews/DateFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/DateFieldPreview.vue
@@ -3,31 +3,31 @@ import TextFieldPreview from "./TextFieldPreview.vue";
 
 export default {
 	extends: TextFieldPreview,
-	inheritAttrs: false,
 	props: {
 		value: String
 	},
 	class: "k-date-field-preview",
 	computed: {
+		display() {
+			return this.column.display ?? this.field.display;
+		},
+		format() {
+			let format = this.display ?? "YYYY-MM-DD";
+
+			if (this.time?.display) {
+				format += " " + this.time.display;
+			}
+
+			return format;
+		},
+		parsed() {
+			return this.$library.dayjs(this.value);
+		},
 		text() {
-			if (typeof this.value !== "string") {
-				return "";
-			}
-
-			const dt = this.$library.dayjs(this.value);
-
-			if (!dt) {
-				return "";
-			}
-
-			let format = this.column?.display ?? this.field?.display ?? "YYYY-MM-DD";
-			let time = this.column?.time?.display ?? this.field?.time?.display;
-
-			if (time) {
-				format += " " + time;
-			}
-
-			return dt.format(format);
+			return this.parsed?.format(this.format);
+		},
+		time() {
+			return this.column.time ?? this.field.time;
 		}
 	}
 };

--- a/panel/src/components/Forms/Previews/FilesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FilesFieldPreview.vue
@@ -12,7 +12,7 @@ export default {
 	},
 	computed: {
 		bubbles() {
-			return (this.value ?? []).map((file) => ({
+			return this.value.map((file) => ({
 				text: file.filename,
 				link: file.link,
 				image: file.image

--- a/panel/src/components/Forms/Previews/FilesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FilesFieldPreview.vue
@@ -3,7 +3,6 @@ import BubblesFieldPreview from "./BubblesFieldPreview.vue";
 
 export default {
 	extends: BubblesFieldPreview,
-	inheritAttrs: false,
 	class: "k-files-field-preview",
 	props: {
 		html: {
@@ -13,7 +12,7 @@ export default {
 	},
 	computed: {
 		bubbles() {
-			return this.value.map((file) => ({
+			return (this.value ?? []).map((file) => ({
 				text: file.filename,
 				link: file.link,
 				image: file.image

--- a/panel/src/components/Forms/Previews/FlagFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FlagFieldPreview.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="k-flag-field-preview">
-		<k-button v-if="value" v-bind="status" size="md" />
+	<div v-if="value" class="k-flag-field-preview">
+		<k-button v-bind="status" size="md" />
 	</div>
 </template>
 

--- a/panel/src/components/Forms/Previews/FlagFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FlagFieldPreview.vue
@@ -1,5 +1,7 @@
 <template>
-	<k-button v-bind="status" class="k-flag-field-preview" />
+	<div class="k-flag-field-preview">
+		<k-button v-if="value" v-bind="status" size="md" />
+	</div>
 </template>
 
 <script>
@@ -7,14 +9,13 @@ import FieldPreview from "@/mixins/forms/fieldPreview.js";
 
 export default {
 	mixins: [FieldPreview],
-	inheritAttrs: false,
 	props: {
 		value: Object
 	},
 	computed: {
 		status() {
 			return {
-				...this.$helper.page.status(this.value.status),
+				...this.$helper.page.status(this.value?.status),
 				...this.value
 			};
 		}
@@ -23,8 +24,10 @@ export default {
 </script>
 
 <style>
-.k-flag-field-preview.k-button {
-	--button-height: var(--table-row-height);
-	--button-width: var(--button-height);
+.k-flag-field-preview {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: var(--table-row-height);
 }
 </style>

--- a/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
@@ -12,7 +12,6 @@ import FieldPreview from "@/mixins/forms/fieldPreview.js";
 
 export default {
 	mixins: [FieldPreview],
-	inheritAttrs: false,
 	props: {
 		value: String
 	},

--- a/panel/src/components/Forms/Previews/ImageFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ImageFieldPreview.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-item-image class="k-image-field-preview" :image="value" />
+	<k-item-image v-if="value" class="k-image-field-preview" :image="value" />
 </template>
 
 <script>
@@ -7,9 +7,14 @@ import FieldPreview from "@/mixins/forms/fieldPreview.js";
 
 export default {
 	mixins: [FieldPreview],
-	inheritAttrs: false,
 	props: {
 		value: [Object]
 	}
 };
 </script>
+
+<style>
+.k-image-field-preview {
+	height: 100%;
+}
+</style>

--- a/panel/src/components/Forms/Previews/ObjectFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ObjectFieldPreview.vue
@@ -3,13 +3,16 @@ import BubblesFieldPreview from "./BubblesFieldPreview.vue";
 
 export default {
 	extends: BubblesFieldPreview,
-	inheritAttrs: false,
 	class: "k-object-field-preview",
 	props: {
 		value: [Array, Object]
 	},
 	computed: {
 		bubbles() {
+			if (!this.value) {
+				return [];
+			}
+
 			return [
 				{
 					text: "{ ... }"

--- a/panel/src/components/Forms/Previews/TimeFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TimeFieldPreview.vue
@@ -1,17 +1,18 @@
 <script>
-import TextFieldPreview from "./TextFieldPreview.vue";
+import DateFieldPreview from "./DateFieldPreview.vue";
 
 export default {
-	extends: TextFieldPreview,
-	inheritAttrs: false,
-	props: {
-		value: String
-	},
+	extends: DateFieldPreview,
 	class: "k-time-field-preview",
 	computed: {
+		format() {
+			return this.display ?? "HH:mm";
+		},
+		parsed() {
+			return this.$library.dayjs.iso(this.value, "time");
+		},
 		text() {
-			const dt = this.$library.dayjs.iso(this.value, "time");
-			return dt?.format(this.field.display) ?? "";
+			return this.parsed?.format(this.format);
 		}
 	}
 };

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -15,7 +15,7 @@ export default {
 	mixins: [FieldPreview],
 	computed: {
 		text() {
-			return this.column?.text !== false ? this.field?.text : null;
+			return this.column.text !== false ? this.field.text : null;
 		}
 	}
 };

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -1,34 +1,28 @@
 <template>
-	<!-- eslint-disable vue/no-mutating-props -->
 	<div class="k-toggle-field-preview">
-		<k-input
+		<k-toggle-input
 			:text="text"
 			:value="value"
-			type="toggle"
 			@input="$emit('input', $event)"
 		/>
 	</div>
 </template>
 
 <script>
+import FieldPreview from "@/mixins/forms/fieldPreview.js";
+
 export default {
-	props: {
-		field: Object,
-		value: Boolean,
-		column: Object
-	},
+	mixins: [FieldPreview],
 	computed: {
 		text() {
-			return this.column.text !== false ? this.field.text : null;
+			return this.column?.text !== false ? this.field?.text : null;
 		}
 	}
 };
 </script>
 
 <style>
-.k-toggle-field-preview .k-input {
-	--input-outline-focus: 0;
-	--input-padding: var(--spacing-3);
-	--input-shadow: none;
+.k-toggle-field-preview {
+	padding-inline: var(--spacing-3);
 }
 </style>

--- a/panel/src/components/Forms/Previews/UrlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UrlFieldPreview.vue
@@ -2,7 +2,7 @@
 	<p class="k-url-field-preview" :class="$options.class" :data-link="link">
 		{{ column.before }}
 		<k-link :to="link" @click.native.stop>
-			{{ text }}
+			<span>{{ text }}</span>
 		</k-link>
 		{{ column.after }}
 	</p>
@@ -33,21 +33,26 @@ export default {
 
 <style>
 .k-url-field-preview {
-	padding: 0.325rem 0.75rem;
-	overflow-x: hidden;
-	text-overflow: ellipsis;
+	padding-inline: var(--spacing-2);
 }
 .k-url-field-preview[data-link] {
 	color: var(--link-color);
 }
 .k-url-field-preview a {
+	display: inline-flex;
+	align-items: center;
+	height: var(--height-xs);
+	padding-inline: var(--spacing-1);
+	border-radius: var(--rounded);
+	max-width: 100%;
+	min-width: 0;
+}
+.k-url-field-preview a > * {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 	text-decoration: underline;
 	text-underline-offset: var(--link-underline-offset);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	border-radius: var(--rounded-xs);
-	outline-offset: 2px;
 }
 .k-url-field-preview a:hover {
 	color: var(--color-black);

--- a/panel/src/components/Forms/Previews/UsersFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UsersFieldPreview.vue
@@ -3,7 +3,6 @@ import BubblesFieldPreview from "./BubblesFieldPreview.vue";
 
 export default {
 	extends: BubblesFieldPreview,
-	inheritAttrs: false,
 	class: "k-users-field-preview",
 	computed: {
 		bubble() {

--- a/panel/src/mixins/forms/fieldPreview.js
+++ b/panel/src/mixins/forms/fieldPreview.js
@@ -2,10 +2,13 @@ export default {
 	inheritAttrs: false,
 	props: {
 		column: {
-			type: Object,
-			default: () => ({})
+			default: () => ({}),
+			type: Object
 		},
-		field: Object,
+		field: {
+			default: () => ({}),
+			type: Object
+		},
 		value: {}
 	}
 };


### PR DESCRIPTION
I've created example setups for all field previews in the sandbox and found quite a few inconsistencies and smaller issues. 

## Enhancements

- Improved focus styles for links and the flag preview
- Improved text overflow behavior for links

## Refactoring

- `k-time-field-preview` now extends `k-date-field-preview` and improves time parsing and the default formatting
- The fieldpreview mixin defines proper defaults for column and field
- `k-toggle-field-preview` uses the low level `k-toggle-input` instead of `k-input` to avoid unnecessary markup

## Fixes

- `k-bubbles-field-preview` and all other previews that extend it now correctly display when there are no bubbles
- `k-color-field-preview` correctly displays the pattern when no color is set
