### PR TITLE
`Toolkit\Date`: Allow formatting with the globally configured handler

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -124,8 +124,7 @@ return function (App $app) {
 				$time = strtotime($fallback);
 			}
 
-			$handler = $app->option('date.handler', 'date');
-			return Str::date($time, $format, $handler);
+			return Str::date($time, $format);
 		},
 
 		/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -492,7 +492,6 @@ class File extends ModelWithContent
 		$file     = $this->modifiedFile();
 		$content  = $this->modifiedContent($languageCode);
 		$modified = max($file, $content);
-		$handler ??= $this->kirby()->option('date.handler', 'date');
 
 		return Str::date($modified, $format, $handler);
 	}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -845,7 +845,7 @@ class Page extends ModelWithContent
 			return null;
 		}
 
-		return Str::date($modified, $format, $handler ?? $this->kirby()->option('date.handler', 'date'));
+		return Str::date($modified, $format, $handler);
 	}
 
 	/**

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -305,11 +305,7 @@ class Site extends ModelWithContent
 		string|null $format = null,
 		string|null $handler = null
 	): int|string {
-		return Dir::modified(
-			$this->root(),
-			$format,
-			$handler ?? $this->kirby()->option('date.handler', 'date')
-		);
+		return Dir::modified($this->root(), $format, $handler);
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -479,7 +479,6 @@ class User extends ModelWithContent
 		$modifiedContent = $this->storage()->modified('published', $languageCode);
 		$modifiedIndex   = F::modified($this->root() . '/index.php');
 		$modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
-		$handler       ??= $this->kirby()->option('date.handler', 'date');
 
 		return Str::date($modifiedTotal, $format, $handler);
 	}

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -426,8 +426,10 @@ class Dir
 	 * subfolders have been modified for the last time.
 	 *
 	 * @param string $dir The path of the directory
+	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
+	 *                                               for the globally configured one
 	 */
