### PR TITLE
ImageMagick: fix focus-cropping bug

### DIFF
--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -170,40 +170,37 @@ class ImageMagick extends Darkroom
 
 		// crop based on focus point
 		if (Focus::isFocalPoint($options['crop']) === true) {
-			$focus = Focus::coords(
+			if ($focus = Focus::coords(
 				$options['crop'],
 				$options['sourceWidth'],
 				$options['sourceHeight'],
 				$options['width'],
 				$options['height']
-			);
-
-			return sprintf(
-				'-crop %sx%s+%s+%s -resize %sx%s^',
-				$focus['width'],
-				$focus['height'],
-				$focus['x1'],
-				$focus['y1'],
-				$options['width'],
-				$options['height']
-			);
+			)) {
+				return sprintf(
+					'-crop %sx%s+%s+%s -resize %sx%s^',
+					$focus['width'],
+					$focus['height'],
+					$focus['x1'],
+					$focus['y1'],
+					$options['width'],
+					$options['height']
+				);
+			}
 		}
 
-		// normal grop with gravities
-		$gravities = [
+		// translate the gravity option into something imagemagick understands
+		$gravity = match ($options['crop'] ?? null) {
 			'top left'     => 'NorthWest',
 			'top'          => 'North',
 			'top right'    => 'NorthEast',
 			'left'         => 'West',
-			'center'       => 'Center',
 			'right'        => 'East',
 			'bottom left'  => 'SouthWest',
 			'bottom'       => 'South',
-			'bottom right' => 'SouthEast'
-		];
-
-		// translate the gravity option into something imagemagick understands
-		$gravity = $gravities[$options['crop']] ?? 'Center';
+			'bottom right' => 'SouthEast',
+			default        => 'Center'
+		};
 
 		$command  = '-thumbnail ' . escapeshellarg(sprintf('%sx%s^', $options['width'], $options['height']));
 		$command .= ' -gravity ' . escapeshellarg($gravity);


### PR DESCRIPTION
Focus::coords returns null when the source ratio is the same as the crop ratio. Adding a check for that case.

fixes #5982

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
