### PR TITLE
Refactor deprecation warning tests

### DIFF
--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -8,10 +8,8 @@ use Kirby\Filesystem\Dir;
 use Kirby\Image\QrCode;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Obj;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\Error\Deprecated;
 
-class HelperFunctionsTest extends TestCase
+class HelperFunctionsTest extends HelpersTestCase
 {
 	protected $fixtures;
 	protected $kirby;
@@ -189,17 +187,11 @@ class HelperFunctionsTest extends TestCase
 
 	public function testDeprecated()
 	{
-		// the deprecation warnings are always triggered in testing mode,
-		// so we cannot test it with disabled debug mode
-
-		try {
-			deprecated('The xyz method is deprecated.');
-		} catch (Deprecated $e) {
-			$this->assertSame('The xyz method is deprecated.', $e->getMessage());
-			return;
-		}
-
-		Assert::fail('Expected deprecation warning was not generated');
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'The xyz method is deprecated.',
+			fn () => deprecated('The xyz method is deprecated.')
+		);
 	}
 
 	public function testDumpOnCli()

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -4,17 +4,13 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Obj;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\Error\Deprecated;
-use PHPUnit\Framework\Error\Warning;
 
 /**
  * @coversDefaultClass Kirby\Cms\Helpers
  */
-class HelpersTest extends TestCase
+class HelpersTest extends HelpersTestCase
 {
 	protected $deprecations = [];
-	protected $hasErrorHandler = false;
 
 	public function setUp(): void
 	{
@@ -28,11 +24,6 @@ class HelpersTest extends TestCase
 		parent::tearDown();
 
 		Helpers::$deprecations = $this->deprecations;
-
-		if ($this->hasErrorHandler === true) {
-			restore_error_handler();
-			$this->hasErrorHandler = false;
-		}
 	}
 
 	/**
@@ -40,17 +31,11 @@ class HelpersTest extends TestCase
 	 */
 	public function testDeprecated()
 	{
-		// the deprecation warnings are always triggered in testing mode,
-		// so we cannot test it with disabled debug mode
-
-		try {
-			Helpers::deprecated('The xyz method is deprecated.');
-		} catch (Deprecated $e) {
-			$this->assertSame('The xyz method is deprecated.', $e->getMessage());
-			return;
-		}
-
-		Assert::fail('Expected deprecation warning was not generated');
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'The xyz method is deprecated.',
+			fn () => Helpers::deprecated('The xyz method is deprecated.')
+		);
 	}
 
 	/**
@@ -58,14 +43,11 @@ class HelpersTest extends TestCase
 	 */
 	public function testDeprecatedKeyUndefined()
 	{
-		try {
-			Helpers::deprecated('The xyz method is deprecated.', 'my-key');
-		} catch (Deprecated $e) {
-			$this->assertSame('The xyz method is deprecated.', $e->getMessage());
-			return;
-		}
-
-		Assert::fail('Expected deprecation warning was not generated');
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'The xyz method is deprecated.',
+			fn () => Helpers::deprecated('The xyz method is deprecated.', 'my-key')
+		);
 	}
 
 	/**
@@ -73,15 +55,14 @@ class HelpersTest extends TestCase
 	 */
 	public function testDeprecatedActivated()
 	{
-		try {
-			Helpers::$deprecations = ['my-key' => true];
-			Helpers::deprecated('The xyz method is deprecated.', 'my-key');
-		} catch (Deprecated $e) {
-			$this->assertSame('The xyz method is deprecated.', $e->getMessage());
-			return;
-		}
-
-		Assert::fail('Expected deprecation warning was not generated');
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'The xyz method is deprecated.',
+			function () {
+				Helpers::$deprecations = ['my-key' => true];
+				Helpers::deprecated('The xyz method is deprecated.', 'my-key');
+			}
+		);
 	}
 
 	/**
@@ -89,8 +70,16 @@ class HelpersTest extends TestCase
 	 */
 	public function testDeprecatedKeyDeactivated()
 	{
-		Helpers::$deprecations = ['my-key' => false];
-		$this->assertFalse(Helpers::deprecated('The xyz method is deprecated.', 'my-key'));
+		$result = $this->assertError(
+			E_USER_DEPRECATED,
+			'The xyz method is deprecated.',
+			function () {
+				Helpers::$deprecations = ['my-key' => false];
+				return Helpers::deprecated('The xyz method is deprecated.', 'my-key');
+			},
+			false
+		);
+		$this->assertFalse($result);
 	}
 
 	/**
@@ -211,24 +200,23 @@ class HelpersTest extends TestCase
 	 */
 	public function testHandleErrorsWarningNotCaught()
 	{
-		try {
-			Helpers::handleErrors(
-				fn () => trigger_error('Some warning', E_USER_WARNING),
-				function (int $errno, string $errstr) {
-					$this->assertSame(E_USER_WARNING, $errno);
-					$this->assertSame('Some warning', $errstr);
+		$this->assertError(
+			E_USER_WARNING,
+			'Some warning',
+			function () {
+				Helpers::handleErrors(
+					fn () => trigger_error('Some warning', E_USER_WARNING),
+					function (int $errno, string $errstr) {
+						$this->assertSame(E_USER_WARNING, $errno);
+						$this->assertSame('Some warning', $errstr);
 
-					// continue the handler chain
-					return false;
-				},
-				'handled'
-			);
-		} catch (Warning $e) {
-			$this->assertSame('Some warning', $e->getMessage());
-			return;
-		}
-
-		Assert::fail('Expected warning was not generated');
+						// continue the handler chain
+						return false;
+					},
+					'handled'
+				);
+			}
+		);
 	}
 
 	/**

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -130,7 +130,7 @@ class HelpersTest extends HelpersTestCase
 	 */
 	public function testHandleErrorsWarningCaught1()
 	{
-		$this->hasErrorHandler = true;
+		$this->activeErrorHandlers++;
 
 		$called = false;
 		set_error_handler(function (int $errno, string $errstr) use (&$called) {
@@ -156,7 +156,7 @@ class HelpersTest extends HelpersTestCase
 	 */
 	public function testHandleErrorsWarningCaught2()
 	{
-		$this->hasErrorHandler = true;
+		$this->activeErrorHandlers++;
 
 		$called = false;
 		set_error_handler(function (int $errno, string $errstr) use (&$called) {
@@ -186,7 +186,7 @@ class HelpersTest extends HelpersTestCase
 	 */
 	public function testHandleErrorsWarningCaughtCallbackValue()
 	{
-		$this->hasErrorHandler = true;
+		$this->activeErrorHandlers++;
 
 		$this->assertSame('handled', Helpers::handleErrors(
 			fn () => trigger_error('Some warning', E_USER_WARNING),

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -186,6 +186,8 @@ class HelpersTest extends HelpersTestCase
 	 */
 	public function testHandleErrorsWarningCaughtCallbackValue()
 	{
+		// TODO: This line should not be necessary
+		// https://github.com/getkirby/kirby/pull/6093#issuecomment-1872569768
 		$this->activeErrorHandlers++;
 
 		$this->assertSame('handled', Helpers::handleErrors(

--- a/tests/Cms/HelpersTestCase.php
+++ b/tests/Cms/HelpersTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Closure;
+
+class HelpersTestCase extends TestCase
+{
+	protected $hasErrorHandler = false;
+
+	public function tearDown(): void
+	{
+		parent::tearDown();
+
+		if ($this->hasErrorHandler === true) {
+			restore_error_handler();
+			$this->hasErrorHandler = false;
+		}
+	}
+
+	public function assertError(
+		int $expectedErrorType,
+		string $exptectedErrorMessage,
+		Closure $callback,
+		bool $expectedFailure = true
+	) {
+		$this->hasErrorHandler = true;
+
+		$called = false;
+
+		set_error_handler(
+			function (int $errno, string $errstr) use ($expectedErrorType, $exptectedErrorMessage, &$called) {
+				$called = true;
+				$this->assertSame($expectedErrorType, $errno);
+				$this->assertSame($exptectedErrorMessage, $errstr);
+			}
+		);
+
+		$result = $callback();
+
+		if ($expectedFailure === false) {
+			$this->assertFalse($called);
+			return $result;
+		}
+
+		$this->assertTrue($called);
+	}
+}

--- a/tests/Cms/HelpersTestCase.php
+++ b/tests/Cms/HelpersTestCase.php
@@ -6,15 +6,15 @@ use Closure;
 
 class HelpersTestCase extends TestCase
 {
-	protected $hasErrorHandler = false;
+	protected int $activeErrorHandlers = 0;
 
 	public function tearDown(): void
 	{
 		parent::tearDown();
 
-		if ($this->hasErrorHandler === true) {
+		while ($this->activeErrorHandlers > 0) {
 			restore_error_handler();
-			$this->hasErrorHandler = false;
+			$this->activeErrorHandlers--;
 		}
 	}
 
@@ -24,7 +24,7 @@ class HelpersTestCase extends TestCase
 		Closure $callback,
 		bool $expectedFailure = true
 	) {
-		$this->hasErrorHandler = true;
+		$this->activeErrorHandlers++;
 
 		$called = false;
 

--- a/tests/Cms/HelpersTestCase.php
+++ b/tests/Cms/HelpersTestCase.php
@@ -20,7 +20,7 @@ class HelpersTestCase extends TestCase
 
 	public function assertError(
 		int $expectedErrorType,
-		string $exptectedErrorMessage,
+		string $expectedErrorMessage,
 		Closure $callback,
 		bool $expectedFailure = true
 	) {
@@ -29,10 +29,10 @@ class HelpersTestCase extends TestCase
 		$called = false;
 
 		set_error_handler(
-			function (int $errno, string $errstr) use ($expectedErrorType, $exptectedErrorMessage, &$called) {
+			function (int $errno, string $errstr) use ($expectedErrorType, $expectedErrorMessage, &$called) {
 				$called = true;
 				$this->assertSame($expectedErrorType, $errno);
-				$this->assertSame($exptectedErrorMessage, $errstr);
+				$this->assertSame($expectedErrorMessage, $errstr);
 			}
 		);
 

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -45,34 +45,35 @@ class ClassLoader
     /** @var \Closure(string):void */
     private static $includeFile;
 
-    /** @var string|null */
+    /** @var ?string */
     private $vendorDir;
 
     // PSR-4
     /**
-     * @var array<string, array<string, int>>
+     * @var array[]
+     * @psalm-var array<string, array<string, int>>
      */
     private $prefixLengthsPsr4 = array();
     /**
-     * @var array<string, list<string>>
+     * @var array[]
+     * @psalm-var array<string, array<int, string>>
      */
     private $prefixDirsPsr4 = array();
     /**
-     * @var list<string>
+     * @var array[]
+     * @psalm-var array<string, string>
      */
     private $fallbackDirsPsr4 = array();
 
     // PSR-0
     /**
-     * List of PSR-0 prefixes
-     *
-     * Structured as array('F (first letter)' => array('Foo\Bar (full prefix)' => array('path', 'path2')))
-     *
-     * @var array<string, array<string, list<string>>>
+     * @var array[]
+     * @psalm-var array<string, array<string, string[]>>
      */
     private $prefixesPsr0 = array();
     /**
-     * @var list<string>
+     * @var array[]
+     * @psalm-var array<string, string>
      */
     private $fallbackDirsPsr0 = array();
 
@@ -80,7 +81,8 @@ class ClassLoader
     private $useIncludePath = false;
 
     /**
-     * @var array<string, string>
+     * @var string[]
+     * @psalm-var array<string, string>
      */
     private $classMap = array();
 
@@ -88,20 +90,21 @@ class ClassLoader
     private $classMapAuthoritative = false;
 
     /**
-     * @var array<string, bool>
+     * @var bool[]
+     * @psalm-var array<string, bool>
      */
     private $missingClasses = array();
 
-    /** @var string|null */
+    /** @var ?string */
     private $apcuPrefix;
 
     /**
-     * @var array<string, self>
+     * @var self[]
      */
     private static $registeredLoaders = array();
 
     /**
-     * @param string|null $vendorDir
+     * @param ?string $vendorDir
      */
     public function __construct($vendorDir = null)
     {
@@ -110,7 +113,7 @@ class ClassLoader
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return string[]
      */
     public function getPrefixes()
     {
@@ -122,7 +125,8 @@ class ClassLoader
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array[]
+     * @psalm-return array<string, array<int, string>>
      */
     public function getPrefixesPsr4()
     {
@@ -130,7 +134,8 @@ class ClassLoader
     }
 
     /**
-     * @return list<string>
+     * @return array[]
+     * @psalm-return array<string, string>
      */
     public function getFallbackDirs()
     {
@@ -138,7 +143,8 @@ class ClassLoader
     }
 
     /**
-     * @return list<string>
+     * @return array[]
+     * @psalm-return array<string, string>
      */
     public function getFallbackDirsPsr4()
     {
@@ -146,7 +152,8 @@ class ClassLoader
     }
 
     /**
-     * @return array<string, string> Array of classname => path
+     * @return string[] Array of classname => path
+     * @psalm-return array<string, string>
      */
     public function getClassMap()
     {
@@ -154,7 +161,8 @@ class ClassLoader
     }
 
     /**
-     * @param array<string, string> $classMap Class to filename map
+     * @param string[] $classMap Class to filename map
+     * @psalm-param array<string, string> $classMap
      *
      * @return void
      */
@@ -171,25 +179,24 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix, either
      * appending or prepending to the ones previously set for this prefix.
      *
-     * @param string              $prefix  The prefix
-     * @param list<string>|string $paths   The PSR-0 root directories
-     * @param bool                $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix
+     * @param string[]|string $paths   The PSR-0 root directories
+     * @param bool            $prepend Whether to prepend the directories
      *
      * @return void
      */
     public function add($prefix, $paths, $prepend = false)
     {
-        $paths = (array) $paths;
         if (!$prefix) {
             if ($prepend) {
                 $this->fallbackDirsPsr0 = array_merge(
-                    $paths,
+                    (array) $paths,
                     $this->fallbackDirsPsr0
                 );
             } else {
                 $this->fallbackDirsPsr0 = array_merge(
                     $this->fallbackDirsPsr0,
-                    $paths
+                    (array) $paths
                 );
             }
 
@@ -198,19 +205,19 @@ class ClassLoader
 
         $first = $prefix[0];
         if (!isset($this->prefixesPsr0[$first][$prefix])) {
-            $this->prefixesPsr0[$first][$prefix] = $paths;
+            $this->prefixesPsr0[$first][$prefix] = (array) $paths;
 
             return;
         }
         if ($prepend) {
             $this->prefixesPsr0[$first][$prefix] = array_merge(
-                $paths,
+                (array) $paths,
                 $this->prefixesPsr0[$first][$prefix]
             );
         } else {
             $this->prefixesPsr0[$first][$prefix] = array_merge(
                 $this->prefixesPsr0[$first][$prefix],
-                $paths
+                (array) $paths
             );
         }
     }
@@ -219,9 +226,9 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace, either
      * appending or prepending to the ones previously set for this namespace.
      *
-     * @param string              $prefix  The prefix/namespace, with trailing '\\'
-     * @param list<string>|string $paths   The PSR-4 base directories
-     * @param bool                $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths   The PSR-4 base directories
+     * @param bool            $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException
      *
@@ -229,18 +236,17 @@ class ClassLoader
      */
     public function addPsr4($prefix, $paths, $prepend = false)
     {
-        $paths = (array) $paths;
         if (!$prefix) {
             // Register directories for the root namespace.
             if ($prepend) {
                 $this->fallbackDirsPsr4 = array_merge(
-                    $paths,
+                    (array) $paths,
                     $this->fallbackDirsPsr4
                 );
             } else {
                 $this->fallbackDirsPsr4 = array_merge(
                     $this->fallbackDirsPsr4,
-                    $paths
+                    (array) $paths
                 );
             }
         } elseif (!isset($this->prefixDirsPsr4[$prefix])) {
@@ -250,18 +256,18 @@ class ClassLoader
                 throw new \InvalidArgumentException("A non-empty PSR-4 prefix must end with a namespace separator.");
             }
             $this->prefixLengthsPsr4[$prefix[0]][$prefix] = $length;
-            $this->prefixDirsPsr4[$prefix] = $paths;
+            $this->prefixDirsPsr4[$prefix] = (array) $paths;
         } elseif ($prepend) {
             // Prepend directories for an already registered namespace.
             $this->prefixDirsPsr4[$prefix] = array_merge(
-                $paths,
+                (array) $paths,
                 $this->prefixDirsPsr4[$prefix]
             );
         } else {
             // Append directories for an already registered namespace.
             $this->prefixDirsPsr4[$prefix] = array_merge(
                 $this->prefixDirsPsr4[$prefix],
-                $paths
+                (array) $paths
             );
         }
     }
@@ -270,8 +276,8 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix,
      * replacing any others previously set for this prefix.
      *
-     * @param string              $prefix The prefix
-     * @param list<string>|string $paths  The PSR-0 base directories
+     * @param string          $prefix The prefix
+     * @param string[]|string $paths  The PSR-0 base directories
      *
      * @return void
      */
@@ -288,8 +294,8 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace,
      * replacing any others previously set for this namespace.
      *
-     * @param string              $prefix The prefix/namespace, with trailing '\\'
-     * @param list<string>|string $paths  The PSR-4 base directories
+     * @param string          $prefix The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths  The PSR-4 base directories
      *
      * @throws \InvalidArgumentException
      *
@@ -475,9 +481,9 @@ class ClassLoader
     }
 
     /**
-     * Returns the currently registered loaders keyed by their corresponding vendor directories.
+     * Returns the currently registered loaders indexed by their corresponding vendor directories.
      *
-     * @return array<string, self>
+     * @return self[]
      */
     public static function getRegisteredLoaders()
     {


### PR DESCRIPTION
PHPUnit 10 won't throw errors anymore, which is why we need to switch to a different test setup for our deprecation errors