### PR TITLE
Fix ColornameInput for more flexible color notations

### DIFF
--- a/panel/src/components/Forms/Input/ColornameInput.vue
+++ b/panel/src/components/Forms/Input/ColornameInput.vue
@@ -63,25 +63,31 @@ export default {
 				return value;
 			}
 
-			// create a new secret tester
-			const test = document.createElement("div");
-
-			// set the text color
-			test.style.color = value;
-
-			// it has to be in the document to work
-			document.body.append(test);
-
-			// check the computed style for a usable rgb value
-			value = window.getComputedStyle(test).color;
-
-			// remove the element
-			test.remove();
-
 			try {
+				// first try to parse the color via the library
 				return this.$library.colors.toString(value, this.format, this.alpha);
 			} catch (e) {
-				return value;
+				// if that fails,
+				// create a new secret tester
+				const test = document.createElement("div");
+
+				// set the text color
+				test.style.color = value;
+
+				// it has to be in the document to work
+				document.body.append(test);
+
+				// check the computed style for a usable rgb value
+				value = window.getComputedStyle(test).color;
+
+				// remove the element
+				test.remove();
+
+				// as we always get a valid rgb value, we can safely
+				// pass it to the library to get a valid color string
+				// in the target format without additional fallback
+				// (getComputedStyle will return rgb(0,0,0) for invalid colors)
+				return this.$library.colors.toString(value, this.format, this.alpha);
 			}
 		},
 		convertAndEmit(value) {

--- a/panel/src/libraries/colors-checks.js
+++ b/panel/src/libraries/colors-checks.js
@@ -1,7 +1,7 @@
 import { isObject } from "@/helpers/object.js";
 
-export const RE_HEX = /^#([\da-f]{3}){1,2}$/i;
-export const RE_HEXA = /^#([\da-f]{4}){1,2}$/i;
+export const RE_HEX = /^#?([\da-f]{3}){1,2}$/i;
+export const RE_HEXA = /^#?([\da-f]{4}){1,2}$/i;
 export const RE_RGB =
 	/^rgba?\(\s*(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s|\/)*(\d*(?:\.\d+)?)(%?)\s*\)?$/i;
 export const RE_HSL =

--- a/panel/src/libraries/colors-checks.test.js
+++ b/panel/src/libraries/colors-checks.test.js
@@ -7,10 +7,11 @@ describe("colors.isHex", () => {
 		["#fffa", true],
 		["#ffffff", true],
 		["#ffffffaa", true],
-		["fff", false],
-		["fffa", false],
-		["ffffff", false],
-		["ffffffaa", false],
+		["fff", true],
+		["fffa", true],
+		["ffffff", true],
+		["ffffffaa", true],
+		["ff", false],
 		["rgba(255, 255, 255)", false]
 	];
 

--- a/panel/src/libraries/colors-func.js
+++ b/panel/src/libraries/colors-func.js
@@ -31,10 +31,11 @@ export function hex2hsv(hex) {
 }
 
 export function hex2rgb(hex) {
-	// without alpha (#ff00ff or #f0f)
-	if (RE_HEX.test(hex) === true) {
+	if (RE_HEX.test(hex) === true || RE_HEXA.test(hex) === true) {
 		// remove leading #
-		hex = hex.slice(1);
+		if (hex[0] === "#") {
+			hex = hex.slice(1);
+		}
 
 		// expand short-notation to full six-digit
 		if (hex.length === 3) {
@@ -43,26 +44,17 @@ export function hex2rgb(hex) {
 
 		const num = parseInt(hex, 16);
 
-		return {
-			r: num >> 16,
-			g: (num >> 8) & 0xff,
-			b: num & 0xff,
-			a: 1
-		};
-	}
-
-	// with alpha (e.g. #ffaa0088)
-	if (RE_HEXA.test(hex) === true) {
-		// remove leading #
-		hex = hex.slice(1);
-
-		// expand short-notation to full eight-digit
-		if (hex.length === 4) {
-			hex = hex.split("").reduce((x, y) => x + y + y, "");
+		// without alpha (#ff00ff or #f0f)
+		if (RE_HEX.test(hex) === true) {
+			return {
+				r: num >> 16,
+				g: (num >> 8) & 0xff,
+				b: num & 0xff,
+				a: 1
+			};
 		}
 
-		const num = parseInt(hex, 16);
-
+		// with alpha (e.g. #ffaa0088)
 		return {
 			r: (num >> 24) & 0xff,
 			g: (num >> 16) & 0xff,

--- a/panel/src/libraries/colors.js
+++ b/panel/src/libraries/colors.js
@@ -26,6 +26,11 @@ import { isHex, isRgb, isHsl, isHsv, RE_RGB, RE_HSL } from "./colors-checks.js";
  */
 export function convert(color, format) {
 	if (isHex(color) === true) {
+		// ensure leading #
+		if (color[0] !== "#") {
+			color = "#" + color;
+		}
+
 		switch (format) {
 			case "hex":
 				return color;
@@ -98,7 +103,11 @@ export function parse(string) {
 	}
 
 	// HEX
-	if (isHex(string)) {
+	if (isHex(string) === true) {
+		if (string[0] !== "#") {
+			string = "#" + string;
+		}
+
 		return string;
 	}
 

--- a/panel/src/libraries/colors.test.js
+++ b/panel/src/libraries/colors.test.js
@@ -7,10 +7,11 @@ describe("colors.parse(hex)", () => {
 		["#fffa", "#fffa"],
 		["#ffffff", "#ffffff"],
 		["#ffffffaa", "#ffffffaa"],
-		["fff", null],
-		["fffa", null],
-		["ffffff", null],
-		["ffffffaa", null]
+		["fff", "#fff"],
+		["fffa", "#fffa"],
+		["ffffff", "#ffffff"],
+		["ffffffaa", "#ffffffaa"],
+		["ff", null]
 	];
 
 	for (const test of tests) {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- colors library supports hex colors without leading `#`
https://github.com/getkirby/kirby/issues/5981

### Fixes
- ColornameInput: only use `getComputedStyle` as last resort when colors library fails