### PR TITLE
Handle default values for fields without props

### DIFF
--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -12,7 +12,8 @@ export function defaultValue(field) {
 
 	const component =
 		window.panel.app.$options.components[`k-${field.type}-field`];
-	const valueProp = component?.options.props.value;
+
+	const valueProp = component?.options.props?.value;
 
 	// if the field has no value prop,
 	// it will be completely skipped


### PR DESCRIPTION
## Fixes

- The defaultValue method no longer trips over fields without props https://github.com/getkirby/kirby/issues/5931