### PR TITLE
Slug field: respect custom slug allow from `Str`

### DIFF
--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -161,16 +161,15 @@ export function rtrim(string = "", replace = "") {
  * Convert string to ASCII slug
  * @param {string} string string to be converted
  * @param {array} rules ruleset to convert non-ASCII characters
- * @param {array} allowed list of allowed non-ASCII characters
- * @param {string} separator character used to replace e.g. spaces
+ * @param {array} allowed list of allowed characters (default: a-z0-9)
+ * @param {string} separator character used to replace non-allowed characters
  * @returns {string}
  */
-export function slug(string, rules = [], allowed = "", separator = "-") {
+export function slug(string, rules = [], allowed = "a-z0-9", separator = "-") {
 	if (!string) {
 		return "";
 	}
 
-	allowed = "a-z0-9" + allowed;
 	string = string.trim().toLowerCase();
 
 	// replace according to language and ascii rules
@@ -189,7 +188,7 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	// remove all other non-ASCII characters
 	string = string.replace("/[^\x09\x0A\x0D\x20-\x7E]/", "");
 
-	// replace spaces with simple dashes
+	// replace non-allowed characters (e.g. spaces) with separator
 	string = string.replace(new RegExp("[^" + allowed + "]", "ig"), separator);
 
 	// remove double separators

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -13,7 +13,7 @@ describe.concurrent("$helper.string.slug()", () => {
 	});
 
 	it("should replace slashes with custom separator", () => {
-		const result = slug("a/b/c", [], [], "%");
+		const result = slug("a/b/c", [], undefined, "%");
 		expect(result).toBe("a%b%c");
 	});
 

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -9,6 +9,7 @@ use Kirby\Cms\Page;
 use Kirby\Form\Form;
 use Kirby\Http\Router;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 /**
  * Provides common field prop definitions
@@ -222,6 +223,7 @@ class Field
 		return array_merge([
 			'label' => I18n::translate('slug'),
 			'type'  => 'slug',
+			'allow' => Str::$defaults['slug']['allowed']
 		], $props);
 	}
 

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -313,6 +313,7 @@ class FieldTest extends TestCase
 		$expected = [
 			'label' => 'URL appendix',
 			'type'  => 'slug',
+			'allow' => 'a-z0-9'
 		];
 
 		$this->assertSame($expected, $field);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Slug field respects custom allowed slug characters from `Str::$defaults['slug']['allowed']`

### Breaking changes
- `$helper.string.slug`: the `allow` parameter now defines the whole set of allowed characters, not just the characters in addition to `a-z0-9`
