### PR TITLE
PHPUnit reliability refactoring (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # tests
 .phpunit.cache
 /tests/coverage
+/tests/tmp
 
 # ignore all the vendor cruft
 /vendor/**/.*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,4 +46,8 @@
 	</php>
 
 	<coverage ignoreDeprecatedCodeUnits="true" />
+
+	<extensions>
+		<bootstrap class="Kirby\PhpUnitExtension"/>
+	</extensions>
 </phpunit>

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -632,10 +632,20 @@ class Api
 			$uploadMaxFileSize = Str::toBytes(ini_get('upload_max_filesize'));
 
 			if ($postMaxSize < $uploadMaxFileSize) {
-				throw new Exception(I18n::translate('upload.error.iniPostSize'));
+				throw new Exception(
+					I18n::translate(
+						'upload.error.iniPostSize',
+						'The uploaded file exceeds the post_max_size directive in php.ini'
+					)
+				);
 			}
 
-			throw new Exception(I18n::translate('upload.error.noFiles'));
+			throw new Exception(
+				I18n::translate(
+					'upload.error.noFiles',
+					'No files were uploaded'
+				)
+			);
 		}
 
 		foreach ($files as $upload) {
@@ -651,7 +661,8 @@ class Api
 			try {
 				if ($upload['error'] !== 0) {
 					throw new Exception(
-						$errorMessages[$upload['error']] ?? I18n::translate('upload.error.default')
+						$errorMessages[$upload['error']] ??
+						I18n::translate('upload.error.default', 'The file could not be uploaded')
 					);
 				}
 

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -310,13 +310,22 @@ class Core
 	 */
 	public function roots(): array
 	{
+		$indexClosure = function (array $roots) {
+			// prevent PHPUnit tests from accessing files outside the repo
+			if (defined('KIRBY_TESTING') === true && KIRBY_TESTING === true) {
+				return '/dev/null';
+			}
+
+			return dirname(__DIR__, 3); // @codeCoverageIgnore
+		};
+
 		return $this->cache['roots'] ??= [
 			'kirby'       => fn (array $roots) => dirname(__DIR__, 2),
 			'i18n'        => fn (array $roots) => $roots['kirby'] . '/i18n',
 			'i18n:translations' => fn (array $roots) => $roots['i18n'] . '/translations',
 			'i18n:rules'  => fn (array $roots) => $roots['i18n'] . '/rules',
 
-			'index'       => fn (array $roots) => dirname(__DIR__, 3),
+			'index'       => $indexClosure,
 			'assets'      => fn (array $roots) => $roots['index'] . '/assets',
 			'content'     => fn (array $roots) => $roots['index'] . '/content',
 			'media'       => fn (array $roots) => $roots['index'] . '/media',

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -30,6 +30,11 @@ use Kirby\Form\Field\LayoutField;
  */
 class Core
 {
+	/**
+	 * Optional override for the auto-detected index root
+	 */
+	public static string|null $indexRoot = null;
+
 	protected array $cache = [];
 	protected string $root;
 
@@ -310,22 +315,13 @@ class Core
 	 */
 	public function roots(): array
 	{
-		$indexClosure = function (array $roots) {
-			// prevent PHPUnit tests from accessing files outside the repo
-			if (defined('KIRBY_TESTING') === true && KIRBY_TESTING === true) {
-				return '/dev/null';
-			}
-
-			return dirname(__DIR__, 3); // @codeCoverageIgnore
-		};
-
 		return $this->cache['roots'] ??= [
 			'kirby'       => fn (array $roots) => dirname(__DIR__, 2),
 			'i18n'        => fn (array $roots) => $roots['kirby'] . '/i18n',
 			'i18n:translations' => fn (array $roots) => $roots['i18n'] . '/translations',
 			'i18n:rules'  => fn (array $roots) => $roots['i18n'] . '/rules',
 
-			'index'       => $indexClosure,
+			'index'       => fn (array $roots) => static::$indexRoot ?? dirname(__DIR__, 3),
 			'assets'      => fn (array $roots) => $roots['index'] . '/assets',
 			'content'     => fn (array $roots) => $roots['index'] . '/content',
 			'media'       => fn (array $roots) => $roots['index'] . '/media',

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -296,7 +296,7 @@ class Form
 		$kirby = App::instance(null, true);
 
 		// only modify the fields if we have a valid Kirby multilang instance
-		if ($kirby?->multilang() === false) {
+		if ($kirby?->multilang() !== true) {
 			return $fields;
 		}
 

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -322,14 +322,15 @@ class Environment
 		}
 
 		// @codeCoverageIgnoreStart
-		if (php_sapi_name() === 'cli') {
+		$sapi = php_sapi_name();
+		if ($sapi === 'cli') {
 			return true;
 		}
 
 		$term = getenv('TERM');
 
 		if (
-			substr(php_sapi_name(), 0, 3) === 'cgi' &&
+			substr($sapi, 0, 3) === 'cgi' &&
 			$term &&
 			$term !== 'unknown'
 		) {

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -322,10 +322,14 @@ class Environment
 		}
 
 		// @codeCoverageIgnoreStart
+		if (php_sapi_name() === 'cli') {
+			return true;
+		}
+
 		$term = getenv('TERM');
 
 		if (
-			substr(PHP_SAPI, 0, 3) === 'cgi' &&
+			substr(php_sapi_name(), 0, 3) === 'cgi' &&
 			$term &&
 			$term !== 'unknown'
 		) {

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -4,10 +4,17 @@ namespace Kirby\Cms;
 
 class RootsTest extends TestCase
 {
+	protected $indexRoot;
+
+	public function setUp(): void
+	{
+		$this->indexRoot = Core::$indexRoot;
+	}
+
 	public function tearDown(): void
 	{
 		// ensure that the index root used for testing is reset
-		Core::$indexRoot = '/dev/null';
+		Core::$indexRoot = $this->indexRoot;
 	}
 
 	protected static function rootProvider(string $index): array

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -4,6 +4,12 @@ namespace Kirby\Cms;
 
 class RootsTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		// ensure that the index root used for testing is reset
+		Core::$indexRoot = '/dev/null';
+	}
+
 	protected static function rootProvider(string $index): array
 	{
 		$kirby = realpath(__DIR__ . '/../../..');
@@ -39,9 +45,7 @@ class RootsTest extends TestCase
 
 	public static function defaultRootProvider(): array
 	{
-		// automatic fallback used in testing mode
-		// we cannot test the actual root with PHPUnit
-		return static::rootProvider('/dev/null');
+		return static::rootProvider(realpath(__DIR__ . '/../../../../'));
 	}
 
 	/**
@@ -49,6 +53,9 @@ class RootsTest extends TestCase
 	 */
 	public function testDefaultRoot($root, $method)
 	{
+		// fake the default behavior for this test
+		Core::$indexRoot = null;
+
 		$roots = (new App())->roots();
 
 		$this->assertSame($root, $roots->$method());

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -39,7 +39,9 @@ class RootsTest extends TestCase
 
 	public static function defaultRootProvider(): array
 	{
-		return static::rootProvider(realpath(__DIR__ . '/../../../../'));
+		// automatic fallback used in testing mode
+		// we cannot test the actual root with PHPUnit
+		return static::rootProvider('/dev/null');
 	}
 
 	/**

--- a/tests/Cms/Site/SiteActionsTest.php
+++ b/tests/Cms/Site/SiteActionsTest.php
@@ -88,10 +88,10 @@ class SiteActionsTest extends TestCase
 	public function testUpdate()
 	{
 		$site = $this->site()->update([
-			'copyright' => 2018
+			'copyright' => '2018'
 		]);
 
-		$this->assertSame(2018, $site->copyright()->value());
+		$this->assertSame('2018', $site->copyright()->value());
 	}
 
 	public function testChangeTitleHooks()

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -11,6 +11,8 @@ use ReflectionClass;
  */
 class LicenseTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.License';
+
 	public function code(LicenseType $type = LicenseType::Basic): string
 	{
 		return $type->prefix() . '1234' . Str::random(28);
@@ -231,6 +233,9 @@ class LicenseTest extends TestCase
 	public function testIsOnCorrectDomain()
 	{
 		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
 			'options' => [
 				'url' => 'https://getkirby.com'
 			]

--- a/tests/Data/tmp/data.json
+++ b/tests/Data/tmp/data.json
@@ -1,1 +1,0 @@
-{"name":"Homer Simpson","email":"homer@simpson.com"}

--- a/tests/Data/tmp/data.txt
+++ b/tests/Data/tmp/data.txt
@@ -1,5 +1,0 @@
-Name: Homer Simpson
-
-----
-
-Email: homer@simpson.com

--- a/tests/Data/tmp/data.yml
+++ b/tests/Data/tmp/data.yml
@@ -1,2 +1,0 @@
-name: Homer Simpson
-email: homer@simpson.com

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -58,6 +58,11 @@ class DatabaseTest extends TestCase
 		]);
 	}
 
+	public function tearDown(): void
+	{
+		Database::$connections = [];
+	}
+
 	public function testInstance()
 	{
 		$this->assertSame($this->database, Database::instance());
@@ -65,10 +70,16 @@ class DatabaseTest extends TestCase
 
 	public function testInstances()
 	{
-		// this unit test order should be second
-		// testInstance() method is #1 instance
-		// testInstances() method is #2 instance
-		$this->assertCount(2, Database::instances());
+		// create another instance
+		$secondInstance = new Database([
+			'database' => ':memory:',
+			'type'     => 'sqlite'
+		]);
+
+		$this->assertSame([
+			$this->database,
+			$secondInstance
+		], array_values(Database::instances()));
 	}
 
 	/**

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -387,7 +387,7 @@ class FileTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid mime type: text/plain');
 
-		// load translations
+		// load translations to get the correct exception message
 		App::instance();
 
 		$this->_file()->match(['mime' => ['image/png', 'application/pdf']]);
@@ -401,7 +401,7 @@ class FileTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid extension: js');
 
-		// load translations
+		// load translations to get the correct exception message
 		App::instance();
 
 		$this->_file()->match(['extension' => ['png', 'pdf']]);
@@ -415,7 +415,7 @@ class FileTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid file type: code');
 
-		// load translations
+		// load translations to get the correct exception message
 		App::instance();
 
 		$this->_file()->match(['type' => ['document', 'video']]);

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -44,6 +44,7 @@ class FileTest extends TestCase
 
 		Dir::remove($this->tmp);
 		static::$block = [];
+		App::destroy();
 	}
 
 	protected function _file($file = 'test.js')
@@ -355,6 +356,10 @@ class FileTest extends TestCase
 	public function testKirby()
 	{
 		$file = $this->_file();
+
+		$this->assertNull($file->kirby());
+
+		App::instance();
 		$this->assertInstanceOf(App::class, $file->kirby());
 	}
 
@@ -382,6 +387,9 @@ class FileTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid mime type: text/plain');
 
+		// load translations
+		App::instance();
+
 		$this->_file()->match(['mime' => ['image/png', 'application/pdf']]);
 	}
 
@@ -393,6 +401,9 @@ class FileTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid extension: js');
 
+		// load translations
+		App::instance();
+
 		$this->_file()->match(['extension' => ['png', 'pdf']]);
 	}
 
@@ -403,6 +414,9 @@ class FileTest extends TestCase
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid file type: code');
+
+		// load translations
+		App::instance();
 
 		$this->_file()->match(['type' => ['document', 'video']]);
 	}

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -13,6 +13,11 @@ use PHPUnit\Framework\TestCase;
  */
 class FormTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		App::destroy();
+	}
+
 	public function testDataWithoutFields()
 	{
 		$form = new Form([
@@ -47,7 +52,7 @@ class FormTest extends TestCase
 		$this->assertSame('info', $field['type']);
 		$this->assertSame('Error in "test" field.', $field['label']);
 		$this->assertStringContainsString('<p>This is an error in file:', $field['text']);
-		$this->assertStringContainsString('tests/Form/FormTest.php line: 34</p>', $field['text']);
+		$this->assertStringContainsString('tests/Form/FormTest.php line: 39</p>', $field['text']);
 		$this->assertSame('negative', $field['theme']);
 	}
 
@@ -367,6 +372,8 @@ class FormTest extends TestCase
 
 	public function testPageForm()
 	{
+		App::instance();
+
 		$page = new Page([
 			'slug' => 'test',
 			'content' => [

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -7,9 +7,16 @@ use PHPUnit\Framework\TestCase;
 
 class CookieTest extends TestCase
 {
+	protected $cookieKey;
+
+	public function setUp(): void
+	{
+		$this->cookieKey = Cookie::$key;
+	}
+
 	public function tearDown(): void
 	{
-		Cookie::$key = 'KirbyHttpCookieKey';
+		Cookie::$key = $this->cookieKey;
 	}
 
 	public function testKey()

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -7,6 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class CookieTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		Cookie::$key = 'KirbyHttpCookieKey';
+	}
+
 	public function testKey()
 	{
 		$this->assertSame('KirbyHttpCookieKey', Cookie::$key);
@@ -24,18 +29,20 @@ class CookieTest extends TestCase
 	public function testSet()
 	{
 		Cookie::set('foo', 'bar');
-		$this->assertSame('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['foo']);
+		$this->assertSame('171fb1229817374e4110110384cb6be060d97351+bar', $_COOKIE['foo']);
 	}
 
 	public function testForever()
 	{
 		Cookie::forever('forever', 'bar');
-		$this->assertSame('703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar', $_COOKIE['forever']);
+		$this->assertSame('171fb1229817374e4110110384cb6be060d97351+bar', $_COOKIE['forever']);
 		$this->assertTrue(Cookie::exists('forever'));
 	}
 
 	public function testRemove()
 	{
+		Cookie::forever('forever', 'bar');
+
 		$this->assertTrue(Cookie::remove('forever'));
 		$this->assertFalse(isset($_COOKIE['forever']));
 		$this->assertFalse(Cookie::remove('none'));
@@ -43,12 +50,16 @@ class CookieTest extends TestCase
 
 	public function testExists()
 	{
+		Cookie::set('foo', 'bar');
+
 		$this->assertTrue(Cookie::exists('foo'));
 		$this->assertFalse(Cookie::exists('new'));
 	}
 
 	public function testGet()
 	{
+		Cookie::set('foo', 'bar');
+
 		$this->assertSame('bar', Cookie::get('foo'));
 		$this->assertSame('some amazing default', Cookie::get('does_not_exist', 'some amazing default'));
 		$this->assertSame($_COOKIE, Cookie::get());
@@ -73,29 +84,29 @@ class CookieTest extends TestCase
 	public function testParse()
 	{
 		// valid
-		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
+		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// no value
-		$_COOKIE['foo'] = '21fdd6d0d6f5b4ac8109e5f2d0c3f0f7e8e89492+';
+		$_COOKIE['foo'] = '11d325720298d99f538012e590502154905b56e1+';
 		$this->assertSame('', Cookie::get('foo'));
-		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
+		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// value with a plus sign
-		$_COOKIE['foo'] = '9c8c403efa31d4e4598d75e9c394b48255b65154+bar+baz';
+		$_COOKIE['foo'] = '04c23eb787bda27a65843cf7e474be5eb77f4807+bar+baz';
 		$this->assertSame('bar+baz', Cookie::get('foo'));
 
 		// separator missing
-		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85';
+		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351';
 		$this->assertNull(Cookie::get('foo'));
-		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
+		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// no hash
 		$_COOKIE['foo'] = '+bar';
 		$this->assertNull(Cookie::get('foo'));
-		$_COOKIE['foo'] = '703a07dc4edca348cb92d9fcb7da1b3931de0a85+bar';
+		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351+bar';
 		$this->assertSame('bar', Cookie::get('foo'));
 
 		// wrong hash

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -16,7 +16,7 @@ class OptionsApiTest extends TestCase
 	 */
 	public function testConstruct()
 	{
-		$options = new OptionsApi($url = 'https://api.getkirby.com');
+		$options = new OptionsApi($url = 'https://api.example.com');
 		$this->assertSame($url, $options->url);
 		$this->assertNull($options->query);
 		$this->assertNull($options->text);
@@ -28,7 +28,7 @@ class OptionsApiTest extends TestCase
 	 */
 	public function testDefaults()
 	{
-		$options = new OptionsApi($url = 'https://api.getkirby.com');
+		$options = new OptionsApi($url = 'https://api.example.com');
 		$this->assertSame($url, $options->url);
 		$this->assertNull($options->text);
 		$this->assertNull($options->value);
@@ -46,7 +46,7 @@ class OptionsApiTest extends TestCase
 	public function testFactory()
 	{
 		$options = OptionsApi::factory([
-			'url'   => $url = 'https://api.getkirby.com',
+			'url'   => $url = 'https://api.example.com',
 			'query' => $query = 'Companies',
 			'text'  => $text = '{{ item.name }}',
 			'value' => $value =  '{{ item.id }}',
@@ -57,7 +57,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame($text, $options->text);
 		$this->assertSame($value, $options->value);
 
-		$options = OptionsApi::factory($url = 'https://api.getkirby.com');
+		$options = OptionsApi::factory($url = 'https://api.example.com');
 		$this->assertSame($url, $options->url);
 		$this->assertNull($options->query);
 		$this->assertNull($options->text);
@@ -67,12 +67,12 @@ class OptionsApiTest extends TestCase
 	/**
 	 * @covers ::load
 	 */
-	public function testLoadNotFound()
+	public function testLoadNoJson()
 	{
 		$model   = new Page(['slug' => 'test']);
-		$options = new OptionsApi(url: 'https://api.getkirby.com');
+		$options = new OptionsApi(url: 'https://example.com');
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Options could not be loaded from API: https://api.getkirby.com');
+		$this->expectExceptionMessage('Options could not be loaded from API: https://example.com');
 		$options->resolve($model);
 	}
 
@@ -81,10 +81,10 @@ class OptionsApiTest extends TestCase
 	 */
 	public function testPolyfill()
 	{
-		$api = 'https//api.getkirby.com';
+		$api = 'https://api.example.com';
 		$this->assertSame(['url' => $api], OptionsApi::polyfill($api));
 
-		$api = ['url' => 'https//api.getkirby.com'];
+		$api = ['url' => 'https://api.example.com'];
 		$this->assertSame($api, OptionsApi::polyfill($api));
 
 		$api = ['fetch' => 'Companies'];

--- a/tests/Panel/PluginsTest.php
+++ b/tests/Panel/PluginsTest.php
@@ -118,6 +118,9 @@ class PluginsTest extends TestCase
 	{
 		$time = $this->createPlugins();
 
+		// app must be created again to load the new plugins
+		$app = $this->app->clone();
+
 		$plugins = new Plugins();
 		$this->assertSame($time, $plugins->modified());
 	}

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -22,8 +22,9 @@ class ModelUserTestForceLocked extends ModelUser
  */
 class UserTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.User';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -31,16 +32,17 @@ class UserTest extends TestCase
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		$this->app->session()->destroy();
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -63,6 +65,9 @@ class UserTest extends TestCase
 	public function testDropdownTotp(): void
 	{
 		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
 			'options' => [
 				'auth' => [
 					'methods' => ['password' => ['2fa' => true]]
@@ -121,7 +126,7 @@ class UserTest extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'blueprints' => [
 				'users/editor' => [
@@ -147,7 +152,7 @@ class UserTest extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'site' => [
 				'children' => [

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kirby;
+
+use Kirby\Cms\App;
+use Kirby\Filesystem\Dir;
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+/**
+ * PHPUnit extension to bootstrap the tests and
+ * manage the temporary directory during testing
+ *
+ * @author Lukas Bestle <lukas@getkirby.com>
+ * @link https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license https://opensource.org/licenses/MIT
+ */
+final class PhpUnitExtension implements Extension
+{
+	public function bootstrap(
+		Configuration $configuration,
+		Facade $facade,
+		ParameterCollection $parameters
+	): void {
+		// disable Whoops for all tests that don't need it
+		// to reduce the impact of memory leaks
+		App::$enableWhoops = false;
+
+		// ensure the temp directory is there
+		Dir::make(KIRBY_TMP_DIR);
+
+		// delete the temp directory again after the tests
+		$facade->registerSubscriber(new TempCleanupSubscriber());
+	}
+
+	public static function defineConstants(): void
+	{
+		// determine a unique path to a temporary directory
+		$tempDir = __DIR__ . '/tmp';
+
+		// when running via ParaTest, use a separate directory for each process
+		if (getenv('UNIQUE_TEST_TOKEN') !== false) {
+			$tempDir .= '/' . getenv('UNIQUE_TEST_TOKEN');
+		}
+
+		define('KIRBY_TMP_DIR', $tempDir);
+		define('KIRBY_TESTING', true);
+	}
+}
+
+/**
+ * PHPUnit event subscriber to be executed after all tests have been run
+ *
+ * @author Lukas Bestle <lukas@getkirby.com>
+ * @link https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license https://opensource.org/licenses/MIT
+ */
+final class TempCleanupSubscriber implements ExecutionFinishedSubscriber
+{
+	public function notify(ExecutionFinished $event): void
+	{
+		Dir::remove(KIRBY_TMP_DIR);
+	}
+}

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -3,6 +3,7 @@
 namespace Kirby;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Core;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
@@ -50,6 +51,9 @@ final class PhpUnitExtension implements Extension
 		// disable Whoops for all tests that don't need it
 		// to reduce the impact of memory leaks
 		App::$enableWhoops = false;
+
+		// prevent PHPUnit tests from accessing files outside the repo
+		Core::$indexRoot = '/dev/null';
 	}
 }
 

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -38,14 +38,14 @@ final class PhpUnitExtension implements Extension
 	public static function init(): void
 	{
 		// determine a unique path to a temporary directory
-		$tempDir = __DIR__ . '/tmp';
+		$tmpDir = __DIR__ . '/tmp';
 
 		// when running via ParaTest, use a separate directory for each process
 		if (getenv('UNIQUE_TEST_TOKEN') !== false) {
-			$tempDir .= '/' . getenv('UNIQUE_TEST_TOKEN');
+			$tmpDir .= '/' . getenv('UNIQUE_TEST_TOKEN');
 		}
 
-		define('KIRBY_TMP_DIR', $tempDir);
+		define('KIRBY_TMP_DIR', $tmpDir);
 		define('KIRBY_TESTING', true);
 
 		// disable Whoops for all tests that don't need it

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -27,10 +27,6 @@ final class PhpUnitExtension implements Extension
 		Facade $facade,
 		ParameterCollection $parameters
 	): void {
-		// disable Whoops for all tests that don't need it
-		// to reduce the impact of memory leaks
-		App::$enableWhoops = false;
-
 		// ensure the temp directory is there
 		Dir::make(KIRBY_TMP_DIR);
 
@@ -38,7 +34,7 @@ final class PhpUnitExtension implements Extension
 		$facade->registerSubscriber(new TempCleanupSubscriber());
 	}
 
-	public static function defineConstants(): void
+	public static function init(): void
 	{
 		// determine a unique path to a temporary directory
 		$tempDir = __DIR__ . '/tmp';
@@ -50,6 +46,10 @@ final class PhpUnitExtension implements Extension
 
 		define('KIRBY_TMP_DIR', $tempDir);
 		define('KIRBY_TESTING', true);
+
+		// disable Whoops for all tests that don't need it
+		// to reduce the impact of memory leaks
+		App::$enableWhoops = false;
 	}
 }
 

--- a/tests/Query/QueryDefaultFunctionsTest.php
+++ b/tests/Query/QueryDefaultFunctionsTest.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use Kirby\Filesystem\Dir;
 use Kirby\Image\QrCode;
 use Kirby\Toolkit\I18n;
 
@@ -16,6 +17,13 @@ use Kirby\Toolkit\I18n;
  */
 class QueryDefaultFunctionsTest extends \PHPUnit\Framework\TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Query.QueryDefaultFunctions';
+
+	public function tearDown(): void
+	{
+		Dir::remove(static::TMP);
+	}
+
 	public function testKirby()
 	{
 		$query = new Query('kirby');
@@ -77,6 +85,9 @@ class QueryDefaultFunctionsTest extends \PHPUnit\Framework\TestCase
 	public function testPage()
 	{
 		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
 			'site' => [
 				'children' => [
 					[

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -37,6 +37,7 @@ class KirbyTagTest extends TestCase
 	{
 		KirbyTag::$aliases = [];
 		KirbyTag::$types = [];
+		App::destroy();
 	}
 
 	/**
@@ -224,90 +225,165 @@ class KirbyTagTest extends TestCase
 
 	/**
 	 * @covers ::parse
+	 * @dataProvider parseProvider
 	 */
-	public function testParse()
+	public function testParse(string $string, array $data, array $options, array $expected)
 	{
-		$tag = KirbyTag::parse('(test: test value)', ['some' => 'data'], ['some' => 'options']);
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame(['some' => 'data'], $tag->data);
-		$this->assertSame(['some' => 'options'], $tag->options);
-		$this->assertSame([], $tag->attrs);
+		$tag = KirbyTag::parse($string, $data, $options);
+		foreach ($expected as $key => $value) {
+			$this->assertSame($value, $tag->$key);
+		}
+	}
 
-		$tag = KirbyTag::parse('test: test value');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([], $tag->attrs);
-
-		$tag = KirbyTag::parse('test:');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('', $tag->value);
-		$this->assertSame([], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: ');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('', $tag->value);
-		$this->assertSame([], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA b: attrB');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => 'attrB'
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test:test value a:attrA b:attrB');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => 'attrB'
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA b:');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => ''
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA b: ');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => ''
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA b: attrB ');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => 'attrB'
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA c: attrC b: attrB');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA c: attrC',
-			'b' => 'attrB'
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('test: test value a: attrA b: attrB c: attrC');
-		$this->assertSame('test', $tag->type);
-		$this->assertSame('test value', $tag->value);
-		$this->assertSame([
-			'a' => 'attrA',
-			'b' => 'attrB c: attrC'
-		], $tag->attrs);
-
-		$tag = KirbyTag::parse('file: file://abc a: attrA b: attrB c: attrC');
-		$this->assertSame('file://abc', $tag->value);
-		$this->assertSame(['a' => 'attrA b: attrB c: attrC'], $tag->attrs);
+	public static function parseProvider(): array
+	{
+		return [
+			[
+				'(test: test value)',
+				['some' => 'data'],
+				['some' => 'options'],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'data'    => ['some' => 'data'],
+					'options' => ['some' => 'options'],
+					'attrs'   => []
+				]
+			],
+			[
+				'test: test value',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => []
+				]
+			],
+			[
+				'test:',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => '',
+					'attrs'   => []
+				]
+			],
+			[
+				'test: ',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => '',
+					'attrs'   => []
+				]
+			],
+			[
+				'test: test value a: attrA b: attrB',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => 'attrB'
+					]
+				]
+			],
+			[
+				'test:test value a:attrA b:attrB',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => 'attrB'
+					]
+				]
+			],
+			[
+				'test: test value a: attrA b:',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => ''
+					]
+				]
+			],
+			[
+				'test: test value a: attrA b: ',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => ''
+					]
+				]
+			],
+			[
+				'test: test value a: attrA b: attrB ',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => 'attrB'
+					]
+				]
+			],
+			[
+				'test: test value a: attrA c: attrC b: attrB',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA c: attrC',
+						'b' => 'attrB'
+					]
+				]
+			],
+			[
+				'test: test value a: attrA b: attrB c: attrC',
+				[],
+				[],
+				[
+					'type'    => 'test',
+					'value'   => 'test value',
+					'attrs'   => [
+						'a' => 'attrA',
+						'b' => 'attrB c: attrC'
+					]
+				]
+			],
+			[
+				'file: file://abc a: attrA b: attrB c: attrC',
+				[],
+				[],
+				[
+					'type'    => 'file',
+					'value'   => 'file://abc',
+					'attrs'   => [
+						'a' => 'attrA b: attrB c: attrC'
+					]
+				]
+			],
+		];
 	}
 
 	/**

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -16,6 +16,59 @@ use PHPUnit\Framework\AssertionFailedError;
  */
 class DomTest extends TestCase
 {
+	protected static $testClosures = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		// define static test closures for use in data providers because returning a closure
+		// from a data provider breaks serialization when using PHPUnit process isolation
+		static::$testClosures = [
+			'listContainsName_customCompare1' => function ($expected, $real): bool {
+				return strtolower($expected) === strtolower($real);
+			},
+			'listContainsName_customCompare2' => function ($expected, $real): bool {
+				return strtolower($expected) === strtolower($real);
+			},
+			'serialize_attrCallback1' => function (DOMAttr $attr, array $options): void {
+				// no return value
+			},
+			'serialize_attrCallback2' => function (DOMAttr $attr, array $options): array {
+				if (is_a($options['attrCallback'], Closure::class) !== true) {
+					throw new AssertionFailedError('Options provided to callback are not complete or invalid');
+				}
+
+				if ($attr->nodeName === 'b') {
+					$attr->ownerElement->removeAttributeNode($attr);
+					return [new InvalidArgumentException('The "b" attribute is not allowed')];
+				}
+
+				return [];
+			},
+			'sanitize_doctypeCallback' => function (DOMDocumentType $doctype, array $options): void {
+				if (is_a($options['doctypeCallback'], Closure::class) !== true) {
+					throw new AssertionFailedError('Options provided to callback are not complete or invalid');
+				}
+
+				throw new InvalidArgumentException('The "' . $doctype->name . '" doctype is not allowed');
+			},
+			'sanitize_elementCallback1' => function (DOMElement $element, array $options): void {
+				// no return value
+			},
+			'sanitize_elementCallback2' => function (DOMElement $element, array $options): array {
+				if (is_a($options['elementCallback'], Closure::class) !== true) {
+					throw new AssertionFailedError('Options provided to callback are not complete or invalid');
+				}
+
+				if ($element->nodeName === 'b') {
+					Dom::remove($element);
+					return [new InvalidArgumentException('The "b" element is not allowed')];
+				}
+
+				return [];
+			},
+		];
+	}
+
 	public static function parseSaveProvider(): array
 	{
 		return [
@@ -1182,9 +1235,7 @@ class DomTest extends TestCase
 				['html', 'bodY'],
 				['BoDy', ''],
 				[],
-				function ($expected, $real): bool {
-					return strtolower($expected) === strtolower($real);
-				},
+				'listContainsName_customCompare1',
 
 				'bodY'
 			],
@@ -1192,9 +1243,7 @@ class DomTest extends TestCase
 				['html', 'bodY'],
 				['BoDy', ''],
 				true,
-				function ($expected, $real): bool {
-					return strtolower($expected) === strtolower($real);
-				},
+				'listContainsName_customCompare2',
 
 				'bodY'
 			],
@@ -1205,8 +1254,12 @@ class DomTest extends TestCase
 	 * @dataProvider listContainsNameProvider
 	 * @covers ::listContainsName
 	 */
-	public function testListContainsName(array $list, array $node, $allowedNamespaces, Closure|null $compare, $expected)
+	public function testListContainsName(array $list, array $node, $allowedNamespaces, string|null $compare, $expected)
 	{
+		if ($compare !== null) {
+			$compare = static::$testClosures[$compare];
+		}
+
 		[$nodeName, $nodeNS] = $node;
 		if ($nodeNS !== null) {
 			$element = new DOMElement($nodeName, null, $nodeNS);
@@ -1654,9 +1707,7 @@ class DomTest extends TestCase
 			[
 				'<xml a="A" b="B"/>',
 				[
-					'attrCallback' => function (DOMAttr $attr, array $options): void {
-						// no return value
-					}
+					'attrCallback' => 'serialize_attrCallback1' // static test closure defined at the top of the file
 				],
 
 				'<xml a="A" b="B"/>',
@@ -1665,18 +1716,7 @@ class DomTest extends TestCase
 			[
 				'<xml a="A" b="B"/>',
 				[
-					'attrCallback' => function (DOMAttr $attr, array $options): array {
-						if (is_a($options['attrCallback'], Closure::class) !== true) {
-							throw new AssertionFailedError('Options provided to callback are not complete or invalid');
-						}
-
-						if ($attr->nodeName === 'b') {
-							$attr->ownerElement->removeAttributeNode($attr);
-							return [new InvalidArgumentException('The "b" attribute is not allowed')];
-						}
-
-						return [];
-					}
+					'attrCallback' => 'serialize_attrCallback2' // static test closure defined at the top of the file
 				],
 
 				'<xml a="A"/>',
@@ -1735,13 +1775,7 @@ class DomTest extends TestCase
 			[
 				'<!DOCTYPE svg><xml/>',
 				[
-					'doctypeCallback' => function (DOMDocumentType $doctype, array $options): void {
-						if (is_a($options['doctypeCallback'], Closure::class) !== true) {
-							throw new AssertionFailedError('Options provided to callback are not complete or invalid');
-						}
-
-						throw new InvalidArgumentException('The "' . $doctype->name . '" doctype is not allowed');
-					}
+					'doctypeCallback' => 'sanitize_doctypeCallback' // static test closure defined at the top of the file
 				],
 
 				'<xml/>',
@@ -1752,9 +1786,7 @@ class DomTest extends TestCase
 			[
 				'<xml><a class="a">A</a><b class="b">B</b></xml>',
 				[
-					'elementCallback' => function (DOMElement $element, array $options): void {
-						// no return value
-					}
+					'elementCallback' => 'sanitize_elementCallback1' // static test closure defined at the top of the file
 				],
 
 				'<xml><a class="a">A</a><b class="b">B</b></xml>',
@@ -1763,18 +1795,7 @@ class DomTest extends TestCase
 			[
 				'<xml><a class="a">A</a><b class="b">B</b></xml>',
 				[
-					'elementCallback' => function (DOMElement $element, array $options): array {
-						if (is_a($options['elementCallback'], Closure::class) !== true) {
-							throw new AssertionFailedError('Options provided to callback are not complete or invalid');
-						}
-
-						if ($element->nodeName === 'b') {
-							Dom::remove($element);
-							return [new InvalidArgumentException('The "b" element is not allowed')];
-						}
-
-						return [];
-					}
+					'elementCallback' => 'sanitize_elementCallback2' // static test closure defined at the top of the file
 				],
 
 				'<xml><a class="a">A</a></xml>',
@@ -1814,6 +1835,13 @@ class DomTest extends TestCase
 	 */
 	public function testSanitize(string $code, array $options, string $expectedCode, array $expectedErrors)
 	{
+		// hydrate the closures in the options from the static closures
+		foreach (['attrCallback', 'doctypeCallback', 'elementCallback'] as $name) {
+			if (isset($options[$name]) === true) {
+				$options[$name] = static::$testClosures[$options[$name]];
+			}
+		}
+
 		$dom    = new Dom($code, 'XML');
 		$errors = $dom->sanitize($options);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ ini_set('display_startup_errors', 'on');
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/PhpUnitExtension.php';
 
-PhpUnitExtension::defineConstants();
+PhpUnitExtension::init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,15 +1,14 @@
 <?php
 
-use Kirby\Cms\App;
+use Kirby\PhpUnitExtension;
 
+// enable all error handling as early as possible to
+// make debugging of issues in the test setup easier
 error_reporting(E_ALL);
 ini_set('display_errors', 'on');
 ini_set('display_startup_errors', 'on');
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/PhpUnitExtension.php';
 
-define('KIRBY_TESTING', true);
-
-// disable Whoops for all tests that don't need it
-// to reduce the impact of memory leaks
-App::$enableWhoops = false;
+PhpUnitExtension::defineConstants();


### PR DESCRIPTION
## Info

First of two PRs. The second one is already done and contains all the temp folder refactoring throughout all tests. To make reviewing easier, I've split the other changes out into this PR. Will push the second PR once this one is merged.

Would be good to have both reviewed and merged soon to avoid merge conflicts. 🙏

---

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Fix fallbacks in the `Kirby/Api/Api` and `Kirby/Form/Form` classes when no app object is loaded
- The CLI detection also works for processes not attached to a terminal (e.g. externally called from another script)

### Housekeeping

- Our PHPUnit tests can now be run individually with process isolation
- New internal PHPUnit extension to manage constants and the temporary folder
- Running the PHPUnit tests no longer spills files outside the repo path
- Replace remote testing domain with example.com
- Delete temporary testing files from the repo

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
