### PR TITLE
Fix Writer toolbar positioning

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -296,16 +296,25 @@ export default {
 			let x = selection.x - editor.x + selection.width / 2 - toolbar.width / 2;
 			let y = selection.y - editor.y - toolbar.height - 5;
 
-			// Contain in viewport
-			const left = editor.x + x;
-			const right = left + toolbar.width;
-			const safeSpaceLeft = menu.width + 20;
-			const safeSpaceRight = 20;
+			// Contain in editor (if possible)
+			if (toolbar.width < editor.width) {
+				if (x < 0) {
+					x = 0;
+				} else if (x + toolbar.width > editor.width) {
+					x = editor.width - toolbar.width;
+				}
+			} else {
+				// Contain in viewport
+				const left = editor.x + x;
+				const right = left + toolbar.width;
+				const safeSpaceLeft = menu.width + 20;
+				const safeSpaceRight = 20;
 
-			if (left < safeSpaceLeft) {
-				x += safeSpaceLeft - left;
-			} else if (right > window.innerWidth - safeSpaceRight) {
-				x -= right - (window.innerWidth - safeSpaceRight);
+				if (left < safeSpaceLeft) {
+					x += safeSpaceLeft - left;
+				} else if (right > window.innerWidth - safeSpaceRight) {
+					x -= right - (window.innerWidth - safeSpaceRight);
+				}
 			}
 
 			this.position = { x, y };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### TBD
- [ ] This can clash with container queries when there is too little space and it will reach into another section that is defined by a container query, that section will overlap the toolbar. I don't think we can avoid this if we don't want to turn the toolbar into a dialog element.

### Fixes
- Writer toolbar now isn't just contained to its editor but will extend to space around it if necessary (= toolbar larger than editor), but will ensure not to reach outside viewport
https://github.com/getkirby/kirby/issues/5449
- https://github.com/getkirby/kirby/issues/5712