### PR TITLE
Revert StructureObject random ID

### DIFF
--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -24,4 +24,26 @@ class Structure extends Items
 	 * All registered structure methods
 	 */
 	public static array $methods = [];
+
+	/**
+	 * Creates a new structure collection from a
+	 * an array of item props
+	 */
+	public static function factory(
+		array $items = null,
+		array $params = []
+	): static {
+		// Bake-in index as ID for all items
+		// TODO: remove when adding UUID supports to Structures
+		if (is_array($items) === true) {
+			$items = array_map(function ($item, $index) {
+				if (is_array($item) === true) {
+					$item['id'] ??= $index;
+				}
+				return $item;
+			}, $items, array_keys($items));
+		}
+
+		return parent::factory($items, $params);
+	}
 }

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -85,8 +85,11 @@ class StructureTest extends TestCase
 		$this->assertInstanceOf(Field::class, $structure->last()->name());
 		$this->assertInstanceOf(Field::class, $structure->last()->prev()->name());
 		$this->assertSame('A', $structure->first()->name()->value());
+		$this->assertSame('0', $structure->first()->id());
 		$this->assertSame('B', $structure->first()->next()->name()->value());
+		$this->assertSame('1', $structure->first()->next()->id());
 		$this->assertSame('C', $structure->last()->name()->value());
+		$this->assertSame('2', $structure->last()->id());
 		$this->assertSame('B', $structure->last()->prev()->name()->value());
 
 		$this->assertSame(2, $structure->last()->indexOf());


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

v4 switched over to UUID for structure fields so far, only that they wouldn't be stored, so each time generated. This is breaking some use cases, that rely on the id being the index in v3 - not secure but at least persistent as long as the structure isn't changed.

This PR brings back the index as id. Until we haven't added UUIDs that are stored/persist, this it the better option to keep around.

### Fixes
-  #5702


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
