### PR TITLE
Some blocks disabled fixes

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -4,61 +4,63 @@
 		:data-multi-select-key="isMultiSelectKey"
 		class="k-blocks"
 	>
-		<k-draggable
-			v-if="hasFieldsets"
-			v-bind="draggableOptions"
-			class="k-blocks-list"
-			@sort="save"
-		>
-			<k-block
-				v-for="(block, index) in blocks"
-				:ref="'block-' + block.id"
-				:key="block.id"
-				v-bind="block"
-				:endpoints="endpoints"
-				:fieldset="fieldset(block)"
-				:is-batched="isSelected(block) && selected.length > 1"
-				:is-last-selected="isLastSelected(block)"
-				:is-full="isFull"
-				:is-hidden="block.isHidden === true"
-				:is-mergable="isMergable"
-				:is-selected="isSelected(block)"
-				:next="prevNext(index + 1)"
-				:prev="prevNext(index - 1)"
-				@append="add($event, index + 1)"
-				@chooseToAppend="choose(index + 1)"
-				@chooseToConvert="chooseToConvert(block)"
-				@chooseToPrepend="choose(index)"
-				@click.native.prevent.stop="onClickBlock(block, $event)"
-				@close="isEditing = false"
-				@copy="copy()"
-				@duplicate="duplicate(block, index)"
-				@focus="onFocus(block)"
-				@hide="hide(block)"
-				@merge="merge()"
-				@open="isEditing = true"
-				@paste="pasteboard()"
-				@prepend="add($event, index)"
-				@remove="remove(block)"
-				@removeSelected="removeSelected"
-				@show="show(block)"
-				@selectDown="selectDown"
-				@selectUp="selectUp"
-				@sortDown="sort(block, index, index + 1)"
-				@sortUp="sort(block, index, index - 1)"
-				@split="split(block, index, $event)"
-				@update="update(block, $event)"
-			/>
-			<template #footer>
-				<k-empty
-					class="k-blocks-empty"
-					icon="box"
-					@click="choose(blocks.length)"
-				>
-					{{ empty ?? $t("field.blocks.empty") }}
-				</k-empty>
-			</template>
-		</k-draggable>
+		<template v-if="hasFieldsets">
+			<k-draggable
+				v-if="blocks.length"
+				v-bind="draggableOptions"
+				class="k-blocks-list"
+				@sort="save"
+			>
+				<k-block
+					v-for="(block, index) in blocks"
+					:ref="'block-' + block.id"
+					:key="block.id"
+					v-bind="block"
+					:endpoints="endpoints"
+					:fieldset="fieldset(block)"
+					:is-batched="isSelected(block) && selected.length > 1"
+					:is-last-selected="isLastSelected(block)"
+					:is-full="isFull"
+					:is-hidden="block.isHidden === true"
+					:is-mergable="isMergable"
+					:is-selected="isSelected(block)"
+					:next="prevNext(index + 1)"
+					:prev="prevNext(index - 1)"
+					@append="add($event, index + 1)"
+					@chooseToAppend="choose(index + 1)"
+					@chooseToConvert="chooseToConvert(block)"
+					@chooseToPrepend="choose(index)"
+					@click.native.prevent.stop="onClickBlock(block, $event)"
+					@close="isEditing = false"
+					@copy="copy()"
+					@duplicate="duplicate(block, index)"
+					@focus="onFocus(block)"
+					@hide="hide(block)"
+					@merge="merge()"
+					@open="isEditing = true"
+					@paste="pasteboard()"
+					@prepend="add($event, index)"
+					@remove="remove(block)"
+					@removeSelected="removeSelected"
+					@show="show(block)"
+					@selectDown="selectDown"
+					@selectUp="selectUp"
+					@sortDown="sort(block, index, index + 1)"
+					@sortUp="sort(block, index, index - 1)"
+					@split="split(block, index, $event)"
+					@update="update(block, $event)"
+				/>
+			</k-draggable>
+
+			<k-empty
+				v-else
+				class="k-blocks-empty"
+				icon="box"
+				@click="choose(blocks.length)"
+			>
+				{{ empty ?? $t("field.blocks.empty") }}
+			</k-empty>
+		</template>
 
 		<k-empty v-else icon="box">
 			{{ $t("field.blocks.fieldsets.empty") }}
