### PR TITLE
Add Vue target version to jsconfig

### DIFF
--- a/panel/jsconfig.json
+++ b/panel/jsconfig.json
@@ -6,6 +6,7 @@
 		}
 	},
 	"vueCompilerOptions": {
-		"experimentalDisableTemplateSupport": true
+		"experimentalDisableTemplateSupport": true,
+		"target": 2.7
 	}
 }


### PR DESCRIPTION
The Vue Language Features extension for VSCode has complained that the installed Vue version does not match the configured one. This change fixes it, but I have not done any research if there are any other implications. Please do before merging.