### PR TITLE
Clearer outline for selected color options

### DIFF
--- a/panel/src/components/Forms/Input/ColoroptionsInput.vue
+++ b/panel/src/components/Forms/Input/ColoroptionsInput.vue
@@ -92,7 +92,7 @@ export default {
 	cursor: not-allowed;
 }
 .k-coloroptions-input input:checked + .k-color-frame {
-	outline: 2px solid currentColor;
+	outline: 1px solid var(--color-gray-600);
 	outline-offset: 2px;
 }
 </style>


### PR DESCRIPTION
## Fixes

- The selected color now has a clear outline, independent from the selected color https://github.com/getkirby/kirby/issues/5962

![Screenshot 2023-11-20 at 10 24 17](https://github.com/getkirby/kirby/assets/24532/718334e2-5bb4-4e90-8e48-dc725f0ce7de)
