### PR TITLE
Document exceptions thrown by `Remote`

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -61,7 +61,7 @@ class Remote
 	/**
 	 * Constructor
 	 *
-	 * @throws Exception when the curl request failed
+	 * @throws \Exception when the curl request failed
 	 */
 	public function __construct(string $url, array $options = [])
 	{
@@ -122,7 +122,7 @@ class Remote
 	 * Sets up all curl options and sends the request
 	 *
 	 * @return $this
-	 * @throws Exception when the curl request failed
+	 * @throws \Exception when the curl request failed
 	 */
 	public function fetch(): static
 	{
@@ -262,7 +262,7 @@ class Remote
 	/**
 	 * Static method to send a GET request
 	 *
-	 * @throws Exception when the curl request failed
+	 * @throws \Exception when the curl request failed
 	 */
 	public static function get(string $url, array $params = []): static
 	{
@@ -345,7 +345,7 @@ class Remote
 	/**
 	 * Static method to init this class and send a request
 	 *
-	 * @throws Exception when the curl request failed
+	 * @throws \Exception when the curl request failed
 	 */
 	public static function request(string $url, array $params = []): static
 	{

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -60,6 +60,8 @@ class Remote
 
 	/**
 	 * Constructor
+	 *
+	 * @throws Exception when the curl request failed
 	 */
 	public function __construct(string $url, array $options = [])
 	{
@@ -120,6 +122,7 @@ class Remote
 	 * Sets up all curl options and sends the request
 	 *
 	 * @return $this
+	 * @throws Exception when the curl request failed
 	 */
 	public function fetch(): static
 	{
@@ -258,6 +261,8 @@ class Remote
 
 	/**
 	 * Static method to send a GET request
+	 *
+	 * @throws Exception when the curl request failed
 	 */
 	public static function get(string $url, array $params = []): static
 	{
@@ -339,6 +344,8 @@ class Remote
 
 	/**
 	 * Static method to init this class and send a request
+	 *
+	 * @throws Exception when the curl request failed
 	 */
 	public static function request(string $url, array $params = []): static
 	{


### PR DESCRIPTION
## This PR adds `@throws` tags in `Remote`

### Fixes
Exceptions for cURL errors in `Remote` were not documented (related [forum topic](https://forum.getkirby.com/t/clearly-indicate-exceptions-that-can-be-thrown-in-docs/29798))

### Breaking changes
None

## Ready?
- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [ ] Tests and checks all pass

### For review team
- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)