### PR TITLE
Slug field: respect custom slug allow from `Str`

### DIFF
--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -161,8 +161,8 @@ export function rtrim(string = "", replace = "") {
  * Convert string to ASCII slug
  * @param {string} string string to be converted
  * @param {array} rules ruleset to convert non-ASCII characters
- * @param {array} allowed list of allowed non-ASCII characters
- * @param {string} separator character used to replace e.g. spaces
+ * @param {string} allowed list of allowed characters (default: a-z0-9)
+ * @param {string} separator character used to replace non-allowed characters
  * @returns {string}
  */
 export function slug(string, rules = [], allowed = "", separator = "-") {
@@ -170,7 +170,10 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 		return "";
 	}
 
-	allowed = "a-z0-9" + allowed;
+	if (!allowed || allowed.length === 0) {
+		allowed = "a-z0-9";
+	}
+
 	string = string.trim().toLowerCase();
 
 	// replace according to language and ascii rules
@@ -189,7 +192,7 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	// remove all other non-ASCII characters
 	string = string.replace("/[^\x09\x0A\x0D\x20-\x7E]/", "");
 
-	// replace spaces with simple dashes
+	// replace non-allowed characters (e.g. spaces) with separator
 	string = string.replace(new RegExp("[^" + allowed + "]", "ig"), separator);
 
 	// remove double separators

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -13,7 +13,7 @@ describe.concurrent("$helper.string.slug()", () => {
 	});
 
 	it("should replace slashes with custom separator", () => {
-		const result = slug("a/b/c", [], [], "%");
+		const result = slug("a/b/c", [], "", "%");
 		expect(result).toBe("a%b%c");
 	});
 


### PR DESCRIPTION
Original PR https://github.com/getkirby/kirby/pull/5991

This time, instead of adding the default in the parameter definition, we check also for e.g. empty string, arrays and set the default.