### PR TITLE
Make the file preview component less dependant on store

### DIFF
--- a/panel/src/components/Views/Files/FileFocusButton.vue
+++ b/panel/src/components/Views/Files/FileFocusButton.vue
@@ -14,12 +14,14 @@
 <script>
 export default {
 	props: {
-		file: Object,
 		focus: Object
 	},
 	methods: {
 		set() {
-			this.$emit("set", "50% 50%");
+			this.$emit("set", {
+				x: 50,
+				y: 50
+			});
 		},
 		reset() {
 			this.$emit("set", undefined);

--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -5,13 +5,12 @@
 			<!-- Image with focus picker -->
 			<template v-if="image.src">
 				<k-coords-input
-					:disabled="!canFocus"
+					:disabled="!focusable"
 					:value="focus"
 					@input="setFocus($event)"
 				>
 					<img v-bind="image" @dragstart.prevent />
 				</k-coords-input>
-
 				<k-button
 					icon="dots"
 					size="xs"
@@ -54,9 +53,8 @@
 					<dt>{{ $t("file.focus.title") }}</dt>
 					<dd>
 						<k-file-focus-button
-							v-if="canFocus"
+							v-if="focusable"
 							ref="focus"
-							:file="file"
 							:focus="focus"
 							@set="setFocus"
 						/>
@@ -74,27 +72,21 @@
 <script>
 export default {
 	props: {
-		details: Array,
-		file: Object,
+		details: {
+			default: () => [],
+			type: Array
+		},
+		focus: {
+			type: Object
+		},
 		focusable: Boolean,
-		image: Object,
-		isLocked: Boolean,
+		image: {
+			default: () => ({}),
+			type: Object
+		},
 		url: String
 	},
 	computed: {
-		focus() {
-			const focus = this.$store.getters["content/values"]()["focus"];
-
-			if (!focus) {
-				return;
-			}
-
-			const [x, y] = focus.replaceAll("%", "").split(" ");
-			return { x: parseFloat(x), y: parseFloat(y) };
-		},
-		canFocus() {
-			return this.focusable && this.image.src && this.isLocked === false;
-		},
 		options() {
 			const options = [
 				{
@@ -105,7 +97,7 @@ export default {
 				}
 			];
 
-			if (this.canFocus) {
+			if (this.focusable) {
 				if (this.focus) {
 					options.push({
 						icon: "cancel",
@@ -122,18 +114,18 @@ export default {
 			}
 
 			return options;
-		},
-		storeId() {
-			return this.$store.getters["content/id"](null, true);
 		}
 	},
 	methods: {
 		setFocus(focus) {
-			if (this.$helper.object.isObject(focus) === true) {
-				focus = `${focus.x.toFixed(1)}% ${focus.y.toFixed(1)}%`;
+			if (!focus) {
+				return this.$emit("focus", null);
 			}
 
-			this.$store.dispatch("content/update", ["focus", focus]);
+			this.$emit("focus", {
+				x: focus.x.toFixed(1),
+				y: focus.y.toFixed(1)
+			});
 		}
 	}
 };

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -53,7 +53,7 @@
 			</template>
 		</k-header>
 
-		<k-file-preview v-bind="preview" :file="model" :is-locked="isLocked" />
+		<k-file-preview v-bind="preview" :focus="focus" @focus="setFocus" />
 
 		<k-model-tabs :tab="tab.name" :tabs="tabs" />
 
@@ -76,9 +76,21 @@ export default {
 		preview: Object
 	},
 	computed: {
+		focus() {
+			const focus = this.$store.getters["content/values"]()["focus"];
+
+			if (!focus) {
+				return;
+			}
+
+			const [x, y] = focus.replaceAll("%", "").split(" ");
+
+			return { x: parseFloat(x), y: parseFloat(y) };
+		},
 		isFocusable() {
 			return (
 				!this.isLocked &&
+				this.preview.image.src &&
 				this.permissions.update &&
 				(!window.panel.multilang ||
 					window.panel.languages.length === 0 ||
@@ -95,6 +107,13 @@ export default {
 						...this.model
 					});
 			}
+		},
+		setFocus(focus) {
+			if (this.$helper.object.isObject(focus) === true) {
+				focus = `${focus.x}% ${focus.y}%`;
+			}
+
+			this.$store.dispatch("content/update", ["focus", focus]);
 		}
 	}
 };


### PR DESCRIPTION
## Refactoring

- `k-file-preview` is no longer connected to the store module and can now be tested more easily in our UI lab. This will also make it more reusable for other cases or replaceable by plugins. 

I've created new test scenarios for the file preview in the sandbox. This should also help with our file preview PR.