### PR TITLE
Pass on allowed characters to slug field

### DIFF
--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -222,6 +222,7 @@ class Field
 		return array_merge([
 			'label' => I18n::translate('slug'),
 			'type'  => 'slug',
+			'allow' => Str::$defaults['slug']['allowed']
 		], $props);
 	}
 

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -9,6 +9,7 @@ use Kirby\Cms\Page;
 use Kirby\Form\Form;
 use Kirby\Http\Router;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 /**
  * Provides common field prop definitions

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -313,6 +313,7 @@ class FieldTest extends TestCase
 		$expected = [
 			'label' => 'URL appendix',
 			'type'  => 'slug',
+			'allow' => 'a-z0-9'
 		];
 
 		$this->assertSame($expected, $field);


### PR DESCRIPTION
## This PR …
Fixes handling of allowed characters in slug field by passing on the allow list to the panel.

### Fixes
#6048

### Breaking changes
None.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
