### PR TITLE
Implement A::every(), A::some(), A::find()

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -60,6 +60,76 @@ class A
 	}
 
 	/**
+	 * Checks if every element in the array passes the test
+	 *
+	 * <code>
+	 * $array = [1, 30, 39, 29, 10, 13];
+	 *
+	 * $isBelowThreshold = fn($value) => $value < 40;
+	 * echo A::every($array, $isBelowThreshold) ? 'true' : 'false';
+	 * // output: 'true'
+	 *
+	 * $isIntegerKey = fn($value, $key) => is_int($key);
+	 * echo A::every($array, $isStringKey) ? 'true' : 'false';
+	 * // output: 'true'
+	 * </code>
+	 *
+	 * @param array $array
+	 * @param callable(mixed $value, int|string $key, array $array):bool $test
+	 * @return bool
+	 */
+	public static function every(array $array, callable $test): bool
+	{
+		foreach ($array as $key => $value) {
+			if (!$test($value, $key, $array)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Finds the first element matching the given callback
+	 *
+	 * <code>
+	 * $array = [1, 30, 39, 29, 10, 13];
+	 *
+	 * $isAboveThreshold = fn($value) => $value > 30;
+	 * echo A::find($array, $isAboveThreshold);
+	 * // output: '39'
+	 *
+	 * $array = [
+	 *   'cat' => 'miao',
+	 *   'cow' => 'moo',
+	 *   'colibri' => 'humm',
+	 *   'dog' => 'wuff',
+	 *   'chicken' => 'cluck',
+	 *   'bird' => 'tweet'
+	 * ];
+	 *
+	 * $keyNotStartingWithC = fn($value, $key) => $key[0] !== 'c';
+	 * echo A::find($array, $keyNotStartingWithC);
+	 * // output: 'wuff'
+	 * </code>
+	 *
+	 * @since 3.9.8
+	 * @param array $array
+	 * @param callable(mixed $value, int|string $key, array $array):bool $callback
+	 * @return mixed
+	 */
+	public static function find(array $array, callable $callback): mixed
+	{
+		foreach ($array as $key => $value) {
+			if ($callback($value, $key, $array)) {
+				return $value;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Gets an element of an array by key
 	 *
 	 * <code>
@@ -256,7 +326,7 @@ class A
 				) {
 					$merged[] = $value;
 
-				// recursively merge the two array values
+					// recursively merge the two array values
 				} elseif (
 					is_array($value) === true &&
 					isset($merged[$key]) === true &&
@@ -264,7 +334,7 @@ class A
 				) {
 					$merged[$key] = static::merge($merged[$key], $value, $mode);
 
-				// simply overwrite with the value from the second array
+					// simply overwrite with the value from the second array
 				} else {
 					$merged[$key] = $value;
 				}
@@ -405,6 +475,37 @@ class A
 		bool $preserveKeys = false
 	): array {
 		return array_slice($array, $offset, $length, $preserveKeys);
+	}
+
+	/**
+	 * Checks if at least one element in the array passes the test
+	 *
+	 * <code>
+	 * $array = [1, 30, 39, 29, 10, 'foo' => 12, 13];
+	 *
+	 * $isAboveThreshold = fn($value) => $value > 30;
+	 * echo A::some($array, $isAboveThreshold) ? 'true' : 'false';
+	 * // output: 'true'
+	 *
+	 * $isStringKey = fn($value, $key) => is_string($key);
+	 * echo A::some($array, $isStringKey) ? 'true' : 'false';
+	 * // output: 'true'
+	 * </code>
+	 *
+	 * @since 3.9.8
+	 * @param array $array
+	 * @param callable(mixed $value, int|string $key, array $array):bool $test
+	 * @return bool
+	 */
+	public static function some(array $array, callable $test): bool
+	{
+		foreach ($array as $key => $value) {
+			if ($test($value, $key, $array)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -74,6 +74,7 @@ class A
 	 * // output: 'true'
 	 * </code>
 	 *
+	 * @since 3.9.8
 	 * @param array $array
 	 * @param callable(mixed $value, int|string $key, array $array):bool $test
 	 * @return bool

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -70,7 +70,7 @@ class A
 	 * // output: 'true'
 	 *
 	 * $isIntegerKey = fn($value, $key) => is_int($key);
-	 * echo A::every($array, $isStringKey) ? 'true' : 'false';
+	 * echo A::every($array, $isIntegerKey) ? 'true' : 'false';
 	 * // output: 'true'
 	 * </code>
 	 *

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -326,7 +326,7 @@ class A
 				) {
 					$merged[] = $value;
 
-					// recursively merge the two array values
+				// recursively merge the two array values
 				} elseif (
 					is_array($value) === true &&
 					isset($merged[$key]) === true &&
@@ -334,7 +334,7 @@ class A
 				) {
 					$merged[$key] = static::merge($merged[$key], $value, $mode);
 
-					// simply overwrite with the value from the second array
+				// simply overwrite with the value from the second array
 				} else {
 					$merged[$key] = $value;
 				}

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -90,6 +90,103 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::every
+	 */
+	public function testEvery()
+	{
+		// The value should be passed to the callback
+		A::every(['foo', 'bar'], function ($value) {
+			$this->assertTrue(is_string($value), 'The value should be passed to the callback');
+		});
+
+		// The key should be passed to the callback
+		A::every(['foo' => 1, 'bar' => 2], function ($value, $key = null) {
+			$this->assertTrue(is_string($key), 'The key should be passed to the callback');
+		});
+
+		// the array should be passed to the callback
+		$arr = ['foo'];
+		A::every($arr, function ($value, $key = null, $array = null) use ($arr) {
+			$this->assertSame($array, $arr, 'The array should be passed to the callback');
+		});
+
+		// It should return false if any callback returns false
+		$this->assertFalse(A::every(['foo', 'bar'], function ($value) {
+			return $value === 'foo';
+		}), 'It should return false if any callback returns false');
+
+		// It should return early if any callback returns false
+		$counter = 0;
+		A::every(['foo', 'bar', 'baz'], function ($value) use (&$counter) {
+			$counter++;
+			return $value === 'foo';
+		});
+		$this->assertSame(2, $counter, 'It should return early if any callback returns false');
+
+		// falsy values should be treated as false
+		$this->assertFalse(A::every(['foo', 'bar', ''], function ($value) {
+			return $value;
+		}), 'falsy values should be treated as false');
+
+		// truthy values should be treated as true
+		$this->assertTrue(A::every(['foo', 'bar', 'baz'], function ($value) {
+			return $value;
+		}), 'truthy values should be treated as true');
+	}
+
+	/**
+	 * @covers ::find
+	 */
+	public function testFind()
+	{
+		$array = $this->_array();
+
+		// The value should be passed to the callback
+		$this->assertSame('miao', A::find($array, function ($value) {
+			return $value === 'miao';
+		}), 'It should return the first value that matches the callback');
+
+		// The key should be passed to the callback
+		$this->assertSame('miao', A::find($array, function ($value = null, $key = null) {
+			return $key === 'cat';
+		}), 'It should pass the key to the callback');
+
+		// The array should be passed to the callback
+		$arr = ['foo'];
+		A::find($arr, function ($value = null, $key = null, $array = null) use ($arr) {
+			$this->assertSame($array, $arr, 'The array should be passed to the callback');
+		});
+
+		// It should return null if no value matches the callback
+		$this->assertNull(A::find($array, function ($value) {
+			return $value === 'MISSING';
+		}), 'It should return null if no value matches the callback');
+
+		// It should return null if the array is empty
+		$this->assertNull(A::find([], function ($value) {
+			return true;
+		}), 'It should return null if the array is empty');
+
+		// It should return early if a value matches the callback
+		$counter = 0;
+		A::find(['foo', 'bar', 'baz'], function ($value) use (&$counter) {
+			$counter++;
+			return $value === 'bar';
+		});
+		$this->assertSame(2, $counter, 'It should return early if a value matches the callback');
+
+		// falsy values should be treated as false
+		$this->assertSame('foo', A::find(['', 'foo', 'bar'], function ($value) {
+			return $value;
+		}), 'falsy values should be treated as false');
+
+		// truthy values should be treated as true
+		$this->assertSame('foo', A::find(['foo', 'bar', 'baz'], function ($value) {
+			return $value;
+		}), 'truthy values should be treated as true');
+	}
+
+	/**
 	 * @covers ::get
 	 */
 	public function testGet()
@@ -436,6 +533,56 @@ class ATest extends TestCase
 		$this->assertSame(['bird' => 'tweet'], A::slice($array, -1));
 		$this->assertSame(['dog' => 'wuff'], A::slice($array, -2, 1));
 		$this->assertSame($array, A::slice($array, 0));
+	}
+
+	/**
+	 * @covers ::some
+	 */
+	public function testSome()
+	{
+		// The value should be passed to the callback
+		A::some(['foo', 'bar'], function ($value = null) {
+			$this->assertTrue(is_string($value), 'The value should be passed to the callback');
+		});
+
+		// The key should be passed to the callback
+		A::some(['foo' => 1, 'bar' => 2], function ($value = null, $key = null) {
+			$this->assertTrue(is_string($key), 'The key should be passed to the callback');
+		});
+
+		// the array should be passed to the callback
+		$arr = ['foo'];
+		A::some($arr, function ($value = null, $key = null, $array = null) use ($arr) {
+			$this->assertSame($array, $arr, 'The array should be passed to the callback');
+		});
+
+		// It should return false if all callbacks returns false
+		$this->assertFalse(A::some(['foo', 'bar'], function () {
+			return false;
+		}), 'It should return false if all callbacks returns false');
+
+		// It should return true if any callback returns true
+		$this->assertTrue(A::some(['foo', 'bar'], function ($value) {
+			return $value === 'foo';
+		}), 'It should return true if any callback returns true');
+
+		// It should return early if any callback returns true
+		$counter = 0;
+		A::some(['foo', 'bar', 'baz'], function () use (&$counter) {
+			$counter++;
+			return true;
+		});
+		$this->assertSame(1, $counter, 'It should return early if any callback returns true');
+
+		// falsy values should be treated as false
+		$this->assertFalse(A::some(['', 0, null], function ($value) {
+			return $value;
+		}), 'falsy values should be treated as false');
+
+		// truthy values should be treated as true
+		$this->assertTrue(A::some(['foo'], function ($value) {
+			return $value;
+		}), 'truthy values should be treated as true');
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

### Features

- New `A::every()`, `A::find()` and `A::some()` methods that implement the functionality of the JavaScript functions with the same names

### Breaking changes
none

## Discussion
The functions mirror the JS ones:
1. in nomenclature, other languages use `any` and `all` instead of `some` and `every`. Idk what you prefer. 
2. in behaviour and function signature: falsy and truthy values are considered `false` and `true`, the callbacks all get `$value, $key, $array` as arguments. 

## Ready?
I've added `@since 3.9.8` tags to the functions, that needs to be corrected of course should the changes be merged later. 

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
