### PR TITLE
Writer toolbar: fix node dropdown and empty marks

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -155,10 +155,7 @@ export default {
 		 * Whether there are any nodes to show in the toolbar
 		 */
 		hasNodes() {
-			// show nodes dropdown when there are at least three nodes incl. paragraph
-			// or when there are at least two one nodes which are not the paragraph
-			const min = Object.keys(this.nodeButtons).includes("paragraph") ? 2 : 1;
-			return this.$helper.object.length(this.nodeButtons) > min;
+			return this.$helper.object.length(this.nodeButtons) > 1;
 		},
 		/**
 		 * All marks that are available and requested based on the `marks` prop

--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -125,20 +125,22 @@ export default {
 			}
 
 			// Marks
-			for (const markType in this.markButtons) {
-				const mark = this.markButtons[markType];
+			if (this.hasMarks) {
+				for (const markType in this.markButtons) {
+					const mark = this.markButtons[markType];
 
-				if (mark === "|") {
-					buttons.push("|");
-					continue;
+					if (mark === "|") {
+						buttons.push("|");
+						continue;
+					}
+
+					buttons.push({
+						current: this.editor.activeMarks.includes(markType),
+						icon: mark.icon,
+						label: mark.label,
+						click: (e) => this.command(mark.command ?? markType, e)
+					});
 				}
-
-				buttons.push({
-					current: this.editor.activeMarks.includes(markType),
-					icon: mark.icon,
-					label: mark.label,
-					click: (e) => this.command(mark.command ?? markType, e)
-				});
 			}
 
 			return buttons;
@@ -162,11 +164,11 @@ export default {
 		 * All marks that are available and requested based on the `marks` prop
 		 */
 		markButtons() {
-			if (this.marks === false) {
+			const available = this.editor.buttons("mark");
+
+			if (this.marks === false || this.$helper.object.length(available) === 0) {
 				return {};
 			}
-
-			const available = this.editor.buttons("mark");
 
 			if (this.marks === true) {
 				return available;
@@ -188,11 +190,11 @@ export default {
 		 * All nodes that are available and requested based on the `nodes` prop
 		 */
 		nodeButtons() {
-			if (this.nodes === false) {
+			const available = this.editor.buttons("node");
+
+			if (this.nodes === false || this.$helper.object.length(available) === 0) {
 				return {};
 			}
-
-			const available = this.editor.buttons("node");
 
 			// remove the paragraph when certain nodes are requested to be loaded
 			if (this.editor.nodes.doc.content !== "block+" && available.paragraph) {

--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -153,9 +153,9 @@ export default {
 		 * Whether there are any nodes to show in the toolbar
 		 */
 		hasNodes() {
-			// show nodes dropdown when there are at least two nodes incl. paragraph
-			// or when there is only one node and it's not the paragraph node
-			const min = Object.keys(this.nodeButtons).includes("paragraph") ? 1 : 0;
+			// show nodes dropdown when there are at least three nodes incl. paragraph
+			// or when there are at least two one nodes which are not the paragraph
+			const min = Object.keys(this.nodeButtons).includes("paragraph") ? 2 : 1;
 			return this.$helper.object.length(this.nodeButtons) > min;
 		},
 		/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- #5883
- Toolbar will ignore default mark/nodes list if no marks/nodes are allowed in writer instance (to not show just separators next to each other, which would be the only default entries that can be rendered)