### PR TITLE
Generate UI docs in `panel/tmp` during `dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # build files
 /dist.zip
 /kirby.zip
+/panel/tmp
 
 # cs fixer
 .php-cs-fixer.cache

--- a/panel/package.json
+++ b/panel/package.json
@@ -2,8 +2,7 @@
 	"name": "kirby",
 	"private": true,
 	"scripts": {
-		"build": "vite build && npm run build:docs",
-		"build:panel": "vite build",
+		"build": "vite build",
 		"build:docs": "node scripts/docs.mjs",
 		"dev": "vite --host",
 		"lint": "eslint \"src/**/*.{js,vue}\"",

--- a/panel/scripts/docs.mjs
+++ b/panel/scripts/docs.mjs
@@ -53,8 +53,15 @@ export function normalizeDoc(data, path) {
 export default async function generate(file) {
 	const script = path.dirname(fileURLToPath(import.meta.url));
 	const root = path.resolve(script, "../");
-	const dist = path.resolve(root, "./dist/ui");
 	const alias = { "@": path.resolve(root, "./src/") };
+
+	let dist;
+
+	if (file) {
+		dist = path.resolve(root, "./tmp");
+	} else {
+		dist = path.resolve(root, "./dist/ui");
+	}
 
 	if (fs.existsSync(dist) === false) {
 		fs.mkdirSync(dist);
@@ -96,11 +103,9 @@ export default async function generate(file) {
 
 // If this file is run from CLI
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-	console.log("\n");
-	console.log("Generating UI documentation...");
-
+	console.log("Generating UI documentation…");
 	// Pass absolute file path from -- argument, if given
-	generate(process.argv[2]).then((components) => {
-		console.log("--> " + components.length + " components compiled");
+	generate(process.argv[2]).then((docs) => {
+		console.log(`\x1b[32m✓\x1b[0m ${docs.length} UI docs generated.`);
 	});
 }

--- a/src/Panel/Lab/Docs.php
+++ b/src/Panel/Lab/Docs.php
@@ -31,7 +31,7 @@ class Docs
 		protected string $name
 	) {
 		$this->kirby = App::instance();
-		$this->json  = Data::read($this->file());
+		$this->json  = $this->read();
 	}
 
 	public static function all(): array
@@ -104,11 +104,16 @@ class Docs
 		return [];
 	}
 
-	public function file(): string
+	public function file(string $context): string
 	{
+		$root = match ($context) {
+			'dev'  => $this->kirby->root('panel') . '/tmp',
+			'dist' => $this->kirby->root('panel') . '/dist/ui',
+		};
+
 		$name = Str::after($this->name, 'k-');
 		$name = Str::kebabToCamel($name);
-		return $this->kirby->root('panel') . '/dist/ui/' . $name . '.json';
+		return $root . '/' . $name . '.json';
 	}
 
 	public function github(): string
@@ -250,6 +255,17 @@ class Docs
 
 		// always return an array
 		return array_values($props);
+	}
+
+	protected function read(): array
+	{
+		$file = $this->file('dev');
+
+		if (file_exists($file) === false) {
+			$file = $this->file('dist');
+		}
+
+		return Data::read($file);
 	}
 
 	public function since(): string|null


### PR DESCRIPTION
Still the question remains what happens with leftover UI docs in `panel/tmp` when switching branches and maybe now an untrue docs JSON stays in `panel/tmp`