### PR TITLE
`k-tabs`: fix badge

### DIFF
--- a/panel/lab/components/tabs/index.vue
+++ b/panel/lab/components/tabs/index.vue
@@ -16,54 +16,55 @@ export default {
 			return [
 				{
 					name: "content",
-					label: "Content",
+					label: "Content"
 				},
 				{
 					name: "settings",
 					label: "Settings",
+					badge: 3
 				},
 				{
 					name: "c",
-					label: "Just another tab C",
+					label: "Just another tab C"
 				},
 				{
 					name: "d",
-					label: "Just another tab D",
+					label: "Just another tab D"
 				},
 				{
 					name: "e",
-					label: "Just another tab E",
+					label: "Just another tab E"
 				},
 				{
 					name: "f",
-					label: "Just another tab F",
+					label: "Just another tab F"
 				},
 				{
 					name: "g",
-					label: "Just another tab G",
+					label: "Just another tab G"
 				},
 				{
 					name: "h",
-					label: "Just another tab H",
+					label: "Just another tab H"
 				},
 				{
 					name: "i",
-					label: "Just another tab I",
+					label: "Just another tab I"
 				},
 				{
 					name: "j",
-					label: "Just another tab J",
+					label: "Just another tab J"
 				},
 				{
 					name: "k",
-					label: "Just another tab K",
+					label: "Just another tab K"
 				},
 				{
 					name: "l",
-					label: "Just another tab L",
-				},
+					label: "Just another tab L"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -1,17 +1,17 @@
 <template>
 	<nav v-if="tabs.length > 1" class="k-tabs">
 		<k-button
-			v-for="btn in visible"
+			v-for="tabBtn in visible"
 			ref="visible"
-			:key="btn.name"
-			v-bind="(btn = button(btn))"
+			:key="tabBtn.name"
+			v-bind="(btn = button(tabBtn))"
 			variant="dimmed"
 			class="k-tab-button"
 		>
 			{{ btn.text }}
 
-			<span v-if="btn.badge" :data-theme="theme" class="k-tabs-badge">
-				{{ btn.badge }}
+			<span v-if="tabBtn.badge" :data-theme="theme" class="k-tabs-badge">
+				{{ tabBtn.badge }}
 			</span>
 		</k-button>
 
@@ -40,7 +40,7 @@
  * 	tab="content"
  * 	tabs="[
  * 		{ name: 'content', label: 'Content', link: '/content' },
- * 		{ name: 'settings', label: 'Settings', link: '/settings' }
+ * 		{ name: 'settings', label: 'Settings', link: '/settings', badge: 3 }
  * 	]"
  * />
  */
@@ -61,7 +61,10 @@ export default {
 		 * Theme to style any badge
 		 * @values "positive", "negative", "notice", "warning", "info", "passive"
 		 */
-		theme: String
+		theme: {
+			type: String,
+			default: "passive"
+		}
 	},
 	data() {
 		return {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

When assigning `btn` to `v-bind` in the template, it left out the badge

### Fixes
- `k-tabs`: badges shown again
