### PR TITLE
Activation

### DIFF
--- a/panel/src/components/View/Activation.vue
+++ b/panel/src/components/View/Activation.vue
@@ -1,0 +1,75 @@
+<template>
+	<aside v-if="!$panel.license" :data-closed="!isOpen" class="k-activation">
+		<span class="k-text">Ready to launch?</span>
+
+		<k-button
+			text="Activate now"
+			dialog="registration"
+			icon="key"
+			theme="positive"
+			variant="filled"
+		/>
+		<k-button icon="cancel-small" class="k-activation-toggle" @click="close" />
+	</aside>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			isOpen: sessionStorage.getItem("kirby$activation$card") !== "true"
+		};
+	},
+	methods: {
+		close() {
+			this.isOpen = false;
+			sessionStorage.setItem("kirby$activation$card", "true");
+		}
+	}
+};
+</script>
+
+<style>
+.k-activation {
+	--button-width: 100%;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-3);
+
+	padding: var(--spacing-6) var(--spacing-3) var(--spacing-3);
+	background: var(--color-white);
+	border-radius: var(--rounded-lg);
+	text-align: center;
+	box-shadow: var(--shadow-lg);
+}
+
+.k-activation-toggle {
+	--button-align: end;
+	position: absolute;
+	top: 0;
+	inset-inline-end: var(--spacing-2);
+}
+
+.k-activation .k-icon-frame {
+	--icon-size: 1.5rem;
+	--icon-color: var(--color-blue-600);
+}
+
+.k-panel[data-menu="false"] .k-activation {
+	position: fixed;
+	width: var(--menu-width-open);
+	inset-inline-end: var(--spacing-4);
+	bottom: var(--spacing-4);
+	border: 1px solid var(--color-gray-300);
+}
+.k-panel[data-menu="false"] .k-activation[data-closed="true"] {
+	display: none;
+}
+.k-panel[data-menu="true"] .k-activation {
+	padding-top: var(--spacing-3);
+}
+.k-panel[data-menu="true"] .k-activation-toggle {
+	display: none;
+}
+</style>

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -31,6 +31,8 @@
 					class="k-panel-menu-button"
 				/>
 			</menu>
+
+			<k-activation />
 		</div>
 
 		<!-- Collapse/expand toggle -->

--- a/panel/src/components/View/index.js
+++ b/panel/src/components/View/index.js
@@ -2,14 +2,16 @@ import Inside from "./Inside.vue";
 import Menu from "./Menu.vue";
 import Outside from "./Outside.vue";
 import Panel from "./Panel.vue";
+import Activation from "./Activation.vue";
 import Topbar from "./Topbar.vue";
 
 export default {
 	install(app) {
+		app.component("k-activation", Activation);
 		app.component("k-panel", Panel);
 		app.component("k-panel-inside", Inside);
 		app.component("k-panel-menu", Menu);
-		app.component("k-panel-outside", Outside);
+		app.component("k-topbar", Topbar);
 		app.component("k-topbar", Topbar);
 
 		// @deprecated 4.0.0 Use `k-panel-inside` instead

--- a/src/Panel/Menu.php
+++ b/src/Panel/Menu.php
@@ -196,7 +196,7 @@ class Menu
 	 */
 	public function options(): array
 	{
-		$options = [
+		return [
 			[
 				'icon'     => 'edit-line',
 				'dialog'   => 'changes',
@@ -215,17 +215,5 @@ class Menu
 				'text' => I18n::translate('logout')
 			]
 		];
-
-		if (App::instance()->system()->license() === false) {
-			array_unshift($options, [
-				'icon'     => 'key',
-				'dialog'   => 'registration',
-				'text'     => I18n::translate('license.register'),
-				'variant'  => 'filled',
-				'theme'    => 'notice',
-			]);
-		}
-
-		return $options;
 	}
 }


### PR DESCRIPTION
When menu is collapsed, show fixed and allow hiding for one sessionStorage length
<img width="1084" alt="Screenshot 2023-10-07 at 14 30 49" src="https://github.com/getkirby/kirby/assets/3788865/2bbe8f23-a64f-427d-ac96-d0fd8c6881d5">

When menu is expanded, always show it
<img width="520" alt="Screenshot 2023-10-07 at 14 31 11" src="https://github.com/getkirby/kirby/assets/3788865/69efef24-f6d1-41a5-9200-20180ee36f89">
