### PR TITLE
Ignore case in `$collection->remove()`

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -66,9 +66,11 @@ class Collection extends BaseCollection
 	}
 
 	/**
-	 * Internal setter for each object in the Collection.
-	 * This takes care of Component validation and of setting
-	 * the collection prop on each object correctly.
+	 * Internal setter for each object in the Collection;
+	 * override from the Toolkit Collection is needed to
+	 * make the CMS collections case-sensitive;
+	 * child classes can override it again to add validation
+	 * and custom behavior depending on the object type
 	 *
 	 * @param string $id
 	 * @param object $object
@@ -80,7 +82,9 @@ class Collection extends BaseCollection
 	}
 
 	/**
-	 * Internal remover for each object in the Collection
+	 * Internal remover for each object in the Collection;
+	 * override from the Toolkit Collection is needed to
+	 * make the CMS collections case-sensitive
 	 */
 	public function __unset($id)
 	{

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -80,6 +80,14 @@ class Collection extends BaseCollection
 	}
 
 	/**
+	 * Internal remover for each object in the Collection
+	 */
+	public function __unset($id)
+	{
+		unset($this->data[$id]);
+	}
+
+	/**
 	 * Adds a single object or
 	 * an entire second collection to the
 	 * current collection

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -123,6 +123,10 @@ class Collection extends Iterator implements Countable
 	 */
 	public function __unset($key)
 	{
+		if ($this->caseSensitive !== true) {
+			$key = strtolower($key);
+		}
+
 		unset($this->data[$key]);
 	}
 

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -87,6 +87,7 @@ class CollectionTest extends TestCase
 	/**
 	 * @covers ::get
 	 * @covers ::set
+	 * @covers ::remove
 	 */
 	public function testCaseSensitive()
 	{
@@ -96,19 +97,17 @@ class CollectionTest extends TestCase
 			'MiXeD'     => 'test3'
 		]);
 		$normalCollection->set('AnOtHeR', 'test4');
+		$normalCollection->remove('upperCase');
 
 		$this->assertSame([
 			'lowercase' => 'test1',
-			'uppercase' => 'test2',
 			'mixed'     => 'test3',
 			'another'   => 'test4'
 		], $normalCollection->data());
 		$this->assertSame('test1', $normalCollection->get('lowercase'));
-		$this->assertSame('test2', $normalCollection->get('UPPERCASE'));
 		$this->assertSame('test3', $normalCollection->get('MiXeD'));
 		$this->assertSame('test4', $normalCollection->get('AnOtHeR'));
 		$this->assertSame('test1', $normalCollection->get('LowerCase'));
-		$this->assertSame('test2', $normalCollection->get('uppercase'));
 		$this->assertSame('test3', $normalCollection->get('mIxEd'));
 		$this->assertSame('test4', $normalCollection->get('another'));
 
@@ -118,20 +117,19 @@ class CollectionTest extends TestCase
 			'MiXeD'     => 'test3'
 		], true);
 		$sensitiveCollection->set('AnOtHeR', 'test4');
+		$sensitiveCollection->remove('upperCase');
+		$sensitiveCollection->remove('MiXeD');
 
 		$this->assertSame([
 			'lowercase' => 'test1',
 			'UPPERCASE' => 'test2',
-			'MiXeD'     => 'test3',
 			'AnOtHeR'   => 'test4'
 		], $sensitiveCollection->data());
 		$this->assertSame('test1', $sensitiveCollection->get('lowercase'));
 		$this->assertSame('test2', $sensitiveCollection->get('UPPERCASE'));
-		$this->assertSame('test3', $sensitiveCollection->get('MiXeD'));
 		$this->assertSame('test4', $sensitiveCollection->get('AnOtHeR'));
 		$this->assertNull($sensitiveCollection->get('Lowercase'));
 		$this->assertNull($sensitiveCollection->get('uppercase'));
-		$this->assertNull($sensitiveCollection->get('mixed'));
 		$this->assertNull($sensitiveCollection->get('another'));
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- `$collection->remove()` and `$collection->__unset()` in Toolkit collections behave like `$collection->set()`/`$collection->__set()` by default and ignore the key case

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
