### PR TITLE
Parsley inline: fix trimming spaces-only elements

### DIFF
--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -28,7 +28,15 @@ class Inline
 	public function __construct(DOMNode $node, array $marks = [])
 	{
 		$this->createMarkRules($marks);
-		$this->html = trim(static::parseNode($node, $this->marks) ?? '');
+
+		$html = static::parseNode($node, $this->marks) ?? '';
+
+		// only trim HTML if it doesn't consist of only spaces
+		if (strlen($html) !== substr_count($html, ' ')) {
+			$html = trim($html);
+		}
+
+		$this->html = $html;
 	}
 
 	/**

--- a/src/Parsley/Inline.php
+++ b/src/Parsley/Inline.php
@@ -32,7 +32,7 @@ class Inline
 		$html = static::parseNode($node, $this->marks) ?? '';
 
 		// only trim HTML if it doesn't consist of only spaces
-		if (strlen($html) !== substr_count($html, ' ')) {
+		if (trim($html) !== '') {
 			$html = trim($html);
 		}
 

--- a/tests/Parsley/InlineTest.php
+++ b/tests/Parsley/InlineTest.php
@@ -11,6 +11,22 @@ use PHPUnit\Framework\TestCase;
 class InlineTest extends TestCase
 {
 	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructTrim()
+	{
+		$dom    = new Dom('<span> Test </span>');
+		$dom    = $dom->query('//span')[0];
+		$inline = new Inline($dom);
+		$this->assertSame('Test', $inline->innerHtml());
+
+		$dom    = new Dom('<span> </span>');
+		$dom    = $dom->query('//span')[0];
+		$inline = new Inline($dom);
+		$this->assertSame(' ', $inline->innerHtml());
+	}
+
+	/**
 	 * @covers ::parseAttrs
 	 */
 	public function testParseAttrs()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Blocks field: pasting HTML does not remove crucial spaces anymore in inline contexts
#4702



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
