### PR TITLE
Fix CalendarInput

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -37,7 +37,7 @@
 							:value="iso.date"
 							:min="min"
 							:max="max"
-							@input="onCalendarInput"
+							@input="onDateInput"
 						/>
 					</k-dropdown-content>
 				</template>
@@ -195,14 +195,6 @@ export default {
 			}
 
 			this.$emit("input", dt?.toISO() ?? "");
-		},
-		/**
-		 * Handle input event from calendar dropdown
-		 * @param {string} value
-		 */
-		onCalendarInput(value) {
-			this.$refs.calendar?.close();
-			this.onDateInput(value);
 		},
 		/**
 		 * Handle input event from date input

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<fieldset class="k-calendar-input">
+	<fieldset class="k-calendar-input" @click.stop>
 		<legend class="sr-only">{{ $t("date.select") }}</legend>
 		<!-- Month + year selects -->
 		<nav>
@@ -60,7 +60,10 @@
 						<k-button
 							:disabled="disabled"
 							:text="$t('today')"
-							@click="select(today)"
+							@click="
+								show(today);
+								select(today);
+							"
 						/>
 					</td>
 				</tr>


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Guess I found where we didn't want the dropdown to close on click...

TBD if the dropdown should stay open also on input. Right now, it feels better to me if it doesn't close immediately on select

### Fixes
- Calendar input dropdown doesn't close without effect on click
- Calendar input dropdown stays open when selecting a date
- Calendar input dropdown: when clicking today button, also update the dropdown to show that date