### PR TITLE
Writer: rely on Vue defaults, more consistent

### DIFF
--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -61,23 +61,6 @@ return [
 		}
 	],
 	'computed' => [
-		'toolbar' => function () {
-			return array_merge([
-				'inline' => true,
-				'marks'  => $this->marks ?? [
-					'bold',
-					'italic',
-					'underline',
-					'strike',
-					'code',
-					'|',
-					'link',
-					'email',
-					'|',
-					'clear'
-				]
-			], $this->toolbar ?? []);
-		},
 		'value' => function () {
 			$value = trim($this->value ?? '');
 			return Sane::sanitize($value, 'html');

--- a/panel/src/components/Forms/Writer/Writer.vue
+++ b/panel/src/components/Forms/Writer/Writer.vue
@@ -12,8 +12,7 @@
 		<k-writer-toolbar
 			v-if="editor && !disabled"
 			ref="toolbar"
-			v-bind="toolbar"
-			:editor="editor"
+			v-bind="toolbarOptions"
 			@command="onCommand"
 		/>
 	</div>
@@ -121,6 +120,14 @@ export default {
 		},
 		isCursorAtStart() {
 			return this.editor.selectionIsAtStart;
+		},
+		toolbarOptions() {
+			return {
+				// if custom set of marks is enabled, use as toolbar default as well
+				marks: Array.isArray(this.marks) ? this.marks : undefined,
+				...this.toolbar,
+				editor: this.editor
+			};
 		}
 	},
 	watch: {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Instead of transforming defaults in the PHP just for a writer field, we should have this default fallback logic baked into the Vue component so that it's present for all use cases (e.g. block previews).

### Fixes
- #5851
