### PR TITLE
Fixes for various block issues

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -60,12 +60,18 @@
 export default {
 	inheritAttrs: false,
 	props: {
-		attrs: [Array, Object],
+		attrs: {
+			default: () => ({}),
+			type: [Array, Object]
+		},
 		content: {
 			default: () => ({}),
 			type: [Array, Object]
 		},
-		endpoints: Object,
+		endpoints: {
+			default: () => ({}),
+			type: [Array, Object]
+		},
 		fieldset: {
 			default: () => ({}),
 			type: Object

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -185,7 +185,7 @@ export default {
 			const tabs = this.fieldset.tabs ?? {};
 
 			for (const [tabName, tab] of Object.entries(tabs)) {
-				for (const [fieldName] of Object.entries(tab.fields)) {
+				for (const [fieldName] of Object.entries(tab.fields ?? {})) {
 					tabs[tabName].fields[fieldName].section = this.name;
 					tabs[tabName].fields[fieldName].endpoints = {
 						field:

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -61,9 +61,15 @@ export default {
 	inheritAttrs: false,
 	props: {
 		attrs: [Array, Object],
-		content: [Array, Object],
+		content: {
+			default: () => ({}),
+			type: [Array, Object]
+		},
 		endpoints: Object,
-		fieldset: Object,
+		fieldset: {
+			default: () => ({}),
+			type: Object
+		},
 		id: String,
 		isBatched: Boolean,
 		isFull: Boolean,
@@ -170,7 +176,7 @@ export default {
 			};
 		},
 		tabs() {
-			const tabs = this.fieldset.tabs;
+			const tabs = this.fieldset.tabs ?? {};
 
 			for (const [tabName, tab] of Object.entries(tabs)) {
 				for (const [fieldName] of Object.entries(tab.fields)) {

--- a/panel/src/components/Forms/Blocks/BlockFigure.vue
+++ b/panel/src/components/Forms/Blocks/BlockFigure.vue
@@ -29,20 +29,13 @@ export default {
 	inheritAttrs: false,
 	props: {
 		caption: String,
-		captionMarks: [Boolean, Array],
-		cover: {
-			type: Boolean,
-			default: true
+		captionMarks: {
+			default: true,
+			type: [Boolean, Array]
 		},
 		isEmpty: Boolean,
 		emptyIcon: String,
-		emptyText: String,
-		ratio: String
-	},
-	computed: {
-		ratioPadding() {
-			return this.$helper.ratio(this.ratio ?? "16/9");
-		}
+		emptyText: String
 	}
 };
 </script>

--- a/panel/src/components/Forms/Blocks/BlockTitle.vue
+++ b/panel/src/components/Forms/Blocks/BlockTitle.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="k-block-title">
 		<k-icon :type="icon" class="k-block-icon" />
-		<span class="k-block-name">
+		<span v-if="name" class="k-block-name">
 			{{ name }}
 		</span>
 		<span v-if="label" class="k-block-label">
@@ -17,8 +17,14 @@
 export default {
 	inheritAttrs: false,
 	props: {
-		fieldset: Object,
-		content: Object
+		fieldset: {
+			default: () => ({}),
+			type: Object
+		},
+		content: {
+			default: () => ({}),
+			type: Object
+		}
 	},
 	computed: {
 		icon() {
@@ -58,19 +64,15 @@ export default {
 	align-items: center;
 	min-width: 0;
 	padding-inline-end: 0.75rem;
-	font-size: var(--text-sm);
 	line-height: 1;
+	gap: var(--spacing-2);
 }
 .k-block-icon {
+	--icon-color: var(--color-gray-600);
 	width: 1rem;
-	margin-inline-end: 0.5rem;
-	color: var(--color-gray-500);
-}
-.k-block-name {
-	margin-inline-end: 0.5rem;
 }
 .k-block-label {
-	color: var(--color-gray-600);
+	color: var(--color-text-dimmed);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/panel/src/components/Forms/Blocks/BlockType.vue
+++ b/panel/src/components/Forms/Blocks/BlockType.vue
@@ -13,7 +13,7 @@ export default {
 		field(name, fallback = null) {
 			let field = null;
 
-			for (const tab of Object.values(this.fieldset.tabs)) {
+			for (const tab of Object.values(this.fieldset.tabs ?? {})) {
 				if (tab.fields[name]) {
 					field = tab.fields[name];
 				}

--- a/panel/src/components/Forms/Blocks/Types/Fields.vue
+++ b/panel/src/components/Forms/Blocks/Types/Fields.vue
@@ -92,11 +92,10 @@ export default {
 .k-block-type-fields-header {
 	display: flex;
 	justify-content: space-between;
-	height: var(--drawer-header-height);
-	padding-inline: var(--spacing-1);
 	background: var(--color-white);
 }
 .k-block-type-fields-header .k-block-title {
+	padding-block: var(--spacing-3);
 	cursor: pointer;
 }
 

--- a/panel/src/components/Forms/Blocks/Types/Gallery.vue
+++ b/panel/src/components/Forms/Blocks/Types/Gallery.vue
@@ -1,7 +1,7 @@
 <template>
 	<figure>
 		<ul @dblclick="open">
-			<template v-if="content.images.length === 0">
+			<template v-if="!content.images?.length">
 				<li
 					v-for="index in 3"
 					:key="index"

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -44,7 +44,7 @@ export default {
 				return this.content.src;
 			}
 
-			if (this.content.image[0]?.url) {
+			if (this.content.image && this.content.image[0]?.url) {
 				return this.content.image[0].url;
 			}
 

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -44,7 +44,7 @@ export default {
 				return this.content.src;
 			}
 
-			if (this.content.image && this.content.image[0]?.url) {
+			if (this.content.image?.[0]?.url) {
 				return this.content.image[0].url;
 			}
 

--- a/panel/src/components/Forms/Blocks/Types/Table.vue
+++ b/panel/src/components/Forms/Blocks/Types/Table.vue
@@ -47,7 +47,7 @@ export default {
 		table() {
 			let table = null;
 
-			for (const tab of Object.values(this.fieldset.tabs)) {
+			for (const tab of Object.values(this.fieldset.tabs ?? {})) {
 				if (tab.fields.rows) {
 					table = tab.fields.rows;
 				}

--- a/panel/src/components/Forms/Blocks/Types/Video.vue
+++ b/panel/src/components/Forms/Blocks/Types/Video.vue
@@ -29,7 +29,7 @@ export default {
 			return this.field("caption", { marks: true }).marks;
 		},
 		video() {
-			return this.$helper.embed.video(this.content.url, true);
+			return this.$helper.embed.video(this.content.url ?? "", true);
 		}
 	}
 };


### PR DESCRIPTION
While setting up the block examples, I found a couple issues in block components. 

## Fixes

- Added default values for object props to avoid breaks
- Fixed various inconsistencies in `k-block-title` styles
- Better defaults and removed outdated props in `k-block-figure`
- Fixed padding in the block header of the field block type component. 