@@ -708,7 +710,7 @@ export default {
 </script>
 
 <style>
-.k-blocks {
+.k-blocks:not([data-empty="true"]) {
 	background: var(--color-white);
 	box-shadow: var(--shadow);
 	border-radius: var(--rounded);
@@ -718,11 +720,6 @@ export default {
 }
 .k-blocks[data-multi-select-key="true"] .k-block-container * {
 	pointer-events: none;
-}
-.k-blocks[data-empty="true"] {
-	padding: 0;
-	background: none;
-	box-shadow: none;
 }
 .k-blocks .k-sortable-ghost {
 	outline: 2px solid var(--color-focus);
@@ -734,8 +731,5 @@ export default {
 .k-blocks-list > .k-blocks-empty {
 	display: flex;
 	align-items: center;
-}
-.k-blocks-list > .k-blocks-empty:not(:only-child) {
-	display: none;
 }
 </style>

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -1,5 +1,6 @@
 <template>
 	<div
+		:data-disabled="disabled"
 		:data-empty="blocks.length === 0"
 		:data-multi-select-key="isMultiSelectKey"
 		class="k-blocks"
@@ -75,6 +76,7 @@ export default {
 	inheritAttrs: false,
 	props: {
 		autofocus: Boolean,
+		disabled: Boolean,
 		empty: String,
 		endpoints: Object,
 		fieldsets: Object,
@@ -710,13 +712,15 @@ export default {
 </script>
 
 <style>
-.k-blocks:not([data-empty="true"]) {
-	background: var(--color-white);
-	box-shadow: var(--shadow);
+.k-blocks {
 	border-radius: var(--rounded);
 }
-[data-disabled="true"] .k-blocks {
-	background: var(--color-background);
+.k-blocks:not([data-empty="true"], [data-disabled="true"]) {
+	background: var(--color-white);
+	box-shadow: var(--shadow);
+}
+.k-blocks[data-disabled="true"]:not([data-empty="true"]) {
+	border: 1px solid var(--input-color-border);
 }
 .k-blocks[data-multi-select-key="true"] .k-block-container * {
 	pointer-events: none;

--- a/panel/src/components/Forms/Blocks/Types/Fields.vue
+++ b/panel/src/components/Forms/Blocks/Types/Fields.vue
@@ -93,7 +93,6 @@ export default {
 .k-block-type-fields-header {
 	display: flex;
 	justify-content: space-between;
-	background: var(--color-white);
 }
 .k-block-type-fields-header .k-block-title {
 	padding-block: var(--spacing-3);

--- a/panel/src/components/Forms/Blocks/Types/Heading.vue
+++ b/panel/src/components/Forms/Blocks/Types/Heading.vue
@@ -116,6 +116,7 @@ export default {
 	font-weight: 700;
 }
 .k-block-type-heading-level {
+	--input-color-back: transparent;
 	--input-color-border: none;
 	--input-color-text: var(--color-gray-600);
 	font-weight: var(--font-bold);

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -26,6 +26,7 @@
 			ref="blocks"
 			:autofocus="autofocus"
 			:compact="false"
+			:disabled="disabled"
 			:empty="empty"
 			:endpoints="endpoints"
 			:fieldsets="fieldsets"

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -44,10 +44,10 @@
 			data-align="center"
 		>
 			<k-button
+				:title="$t('add')"
 				icon="add"
 				size="xs"
 				variant="filled"
-				:title="$t('add')"
 				@click="$refs.blocks.choose(value.length)"
 			/>
 		</footer>

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-field v-bind="$props" class="k-blocks-field">
-		<template v-if="hasFieldsets" #options>
+		<template v-if="!disabled && hasFieldsets" #options>
 			<k-button-group layout="collapsed">
 				<k-button
 					:autofocus="autofocus"
@@ -39,7 +39,7 @@
 		/>
 
 		<footer
-			v-if="!isEmpty && !isFull && hasFieldsets"
+			v-if="!disabled && !isEmpty && !isFull && hasFieldsets"
 			class="k-bar"
 			data-align="center"
 		>

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-field v-bind="$props" class="k-layout-field">
-		<template #options>
+		<template v-if="!disabled" #options>
 			<k-button-group layout="collapsed">
 				<k-button
 					:autofocus="autofocus"
@@ -19,7 +19,18 @@
 				<k-dropdown-content ref="options" :options="options" align-x="end" />
 			</k-button-group>
 		</template>
+
 		<k-layouts ref="layouts" v-bind="$props" @input="$emit('input', $event)" />
+
+		<footer v-if="!disabled" class="k-bar" data-align="center">
+			<k-button
+				:title="$t('add')"
+				icon="add"
+				size="xs"
+				variant="filled"
+				@click="$refs.layouts.select(value.length)"
+			/>
+		</footer>
 	</k-field>
 </template>
 
@@ -74,3 +85,10 @@ export default {
 	}
 };
 </script>
+
+<style>
+/** TODO: .k-layout-field > :has(+ footer) { margin-bottom: var(--spacing-3);} */
+.k-layout-field > footer {
+	margin-top: var(--spacing-3);
+}
+</style>

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -25,27 +25,11 @@
 					@updateColumn="updateColumn({ layout, index, ...$event })"
 				/>
 			</k-draggable>
-
-			<footer
-				v-if="!disabled"
-				class="k-layouts-footer k-bar"
-				data-align="center"
-			>
-				<k-button
-					:title="$t('add')"
-					icon="add"
-					size="xs"
-					variant="filled"
-					@click="select(rows.length)"
-				/>
-			</footer>
 		</template>
 
-		<template v-else>
-			<k-empty icon="dashboard" class="k-layout-empty" @click="select(0)">
-				{{ empty ?? $t("field.layout.empty") }}
-			</k-empty>
-		</template>
+		<k-empty v-else icon="dashboard" class="k-layout-empty" @click="select(0)">
+			{{ empty ?? $t("field.layout.empty") }}
+		</k-empty>
 	</div>
 </template>
 
@@ -340,8 +324,5 @@ export default {
 	outline: 2px solid var(--color-focus);
 	cursor: grabbing;
 	z-index: 1;
-}
-.k-layouts-footer {
-	margin-top: var(--spacing-3);
 }
 </style>


### PR DESCRIPTION
There are still more left but some first ones
- Blocks: align disabled styling with other fields (no drop shadow, solid border)
- when blocks/layout field is disabled, don't show add buttons and dropdown
- move add btn to `k-layout-field` instead `k-layouts` to be consistent with `k-blocks-field`
- heading block: select should have no background when disabled
- fields: block: header should have no background when disabled