### PR TITLE
Fix CSS selectors for boolean attributes

### DIFF
--- a/panel/lab/components/tables/1_horizontal/index.vue
+++ b/panel/lab/components/tables/1_horizontal/index.vue
@@ -47,8 +47,8 @@
 				<table>
 					<thead>
 						<tr>
-							<th data-has-button><button>Name</button></th>
-							<th data-has-button><button>Date</button></th>
+							<th data-has-button="true"><button>Name</button></th>
+							<th data-has-button="true"><button>Date</button></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/panel/lab/components/tables/2_vertical/index.vue
+++ b/panel/lab/components/tables/2_vertical/index.vue
@@ -17,7 +17,7 @@
 				<table style="table-layout: auto">
 					<tbody>
 						<tr v-for="i in 4" :key="i">
-							<th data-has-button>
+							<th data-has-button="true">
 								<button>Label {{ i }}</button>
 							</th>
 							<td>Value {{ i }}</td>
@@ -48,19 +48,19 @@ export default {
 			return [
 				{
 					text: "Edit",
-					icon: "edit",
+					icon: "edit"
 				},
 				{
 					text: "Duplicate",
-					icon: "copy",
+					icon: "copy"
 				},
 				"-",
 				{
 					text: "Delete",
-					icon: "trash",
-				},
+					icon: "trash"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -62,7 +62,7 @@ export default {
 	margin-bottom: 0.5rem;
 	padding-inline-end: 38px;
 }
-.k-pages-dialog-navbar .k-button[aria-disabled] {
+.k-pages-dialog-navbar .k-button[aria-disabled="true"] {
 	opacity: 0;
 }
 .k-pages-dialog-navbar .k-headline {
@@ -70,7 +70,7 @@ export default {
 	text-align: center;
 }
 
-.k-pages-dialog-option[aria-disabled] {
+.k-pages-dialog-option[aria-disabled="true"] {
 	opacity: 0.25;
 }
 </style>

--- a/panel/src/components/Dialogs/UploadDialog.vue
+++ b/panel/src/components/Dialogs/UploadDialog.vue
@@ -203,7 +203,7 @@ export default {
 .k-upload-item-toggle > * {
 	padding: var(--spacing-3);
 }
-.k-upload-item[data-completed] .k-upload-item-progress {
+.k-upload-item[data-completed="true"] .k-upload-item-progress {
 	--progress-color-value: var(--color-green-400);
 }
 </style>

--- a/panel/src/components/Drawers/Elements/Header.vue
+++ b/panel/src/components/Drawers/Elements/Header.vue
@@ -84,7 +84,7 @@ export default {
 .k-drawer-option {
 	--button-width: var(--button-height);
 }
-.k-drawer-option[aria-disabled] {
+.k-drawer-option[aria-disabled="true"] {
 	opacity: var(--opacity-disabled);
 }
 </style>

--- a/panel/src/components/Drawers/Elements/Tabs.vue
+++ b/panel/src/components/Drawers/Elements/Tabs.vue
@@ -53,7 +53,7 @@ export default {
 	font-size: var(--text-xs);
 	overflow-x: visible;
 }
-.k-drawer-tab.k-button[aria-current]::after {
+.k-drawer-tab.k-button[aria-current="true"]::after {
 	position: absolute;
 	bottom: -2px;
 	inset-inline: var(--button-padding);

--- a/panel/src/components/Drawers/FiberDrawer.vue
+++ b/panel/src/components/Drawers/FiberDrawer.vue
@@ -24,7 +24,7 @@ export default {
 </script>
 
 <style>
-.k-drawer[aria-disabled] {
+.k-drawer[aria-disabled="true"] {
 	display: none;
 	pointer-events: none;
 }

--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -56,10 +56,10 @@ export default {
 .k-dropdown-item.k-button:focus {
 	outline: var(--outline);
 }
-.k-dropdown-item.k-button[aria-current] {
+.k-dropdown-item.k-button[aria-current="true"] {
 	--button-color-text: var(--color-blue-500);
 }
-.k-dropdown-item.k-button:not([aria-disabled]):hover {
+.k-dropdown-item.k-button:not([aria-disabled="true"]):hover {
 	--button-color-back: var(--dropdown-color-hr);
 }
 </style>

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -173,7 +173,7 @@ export default {
 	gap: 1rem;
 	box-shadow: var(--shadow);
 }
-.k-block-types .k-button[aria-disabled] {
+.k-block-types .k-button[aria-disabled="true"] {
 	opacity: var(--opacity-disabled);
 	--button-color-back: var(--color-gray-200);
 	box-shadow: none;

--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -86,7 +86,7 @@ export default {
 .k-choice-input-label-info {
 	color: var(--choice-color-info);
 }
-.k-choice-input[aria-disabled] {
+.k-choice-input[aria-disabled="true"] {
 	cursor: not-allowed;
 }
 

--- a/panel/src/components/Forms/Input/CoordsInput.vue
+++ b/panel/src/components/Forms/Input/CoordsInput.vue
@@ -199,7 +199,7 @@ export default {
 	transform: translate(-50%, -50%);
 	cursor: move;
 }
-.k-coords-input[data-empty] .k-coords-input-thumb {
+.k-coords-input[data-empty="true"] .k-coords-input-thumb {
 	opacity: 0;
 }
 .k-coords-input-thumb:active {
@@ -208,7 +208,7 @@ export default {
 .k-coords-input:focus-within {
 	outline: var(--outline);
 }
-.k-coords-input[aria-disabled] {
+.k-coords-input[aria-disabled="true"] {
 	pointer-events: none;
 	opacity: var(--opacity-disabled);
 }

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -103,7 +103,7 @@ export default {
 .k-input[data-type="toggle"] .k-toggle-input {
 	padding-inline-start: var(--input-padding);
 }
-.k-input[data-type="toggle"][data-disabled] {
+.k-input[data-type="toggle"][data-disabled="true"] {
 	box-shadow: none;
 }
 </style>

--- a/panel/src/components/Forms/Layouts/LayoutSelector.vue
+++ b/panel/src/components/Forms/Layouts/LayoutSelector.vue
@@ -113,7 +113,7 @@ export default {
 	--color-border: var(--color-gray-500);
 	--color-back: var(--color-gray-100);
 }
-.k-layout-selector-option[aria-current] {
+.k-layout-selector-option[aria-current="true"] {
 	--color-border: var(--color-focus);
 	--color-back: var(--color-blue-300);
 }

--- a/panel/src/components/Forms/Toolbar/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar/Toolbar.vue
@@ -122,7 +122,7 @@ export default {
 .k-toolbar-button:hover {
 	--button-color-back: var(--toolbar-hover);
 }
-.k-toolbar .k-button[aria-current] {
+.k-toolbar .k-button[aria-current="true"] {
 	--button-color-text: var(--toolbar-current);
 }
 .k-toolbar > .k-button:first-child {

--- a/panel/src/components/Lab/Example.vue
+++ b/panel/src/components/Lab/Example.vue
@@ -89,7 +89,7 @@ export default {
 .k-lab-example-code {
 	padding: var(--spacing-16);
 }
-.k-lab-example[data-flex] .k-lab-example-canvas {
+.k-lab-example[data-flex="true"] .k-lab-example-canvas {
 	display: flex;
 	align-items: center;
 	gap: var(--spacing-6);

--- a/panel/src/components/Layout/Overlay.vue
+++ b/panel/src/components/Layout/Overlay.vue
@@ -180,10 +180,10 @@ export default {
 }
 
 /* Scroll lock */
-html[data-overlay] {
+html[data-overlay="true"] {
 	overflow: hidden;
 }
-html[data-overlay] body {
+html[data-overlay="true"] body {
 	overflow: scroll;
 }
 </style>

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -399,7 +399,7 @@ export default {
 	color: var(--table-color-th-text);
 	background: var(--table-color-th-back);
 }
-.k-table th[data-has-button] {
+.k-table th[data-has-button="true"] {
 	padding: 0;
 }
 .k-table th button {

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -159,7 +159,7 @@ export default {
 	overflow-x: visible;
 }
 
-.k-tab-button[aria-current]::after {
+.k-tab-button[aria-current="true"]::after {
 	position: absolute;
 	content: "";
 	height: 2px;

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -300,9 +300,9 @@ export default {
 	--button-color-dimmed-off: var(--color-text);
 	--button-color-text: var(--button-color-dimmed-on);
 }
-.k-button:where([data-variant="dimmed"]):not([aria-disabled]):is(
+.k-button:where([data-variant="dimmed"]):not([aria-disabled="true"]):is(
 		:hover,
-		[aria-current]
+		[aria-current="true"]
 	) {
 	--button-color-text: var(--button-color-dimmed-off);
 }
@@ -316,7 +316,7 @@ export default {
 .k-button:where([data-variant="filled"]) {
 	--button-color-back: var(--color-gray-300);
 }
-.k-button:where([data-variant="filled"]):not([aria-disabled]):hover {
+.k-button:where([data-variant="filled"]):not([aria-disabled="true"]):hover {
 	filter: brightness(97%);
 }
 .k-button:where([data-theme][data-variant="filled"]) {
@@ -344,7 +344,7 @@ export default {
 		--button-icon-display: none;
 	}
 	/** TODO: .k-button:is([data-responsive]:has(.k-button-icon)) .k-button-arrow */
-	.k-button[data-responsive][data-has-icon="true"] .k-button-arrow {
+	.k-button[data-responsive="true"][data-has-icon="true"] .k-button-arrow {
 		display: none;
 	}
 }
@@ -375,10 +375,10 @@ export default {
 }
 
 /** Disabled button **/
-.k-button:where([aria-disabled]) {
+.k-button:where([aria-disabled="true"]) {
 	cursor: not-allowed;
 }
-.k-button:where([aria-disabled]) > * {
+.k-button:where([aria-disabled="true"]) > * {
 	opacity: var(--opacity-disabled);
 }
 </style>

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -99,7 +99,7 @@ export default {
 	cursor: pointer;
 	user-select: none;
 }
-.k-tag:not([aria-disabled]):focus {
+.k-tag:not([aria-disabled="true"]):focus {
 	outline: var(--outline);
 }
 .k-tag-image {
@@ -129,7 +129,7 @@ export default {
 	filter: brightness(100%);
 }
 
-.k-tag:where([aria-disabled]) {
+.k-tag:where([aria-disabled="true"]) {
 	background-color: var(--tag-color-disabled-back);
 	color: var(--tag-color-disabled-text);
 	cursor: not-allowed;

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -131,12 +131,12 @@ export default {
 	background: var(--tree-color-back);
 }
 .k-tree-branch:hover,
-li[aria-current] > .k-tree-branch {
+li[aria-current="true"] > .k-tree-branch {
 	--tree-color-text: var(--tree-color-selected-text);
 	background: var(--tree-color-hover-back);
 	border-radius: var(--rounded);
 }
-li[aria-current] > .k-tree-branch {
+li[aria-current="true"] > .k-tree-branch {
 	background: var(--tree-color-selected-back);
 }
 .k-tree-toggle {

--- a/panel/src/components/Text/Label.vue
+++ b/panel/src/components/Text/Label.vue
@@ -76,7 +76,7 @@ export default {
 	font-weight: var(--font-semi);
 	min-width: 0;
 }
-[aria-disabled] .k-label {
+[aria-disabled="true"] .k-label {
 	opacity: var(--opacity-disabled);
 	cursor: not-allowed;
 }
@@ -111,14 +111,17 @@ export default {
 
 /** Tracking invalid via CSS */
 /** TODO: replace once invalid state is tracked in panel.content */
-:where(.k-field:has([data-invalid]), .k-section:has([data-invalid]))
+:where(
+		.k-field:has([data-invalid="true"]),
+		.k-section:has([data-invalid="true"])
+	)
 	> header
 	> .k-label
 	abbr.k-label-invalid {
 	display: inline-block;
 }
 
-.k-field:has([data-invalid])
+.k-field:has([data-invalid="true"])
 	> .k-field-header
 	> .k-label
 	abbr:has(+ abbr.k-label-invalid) {

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -169,7 +169,7 @@ export default {
 	/* Make sure that buttons don't shrink in height */
 	flex-shrink: 0;
 }
-.k-panel-menu-button[aria-current] {
+.k-panel-menu-button[aria-current="true"] {
 	--button-color-back: var(--color-white);
 	box-shadow: var(--shadow);
 }
@@ -264,7 +264,7 @@ export default {
 	/* The toggle is visible on hover or focus */
 	.k-panel-menu-toggle:focus-visible,
 	/* The hover state is controlled via JS to avoid flickering */
-	.k-panel-menu[data-hover] .k-panel-menu-toggle {
+	.k-panel-menu[data-hover="true"] .k-panel-menu-toggle {
 		opacity: 1;
 	}
 	/* Create the outline on the icon on focus */


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Use strict CSS selectors for boolean (data) attributes

### Breaking changes
- CSS attribute selectors must be written fully qualified (e.g. `[data-hidden="true"]` as only `[data-hidden]` can start matching also elements where that attribute is `false`)


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
