### PR TITLE
Improve tags selector

### DIFF
--- a/panel/src/components/Forms/Selector.vue
+++ b/panel/src/components/Forms/Selector.vue
@@ -5,9 +5,6 @@
 		:data-has-current="filtered?.includes(selected)"
 	>
 		<header class="k-selector-header">
-			<h2 v-if="label" class="k-selector-label">
-				{{ label }}
-			</h2>
 			<div v-if="showSearch" class="k-selector-search">
 				<input
 					ref="input"
@@ -26,28 +23,26 @@
 			</div>
 		</header>
 
-		<div v-if="filtered.length || options.length" class="k-selector-body">
-			<template v-if="filtered.length">
-				<k-navigate ref="results" axis="y" class="k-selector-results">
-					<k-button
-						v-for="(option, key) in filtered"
-						:key="key"
-						:current="selected === key"
-						:disabled="option.disabled"
-						:icon="option.icon ?? icon"
-						class="k-selector-button"
-						@click="select(key)"
-						@focus.native="pick(key)"
-					>
-						<!-- eslint-disable-next-line vue/no-v-html -->
-						<span v-html="highlight(option.text)" />
-					</k-button>
-				</k-navigate>
-			</template>
-			<template v-else-if="options.length">
-				<p class="k-selector-empty">{{ empty }}</p>
-			</template>
-		</div>
+		<k-navigate
+			v-if="filtered.length && options.length"
+			ref="results"
+			axis="y"
+			class="k-selector-results"
+		>
+			<k-button
+				v-for="(option, key) in filtered"
+				:key="key"
+				:current="selected === key"
+				:disabled="option.disabled"
+				:icon="option.icon ?? icon"
+				class="k-selector-button"
+				@click="select(key)"
+				@focus.native="pick(key)"
+			>
+				<!-- eslint-disable-next-line vue/no-v-html -->
+				<span v-html="highlight(option.text)" />
+			</k-button>
+		</k-navigate>
 
 		<footer v-if="showCreateButton" class="k-selector-footer">
 			<k-button
@@ -76,9 +71,6 @@ export const props = {
 		ignore: {
 			default: () => [],
 			type: Array
-		},
-		label: {
-			type: String
 		},
 		options: {
 			default: () => [],
@@ -139,9 +131,9 @@ export default {
 				return false;
 			}
 
-			const matches = this.filtered.filter((result) => {
-				return result.text === this.query || result.value === this.query;
-			});
+			const matches = this.filtered.filter(
+				(result) => result.text === this.query || result.value === this.query
+			);
 
 			return matches.length === 0;
 		},

--- a/panel/src/components/Forms/Selector.vue
+++ b/panel/src/components/Forms/Selector.vue
@@ -23,26 +23,30 @@
 			</div>
 		</header>
 
-		<k-navigate
-			v-if="filtered.length && options.length"
-			ref="results"
-			axis="y"
-			class="k-selector-results"
-		>
-			<k-button
-				v-for="(option, key) in filtered"
-				:key="key"
-				:current="selected === key"
-				:disabled="option.disabled"
-				:icon="option.icon ?? icon"
-				class="k-selector-button"
-				@click="select(key)"
-				@focus.native="pick(key)"
+		<div v-if="filtered.length || showEmpty" class="k-selector-body">
+			<k-navigate
+				v-if="filtered.length"
+				ref="results"
+				axis="y"
+				class="k-selector-results"
 			>
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-html="highlight(option.text)" />
-			</k-button>
-		</k-navigate>
+				<k-button
+					v-for="(option, key) in filtered"
+					:key="key"
+					:current="selected === key"
+					:disabled="option.disabled"
+					:icon="option.icon ?? icon"
+					class="k-selector-button"
+					@click="select(key)"
+					@focus.native="pick(key)"
+				>
+					<!-- eslint-disable-next-line vue/no-v-html -->
+					<span v-html="highlight(option.text)" />
+				</k-button>
+			</k-navigate>
+
+			<p v-else-if="showEmpty" class="k-selector-empty">{{ empty }}</p>
+		</div>
 
 		<footer v-if="showCreateButton" class="k-selector-footer">
 			<k-button
@@ -136,6 +140,13 @@ export default {
 			);
 
 			return matches.length === 0;
+		},
+		showEmpty() {
+			return (
+				this.accept === "options" &&
+				this.filtered.legnth === 0 &&
+				this.options.length
+			);
 		},
 		showSearch() {
 			// if new options can be added,

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -27,7 +27,6 @@
 					v-if="showSelector"
 					ref="selector"
 					v-bind="selectorOptions"
-					:label="$t('add')"
 					@create="add($event)"
 					@select="add($event)"
 				>
@@ -49,7 +48,6 @@
 				<k-selector-dropdown
 					ref="editor"
 					v-bind="selectorOptions"
-					:label="$t('replace.with')"
 					:value="editing?.tag.text"
 					@create="replace($event)"
 					@select="replace($event)"


### PR DESCRIPTION
I think the tags selector is still a quite messy UX. Trying to improve it step by step. Two first improvements

- Remove the label on top of the selector. IMO it's more confusing than providing guidance for users. Removing it does improve the understanding and UX for me.
- Don't show "no options" when query doesn't show any matches and creating a new option is allowed. The create button already provides enough context of what action is available. For `accept: options` keep the empty text to give context what's happening.

### Fixes
- https://github.com/getkirby/kirby/issues/5723