### PR TITLE
Fix textarea scroll jumps

### DIFF
--- a/panel/src/components/Forms/Autosize.js
+++ b/panel/src/components/Forms/Autosize.js
@@ -15,12 +15,14 @@ export default class Autosize extends HTMLElement {
 
 			// attach custom autosize method to textarea
 			textarea.autosize = () => {
-				textarea.style.height = 0;
+				textarea.style.height = "auto";
 				textarea.style.height = textarea.scrollHeight + "px";
+				this.restoreScroll();
 			};
 
 			// trigger resize on input
 			textarea.addEventListener("input", () => textarea.autosize());
+			textarea.addEventListener("beforeinput", () => this.storeScroll());
 		}
 
 		// resize all textareas when the container size changes
@@ -35,5 +37,16 @@ export default class Autosize extends HTMLElement {
 
 	disconnectedCallback() {
 		this.resizer.unobserve(this);
+	}
+
+	restoreScroll() {
+		if (this.scrollY) {
+			window.scroll(0, this.scrollY);
+			this.scroll = null;
+		}
+	}
+
+	storeScroll() {
+		this.scrollY = window.scrollY;
 	}
 }

--- a/panel/src/components/Forms/Autosize.js
+++ b/panel/src/components/Forms/Autosize.js
@@ -40,9 +40,9 @@ export default class Autosize extends HTMLElement {
 	}
 
 	restoreScroll() {
-		if (this.scrollY) {
+		if (this.scrollY !== undefined) {
 			window.scroll(0, this.scrollY);
-			this.scroll = null;
+			this.scroll = undefined;
 		}
 	}
 

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -107,9 +107,6 @@ export default {
 	watch: {
 		value() {
 			this.onInvalid();
-			this.$nextTick(() => {
-				this.$refs.input.autosize();
-			});
 		}
 	},
 	mounted() {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

It seems like this wasn't at all related with autosizing, but a Chrome bug that exists with every very long textarea. Safari worked fine for me. However, storing scroll position on `beforeinput` seems to work for me. Please give it thorough testing.

### Fixes
- #5251
