### PR TITLE
Update check: Warning for EOL PHP versions

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -503,6 +503,7 @@
 	"system.issues.content": "The content folder seems to be exposed",
 	"system.issues.eol.kirby": "Your installed Kirby version has reached end-of-life and will not receive further security updates",
 	"system.issues.eol.plugin": "Your installed version of the { plugin } plugin is has reached end-of-life and will not receive further security updates",
+	"system.issues.eol.php": "Your installed PHP release { release } has reached end-of-life and will not receive further security updates",
 	"system.issues.debug": "Debugging must be turned off in production",
 	"system.issues.git": "The .git folder seems to be exposed",
 	"system.issues.https": "We recommend HTTPS for all your sites",

--- a/src/Cms/System/UpdateStatus.php
+++ b/src/Cms/System/UpdateStatus.php
@@ -206,6 +206,20 @@ class UpdateStatus
 			];
 		}
 
+		// add special message for end-of-life PHP versions
+		$phpMajor = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+		$phpEol   = $this->data['php'][$phpMajor] ?? null;
+		if (is_string($phpEol) === true && $eolTime = strtotime($phpEol)) {
+			// the timestamp is available and valid, now check if it is in the past
+			if ($eolTime < time()) {
+				$messages[] = [
+					'text' => I18n::template('system.issues.eol.php', null, ['release' => $phpMajor]),
+					'link' => 'https://getkirby.com/security/php-end-of-life',
+					'icon' => 'bell'
+				];
+			}
+		}
+
 		return $this->messages = $messages;
 	}
 

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -65,6 +65,11 @@ class UpdateStatusTest extends TestCase
 					'upgrade' => 'https://getkirby.com/releases/99999'
 				]
 			],
+			'php' => [
+				'8.0' => '2023-11-26',
+				'8.1' => '2024-11-25',
+				'8.2' => '2025-12-08'
+			],
 			'incidents' => [],
 			'messages' => [],
 			'_version' => '88888.8.5'
@@ -84,6 +89,11 @@ class UpdateStatusTest extends TestCase
 					'latest' => '88888.8.6',
 					'status' => 'active-support'
 				]
+			],
+			'php' => [
+				'8.0' => '2023-11-26',
+				'8.1' => '2024-11-25',
+				'8.2' => '2025-12-08'
 			],
 			'urls' => [
 				'*' => [
@@ -122,6 +132,11 @@ class UpdateStatusTest extends TestCase
 					'download' => 'https://repoofthefuture.com/{{ version }}.zip',
 					'upgrade' => 'https://getkirby.com/releases/99999'
 				]
+			],
+			'php' => [
+				'8.0' => '2023-11-26',
+				'8.1' => '2024-11-25',
+				'8.2' => '2025-12-08'
 			],
 			'incidents' => [],
 			'messages' => [],
@@ -235,6 +250,11 @@ class UpdateStatusTest extends TestCase
 					'download' => 'https://repoofthefuture.com/{{ version }}.zip',
 					'upgrade' => 'https://getkirby.com/releases/99999'
 				]
+			],
+			'php' => [
+				'8.0' => '2023-11-26',
+				'8.1' => '2024-11-25',
+				'8.2' => '2025-12-08'
 			],
 			'incidents' => [],
 			'messages' => [],
@@ -1068,6 +1088,33 @@ class UpdateStatusTest extends TestCase
 					'exceptionMessages' => []
 				]
 			],
+			'EOL warning (PHP)' => [
+				'app',
+				'88888.8.8',
+				false,
+				$this->data('php'),
+				[
+					'currentVersion' => '88888.8.8',
+					'icon' => 'check',
+					'label' => 'Up to date',
+					'latestVersion' => '88888.8.8',
+					'messages' => [
+						[
+							'text' => 'Your installed PHP release ' .
+								PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION .
+								' has reached end-of-life and will not receive further security updates',
+							'link' => 'https://getkirby.com/security/php-end-of-life',
+							'icon' => 'bell'
+						]
+					],
+					'status' => 'up-to-date',
+					'targetVersion' => null,
+					'theme' => 'positive',
+					'url' => 'https://getkirby.com/releases/88888.8.8',
+					'vulnerabilities' => [],
+					'exceptionMessages' => []
+				]
+			],
 			'EOL warning with custom link' => [
 				'app',
 				'44444.1.2',
@@ -1230,6 +1277,25 @@ class UpdateStatusTest extends TestCase
 					'exceptionMessages' => [
 						'No matching URL found for Kirby@77777.7.7'
 					]
+				]
+			],
+			'No PHP' => [
+				'app',
+				'77777.7.7',
+				false,
+				$this->data('no-php'),
+				[
+					'currentVersion' => '77777.7.7',
+					'icon' => 'info',
+					'label' => 'Upgrade 88888.8.8 available',
+					'latestVersion' => '88888.8.8',
+					'messages' => [],
+					'status' => 'upgrade',
+					'targetVersion' => '88888.8.8',
+					'theme' => 'info',
+					'url' => 'https://getkirby.com/releases/88888',
+					'vulnerabilities' => [],
+					'exceptionMessages' => []
 				]
 			],
 			'No incidents' => [
@@ -1561,7 +1627,16 @@ class UpdateStatusTest extends TestCase
 		}
 
 		$path = __DIR__ . '/fixtures/UpdateStatusTest/logic/' . $name . '.json';
