### PR TITLE
Session: Allow write access to moved sessions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
 		"ext-fileinfo": "Improved mime type detection for files",
 		"ext-intl": "Improved i18n number formatting",
 		"ext-memcached": "Support for the Memcached cache driver",
+		"ext-sodium": "Support for the crypto class and more robust session handling",
 		"ext-zip": "Support for ZIP archive file functions",
 		"ext-zlib": "Sanitization and validation for svgz files"
 	},

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -578,7 +578,7 @@ class Session
 			$this->tokenKey === null ||
 			SymmetricCrypto::isAvailable() === false
 		) {
-			return null;
+			return null; // @codeCoverageIgnore
 		}
 
 		return new SymmetricCrypto(secretKey: hex2bin($this->tokenKey));

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -10,6 +10,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Http\Cookie;
 use Kirby\Http\Url;
 use Kirby\Toolkit\Str;
+use Kirby\Toolkit\SymmetricCrypto;
 use Throwable;
 
 /**
@@ -38,7 +39,7 @@ class Session
 	protected $lastActivity;
 	protected $renewable;
 	protected $data;
-	protected $newSession;
+	protected array|null $newSession;
 
 	// temporary state flags
 	protected $updatingLastActivity = false;
@@ -348,15 +349,27 @@ class Session
 		}
 
 		// collect all data
-		if ($this->newSession) {
+		if (isset($this->newSession) === true) {
 			// the token has changed
 			// we are writing to the old session: it only gets the reference to the new session
 			// and a shortened expiry time (30 second grace period)
 			$data = [
 				'startTime'  => $this->startTime(),
 				'expiryTime' => time() + 30,
-				'newSession' => $this->newSession
+				'newSession' => $this->newSession[0]
 			];
+
+			// include the token key for the new session if we
+			// have access to the PHP `sodium` extension;
+			// otherwise (if no encryption is possible), the token key
+			// is omitted, which makes the new session read-only
+			// when accessed through the old session
+			if ($crypto = $this->crypto()) {
+				// encrypt the new token key with the old token key
+				// so that attackers with read access to the session file
+				// (e.g. via directory traversal) cannot impersonate the new session
+				$data['newSessionKey'] = $crypto->encrypt($this->newSession[1]);
+			}
 		} else {
 			$data = [
 				'startTime'    => $this->startTime(),
@@ -446,7 +459,7 @@ class Session
 
 		// mark the old session as moved if there is one
 		if ($this->tokenExpiry !== null) {
-			$this->newSession = $tokenExpiry . '.' . $tokenId;
+			$this->newSession = [$tokenExpiry . '.' . $tokenId, $tokenKey];
 			$this->commit();
 
 			// we are now in the context of the new session
@@ -536,7 +549,7 @@ class Session
 		}
 
 		// don't allow writing for read-only sessions
-		// (only the case for moved sessions)
+		// (only the case for moved sessions when the PHP `sodium` extension is not available)
 		/**
 		 * @todo This check gets flagged by Psalm for unknown reasons
 		 * @psalm-suppress ParadoxicalCondition
@@ -553,6 +566,22 @@ class Session
 		$this->sessions->store()->lock($this->tokenExpiry, $this->tokenId);
 		$this->init();
 		$this->writeMode = true;
+	}
+
+	/**
+	 * Returns a symmetric crypto instance based on the
+	 * token key of the session
+	 */
+	protected function crypto(): SymmetricCrypto|null
+	{
+		if (
+			$this->tokenKey === null ||
+			SymmetricCrypto::isAvailable() === false
+		) {
+			return null;
+		}
+
+		return new SymmetricCrypto(secretKey: hex2bin($this->tokenKey));
 	}
 
 	/**
@@ -698,6 +727,20 @@ class Session
 
 		// follow to the new session if there is one
 		if (isset($data['newSession'])) {
+			// decrypt the token key if provided and we have access to
+			// the PHP `sodium` extension for decryption
+			if (
+				isset($data['newSessionKey']) === true &&
+				$crypto = $this->crypto()
+			) {
+				$tokenKey = $crypto->decrypt($data['newSessionKey']);
+
+				$this->parseToken($data['newSession'] . '.' . $tokenKey);
+				$this->init();
+				return;
+			}
+
+			// otherwise initialize without the token key (read-only mode)
 			$this->parseToken($data['newSession'], true);
 			$this->init();
 			return;

--- a/src/Toolkit/SymmetricCrypto.php
+++ b/src/Toolkit/SymmetricCrypto.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Kirby\Data\Json;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
+use SensitiveParameter;
+
+/**
+ * User-friendly and safe abstraction for symmetric
+ * authenticated encryption and decryption using the
+ * PHP `sodium` extension
+ * @since 3.9.8
+ *
+ * @package   Kirby Toolkit
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class SymmetricCrypto
+{
+	/**
+	 * Cache for secret keys derived from the password
+	 * indexed by the used salt and limits
+	 */
+	protected array $secretKeysByOptions = [];
+
+	/**
+	 * Initializes the keys used for crypto, both optional
+	 *
+	 * @param string|null $password Password to be derived into a `$secretKey`
+	 * @param string|null $secretKey 256-bit key, alternatively a `$password` can be used
+	 */
+	public function __construct(
+		#[SensitiveParameter]
+		protected string|null $password = null,
+		#[SensitiveParameter]
+		protected string|null $secretKey = null,
+	) {
+		if ($password !== null && $secretKey !== null) {
+			throw new InvalidArgumentException('Passing both a secret key and a password is not supported');
+		}
+
+		if ($secretKey !== null && strlen($secretKey) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+			throw new InvalidArgumentException('Invalid secret key length, expected ' . SODIUM_CRYPTO_SECRETBOX_KEYBYTES . ' bytes');
+		}
+	}
+
+	/**
+	 * Hide values of secrets when printing the object
+	 */
+	public function __debugInfo(): array
+	{
+		return [
+			'hasPassword'  => isset($this->password),
+			'hasSecretKey' => isset($this->secretKey),
+		];
+	}
+
+	/**
+	 * Wipes the secrets from memory when they are no longer needed
+	 */
+	public function __destruct()
+	{
+		$this->memzero($this->password);
+		$this->memzero($this->secretKey);
+
+		foreach ($this->secretKeysByOptions as $key => &$value) {
+			$this->memzero($value);
+			unset($this->secretKeysByOptions[$key]);
+		}
+	}
+
+	/**
+	 * Decrypts JSON data encrypted by `SymmetricCrypto::encrypt()` using the secret key or password
+	 *
+	 * <code>
+	 * // decryption with a password
+	 * $crypto    = new SymmetricCrypto(password: 'super secure');
+	 * $plaintext = $crypto->decrypt('a very confidential string');
+	 *
+	 * // decryption with a previously generated key
+	 * $crypto    = new SymmetricCrypto(secretKey: $secretKey);
+	 * $plaintext = $crypto->decrypt('{"mode":"secretbox"...}');
+	 * </code>
+	 */
+	public function decrypt(string $json): string
+	{
+		$props = Json::decode($json);
+
+		if (($props['mode'] ?? null) !== 'secretbox') {
+			throw new InvalidArgumentException('Unsupported encryption mode "' . ($props['mode'] ?? '') . '"');
+		}
+
+		if (
+			isset($props['data']) !== true ||
+			isset($props['nonce']) !== true ||
+			isset($props['salt']) !== true ||
+			isset($props['limits']) !== true
+		) {
+			throw new InvalidArgumentException('Input data does not contain all required props');
+		}
+
+		$data   = base64_decode($props['data']);
+		$nonce  = base64_decode($props['nonce']);
+		$salt   = base64_decode($props['salt']);
+		$limits = $props['limits'];
+
+		$plaintext = sodium_crypto_secretbox_open($data, $nonce, $this->secretKey($salt, $limits));
+
+		if (is_string($plaintext) !== true) {
+			throw new LogicException('Encrypted string was tampered with');
+		}
+
+		return $plaintext;
+	}
+
+	/**
+	 * Encrypts a string using the secret key or password
+	 *
+	 * <code>
+	 * // encryption with a password
+	 * $crypto     = new SymmetricCrypto(password: 'super secure');
+	 * $ciphertext = $crypto->encrypt('a very confidential string');
+	 *
+	 * // encryption with a random key
+	 * $crypto     = new SymmetricCrypto();
+	 * $ciphertext = $crypto->encrypt('a very confidential string');
+	 * $secretKey  = $crypto->secretKey();
+	 * </code>
+	 */
+	public function encrypt(
+		#[SensitiveParameter]
+		string $string
+	): string {
+		$nonce  = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+		$salt   = random_bytes(SODIUM_CRYPTO_PWHASH_SALTBYTES);
+		$limits = [SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE];
+		$key    = $this->secretKey($salt, $limits);
+
+		$ciphertext = sodium_crypto_secretbox($string, $nonce, $key);
+
+		// bundle all necessary information in a JSON object;
+		// always include the salt and limits to hide whether a key or password was used
+		return Json::encode([
+			'mode'   => 'secretbox',
+			'data'   => base64_encode($ciphertext),
+			'nonce'  => base64_encode($nonce),
+			'salt'   => base64_encode($salt),
+			'limits' => $limits,
+		]);
+	}
+
+	/**
+	 * Checks if the required PHP `sodium` extension is available
+	 */
+	public static function isAvailable(): bool
+	{
+		return defined('SODIUM_LIBRARY_MAJOR_VERSION') === true && SODIUM_LIBRARY_MAJOR_VERSION >= 10;
+	}
+
+	/**
+	 * Returns the binary secret key, optionally derived from the password
+	 * or randomly generated
+	 *
+	 * @param string|null $salt Salt for password-based key derivation
+	 * @param array|null $limits Processing limits for password-based key derivation
+	 */
+	public function secretKey(
+		#[SensitiveParameter]
+		string|null $salt = null,
+		array|null $limits = null
+	): string {
+		if (isset($this->secretKey) === true) {
+			return $this->secretKey;
+		}
+
+		// derive from password
+		if (isset($this->password) === true) {
+			if ($salt === null || $limits === null) {
+				throw new InvalidArgumentException('Salt and limits are required when deriving a secret key from a password');
+			}
+
+			// access from cache
+			$options = $salt . ':' . implode(',', $limits);
+			if (isset($this->secretKeysByOptions[$options]) === true) {
+				return $this->secretKeysByOptions[$options];
+			}
+
+			return $this->secretKeysByOptions[$options] = sodium_crypto_pwhash(
+				SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
+				$this->password,
+				$salt,
+				$limits[0],
+				$limits[1],
+				SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13
+			);
+		}
+
+		// generate a random key
+		return $this->secretKey = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+	}
+
+	/**
+	 * Wipes a variable from memory if it is a string
+	 */
+	protected function memzero(mixed &$value): void
+	{
+		if (is_string($value) === true) {
+			sodium_memzero($value);
+			$value = '';
+		}
+	}
+}

