### PR TITLE
`Panel\Model::image()`: fix `false` from blueprint

### DIFF
--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -103,6 +103,18 @@ abstract class Model
 			return null;
 		}
 
+		// switched off from blueprint,
+		// only if not overwritten by $settings
+		$blueprint = $this->model->blueprint()->image();
+
+		if ($blueprint === false) {
+			if (empty($settings) === true) {
+				return null;
+			}
+
+			$blueprint = null;
+		}
+
 		// skip image thumbnail if option
 		// is explicitly set to show the icon
 		if ($settings === 'icon') {
@@ -116,7 +128,7 @@ abstract class Model
 		$settings = array_merge(
 			$this->imageDefaults(),
 			$settings ?? [],
-			$this->model->blueprint()->image() ?? [],
+			$blueprint ?? [],
 		);
 
 		if ($image = $this->imageSource($settings['query'] ?? null)) {

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -386,6 +386,38 @@ class ModelTest extends TestCase
 	/**
 	 * @covers ::image
 	 */
+	public function testImageWithBlueprintFalse()
+	{
+		$app  = $this->app->clone([
+			'blueprints' => [
+				'pages/foo' => [
+					'image' => false
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'template' => 'foo'
+					]
+				]
+			]
+		]);
+
+		$panel = $app->page('test')->panel();
+		$image = $panel->image(['icon' => 'heart']);
+		$this->assertSame('heart', $image['icon']);
+
+		$image = $panel->image([]);
+		$this->assertNull($image);
+
+		$image = $panel->image();
+		$this->assertNull($image);
+	}
+
+	/**
+	 * @covers ::image
+	 */
 	public function testImageWithQuery()
 	{
 		$site  = new ModelSiteWithImageMethod();


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

For next minor release as side effects aren't as easy to oversee as that it would qualify for patch release.

### Fixes
- Fix handling `image: false` in blueprint for Panel preview images  #6020



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ˜˜Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)˜˜
