### PR TITLE
`field.isVisible()`: fix if statement

### DIFF
--- a/panel/src/helpers/field.js
+++ b/panel/src/helpers/field.js
@@ -76,7 +76,10 @@ export function isVisible(field, values) {
 		const condition = field.when[key];
 
 		// if condition is checking for empty field
-		if (value === undefined && (condition === "" || condition === [])) {
+		if (
+			value === undefined &&
+			(condition === "" || (Array.isArray(condition) && condition.length === 0))
+		) {
 			continue;
 		}
 


### PR DESCRIPTION
`condition === []` would always be false as JavaScript compares arrays/objects by reference not value