--- a/tests/Session/mocks.php
+++ b/tests/Session/mocks.php
@@ -4,6 +4,7 @@ namespace Kirby\Session;
 
 use Exception;
 use Kirby\Toolkit\Str;
+use Kirby\Toolkit\SymmetricCrypto;
 
 class InvalidSessionStore
 {
@@ -185,6 +186,28 @@ class TestSessionStore extends SessionStore
 				]
 			]
 		];
+
+		// add moved test sessions when the PHP `sodium` extension is available
+		if (SymmetricCrypto::isAvailable() === true) {
+			$crypto        = new SymmetricCrypto(secretKey: hex2bin($this->validKey));
+			$newSessionKey = $crypto->encrypt($this->validKey);
+
+			// valid session that has moved to a nearly expired session
+			$this->sessions['9999999999.movedRenewalWithKey'] = [
+				'startTime'       => 0,
+				'expiryTime'      => 9999999999,
+				'newSession'      => '2000000000.renewal',
+				'newSessionKey'   => $newSessionKey
+			];
+
+			// valid session that has moved to a session that could be refreshed
+			$this->sessions['9999999999.movedTimeoutActivityWithKey'] = [
+				'startTime'       => 0,
+				'expiryTime'      => 9999999999,
+				'newSession'      => '9999999999.timeoutActivity2',
+				'newSessionKey'   => $newSessionKey
+			];
+		}
 	}
 
 	public function createId(int $expiryTime): string

