### PR TITLE
New k-timeoptions-input

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -65,7 +65,7 @@
 						@click="$refs.times.toggle()"
 					/>
 					<k-dropdown-content ref="times" align-x="end">
-						<k-times
+						<k-timeoptions-input
 							:display="time.display"
 							:value="value"
 							@input="onTimesInput"

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -16,7 +16,11 @@
 					@click="$refs.times.toggle()"
 				/>
 				<k-dropdown-content ref="times" align-x="end">
-					<k-times :display="display" :value="value" @input="select" />
+					<k-timeoptions-input
+						:display="display"
+						:value="value"
+						@input="select"
+					/>
 				</k-dropdown-content>
 			</template>
 		</k-input>

--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -12,6 +12,7 @@
 				value
 			}"
 			:data-variant="variant"
+			:class="{ 'sr-only': variant === 'invisible' }"
 			@input="$emit('input', $event.target.checked)"
 		/>
 		<span v-if="label || info" class="k-choice-input-label">
@@ -89,7 +90,8 @@ export default {
 	cursor: not-allowed;
 }
 
-.k-field .k-choice-input {
+/* Field context */
+:where(.k-checkboxes-field, .k-radio-field) .k-choice-input {
 	background: var(--input-color-back);
 	min-height: var(--input-height);
 	padding-block: var(--spacing-2);

--- a/panel/src/components/Forms/Input/TimeoptionsInput.vue
+++ b/panel/src/components/Forms/Input/TimeoptionsInput.vue
@@ -1,28 +1,39 @@
 <template>
-	<div class="k-times">
-		<div class="k-times-slot">
+	<div class="k-timeoptions-input">
+		<div>
 			<h3>
 				<k-icon type="sun" /> <span class="sr-only">{{ $t("day") }}</span>
 			</h3>
 			<ul>
-				<li v-for="time in day" :key="time.select">
+				<li v-for="(time, index) in day" :key="time.select">
 					<hr v-if="time === '-'" />
-					<k-button v-else @click="select(time.select)">{{
-						time.display
-					}}</k-button>
+					<k-button
+						v-else
+						:autofocus="autofocus && index === 0"
+						:disabled="disabled"
+						:selected="time.select === value ? 'time' : false"
+						@click="select(time.select)"
+					>
+						{{ time.display }}
+					</k-button>
 				</li>
 			</ul>
 		</div>
-		<div class="k-times-slot">
+		<div>
 			<h3>
 				<k-icon type="moon" /> <span class="sr-only">{{ $t("night") }}</span>
 			</h3>
 			<ul>
 				<li v-for="time in night" :key="time.select">
 					<hr v-if="time === '-'" />
-					<k-button v-else @click="select(time.select)">{{
-						time.display
-					}}</k-button>
+					<k-button
+						v-else
+						:disabled="disabled"
+						:selected="time.select === value ? 'time' : false"
+						@click="select(time.select)"
+					>
+						{{ time.display }}
+					</k-button>
 				</li>
 			</ul>
 		</div>
@@ -30,13 +41,20 @@
 </template>
 
 <script>
+import Input, { props as InputProps } from "@/mixins/input.js";
+
+export const props = {
+	mixins: [InputProps]
+};
+
 /**
  * The Times component displayes available times to choose from
  * @public
  *
- * @example <k-times value="12:12" @input="onInput" />
+ * @example <k-timeoptions-input value="12:12" @input="onInput" />
  */
 export default {
+	mixins: [Input, props],
 	props: {
 		display: {
 			type: String,
@@ -88,21 +106,24 @@ export default {
 </script>
 
 <style>
-.k-times {
+.k-timeoptions-input {
 	--button-height: var(--height-sm);
-	--button-padding: var(--spacing-3);
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: var(--spacing-3);
 }
-.k-times h3 {
+.k-timeoptions-input h3 {
 	display: flex;
 	align-items: center;
 	padding-inline: var(--button-padding);
 	height: var(--button-height);
 	margin-bottom: var(--spacing-1);
 }
-.k-times .k-times-slot hr {
+.k-timeoptions-input hr {
 	margin: var(--spacing-2) var(--spacing-3);
+}
+.k-timeoptions-input .k-button[aria-selected="time"] {
+	--button-color-text: var(--color-text);
+	--button-color-back: var(--color-blue-500);
 }
 </style>

--- a/panel/src/components/Forms/Input/TimeoptionsInput.vue
+++ b/panel/src/components/Forms/Input/TimeoptionsInput.vue
@@ -85,6 +85,9 @@ export default {
 		}
 	},
 	methods: {
+		focus() {
+			this.$el.querySelector("button").focus();
+		},
 		formatTimes(times) {
 			return times.map((time) => {
 				if (time === "-") {

--- a/panel/src/components/Forms/Input/index.js
+++ b/panel/src/components/Forms/Input/index.js
@@ -22,6 +22,7 @@ import TelInput from "./TelInput.vue";
 import TextInput from "./TextInput.vue";
 import TextareaInput from "./TextareaInput.vue";
 import TimeInput from "./TimeInput.vue";
+import TimeoptionsInput from "./TimeoptionsInput.vue";
 import ToggleInput from "./ToggleInput.vue";
 import TogglesInput from "./TogglesInput.vue";
 import UrlInput from "./UrlInput.vue";
@@ -53,12 +54,14 @@ export default {
 		app.component("k-text-input", TextInput);
 		app.component("k-textarea-input", TextareaInput);
 		app.component("k-time-input", TimeInput);
+		app.component("k-timeoptions-input", TimeoptionsInput);
 		app.component("k-toggle-input", ToggleInput);
 		app.component("k-toggles-input", TogglesInput);
 		app.component("k-url-input", UrlInput);
 		app.component("k-writer-input", WriterInput);
 
-		/** Keep k-calendar as legacy alias */
+		/** Keep k-calendar and k-times as legacy aliases */
 		app.component("k-calendar", CalendarInput);
+		app.component("k-times", TimeoptionsInput);
 	}
 };

--- a/panel/src/components/Forms/index.js
+++ b/panel/src/components/Forms/index.js
@@ -11,7 +11,6 @@ import Input from "./Input.vue";
 import Login from "./Login.vue";
 import LoginCode from "./LoginCode.vue";
 import Selector from "./Selector.vue";
-import Times from "./Times.vue";
 import Upload from "./Upload.vue";
 
 /** Form Helpers */
@@ -47,7 +46,6 @@ export default {
 		app.component("k-login", Login);
 		app.component("k-login-code", LoginCode);
 		app.component("k-selector", Selector);
-		app.component("k-times", Times);
 		app.component("k-upload", Upload);
 
 		app.component("k-login-alert", LoginAlert);

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -90,6 +90,10 @@ export default {
 		 */
 		role: String,
 		/**
+		 * Sets the `aria-selected` attribute.
+		 */
+		selected: [String, Boolean],
+		/**
 		 * Specific sizes for buttong styling
 		 * @values `xs`, `sm`
 		 */
@@ -137,6 +141,7 @@ export default {
 			const attrs = {
 				"aria-current": this.current,
 				"aria-disabled": this.disabled,
+				"aria-selected": this.selected,
 				"data-responsive": this.responsive,
 				"data-size": this.size,
 				"data-theme": this.theme,


### PR DESCRIPTION
## Enhancements

- New `selected` prop for `k-button` to set the `aria-selected` attribute.

## Refactoring

- `k-timeoptions-input` replaces `k-times`. `k-times` is still available as deprecated alias.
- Date and Time fields use the new input

