### PR TITLE
Block selector: fix for empty groups

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -94,22 +94,22 @@ export default {
 			};
 
 			for (const key in fieldsetGroups) {
-				let group = fieldsetGroups[key];
+				const group = fieldsetGroups[key];
 
-				group.open = group.open === false ? false : true;
+				group.open = group.open !== false;
 				group.fieldsets = group.sets
-					.filter((fieldsetName) => this.fieldsets[fieldsetName])
-					.map((fieldsetName) => {
+					.filter((name) => this.fieldsets[name])
+					.map((name) => {
 						index++;
 
 						return {
-							...this.fieldsets[fieldsetName],
+							...this.fieldsets[name],
 							index
 						};
 					});
 
 				if (group.fieldsets.length === 0) {
-					return;
+					continue;
 				}
 
 				groups[key] = group;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

If one group in the block selector has no field sets (empty), we should not stop processing all groups (return) but only skip that specific group (continue).

### Fixes
- https://github.com/getkirby/kirby/issues/5794
