### PR TITLE
Plugin version outside of the composer.json

### DIFF
--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -271,7 +271,7 @@ class Plugin extends Model
 	public function version(): string|null
 	{
 		$composerName = $this->info()['name'] ?? null;
-		$version      = $this->info()['version'] ?? null;
+		$version      = $this->info()['version'] ?? $this->extends()['version'] ?? null;
 
 		try {
 			// if plugin doesn't have version key in composer.json file


### PR DESCRIPTION
## This PR …
Adds the option to specify the plugin `version` in your plugin definition outside of the `composer.json`.
You can still just use the `composer.json`. This PR just adds an **additional** way to specifiy the plugin version.

```php
<?php

use Kirby\Cms\App;

@include_once __DIR__ . '/helpers.php';

App::plugin('lukaskleinschmidt/snippet-controller', [
    'version' => '2.1.0', // <- This one here
    'options' => [
        'name' => fn (string $name) => $name . '.controller',
    ],
    'components' => [
        'snippet' => function (App $kirby, $name, array $data = [], bool $slots = false) {
            $data = snippet_controller($name, $data);

            return $kirby->nativeComponent('snippet')(
                $kirby,
                $name,
                $data,
                $slots,
            );
        }
    ],
]);
```

I usually create my composer plugins without adding the `version` key.

The version detection from Kirby works as long as my plugins are installed via composer.
But adding it as a git submodule or simply copy pasting it does not work.

The reason why I avoid using the `version` key in my composer packages:
https://getcomposer.org/doc/04-schema.md#version

TLDR: Version of the docs:

> **Note**
> Specifying the version yourself will most likely end up creating problems at some point due to human error.

Not a must have and I also understand arguments that prefer using solely the `composer.json` for such things but I think the solution might fit the bill to make both worlds happy.

### Fixes
https://github.com/lukaskleinschmidt/kirby-snippet-controller/issues/2

### Breaking changes

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