-		return $this->data[$name] = Json::read($path);
+		$json = Json::read($path);
+
+		// dynamically insert the current PHP version
+		// because we cannot mock it easily
+		if (isset($json['php']['<CURRENT>']) === true) {
+			$json['php'][PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION] = $json['php']['<CURRENT>'];
+			unset($json['php']['<CURRENT>']);
+		}
+
+		return $this->data[$name] = $json;
 	}
 
 	protected function plugin(string|null $version): Plugin

--- a/tests/Cms/System/fixtures/UpdateStatusTest/getkirby.com/security.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/getkirby.com/security.json
@@ -18,6 +18,11 @@
 			"upgrade": "https://getkirby.com/releases/99999"
 		}
 	},
+	"php": {
+		"8.0": "2023-11-26",
+		"8.1": "2024-11-25",
+		"8.2": "2025-12-08"
+	},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/basic.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/basic.json
@@ -36,6 +36,9 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {
+		"<CURRENT>": "9999-01-01"
+	},
 	"incidents": [
 		{
 			"affected": "<=66666.5.4 || 77777.0.0 - 77777.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/eol-link.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/eol-link.json
@@ -32,6 +32,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=66666.5.4 || 77777.0.0 - 77777.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-cascade.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-cascade.json
@@ -23,6 +23,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=77777.2.5 || 88888.0.0 - 88888.3.2",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-loop.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-loop.json
@@ -23,6 +23,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=66666.5.4 || 77777.0.0 - 88888.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-severity.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/incidents-severity.json
@@ -23,6 +23,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=77777.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-incident.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-incident.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=66666.5.4 || 77777.0.0-77777.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-message.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-message.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": [
 		{

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-url.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-url.json
@@ -24,6 +24,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-version.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/invalid-constraint-version.json
@@ -22,6 +22,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/missing-constraint-incident.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/missing-constraint-incident.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"description": "Some incident",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/missing-constraint-message.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/missing-constraint-message.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": [
 		{

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-latest.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-latest.json
@@ -18,6 +18,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-messages.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-messages.json
@@ -19,5 +19,6 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-php.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-php.json
@@ -19,6 +19,6 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
-	"php": {},
+	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-url-entry.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-url-entry.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-urls.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-urls.json
@@ -12,6 +12,7 @@
 			"status": "active-support"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-version-entry.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-version-entry.json
@@ -19,6 +19,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [
 		{
 			"affected": "<=66666.5.4 || 77777.0.0 - 77777.5.4",

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-versions.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/no-versions.json
@@ -7,6 +7,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/php.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/php.json
@@ -19,6 +19,9 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
-	"php": {},
+	"php": {
+		"<CURRENT>": "2022-01-01"
+	},
+	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/url-entry-without-changes.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/url-entry-without-changes.json
@@ -17,6 +17,7 @@
 			"download": "https://repoofthefuture.com/{{ version }}.zip"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }

--- a/tests/Cms/System/fixtures/UpdateStatusTest/logic/version-entry-without-latest.json
+++ b/tests/Cms/System/fixtures/UpdateStatusTest/logic/version-entry-without-latest.json
@@ -18,6 +18,7 @@
 			"upgrade": "https://getkirby.com/releases/88888"
 		}
 	},
+	"php": {},
 	"incidents": [],
 	"messages": []
 }


### PR DESCRIPTION
With the EOL of PHP 8.0 coming quite soon, I think it makes sense to warn affected users right in the Panel. The same will apply to all future PHP versions, so I think it makes sense to include this enhancement already in v3.

⚠️ Requires the following PR to getkirby.com: https://github.com/getkirby/getkirby.com/pull/2095

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- The System view in the Panel now warns when the used PHP version is end-of-life and no longer receives security updates.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
