### PR TITLE
add settings and method to sharpen images

### DIFF
--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -60,6 +60,7 @@ class Darkroom
 			'quality'     => 90,
 			'scaleHeight' => null,
 			'scaleWidth'  => null,
+			'sharpen'     => null,
 			'width'       => null,
 		];
 	}
@@ -91,6 +92,11 @@ class Darkroom
 		if (isset($options['bw']) === true) {
 			$options['grayscale'] = $options['bw'];
 			unset($options['bw']);
+		}
+
+		// normalize the sharpen option
+		if ($options['sharpen'] === true) {
+			$options['sharpen'] = 50;
 		}
 
 		$options['quality'] ??= $this->settings['quality'];

--- a/src/Image/Darkroom/GdLib.php
+++ b/src/Image/Darkroom/GdLib.php
@@ -33,6 +33,7 @@ class GdLib extends Darkroom
 		$image = $this->autoOrient($image, $options);
 		$image = $this->blur($image, $options);
 		$image = $this->grayscale($image, $options);
+		$image = $this->sharpen($image, $options);
 
 		$image->toFile($file, $mime, $options);
 
@@ -114,6 +115,18 @@ class GdLib extends Darkroom
 		}
 
 		return $image->desaturate();
+	}
+
+	/**
+	 * Applies sharpening if activated in the options.
+	 */
+	protected function sharpen(SimpleImage $image, array $options): SimpleImage
+	{
+		if ($options['sharpen'] === false) {
+			return $image;
+		}
+
+		return $image->sharpen((int)$options['sharpen']);
 	}
 
 	/**

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -101,6 +101,19 @@ class ImageMagick extends Darkroom
 	}
 
 	/**
+	 * Applies sharpening if activated in the options.
+	 */
+	protected function sharpen(string $file, array $options): string|null
+	{
+		if ($options['sharpen'] !== false) {
+			$amount = max(1, min(100, $options['sharpen'])) / 100;
+			return '-sharpen ' . escapeshellarg('0x' . $amount);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Applies the correct settings for interlaced JPEGs if
 	 * activated via options
 	 */


### PR DESCRIPTION
## This PR …

As both SimpleImage and ImageMagick have capabilities to sharpen thumbnails, I'd like to make use of them. This PR adds a thumb config option `sharpen` which can be used to sharpen an image.

Will add tests, if this is something you'd like to include. Also, instead of giving a number between 0-100, we could also just use the default of 50 and make `sharpen` a boolean config option.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [X] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
