### PR TITLE
Color field: options query support

### DIFF
--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Field\FieldOptions;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
@@ -52,9 +53,18 @@ return [
 			return Str::lower($this->default);
 		},
 		'options' => function (): array {
-			return A::map(array_keys($this->options), fn ($key) => [
-				'value' => $this->options[$key],
-				'text'  => is_string($key) ? $key : null
+			// resolve options to support manual arrays
+			// alongside api and query options
+			$props   = FieldOptions::polyfill($this->props);
+			$options = FieldOptions::factory($props['options']);
+			$options = $options->render($this->model());
+
+			// flip value and text as the notation of the
+			// color options is `text: value`;
+			// only add text if it is different from value
+			return A::map($options, fn ($option) => [
+				'value' => $option['text'],
+				'text'  => $option['value'] !== $option['text'] ? $option['value'] : null
 			]);
 		}
 	],


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Features
- Color field: query and API support for `options`

```yml
myColorField:
  type: color
  options:
    type: query
    query: kirby.option('my.colors')
```

When passing an options array, keep in mind that keys will be used as the color values and the corresponding array value as preview text (for associative arrays, simple arrays are all color values only).


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