--- a/tests/Toolkit/SymmetricCryptoTest.php
+++ b/tests/Toolkit/SymmetricCryptoTest.php
@@ -6,7 +6,6 @@ use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 
 /**
  * @coversDefaultClass \Kirby\Toolkit\SymmetricCrypto

--- a/tests/Toolkit/SymmetricCryptoTest.php
+++ b/tests/Toolkit/SymmetricCryptoTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Closure;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @coversDefaultClass \Kirby\Toolkit\SymmetricCrypto
+ */
+class SymmetricCryptoTest extends TestCase
+{
+	public function setUp(): void
+	{
+		if (defined('SODIUM_LIBRARY_VERSION') !== true) {
+			$this->markTestSkipped('PHP sodium extension is not available');
+		}
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructKeyAndPassword()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Passing both a secret key and a password is not supported');
+
+		new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop', password: 'super secure');
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructKeyLength()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid secret key length');
+
+		new SymmetricCrypto(secretKey: 'not secure');
+	}
+
+	/**
+	 * @covers ::__debugInfo
+	 */
+	public function testDebugInfo()
+	{
+		$crypto = new SymmetricCrypto();
+		$this->assertSame([
+			'hasPassword'  => false,
+			'hasSecretKey' => false,
+		], $crypto->__debugInfo());
+		$crypto->secretKey();
+		$this->assertSame([
+			'hasPassword'  => false,
+			'hasSecretKey' => true,
+		], $crypto->__debugInfo());
+
+		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+		$this->assertSame([
+			'hasPassword'  => false,
+			'hasSecretKey' => true,
+		], $crypto->__debugInfo());
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+		$this->assertSame([
+			'hasPassword'  => true,
+			'hasSecretKey' => false,
+		], $crypto->__debugInfo());
+	}
+
+	/**
+	 * @covers ::__destruct
+	 */
+	public function testDestruct()
+	{
+		// helper to access protected props by reference
+		$reader = function () {
+			return [
+				'password'            => &$this->password,
+				'secretKey'           => &$this->secretKey,
+				'secretKeysByOptions' => &$this->secretKeysByOptions,
+			];
+		};
+
+		$crypto = new SymmetricCrypto(secretKey: $secretKey = 'abcdefghijklmnopabcdefghijklmnop');
+		$values = Closure::bind($reader, $crypto, $crypto)();
+		$this->assertSame(['password' => null, 'secretKey' => $secretKey, 'secretKeysByOptions' => []], $values);
+		unset($crypto);
+		$this->assertSame(['password' => null, 'secretKey' => '', 'secretKeysByOptions' => []], $values);
+
+		$crypto = new SymmetricCrypto(password: $password = 'super secure');
+		$crypto->secretKey(str_repeat('A', SODIUM_CRYPTO_PWHASH_SALTBYTES), [SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE]);
+		$crypto->secretKey(str_repeat('B', SODIUM_CRYPTO_PWHASH_SALTBYTES), [SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE]);
+		$values = Closure::bind($reader, $crypto, $crypto)();
+		$limits = SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE . ',' . SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE;
+		$this->assertSame([
+			'password' => $password,
+			'secretKey' => null,
+			'secretKeysByOptions' => [
+				str_repeat('A', SODIUM_CRYPTO_PWHASH_SALTBYTES) . ':' . $limits => hex2bin('8bfb935f72ecc1c77aecde1a44168f73aed70a21d35d8bd11c8c43dcec07ccb3'),
+				str_repeat('B', SODIUM_CRYPTO_PWHASH_SALTBYTES) . ':' . $limits => hex2bin('957a8b8b435aefb479351c8c5b5dcf0ca76253846d47c69dcc0ddba569c14d62'),
+			]
+		], $values);
+		unset($crypto);
+		$this->assertSame(['password' => '', 'secretKey' => null, 'secretKeysByOptions' => []], $values);
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecrypt()
+	{
+		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+
+		$input = '{"mode":"secretbox","data":"tXH/eNjDMhL+BIgPDWkeYZvBpqBbMKEfUhoHHrhLde7gbTBGqsz1IzhG7Q==",' .
+			'"nonce":"X3xgVLA1Zyffp5/AOlZQeccD6aynPj43","salt":"VHC6wQ2g7Z9+HK0XJUWV6Q==","limits":[2,67108864]}';
+
+		$this->assertSame('a very confidential message', $crypto->decrypt($input));
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptInvalidJson()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('JSON string is invalid');
+
+		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+		$crypto->decrypt('not JSON!');
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptInvalidMode()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unsupported encryption mode "box"');
+
+		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+
+		$input = '{"mode":"box","data":"L9kUIhjbXC/gMkiJtt/HHmhJVMJ7nFek8t0GUy9AkWwZjLJpKJxHEIZ/vA==",' .
+			'"nonce":"QZ9NM4JIP0jDgfzQRe1ir6fcAwjBuRKZ"}';
+
+		$crypto->decrypt($input);
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptMissingProps()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Input data does not contain all required props');
+
+		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+		$crypto->decrypt('{"mode":"secretbox","data":"this is set","nonce":"this is also set"}');
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptTampered1()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Encrypted string was tampered with');
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+
+		// modified data
+		$input = '{"mode":"secretbox","data":"tXH/eNjDMiL+BIgPDWkeYZvBpqBbMKEfUhoHHrhLde7gbTBGqsz1IzhG7Q==",' .
+			'"nonce":"X3xgVLA1Zyffp5/AOlZQeccD6aynPj43","salt":"VHC6wQ2g7Z9+HK0XJUWV6Q==","limits":[2,67108864]}';
+
+		$crypto->decrypt($input);
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptTampered2()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Encrypted string was tampered with');
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+
+		// modified nonce
+		$input = '{"mode":"secretbox","data":"tXH/eNjDMhL+BIgPDWkeYZvBpqBbMKEfUhoHHrhLde7gbTBGqsz1IzhG7Q==",' .
+			'"nonce":"X3xgVLA1Zzffp5/AOlZQeccD6aynPj43","salt":"VHC6wQ2g7Z9+HK0XJUWV6Q==","limits":[2,67108864]}';
+
+		$crypto->decrypt($input);
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptTampered3()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Encrypted string was tampered with');
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+
+		// modified salt
+		$input = '{"mode":"secretbox","data":"tXH/eNjDMhL+BIgPDWkeYZvBpqBbMKEfUhoHHrhLde7gbTBGqsz1IzhG7Q==",' .
+			'"nonce":"X3xgVLA1Zyffp5/AOlZQeccD6aynPj43","salt":"VHC6wQ2g7Z9+HK0YJUWV6Q==","limits":[2,67108864]}';
+
+		$crypto->decrypt($input);
+	}
+
+	/**
+	 * @covers ::decrypt
+	 */
+	public function testDecryptTampered4()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Encrypted string was tampered with');
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+
+		// modified limits
+		$input = '{"mode":"secretbox","data":"tXH/eNjDMhL+BIgPDWkeYZvBpqBbMKEfUhoHHrhLde7gbTBGqsz1IzhG7Q==",' .
+			'"nonce":"X3xgVLA1Zyffp5/AOlZQeccD6aynPj43","salt":"VHC6wQ2g7Z9+HK0XJUWV6Q==","limits":[2,67208864]}';
+
+		$crypto->decrypt($input);
+	}
+
+	/**
+	 * @covers ::encrypt
+	 */
+	public function testEncrypt()
+	{
+		$crypto1    = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+		$encrypted1 = $crypto1->encrypt($message = 'a very confidential message');
+
+		$props1 = json_decode($encrypted1, true);
+		$this->assertIsArray($props1);
+		$this->assertSame(['mode', 'data', 'nonce', 'salt', 'limits'], array_keys($props1));
+		$this->assertSame('secretbox', $props1['mode']);
+		$this->assertSame(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES, strlen(base64_decode($props1['nonce'])));
+		$this->assertSame(SODIUM_CRYPTO_PWHASH_SALTBYTES, strlen(base64_decode($props1['salt'])));
+		$this->assertSame(
+			[SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE],
+			$props1['limits']
+		);
+
+		// if we can decrypt the string again, encryption was probably successful
+		$crypto2 = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
+		$this->assertSame($message, $crypto1->decrypt($encrypted1));
+
+		// encrypting again should use a different nonce and salt
+		$encrypted2 = $crypto1->encrypt('a very confidential message');
+		$this->assertNotSame($encrypted1, $encrypted2);
+		$props2 = json_decode($encrypted2, true);
+		$this->assertNotSame($props1['data'], $props2['data']);
+		$this->assertNotSame($props1['nonce'], $props2['nonce']);
+		$this->assertNotSame($props1['salt'], $props2['salt']);
+	}
+
+	/**
+	 * @covers ::isAvailable
+	 */
+	public function testIsAvailable()
+	{
+		$this->assertTrue(SymmetricCrypto::isAvailable());
+	}
+
+	/**
+	 * @covers ::secretKey
+	 */
+	public function testSecretKeyFromKey()
+	{
+		$crypto = new SymmetricCrypto(secretKey: $key = 'abcdefghijklmnopabcdefghijklmnop');
+		$this->assertSame($key, $crypto->secretKey());
+	}
+
+	/**
+	 * @covers ::secretKey
+	 */
+	public function testSecretKeyFromPassword()
+	{
+		$crypto = new SymmetricCrypto(password: 'super secure');
+		$this->assertSame(
+			'b3689bcad735e4537be1ad05185f482fab2d6242b4d30decf71b8c778b7fbf0d',
+			bin2hex($crypto->secretKey('abcdefghijklmnop', [SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE]))
+		);
+
+		// cached result is the same
+		$this->assertSame(
+			'b3689bcad735e4537be1ad05185f482fab2d6242b4d30decf71b8c778b7fbf0d',
+			bin2hex($crypto->secretKey('abcdefghijklmnop', [SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE, SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE]))
+		);
+	}
+
+	/**
+	 * @covers ::secretKey
+	 */
+	public function testSecretKeyFromPasswordNoSalt()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Salt and limits are required when deriving a secret key from a password');
+
+		$crypto = new SymmetricCrypto(password: 'super secure');
+		$crypto->secretKey();
+	}
+
+	/**
+	 * @covers ::secretKey
+	 */
+	public function testSecretKeyRandom()
+	{
+		$crypto1 = new SymmetricCrypto();
+		$key1   = $crypto1->secretKey();
+		$key2   = $crypto1->secretKey();
+
+		$crypto2 = new SymmetricCrypto();
+		$key3   = $crypto2->secretKey();
+		$key4   = $crypto2->secretKey();
+
+		$this->assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($key1));
+		$this->assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($key2));
+		$this->assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($key3));
+		$this->assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($key4));
+
+		// each key is random
+		$this->assertNotSame($key1, $key3);
+
+		// key is cached
+		$this->assertSame($key1, $key2);
+		$this->assertSame($key3, $key4);
+	}
+}


