### PR TITLE
Better way to handle default values for objects

### DIFF
--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -56,7 +56,6 @@
 </template>
 
 <script>
-import { set } from "vue";
 import { props as Field } from "../Field.vue";
 import { props as Input } from "../Input.vue";
 
@@ -69,7 +68,7 @@ export default {
 	},
 	data() {
 		return {
-			object: null
+			object: {}
 		};
 	},
 	computed: {
@@ -77,7 +76,9 @@ export default {
 			return this.$helper.object.length(this.fields) > 0;
 		},
 		isEmpty() {
-			return this.object === null;
+			return (
+				this.object === null || this.$helper.object.length(this.object) === 0
+			);
 		},
 		isInvalid() {
 			return this.required === true && this.isEmpty;
@@ -98,7 +99,7 @@ export default {
 			this.open();
 		},
 		cell(name, value) {
-			set(this.object, name, value);
+			this.$set(this.object, name, value);
 			this.save();
 		},
 		/**
@@ -118,11 +119,7 @@ export default {
 			return fields;
 		},
 		remove() {
-			// we need to use an empty string here
-			// it would be more correct to send null, but
-			// that will ignore the input in the form submission
-			// and simply keep the last values.
-			this.object = "";
+			this.object = {};
 			this.save();
 		},
 		// TODO: field is not yet used to pre-focus correct field
@@ -164,7 +161,7 @@ export default {
 			this.$emit("input", this.object);
 		},
 		valueToObject(value) {
-			return typeof value !== "object" ? null : value;
+			return typeof value !== "object" ? {} : value;
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -118,7 +118,11 @@ export default {
 			return fields;
 		},
 		remove() {
-			this.object = null;
+			// we need to use an empty string here
+			// it would be more correct to send null, but
+			// that will ignore the input in the form submission
+			// and simply keep the last values.
+			this.object = "";
 			this.save();
 		},
 		// TODO: field is not yet used to pre-focus correct field

--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -13,13 +13,14 @@ export function defaultValue(field) {
 	const component =
 		window.panel.app.$options.components[`k-${field.type}-field`];
 	const valueProp = component?.options.props.value;
-	const valuePropDefault = valueProp?.default;
 
 	// if the field has no value prop,
 	// it will be completely skipped
 	if (valueProp === undefined) {
 		return undefined;
 	}
+
+	const valuePropDefault = valueProp?.default;
 
 	// resolve default prop functions
 	if (typeof valuePropDefault === "function") {

--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -1,6 +1,39 @@
 import { clone } from "./object.js";
 
 /**
+ * Loads the default value for a field definition
+ * @param {Object} field
+ * @returns {mixed}
+ */
+export function defaultValue(field) {
+	if (field.default !== undefined) {
+		return clone(field.default);
+	}
+
+	const component =
+		window.panel.app.$options.components[`k-${field.type}-field`];
+	const valueProp = component?.options.props.value;
+	const valuePropDefault = valueProp?.default;
+
+	// if the field has no value prop,
+	// it will be completely skipped
+	if (valueProp === undefined) {
+		return undefined;
+	}
+
+	// resolve default prop functions
+	if (typeof valuePropDefault === "function") {
+		return valuePropDefault();
+	}
+
+	if (valuePropDefault !== undefined) {
+		return valuePropDefault;
+	}
+
+	return null;
+}
+
+/**
  * Creates form values for provided fields
  * @param {Object} fields
  * @returns {Object}
@@ -9,7 +42,11 @@ export function form(fields) {
 	const form = {};
 
 	for (const fieldName in fields) {
-		form[fieldName] = clone(fields[fieldName].default);
+		const defaultVal = defaultValue(fields[fieldName]);
+
+		if (defaultVal !== undefined) {
+			form[fieldName] = defaultVal;
+		}
 	}
 
 	return form;
@@ -80,6 +117,7 @@ export function subfields(field, fields) {
 }
 
 export default {
+	defaultValue,
 	form,
 	isVisible,
 	subfields

--- a/panel/src/helpers/field.test.js
+++ b/panel/src/helpers/field.test.js
@@ -1,19 +1,46 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import { describe, expect, it } from "vitest";
 import { form } from "./field";
 
 describe.concurrent("$helper.field.form()", () => {
+	// mock the app with the component setup
+	window.panel = {
+		app: {
+			$options: {
+				components: {
+					"k-custom-field": {
+						options: {
+							props: {
+								value: {
+									default: "test"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	};
+
 	it("should create form object with default values for each field", () => {
 		const fields = {
 			name: { default: "John" },
 			age: { default: 30 },
-			email: {}
+			email: {},
+			custom: {
+				type: "custom"
+			}
 		};
 		const result = form(fields);
 
 		expect(result).toEqual({
 			name: "John",
 			age: 30,
-			email: undefined
+			email: undefined,
+			custom: "test"
 		});
 	});
 });


### PR DESCRIPTION
I think this is a more stable option to create default objects for a set of fields. It is a bit more complex, but I think we can handle it. 

@afbora @distantnative what do you think about it? 

## Fixes

- Improved empty content state for object fields
- Content is no longer kept when clearing an object field #5877

## Enhancements

- New `$helper.field.defaultValue(field)` method
- Better default value creation in `$helper.field.form(fields)`