### PR TITLE
`Str::pool()`: New `base32`/`base32hex` pools

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -626,6 +626,8 @@ class Str
 				'alpha'      => static::pool(['alphaLower', 'alphaUpper']),
 				'num'        => range(0, 9),
 				'alphanum'   => static::pool(['alpha', 'num']),
+				'base32'     => array_merge(static::pool('alphaUpper'), range(2, 7)),
+				'base32hex'  => array_merge(range(0, 9), range('A', 'V')),
 				default      => $pool
 			};
 		}

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -570,33 +570,53 @@ class StrTest extends TestCase
 	{
 		// alpha
 		$string = Str::pool('alpha', false);
-		$this->assertTrue(V::alpha($string));
 		$this->assertSame(52, strlen($string));
+		$this->assertSame(
+			'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+			$string
+		);
 
 		// alphaLower
 		$string = Str::pool('alphaLower', false);
-		$this->assertTrue(V::alpha($string));
 		$this->assertSame(26, strlen($string));
+		$this->assertSame('abcdefghijklmnopqrstuvwxyz', $string);
 
 		// alphaUpper
 		$string = Str::pool('alphaUpper', false);
-		$this->assertTrue(V::alpha($string));
 		$this->assertSame(26, strlen($string));
+		$this->assertSame('ABCDEFGHIJKLMNOPQRSTUVWXYZ', $string);
 
 		// num
 		$string = Str::pool('num', false);
-		$this->assertTrue(V::num($string));
 		$this->assertSame(10, strlen($string));
+		$this->assertSame('0123456789', $string);
 
 		// alphaNum
 		$string = Str::pool('alphaNum', false);
-		$this->assertTrue(V::alphanum($string));
 		$this->assertSame(62, strlen($string));
+		$this->assertSame(
+			'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+			$string
+		);
+
+		// base32
+		$string = Str::pool('base32', false);
+		$this->assertSame(32, strlen($string));
+		$this->assertSame('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', $string);
+
+		// base32hex
+		$string = Str::pool('base32hex', false);
+		$this->assertSame(32, strlen($string));
+		$this->assertSame('0123456789ABCDEFGHIJKLMNOPQRSTUV', $string);
+
+		// default fallback: empty pool
+		$pool = Str::pool('invalid', true);
+		$this->assertSame([], $pool);
 
 		// [alphaLower, num]
 		$string = Str::pool(['alphaLower', 'num'], false);
-		$this->assertTrue(V::alphanum($string));
 		$this->assertSame(36, strlen($string));
+		$this->assertSame('abcdefghijklmnopqrstuvwxyz0123456789', $string);
 
 		// string vs. array
 		$this->assertIsString(Str::pool('alpha', false));


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement

- `Str::pool()`: New `base32` and `base32hex` pools (useful when a `Str::random()` needs to be printed in a human-readable way without easy to confuse `0/O` and `1/I`).

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
