### PR TITLE
Don’t pass kirby as property to models

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1482,9 +1482,7 @@ class App
 	protected function setSite(Site|array $site = null): static
 	{
 		if (is_array($site) === true) {
-			$site = new Site($site + [
-				'kirby' => $this
-			]);
+			$site = new Site($site);
 		}
 
 		$this->site = $site;

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1499,7 +1499,6 @@ class App
 		return $this->site ??= new Site([
 			'errorPageId' => $this->options['error'] ?? 'error',
 			'homePageId'  => $this->options['home']  ?? 'home',
-			'kirby'       => $this,
 			'url'         => $this->url('index'),
 		]);
 	}

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1466,9 +1466,7 @@ class App
 	protected function setRoles(array $roles = null): static
 	{
 		if ($roles !== null) {
-			$this->roles = Roles::factory($roles, [
-				'kirby' => $this
-			]);
+			$this->roles = Roles::factory($roles);
 		}
 
 		return $this;

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -86,9 +86,7 @@ trait AppUsers
 	protected function setUsers(array $users = null): static
 	{
 		if ($users !== null) {
-			$this->users = Users::factory($users, [
-				'kirby' => $this
-			]);
+			$this->users = Users::factory($users);
 		}
 
 		return $this;
@@ -128,7 +126,6 @@ trait AppUsers
 	{
 		return $this->users ??= Users::load(
 			$this->root('accounts'),
-			['kirby' => $this]
 		);
 	}
 }

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -94,7 +94,6 @@ class Files extends Collection
 
 		foreach ($files as $props) {
 			$props['collection'] = $collection;
-			$props['kirby']      = $kirby;
 			$props['parent']     = $parent;
 
 			$file = File::factory($props);

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -90,7 +90,6 @@ class Files extends Collection
 	public static function factory(array $files, Page|Site|User $parent): static
 	{
 		$collection = new static([], $parent);
-		$kirby      = $parent->kirby();
 
 		foreach ($files as $props) {
 			$props['collection'] = $collection;

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -158,7 +158,6 @@ class Pages extends Collection
 		}
 
 		foreach ($pages as $props) {
-			$props['kirby']   = $kirby;
 			$props['parent']  = $parent;
 			$props['site']    = $site;
 			$props['isDraft'] = $draft ?? $props['isDraft'] ?? $props['draft'] ?? false;

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -147,7 +147,6 @@ class Pages extends Collection
 	): static {
 		$model  ??= App::instance()->site();
 		$children = new static([], $model);
-		$kirby    = $model->kirby();
 
 		if ($model instanceof Page) {
 			$parent = $model;


### PR DESCRIPTION
## This PR …

With the refactoring of property setters in models in v4, Kirby got passed as an instance to `propertyData['kirby']` This broke serializing and could have other side effects. I wonder if some whoops issues are related to it as well. 

I've tracked down all the parts where we pass Kirby to a model. This should have no side-effects in theory. The models use static::$kirby as property and don't fetch the Kirby instance from the propertyData array anyway. But it remains a bit risk. 

### Fixes

- Objects are serializable again https://github.com/getkirby/kirby/issues/6061

### Breaking changes

- Hopefully none

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
