### PR TITLE
Allow string for `$site->search(params: )` again

### DIFF
--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -407,7 +407,7 @@ class Site extends ModelWithContent
 	/**
 	 * Search all pages in the site
 	 */
-	public function search(string|null $query = null, array $params = []): Pages
+	public function search(string|null $query = null, string|array $params = []): Pages
 	{
 		return $this->index()->search($query, $params);
 	}

--- a/tests/Cms/Site/SiteChildrenTest.php
+++ b/tests/Cms/Site/SiteChildrenTest.php
@@ -27,4 +27,83 @@ class SiteChildrenTest extends TestCase
 
 		$this->assertInstanceOf(Pages::class, $site->children());
 	}
+
+	public function testSearch()
+	{
+		$site = new Site([
+			'children' => [
+				[
+					'slug'    => 'mtb',
+					'content' => [
+						'title' => 'Mountainbike'
+					]
+				],
+				[
+					'slug'    => 'mountains',
+					'content' => [
+						'title' => 'Mountains'
+					]
+				],
+				[
+					'slug'    => 'lakes',
+					'content' => [
+						'title' => 'Lakes'
+					]
+				]
+			]
+		]);
+
+		$result = $site->search('mountain');
+		$this->assertCount(2, $result);
+
+		$result = $site->search('mountain', 'title|text');
+		$this->assertCount(2, $result);
+
+		$result = $site->search('mountain', 'text');
+		$this->assertCount(0, $result);
+	}
+
+	public function testSearchWords()
+	{
+		$site = new Site([
+			'children' => [
+				[
+					'slug'    => 'mtb',
+					'content' => [
+						'title' => 'Mountainbike'
+					]
+				],
+				[
+					'slug'    => 'mountain',
+					'content' => [
+						'title' => 'Mountain'
+					]
+				],
+				[
+					'slug'    => 'everest-mountain',
+					'content' => [
+						'title' => 'Everest Mountain'
+					]
+				],
+				[
+					'slug'    => 'mount',
+					'content' => [
+						'title' => 'Mount'
+					]
+				],
+				[
+					'slug'    => 'lakes',
+					'content' => [
+						'title' => 'Lakes'
+					]
+				]
+			]
+		]);
+
+		$result = $site->search('mountain', ['words' => true]);
+		$this->assertCount(2, $result);
+
+		$result = $site->search('mount', ['words' => false]);
+		$this->assertCount(4, $result);
+	}
 }


### PR DESCRIPTION
Follow-up to #5675

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- `$site->search()` allows to provide a string with field names as `$params` again

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
