### PR TITLE
Fix DropdownItem after k-navigate

### DIFF
--- a/panel/src/components/Dropdowns/DropdownContent.vue
+++ b/panel/src/components/Dropdowns/DropdownContent.vue
@@ -182,6 +182,8 @@ export default {
 			}
 		},
 		onOptionClick(option) {
+			this.close();
+
 			if (typeof option.click === "function") {
 				option.click.call(this);
 			} else if (option.click) {

--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -34,7 +34,6 @@ export default {
 			this.$refs.button.focus();
 		},
 		onClick(event) {
-			this.$parent.close();
 			this.$emit("click", event);
 		},
 		tab() {


### PR DESCRIPTION
After turning `k-navigate` into a Vue component, `this.$parent` doesn't work anymore.