### PR TITLE
`Xml::attr()`: Support empty string as empty value

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -113,7 +113,7 @@ return [
 		'html' => function (KirbyTag $tag): string {
 			if ($tag->file = $tag->file($tag->value)) {
 				$tag->src       = $tag->file->url();
-				$tag->alt     ??= $tag->file->alt()->or(' ')->value();
+				$tag->alt     ??= $tag->file->alt()->or('')->value();
 				$tag->title   ??= $tag->file->title()->value();
 				$tag->caption ??= $tag->file->caption()->value();
 
@@ -153,7 +153,7 @@ return [
 				'height' => $tag->height,
 				'class'  => $tag->imgclass,
 				'title'  => $tag->title,
-				'alt'    => $tag->alt ?? ' '
+				'alt'    => $tag->alt ?? ''
 			]);
 
 			if ($tag->kirby()->option('kirbytext.image.figure', true) === false) {

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -29,6 +29,12 @@ class Helpers
 	 * ```
 	 */
 	public static $deprecations = [
+		// Passing a single space as value to `Xml::attr()` has been
+		// deprecated. In a future version, passing a single space won't
+		// render an empty value anymore but a single space.
+		// To render an empty value, please pass an empty string.
+		'xml-attr-single-space' => true,
+
 		// The internal `$model->contentFile*()` methods have been deprecated
 		'model-content-file' => true,
 	];

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -29,12 +29,6 @@ class Helpers
 	 * ```
 	 */
 	public static $deprecations = [
-		// Passing an empty string as value to `Xml::attr()` has been
-		// deprecated. In a future version, passing an empty string won't
-		// omit the attribute anymore but render it with an empty value.
-		// To omit the attribute, please pass `null`.
-		'xml-attr-empty-string' => false,
-
 		// The internal `$model->contentFile*()` methods have been deprecated
 		'model-content-file' => true,
 	];

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -323,7 +323,7 @@ class Html extends Xml
 	{
 		$attr = array_merge([
 			'src' => $src,
-			'alt' => ' '
+			'alt' => ''
 		], $attr);
 
 		return static::tag('img', '', $attr);

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -98,11 +98,14 @@ class Xml
 			return null;
 		}
 
-		// TODO: In 3.10, add deprecation message for space = empty attribute
-		// TODO: In 3.11, render space as space
+		// TODO: In 5.0, remove this block to render space as space
+		// @codeCoverageIgnoreStart
 		if ($value === ' ') {
+			Helpers::deprecated('Passing a single space as value to `Xml::attr()` has been deprecated. In a future version, passing a single space won\'t render an empty value anymore but a single space. To render an empty value, please pass an empty string.', 'xml-attr-single-space');
+
 			return $name . '=""';
 		}
+		// @codeCoverageIgnoreEnd
 
 		if ($value === true) {
 			return $name . '="' . $name . '"';

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -94,15 +94,7 @@ class Xml
 			return implode(' ', $attributes);
 		}
 
-		// TODO: In 3.10, treat $value === '' to render as name=""
-		if ($value === null || $value === '' || $value === []) {
-			// TODO: Remove in 3.10
-			// @codeCoverageIgnoreStart
-			if ($value === '') {
-				Helpers::deprecated('Passing an empty string as value to `Xml::attr()` has been deprecated. In a future version, passing an empty string won\'t omit the attribute anymore but render it with an empty value. To omit the attribute, please pass `null`.', 'xml-attr-empty-string');
-			}
-			// @codeCoverageIgnoreEnd
-
+		if ($value === null || $value === false || $value === []) {
 			return null;
 		}
 
@@ -114,10 +106,6 @@ class Xml
 
 		if ($value === true) {
 			return $name . '="' . $name . '"';
-		}
-
-		if ($value === false) {
-			return null;
 		}
 
 		if (is_array($value) === true) {

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -122,7 +122,6 @@ class HtmlTest extends TestCase
 			[['B' => 'b', 'A' => 'a'],   true,  'a="a" b="b"'],
 			[['B' => 'b', 'A' => 'a'],   false, 'b="b" a="a"'],
 			[['a' => 'a', 'b' => true],  null,  'a="a" b'],
-			[['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => ''],    null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -123,6 +123,7 @@ class HtmlTest extends TestCase
 			[['B' => 'b', 'A' => 'a'],   false, 'b="b" a="a"'],
 			[['a' => 'a', 'b' => true],  null,  'a="a" b'],
 			[['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
+			[['a' => 'a', 'b' => ''],    null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],
 			[['a' => 'a', 'b' => []],    null,  'a="a"'],

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -27,6 +27,7 @@ class XmlTest extends TestCase
 			[['B' => 'b', 'A' => 'a'],   false, 'B="b" A="a"'],
 			[['a' => 'a', 'b' => true],  null,  'a="a" b="b"'],
 			[['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
+			[['a' => 'a', 'b' => ''],    null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],
 			[['a' => 'a', 'b' => []],    null,  'a="a"'],

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -26,7 +26,6 @@ class XmlTest extends TestCase
 			[['B' => 'b', 'A' => 'a'],   true,  'A="a" B="b"'],
 			[['B' => 'b', 'A' => 'a'],   false, 'B="b" A="a"'],
 			[['a' => 'a', 'b' => true],  null,  'a="a" b="b"'],
-			[['a' => 'a', 'b' => ' '],   null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => ''],    null,  'a="a" b=""'],
 			[['a' => 'a', 'b' => false], null,  'a="a"'],
 			[['a' => 'a', 'b' => null],  null,  'a="a"'],


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancements

- `Xml::attr()`: Support passing an empty string as value to generate an attribute with an empty value

### Deprecated

- Passing a single space as value to `Xml::attr()` (with the intention to generate an attribute with an empty value) has been deprecated in favor of passing an empty string.

### Breaking changes

- Passing an empty string as value to `Xml::attr()` no longer omits the attribute but generates an attribute with an empty value.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
