### PR TITLE
`k-lab-docs-view` with support for better docs

### DIFF
--- a/config/areas/lab/views.php
+++ b/config/areas/lab/views.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Panel\Lab\Category;
+use Kirby\Panel\Lab\Docs;
 
 return [
 	'lab' => [
@@ -9,8 +10,56 @@ return [
 			return [
 				'component' => 'k-lab-index-view',
 				'props' => [
+					'tab'        => 'examples',
 					'categories' => Category::all(),
 				],
+			];
+		}
+	],
+	'lab.docs' => [
+		'pattern' => 'lab/docs',
+		'action'  => function () {
+			return [
+				'component' => 'k-lab-index-view',
+				'title'     => 'Docs',
+				'breadcrumb' => [
+					[
+						'label' => 'Docs',
+						'link'  => 'lab/docs'
+					]
+				],
+				'props' => [
+					'tab'        => 'docs',
+					'categories' => [
+						['examples' => Docs::all()]
+					],
+				],
+			];
+		}
+	],
+	'lab.doc' => [
+		'pattern' => 'lab/docs/(:any)',
+		'action'  => function (string $component) {
+			$docs = new Docs($component);
+
+			return [
+				'component' => 'k-lab-docs-view',
+				'title'     => $component,
+				'breadcrumb' => [
+					[
+						'label' => 'Docs',
+						'link'  => 'lab/docs'
+					],
+					[
+						'label' => $component,
+						'link'  => 'lab/docs/' . $component
+					]
+				],
+				'props' => [
+					'component' => $component,
+					'docs'      => $docs->toArray(),
+					'lab'       => $docs->lab()
+				]
 			];
 		}
 	],

--- a/panel/scripts/vite-kirby.mjs
+++ b/panel/scripts/vite-kirby.mjs
@@ -61,6 +61,19 @@ function labWatcher() {
 	};
 }
 
+function removeDocsBlock() {
+	return {
+		name: "kirby-remove-docs-block",
+		transform(code, id) {
+			if (/vue&type=docs/.test(id) === false) {
+				return;
+			}
+
+			return `export default ''`;
+		}
+	};
+}
+
 export default function kirby() {
-	return [devMode(), labWatcher()];
+	return [devMode(), labWatcher(), removeDocsBlock()];
 }

--- a/panel/src/components/Lab/Docs.vue
+++ b/panel/src/components/Lab/Docs.vue
@@ -1,38 +1,55 @@
 <template>
 	<div class="k-lab-docs">
-		<k-lab-docs-description :description="description" />
+		<k-lab-docs-deprecated :deprecated="deprecated" />
+		<k-lab-docs-description :description="description" :since="since" />
 		<k-lab-docs-examples :examples="examples" />
 		<k-lab-docs-props :props="props" />
 		<k-lab-docs-slots :slots="slots" />
 		<k-lab-docs-events :events="events" />
 		<k-lab-docs-methods :methods="methods" />
+		<k-lab-docs-docblock :doc-block="docBlock" />
 	</div>
 </template>
 
 <script>
+import Vue from "vue";
+
+import Deprecated, { props as DeprecatedProps } from "./Docs/Deprecated.vue";
 import Desc, { props as DescProps } from "./Docs/Description.vue";
 import Examples, { props as ExamplesProps } from "./Docs/Examples.vue";
 import Props, { props as PropsProps } from "./Docs/Props.vue";
 import Slots, { props as SlotsProps } from "./Docs/Slots.vue";
 import Events, { props as EventsProps } from "./Docs/Events.vue";
 import Methods, { props as MethodsProps } from "./Docs/Methods.vue";
