### PR TITLE
Writer toolbar: don’t set position when not inline

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -5,10 +5,7 @@
 		:buttons="buttons"
 		:data-inline="inline"
 		:theme="inline ? 'dark' : 'light'"
-		:style="{
-			top: position.y + 'px',
-			left: position.x + 'px'
-		}"
+		:style="positions"
 		class="k-writer-toolbar"
 	/>
 </template>
@@ -208,6 +205,19 @@ export default {
 			}
 
 			return buttons;
+		},
+		positions() {
+			// only set position when toolbar is inline,
+			// otherwise the top value is overwriting the top offset
+			// for the sticky non-inline toolbar
+			if (this.inline === false) {
+				return null;
+			}
+
+			return {
+				top: this.position.y + "px",
+				left: this.position.x + "px"
+			};
 		}
 	},
 	methods: {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Writer: Fixed non-inline toolbar having correct offset when sticky #6021

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [X] ~~Unit tests for fixed bug/feature~~
- [X] In-code documentation (wherever needed)
- [X] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [X] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
