### PR TITLE
Fix structure field footer

### DIFF
--- a/panel/lab/components/tables/1_horizontal/index.vue
+++ b/panel/lab/components/tables/1_horizontal/index.vue
@@ -125,7 +125,7 @@
 						:handle="true"
 						:options="{
 							fallbackClass: 'k-table-row-fallback',
-							ghostClass: 'k-table-row-ghost',
+							ghostClass: 'k-table-row-ghost'
 						}"
 						element="tbody"
 					>
@@ -172,6 +172,39 @@
 				</table>
 			</div>
 		</k-lab-example>
+		<k-lab-example label="Pagination">
+			<div class="k-table">
+				<table>
+					<thead>
+						<tr>
+							<th class="k-table-index-column">#</th>
+							<th>Name</th>
+							<th>Date</th>
+							<th class="k-table-options-column"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="i in 2" :key="i">
+							<td class="k-table-index-column">
+								<span class="k-table-index">{{ i }}</span>
+							</td>
+							<td>Kirby</td>
+							<td>2023-09-25</td>
+							<td class="k-table-options-column">
+								<k-options-dropdown :disabled="true" :options="options" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<k-pagination
+					class="k-table-pagination"
+					:details="true"
+					:limit="2"
+					:page="1"
+					:total="10"
+				/>
+			</div>
+		</k-lab-example>
 		<k-lab-example label="Empty">
 			<div class="k-table">
 				<table>
@@ -201,19 +234,19 @@ export default {
 			return [
 				{
 					text: "Edit",
-					icon: "edit",
+					icon: "edit"
 				},
 				{
 					text: "Duplicate",
-					icon: "copy",
+					icon: "copy"
 				},
 				"-",
 				{
 					text: "Delete",
-					icon: "trash",
-				},
+					icon: "trash"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -523,4 +523,19 @@ export default {
 		position: static;
 	}
 }
+
+/* Pagination */
+.k-table-pagination {
+	border-top: 1px solid var(--table-color-border);
+	height: var(--table-row-height);
+	background: var(--table-color-th-back);
+	display: flex;
+	justify-content: center;
+	border-end-start-radius: var(--rounded);
+	border-end-end-radius: var(--rounded);
+}
+.k-table-pagination > .k-button {
+	--button-color-back: transparent;
+	border-left: 0 !important;
+}
 </style>


### PR DESCRIPTION
## This PR …
@bastianallgeier That's all I could do. I tried to use slot in `k-table` component and css grid for the UI. Feel free to close the PR if not acceptable for you 👍 

![screen-capture-1735-Test - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/6d844d3f-89a4-4b70-ad2a-b1da46e0ad40)

But still there is a minor issue that I couldn't fix it 🙈 If only plus icon available, it should be centered but not for this PR 🙁 Would be nice if you help about that.

![screen-capture-1736-Test - Mægazine-localhost](https://github.com/getkirby/kirby/assets/3393422/3b6149e9-737d-4162-a8ac-0e34c6a53331)

### Fixes
- Structure field: pagination position broken #5941

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
