### PR TITLE
`Helpers::handleErrors()`: Exception robustness

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -135,9 +135,14 @@ class Helpers
 			return true;
 		});
 
-		$result = $action();
-
-		restore_error_handler();
+		try {
+			$result = $action();
+		} finally {
+			// always restore the error handler, even if the
+			// action or the standard error handler threw an
+			// exception; this avoids modifying global state
+			restore_error_handler();
+		}
 
 		return $override ?? $result;
 	}

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Obj;
 
@@ -123,6 +124,20 @@ class HelpersTest extends HelpersTestCase
 			fn () => 'return',
 			fn () => $this->fail('Condition handler should not be called because no warning was triggered')
 		));
+	}
+
+	/**
+	 * @covers ::handleErrors
+	 */
+	public function testHandleErrorsException()
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Exception inside the action');
+
+		Helpers::handleErrors(
+			fn () => throw new Exception('Exception inside the action'),
+			fn () => $this->fail('Condition handler should not be called because no warning was triggered')
+		);
 	}
 
 	/**


### PR DESCRIPTION
Interestingly, this change didn't allow to remove the superfluous error handler restore in the `testHandleErrorsWarningCaughtCallbackValue`. So something super weird seems to be going on in PHPUnit 9.

However the test I've newly added only works with the `try {} finally {}` change. Without the change, the new test would introduce the same "missing restore" behavior. So the change is at least useful for exceptions that are thrown by or in the action, which should be the most common case in practice. Now I understand why PHPUnit 10 removed the conversion from errors/warnings to exceptions: It's a pain in the butt. ;)

---

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- `Helpers::handleErrors()` correctly restores the original error handler even if an exception is thrown in the action

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
