### PR TITLE
Table CSS refactoring

### DIFF
--- a/panel/src/components/Dropdowns/OptionsDropdown.vue
+++ b/panel/src/components/Dropdowns/OptionsDropdown.vue
@@ -2,6 +2,7 @@
 	<!-- Single option = button -->
 	<k-button
 		v-if="hasSingleOption"
+		:disabled="disabled"
 		:icon="options[0].icon ?? icon"
 		:size="options[0].size ?? size"
 		:title="options[0].title ?? options[0].tooltip ?? options[0].text"
@@ -20,6 +21,7 @@
 	<!-- Multiple options = dropdown -->
 	<div v-else-if="options.length" class="k-options-dropdown">
 		<k-button
+			:disabled="disabled"
 			:dropdown="true"
 			:icon="icon"
 			:size="size"
@@ -49,6 +51,9 @@ export default {
 		align: {
 			type: String,
 			default: "right"
+		},
+		disabled: {
+			type: Boolean
 		},
 		/**
 		 * Icon for the dropdown button

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -31,7 +31,7 @@
 							:key="field.name"
 							@click="open(field.name)"
 						>
-							<th data-mobile="true">
+							<th data-has-button data-mobile="true">
 								<button type="button">{{ field.label }}</button>
 							</th>
 							<k-table-cell
@@ -169,13 +169,6 @@ export default {
 <style>
 .k-table.k-object-field-table {
 	table-layout: auto;
-}
-.k-table.k-object-field-table tbody td,
-.k-table.k-object-field-table tbody th,
-.k-table.k-object-field-table tbody th button {
-	cursor: pointer;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 .k-table.k-object-field-table tbody td {
 	max-width: 0;

--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -53,7 +53,10 @@ export default {
 	--bubble-back: var(--color-light);
 	--bubble-text: var(--color-black);
 
-	padding: 0.325rem 0.75rem;
+	padding: 0.375rem var(--table-cell-padding);
 	overflow: hidden;
+}
+.k-bubbles-field-preview .k-bubbles {
+	gap: 0.375rem;
 }
 </style>

--- a/panel/src/components/Forms/Previews/ColorFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ColorFieldPreview.vue
@@ -49,7 +49,7 @@ export default {
 .k-color-field-preview {
 	--color-frame-rounded: var(--tag-rounded);
 	--color-frame-size: var(--tag-height);
-	padding: 0.325rem 0.75rem;
+	padding: 0.375rem var(--table-cell-padding);
 	display: flex;
 	align-items: center;
 	gap: var(--spacing-2);

--- a/panel/src/components/Forms/Previews/FlagFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FlagFieldPreview.vue
@@ -1,7 +1,10 @@
 <template>
-	<div v-if="value" class="k-flag-field-preview">
-		<k-button v-bind="status" size="md" />
-	</div>
+	<k-button
+		v-if="value"
+		v-bind="status"
+		class="k-flag-field-preview"
+		size="md"
+	/>
 </template>
 
 <script>
@@ -25,9 +28,8 @@ export default {
 
 <style>
 .k-flag-field-preview {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: var(--table-row-height);
+	--button-height: var(--table-row-height);
+	--button-width: 100%;
+	outline-offset: -2px;
 }
 </style>

--- a/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
@@ -2,7 +2,7 @@
 	<div class="k-html-field-preview" :class="$options.class">
 		{{ column.before }}
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<div v-html="html" />
+		<div class="k-text" v-html="html" />
 		{{ column.after }}
 	</div>
 </template>
@@ -25,35 +25,8 @@ export default {
 
 <style>
 .k-html-field-preview {
-	padding: 0.325rem 0.75rem;
+	padding: 0.375rem var(--table-cell-padding);
 	overflow: hidden;
 	text-overflow: ellipsis;
-	white-space: nowrap;
-	line-height: 1.5em;
-}
-.k-html-field-preview p:not(:last-child) {
-	margin-bottom: 1.5em;
-}
-.k-html-field-preview ul,
-.k-html-field-preview ol {
-	margin-inline-start: 1rem;
-}
-.k-html-field-preview ul > li {
-	list-style: disc;
-}
-.k-html-field-preview ol ul > li,
-.k-html-field-preview ul ul > li {
-	list-style: circle;
-}
-.k-html-field-preview ol > li {
-	list-style: decimal;
-}
-.k-html-field-preview ol > li::marker {
-	color: var(--color-gray-500);
-	font-size: var(--text-xs);
-}
-.k-html-field-preview a {
-	color: var(--color-focus);
-	text-decoration: underline;
 }
 </style>

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -23,6 +23,6 @@ export default {
 
 <style>
 .k-toggle-field-preview {
-	padding-inline: var(--spacing-3);
+	padding-inline: var(--table-cell-padding);
 }
 </style>

--- a/panel/src/components/Forms/Previews/UrlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UrlFieldPreview.vue
@@ -33,7 +33,7 @@ export default {
 
 <style>
 .k-url-field-preview {
-	padding-inline: var(--spacing-2);
+	padding-inline: var(--table-cell-padding);
 }
 .k-url-field-preview[data-link] {
 	color: var(--link-color);
@@ -43,6 +43,7 @@ export default {
 	align-items: center;
 	height: var(--height-xs);
 	padding-inline: var(--spacing-1);
+	margin-inline: calc(var(--spacing-1) * -1);
 	border-radius: var(--rounded);
 	max-width: 100%;
 	min-width: 0;

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -505,6 +505,9 @@ export default {
 	border: 1px solid var(--table-color-border);
 	box-shadow: none;
 }
+.k-table[aria-disabled="true"] thead th {
+	position: static;
+}
 
 /* Mobile */
 @container (max-width: 40rem) {

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="k-table">
+	<div :aria-disabled="disabled" class="k-table">
 		<table :data-disabled="disabled" :data-indexed="hasIndexColumn">
 			<!-- Header row -->
 			<thead>
@@ -338,107 +338,100 @@ export default {
 </script>
 
 <style>
-/** Table Layout **/
+:root {
+	--table-cell-padding: var(--spacing-3);
+	--table-color-back: var(--color-white);
+	--table-color-border: var(--color-background);
+	--table-color-hover: var(--color-gray-100);
+	--table-color-th-back: var(--color-gray-100);
+	--table-color-th-text: var(--color-text-dimmed);
+	--table-row-height: var(--input-height);
+}
+
+/* Table Layout */
 .k-table {
-	--table-row-height: 38px;
 	position: relative;
-	background: var(--color-white);
-	font-size: var(--text-sm);
+	background: var(--table-color-back);
 	box-shadow: var(--shadow);
 	border-radius: var(--rounded);
 }
+
 .k-table table {
-	width: 100%;
-	border-spacing: 0;
 	table-layout: fixed;
-	font-variant-numeric: tabular-nums;
-}
-.k-table[data-invalid] {
-	border: 0;
-	box-shadow:
-		var(--color-red-900) 0 0 0 1px,
-		var(--color-red-900) 0 0 3px 2px;
 }
 
-/** Cells **/
+/* All Cells */
 .k-table th,
 .k-table td {
+	padding-inline: var(--table-cell-padding);
 	height: var(--table-row-height);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	width: 100%;
-	border-inline-end: 1px solid var(--color-background);
-	line-height: 1.25em;
+	border-inline-end: 1px solid var(--table-color-border);
+	line-height: 1.25;
 }
-
-.k-table thead th:first-child {
-	border-start-start-radius: var(--rounded);
-}
-.k-table thead th:last-child {
-	border-start-end-radius: var(--rounded);
-}
-.k-table th:last-child,
-.k-table td:last-child {
-	height: var(--table-row-height);
+.k-table tr > *:last-child {
 	border-inline-end: 0;
 }
 
 .k-table th,
 .k-table tr:not(:last-child) td {
-	border-block-end: 1px solid var(--color-background);
+	border-block-end: 1px solid var(--table-color-border);
 }
 
-.k-table td:last-child {
-	overflow: visible;
+/* Text aligment */
+.k-table :where(td, th)[data-align] {
+	text-align: var(--align);
 }
 
-.k-table th,
-.k-table td {
-	border-inline-end: 1px solid var(--color-background);
-	text-align: start;
-}
-
+/* TH */
 .k-table th {
-	padding: 0 0.75rem;
+	padding-inline: var(--table-cell-padding);
 	font-family: var(--font-mono);
 	font-size: var(--text-xs);
-	font-weight: 400;
-	color: var(--color-text-dimmed);
-	background: var(--color-gray-100);
-	width: 100%;
+	color: var(--table-color-th-text);
+	background: var(--table-color-th-back);
 }
-
+.k-table th[data-has-button] {
+	padding: 0;
+}
 .k-table th button {
-	font: inherit;
-	display: block;
-	padding: 0 0.75rem;
+	padding-inline: var(--table-cell-padding);
 	height: 100%;
 	width: 100%;
 	border-radius: var(--rounded);
 	text-align: start;
 }
 .k-table th button:focus-visible {
-	outline: 2px solid var(--color-black);
 	outline-offset: -2px;
 }
 
-.k-table tbody tr:hover td {
-	background: rgba(239, 239, 239, 0.25);
+/* Table Header */
+.k-table thead th:first-child {
+	border-start-start-radius: var(--rounded);
+}
+.k-table thead th:last-child {
+	border-start-end-radius: var(--rounded);
 }
 
-/** Sticky header **/
+/* Sticky Header */
 .k-table thead th {
 	position: sticky;
-	top: 0;
+	top: var(--header-sticky-offset);
 	inset-inline: 0;
 	z-index: 1;
 }
 
-/** Header cells in the body **/
+/* Table Body */
+.k-table tbody tr:hover td {
+	background: var(--table-color-hover);
+}
+
+/* Header cells in the body */
 .k-table tbody th {
 	width: auto;
 	white-space: nowrap;
-	padding: 0;
 	overflow: visible;
 	border-radius: 0;
 }
@@ -450,28 +443,7 @@ export default {
 	border-block-end: 0;
 }
 
-/** Text aligment **/
-.k-table-column[data-align] {
-	text-align: var(--align) !important;
-}
-.k-table-column[data-align="right"] > .k-input {
-	flex-direction: column;
-	align-items: flex-end;
-}
-
-/** Index & Sort handle */
-td.k-table-index-column {
-	display: grid;
-	place-items: center;
-}
-.k-table .k-sort-handle,
-.k-table tr:hover .k-table-index-column[data-sortable="true"] .k-table-index {
-	display: none;
-}
-.k-table tr:hover .k-sort-handle {
-	display: flex;
-}
-
+/* Sortable tables */
 .k-table-row-ghost {
 	background: var(--color-white);
 	outline: var(--outline);
@@ -479,67 +451,68 @@ td.k-table-index-column {
 	margin-bottom: 2px;
 	cursor: grabbing;
 }
-
 .k-table-row-fallback {
 	opacity: 0 !important;
 }
 
-/** Index column **/
-:is(th, td).k-table-index-column,
-:is(th, td).k-table-options-column {
+/* Table Index */
+.k-table .k-table-index-column {
 	width: var(--table-row-height);
 	text-align: center;
 }
-.k-table-index {
+.k-table .k-table-index {
 	font-size: var(--text-xs);
 	color: var(--color-text-dimmed);
 	line-height: 1.1em;
 }
 
-/** Empty */
+/* Table Index with sort handle */
+.k-table .k-table-index-column .k-sort-handle {
+	--button-width: 100%;
+	display: none;
+}
+.k-table tr:hover .k-table-index-column[data-sortable="true"] .k-table-index {
+	display: none;
+}
+.k-table tr:hover .k-table-index-column[data-sortable="true"] .k-sort-handle {
+	display: flex;
+}
+
+/* Table Options */
+.k-table .k-table-options-column {
+	padding: 0;
+	width: var(--table-row-height);
+	text-align: center;
+}
+.k-table .k-table-options-column .k-options-dropdown-toggle {
+	--button-width: 100%;
+	--button-height: 100%;
+	outline-offset: -2px;
+}
+
+/* Empty */
 .k-table-empty {
 	color: var(--color-text-dimmed);
 	font-size: var(--text-sm);
 }
 
-/** Disabled */
-[data-disabled="true"] .k-table {
-	background: var(--color-gray-100);
-}
-[data-disabled="true"] .k-table th,
-[data-disabled="true"] .k-table tbody td {
-	border-color: var(--color-gray-200);
-}
-[data-disabled="true"] .k-table td:last-child {
-	overflow: hidden;
-	text-overflow: ellipsis;
+/* Disabled */
+.k-table[aria-disabled="true"] {
+	--table-color-back: transparent;
+	--table-color-border: var(--color-border);
+	--table-color-hover: transparent;
+	--table-color-th-back: transparent;
+	border: 1px solid var(--table-color-border);
+	box-shadow: none;
 }
 
-/** Mobile */
+/* Mobile */
 @container (max-width: 40rem) {
-	.k-table tbody td:not([data-mobile]),
-	.k-table thead th:not([data-mobile]) {
-		display: none;
+	.k-table {
+		overflow-x: scroll;
 	}
-}
-
-.k-table-pagination.k-pagination {
-	border-top: 1px solid var(--color-gray-200);
-	background: var(--color-gray-100);
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	height: var(--table-row-height);
-	border-end-start-radius: var(--rounded);
-	border-end-end-radius: var(--rounded);
-}
-.k-table-pagination.k-pagination .k-button {
-	--button-color-back: transparent;
-	padding: 0 0.75rem;
-	display: flex;
-	align-items: center;
-	line-height: 1;
-	height: var(--table-row-height);
-	border-left: 0 !important;
+	.k-table thead th {
+		position: static;
+	}
 }
 </style>

--- a/panel/src/components/Layout/TableCell.vue
+++ b/panel/src/components/Layout/TableCell.vue
@@ -1,5 +1,5 @@
 <template>
-	<td :data-align="column.align" :data-mobile="mobile">
+	<td :data-align="column.align" :data-mobile="mobile" class="k-table-cell">
 		<template v-if="$helper.object.isEmpty(value) === false">
 			<!-- Table cell type component -->
 			<component
@@ -74,3 +74,9 @@ export default {
 	}
 };
 </script>
+
+<style>
+.k-table .k-table-cell {
+	padding: 0;
+}
+</style>

--- a/panel/src/components/Text/Text.vue
+++ b/panel/src/components/Text/Text.vue
@@ -93,7 +93,31 @@ export default {
 }
 
 /* Element margins */
-.k-text > * + * {
+.k-text
+	> :where(
+		audio,
+		blockquote,
+		details,
+		div,
+		figure,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		hr,
+		iframe,
+		img,
+		object,
+		ol,
+		p,
+		picture,
+		pre,
+		table,
+		ul
+	)
+	+ * {
 	margin-block-start: calc(var(--text-line-height) * 1em);
 }
 


### PR DESCRIPTION
## Enhancements 

- Better focus styles for the option and flag buttons in the table
- Simplified CSS styles for the table
- New --table CSS properties for more control
- Better mobile responsiveness for tables with a scrollable container instead of hiding cells
- Better disabled state with aria-disabled property
- New disabled property for the `k-options-dropdown` component
- More reliable margin rules for `k-text`
- Full `k-text` style support for the `k-html-field-preview` component
- The table rows are now the same height as inputs, boxes and items, which cleans up the design quite a bit
- All field previews now use the `--table-cell-padding` property to control their padding, which leads to more reliable styling options
- All table setup variants have examples in the lab

## Fixed

- The sticky header in the table now uses the --header-sticky-offset to fix it's stickiness. 
