### PR TITLE
Don’t override permissions via any roles’ options

### DIFF
--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -85,7 +85,13 @@ abstract class ModelPermissions
 				is_array($options) === true &&
 				A::isAssociative($options) === true
 			) {
-				return $options[$role] ?? $options['*'] ?? false;
+				if (isset($options[$role]) === true) {
+					return $options[$role];
+				}
+
+				if (isset($options['*']) === true) {
+					return $options['*'];
+				}
 			}
 		}
 

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -215,6 +215,55 @@ class PagePermissionsTest extends TestCase
 	 * @covers \Kirby\Cms\ModelPermissions::can
 	 * @dataProvider actionProvider
 	 */
+	public function testWithAdminAndNegativeOptionForOtherRole($action)
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page([
+			'slug' => 'test',
+			'num'  => 1,
+			'blueprint' => [
+				'name' => 'test',
+				'options' => [
+					$action => [
+						'visitor' => false
+					]
+				]
+			]
+		]);
+
+		$this->assertTrue($page->permissions()->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::can
+	 * @dataProvider actionProvider
+	 */
+	public function testWithAdminAndNegativeOptionForOtherRoleAndNegativeFallback($action)
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page([
+			'slug' => 'test',
+			'num'  => 1,
+			'blueprint' => [
+				'name' => 'test',
+				'options' => [
+					$action => [
+						'*'       => false,
+						'visitor' => false
+					]
+				]
+			]
+		]);
+
+		$this->assertFalse($page->permissions()->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::can
+	 * @dataProvider actionProvider
+	 */
 	public function testWithNobody($action)
 	{
 		$page  = new Page(['slug' => 'test']);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Options, e.g. page `options`, won't override other roles' permissions anymore 
 #4966

e.g.

```yml
options:
  update:
    editor: true
```

Would set `update` to false for any other roles, even if their permissions would allow it.

Before:
- check entry for role's name
- check `*` entry
- deny, no matter if permissions generally allow

With this PR
- check entry for role's name
- check `*` entry
- whether permissions generally allow


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
