### PR TITLE
Deprecate `k-plugin-view`

### DIFF
--- a/panel/dist/ui/LegacyPluginView.json
+++ b/panel/dist/ui/LegacyPluginView.json
@@ -1,1 +1,1 @@
-{"displayName":"LegacyPluginView","description":"","tags":{},"props":[{"name":"id","type":{"name":"string"}}],"component":"k-legacy-plugin-view","sourceFile":"src/components/Views/LegacyPluginView.vue"}
+{"description":"","tags":{"deprecated":[{"description":"Will be removed in v5.0.0","title":"deprecated"}],"todo":[{"description":"Remove in v5.0.0","title":"todo"}]},"displayName":"LegacyPluginView","props":[{"name":"id","type":{"name":"string"}}],"component":"k-legacy-plugin-view","sourceFile":"src/components/Views/LegacyPluginView.vue"}

--- a/panel/src/components/Views/LegacyPluginView.vue
+++ b/panel/src/components/Views/LegacyPluginView.vue
@@ -5,9 +5,18 @@
 </template>
 
 <script>
+/**
+ * @deprecated Will be removed in v5.0.0
+ * @todo Remove in v5.0.0
+ */
 export default {
 	props: {
 		id: String
+	},
+	created() {
+		window.panel.deprecated(
+			"<k-plugin-view> will be removed in a future version."
+		);
 	}
 };
 </script>


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Deprecated
- `k-plugin-view`, use `k-panel-inside` or `k-panel-outside` as wrappers instead

