### PR TITLE
Improve link kirbytag behavior when uuid point to non-existing page

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -210,7 +210,7 @@ return [
 						throw new NotFoundException('The linked page cannot be found');
 					}
 				} else {
-					$tag->value = $tag->kirby()->site()->errorPageId();
+					$tag->value = Url::to($tag->kirby()->site()->errorPageId());
 				}
 			}
 

--- a/config/tags.php
+++ b/config/tags.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
+use Kirby\Exception\NotFoundException;
 use Kirby\Text\KirbyTag;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
@@ -197,7 +198,20 @@ return [
 				Uuid::is($tag->value, 'page') === true ||
 				Uuid::is($tag->value, 'file') === true
 			) {
-				$tag->value = Uuid::for($tag->value)->model()?->url() ?? '';
+				$tag->value = Uuid::for($tag->value)->model()?->url();
+			}
+
+			// if url is empty, throw exception or link to the error page
+			if ($tag->value === null) {
+				if ($tag->kirby()->option('debug', false) === true) {
+					if (empty($tag->text) === false) {
+						throw new NotFoundException('The linked page is not found for the link text "' . $tag->text . '"');
+					} else {
+						throw new NotFoundException('The linked page is not found');
+					}
+				} else {
+					$tag->value = $tag->kirby()->site()->errorPageId();
+				}
 			}
 
 			return Html::a($tag->value, $tag->text, [

--- a/config/tags.php
+++ b/config/tags.php
@@ -197,7 +197,7 @@ return [
 				Uuid::is($tag->value, 'page') === true ||
 				Uuid::is($tag->value, 'file') === true
 			) {
-				$tag->value = Uuid::for($tag->value)->model()->url();
+				$tag->value = Uuid::for($tag->value)->model()?->url() ?? '';
 			}
 
 			return Html::a($tag->value, $tag->text, [

--- a/config/tags.php
+++ b/config/tags.php
@@ -205,9 +205,9 @@ return [
 			if ($tag->value === null) {
 				if ($tag->kirby()->option('debug', false) === true) {
 					if (empty($tag->text) === false) {
-						throw new NotFoundException('The linked page is not found for the link text "' . $tag->text . '"');
+						throw new NotFoundException('The linked page cannot be found for the link text "' . $tag->text . '"');
 					} else {
-						throw new NotFoundException('The linked page is not found');
+						throw new NotFoundException('The linked page cannot be found');
 					}
 				} else {
 					$tag->value = $tag->kirby()->site()->errorPageId();

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Text;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\TestCase;
@@ -613,13 +614,75 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com/a">getkirby.com/a</a>', $result);
 
 		$result = $app->kirbytags('(link: page://not-exists)');
-		$this->assertSame('<a href="https://getkirby.com">getkirby.com</a>', $result);
+		$this->assertSame('<a href="https://getkirby.com/error">getkirby.com/error</a>', $result);
 
 		$result = $app->kirbytags('(link: file://file-uuid text: file)');
 		$this->assertSame('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
 
 		$result = $app->kirbytags('(link: file://not-exists text: file)');
-		$this->assertSame('<a href="https://getkirby.com">file</a>', $result);
+		$this->assertSame('<a href="https://getkirby.com/error">file</a>', $result);
+	}
+
+	public function testLinkWithUuidDebug()
+	{
+		$app = $this->app->clone([
+			'urls' => [
+				'index' => 'https://getkirby.com'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'    => 'a',
+						'content' => ['uuid' => 'page-uuid'],
+						'files'   => [
+							[
+								'filename' => 'foo.jpg',
+								'content' => ['uuid' => 'file-uuid'],
+							]
+						]
+					]
+				]
+			],
+			'options' => [
+				'debug' => true
+			]
+		]);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The linked page is not found');
+
+		$app->kirbytags('(link: page://not-exists)');
+	}
+
+	public function testLinkWithUuidDebugText()
+	{
+		$app = $this->app->clone([
+			'urls' => [
+				'index' => 'https://getkirby.com'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'    => 'a',
+						'content' => ['uuid' => 'page-uuid'],
+						'files'   => [
+							[
+								'filename' => 'foo.jpg',
+								'content' => ['uuid' => 'file-uuid'],
+							]
+						]
+					]
+				]
+			],
+			'options' => [
+				'debug' => true
+			]
+		]);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The linked page is not found for the link text "click here"');
+
+		$app->kirbytags('(link: page://not-exists text: click here)');
 	}
 
 	public function testLinkWithUuidAndLang()

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -649,7 +649,7 @@ class KirbyTagsTest extends TestCase
 		]);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('The linked page is not found');
+		$this->expectExceptionMessage('The linked page cannot be found');
 
 		$app->kirbytags('(link: page://not-exists)');
 	}
@@ -680,7 +680,7 @@ class KirbyTagsTest extends TestCase
 		]);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('The linked page is not found for the link text "click here"');
+		$this->expectExceptionMessage('The linked page cannot be found for the link text "click here"');
 
 		$app->kirbytags('(link: page://not-exists text: click here)');
 	}

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -612,8 +612,14 @@ class KirbyTagsTest extends TestCase
 		$result = $app->kirbytags('(link: page://page-uuid)');
 		$this->assertSame('<a href="https://getkirby.com/a">getkirby.com/a</a>', $result);
 
+		$result = $app->kirbytags('(link: page://not-exists)');
+		$this->assertSame('<a href="https://getkirby.com">getkirby.com</a>', $result);
+
 		$result = $app->kirbytags('(link: file://file-uuid text: file)');
 		$this->assertSame('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
+
+		$result = $app->kirbytags('(link: file://not-exists text: file)');
+		$this->assertSame('<a href="https://getkirby.com">file</a>', $result);
 	}
 
 	public function testLinkWithUuidAndLang()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- kirbytext() fails, if text contains a link to a non-existing page #6083

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