-	public static function modified(string $dir, string $format = null, string $handler = 'date'): int|string
+	public static function modified(string $dir, string $format = null, string|null $handler = null): int|string
 	{
 		$modified = filemtime($dir);
 		$items    = static::read($dir);

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -475,12 +475,13 @@ class F
 	/**
 	 * Get the file's last modification time.
 	 *
-	 * @param string $handler date, intl or strftime
+	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
+	 *                                               for the globally configured one
 	 */
 	public static function modified(
 		string $file,
 		string|IntlDateFormatter|null $format = null,
-		string $handler = 'date'
+		string|null $handler = null
 	): string|int|false {
 		if (file_exists($file) !== true) {
 			return false;

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -351,19 +351,14 @@ class File
 	/**
 	 * Returns the file's last modification time
 	 *
-	 * @param string|null $handler date, intl or strftime
+	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
+	 *                                               for the globally configured one
 	 */
 	public function modified(
 		string|IntlDateFormatter|null $format = null,
 		string|null $handler = null
 	): string|int|false {
-		$kirby = $this->kirby();
-
-		return F::modified(
-			$this->root(),
-			$format,
-			$handler ?? $kirby?->option('date.handler', 'date') ?? 'date'
-		);
+		return F::modified($this->root(), $format, $handler);
 	}
 
 	/**

--- a/src/Toolkit/Date.php
+++ b/src/Toolkit/Date.php
@@ -7,6 +7,7 @@ use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
+use IntlDateFormatter;
 use Kirby\Exception\InvalidArgumentException;
 
 /**
@@ -117,6 +118,20 @@ class Date extends DateTime
 		$flooredDate = date($formats[$unit], $this->timestamp());
 		$this->set($flooredDate);
 		return $this;
+	}
+
+	/**
+	 * Formats the datetime value with a custom handler
+	 * or with the globally configured one
+	 *
+	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
+	 *                                               for the globally configured one
+	 */
+	public function formatWithHandler(
+		string|IntlDateFormatter|null $format = null,
+		string|null $handler = null
+	): string|int|false {
+		return Str::date($this->timestamp(), $format, $handler);
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -319,7 +319,7 @@ class Str
 
 		// automatically determine the handler from global configuration
 		// if an app instance is already running; otherwise fall back to
-	 	// `date` for backwards-compatibility
+		// `date` for backwards-compatibility
 		if ($handler === null) {
 			$handler = App::instance(null, true)?->option('date.handler') ?? 'date';
 		}

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -318,16 +318,10 @@ class Str
 		}
 
 		// automatically determine the handler from global configuration
-		// if an app instance is already running
+		// if an app instance is already running; otherwise fall back to
+	 	// `date` for backwards-compatibility
 		if ($handler === null) {
-			if ($app = App::instance(null, true)) {
-				$handler = $app->option('date.handler', 'date');
-			}
-
-			// fall back to `date` for backwards-compatibility
-			// when the method was called without app and without
-			// overriding the default handler
-			$handler ??= 'date';
+			$handler = App::instance(null, true)?->option('date.handler') ?? 'date';
 		}
 
 		// `intl` handler

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTime;
 use Exception;
 use IntlDateFormatter;
+use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Query\Query;
 use Throwable;
@@ -299,12 +300,13 @@ class Str
 	 * Convert timestamp to date string
 	 * according to locale settings
 	 *
-	 * @param string $handler date, intl or strftime
+	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
+	 *                                               for the globally configured one
 	 */
 	public static function date(
 		int|null $time = null,
 		string|IntlDateFormatter $format = null,
-		string $handler = 'date'
+		string|null $handler = null
 	): string|int|false {
 		if (is_null($format) === true) {
 			return $time;
@@ -313,6 +315,19 @@ class Str
 		// $format is an IntlDateFormatter instance
 		if ($format instanceof IntlDateFormatter) {
 			return $format->format($time ?? time());
+		}
+
+		// automatically determine the handler from global configuration
+		// if an app instance is already running
+		if ($handler === null) {
+			if ($app = App::instance(null, true)) {
+				$handler = $app->option('date.handler', 'date');
+			}
+
+			// fall back to `date` for backwards-compatibility
+			// when the method was called without app and without
+			// overriding the default handler
+			$handler ??= 'date';
 		}
 
 		// `intl` handler

--- a/tests/Toolkit/DateTest.php
+++ b/tests/Toolkit/DateTest.php
@@ -100,13 +100,14 @@ class DateTest extends TestCase
 		$this->assertSame('29.01.2020', $date->formatWithHandler('d.m.Y'));
 
 		// default handler (global app object)
-		new App([
+		$app = new App([
 			'options' => [
 				'date' => [
 					'handler' => 'intl'
 				]
 			]
 		]);
+		$app->setCurrentLanguage('en');
 		$this->assertSame($date->timestamp(), $date->formatWithHandler());
 		$this->assertSame('29/1/2020 01:01', $date->formatWithHandler('d/M/yyyy HH:mm'));
 

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Toolkit;
 
 use Exception;
 use IntlDateFormatter;
+use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Query\TestUser as QueryTestUser;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,11 @@ class StrTest extends TestCase
 	public static function setUpBeforeClass(): void
 	{
 		Str::$language = [];
+	}
+
+	public function tearDown(): void
+	{
+		App::destroy();
 	}
 
 	/**
@@ -205,9 +211,24 @@ class StrTest extends TestCase
 	{
 		$time = mktime(1, 1, 1, 1, 29, 2020);
 
-		// default `date` handler
+		// default handler (fallback to `date`)
 		$this->assertSame($time, Str::date($time));
 		$this->assertSame('29.01.2020', Str::date($time, 'd.m.Y'));
+
+		// default handler (global app object)
+		new App([
+			'options' => [
+				'date' => [
+					'handler' => 'intl'
+				]
+			]
+		]);
+		$this->assertSame($time, Str::date($time));
+		$this->assertSame('29/1/2020 01:01', Str::date($time, 'd/M/yyyy HH:mm'));
+
+		// explicit `date` handler
+		$this->assertSame($time, Str::date($time, null, 'date'));
+		$this->assertSame('29.01.2020', Str::date($time, 'd.m.Y', 'date'));
 
 		// `intl` handler
 		$this->assertSame($time, Str::date($time, null, 'intl'));

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Kirby\Cms\App;
 use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +28,11 @@ class HasCount
  */
 class VTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		App::destroy();
+	}
+
 	/**
 	 * @covers ::validators
 	 */
@@ -802,7 +808,7 @@ class VTest extends TestCase
 					]
 				],
 				false,
-				'The "email" validation failed for field "email"',
+				'Please enter a valid email address for field "email"',
 			],
 			// missing required field
 			[
@@ -842,6 +848,9 @@ class VTest extends TestCase
 	 */
 	public function testInput($input, $rules, $result, $message = null)
 	{
+		// load the translation strings
+		new App();
+
 		if ($result === false) {
 			$this->expectException('Exception');
 			$this->expectExceptionMessage($message);
@@ -869,8 +878,11 @@ class VTest extends TestCase
 	 */
 	public function testValueFails()
 	{
+		// load the translation strings
+		new App();
+
 		$this->expectException('Exception');
-		$this->expectExceptionMessage('The "same" validation failed');
+		$this->expectExceptionMessage('Please enter "b"');
 
 		$result = V::value('a', [
 			'same' => 'b'


### PR DESCRIPTION
Taken from https://discord.com/channels/525634039965679616/1111220342522904706/1149433392543313921. I had first planned to override the native `format()` method, however that would break use cases that expect to use `date()`-style formatting. So I made it a separate method.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features

- New `$date->formatWithHandler()` method for Kirby date objects that allows to use different date handlers or even the globally configured one (default).

### Enhancements

- `Str::date()` and its dependents (e.g. `F::modified()`, `File::modified()`, `Dir::modified()`) now respect the globally configured date handler

### Breaking changes

- The `Str::date()` method and its dependents (e.g. `F::modified()`, `File::modified()`, `Dir::modified()`) no longer use the `date` handler if a different handler was configured globally with the `date.handler` option

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
