### PR TITLE
Fixes for sticky table headers

### DIFF
--- a/panel/lab/components/blocks/table/index.vue
+++ b/panel/lab/components/blocks/table/index.vue
@@ -5,3 +5,9 @@
 		</k-lab-example>
 	</k-lab-examples>
 </template>
+
+<style>
+.k-lab-examples {
+	padding-bottom: 100rem;
+}
+</style>

--- a/panel/src/components/Forms/Blocks/Types/Table.vue
+++ b/panel/src/components/Forms/Blocks/Types/Table.vue
@@ -65,10 +65,8 @@ export default {
 	border: 1px solid var(--color-gray-300);
 	border-spacing: 0;
 	border-radius: var(--rounded-sm);
-	overflow: hidden;
 }
-.k-block-type-table-preview td,
-.k-block-type-table-preview th {
+.k-block-type-table-preview :where(th, td) {
 	text-align: start;
 	line-height: 1.5em;
 	font-size: var(--text-sm);

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -92,7 +92,7 @@ export default {
 :root {
 	--header-color-back: var(--color-light);
 	--header-padding-block: var(--spacing-4);
-	--header-sticky-offset: calc(var(--scroll-top, 0rem) + 4rem);
+	--header-sticky-offset: calc(var(--scroll-top) + 4rem);
 }
 
 .k-header {
@@ -161,7 +161,7 @@ export default {
 /** TODO: .k-header:has(.k-header-buttons) */
 .k-header[data-has-buttons="true"] {
 	position: sticky;
-	top: var(--scroll-top, 0);
+	top: var(--scroll-top);
 	z-index: var(--z-toolbar);
 }
 </style>

--- a/panel/src/components/View/Panel.vue
+++ b/panel/src/components/View/Panel.vue
@@ -60,6 +60,10 @@ export default {};
 </script>
 
 <style>
+:root {
+	--scroll-top: 0rem;
+}
+
 html {
 	overflow-x: hidden;
 	overflow-y: scroll;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Table headers in table block preview would be offset by `--scroll-top` value even when scroll hadn't reached them (effectively sticky positioning is broken). Visible also at https://lab.getkirby.com/public/lab/components/blocks/table

### Fixes
- Proper default value for `--scroll-top`
- Table block: fix sticky table headers inside table block preview https://github.com/getkirby/kirby/issues/6016

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
