### PR TITLE
Include max date in error msg for date.between

### DIFF
--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -129,7 +129,7 @@ return [
 					'key' => 'validation.date.between',
 					'data' => [
 						'min' => $min->format($format),
-						'max' => $min->format($format)
+						'max' => $max->format($format)
 					]
 				]);
 			} elseif ($min && $value->isMin($min) === false) {

--- a/tests/Form/Fields/DateFieldTest.php
+++ b/tests/Form/Fields/DateFieldTest.php
@@ -80,6 +80,24 @@ class DateFieldTest extends TestCase
 		$field->validate();
 		$this->assertFalse($field->isValid());
 		$this->assertTrue($field->isInvalid());
+		$this->assertSame([
+			'minMax' => 'Please enter a date between 01.10.2020 and 02.10.2020',
+		], $field->errors());
+
+		// min & max failed (with time)
+		$field = $this->field('date', [
+			'time'  => true,
+			'min'   => '2020-10-01 10:04',
+			'max'   => '2020-10-02 08:15',
+			'value' => '2020-10-03 12:34'
+		]);
+
+		$field->validate();
+		$this->assertFalse($field->isValid());
+		$this->assertTrue($field->isInvalid());
+		$this->assertSame([
+			'minMax' => 'Please enter a date between 01.10.2020 10:04 and 02.10.2020 08:15',
+		], $field->errors());
 
 		// min failed
 		$field = $this->field('date', [
@@ -90,16 +108,22 @@ class DateFieldTest extends TestCase
 		$field->validate();
 		$this->assertFalse($field->isValid());
 		$this->assertTrue($field->isInvalid());
+		$this->assertSame([
+			'minMax' => 'Please enter a date after 01.10.2020',
+		], $field->errors());
 
 		// max failed
 		$field = $this->field('date', [
-			'value' => '2020-11-10',
-			'max'   => '2020-10-31'
+			'max'   => '2020-10-31',
+			'value' => '2020-11-10'
 		]);
 
 		$field->validate();
 		$this->assertFalse($field->isValid());
 		$this->assertTrue($field->isInvalid());
+		$this->assertSame([
+			'minMax' => 'Please enter a date before 31.10.2020',
+		], $field->errors());
 	}
 
 	public function valueProvider()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- The validation error "Please enter a date between ... and ..." for the date field now correctly includes the maximum date.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
