### PR TITLE
Textarea: properly restore selection after file select

### DIFF
--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -146,6 +146,8 @@ export default {
 			});
 		},
 		file() {
+			const restoreSelection = this.restoreSelectionCallback();
+
 			this.$panel.dialog.open({
 				component: "k-files-dialog",
 				props: {
@@ -153,9 +155,9 @@ export default {
 					multiple: false
 				},
 				on: {
-					cancel: this.cancel,
+					cancel: restoreSelection,
 					submit: (file) => {
-						this.insertFile(file);
+						restoreSelection(() => this.insertFile(file));
 						this.$panel.dialog.close();
 					}
 				}


### PR DESCRIPTION
## This PR …

Implemented @distantnative solution in https://github.com/getkirby/kirby/pull/5865

### Fixes
- Textarea file select kirbytext inserting always start of content #5869

### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