+import DocBlock, { props as DocBlockProps } from "./Docs/DocBlock.vue";
+
+import DocDeprecated from "./DocsDeprecated.vue";
+import DocParams from "./DocsParams.vue";
+import DocTypes from "./DocsTypes.vue";
+Vue.component("k-lab-docs-deprecated", DocDeprecated);
+Vue.component("k-lab-docs-params", DocParams);
+Vue.component("k-lab-docs-types", DocTypes);
 
 export default {
 	components: {
+		"k-lab-docs-deprecated": Deprecated,
 		"k-lab-docs-description": Desc,
 		"k-lab-docs-examples": Examples,
 		"k-lab-docs-props": Props,
 		"k-lab-docs-slots": Slots,
 		"k-lab-docs-events": Events,
-		"k-lab-docs-methods": Methods
+		"k-lab-docs-methods": Methods,
+		"k-lab-docs-docblock": DocBlock
 	},
 	mixins: [
+		DeprecatedProps,
 		DescProps,
 		ExamplesProps,
 		PropsProps,
 		SlotsProps,
 		EventsProps,
-		MethodsProps
+		MethodsProps,
+		DocBlockProps
 	],
 	props: {
 		component: String
@@ -53,60 +70,20 @@ export default {
 	line-height: 1.5;
 	word-break: break-word;
 }
-.k-lab-docs-types {
-	display: inline-flex;
-	flex-wrap: wrap;
-	gap: var(--spacing-1);
-}
 
 .k-lab-docs-description :where(.k-text, .k-box) + :where(.k-text, .k-box) {
 	margin-top: var(--spacing-3);
 }
 
-.k-lab-docs-deprecated {
-	--box-height: var(--height-xs);
+.k-lab-docs-required {
+	margin-inline-start: var(--spacing-1);
+	font-size: 0.7rem;
+	vertical-align: super;
+	color: var(--color-red-600);
+}
+.k-lab-docs-since {
+	margin-top: var(--spacing-1);
 	font-size: var(--text-xs);
-}
-
-.k-lab-docs-values {
-	font-size: var(--text-xs);
-	border-left: 2px solid var(--color-blue-300);
-	padding-inline-start: var(--spacing-2);
-}
-.k-lab-docs-values span {
-	display: inline-flex;
-	flex-wrap: wrap;
-	gap: var(--spacing-1);
-}
-
-.k-lab-docs-types code[data-type="boolean"] {
-	color: var(--color-purple-800);
-	outline-color: var(--color-purple-400);
-	background: var(--color-purple-300);
-}
-.k-lab-docs-types code[data-type="string"] {
-	color: var(--color-green-800);
-	outline-color: var(--color-green-500);
-	background: var(--color-green-300);
-}
-.k-lab-docs-types code[data-type="number"] {
-	color: var(--color-orange-800);
-	outline-color: var(--color-orange-500);
-	background: var(--color-orange-300);
-}
-.k-lab-docs-types code[data-type="array"] {
-	color: var(--color-aqua-800);
-	outline-color: var(--color-aqua-500);
-	background: var(--color-aqua-300);
-}
-.k-lab-docs-types code[data-type="object"] {
-	color: var(--color-yellow-800);
-	outline-color: var(--color-yellow-500);
-	background: var(--color-yellow-300);
-}
-.k-lab-docs-types code[data-type="func"] {
-	color: var(--color-pink-800);
-	outline-color: var(--color-pink-400);
-	background: var(--color-pink-300);
+	color: var(--color-gray-600);
 }
 </style>

--- a/panel/src/components/Lab/Docs/Deprecated.vue
+++ b/panel/src/components/Lab/Docs/Deprecated.vue
@@ -1,0 +1,26 @@
+<template>
+	<section
+		v-if="deprecated.length"
+		class="k-lab-docs-section k-lab-docs-deprecated"
+	>
+		<k-lab-docs-deprecated :deprecated="deprecated" />
+	</section>
+</template>
+
+<script>
+export const props = {
+	props: {
+		deprecated: String
+	}
+};
+
+export default {
+	mixins: [props]
+};
+</script>
+
+<style>
+.k-lab-docs-deprecated .k-box {
+	box-shadow: var(--shadow);
+}
+</style>

--- a/panel/src/components/Lab/Docs/Description.vue
+++ b/panel/src/components/Lab/Docs/Description.vue
@@ -1,6 +1,15 @@
 <template>
-	<section v-if="description.length" class="k-lab-docs-section">
-		<k-headline class="h3">Description</k-headline>
+	<section
+		v-if="description?.length || since?.length"
+		class="k-lab-docs-section"
+	>
+		<header class="k-lab-docs-desc-header">
+			<k-headline class="h3">Description</k-headline>
+			<k-text v-if="since?.length">
+				Since <code>{{ since }}</code>
+			</k-text>
+		</header>
+
 		<k-box theme="text">
 			<k-text :html="description" />
 		</k-box>
@@ -10,7 +19,8 @@
 <script>
 export const props = {
 	props: {
-		description: String
+		description: String,
+		since: String
 	}
 };
 
@@ -18,3 +28,11 @@ export default {
 	mixins: [props]
 };
 </script>
+
+<style>
+.k-lab-docs-desc-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+</style>

--- a/panel/src/components/Lab/Docs/DocBlock.vue
+++ b/panel/src/components/Lab/Docs/DocBlock.vue
@@ -1,0 +1,31 @@
+<template>
+	<section v-if="docBlock?.length" class="k-lab-docs-section">
+		<header>
+			<k-headline class="h3">Further information</k-headline>
+		</header>
+
+		<k-box theme="text">
+			<k-text :html="docBlock" />
+		</k-box>
+	</section>
+</template>
+
+<script>
+export const props = {
+	props: {
+		docBlock: String
+	}
+};
+
+export default {
+	mixins: [props]
+};
+</script>
+
+<style>
+.k-lab-docs-desc-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+</style>

--- a/panel/src/components/Lab/Docs/Events.vue
+++ b/panel/src/components/Lab/Docs/Events.vue
@@ -6,16 +6,24 @@
 				<thead>
 					<th style="width: 10rem">Event</th>
 					<th>Description</th>
+					<th v-if="hasProperties">Properties</th>
 				</thead>
 				<tbody>
 					<tr v-for="event in events" :key="event.name">
-						<td style="width: 12rem">
+						<td>
 							<k-text>
 								<code>{{ event.name }}</code>
+								<div v-if="event.since?.length" class="k-lab-docs-since">
+									since {{ event.since }}
+								</div>
 							</k-text>
 						</td>
 						<td>
+							<k-lab-docs-deprecated :deprecated="event.deprecated" />
 							<k-text :html="event.description" />
+						</td>
+						<td v-if="hasProperties">
+							<k-lab-docs-params :params="event.properties" />
 						</td>
 					</tr>
 				</tbody>
@@ -30,6 +38,11 @@ export const props = {
 		events: {
 			default: () => [],
 			type: Array
+		}
+	},
+	computed: {
+		hasProperties() {
+			return this.events.filter((event) => event.properties.length).length;
 		}
 	}
 };

--- a/panel/src/components/Lab/Docs/Examples.vue
+++ b/panel/src/components/Lab/Docs/Examples.vue
@@ -1,5 +1,8 @@
 <template>
-	<section v-if="examples.length" class="k-lab-docs-section">
+	<section
+		v-if="examples.length"
+		class="k-lab-docs-section k-lab-docs-examples"
+	>
 		<k-headline class="h3">Examples</k-headline>
 		<k-code v-for="(example, index) in examples" :key="index" language="html">{{
 			example.content
@@ -21,3 +24,9 @@ export default {
 	mixins: [props]
 };
 </script>
+
+<style>
+.k-lab-docs-examples .k-code + .k-code {
+	margin-top: var(--spacing-4);
+}
+</style>

--- a/panel/src/components/Lab/Docs/Methods.vue
+++ b/panel/src/components/Lab/Docs/Methods.vue
@@ -1,21 +1,34 @@
 <template>
 	<section v-if="methods.length" class="k-lab-docs-section">
 		<k-headline class="h3">Methods</k-headline>
+
 		<div class="k-table">
 			<table>
 				<thead>
-					<th style="width: 8rem">Method</th>
+					<th style="width: 10rem">Method</th>
 					<th>Description</th>
+					<th style="width: 16rem">Params</th>
+					<th style="width: 10rem">Returns</th>
 				</thead>
 				<tbody>
 					<tr v-for="method in methods" :key="method.name">
-						<td style="width: 12rem">
+						<td>
 							<k-text>
 								<code>{{ method.name }}</code>
+								<div v-if="method.since?.length" class="k-lab-docs-since">
+									since {{ method.since }}
+								</div>
 							</k-text>
 						</td>
 						<td>
+							<k-lab-docs-deprecated :deprecated="method.deprecated" />
 							<k-text :html="method.description" />
+						</td>
+						<td>
+							<k-lab-docs-params :params="method.params" />
+						</td>
+						<td>
+							<k-lab-docs-types :types="[method.returns]" />
 						</td>
 					</tr>
 				</tbody>

--- a/panel/src/components/Lab/Docs/Props.vue
+++ b/panel/src/components/Lab/Docs/Props.vue
@@ -14,18 +14,14 @@
 						<td>
 							<k-text>
 								<code>{{ prop.name }}</code>
+								<abbr v-if="prop.required" class="k-lab-docs-required">✶</abbr>
+								<div v-if="prop.since?.length" class="k-lab-docs-since">
+									since {{ prop.since }}
+								</div>
 							</k-text>
 						</td>
 						<td>
-							<k-text class="k-lab-docs-types">
-								<code
-									v-for="type in prop.type?.split('|')"
-									:key="type"
-									:data-type="type"
-								>
-									{{ type }}
-								</code>
-							</k-text>
+							<k-lab-docs-types :types="prop.type?.split('|')" />
 						</td>
 						<td>
 							<k-text v-if="prop.default">
@@ -33,28 +29,43 @@
 							</k-text>
 						</td>
 						<td class="k-lab-docs-description">
+							<k-lab-docs-deprecated :deprecated="prop.deprecated" />
+
 							<k-text
 								v-if="prop.description?.length"
 								:html="prop.description"
 							/>
 
-							<k-box
-								v-if="prop.deprecated?.length"
-								theme="warning"
-								class="k-lab-docs-deprecated"
+							<k-text
+								v-if="
+									prop.value?.length ||
+									prop.values?.length ||
+									prop.example?.length
+								"
+								class="k-lab-docs-prop-values"
 							>
-								Deprecated: {{ prop.deprecated }}
-							</k-box>
+								<dl v-if="prop.value?.length">
+									<dt>Value</dt>
+									<dd>
+										<code>{{ prop.value }}</code>
+									</dd>
+								</dl>
 
-							<k-text v-if="prop.values?.length">
-								<p class="k-lab-docs-values">
-									<strong>Values</strong><br />
-									<span>
+								<dl v-if="prop.values?.length">
+									<dt>Values</dt>
+									<dd>
 										<code v-for="value in prop.values" :key="value">
 											{{ value.replaceAll("`", "") }}
 										</code>
-									</span>
-								</p>
+									</dd>
+								</dl>
+
+								<dl v-if="prop.example?.length">
+									<dt>Example</dt>
+									<dd>
+										<code>{{ prop.example }}</code>
+									</dd>
+								</dl>
 							</k-text>
 						</td>
 					</tr>
@@ -78,3 +89,22 @@ export default {
 	mixins: [props]
 };
 </script>
+
+<style>
+.k-lab-docs-prop-values {
+	font-size: var(--text-xs);
+	border-left: 2px solid var(--color-blue-300);
+	padding-inline-start: var(--spacing-2);
+}
+.k-lab-docs-prop-values dl {
+	font-weight: var(--font-bold);
+}
+.k-lab-docs-prop-values dl + dl {
+	margin-top: var(--spacing-2);
+}
+.k-lab-docs-prop-values dd {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-1);
+}
+</style>

--- a/panel/src/components/Lab/Docs/Slots.vue
+++ b/panel/src/components/Lab/Docs/Slots.vue
@@ -6,16 +6,24 @@
 				<thead>
 					<th style="width: 10rem">Slot</th>
 					<th>Description</th>
+					<th v-if="hasBindings">Bindings</th>
 				</thead>
 				<tbody>
 					<tr v-for="slot in slots" :key="slot.name">
 						<td style="width: 12rem">
 							<k-text>
 								<code>{{ slot.name }}</code>
+								<div v-if="slot.since?.length" class="k-lab-docs-since">
+									since {{ slot.since }}
+								</div>
 							</k-text>
 						</td>
 						<td>
+							<k-lab-docs-deprecated :deprecated="slot.deprecated" />
 							<k-text :html="slot.description" />
+						</td>
+						<td v-if="hasBindings">
+							<k-lab-docs-params :params="slot.bindings" />
 						</td>
 					</tr>
 				</tbody>
@@ -30,6 +38,11 @@ export const props = {
 		slots: {
 			default: () => [],
 			type: Array
+		}
+	},
+	computed: {
+		hasBindings() {
+			return this.slots.filter((slot) => slot.bindings.length).length;
 		}
 	}
 };

--- a/panel/src/components/Lab/DocsDeprecated.vue
+++ b/panel/src/components/Lab/DocsDeprecated.vue
@@ -1,0 +1,27 @@
+<template>
+	<k-box
+		v-if="deprecated?.length"
+		icon="protected"
+		theme="warning"
+		class="k-lab-docs-deprecated"
+	>
+		<k-text :html="'<strong>Deprecated:</strong> ' + deprecated" />
+	</k-box>
+</template>
+
+<script>
+export default {
+	props: {
+		deprecated: {
+			type: String
+		}
+	}
+};
+</script>
+
+<style>
+.k-table .k-lab-docs-deprecated {
+	--box-height: var(--height-xs);
+	--text-font-size: var(--text-xs);
+}
+</style>

--- a/panel/src/components/Lab/DocsDrawer.vue
+++ b/panel/src/components/Lab/DocsDrawer.vue
@@ -17,10 +17,15 @@ export default {
 	},
 	computed: {
 		options() {
-			const options = [];
+			const options = [
+				{
+					icon: "expand",
+					link: "lab/docs/" + this.docs.component
+				}
+			];
 
 			if (this.docs.github) {
-				options.push({
+				options.unshift({
 					icon: "github",
 					link: this.docs.github,
 					target: "_blank"

--- a/panel/src/components/Lab/DocsParams.vue
+++ b/panel/src/components/Lab/DocsParams.vue
@@ -1,0 +1,33 @@
+<template>
+	<ul v-if="params.length" class="k-labs-docs-params">
+		<li v-for="param in params" :key="param.name">
+			<k-text>
+				<code>{{ param.name }}</code>
+				<k-lab-docs-types :types="[param.type]" />
+				<!-- eslint-disable-next-line vue/no-v-html -->
+				<span v-if="param.description.length" v-html="param.description" />
+			</k-text>
+		</li>
+	</ul>
+</template>
+
+<script>
+export default {
+	props: {
+		params: {
+			type: Array,
+			default: () => []
+		}
+	}
+};
+</script>
+
+<style>
+.k-labs-docs-params li {
+	list-style: square;
+	margin-inline-start: var(--spacing-3);
+}
+.k-labs-docs-params .k-lab-docs-types {
+	margin-inline: 1ch;
+}
+</style>

--- a/panel/src/components/Lab/DocsTypes.vue
+++ b/panel/src/components/Lab/DocsTypes.vue
@@ -1,0 +1,62 @@
+<template>
+	<k-text class="k-lab-docs-types">
+		<code v-for="type in types" :key="type" :data-type="type">
+			{{ type }}
+		</code>
+	</k-text>
+</template>
+
+<script>
+export default {
+	props: {
+		types: {
+			type: Array,
+			default: () => []
+		}
+	}
+};
+</script>
+
+<style>
+.k-lab-docs-types {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-1);
+}
+
+.k-lab-docs-types.k-text code {
+	color: var(--color-gray-800);
+	outline-color: var(--color-gray-400);
+	background: var(--color-gray-300);
+}
+.k-lab-docs-types code:is([data-type="boolean"], [data-type="Boolean"]) {
+	color: var(--color-purple-800);
+	outline-color: var(--color-purple-400);
+	background: var(--color-purple-300);
+}
+.k-lab-docs-types code:is([data-type="string"], [data-type="String"]) {
+	color: var(--color-green-800);
+	outline-color: var(--color-green-500);
+	background: var(--color-green-300);
+}
+.k-lab-docs-types code:is([data-type="number"], [data-type="Number"]) {
+	color: var(--color-orange-800);
+	outline-color: var(--color-orange-500);
+	background: var(--color-orange-300);
+}
+.k-lab-docs-types code:is([data-type="array"], [data-type="Array"]) {
+	color: var(--color-aqua-800);
+	outline-color: var(--color-aqua-500);
+	background: var(--color-aqua-300);
+}
+.k-lab-docs-types code:is([data-type="object"], [data-type="Object"]) {
+	color: var(--color-yellow-800);
+	outline-color: var(--color-yellow-500);
+	background: var(--color-yellow-300);
+}
+.k-lab-docs-types code[data-type="func"] {
+	color: var(--color-pink-800);
+	outline-color: var(--color-pink-400);
+	background: var(--color-pink-300);
+}
+</style>

--- a/panel/src/components/Lab/DocsView.vue
+++ b/panel/src/components/Lab/DocsView.vue
@@ -1,0 +1,51 @@
+<template>
+	<k-panel-inside class="k-lab-docs-view">
+		<k-header>
+			{{ component }}
+
+			<k-button-group v-if="docs.github || lab" slot="buttons">
+				<k-button
+					v-if="lab"
+					icon="lab"
+					text="Lab examples"
+					size="sm"
+					variant="filled"
+					:link="'/lab/' + lab"
+				/>
+				<k-button
+					v-if="docs.github"
+					icon="github"
+					size="sm"
+					variant="filled"
+					:link="docs.github"
+					target="_blank"
+				/>
+			</k-button-group>
+		</k-header>
+
+		<k-lab-docs v-bind="docs" />
+	</k-panel-inside>
+</template>
+
+<script>
+import Docs from "./Docs.vue";
+
+export default {
+	components: {
+		"k-lab-docs": Docs
+	},
+	props: {
+		component: String,
+		docs: Object,
+		lab: String
+	},
+	mounted() {
+		import.meta.hot?.on("kirby:docs:" + this.component, this.reloadDocs);
+	},
+	methods: {
+		reloadDocs() {
+			this.$panel.view.refresh();
+		}
+	}
+};
+</script>

--- a/panel/src/components/Lab/IndexView.vue
+++ b/panel/src/components/Lab/IndexView.vue
@@ -2,6 +2,14 @@
 	<k-panel-inside class="k-lab-index-view">
 		<k-header>Lab</k-header>
 
+		<k-tabs
+			:tab="tab"
+			:tabs="[
+				{ name: 'examples', label: 'Examples', link: '/lab' },
+				{ name: 'docs', label: 'Docs', link: '/lab/docs' }
+			]"
+		/>
+
 		<k-section
 			v-for="category in categories"
 			:key="category.name"
@@ -21,12 +29,16 @@
 <script>
 export default {
 	props: {
-		categories: Array
+		categories: Array,
+		tab: String
 	}
 };
 </script>
 
 <style>
+.k-lab-index-view .k-header {
+	margin-bottom: 0;
+}
 .k-lab-index-view .k-list-items {
 	grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
 }

--- a/panel/src/components/Lab/index.js
+++ b/panel/src/components/Lab/index.js
@@ -1,9 +1,11 @@
 const IndexView = () => import("./IndexView.vue");
+const DocsView = () => import("./DocsView.vue");
 const PlaygroundView = () => import("./PlaygroundView.vue");
 
 export default {
 	install(app) {
 		app.component("k-lab-index-view", IndexView);
+		app.component("k-lab-docs-view", DocsView);
 		app.component("k-lab-playground-view", PlaygroundView);
 	}
 };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->


### Features
- New single docs view for each Vue component

<img width="1237" alt="Screenshot 2023-10-15 at 10 14 28" src="https://github.com/getkirby/kirby/assets/3788865/d17ece03-e758-43ee-8e66-1e5e52c02977">

<img width="1218" alt="Screenshot 2023-10-15 at 10 14 05" src="https://github.com/getkirby/kirby/assets/3788865/5257fc50-0034-4061-917f-a46346da55f4">

### Enhancements
- Backlinks from docs to lab examples
- Support for `<docs>` block in Vue SFC
- Document slot bindings, event properties, method params and return type
- Support for prop's `@values`, `@values`, `@example`
- Support for individual `@since` per prop, method, event, slot