### PR DESCRIPTION
To explain why it we had the exception before and why encryption is necessary to avoid the exception:

- Our session implementation is designed so that attackers with read access to the session files (e.g. when HTTP access to `site/sessions` isn't blocked and directory indexes are enabled) cannot impersonate a session and therefore a logged in user.
- To make this work, each session has a token key that is included in the session cookie but never stored anywhere. Only requests that contain the valid token key can use the session.
- If a session token is regenerated, the old session stays valid temporarily (for 30 seconds). This is done by replacing the old session with a reference to the new one. But we cannot store the token key of the new session in the old session, otherwise the security requirement of the first point is broken.
- Before this PR, the session implementation circumvented this problem by allowing to access the new session without key when (and only when) it was accessed through the old session with a valid token key. However a write access to the new session was not possible without knowing the new key because writing to a session requires the key to recalculate the HMAC that is stored to verify the key later.
- This PR fixes this issue by storing the encrypted token key of the new session in the old session. Only the actual user (who knows the old token key) can decrypt it, so the attack scenario of the first point is still taken care of.
- Encryption is done with the PHP `sodium` extension, which provides secure defaults and is therefore a lot more solid than OpenSSL. To avoid having to add `sodium` to Kirby's list of required extensions, the key storage is optional (only if `sodium` is available). Otherwise the session class behaves exactly like before.

---

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `Kirby\Toolkit\SymmetricCrypto` class (user-friendly and safe abstraction for symmetrical authenticated encryption using the PHP `sodium` extension)
  ```php
  // encryption/decryption with a password
  $crypto     = new SymmetricCrypto(password: 'super secure');
  $ciphertext = $crypto->encrypt('a very confidential string');
  $plaintext  = $crypto->decrypt($ciphertext);

  // encryption with a random key
  $crypto     = new SymmetricCrypto();
  $ciphertext = $crypto->encrypt('a very confidential string');
  $secretKey  = $crypto->secretKey();

  // encryption/decryption with a previously generated key
  $crypto     = new SymmetricCrypto(secretKey: $secretKey);
  $ciphertext = $crypto->encrypt('a very confidential string');
  $plaintext  = $crypto->decrypt($ciphertext);
  ```

### Enhancements

- The "Session ... is currently read-only because it was accessed via an old session" error is circumvented when the PHP `sodium` extension is available #5319

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
