### PR TITLE
Use proper tmp and fixture directories in tests

### DIFF
--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -644,7 +644,7 @@ class ApiTest extends TestCase
 				'files' => [
 					[
 						'name'     => 'test.txt',
-						'tmp_name' => __DIR__ . '/fixtures/tmp/abc',
+						'tmp_name' => KIRBY_TMP_DIR . '/api.api/abc',
 						'size'     => 123,
 						'error'    => 0
 					]
@@ -711,13 +711,13 @@ class ApiTest extends TestCase
 				'files' => [
 					[
 						'name'     => 'foo.txt',
-						'tmp_name' => __DIR__ . '/fixtures/tmp/foo',
+						'tmp_name' => KIRBY_TMP_DIR . '/api.api/foo',
 						'size'     => 123,
 						'error'    => 0
 					],
 					[
 						'name'     => 'bar.txt',
-						'tmp_name' => __DIR__ . '/fixtures/tmp/bar',
+						'tmp_name' => KIRBY_TMP_DIR . '/api.api/bar',
 						'size'     => 123,
 						'error'    => 0
 					]

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -13,9 +13,11 @@ require_once __DIR__ . '/mocks.php';
  */
 class FileCacheTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cache.FileCache';
+
 	public function tearDown(): void
 	{
-		Dir::remove(__DIR__ . '/tmp');
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -25,7 +27,7 @@ class FileCacheTest extends TestCase
 	public function testConstruct()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp'
+			'root' => $root = static::TMP
 		]);
 
 		$this->assertSame($root, $cache->root());
@@ -39,7 +41,7 @@ class FileCacheTest extends TestCase
 	public function testConstructWithPrefix()
 	{
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/tmp',
+			'root'   => $root = static::TMP,
 			'prefix' => 'test'
 		]);
 
@@ -53,7 +55,7 @@ class FileCacheTest extends TestCase
 	public function testEnabled()
 	{
 		$cache = new FileCache([
-			'root' => __DIR__ . '/tmp'
+			'root' => static::TMP
 		]);
 
 		$this->assertTrue($cache->enabled());
@@ -65,7 +67,7 @@ class FileCacheTest extends TestCase
 	public function testEnabledNotWritable()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp'
+			'root' => $root = static::TMP
 		]);
 
 		chmod($root, 0444);
@@ -82,56 +84,56 @@ class FileCacheTest extends TestCase
 		$method->setAccessible(true);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp'
+			'root' => $root = static::TMP
 		]);
 		$this->assertSame($root . '/test', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'extension' => 'cache'
 		]);
 		$this->assertSame($root . '/test.cache', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/tmp',
+			'root'   => $root = static::TMP,
 			'prefix' => 'test1'
 		]);
 		$this->assertSame($root . '/test1/test', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'prefix'    => 'test1',
 			'extension' => 'cache'
 		]);
 		$this->assertSame($root . '/test1/test.cache', $method->invoke($cache, 'test'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/_empty/test', $method->invoke($cache, '/test'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/test/_empty', $method->invoke($cache, 'test/'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/test/_backslash/foo/bar', $method->invoke($cache, 'test\\foo/bar'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/test/_backslash/_empty/foo/_backslash/bar', $method->invoke($cache, 'test\\/foo\\bar'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/_empty/test/_empty', $method->invoke($cache, '/test/'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/_9d891e731f75deae56884d79e9816736b7488080/test',
@@ -139,7 +141,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -147,12 +149,12 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame($root . '/_3a52ce780950d4d969792a2559cd519d7ee8c727/test-page', $method->invoke($cache, './test-page'));
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame(
 			$root . '/_3a52ce780950d4d969792a2559cd519d7ee8c727/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -160,7 +162,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/pages/test/_empty',
@@ -168,7 +170,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 		]);
 		$this->assertSame(
 			$root . '/_9d891e731f75deae56884d79e9816736b7488080/pages/test-cache_4caff0c1d0c8eb128ed9896b4b0258ef2848816b',
@@ -176,7 +178,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'extension' => 'cache'
 		]);
 		$this->assertSame(
@@ -185,7 +187,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'   => $root = __DIR__ . '/tmp',
+			'root'   => $root = static::TMP,
 			'prefix' => 'prefix'
 		]);
 		$this->assertSame(
@@ -194,7 +196,7 @@ class FileCacheTest extends TestCase
 		);
 
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'prefix'    => 'prefix',
 			'extension' => 'cache'
 		]);
@@ -217,7 +219,7 @@ class FileCacheTest extends TestCase
 	public function testOperations()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp'
+			'root' => $root = static::TMP
 		]);
 
 		$time = time();
@@ -252,7 +254,7 @@ class FileCacheTest extends TestCase
 	public function testOperationsWithExtension()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'extension' => 'cache'
 		]);
 
@@ -286,11 +288,11 @@ class FileCacheTest extends TestCase
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 			'prefix' => 'test1'
 		]);
 		$cache2 = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 			'prefix' => 'test2'
 		]);
 
@@ -329,7 +331,7 @@ class FileCacheTest extends TestCase
 	public function testFlush()
 	{
 		$cache = new FileCache([
-			'root' => $root = __DIR__ . '/tmp'
+			'root' => $root = static::TMP
 		]);
 
 		$cache->set('a', 'A basic value');
@@ -354,11 +356,11 @@ class FileCacheTest extends TestCase
 	public function testFlushWithPrefix()
 	{
 		$cache1 = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 			'prefix' => 'test1'
 		]);
 		$cache2 = new FileCache([
-			'root' => $root = __DIR__ . '/tmp',
+			'root' => $root = static::TMP,
 			'prefix' => 'test2'
 		]);
 
@@ -390,7 +392,7 @@ class FileCacheTest extends TestCase
 	public function testRemoveEmptyDirectories()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'extension' => 'cache'
 		]);
 
@@ -414,7 +416,7 @@ class FileCacheTest extends TestCase
 	public function testRemoveEmptyDirectoriesWithNotEmptyDirs()
 	{
 		$cache = new FileCache([
-			'root'      => $root = __DIR__ . '/tmp',
+			'root'      => $root = static::TMP,
 			'extension' => 'cache'
 		]);
 

--- a/tests/Cms/Api/ApiCollectionTestCase.php
+++ b/tests/Cms/Api/ApiCollectionTestCase.php
@@ -10,22 +10,37 @@ class ApiCollectionTestCase extends TestCase
 {
 	protected $api;
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
+
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => $this->hasTmp() ? static::TMP : '/dev/null',
 			],
 		]);
 
 		$this->api = $this->app->api();
-		Dir::make($this->tmp);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		App::destroy();
+
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
+	}
+
+	/**
+	 * Checks if the test class extending this test case class
+	 * has defined a temporary directory
+	 */
+	protected function hasTmp(): bool
+	{
+		return defined(get_class($this) . '::TMP');
 	}
 }

--- a/tests/Cms/Api/ApiModelTestCase.php
+++ b/tests/Cms/Api/ApiModelTestCase.php
@@ -10,23 +10,29 @@ class ApiModelTestCase extends TestCase
 {
 	protected $api;
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
+
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => $this->hasTmp() ? static::TMP : '/dev/null',
 			],
 		]);
 
 		$this->api = $this->app->api();
-		Dir::make($this->tmp);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		App::destroy();
+
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
 	}
 
 	public function attr($object, $attr)
@@ -37,5 +43,14 @@ class ApiModelTestCase extends TestCase
 	public function assertAttr($object, $attr, $value)
 	{
 		$this->assertSame($this->attr($object, $attr), $value);
+	}
+
+	/**
+	 * Checks if the test class extending this test case class
+	 * has defined a temporary directory
+	 */
+	protected function hasTmp(): bool
+	{
+		return defined(get_class($this) . '::TMP');
 	}
 }

--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -11,16 +11,17 @@ use Kirby\Toolkit\I18n;
 
 class ApiTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Api';
+
 	protected $api;
 	protected $locale;
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -72,12 +73,12 @@ class ApiTest extends TestCase
 		$this->api = $this->app->api();
 
 		$this->locale = setlocale(LC_ALL, 0);
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 		setlocale(LC_ALL, $this->locale);
 	}
 

--- a/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
+++ b/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiCollectionTestCase;
 
 class ChildrenApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.ChildrenApiCollection';
+
 	public function testCollection()
 	{
 		$site = new Site([

--- a/tests/Cms/Api/collections/FilesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/FilesApiCollectionTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiCollectionTestCase;
 
 class FilesApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.FilesApiCollection';
+
 	public function testCollection()
 	{
 		$page = new Page([

--- a/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
@@ -7,11 +7,13 @@ use Kirby\Filesystem\Dir;
 
 class LanguagesApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguagesApiCollection';
+
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'languages' => [
 				[
@@ -25,7 +27,7 @@ class LanguagesApiCollectionTest extends ApiCollectionTestCase
 		]);
 
 		$this->api = $this->app->api();
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function testCollection()

--- a/tests/Cms/Api/collections/PagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/PagesApiCollectionTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiCollectionTestCase;
 
 class PagesApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PagesApiCollection';
+
 	public function testCollection()
 	{
 		$collection = $this->api->collection('pages', new Pages([

--- a/tests/Cms/Api/collections/RolesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/RolesApiCollectionTest.php
@@ -7,11 +7,13 @@ use Kirby\Filesystem\Dir;
 
 class RolesApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.RolesApiCollection';
+
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'roles' => [
 				[
@@ -24,7 +26,7 @@ class RolesApiCollectionTest extends ApiCollectionTestCase
 		]);
 
 		$this->api = $this->app->api();
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function testCollection()

--- a/tests/Cms/Api/collections/UsersApiCollectionTest.php
+++ b/tests/Cms/Api/collections/UsersApiCollectionTest.php
@@ -7,11 +7,13 @@ use Kirby\Filesystem\Dir;
 
 class UsersApiCollectionTest extends ApiCollectionTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.UsersApiCollection';
+
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'users' => [
 				['email' => 'a@getkirby.com'],
@@ -20,7 +22,7 @@ class UsersApiCollectionTest extends ApiCollectionTestCase
 		]);
 
 		$this->api = $this->app->api();
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function testDefaultCollection()

--- a/tests/Cms/Api/models/FileApiModelTest.php
+++ b/tests/Cms/Api/models/FileApiModelTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiModelTestCase;
 
 class FileApiModelTest extends ApiModelTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.FileApiModel';
+
 	public function testNextWithTemplate()
 	{
 		$page = new Page([

--- a/tests/Cms/Api/models/FileVersionApiModelTest.php
+++ b/tests/Cms/Api/models/FileVersionApiModelTest.php
@@ -7,16 +7,17 @@ use Kirby\Filesystem\Dir;
 
 class FileVersionApiModelTest extends ApiModelTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.FileVersionApiModel';
+
 	protected $file;
 	protected $parent;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		parent::setUp();
 
 		$this->parent = new Page([
-			'root' => $this->fixtures = __DIR__ . '/fixtures',
+			'root' => static::TMP,
 			'slug' => 'test'
 		]);
 
@@ -31,14 +32,14 @@ class FileVersionApiModelTest extends ApiModelTestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function testExists()
 	{
 		$version = new FileVersion([
 			'original' => $this->file,
-			'root'     => $this->fixtures . '/test-version.jpg',
+			'root'     => static::TMP . '/test-version.jpg',
 		]);
 
 		$this->assertAttr($version, 'exists', false);
@@ -48,7 +49,7 @@ class FileVersionApiModelTest extends ApiModelTestCase
 	{
 		$version = new FileVersion([
 			'original' => $this->file,
-			'root'     => $this->fixtures . '/test-version.jpg',
+			'root'     => static::TMP . '/test-version.jpg',
 		]);
 
 		$this->assertAttr($version, 'type', 'image');
@@ -58,7 +59,7 @@ class FileVersionApiModelTest extends ApiModelTestCase
 	{
 		$version = new FileVersion([
 			'original' => $this->file,
-			'root'     => $this->fixtures . '/test-version.jpg',
+			'root'     => static::TMP . '/test-version.jpg',
 		]);
 
 		$this->assertAttr($version, 'url', null);

--- a/tests/Cms/Api/models/PageApiModelTest.php
+++ b/tests/Cms/Api/models/PageApiModelTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiModelTestCase;
 
 class PageApiModelTest extends ApiModelTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageApiModel';
+
 	public function testChildren()
 	{
 		$page = new Page([

--- a/tests/Cms/Api/models/SiteApiModelTest.php
+++ b/tests/Cms/Api/models/SiteApiModelTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiModelTestCase;
 
 class SiteApiModelTest extends ApiModelTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.SiteApiModel';
+
 	public function testBlueprint()
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\Api\ApiModelTestCase;
 
 class UserApiModelTest extends ApiModelTestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.UserApiModel';
+
 	protected $user;
 
 	public function setUp(): void

--- a/tests/Cms/Api/routes/AccountRoutesTest.php
+++ b/tests/Cms/Api/routes/AccountRoutesTest.php
@@ -8,8 +8,10 @@ use PHPUnit\Framework\TestCase;
 
 class AccountRoutesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AccountRoutes';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -28,7 +30,7 @@ class AccountRoutesTest extends TestCase
 				]
 			],
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -43,16 +45,16 @@ class AccountRoutesTest extends TestCase
 		]);
 
 		$this->app->impersonate('test@getkirby.com');
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		App::destroy();
 		Field::$types = [];
 		Section::$types = [];
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function testAvatar()
@@ -60,7 +62,7 @@ class AccountRoutesTest extends TestCase
 		// create an avatar for the user
 		$this->app->user()->createFile([
 			'filename' => 'profile.jpg',
-			'source'   => __DIR__ . '/fixtures/avatar.jpg',
+			'source'   => static::FIXTURES . '/avatar.jpg',
 			'template' => 'avatar',
 		]);
 
@@ -74,7 +76,7 @@ class AccountRoutesTest extends TestCase
 		// create an avatar for the user
 		$this->app->user()->createFile([
 			'filename' => 'profile.jpg',
-			'source'   => __DIR__ . '/fixtures/avatar.jpg',
+			'source'   => static::FIXTURES . '/avatar.jpg',
 			'template' => 'avatar',
 		]);
 

--- a/tests/Cms/Api/routes/AuthRoutesTest.php
+++ b/tests/Cms/Api/routes/AuthRoutesTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class AuthRoutesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthRoutes';
+
 	protected $app;
 
 	public function setUp(): void
@@ -17,16 +19,15 @@ class AuthRoutesTest extends TestCase
 				'api.allowImpersonation' => true
 			],
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/AuthRoutesTest'
+				'index' => static::TMP
 			],
 		]);
-
-		Dir::remove($fixtures);
 	}
 
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
+		Dir::remove(static::TMP);
 	}
 
 	public function testGet()

--- a/tests/Cms/Api/routes/LanguagesRoutesTest.php
+++ b/tests/Cms/Api/routes/LanguagesRoutesTest.php
@@ -2,18 +2,19 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
 class LanguagesRoutesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguagesRoutes';
+
 	protected $app;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/LanguagesRoutesTest'
+				'index' => static::TMP
 			],
 			'options' => [
 				'api.allowImpersonation' => true,
@@ -33,8 +34,6 @@ class LanguagesRoutesTest extends TestCase
 		]);
 
 		$this->app->impersonate('kirby');
-
-		Dir::remove($fixtures);
 	}
 
 	public function testList()

--- a/tests/Cms/Api/routes/PagesRoutesTest.php
+++ b/tests/Cms/Api/routes/PagesRoutesTest.php
@@ -7,8 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class PagesRoutesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PagesRoutes';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -17,15 +18,15 @@ class PagesRoutesTest extends TestCase
 				'api.allowImpersonation' => true
 			],
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testGet()

--- a/tests/Cms/Api/routes/SiteRoutesTest.php
+++ b/tests/Cms/Api/routes/SiteRoutesTest.php
@@ -7,8 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class SiteRoutesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.SiteRoutes';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -17,7 +18,7 @@ class SiteRoutesTest extends TestCase
 				'api.allowImpersonation' => true
 			],
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'site' => [
 				'content' => [
@@ -27,12 +28,13 @@ class SiteRoutesTest extends TestCase
 		]);
 
 		$this->app->impersonate('kirby');
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function testGet()

--- a/tests/Cms/Api/routes/SystemRoutesTest.php
+++ b/tests/Cms/Api/routes/SystemRoutesTest.php
@@ -2,22 +2,21 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
 class SystemRoutesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.SystemRoutes';
+
 	protected $app;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/SystemRoutesTest'
+				'index' => static::TMP
 			]
 		]);
-
-		Dir::remove($fixtures);
 	}
 
 	public function testGetWithInvalidServerSoftware()

--- a/tests/Cms/Api/routes/UsersRoutesTest.php
+++ b/tests/Cms/Api/routes/UsersRoutesTest.php
@@ -8,8 +8,10 @@ use PHPUnit\Framework\TestCase;
 
 class UsersRoutesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.UsersRoutes';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
@@ -28,7 +30,7 @@ class UsersRoutesTest extends TestCase
 				]
 			],
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/UsersRoutesTest'
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -52,17 +54,15 @@ class UsersRoutesTest extends TestCase
 		App::destroy();
 		Field::$types = [];
 		Section::$types = [];
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function testAvatar()
 	{
-		$this->app->impersonate('kirby');
-
 		// create an avatar for the user
 		$this->app->user('admin@getkirby.com')->createFile([
 			'filename' => 'profile.jpg',
-			'source'   => __DIR__ . '/fixtures/avatar.jpg',
+			'source'   => static::FIXTURES . '/avatar.jpg',
 			'template' => 'avatar',
 		]);
 
@@ -73,12 +73,10 @@ class UsersRoutesTest extends TestCase
 
 	public function testAvatarDelete()
 	{
-		$this->app->impersonate('kirby');
-
 		// create an avatar for the user
 		$this->app->user('admin@getkirby.com')->createFile([
 			'filename' => 'profile.jpg',
-			'source'   => __DIR__ . '/fixtures/avatar.jpg',
+			'source'   => static::FIXTURES . '/avatar.jpg',
 			'template' => 'avatar',
 		]);
 

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -9,11 +9,13 @@ use Kirby\Filesystem\Dir;
 
 class AppCachesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.AppCaches';
+
 	public function app(array $props = [])
 	{
 		return new App(array_merge([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/AppCachesTest',
+				'index' => static::TMP,
 			]
 		], $props));
 	}
@@ -22,7 +24,7 @@ class AppCachesTest extends TestCase
 	{
 		parent::tearDown();
 
-		Dir::remove(__DIR__ . '/fixtures/AppCachesTest');
+		Dir::remove(static::TMP);
 	}
 
 	public function testDisabledCache()
@@ -67,7 +69,7 @@ class AppCachesTest extends TestCase
 			'options' => [
 				'cache.pages' => [
 					'type' => 'file',
-					'root' => $root = __DIR__ . '/fixtures/AppCachesTest/cache'
+					'root' => $root = static::TMP . '/cache'
 				]
 			]
 		]);
@@ -88,7 +90,7 @@ class AppCachesTest extends TestCase
 			'options' => [
 				'cache.pages' => [
 					'type' => 'file',
-					'root' => $root = __DIR__ . '/fixtures/AppCachesTest/cache'
+					'root' => $root = static::TMP . '/cache'
 				]
 			]
 		]);

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Kirby\Content\Field;
 use Kirby\Email\Email;
 use Kirby\Exception\NotFoundException;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Template\Template;
 use Kirby\Toolkit\Obj;
@@ -28,6 +27,8 @@ class CustomEmailProvider extends Email
 
 class AppComponentsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.AppComponents';
+
 	protected $kirby;
 
 	public function setUp(): void
@@ -302,18 +303,18 @@ class AppComponentsTest extends TestCase
 	{
 		$app = $this->kirby->clone([
 			'roots' => [
-				'snippets' => $tmp = __DIR__ . '/tmp/snippets'
+				'snippets' => static::TMP
 			],
 			'snippets' => [
-				'plugin' => $tmp . '/plugin-snippet.php' // explicitly different filename
+				'plugin' => static::TMP . '/plugin-snippet.php' // explicitly different filename
 			]
 		]);
 
-		F::write($tmp . '/variable.php', '<?= $message;');
-		F::write($tmp . '/item.php', '<?= $item->method();');
-		F::write($tmp . '/test.php', 'test');
-		F::write($tmp . '/fallback.php', 'fallback');
-		F::write($tmp . '/plugin-snippet.php', 'plugin');
+		F::write(static::TMP . '/variable.php', '<?= $message;');
+		F::write(static::TMP . '/item.php', '<?= $item->method();');
+		F::write(static::TMP . '/test.php', 'test');
+		F::write(static::TMP . '/fallback.php', 'fallback');
+		F::write(static::TMP . '/plugin-snippet.php', 'plugin');
 
 		// simple string
 		$this->assertSame('test', $app->snippet('test'));
@@ -349,8 +350,6 @@ class AppComponentsTest extends TestCase
 		// with direct output
 		$this->expectOutputString('test');
 		$app->snippet('variable', ['message' => 'test'], false);
-
-		Dir::remove($tmp);
 	}
 
 	public function testTemplate()
@@ -393,7 +392,7 @@ class AppComponentsTest extends TestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/AppComponentsTest',
+				'index' => static::TMP,
 			]
 		]);
 

--- a/tests/Cms/App/AppIoTest.php
+++ b/tests/Cms/App/AppIoTest.php
@@ -8,12 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class AppIoTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function app()
 	{
 		return new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => __DIR__ . '/fixtures/AppIoTest/templates'
+				'templates' => static::FIXTURES . '/AppIoTest/templates'
 			]
 		]);
 	}

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -53,15 +53,11 @@ class DummyUser extends User
  */
 class AppPluginsTest extends TestCase
 {
-	public $fixtures;
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppPlugins';
 
 	// used for testPluginLoader()
 	public static $calledPluginsLoadedHook = false;
-
-	public function setUp(): void
-	{
-		App::destroy();
-	}
 
 	public function testApi()
 	{
@@ -247,7 +243,7 @@ class AppPluginsTest extends TestCase
 	{
 		$kirby = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/AppPluginsTest/testAuthChallenge'
+				'index' => static::TMP
 			],
 			'authChallenges' => [
 				'dummy' => 'Kirby\Cms\DummyAuthChallenge'
@@ -282,7 +278,6 @@ class AppPluginsTest extends TestCase
 		);
 
 		$kirby->session()->destroy();
-		Dir::remove($fixtures);
 	}
 
 	public function testBlueprint()
@@ -303,7 +298,7 @@ class AppPluginsTest extends TestCase
 	{
 		$kirby = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/AppPluginsTest/testCacheType'
+				'index' => static::TMP
 			],
 			'cacheTypes' => [
 				'file' => DummyCache::class
@@ -316,8 +311,6 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$this->assertInstanceOf(DummyCache::class, $kirby->cache('pages'));
-
-		Dir::remove($fixtures);
 	}
 
 	public function testCollection()
@@ -427,7 +420,7 @@ class AppPluginsTest extends TestCase
 				'index' => '/dev/null'
 			],
 			'fields' => [
-				'dummy' => __DIR__ . '/fixtures/fields/DummyField.php'
+				'dummy' => static::FIXTURES . '/fields/DummyField.php'
 			]
 		]);
 
@@ -534,7 +527,7 @@ class AppPluginsTest extends TestCase
 		$kirby = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'models' => __DIR__ . '/fixtures/models'
+				'models' => static::FIXTURES . '/models'
 			]
 		]);
 
@@ -611,10 +604,11 @@ class AppPluginsTest extends TestCase
 	public function testExtensionsFromFolders()
 	{
 		Page::$models = [];
+		Dir::copy(static::FIXTURES . '/AppPluginsTest', static::TMP);
 
 		$kirby = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/AppPluginsTest'
+				'index' => static::TMP
 			]
 		]);
 
@@ -920,13 +914,15 @@ class AppPluginsTest extends TestCase
 		$phpUnit  = $this;
 		$executed = 0;
 
+		Dir::copy(static::FIXTURES . '/AppPluginsTest', $tmp = static::TMP);
+
 		$kirby = new App([
 			'roots' => [
-				'index'   => $this->fixtures = __DIR__ . '/fixtures/AppPluginsTest',
-				'plugins' => $this->fixtures . '/site/plugins-loader'
+				'index'   => static::TMP,
+				'plugins' => static::TMP . '/site/plugins-loader'
 			],
 			'hooks' => [
-				'system.loadPlugins:after' => function () use ($phpUnit, &$executed) {
+				'system.loadPlugins:after' => function () use ($phpUnit, &$executed, $tmp) {
 					if (count($this->plugins()) === 2) {
 						$phpUnit->assertSame([
 							'kirby/manual1' => new Plugin('kirby/manual1', []),
@@ -941,7 +937,7 @@ class AppPluginsTest extends TestCase
 										// just a dummy closure to compare against
 									}
 								],
-								'root' => $phpUnit->fixtures . '/site/plugins-loader/test1'
+								'root' => $tmp . '/site/plugins-loader/test1'
 							])
 						], $this->plugins());
 					}
@@ -970,10 +966,12 @@ class AppPluginsTest extends TestCase
 
 	public function testPluginLoaderAnonymous()
 	{
+		Dir::copy(static::FIXTURES . '/AppPluginsTest', static::TMP);
+
 		$kirby = new App([
 			'roots' => [
-				'index'   => $this->fixtures = __DIR__ . '/fixtures/AppPluginsTest',
-				'plugins' => $dir = $this->fixtures . '/site/plugins-loader-anonymous'
+				'index'   => static::TMP,
+				'plugins' => $dir = static::TMP . '/site/plugins-loader-anonymous'
 			]
 		]);
 

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -2,22 +2,12 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
 class AppResolveTest extends TestCase
 {
-	protected $fixtures;
-
-	public function setUp(): void
-	{
-		$this->fixtures = __DIR__ . '/fixtures/AppResolveTest';
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove($this->fixtures);
-	}
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppResolve';
 
 	public function testResolveHomePage()
 	{
@@ -87,17 +77,17 @@ class AppResolveTest extends TestCase
 
 	public function testResolvePageRepresentation()
 	{
-		F::write($template = $this->fixtures . '/test.php', 'html');
-		F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+		F::write($template = static::TMP . '/test.php', 'html');
+		F::write($template = static::TMP . '/test.xml.php', 'xml');
 		F::write(
-			$template = $this->fixtures . '/test.png.php',
+			$template = static::TMP . '/test.png.php',
 			'<?php $kirby->response()->type("image/jpeg"); ?>png'
 		);
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -183,13 +173,13 @@ class AppResolveTest extends TestCase
 
 	public function testResolveMultilangPageRepresentation()
 	{
-		F::write($template = $this->fixtures . '/test.php', 'html');
-		F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+		F::write($template = static::TMP . '/test.php', 'html');
+		F::write($template = static::TMP . '/test.xml.php', 'xml');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -267,7 +257,7 @@ class AppResolveTest extends TestCase
 	{
 		$this->app = new App([
 			'templates' => [
-				'blog' => __DIR__ . '/fixtures/templates/test.php',
+				'blog' => static::FIXTURES . '/templates/test.php',
 			],
 			'site' => [
 				'children' => [

--- a/tests/Cms/App/AppRolesTest.php
+++ b/tests/Cms/App/AppRolesTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 class AppRolesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function testSet()
 	{
 		$app = new App([
@@ -23,7 +25,7 @@ class AppRolesTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures'
+				'site' => static::FIXTURES
 			]
 		]);
 

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -17,18 +17,19 @@ use ReflectionMethod;
  */
 class AppTest extends TestCase
 {
-	protected $tmp;
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.App';
+
 	protected $_SERVER;
 
 	public function setUp(): void
 	{
 		$this->_SERVER = $_SERVER;
-		$this->tmp = __DIR__ . '/tmp';
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 		$_SERVER = $this->_SERVER;
 	}
 
@@ -302,7 +303,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'sessions' => $this->tmp,
+				'sessions' => static::TMP,
 			]
 		]);
 
@@ -630,7 +631,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'config' => __DIR__ . '/fixtures/AppTest/options'
+				'config' => static::FIXTURES . '/AppTest/options'
 			],
 			'server' => [
 				'SERVER_NAME' => 'getkirby.com',
@@ -655,7 +656,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'config' => __DIR__ . '/fixtures/AppTest/options-env1'
+				'config' => static::FIXTURES . '/AppTest/options-env1'
 			],
 			'server' => [
 				'SERVER_NAME' => 'getkirby.com',
@@ -681,7 +682,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'config' => __DIR__ . '/fixtures/AppTest/options-env2'
+				'config' => static::FIXTURES . '/AppTest/options-env2'
 			],
 			'server' => [
 				'SERVER_NAME' => 'getkirby.com',
@@ -758,7 +759,8 @@ class AppTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures'
+				'index' => '/dev/null',
+				'site' => static::FIXTURES
 			]
 		]);
 
@@ -809,7 +811,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'sessions' => $this->tmp,
+				'sessions' => static::TMP,
 			]
 		]);
 
@@ -963,7 +965,7 @@ class AppTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -991,7 +993,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'blueprints' => $this->tmp,
+				'blueprints' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/a' => ['title' => 'A'],
@@ -1000,9 +1002,9 @@ class AppTest extends TestCase
 			]
 		]);
 
-		Data::write($this->tmp . '/pages/b.yml', ['title' => 'B']);
-		Data::write($this->tmp . '/pages/c.yml', ['title' => 'C']);
-		Data::write($this->tmp . '/files/b.yml', ['title' => 'File B']);
+		Data::write(static::TMP . '/pages/b.yml', ['title' => 'B']);
+		Data::write(static::TMP . '/pages/c.yml', ['title' => 'C']);
+		Data::write(static::TMP . '/files/b.yml', ['title' => 'File B']);
 
 		$expected = [
 			'a',
@@ -1220,7 +1222,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'config' => __DIR__ . '/fixtures/AppTest/options'
+				'config' => static::FIXTURES . '/AppTest/options'
 			],
 			'server' => [
 				'SERVER_NAME' => 'trykirby.com',
@@ -1240,7 +1242,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index'  => '/dev/null',
-				'config' => __DIR__ . '/fixtures/AppTest/options'
+				'config' => static::FIXTURES . '/AppTest/options'
 			],
 			'server' => [
 				'SERVER_NAME' => 'getkirby.com',
@@ -1304,7 +1306,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'controllers' => __DIR__ . '/fixtures/controllers'
+				'controllers' => static::FIXTURES . '/controllers'
 			]
 		]);
 
@@ -1350,7 +1352,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'controllers' => __DIR__ . '/fixtures/controllers'
+				'controllers' => static::FIXTURES . '/controllers'
 			]
 		]);
 
@@ -1375,7 +1377,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'controllers' => __DIR__ . '/fixtures/controllers'
+				'controllers' => static::FIXTURES . '/controllers'
 			]
 		]);
 
@@ -1396,7 +1398,7 @@ class AppTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'controllers' => __DIR__ . '/fixtures/controllers'
+				'controllers' => static::FIXTURES . '/controllers'
 			]
 		]);
 
@@ -1455,7 +1457,7 @@ class AppTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -1478,8 +1480,8 @@ class AppTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp,
-				'templates' => $this->tmp
+				'index' => static::TMP,
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -1490,7 +1492,7 @@ class AppTest extends TestCase
 			]
 		]);
 
-		F::write($this->tmp . '/default.php', 'Hello');
+		F::write(static::TMP . '/default.php', 'Hello');
 
 		$this->assertSame('Hello', $app->render()->body());
 

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\Exception;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Locale;
@@ -11,8 +10,10 @@ use Kirby\Toolkit\Str;
 
 class AppTranslationsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppTranslations';
+
 	protected $app;
-	protected $fixtures;
 	protected $locale = [];
 	protected $localeSuffix;
 
@@ -62,13 +63,11 @@ class AppTranslationsTest extends TestCase
 				]
 			]
 		]);
-
-		$this->fixtures = __DIR__ . '/fixtures/AppTranslationsTest';
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		parent::tearDown();
 
 		Locale::set($this->locale);
 		$this->locale = [];
@@ -84,7 +83,7 @@ class AppTranslationsTest extends TestCase
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'translations' => __DIR__ . '/fixtures/translations'
+				'translations' => static::FIXTURES . '/translations'
 			]
 		]);
 
@@ -218,12 +217,12 @@ class AppTranslationsTest extends TestCase
 	public function testTranslationInTemplate()
 	{
 		// create a dummy template
-		F::write($this->fixtures . '/test.php', '<?= t("button") ?>');
+		F::write(static::TMP . '/test.php', '<?= t("button") ?>');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'languages' => [
 				[
@@ -328,12 +327,12 @@ class AppTranslationsTest extends TestCase
 	public function testLanguageTranslationWithSlugs()
 	{
 		// create a dummy template
-		F::write($this->fixtures . '/test.php', '<?= t("button") ?>');
+		F::write(static::TMP . '/test.php', '<?= t("button") ?>');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'languages' => [
 				[

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -6,26 +6,22 @@ use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
-use Kirby\Filesystem\Dir;
 use Kirby\Http\Request\Auth\BasicAuth;
 
 class AppUsersTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppUsers';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/AppUsersTest'
+				'index' => static::TMP
 			]
 		]);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove($this->fixtures);
 	}
 
 	public function testImpersonate()
@@ -120,7 +116,7 @@ class AppUsersTest extends TestCase
 	{
 		$app = $this->app->clone([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures'
+				'site' => static::FIXTURES
 			]
 		]);
 

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -19,11 +19,12 @@ require_once __DIR__ . '/mocks.php';
  */
 class AuthChallengeTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthChallenge';
+
 	public $failedEmail;
 
 	protected $app;
 	protected $auth;
-	protected $tmp;
 
 	public function setUp(): void
 	{
@@ -48,7 +49,7 @@ class AuthChallengeTest extends TestCase
 				]
 			],
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -66,7 +67,7 @@ class AuthChallengeTest extends TestCase
 				]
 			]
 		]);
-		Dir::make($this->tmp . '/site/accounts');
+		Dir::make(static::TMP . '/site/accounts');
 
 		$this->auth = new Auth($this->app);
 	}
@@ -74,7 +75,7 @@ class AuthChallengeTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		unset(Auth::$challenges['errorneous']);
 		Email::$debug = false;

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -9,15 +9,16 @@ use Kirby\Filesystem\Dir;
  */
 class AuthCsrfTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthCsrf';
+
 	protected $app;
 	protected $auth;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/AuthTest'
+				'index' => static::TMP
 			],
 		]);
 
@@ -27,7 +28,7 @@ class AuthCsrfTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 		$_GET = [];
 	}
 

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -14,11 +14,13 @@ require_once __DIR__ . '/../mocks.php';
  */
 class AuthProtectionTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.AuthProtection';
+
 	public $failedEmail;
 
 	protected $app;
 	protected $auth;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
@@ -31,7 +33,7 @@ class AuthProtectionTest extends TestCase
 				]
 			],
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/AuthTest'
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -53,14 +55,14 @@ class AuthProtectionTest extends TestCase
 				}
 			]
 		]);
-		Dir::make($this->fixtures . '/site/accounts');
+		Dir::make(static::TMP . '/site/accounts');
 
 		$this->auth = new Auth($this->app);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 		$this->failedEmail = null;
 	}
 
@@ -69,7 +71,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testLogfile()
 	{
-		$this->assertSame($this->fixtures . '/site/accounts/.logins', $this->auth->logfile());
+		$this->assertSame(static::TMP . '/site/accounts/.logins', $this->auth->logfile());
 	}
 
 	/**
@@ -77,7 +79,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testLog()
 	{
-		copy(__DIR__ . '/fixtures/logins.cleanup.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.cleanup.json', static::TMP . '/site/accounts/.logins');
 
 		// should delete expired and old entries and add by-email array
 		$this->assertSame([
@@ -89,23 +91,23 @@ class AuthProtectionTest extends TestCase
 			],
 			'by-email' => []
 		], $this->auth->log());
-		$this->assertFileEquals(__DIR__ . '/fixtures/logins.cleanup-cleaned.json', $this->fixtures . '/site/accounts/.logins');
+		$this->assertFileEquals(static::FIXTURES . '/logins.cleanup-cleaned.json', static::TMP . '/site/accounts/.logins');
 
 		// should handle missing .logins file
-		unlink($this->fixtures . '/site/accounts/.logins');
+		unlink(static::TMP . '/site/accounts/.logins');
 		$this->assertSame([
 			'by-ip'    => [],
 			'by-email' => []
 		], $this->auth->log());
-		$this->assertFileDoesNotExist($this->fixtures . '/site/accounts/.logins');
+		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
 
 		// should handle invalid .logins file
-		file_put_contents($this->fixtures . '/site/accounts/.logins', 'some gibberish');
+		file_put_contents(static::TMP . '/site/accounts/.logins', 'some gibberish');
 		$this->assertSame([
 			'by-ip'    => [],
 			'by-email' => []
 		], $this->auth->log());
-		$this->assertFileDoesNotExist($this->fixtures . '/site/accounts/.logins');
+		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
 	}
 
 	/**
@@ -123,7 +125,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testIsBlocked()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.1.123.234');
 		$this->assertFalse($this->auth->isBlocked('marge@simpsons.com'));
@@ -141,7 +143,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testTrack()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.1.123.234');
 		$this->assertTrue($this->auth->track('homer@simpsons.com'));
@@ -191,7 +193,7 @@ class AuthProtectionTest extends TestCase
 			]
 		];
 		$this->assertSame($data, $this->auth->log());
-		$this->assertSame(json_encode($data), file_get_contents($this->fixtures . '/site/accounts/.logins'));
+		$this->assertSame(json_encode($data), file_get_contents(static::TMP . '/site/accounts/.logins'));
 	}
 
 	/**
@@ -199,7 +201,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordValid()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.3.123.234');
 		$user = $this->auth->validatePassword('marge@simpsons.com', 'springfield123');
@@ -215,7 +217,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordInvalid1()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.3.123.234');
 
@@ -238,7 +240,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordInvalid2()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.3.123.234');
 
@@ -262,7 +264,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordBlocked()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.2.123.234');
 
@@ -284,7 +286,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordDebugInvalid1()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => [
@@ -315,7 +317,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordDebugInvalid2()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => [
@@ -348,7 +350,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordDebugBlocked()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => [
@@ -377,7 +379,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordWithUnicodeEmail()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.3.123.234');
 		$user = $this->auth->validatePassword('test@exämple.com', 'springfield123');
@@ -391,7 +393,7 @@ class AuthProtectionTest extends TestCase
 	 */
 	public function testValidatePasswordWithPunycodeEmail()
 	{
-		copy(__DIR__ . '/fixtures/logins.json', $this->fixtures . '/site/accounts/.logins');
+		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
 		$this->app->visitor()->ip('10.3.123.234');
 		$user = $this->auth->validatePassword('test@xn--exmple-cua.com', 'springfield123');

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -14,15 +14,16 @@ use Throwable;
  */
 class AuthTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth';
+
 	protected $app;
 	protected $auth;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			],
 			'options' => [
 				'api' => [
@@ -51,9 +52,9 @@ class AuthTest extends TestCase
 				],
 			]
 		]);
-		Dir::make($this->tmp . '/site/accounts/homer');
-		F::write($this->tmp . '/site/accounts/homer/.htpasswd', $hash);
-		touch($this->tmp . '/site/accounts/homer/.htpasswd', 1337000000);
+		Dir::make(static::TMP . '/site/accounts/homer');
+		F::write(static::TMP . '/site/accounts/homer/.htpasswd', $hash);
+		touch(static::TMP . '/site/accounts/homer/.htpasswd', 1337000000);
 
 		$this->auth = $this->app->auth();
 	}
@@ -61,7 +62,7 @@ class AuthTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 		App::destroy();
 	}
 

--- a/tests/Cms/Auth/Challenge/ChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/ChallengeTest.php
@@ -23,15 +23,16 @@ class MockChallenge extends Challenge
  */
 class ChallengeTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.Challenge';
+
 	protected $app;
-	protected $fixtures;
 	protected $session;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = dirname(__DIR__) . '/fixtures/AuthChallengeTest'
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -46,7 +47,7 @@ class ChallengeTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->session->destroy();
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -12,8 +12,10 @@ use Kirby\Filesystem\Dir;
  */
 class EmailChallengeTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/../fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Auth.EmailChallenge';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -23,7 +25,7 @@ class EmailChallengeTest extends TestCase
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'content' => [
@@ -45,12 +47,12 @@ class EmailChallengeTest extends TestCase
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		Email::$debug = false;
 		Email::$emails = [];
@@ -225,7 +227,7 @@ class EmailChallengeTest extends TestCase
 				'auth.challenge.email.subject' => 'Custom subject'
 			],
 			'templates' => [
-				'emails/auth/login' => dirname(__DIR__) . '/fixtures/auth.email.text.php'
+				'emails/auth/login' => static::FIXTURES . '/auth.email.text.php'
 			]
 		]);
 
@@ -254,8 +256,8 @@ class EmailChallengeTest extends TestCase
 	{
 		$this->app = $this->app->clone([
 			'templates' => [
-				'emails/auth/login'      => dirname(__DIR__) . '/fixtures/auth.email.text.php',
-				'emails/auth/login.html' => dirname(__DIR__) . '/fixtures/auth.email.html.php'
+				'emails/auth/login'      => static::FIXTURES . '/auth.email.text.php',
+				'emails/auth/login.html' => static::FIXTURES . '/auth.email.html.php'
 			]
 		]);
 

--- a/tests/Cms/Auth/Challenge/TotpChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/TotpChallengeTest.php
@@ -12,14 +12,15 @@ use Kirby\Toolkit\Totp;
  */
 class TotpChallengeTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.TotpChallenge';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -29,12 +30,12 @@ class TotpChallengeTest extends TestCase
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class BlockTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Block';
+
 	protected $app;
 	protected $page;
 
@@ -195,7 +198,7 @@ class BlockTest extends TestCase
 		new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'snippets' => __DIR__ . '/fixtures/snippets'
+				'snippets' => static::FIXTURES . '/snippets'
 			]
 		]);
 
@@ -214,7 +217,7 @@ class BlockTest extends TestCase
 		new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'snippets' => __DIR__ . '/fixtures/snippets'
+				'snippets' => static::FIXTURES . '/snippets'
 			],
 			'options' => [
 				'debug' => true
@@ -237,7 +240,7 @@ class BlockTest extends TestCase
 		$this->app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'snippets' => __DIR__ . '/fixtures/snippets'
+				'snippets' => static::FIXTURES . '/snippets'
 			],
 		]);
 
@@ -364,8 +367,8 @@ class BlockTest extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index'   => __DIR__ . '/tmp',
-				'content' => __DIR__ . '/fixtures/files'
+				'index'   => static::TMP,
+				'content' => static::FIXTURES . '/files'
 			]
 		]);
 

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class BlocksTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	protected $app;
 	protected $page;
 
@@ -187,7 +189,7 @@ class BlocksTest extends TestCase
 		$this->app = new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'snippets' => __DIR__ . '/fixtures/snippets'
+				'snippets' => static::FIXTURES . '/snippets'
 			],
 		]);
 

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -13,9 +13,10 @@ use PHPUnit\Framework\TestCase;
  */
 class BlueprintTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Blueprint';
+
 	protected $app;
 	protected $model;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -27,12 +28,12 @@ class BlueprintTest extends TestCase
 
 		$this->model = new Page(['slug' => 'a']);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -432,16 +433,16 @@ class BlueprintTest extends TestCase
 		$this->app = $this->app->clone([
 			'roots' => [
 				'index' => '/dev/null',
-				'blueprints' => $this->tmp,
+				'blueprints' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/test' => function () {
-					return $this->tmp . '/custom/test.yml';
+					return static::TMP . '/custom/test.yml';
 				}
 			]
 		]);
 
-		Data::write($this->tmp . '/custom/test.yml', ['title' => 'Test']);
+		Data::write(static::TMP . '/custom/test.yml', ['title' => 'Test']);
 
 		$blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
 

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -41,6 +41,8 @@ class MockObject extends Model
 
 class CollectionTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Collection';
+
 	public function testCollectionMethods()
 	{
 		$kirby = $this->kirby([

--- a/tests/Cms/Collections/CollectionsTest.php
+++ b/tests/Cms/Collections/CollectionsTest.php
@@ -4,11 +4,13 @@ namespace Kirby\Cms;
 
 class CollectionsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/collections';
+
 	protected function _app()
 	{
 		return new App([
 			'roots' => [
-				'collections' => __DIR__ . '/fixtures/collections'
+				'collections' => static::FIXTURES
 			]
 		]);
 	}

--- a/tests/Cms/Content/ContentLockTest.php
+++ b/tests/Cms/Content/ContentLockTest.php
@@ -10,14 +10,15 @@ use PHPUnit\Framework\TestCase;
 
 class ContentLockTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.ContentLock';
+
 	protected $app;
-	protected $fixtures;
 
 	public function app()
 	{
 		return new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/ContentLockTest'
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -36,12 +37,12 @@ class ContentLockTest extends TestCase
 	public function setUp(): void
 	{
 		$this->app = $this->app();
-		Dir::make($this->fixtures . '/content/test');
+		Dir::make(static::TMP . '/content/test');
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function testCreate()
@@ -124,11 +125,11 @@ class ContentLockTest extends TestCase
 
 		$app->impersonate('test@getkirby.com');
 		$page->lock()->create();
-		$this->assertFileExists($this->fixtures . '/content/test/.lock');
+		$this->assertFileExists(static::TMP . '/content/test/.lock');
 
 		$app->impersonate('homer@simpson.com');
 		$data = $page->lock()->get();
-		$this->assertFileExists($this->fixtures . '/content/test/.lock');
+		$this->assertFileExists(static::TMP . '/content/test/.lock');
 		$this->assertNotEmpty($data);
 		$this->assertFalse($data['unlockable']);
 		$this->assertSame('test@getkirby.com', $data['email']);
@@ -136,7 +137,7 @@ class ContentLockTest extends TestCase
 
 		$app->users()->remove($app->user('test@getkirby.com'));
 		$data = $page->lock()->get();
-		$this->assertFileDoesNotExist($this->fixtures . '/content/test/.lock');
+		$this->assertFileDoesNotExist(static::TMP . '/content/test/.lock');
 		$this->assertFalse($data);
 	}
 

--- a/tests/Cms/Content/ContentLocksTest.php
+++ b/tests/Cms/Content/ContentLocksTest.php
@@ -9,14 +9,15 @@ use PHPUnit\Framework\TestCase;
 
 class ContentLocksTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.ContentLocks';
+
 	protected $app;
-	protected $fixtures;
 
 	public function app()
 	{
 		return new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/ContentLocksTest'
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -31,12 +32,12 @@ class ContentLocksTest extends TestCase
 	public function setUp(): void
 	{
 		$this->app = $this->app();
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function testFile()
@@ -57,9 +58,9 @@ class ContentLocksTest extends TestCase
 	{
 		$app = $this->app;
 		$page = $app->page('test');
-		$root = $this->fixtures . '/content/test';
+		$root = static::TMP . '/content/test';
 
-		// create fixtures directory
+		// create temp directory
 		$this->assertSame($root . '/.lock', $app->locks()->file($page));
 		Dir::make($root);
 

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -7,6 +7,8 @@ use PHPMailer\PHPMailer\PHPMailer as Mailer;
 
 class EmailTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/emails';
+
 	public function testToArray()
 	{
 		$props = [
@@ -67,7 +69,7 @@ class EmailTest extends TestCase
 	{
 		$app = new App([
 			'templates' => [
-				'emails/contact' => __DIR__ . '/fixtures/emails/contact.php'
+				'emails/contact' => static::FIXTURES . '/contact.php'
 			]
 		]);
 		$email = new Email([
@@ -83,7 +85,7 @@ class EmailTest extends TestCase
 	{
 		$app = new App([
 			'templates' => [
-				'emails/media.html' => __DIR__ . '/fixtures/emails/media.html.php'
+				'emails/media.html' => static::FIXTURES . '/media.html.php'
 			]
 		]);
 		$email = new Email(['template' => 'media']);
@@ -96,8 +98,8 @@ class EmailTest extends TestCase
 	{
 		$app = new App([
 			'templates' => [
-				'emails/media.html' => __DIR__ . '/fixtures/emails/media.html.php',
-				'emails/media.text' => __DIR__ . '/fixtures/emails/media.text.php',
+				'emails/media.html' => static::FIXTURES . '/media.html.php',
+				'emails/media.text' => static::FIXTURES . '/media.text.php',
 			]
 		]);
 		$email = new Email(['template' => 'media']);
@@ -223,7 +225,7 @@ class EmailTest extends TestCase
 				'index' => '/dev/null'
 			],
 			'templates' => [
-				'emails/user-info' => __DIR__ . '/fixtures/emails/user-info.php'
+				'emails/user-info' => static::FIXTURES . '/user-info.php'
 			]
 		]);
 

--- a/tests/Cms/Facades/STest.php
+++ b/tests/Cms/Facades/STest.php
@@ -6,23 +6,24 @@ use Kirby\Filesystem\Dir;
 
 class STest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.STest';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/STest'
+				'index' => static::TMP
 			]
 		]);
 
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function testInstance()

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -2,11 +2,12 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
 class UrlTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Url';
+
 	protected $app;
 
 	public function setUp(): void
@@ -79,7 +80,7 @@ class UrlTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/UrlTest'
+				'index' => static::TMP
 			],
 			'urls' => [
 				'index' => 'https://getkirby.com'
@@ -106,7 +107,5 @@ class UrlTest extends TestCase
 		$expected = 'https://getkirby.com/assets/js/default.js';
 
 		$this->assertSame($expected, Url::toTemplateAsset('js', 'js'));
-
-		Dir::remove($fixtures);
 	}
 }

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -10,26 +10,28 @@ use Kirby\Image\Image;
 
 class FileActionsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.FileActions';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 		$this->app = static::app();
 	}
 
 	public function tearDown(): void
 	{
 		Blueprint::$loaded = [];
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public static function app(): App
 	{
 		return new App([
 			'roots' => [
-				'index' => __DIR__ . '/tmp'
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -492,7 +494,7 @@ class FileActionsTest extends TestCase
 	public function testCopyRenewUuid()
 	{
 		// create dumy file
-		F::write($source = $this->tmp . '/original.md', '# Foo');
+		F::write($source = static::TMP . '/original.md', '# Foo');
 
 		$file = File::create([
 			'filename' => 'test.md',
@@ -505,7 +507,7 @@ class FileActionsTest extends TestCase
 
 		$destination = new Page([
 			'slug' => 'newly',
-			'root' => $this->tmp . '/new-page'
+			'root' => static::TMP . '/new-page'
 		]);
 
 		$copy = $file->copy($destination);
@@ -520,7 +522,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreate($parent)
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');
@@ -545,7 +547,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreateMove($parent)
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');
@@ -570,7 +572,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreateWithDefaults($parent)
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');
@@ -603,7 +605,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreateWithDefaultsAndContent($parent)
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');
@@ -639,7 +641,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreateImage($parent)
 	{
-		$source =  __DIR__ . '/fixtures/files/test.jpg';
+		$source = static::FIXTURES . '/test.jpg';
 
 		$result = File::create([
 			'filename' => 'test.jpg',
@@ -657,7 +659,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testCreateImageAndManipulate($parent)
 	{
-		$source =  __DIR__ . '/fixtures/files/test.jpg';
+		$source = static::FIXTURES . '/test.jpg';
 		$result = File::create([
 			'filename' => 'test.jpg',
 			'source'   => $source,
@@ -705,7 +707,7 @@ class FileActionsTest extends TestCase
 		]);
 
 		// create the dummy source
-		F::write($source = $this->tmp . '/source.md', '# Test');
+		F::write($source = static::TMP . '/source.md', '# Test');
 
 		$result = File::create([
 			'filename' => 'test.md',
@@ -758,8 +760,8 @@ class FileActionsTest extends TestCase
 	 */
 	public function testReplace($parent)
 	{
-		$original    = $this->tmp . '/original.md';
-		$replacement = $this->tmp . '/replacement.md';
+		$original    = static::TMP . '/original.md';
+		$replacement = static::TMP . '/replacement.md';
 
 		// create the dummy files
 		F::write($original, '# Original');
@@ -788,8 +790,8 @@ class FileActionsTest extends TestCase
 	 */
 	public function testReplaceMove($parent)
 	{
-		$original    = $this->tmp . '/original.md';
-		$replacement = $this->tmp . '/replacement.md';
+		$original    = static::TMP . '/original.md';
+		$replacement = static::TMP . '/replacement.md';
 
 		// create the dummy files
 		F::write($original, '# Original');
@@ -818,8 +820,8 @@ class FileActionsTest extends TestCase
 	 */
 	public function testReplaceImage($parent)
 	{
-		$original =  __DIR__ . '/fixtures/files/test.jpg';
-		$replacement =  __DIR__ . '/fixtures/files/cat.jpg';
+		$original    = static::FIXTURES . '/test.jpg';
+		$replacement = static::FIXTURES . '/cat.jpg';
 
 		$originalFile = File::create([
 			'filename' => 'test.jpg',
@@ -886,7 +888,7 @@ class FileActionsTest extends TestCase
 	 */
 	public function testManipulate($parent)
 	{
-		$original =  __DIR__ . '/fixtures/files/test.jpg';
+		$original = static::FIXTURES . '/test.jpg';
 
 		$originalFile = File::create([
 			'filename' => 'test.jpg',
@@ -1001,7 +1003,7 @@ class FileActionsTest extends TestCase
 		]);
 
 		// create the dummy source
-		F::write($source = $this->tmp . '/source.md', '# Test');
+		F::write($source = static::TMP . '/source.md', '# Test');
 
 		$file = File::create([
 			'filename' => 'test.md',
@@ -1044,7 +1046,7 @@ class FileActionsTest extends TestCase
 		]);
 
 		// create the dummy source
-		F::write($source = $this->tmp . '/replace.csv', 'Replace');
+		F::write($source = static::TMP . '/replace.csv', 'Replace');
 
 		File::create([
 			'filename' => 'replace.csv',

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -12,24 +12,26 @@ use Kirby\Filesystem\File as BaseFile;
 
 class FileRulesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.FileRules';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/FileRulesTest'
+				'index' => static::TMP
 			]
 		]);
 
 		$this->app->impersonate('kirby');
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testChangeName()
@@ -215,11 +217,11 @@ class FileRulesTest extends TestCase
 
 	public function testCreateSameFile()
 	{
-		$testImage =  __DIR__ . '/fixtures/files/test.jpg';
+		$testImage = static::FIXTURES . '/test.jpg';
 
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/FileRulesTest/createSameFile',
+				'index' => static::TMP,
 			],
 			'site' => [
 				'children' => [
@@ -256,11 +258,11 @@ class FileRulesTest extends TestCase
 
 	public function testCreateSameFileWithDifferentTemplate()
 	{
-		$testImage =  __DIR__ . '/fixtures/files/test.jpg';
+		$testImage = static::FIXTURES . '/test.jpg';
 
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/FileRulesTest/createSameFileWithDifferentTemplate',
+				'index' => static::TMP,
 			],
 			'site' => [
 				'children' => [
@@ -297,11 +299,11 @@ class FileRulesTest extends TestCase
 
 	public function testCreateDifferentFileWithSameFilename()
 	{
-		$testImage =  __DIR__ . '/fixtures/files/test.jpg';
+		$testImage = static::FIXTURES . '/test.jpg';
 
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/FileRulesTest/createDifferentFileWithSameFilename',
+				'index' => static::TMP,
 			],
 			'site' => [
 				'children' => [
@@ -332,7 +334,7 @@ class FileRulesTest extends TestCase
 		$this->expectException(DuplicateException::class);
 		$this->expectExceptionMessage('A file with the name "test.jpg" already exists');
 
-		$upload = new BaseFile(__DIR__ . '/fixtures/files/cat.jpg');
+		$upload = new BaseFile(static::FIXTURES . '/cat.jpg');
 		FileRules::create($newFile, $upload);
 	}
 
@@ -353,7 +355,7 @@ class FileRulesTest extends TestCase
 		$file->method('filename')->willReturn('test.svg');
 		$file->method('permissions')->willReturn($permissions);
 
-		$upload = new BaseFile(__DIR__ . '/fixtures/files/test.svg');
+		$upload = new BaseFile(static::FIXTURES . '/test.svg');
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL is not allowed in attribute "xlink:href" (line 2)');
@@ -450,7 +452,7 @@ class FileRulesTest extends TestCase
 		$file->method('filename')->willReturn('test.svg');
 		$file->method('permissions')->willReturn($permissions);
 
-		$upload = new BaseFile(__DIR__ . '/fixtures/files/test.svg');
+		$upload = new BaseFile(static::FIXTURES . '/test.svg');
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL is not allowed in attribute "xlink:href" (line 2)');

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
 use Kirby\Panel\File as Panel;
@@ -16,6 +15,8 @@ class FileTestModel extends File
  */
 class FileTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.File';
+
 	protected function defaults(?App $kirby = null): array
 	{
 		$page = new Page([
@@ -564,16 +565,16 @@ class FileTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/FileTest/mediaHash',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'options' => [
 				'content.salt' => 'test'
 			]
 		]);
 
-		F::write($index . '/test.jpg', 'test');
-		touch($index . '/test.jpg', 5432112345);
+		F::write(static::TMP . '/test.jpg', 'test');
+		touch(static::TMP . '/test.jpg', 5432112345);
 		$file = $this->file([
 			'kirby'    => $app,
 			'parent'   => $app->site(),
@@ -581,16 +582,14 @@ class FileTest extends TestCase
 		]);
 
 		$this->assertSame('08756f3115-5432112345', $file->mediaHash());
-
-		Dir::remove(dirname($index));
 	}
 
 	public function testMediaToken()
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/FileTest/mediaHash',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'options' => [
 				'content.salt' => 'test'
@@ -610,13 +609,13 @@ class FileTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			]
 		]);
 
 		// create a file
-		F::write($file = $index . '/test.js', 'test');
+		F::write($file = static::TMP . '/test.js', 'test');
 
 		$modified = filemtime($file);
 		$file     = $app->file('test.js');
@@ -630,40 +629,36 @@ class FileTest extends TestCase
 		// custom date handler
 		$format = '%d.%m.%Y';
 		$this->assertSame(@strftime($format, $modified), $file->modified($format, 'strftime'));
-
-		Dir::remove(dirname($index));
 	}
 
 	public function testModifiedContent()
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			]
 		]);
 
 		// create a file
-		F::write($file = $index . '/test.js', 'test');
+		F::write($file = static::TMP . '/test.js', 'test');
 		touch($file, $modifiedFile = \time() + 2);
 
-		F::write($content = $index . '/test.js.txt', 'test');
+		F::write($content = static::TMP . '/test.js.txt', 'test');
 		touch($file, $modifiedContent = \time() + 5);
 
 		$file = $app->file('test.js');
 
 		$this->assertNotEquals($modifiedFile, $file->modified());
 		$this->assertSame($modifiedContent, $file->modified());
-
-		Dir::remove(dirname($index));
 	}
 
 	public function testModifiedSpecifyingLanguage()
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/FileTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'languages' => [
 				[
@@ -679,22 +674,20 @@ class FileTest extends TestCase
 		]);
 
 		// create a file
-		F::write($index . '/test.js', 'test');
+		F::write(static::TMP . '/test.js', 'test');
 
 		// create the english content
-		F::write($file = $index . '/test.js.en.txt', 'test');
+		F::write($file = static::TMP . '/test.js.en.txt', 'test');
 		touch($file, $modifiedEnContent = \time() + 2);
 
 		// create the german content
-		F::write($file = $index . '/test.js.de.txt', 'test');
+		F::write($file = static::TMP . '/test.js.de.txt', 'test');
 		touch($file, $modifiedDeContent = \time() + 5);
 
 		$file = $app->file('test.js');
 
 		$this->assertSame($modifiedEnContent, $file->modified(null, null, 'en'));
 		$this->assertSame($modifiedDeContent, $file->modified(null, null, 'de'));
-
-		Dir::remove(dirname($index));
 	}
 
 	public function testPanel()

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -4,6 +4,9 @@ namespace Kirby\Cms;
 
 class FileVersionTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.FileVersion';
+
 	protected $app;
 
 	public function setUp(): void
@@ -13,11 +16,6 @@ class FileVersionTest extends TestCase
 				'index' => '/dev/null'
 			],
 		]);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove(__DIR__ . '/tmp');
 	}
 
 	public function testConstruct()
@@ -53,7 +51,7 @@ class FileVersionTest extends TestCase
 	public function testExists()
 	{
 		$page = new Page([
-			'root' => __DIR__ . '/fixtures/files',
+			'root' => static::FIXTURES,
 			'slug' => 'files'
 		]);
 
@@ -64,7 +62,7 @@ class FileVersionTest extends TestCase
 
 		$version = new FileVersion([
 			'original' => $original,
-			'root'     => __DIR__ . '/tmp/test-version.jpg',
+			'root'     => static::TMP . '/test-version.jpg',
 			'modifications' => [
 				'width' => 50,
 			]
@@ -96,7 +94,7 @@ class FileVersionTest extends TestCase
 
 		$version = new FileVersion([
 			'original' => $original,
-			'root'     => __DIR__ . '/fixtures/files/test.jpg'
+			'root'     => static::FIXTURES . '/test.jpg'
 		]);
 
 		$this->assertSame('jpg', $version->toArray()['extension']);
@@ -112,7 +110,7 @@ class FileVersionTest extends TestCase
 		$original = new File(['filename' => 'test.jpg', 'parent' => $page]);
 		$version  = new FileVersion([
 			'original' => $original,
-			'root'     => __DIR__ . '/fixtures/files/test.txt',
+			'root'     => static::FIXTURES . '/test.txt',
 			'url'      => $url = 'https://assets.getkirby.com/test-200x200.txt',
 		]);
 
@@ -120,7 +118,7 @@ class FileVersionTest extends TestCase
 
 		$version  = new FileVersion([
 			'original' => $original,
-			'root'     => __DIR__ . '/fixtures/files/test.jpg',
+			'root'     => static::FIXTURES . '/test.jpg',
 			'url'      => $url = 'https://assets.getkirby.com/test-200x200.jpg',
 		]);
 

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Uuid\Uuids;
 
@@ -12,6 +11,8 @@ use Kirby\Uuid\Uuids;
  */
 class FilesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Files';
+
 	public function testAddFile()
 	{
 		$parent = new Page(['slug' => 'test']);
@@ -153,12 +154,9 @@ class FilesTest extends TestCase
 	 */
 	public function testSize()
 	{
-		$tmp = __DIR__ . '/tmp';
-		Dir::make($tmp);
-
 		$app = new App([
 			'roots' => [
-				'index' => $tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -167,8 +165,8 @@ class FilesTest extends TestCase
 			]
 		]);
 
-		F::write($a = $tmp . '/content/test/a.txt', 'foo');
-		F::write($b = $tmp . '/content/test/b.txt', 'bar');
+		F::write($a = static::TMP . '/content/test/a.txt', 'foo');
+		F::write($b = static::TMP . '/content/test/b.txt', 'bar');
 
 		$files = Files::factory([
 			['filename' => 'a.txt', 'root' => $a],
@@ -178,8 +176,6 @@ class FilesTest extends TestCase
 
 		$this->assertSame(6, $files->size());
 		$this->assertSame('6 B', $files->niceSize());
-
-		Dir::remove($tmp);
 	}
 
 	/**

--- a/tests/Cms/Files/HasFilesTest.php
+++ b/tests/Cms/Files/HasFilesTest.php
@@ -21,17 +21,17 @@ class HasFileTraitUser
 	}
 }
 
-
 class HasFilesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.HasFiles';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -42,12 +42,13 @@ class HasFilesTest extends TestCase
 			'user' => 'admin@domain.com'
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public static function fileProvider(): array
@@ -68,7 +69,7 @@ class HasFilesTest extends TestCase
 
 	public function testCreateFile()
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');
@@ -91,7 +92,7 @@ class HasFilesTest extends TestCase
 
 	public function testCreateFileMove()
 	{
-		$source = $this->tmp . '/source.md';
+		$source = static::TMP . '/source.md';
 
 		// create the dummy source
 		F::write($source, '# Test');

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -11,20 +11,17 @@ use Kirby\Filesystem\Dir;
  */
 class FindTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Find';
+
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $tmp = __DIR__ . 'tmp'
+				'index' => static::TMP
 			]
 		]);
 
-		Dir::make($tmp);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove(__DIR__ . 'tmp');
+		Dir::make(static::TMP);
 	}
 
 	/**

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -11,26 +11,30 @@ use Kirby\Toolkit\Obj;
 
 class HelperFunctionsTest extends HelpersTestCase
 {
-	protected $fixtures;
+	public const FIXTURES = __DIR__ . '/fixtures/HelpersTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.HelperFunctions';
+
 	protected $kirby;
 
 	public function setUp(): void
 	{
+		Dir::copy(static::FIXTURES, static::TMP);
+
 		$this->kirby = new Kirby([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/HelpersTest'
+				'index' => static::TMP
 			],
 			'urls' => [
 				'index' => 'https://getkirby.com'
 			]
 		]);
 
-		Dir::make($this->fixtures . '/site');
+		Dir::make(static::TMP . '/site');
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures . '/site');
+		Dir::remove(static::TMP);
 	}
 
 	public function testAttrWithBeforeValue()
@@ -531,12 +535,12 @@ class HelperFunctionsTest extends HelpersTestCase
 	public function testLoad()
 	{
 		load([
-			'helperstest\\a' => __DIR__ . '/fixtures/HelpersTest/load/a/a.php',
+			'helperstest\\a' => static::FIXTURES . '/load/a/a.php',
 		]);
 
 		load([
 			'HelpersTest\\B' => 'B.php',
-		], __DIR__ . '/fixtures/HelpersTest/load/B');
+		], static::FIXTURES . '/load/B');
 
 		$this->assertTrue(class_exists('HelpersTest\\A'));
 		$this->assertTrue(class_exists('HelpersTest\\B'));
@@ -752,8 +756,8 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index,
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -765,8 +769,8 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index,
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -778,8 +782,8 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -791,8 +795,8 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index,
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -808,8 +812,8 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index,
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -823,8 +827,8 @@ class HelperFunctionsTest extends HelpersTestCase
 
 		$this->kirby->clone([
 			'roots' => [
-				'index'     => $index = __DIR__ . '/fixtures/HelpersTest',
-				'snippets'  => $index,
+				'index'     => '/dev/null',
+				'snippets'  => static::FIXTURES,
 			]
 		]);
 
@@ -835,7 +839,7 @@ class HelperFunctionsTest extends HelpersTestCase
 	{
 		$this->kirby->clone([
 			'roots' => [
-				'snippets' => __DIR__ . '/fixtures/HelpersTest'
+				'snippets' => static::FIXTURES
 			]
 		]);
 
@@ -858,7 +862,7 @@ class HelperFunctionsTest extends HelpersTestCase
 
 	public function testSvgWithAbsolutePath()
 	{
-		$result = svg(__DIR__ . '/fixtures/HelpersTest/test.svg');
+		$result = svg(static::FIXTURES . '/test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 

--- a/tests/Cms/Html/HtmlTest.php
+++ b/tests/Cms/Html/HtmlTest.php
@@ -2,19 +2,25 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\Dir;
+
 /**
  * @coversDefaultClass Kirby\Cms\Html
  */
 class HtmlTest extends TestCase
 {
-	protected $fixtures;
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Html';
+
 	protected $kirby;
 
 	public function setUp(): void
 	{
+		Dir::copy(static::FIXTURES, static::TMP);
+
 		$this->kirby = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures'
+				'index' => static::TMP
 			],
 			'urls' => [
 				'index' => 'https://getkirby.com'
@@ -110,7 +116,7 @@ class HtmlTest extends TestCase
 	public function testCssWithPluginAssets()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $root = $this->fixtures . '/plugin'
+			'root' => $root = static::TMP . '/plugin'
 		]);
 		touch($root . '/assets/styles.css', 1337000000);
 		$result = Html::css($plugin);
@@ -175,7 +181,7 @@ class HtmlTest extends TestCase
 	public function testJsWithPluginAssets()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $root = $this->fixtures . '/plugin'
+			'root' => $root = static::TMP . '/plugin'
 		]);
 		touch($root . '/assets/scripts.js', 1337000000);
 		$result = Html::js($plugin);
@@ -199,7 +205,7 @@ class HtmlTest extends TestCase
 	 */
 	public function testSvgWithAbsolutePath()
 	{
-		$result = Html::svg($this->fixtures . '/test.svg');
+		$result = Html::svg(static::TMP . '/test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -14,23 +14,24 @@ use PHPUnit\Framework\TestCase;
  */
 class LanguageTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Language';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/LanguageTest',
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -108,7 +109,7 @@ class LanguageTest extends TestCase
 
 		new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/CreateHooksTest',
+				'index' => static::TMP,
 			],
 			'hooks' => [
 				'language.create:before' => function (Language $language, array $input) use ($phpunit, &$calls) {
@@ -163,7 +164,7 @@ class LanguageTest extends TestCase
 
 		new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/DeleteHooksTest',
+				'index' => static::TMP,
 			],
 			'hooks' => [
 				'language.delete:before' => function (Language $language) use ($phpunit, &$calls) {
@@ -231,7 +232,7 @@ class LanguageTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'index' => __DIR__ . '/tmp'
+				'index' => static::TMP
 			]
 		]);
 
@@ -244,8 +245,6 @@ class LanguageTest extends TestCase
 		F::write($language->root(), 'test');
 
 		$this->assertTrue($language->exists());
-
-		Dir::remove(__DIR__ . '/tmp');
 	}
 
 	/**
@@ -469,7 +468,7 @@ class LanguageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			]
 		]);
 
@@ -477,7 +476,7 @@ class LanguageTest extends TestCase
 			'code' => 'de'
 		]);
 
-		$this->assertSame($tmp . '/site/languages/de.php', $language->root());
+		$this->assertSame(static::TMP . '/site/languages/de.php', $language->root());
 	}
 
 	/**
@@ -499,12 +498,12 @@ class LanguageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'     => $tmp = __DIR__ . '/tmp/LanguageTest',
-				'languages' => $tmp
+				'index'     => static::TMP,
+				'languages' => static::TMP
 			]
 		]);
 
-		$file = $tmp . '/de.php';
+		$file = static::TMP . '/de.php';
 
 		// default
 		$language = new Language([
@@ -564,8 +563,6 @@ class LanguageTest extends TestCase
 		$data = include $file;
 
 		$this->assertSame('test', $data['custom']);
-
-		Dir::remove($tmp);
 	}
 
 	/**
@@ -650,7 +647,7 @@ class LanguageTest extends TestCase
 	 */
 	public function testUpdate()
 	{
-		Dir::make($this->tmp . '/content');
+		Dir::make(static::TMP . '/content');
 
 		$language = Language::create([
 			'code' => 'en'
@@ -668,7 +665,7 @@ class LanguageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
@@ -718,12 +715,11 @@ class LanguageTest extends TestCase
 		$calls = 0;
 		$phpunit = $this;
 
-		$this->tmp = __DIR__ . '/tmp/UpdateHooksTest';
-		Dir::make($this->tmp . '/content');
+		Dir::make(static::TMP . '/content');
 
 		new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'hooks' => [
 				'language.update:before' => function (Language $language, array $input) use ($phpunit, &$calls) {

--- a/tests/Cms/Languages/LanguageVariableTest.php
+++ b/tests/Cms/Languages/LanguageVariableTest.php
@@ -11,23 +11,24 @@ use PHPUnit\Framework\TestCase;
  */
 class LanguageVariableTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageVariable';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/LanguageVariableTest',
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -9,15 +9,16 @@ use PHPUnit\Framework\TestCase;
 
 class LanguagesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Languages';
+
 	protected $app;
 	protected $languages;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/LanguagesTest',
+				'index' => static::TMP,
 			],
 			'languages' => [
 				[
@@ -41,14 +42,14 @@ class LanguagesTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testCodes()
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/LanguagesTest',
+				'index' => static::TMP,
 			],
 			'languages' => [
 				[
@@ -71,7 +72,7 @@ class LanguagesTest extends TestCase
 
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp/LanguagesTest',
+				'index' => static::TMP,
 			]
 		]);
 
@@ -89,16 +90,16 @@ class LanguagesTest extends TestCase
 	{
 		$this->app->clone([
 			'roots' => [
-				'languages' => $root = __DIR__ . '/tmp/LanguagesTest'
+				'languages' => static::TMP
 			]
 		]);
 
-		Data::write($root . '/en.php', [
+		Data::write(static::TMP . '/en.php', [
 			'code' => 'en',
 			'default' => true
 		]);
 
-		Data::write($root . '/de.php', [
+		Data::write(static::TMP . '/de.php', [
 			'code' => 'de'
 		]);
 
@@ -108,7 +109,7 @@ class LanguagesTest extends TestCase
 		$this->assertSame(['de', 'en'], $languages->codes());
 		$this->assertSame('en', $languages->default()->code());
 
-		Dir::remove($root);
+		Dir::remove(static::TMP);
 	}
 
 	public function testDefault()

--- a/tests/Cms/Loader/LoaderTest.php
+++ b/tests/Cms/Loader/LoaderTest.php
@@ -7,6 +7,8 @@ namespace Kirby\Cms;
  */
 class LoaderTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public $loader;
 
 	public function setUp(): void
@@ -190,7 +192,7 @@ class LoaderTest extends TestCase
 	 */
 	public function testResolvePHPFile()
 	{
-		$resolved = $this->loader->resolve(__DIR__ . '/fixtures/resolve.php');
+		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.php');
 
 		$this->assertSame('Test', $resolved['test']);
 	}
@@ -200,7 +202,7 @@ class LoaderTest extends TestCase
 	 */
 	public function testResolveYamlFile()
 	{
-		$resolved = $this->loader->resolve(__DIR__ . '/fixtures/resolve.yml');
+		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.yml');
 
 		$this->assertSame('Test', $resolved['test']);
 	}
@@ -211,7 +213,7 @@ class LoaderTest extends TestCase
 	public function testResolveAll()
 	{
 		$resolved = $this->loader->resolveAll([
-			'test' => __DIR__ . '/fixtures/resolve.php'
+			'test' => static::FIXTURES . '/resolve.php'
 		]);
 
 		$this->assertSame('Test', $resolved['test']['test']);

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -4,32 +4,15 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
-use PHPUnit\Framework\TestCase;
 
 class MediaTest extends TestCase
 {
-	protected $app;
-	protected $fixtures;
-
-	public function setUp(): void
-	{
-		$this->app = new App([
-			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/MediaTest',
-			],
-		]);
-
-		Dir::make($this->fixtures);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove($this->fixtures);
-	}
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Media';
 
 	public function testLinkSiteFile()
 	{
-		F::write($this->fixtures . '/content/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+		F::write(static::TMP . '/content/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
 		$file   = $this->app->file('test.svg');
 		$result = Media::link($this->app->site(), $file->mediaHash(), $file->filename());
@@ -41,7 +24,7 @@ class MediaTest extends TestCase
 
 	public function testLinkPageFile()
 	{
-		F::write($this->fixtures . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+		F::write(static::TMP . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
 		$file   = $this->app->file('projects/test.svg');
 		$result = Media::link($this->app->page('projects'), $file->mediaHash(), $file->filename());
@@ -53,7 +36,7 @@ class MediaTest extends TestCase
 
 	public function testLinkWithInvalidHash()
 	{
-		F::write($this->fixtures . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+		F::write(static::TMP . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
 		// with the correct media token
 		$file   = $this->app->file('projects/test.svg');
@@ -78,7 +61,7 @@ class MediaTest extends TestCase
 	{
 		$site = new Site();
 
-		F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+		F::write($src = static::TMP . '/content/test.jpg', 'nice jpg');
 		$file = new File([
 			'kirby'    => $this->app,
 			'parent'   => $site,
@@ -87,7 +70,7 @@ class MediaTest extends TestCase
 
 		$oldToken  = crc32($filename);
 		$newToken  = $file->mediaToken();
-		$directory = $this->fixtures . '/media/site';
+		$directory = static::TMP . '/media/site';
 
 		Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
 		Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
@@ -112,7 +95,7 @@ class MediaTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+		F::write($src = static::TMP . '/content/test.jpg', 'nice jpg');
 		$file = new File([
 			'kirby'    => $this->app,
 			'parent'   => $page,
@@ -121,7 +104,7 @@ class MediaTest extends TestCase
 
 		$oldToken  = crc32($filename);
 		$newToken  = $file->mediaToken();
-		$directory = $this->fixtures . '/media/site';
+		$directory = static::TMP . '/media/site';
 
 		Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
 		Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
@@ -147,7 +130,7 @@ class MediaTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		F::write($src = $this->fixtures . '/content/test.jpg', 'nice jpg');
+		F::write($src = static::TMP . '/content/test.jpg', 'nice jpg');
 		$file = new File([
 			'kirby'    => $this->app,
 			'parent'   => $page,
@@ -156,7 +139,7 @@ class MediaTest extends TestCase
 
 		$oldToken  = crc32($filename);
 		$newToken  = $file->mediaToken();
-		$directory = $this->fixtures . '/media/site';
+		$directory = static::TMP . '/media/site';
 
 		Dir::make($versionA1 = $directory . '/' . $oldToken . '-1234');
 		Dir::make($versionA2 = $directory . '/' . $oldToken . '-5678');
@@ -178,7 +161,7 @@ class MediaTest extends TestCase
 
 	public function testUnpublishNonExistingDirectory()
 	{
-		$directory = $this->fixtures . '/does-not-exist';
+		$directory = static::TMP . '/does-not-exist';
 
 		$page = new Page([
 			'slug' => 'test'
@@ -195,10 +178,10 @@ class MediaTest extends TestCase
 
 	public function testThumb()
 	{
-		Dir::make($this->fixtures . '/content');
+		Dir::make(static::TMP . '/content');
 
 		// copy test image to content
-		F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
@@ -225,10 +208,10 @@ class MediaTest extends TestCase
 
 	public function testThumbWithoutJobsFile()
 	{
-		Dir::make($this->fixtures . '/content');
+		Dir::make(static::TMP . '/content');
 
 		// copy test image to content
-		F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
 		$file = $this->app->file('test.jpg');
@@ -243,10 +226,10 @@ class MediaTest extends TestCase
 
 	public function testThumbWithIncompleteJobFile()
 	{
-		Dir::make($this->fixtures . '/content');
+		Dir::make(static::TMP . '/content');
 
 		// copy test image to content
-		F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
 		$file = $this->app->file('test.jpg');
@@ -263,10 +246,10 @@ class MediaTest extends TestCase
 
 	public function testThumbWhenGenerationFails()
 	{
-		Dir::make($this->fixtures . '/content');
+		Dir::make(static::TMP . '/content');
 
 		// copy test image to content
-		F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
 		$file = $this->app->file('test.jpg');
@@ -284,22 +267,22 @@ class MediaTest extends TestCase
 
 	public function testThumbStringModel()
 	{
-		Dir::make($this->fixtures . '/content');
+		Dir::make(static::TMP . '/content');
 
 		// copy test image to content
-		F::copy($this->fixtures . '/../files/test.jpg', $this->fixtures . '/content/test.jpg');
+		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
-		Dir::make($this->fixtures . '/media/assets/site/' . $file->mediaHash());
+		Dir::make(static::TMP . '/media/assets/site/' . $file->mediaHash());
 		$this->assertInstanceOf(File::class, $file);
 
 		// create job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write($this->fixtures . '/media/assets/site/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write(static::TMP . '/media/assets/site/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		// copy to media folder
-		$file->asset()->copy($mediaPath = $this->fixtures . '/media/assets/site/' . $file->mediaHash() . '/' . $file->filename());
+		$file->asset()->copy($mediaPath = static::TMP . '/media/assets/site/' . $file->mediaHash() . '/' . $file->filename());
 
 		$thumb = Media::thumb('site', $file->mediaHash(), $file->filename());
 		$this->assertInstanceOf(Response::class, $thumb);

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -97,6 +97,8 @@ class BlueprintsModelWithContent extends ExtendedModelWithContent
 
 class ModelWithContentTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.ModelWithContent';
+
 	public static function modelsProvider(): array
 	{
 		$app = new App([

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -9,16 +9,17 @@ use PHPUnit\Framework\TestCase;
 
 class PageActionsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageActions';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
-		Dir::make($this->tmp = __DIR__ . '/tmp');
+		Dir::make(static::TMP);
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 		]);
 
@@ -27,7 +28,8 @@ class PageActionsTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function site()
@@ -139,8 +141,8 @@ class PageActionsTest extends TestCase
 			]);
 
 			$in      = 'drafts';
-			$oldRoot = $this->tmp . '/content/_drafts/test';
-			$newRoot = $this->tmp . '/content/_drafts/' . $expected;
+			$oldRoot = static::TMP . '/content/_drafts/test';
+			$newRoot = static::TMP . '/content/_drafts/' . $expected;
 		} else {
 			$page = Page::create([
 				'slug' => 'test',
@@ -148,8 +150,8 @@ class PageActionsTest extends TestCase
 			]);
 
 			$in      = 'children';
-			$oldRoot = $this->tmp . '/content/1_test';
-			$newRoot = $this->tmp . '/content/1_' . $expected;
+			$oldRoot = static::TMP . '/content/1_test';
+			$newRoot = static::TMP . '/content/1_' . $expected;
 		}
 
 		$this->assertTrue($page->exists());
@@ -200,7 +202,7 @@ class PageActionsTest extends TestCase
 			]);
 
 			$in   = 'drafts';
-			$root = $this->tmp . '/content/_drafts/test';
+			$root = static::TMP . '/content/_drafts/test';
 		} else {
 			$page = Page::create([
 				'slug' => 'test',
@@ -208,7 +210,7 @@ class PageActionsTest extends TestCase
 			]);
 
 			$in   = 'children';
-			$root = $this->tmp . '/content/1_test';
+			$root = static::TMP . '/content/1_test';
 		}
 
 		$page = $page->update(['slug' => 'test-de'], 'de');
@@ -851,7 +853,7 @@ class PageActionsTest extends TestCase
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileDoesNotExist($this->tmp . $copy->root() . '/.lock');
+		$this->assertFileDoesNotExist(static::TMP . $copy->root() . '/.lock');
 
 		$this->assertSame($page, $drafts->find('test'));
 		$this->assertSame($page, $childrenAndDrafts->find('test'));
@@ -950,7 +952,7 @@ class PageActionsTest extends TestCase
 			]
 		]);
 
-		F::write($this->tmp . '/content/_drafts/test/foo.jpg', '');
+		F::write(static::TMP . '/content/_drafts/test/foo.jpg', '');
 
 		$copy = $page->duplicate('test-copy', ['files' => true]);
 
@@ -985,7 +987,7 @@ class PageActionsTest extends TestCase
 			]
 		]);
 
-		F::write($this->tmp . '/content/_drafts/test/foo.jpg', '');
+		F::write(static::TMP . '/content/_drafts/test/foo.jpg', '');
 
 		$page = $app->call('de/test');
 		$page->duplicate('test-copy', ['files' => true]);
@@ -1064,7 +1066,7 @@ class PageActionsTest extends TestCase
 				['filename' => 'foo.jpg'],
 			]
 		]);
-		F::write($this->tmp . '/content/_drafts/test/_drafts/foo/foo.jpg', '');
+		F::write(static::TMP . '/content/_drafts/test/_drafts/foo/foo.jpg', '');
 
 		$page = $app->page('test');
 		$copy = $page->duplicate('test-copy', [

--- a/tests/Cms/Pages/PageCacheTest.php
+++ b/tests/Cms/Pages/PageCacheTest.php
@@ -8,15 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 class PageCacheTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/PageCacheTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.PageCache';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index'     => $this->tmp = __DIR__ . '/tmp',
-				'templates' => __DIR__ . '/fixtures/PageCacheTest'
+				'index'     => static::TMP,
+				'templates' => static::FIXTURES
 			],
 			'site' => [
 				'children' => [
@@ -54,12 +56,12 @@ class PageCacheTest extends TestCase
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		unset(
 			$_COOKIE['foo'],

--- a/tests/Cms/Pages/PageCreateTest.php
+++ b/tests/Cms/Pages/PageCreateTest.php
@@ -18,20 +18,21 @@ class UncreatablePage extends Page
 
 class PageCreateTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageCreate';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/PageCreateTest'
+				'index' => static::TMP
 			]
 		]);
 
 		$this->app->impersonate('kirby');
 
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 
 		Page::$models = [
 			'uncreatable-page' => UncreatablePage::class
@@ -40,7 +41,7 @@ class PageCreateTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 
 		Page::$models = [];
 	}
@@ -210,7 +211,7 @@ class PageCreateTest extends TestCase
 
 	public function testCreateFile()
 	{
-		F::write($source = $this->fixtures . '/source.md', '');
+		F::write($source = static::TMP . '/source.md', '');
 
 		$page = Page::create([
 			'slug' => 'test'

--- a/tests/Cms/Pages/PageDeleteTest.php
+++ b/tests/Cms/Pages/PageDeleteTest.php
@@ -8,25 +8,26 @@ use PHPUnit\Framework\TestCase;
 
 class PageDeleteTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageDelete';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/PageDeleteTest'
+				'index' => static::TMP
 			],
 		]);
 
 		$this->app->impersonate('kirby');
 
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function site()

--- a/tests/Cms/Pages/PageFilesTest.php
+++ b/tests/Cms/Pages/PageFilesTest.php
@@ -4,14 +4,15 @@ namespace Kirby\Cms;
 
 class PageFilesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageFiles';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/PageFilesTest'
+				'index' => static::TMP
 			]
 		]);
 	}

--- a/tests/Cms/Pages/PageModelTest.php
+++ b/tests/Cms/Pages/PageModelTest.php
@@ -2,20 +2,19 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
-
 class PageModelTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/PageModelTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.PageModel';
+
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index'  => $this->tmp = __DIR__ . '/tmp',
-				'models' => __DIR__ . '/fixtures/PageModelTest'
+				'index'  => static::TMP,
+				'models' => static::FIXTURES
 			]
 		]);
-
-		Dir::make($this->tmp);
 	}
 
 	public function testPageModelWithTemplate()

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -12,6 +12,8 @@ use Kirby\Exception\PermissionException;
  */
 class PageRulesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageRules';
+
 	public function appWithAdmin()
 	{
 		return new App([
@@ -864,7 +866,7 @@ class PageRulesTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'site' => [
 				'children' => [

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -8,25 +8,26 @@ use PHPUnit\Framework\TestCase;
 
 class PageSortTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageSort';
+
 	protected $app;
-	protected $fixtures;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures = __DIR__ . '/fixtures/PageSortTest'
+				'index' => static::TMP
 			]
 		]);
 
 		$this->app->impersonate('kirby');
 
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function site()
@@ -626,10 +627,10 @@ class PageSortTest extends TestCase
 
 		$this->assertSame(array_reverse($chars), $this->site()->children()->keys());
 
-		$this->assertDirectoryExists($this->fixtures . '/content/4_a');
-		$this->assertDirectoryExists($this->fixtures . '/content/3_b');
-		$this->assertDirectoryExists($this->fixtures . '/content/2_c');
-		$this->assertDirectoryExists($this->fixtures . '/content/1_d');
+		$this->assertDirectoryExists(static::TMP . '/content/4_a');
+		$this->assertDirectoryExists(static::TMP . '/content/3_b');
+		$this->assertDirectoryExists(static::TMP . '/content/2_c');
+		$this->assertDirectoryExists(static::TMP . '/content/1_d');
 	}
 
 	public function testUpdateWithDateBasedNumbering()

--- a/tests/Cms/Pages/PageStatesTest.php
+++ b/tests/Cms/Pages/PageStatesTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 class PageStatesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageStates';
+
 	/**
 	 * Deregister any plugins for the page
 	 */
@@ -11,7 +13,7 @@ class PageStatesTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/PageStatesTest'
+				'index' => static::TMP
 			]
 		]);
 	}

--- a/tests/Cms/Pages/PageTemplateTest.php
+++ b/tests/Cms/Pages/PageTemplateTest.php
@@ -8,18 +8,20 @@ use PHPUnit\Framework\TestCase as TestCase;
 
 class PageTemplateTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/PageTemplateTest';
+
 	protected $app;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'templates' => [
-				'default'               => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'default.json'          => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'default.xml'           => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'template'              => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'template.json'         => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'another-template.json' => __DIR__ . '/fixtures/PageTemplateTest/template.php'
+				'default'               => static::FIXTURES . '/template.php',
+				'default.json'          => static::FIXTURES . '/template.php',
+				'default.xml'           => static::FIXTURES . '/template.php',
+				'template'              => static::FIXTURES . '/template.php',
+				'template.json'         => static::FIXTURES . '/template.php',
+				'another-template.json' => static::FIXTURES . '/template.php'
 			],
 			'site' => [
 				'children' => [

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\Page as Panel;
 use ReflectionMethod;
@@ -17,11 +16,8 @@ class PageTestModel extends Page
  */
 class PageTest extends TestCase
 {
-	public function tearDown(): void
-	{
-		parent::tearDown();
-		Dir::remove(__DIR__ . '/fixtures/PageTest');
-	}
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Page';
 
 	public function testBlueprints()
 	{
@@ -812,13 +808,13 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			]
 		]);
 
 		// create a page
-		F::write($file = $index . '/test/test.txt', 'test');
+		F::write($file = static::TMP . '/test/test.txt', 'test');
 
 		$modified = filemtime($file);
 		$page     = $app->page('test');
@@ -841,8 +837,8 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'languages' => [
 				[
@@ -858,13 +854,13 @@ class PageTest extends TestCase
 		]);
 
 		// create the english page
-		F::write($file = $index . '/test/test.en.txt', 'test');
+		F::write($file = static::TMP . '/test/test.en.txt', 'test');
 		touch($file, $modified = \time() + 2);
 
 		$this->assertSame($modified, $app->page('test')->modified());
 
 		// create the german page
-		F::write($file = $index . '/test/test.de.txt', 'test');
+		F::write($file = static::TMP . '/test/test.de.txt', 'test');
 		touch($file, $modified = \time() + 5);
 
 		// change the language
@@ -878,8 +874,8 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/PageTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'languages' => [
 				[
@@ -895,11 +891,11 @@ class PageTest extends TestCase
 		]);
 
 		// create the english page
-		F::write($file = $index . '/test/test.en.txt', 'test');
+		F::write($file = static::TMP . '/test/test.en.txt', 'test');
 		touch($file, $modifiedEnContent = \time() + 2);
 
 		// create the german page
-		F::write($file = $index . '/test/test.de.txt', 'test');
+		F::write($file = static::TMP . '/test/test.de.txt', 'test');
 		touch($file, $modifiedDeContent = \time() + 5);
 
 		$page = $app->page('test');
@@ -994,11 +990,11 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/PageTest'
+				'index' => static::TMP
 			],
 			'templates' => [
-				'foo' => __DIR__ . '/fixtures/PageTemplateTest/template.php',
-				'bar' => __DIR__ . '/fixtures/PageTemplateTest/template.php',
+				'foo' => static::FIXTURES . '/PageTemplateTest/template.php',
+				'bar' => static::FIXTURES . '/PageTemplateTest/template.php',
 			],
 			'site' => [
 				'children' => [
@@ -1098,10 +1094,10 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/PageTest'
+				'index' => static::TMP
 			],
 			'templates' => [
-				'bar' => __DIR__ . '/fixtures/PageRenderHookTest/bar.php'
+				'bar' => static::FIXTURES . '/PageRenderHookTest/bar.php'
 			],
 			'site' => [
 				'children' => [
@@ -1130,10 +1126,10 @@ class PageTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => __DIR__ . '/fixtures/PageTest'
+				'index' => static::TMP
 			],
 			'templates' => [
-				'foo' => __DIR__ . '/fixtures/PageRenderHookTest/foo.php'
+				'foo' => static::FIXTURES . '/PageRenderHookTest/foo.php'
 			],
 			'site' => [
 				'children' => [

--- a/tests/Cms/Pages/PageTranslationsTest.php
+++ b/tests/Cms/Pages/PageTranslationsTest.php
@@ -2,11 +2,12 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\TestCase;
 
 class PageTranslationsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PageTranslations';
+
 	public function app($language = null)
 	{
 		$app = new App([
@@ -205,7 +206,7 @@ class PageTranslationsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $fixtures = __DIR__ . '/fixtures/PageTranslationsTest'
+				'index' => static::TMP
 			],
 			'languages' => [
 				[
@@ -278,7 +279,5 @@ class PageTranslationsTest extends TestCase
 		];
 
 		$this->assertSame($expected, $de->content('de')->data());
-
-		Dir::remove($fixtures);
 	}
 }

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -6,6 +6,8 @@ use Kirby\Exception\InvalidArgumentException;
 
 class PagesTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Pages';
+
 	public function pages()
 	{
 		return new Pages([

--- a/tests/Cms/Plugins/PluginAssetTest.php
+++ b/tests/Cms/Plugins/PluginAssetTest.php
@@ -2,23 +2,29 @@
 
 namespace Kirby\Cms;
 
-use PHPUnit\Framework\TestCase;
+use Kirby\Filesystem\Dir;
 
 /**
  * @coversDefaultClass \Kirby\Cms\PluginAsset
  */
 class PluginAssetTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.PluginAsset';
+
 	protected Plugin $plugin;
-	protected string $fixture = __DIR__ . '/fixtures/plugin-assets';
 
 	public function setUp(): void
 	{
+		parent::setUp();
+
+		Dir::copy(static::FIXTURES, static::TMP . '/test-plugin');
+
 		$this->plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $this->fixture
+			'root' => static::TMP . '/test-plugin'
 		]);
 
-		touch($this->fixture . '/assets/test.css', 1337000000);
+		touch(static::TMP . '/test-plugin/assets/test.css', 1337000000);
 	}
 
 	/**
@@ -28,7 +34,7 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			'test.css',
-			$this->fixture . '/assets/test.css',
+			static::TMP . '/test-plugin/assets/test.css',
 			$this->plugin
 		);
 
@@ -42,7 +48,7 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			'test.css',
-			$this->fixture . '/assets/test.css',
+			static::TMP . '/test-plugin/assets/test.css',
 			$this->plugin
 		);
 
@@ -60,7 +66,7 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			'test.css',
-			$this->fixture . '/assets/test.css',
+			static::TMP . '/test-plugin/assets/test.css',
 			$this->plugin
 		);
 
@@ -78,7 +84,7 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			'test.css',
-			$this->fixture . '/assets/test.css',
+			static::TMP . '/test-plugin/assets/test.css',
 			$this->plugin
 		);
 
@@ -95,7 +101,7 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			$path = 'test.css',
-			$root = $this->fixture . '/assets/test.css',
+			$root = static::TMP . '/test-plugin/assets/test.css',
 			$plugin = $this->plugin
 		);
 
@@ -111,13 +117,12 @@ class PluginAssetTest extends TestCase
 	{
 		$asset = new PluginAsset(
 			'test.css',
-			$this->fixture . '/assets/test.css',
+			static::TMP . '/test-plugin/assets/test.css',
 			$this->plugin
 		);
 
 		$this->assertFileDoesNotExist($asset->mediaRoot());
 		$asset->publish();
 		$this->assertFileExists($asset->mediaRoot());
-		unlink($asset->mediaRoot());
 	}
 }

--- a/tests/Cms/Plugins/PluginAssetsTest.php
+++ b/tests/Cms/Plugins/PluginAssetsTest.php
@@ -11,33 +11,35 @@ use PHPUnit\Framework\TestCase;
  */
 class PluginAssetsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.PluginAssets';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp/PluginAssetsTest';
 
 	public function setUp(): void
 	{
-		$a = $this->tmp . '/site/plugins/a';
+		$a = static::TMP . '/site/plugins/a';
 		F::write($a . '/index.php', '<?php Kirby::plugin("getkirby/a", []);');
 		F::write($a . '/assets/test.css', 'test');
 
-		$b = $this->tmp . '/site/plugins/b';
+		$b = static::TMP . '/site/plugins/b';
 		F::write($b . '/index.php', '<?php Kirby::plugin("getkirby/b", ["assets" => ["' . $b . '/foo/bar.css"]]);');
 		F::write($b . '/foo/bar.css', 'test');
 
-		$c = $this->tmp . '/site/plugins/c';
+		$c = static::TMP . '/site/plugins/c';
 		F::write($c . '/index.php', '<?php Kirby::plugin("getkirby/c", ["assets" => ["test.css" => "' . $c . '/foo/bar.css"]]);');
 		F::write($c . '/foo/bar.css', 'test');
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -47,11 +49,11 @@ class PluginAssetsTest extends TestCase
 	{
 		// create orphans
 		F::write(
-			$a = $this->tmp . '/media/plugins/getkirby/a/orphan.css',
+			$a = static::TMP . '/media/plugins/getkirby/a/orphan.css',
 			'test'
 		);
 		F::write(
-			$b = $this->tmp . '/media/plugins/getkirby/a/assets/orphan.css',
+			$b = static::TMP . '/media/plugins/getkirby/a/assets/orphan.css',
 			'test'
 		);
 
@@ -72,10 +74,10 @@ class PluginAssetsTest extends TestCase
 	{
 		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => $root = __DIR__ . '/tmp',
+			'root'   => static::TMP,
 			'assets' => [
-				'test.css' => $root . '/test.css',
-				'test.js'  => $root . '/test.js'
+				'test.css' => static::TMP . '/test.css',
+				'test.js'  => static::TMP . '/test.js'
 			]
 		]);
 
@@ -94,58 +96,58 @@ class PluginAssetsTest extends TestCase
 	{
 		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => $root = __DIR__ . '/fixtures/plugin-assets',
+			'root'   => static::FIXTURES,
 			'assets' => [
-				'c.css' => $root . '/a.css',
-				'd.css' => $root . '/foo/b.css'
+				'c.css' => static::FIXTURES . '/a.css',
+				'd.css' => static::FIXTURES . '/foo/b.css'
 			]
 		]);
 
 		$assets = PluginAssets::factory($plugin);
 		$this->assertInstanceOf(PluginAssets::class, $assets);
 		$this->assertSame(2, $assets->count());
-		$this->assertSame($root . '/a.css', $assets->get('c.css')->root());
-		$this->assertSame($root . '/foo/b.css', $assets->get('d.css')->root());
+		$this->assertSame(static::FIXTURES . '/a.css', $assets->get('c.css')->root());
+		$this->assertSame(static::FIXTURES . '/foo/b.css', $assets->get('d.css')->root());
 
 		// assets defined as non-associative array in the plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => $root,
+			'root'   => static::FIXTURES,
 			'assets' => [
-				$root . '/a.css',
-				$root . '/foo/b.css'
+				static::FIXTURES . '/a.css',
+				static::FIXTURES . '/foo/b.css'
 			]
 		]);
 
 		$assets = PluginAssets::factory($plugin);
 		$this->assertInstanceOf(PluginAssets::class, $assets);
 		$this->assertSame(2, $assets->count());
-		$this->assertSame($root . '/a.css', $assets->get('a.css')->root());
-		$this->assertSame($root . '/foo/b.css', $assets->get('foo/b.css')->root());
+		$this->assertSame(static::FIXTURES . '/a.css', $assets->get('a.css')->root());
+		$this->assertSame(static::FIXTURES . '/foo/b.css', $assets->get('foo/b.css')->root());
 
 		// assets defined als closure in the plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => __DIR__ . '/fixtures/plugin-assets',
+			'root'   => static::FIXTURES,
 			'assets' => fn () => [
-				$root . '/a.css',
-				$root . '/foo/b.css'
+				static::FIXTURES . '/a.css',
+				static::FIXTURES . '/foo/b.css'
 			]
 		]);
 
 		$assets = PluginAssets::factory($plugin);
 		$this->assertInstanceOf(PluginAssets::class, $assets);
 		$this->assertSame(2, $assets->count());
-		$this->assertSame($root . '/a.css', $assets->get('a.css')->root());
-		$this->assertSame($root . '/foo/b.css', $assets->get('foo/b.css')->root());
+		$this->assertSame(static::FIXTURES . '/a.css', $assets->get('a.css')->root());
+		$this->assertSame(static::FIXTURES . '/foo/b.css', $assets->get('foo/b.css')->root());
 
 		// assets gathered from `assets` folder inside plugin root
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-assets'
+			'root' => static::FIXTURES
 		]);
 
 		$assets = PluginAssets::factory($plugin);
 		$this->assertInstanceOf(PluginAssets::class, $assets);
 		$this->assertSame(1, $assets->count());
-		$this->assertSame($root . '/assets/test.css', $assets->get('test.css')->root());
+		$this->assertSame(static::FIXTURES . '/assets/test.css', $assets->get('test.css')->root());
 	}
 
 	/**
@@ -154,7 +156,7 @@ class PluginAssetsTest extends TestCase
 	public function testPlugin()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-assets'
+			'root' => static::FIXTURES
 		]);
 
 		$assets = PluginAssets::factory($plugin);
@@ -166,10 +168,10 @@ class PluginAssetsTest extends TestCase
 	 */
 	public function testResolve()
 	{
-		touch($this->tmp . '/site/plugins/b/foo/bar.css', 1337000000);
+		touch(static::TMP . '/site/plugins/b/foo/bar.css', 1337000000);
 
 		// right path and hash
-		$media    = $this->tmp . '/media/plugins/getkirby/b/110971429-1337000000/foo/bar.css';
+		$media    = static::TMP . '/media/plugins/getkirby/b/110971429-1337000000/foo/bar.css';
 		$response = PluginAssets::resolve(
 			'getkirby/b',
 			'110971429-1337000000',
@@ -181,7 +183,7 @@ class PluginAssetsTest extends TestCase
 		$this->assertSame('text/css', $response->type());
 
 		// wrong path
-		$media    = $this->tmp . '/media/plugins/getkirby/b/110971429-1337000000/assets/foo.css';
+		$media    = static::TMP . '/media/plugins/getkirby/b/110971429-1337000000/assets/foo.css';
 		$response = PluginAssets::resolve(
 			'getkirby/b',
 			'110971429-1337000000',
@@ -193,7 +195,7 @@ class PluginAssetsTest extends TestCase
 
 		// wrong hash
 		// TODO: remove when media hash is enforced as mandatory
-		// $media    = $this->tmp . '/media/plugins/getkirby/b/110971429-1337000000/foo/bar.css';
+		// $media    = static::TMP . '/media/plugins/getkirby/b/110971429-1337000000/foo/bar.css';
 		// $response = PluginAssets::resolve(
 		// 	'getkirby/b',
 		// 	'110971429-12345678',
@@ -204,9 +206,9 @@ class PluginAssetsTest extends TestCase
 		// $this->assertFalse(is_link($media));
 
 		// correct: different path and root
-		touch($this->tmp . '/site/plugins/c/foo/bar.css', 1337000000);
+		touch(static::TMP . '/site/plugins/c/foo/bar.css', 1337000000);
 
-		$media    = $this->tmp . '/media/plugins/getkirby/c/3526409702-1337000000/test.css';
+		$media    = static::TMP . '/media/plugins/getkirby/c/3526409702-1337000000/test.css';
 		$response = PluginAssets::resolve(
 			'getkirby/c',
 			'3526409702-1337000000',
@@ -220,9 +222,9 @@ class PluginAssetsTest extends TestCase
 
 	public function testResolveAutomaticFromAssetsFolder()
 	{
-		touch($this->tmp . '/site/plugins/a/assets/test.css', 1337000000);
+		touch(static::TMP . '/site/plugins/a/assets/test.css', 1337000000);
 
-		$media    = $this->tmp . '/media/plugins/getkirby/a/3526409702-1337000000/test.css';
+		$media    = static::TMP . '/media/plugins/getkirby/a/3526409702-1337000000/test.css';
 		$response = PluginAssets::resolve(
 			'getkirby/a',
 			'3526409702-1337000000',
@@ -234,7 +236,7 @@ class PluginAssetsTest extends TestCase
 		$this->assertSame('text/css', $response->type());
 
 
-		$media    = $this->tmp . '/media/plugins/getkirby/a/3526409702-1337000000/assets/test.css';
+		$media    = static::TMP . '/media/plugins/getkirby/a/3526409702-1337000000/assets/test.css';
 		$response = PluginAssets::resolve(
 			'getkirby/a',
 			'3526409702-1337000000',

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -13,18 +13,20 @@ use Kirby\Filesystem\Dir;
  */
 class PluginTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Plugin';
+
 	protected static $classLoader;
 	protected static $updateStatusHost;
 
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public static function setUpBeforeClass(): void
 	{
 		static::$updateStatusHost = UpdateStatus::$host;
-		UpdateStatus::$host = 'file://' . __DIR__ . '/fixtures/updateStatus';
+		UpdateStatus::$host = 'file://' . static::FIXTURES . '/updateStatus';
 
-		static::$classLoader = new ClassLoader(__DIR__ . '/fixtures/vendor');
+		static::$classLoader = new ClassLoader(static::FIXTURES . '/vendor');
 		static::$classLoader->register();
 	}
 
@@ -39,11 +41,11 @@ class PluginTest extends TestCase
 	{
 		App::destroy();
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 	}
@@ -51,7 +53,7 @@ class PluginTest extends TestCase
 	public function tearDown(): void
 	{
 		App::destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -60,7 +62,7 @@ class PluginTest extends TestCase
 	public function test__call()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin'
+			'root' => static::FIXTURES . '/plugin'
 		]);
 
 		$this->assertSame('MIT', $plugin->license());
@@ -71,7 +73,7 @@ class PluginTest extends TestCase
 	 */
 	public function testAsset()
 	{
-		$root = __DIR__ . '/fixtures/plugin-assets';
+		$root = static::FIXTURES . '/plugin-assets';
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'assets' => [
 				'c.css' => $a = $root . '/a.css',
@@ -88,7 +90,7 @@ class PluginTest extends TestCase
 	 */
 	public function testAssets()
 	{
-		$root = __DIR__ . '/fixtures/plugin-assets';
+		$root = static::FIXTURES . '/plugin-assets';
 
 		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -108,7 +110,7 @@ class PluginTest extends TestCase
 	public function testAuthors()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin'
+			'root' => static::FIXTURES . '/plugin'
 		]);
 
 		$authors = [
@@ -131,7 +133,7 @@ class PluginTest extends TestCase
 	public function testAuthorsNames()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin'
+			'root' => static::FIXTURES . '/plugin'
 		]);
 
 		$this->assertSame('A, B', $plugin->authorsNames());
@@ -167,7 +169,7 @@ class PluginTest extends TestCase
 	public function testInfo()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 
 		$authors = [
@@ -405,7 +407,7 @@ class PluginTest extends TestCase
 	public function testToArray()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $root = __DIR__ . '/fixtures/plugin-version'
+			'root' => $root = static::FIXTURES . '/plugin-version'
 		]);
 
 		$expected = [
@@ -430,7 +432,7 @@ class PluginTest extends TestCase
 	public function testUpdateStatus()
 	{
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -452,7 +454,7 @@ class PluginTest extends TestCase
 	public function testUpdateStatusWithPrefix()
 	{
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version-prefix'
+			'root' => static::FIXTURES . '/plugin-version-prefix'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -474,7 +476,7 @@ class PluginTest extends TestCase
 	public function testUpdateStatusWithoutVersion()
 	{
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin'
+			'root' => static::FIXTURES . '/plugin'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -497,7 +499,7 @@ class PluginTest extends TestCase
 	public function testUpdateStatusUnknownPlugin()
 	{
 		$plugin = new Plugin('getkirby/unknown', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -513,7 +515,7 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 		$this->assertSame([
 			'Could not load update data for plugin getkirby/unknown: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/updateStatus/plugins/getkirby/unknown.json'
+			static::FIXTURES . '/updateStatus/plugins/getkirby/unknown.json'
 		], $updateStatus->exceptionMessages());
 	}
 
@@ -531,7 +533,7 @@ class PluginTest extends TestCase
 		]);
 
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -557,7 +559,7 @@ class PluginTest extends TestCase
 		]);
 
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -576,7 +578,7 @@ class PluginTest extends TestCase
 		]);
 
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -599,7 +601,7 @@ class PluginTest extends TestCase
 		]);
 
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -622,7 +624,7 @@ class PluginTest extends TestCase
 		]);
 
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus();
 
@@ -644,7 +646,7 @@ class PluginTest extends TestCase
 	public function testUpdateStatusCustomData()
 	{
 		$plugin = new Plugin('getkirby/public', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 		$updateStatus = $plugin->updateStatus([
 			'latest' => '87654.3.2',
@@ -681,7 +683,7 @@ class PluginTest extends TestCase
 	public function testVersion()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-version'
+			'root' => static::FIXTURES . '/plugin-version'
 		]);
 
 		$this->assertSame('1.0.0', $plugin->version());
@@ -693,7 +695,7 @@ class PluginTest extends TestCase
 	public function testVersionMissing()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin'
+			'root' => static::FIXTURES . '/plugin'
 		]);
 
 		$this->assertNull($plugin->version());
@@ -705,7 +707,7 @@ class PluginTest extends TestCase
 	public function testVersionPrefixed()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-version-prefix'
+			'root' => static::FIXTURES . '/plugin-version-prefix'
 		]);
 
 		$this->assertSame('1.0.0', $plugin->version());
@@ -717,7 +719,7 @@ class PluginTest extends TestCase
 	public function testVersionInvalid()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-version-invalid'
+			'root' => static::FIXTURES . '/plugin-version-invalid'
 		]);
 
 		$this->assertNull($plugin->version());
@@ -729,7 +731,7 @@ class PluginTest extends TestCase
 	public function testVersionComposer()
 	{
 		$plugin = new Plugin('getkirby/test-plugin-composer', [
-			'root' => __DIR__ . '/fixtures/plugin-version-composer'
+			'root' => static::FIXTURES . '/plugin-version-composer'
 		]);
 
 		$this->assertSame('5.2.3', $plugin->version());
@@ -741,7 +743,7 @@ class PluginTest extends TestCase
 	public function testVersionComposerNoVersionSet()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__ . '/fixtures/plugin-version-composer-noversionset'
+			'root' => static::FIXTURES . '/plugin-version-composer-noversionset'
 		]);
 
 		$this->assertNull($plugin->version());
@@ -753,7 +755,7 @@ class PluginTest extends TestCase
 	public function testVersionComposerOverride()
 	{
 		$plugin = new Plugin('getkirby/test-plugin-composer', [
-			'root' => __DIR__ . '/fixtures/plugin-version-composer-override'
+			'root' => static::FIXTURES . '/plugin-version-composer-override'
 		]);
 
 		$this->assertSame('3.1.2', $plugin->version());

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -4,11 +4,13 @@ namespace Kirby\Cms;
 
 class RoleTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function app()
 	{
 		return new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures'
+				'site' => static::FIXTURES
 			]
 		]);
 	}
@@ -29,7 +31,7 @@ class RoleTest extends TestCase
 	public function testFactory()
 	{
 		$app  = $this->app();
-		$role = Role::load(__DIR__ . '/fixtures/blueprints/users/editor.yml');
+		$role = Role::load(static::FIXTURES . '/blueprints/users/editor.yml');
 
 		$this->assertSame('editor', $role->name());
 		$this->assertSame('Editor', $role->title());

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -3,10 +3,12 @@
 namespace Kirby\Cms;
 
 use Kirby\Data\Data;
-use Kirby\Filesystem\Dir;
 
 class RolesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.Roles';
+
 	public function testFactory()
 	{
 		$roles = Roles::factory([
@@ -26,7 +28,7 @@ class RolesTest extends TestCase
 
 	public function testLoad()
 	{
-		$roles = Roles::load(__DIR__ . '/fixtures/blueprints/users');
+		$roles = Roles::load(static::FIXTURES . '/blueprints/users');
 
 		$this->assertInstanceOf(Roles::class, $roles);
 
@@ -63,24 +65,24 @@ class RolesTest extends TestCase
 		new App([
 			'roots' => [
 				'index' => '/dev/null',
-				'blueprints' => $fixtures = __DIR__ . '/fixtures/RolesTest/loadFromPluginsCallbackString',
+				'blueprints' => static::TMP,
 			],
 			'blueprints' => [
-				'users/admin' => function () use ($fixtures) {
-					return $fixtures . '/custom/admin.yml';
+				'users/admin' => function () {
+					return static::TMP . '/custom/admin.yml';
 				},
-				'users/editor' => function () use ($fixtures) {
-					return $fixtures . '/custom/editor.yml';
+				'users/editor' => function () {
+					return static::TMP . '/custom/editor.yml';
 				}
 			]
 		]);
 
-		Data::write($fixtures . '/custom/admin.yml', [
+		Data::write(static::TMP . '/custom/admin.yml', [
 			'name' => 'admin',
 			'title' => 'Admin'
 		]);
 
-		Data::write($fixtures . '/custom/editor.yml', [
+		Data::write(static::TMP . '/custom/editor.yml', [
 			'name' => 'editor',
 			'title' => 'Editor'
 		]);
@@ -90,8 +92,6 @@ class RolesTest extends TestCase
 		$this->assertCount(2, $roles);
 		$this->assertSame('admin', $roles->first()->name());
 		$this->assertSame('editor', $roles->last()->name());
-
-		Dir::remove($fixtures);
 	}
 
 	public function testLoadFromPluginsCallbackArray()

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -3,30 +3,12 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
 
 class RouterTest extends TestCase
 {
-	protected $app;
-	protected $fixtures;
-
-	public function setUp(): void
-	{
-		$this->fixtures = __DIR__ . '/fixtures/RouterTest';
-
-		$this->app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			]
-		]);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove($this->fixtures);
-	}
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Router';
 
 	public function testHomeRoute()
 	{
@@ -111,13 +93,13 @@ class RouterTest extends TestCase
 
 	public function testPageRepresentationRoute()
 	{
-		F::write($template = $this->fixtures . '/test.php', 'html');
-		F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+		F::write($template = static::TMP . '/test.php', 'html');
+		F::write($template = static::TMP . '/test.xml.php', 'xml');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -655,13 +637,13 @@ class RouterTest extends TestCase
 
 	public function testMultilangPageRepresentationRoute()
 	{
-		F::write($template = $this->fixtures . '/test.php', 'html');
-		F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+		F::write($template = static::TMP . '/test.php', 'html');
+		F::write($template = static::TMP . '/test.xml.php', 'xml');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -713,13 +695,13 @@ class RouterTest extends TestCase
 
 	public function testMultilangPageRepresentationRouteWithoutLanguageCode()
 	{
-		F::write($template = $this->fixtures . '/test.php', 'html');
-		F::write($template = $this->fixtures . '/test.xml.php', 'xml');
+		F::write($template = static::TMP . '/test.php', 'html');
+		F::write($template = static::TMP . '/test.xml.php', 'xml');
 
 		$app = new App([
 			'roots' => [
 				'index'     => '/dev/null',
-				'templates' => $this->fixtures
+				'templates' => static::TMP
 			],
 			'site' => [
 				'children' => [

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -7,26 +7,27 @@ use PHPUnit\Framework\TestCase;
 
 class FilesSectionTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.FilesSection';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 		$this->app();
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function app(array $props = [])
 	{
-		App::destroy();
 		$this->app = new App(array_replace_recursive([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		], $props));
 

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -9,17 +9,17 @@ use PHPUnit\Framework\TestCase;
 
 class PagesSectionTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.PagesSection';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
-		App::destroy();
-		Dir::make($this->tmp = __DIR__ . '/tmp');
+		Dir::make(static::TMP);
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 
@@ -28,7 +28,8 @@ class PagesSectionTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function testHeadline()

--- a/tests/Cms/Site/SiteActionsTest.php
+++ b/tests/Cms/Site/SiteActionsTest.php
@@ -8,14 +8,15 @@ use PHPUnit\Framework\TestCase;
 
 class SiteActionsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.SiteActions';
+
 	protected $app;
-	protected $fixtures = __DIR__ . '/fixtures/SiteActionsTest';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->fixtures
+				'index' => static::TMP
 			],
 			'users' => [
 				[
@@ -37,12 +38,12 @@ class SiteActionsTest extends TestCase
 			]
 		]);
 
-		Dir::make($this->fixtures);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->fixtures);
+		Dir::remove(static::TMP);
 	}
 
 	public function site()
@@ -69,7 +70,7 @@ class SiteActionsTest extends TestCase
 
 	public function testCreateFile()
 	{
-		F::write($source = $this->fixtures . '/source.md', '');
+		F::write($source = static::TMP . '/source.md', '');
 
 		$file = $this->site()->createFile([
 			'filename' => 'test.md',

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -2,12 +2,13 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\Site as Panel;
 
 class SiteTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Site';
+
 	public function testUrl()
 	{
 		$site = new Site([
@@ -102,13 +103,13 @@ class SiteTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/SitePropsTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			]
 		]);
 
 		// create the site file
-		F::write($file = $index . '/site.txt', 'test');
+		F::write($file = static::TMP . '/site.txt', 'test');
 
 		$modified = filemtime($file);
 		$site     = $app->site();
@@ -122,16 +123,14 @@ class SiteTest extends TestCase
 		// custom date handler
 		$format = '%d.%m.%Y';
 		$this->assertSame(@strftime($format, $modified), $site->modified($format, 'strftime'));
-
-		Dir::remove($index);
 	}
 
 	public function testModifiedInMultilangInstallation()
 	{
 		$app = new App([
 			'roots' => [
-				'index'   => $index = __DIR__ . '/fixtures/SitePropsTest/modified',
-				'content' => $index
+				'index'   => static::TMP,
+				'content' => static::TMP
 			],
 			'languages' => [
 				[
@@ -147,13 +146,13 @@ class SiteTest extends TestCase
 		]);
 
 		// create the english site
-		F::write($file = $index . '/site.en.txt', 'test');
+		F::write($file = static::TMP . '/site.en.txt', 'test');
 		touch($file, $modified = \time() + 2);
 
 		$this->assertSame($modified, $app->site()->modified());
 
 		// create the german site
-		F::write($file = $index . '/site.de.txt', 'test');
+		F::write($file = static::TMP . '/site.de.txt', 'test');
 		touch($file, $modified = \time() + 5);
 
 		// change the language
@@ -161,8 +160,6 @@ class SiteTest extends TestCase
 		$app->setCurrentTranslation('de');
 
 		$this->assertSame($modified, $app->site()->modified());
-
-		Dir::remove($index);
 	}
 
 	public function testIs()

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -11,7 +11,8 @@ use ReflectionClass;
  */
 class LicenseTest extends TestCase
 {
-	public const TMP = KIRBY_TMP_DIR . '/Cms.License';
+	public const FIXTURES = __DIR__ . '/fixtures/LicenseTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.License';
 
 	public function code(LicenseType $type = LicenseType::Basic): string
 	{
@@ -322,7 +323,7 @@ class LicenseTest extends TestCase
 		// existing license
 		$this->app = new App([
 			'roots' => [
-				'license' => __DIR__ . '/fixtures/LicenseTest/.license'
+				'license' => static::FIXTURES . '/.license'
 			]
 		]);
 
@@ -333,7 +334,7 @@ class LicenseTest extends TestCase
 		// non-existing license root
 		$this->app = new App([
 			'roots' => [
-				'license' => __DIR__ . '/fixtures/LicenseTest/foo'
+				'license' => static::FIXTURES . '/foo'
 			]
 		]);
 

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -13,16 +13,18 @@ use Kirby\Filesystem\F;
  */
 class SystemTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/SystemTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.System';
+
 	protected static $updateStatusHost;
 
 	protected $app;
-	protected $tmp;
 	protected $subTmp;
 
 	public static function setUpBeforeClass(): void
 	{
 		static::$updateStatusHost = UpdateStatus::$host;
-		UpdateStatus::$host = 'file://' . __DIR__ . '/fixtures/SystemTest';
+		UpdateStatus::$host = 'file://' . static::FIXTURES;
 	}
 
 	public static function tearDownAfterClass(): void
@@ -34,7 +36,7 @@ class SystemTest extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			]
 		]);
 	}
@@ -46,7 +48,7 @@ class SystemTest extends TestCase
 			Dir::remove($this->subTmp);
 		}
 
-		Dir::remove($this->tmp);
+		parent::tearDown();
 	}
 
 	public static function providerForIndexUrls(): array
@@ -157,17 +159,17 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'content' => $this->tmp . '/content',
-				'index'   => $this->tmp
+				'content' => static::TMP . '/content',
+				'index'   => static::TMP
 			]
 		]));
 
-		Dir::remove($this->tmp . '/content');
+		Dir::remove(static::TMP . '/content');
 
 		$this->assertNull($system->folderUrl('content'));
 		$this->assertNull($system->exposedFileUrl('content'));
 
-		Dir::make($this->tmp . '/content');
+		Dir::make(static::TMP . '/content');
 
 		$this->assertSame('/content', $system->folderUrl('content'));
 		$this->assertSame('/content/site.txt', $system->exposedFileUrl('content'));
@@ -181,16 +183,16 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]));
 
-		Dir::remove($this->tmp . '/.git');
+		Dir::remove(static::TMP . '/.git');
 
 		$this->assertNull($system->folderUrl('git'));
 		$this->assertNull($system->exposedFileUrl('git'));
 
-		Dir::make($this->tmp . '/.git');
+		Dir::make(static::TMP . '/.git');
 
 		$this->assertSame('/.git', $system->folderUrl('git'));
 		$this->assertSame('/.git/config', $system->exposedFileUrl('git'));
@@ -204,12 +206,12 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
-				'media' => $this->tmp . '/media'
+				'index' => static::TMP,
+				'media' => static::TMP . '/media'
 			]
 		]));
 
-		Dir::make($this->tmp . '/media');
+		Dir::make(static::TMP . '/media');
 
 		$this->assertSame('/media', $system->folderUrl('media'));
 		$this->assertNull($system->exposedFileUrl('media'));
@@ -223,17 +225,17 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'kirby' => $this->tmp . '/kirby',
-				'index' => $this->tmp
+				'kirby' => static::TMP . '/kirby',
+				'index' => static::TMP
 			]
 		]));
 
-		Dir::remove($this->tmp . '/kirby');
+		Dir::remove(static::TMP . '/kirby');
 
 		$this->assertNull($system->folderUrl('kirby'));
 		$this->assertNull($system->exposedFileUrl('kirby'));
 
-		Dir::make($this->tmp . '/kirby');
+		Dir::make(static::TMP . '/kirby');
 
 		$this->assertSame('/kirby', $system->folderUrl('kirby'));
 		$this->assertSame('/kirby/composer.json', $system->exposedFileUrl('kirby'));
@@ -247,32 +249,32 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'site'  => $this->tmp . '/site',
-				'index' => $this->tmp
+				'site'  => static::TMP . '/site',
+				'index' => static::TMP
 			]
 		]));
 
-		Dir::remove($this->tmp . '/site');
+		Dir::remove(static::TMP . '/site');
 
 		$this->assertNull($system->folderUrl('site'));
 
 		// with blueprints
-		Dir::remove($this->tmp . '/site');
-		F::write($this->tmp . '/site/blueprints/site.yml', 'test');
+		Dir::remove(static::TMP . '/site');
+		F::write(static::TMP . '/site/blueprints/site.yml', 'test');
 
 		$this->assertSame('/site', $system->folderUrl('site'));
 		$this->assertSame('/site/blueprints/site.yml', $system->exposedFileUrl('site'));
 
 		// with templates
-		Dir::remove($this->tmp . '/site');
-		F::write($this->tmp . '/site/templates/default.php', 'test');
+		Dir::remove(static::TMP . '/site');
+		F::write(static::TMP . '/site/templates/default.php', 'test');
 
 		$this->assertSame('/site', $system->folderUrl('site'));
 		$this->assertSame('/site/templates/default.php', $system->exposedFileUrl('site'));
 
 		// with snippets
-		Dir::remove($this->tmp . '/site');
-		F::write($this->tmp . '/site/snippets/header.php', 'test');
+		Dir::remove(static::TMP . '/site');
+		F::write(static::TMP . '/site/snippets/header.php', 'test');
 
 		$this->assertSame('/site', $system->folderUrl('site'));
 		$this->assertSame('/site/snippets/header.php', $system->exposedFileUrl('site'));
@@ -286,7 +288,7 @@ class SystemTest extends TestCase
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]));
 
@@ -315,11 +317,11 @@ class SystemTest extends TestCase
 	 */
 	public function testInitPermission($root)
 	{
-		$this->subTmp = $this->tmp . '/' . ucfirst($root) . 'Test';
+		$this->subTmp = static::TMP . '/' . ucfirst($root) . 'Test';
 
 		$app = $this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 				$root   => $this->subTmp . '/' . $root,
 			]
 		]);

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -14,14 +14,16 @@ require_once __DIR__ . '/mocks.php';
  */
 class UpdateStatusTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/UpdateStatusTest';
+	public const TMP      = KIRBY_TMP_DIR . '/Cms.System.UpdateStatus';
+
 	protected static $host;
 	protected static $data = [];
-	protected $tmp = __DIR__ . '/tmp';
 
 	public static function setUpBeforeClass(): void
 	{
 		static::$host = UpdateStatus::$host;
-		UpdateStatus::$host = 'file://' . __DIR__ . '/fixtures/UpdateStatusTest/getkirby.com';
+		UpdateStatus::$host = 'file://' . static::FIXTURES . '/getkirby.com';
 	}
 
 	public static function tearDownAfterClass(): void
@@ -31,7 +33,7 @@ class UpdateStatusTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -298,12 +300,12 @@ class UpdateStatusTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 		$this->assertSame([
 			'Could not load update data for plugin getkirby/test: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/UpdateStatusTest/getkirby.com/plugins/getkirby/test.json'
+			static::FIXTURES . '/getkirby.com/plugins/getkirby/test.json'
 		], $updateStatus->exceptionMessages());
 
 		$this->assertSame(
 			'Could not load update data for plugin getkirby/test: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/UpdateStatusTest/getkirby.com/plugins/getkirby/test.json',
+			static::FIXTURES . '/getkirby.com/plugins/getkirby/test.json',
 			$app->cache('updates')->get('plugins/getkirby/test')
 		);
 
@@ -312,7 +314,7 @@ class UpdateStatusTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 		$this->assertSame([
 			'Could not load update data for plugin getkirby/test: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/UpdateStatusTest/getkirby.com/plugins/getkirby/test.json'
+			static::FIXTURES . '/getkirby.com/plugins/getkirby/test.json'
 		], $updateStatus->exceptionMessages());
 	}
 
@@ -1173,7 +1175,7 @@ class UpdateStatusTest extends TestCase
 					'vulnerabilities' => null,
 					'exceptionMessages' => [
 						'Could not load update data for plugin getkirby/test: Couldn\'t open file ' .
-						__DIR__ . '/fixtures/UpdateStatusTest/getkirby.com/plugins/getkirby/test.json'
+						static::FIXTURES . '/getkirby.com/plugins/getkirby/test.json'
 					]
 				]
 			],
@@ -1615,7 +1617,7 @@ class UpdateStatusTest extends TestCase
 		MockApp::$version = $version;
 		return new MockApp([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 	}
@@ -1626,7 +1628,7 @@ class UpdateStatusTest extends TestCase
 			return static::$data[$name];
 		}
 
-		$path = __DIR__ . '/fixtures/UpdateStatusTest/logic/' . $name . '.json';
+		$path = static::FIXTURES . '/logic/' . $name . '.json';
 		$json = Json::read($path);
 
 		// dynamically insert the current PHP version

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -14,17 +14,14 @@ class TestCase extends BaseTestCase
 {
 	protected $app;
 	protected $page = null;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		App::destroy();
 
-		Dir::make($this->tmp);
-
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => $this->hasTmp() ? static::TMP : '/dev/null'
 			]
 		]);
 
@@ -39,8 +36,11 @@ class TestCase extends BaseTestCase
 	public function tearDown(): void
 	{
 		App::destroy();
-		Dir::remove($this->tmp);
 		Blueprint::$loaded = [];
+
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
 
 		// mock class
 		ErrorLog::$log = '';
@@ -133,5 +133,14 @@ class TestCase extends BaseTestCase
 
 		$action->call($this, $app);
 		$this->assertSame(count($hooks), $triggered);
+	}
+
+	/**
+	 * Checks if the test class extending this test case class
+	 * has defined a temporary directory
+	 */
+	protected function hasTmp(): bool
+	{
+		return defined(get_class($this) . '::TMP');
 	}
 }

--- a/tests/Cms/Translations/TranslationTest.php
+++ b/tests/Cms/Translations/TranslationTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 class TranslationTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function testProps()
 	{
 		$translation = new Translation('en', [
@@ -23,13 +25,13 @@ class TranslationTest extends TestCase
 
 	public function testLoad()
 	{
-		$translation = Translation::load('de', __DIR__ . '/fixtures/translations/de.json');
+		$translation = Translation::load('de', static::FIXTURES . '/translations/de.json');
 
 		$this->assertSame('de', $translation->code());
 		$this->assertSame('Deutsch', $translation->name());
 
 		// invalid
-		$translation = Translation::load('zz', __DIR__ . '/fixtures/translations/zz.json');
+		$translation = Translation::load('zz', static::FIXTURES . '/translations/zz.json');
 
 		$this->assertSame('zz', $translation->code());
 		$this->assertSame([], $translation->data());
@@ -37,7 +39,7 @@ class TranslationTest extends TestCase
 
 	public function testToArray()
 	{
-		$translation = Translation::load('de', __DIR__ . '/fixtures/translations/de.json');
+		$translation = Translation::load('de', static::FIXTURES . '/translations/de.json');
 
 		$this->assertSame([
 			'code' => 'de',

--- a/tests/Cms/Translations/TranslationsTest.php
+++ b/tests/Cms/Translations/TranslationsTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 class TranslationsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function testFactory()
 	{
 		$translations = Translations::factory([
@@ -22,7 +24,7 @@ class TranslationsTest extends TestCase
 
 	public function testLoad()
 	{
-		$translations = Translations::load(__DIR__ . '/fixtures/translations');
+		$translations = Translations::load(static::FIXTURES . '/translations');
 
 		$this->assertCount(2, $translations);
 		$this->assertTrue($translations->has('de'));

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -8,17 +8,18 @@ use Kirby\Filesystem\F;
 
 class UserActionsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.UserActions';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
-		Dir::remove($this->tmp);
-		Data::write($this->tmp . '/accounts/admin/index.php', [
+		Dir::remove(static::TMP);
+		Data::write(static::TMP . '/accounts/admin/index.php', [
 			'email' => 'admin@domain.com',
 			'role' => 'admin'
 		]);
-		Data::write($this->tmp . '/accounts/editor/index.php', [
+		Data::write(static::TMP . '/accounts/editor/index.php', [
 			'email' => 'editor@domain.com',
 			'role' => 'editor'
 		]);
@@ -34,8 +35,8 @@ class UserActionsTest extends TestCase
 			],
 			'roots' => [
 				'index'    => '/dev/null',
-				'accounts' => $this->tmp . '/accounts',
-				'sessions' => $this->tmp . '/sessions'
+				'accounts' => static::TMP . '/accounts',
+				'sessions' => static::TMP . '/sessions'
 			],
 			'user'  => 'admin@domain.com'
 		]);
@@ -44,7 +45,7 @@ class UserActionsTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 		App::destroy();
 	}
 
@@ -125,18 +126,18 @@ class UserActionsTest extends TestCase
 	public function testChangeTotp()
 	{
 		$user = $this->app->user('admin@domain.com');
-		F::write($this->tmp . '/accounts/admin/.htpasswd', 'a very secure hash');
+		F::write(static::TMP . '/accounts/admin/.htpasswd', 'a very secure hash');
 		$this->assertNull($user->secret('totp'));
 
 		$user->changeTotp('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
 		$this->assertSame(
 			"a very secure hash\n" . '{"totp":"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"}',
-			F::read($this->tmp . '/accounts/admin/.htpasswd')
+			F::read(static::TMP . '/accounts/admin/.htpasswd')
 		);
 		$this->assertSame('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', $user->secret('totp'));
 
 		$user->changeTotp(null);
-		$this->assertSame('a very secure hash', F::read($this->tmp . '/accounts/admin/.htpasswd'));
+		$this->assertSame('a very secure hash', F::read(static::TMP . '/accounts/admin/.htpasswd'));
 		$this->assertNull($user->secret('totp'));
 	}
 

--- a/tests/Cms/Users/UserAuthTest.php
+++ b/tests/Cms/Users/UserAuthTest.php
@@ -6,17 +6,17 @@ use Kirby\Filesystem\F;
 
 class UserAuthTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Cms.UserAuth';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
-		Dir::remove($this->tmp);
 		$this->app = new App([
 			'roots' => [
 				'index'    => '/dev/null',
-				'accounts' => $this->tmp . '/accounts',
-				'sessions' => $this->tmp . '/sessions'
+				'accounts' => static::TMP . '/accounts',
+				'sessions' => static::TMP . '/sessions'
 			],
 			'users' => [
 				[
@@ -31,7 +31,7 @@ class UserAuthTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 		App::destroy();
 	}
 
@@ -116,7 +116,7 @@ class UserAuthTest extends TestCase
 
 	public function testSessionDataWithPassword()
 	{
-		F::write($this->tmp . '/accounts/testuser/.htpasswd', 'a very secure hash');
+		F::write(static::TMP . '/accounts/testuser/.htpasswd', 'a very secure hash');
 
 		$user    = $this->app->user('test@getkirby.com');
 		$session = $this->app->session();

--- a/tests/Cms/Users/UserRulesTest.php
+++ b/tests/Cms/Users/UserRulesTest.php
@@ -10,11 +10,13 @@ use Kirby\Exception\PermissionException;
 
 class UserRulesTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function app()
 	{
 		return new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures'
+				'site' => static::FIXTURES
 			]
 		]);
 	}
@@ -118,7 +120,7 @@ class UserRulesTest extends TestCase
 	{
 		$kirby = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures',
+				'site' => static::FIXTURES,
 			],
 			'user' => 'admin@domain.com',
 			'users' => [
@@ -147,7 +149,7 @@ class UserRulesTest extends TestCase
 	{
 		$kirby = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures',
+				'site' => static::FIXTURES,
 			],
 			'user' => 'admin@domain.com',
 			'users' => [
@@ -167,7 +169,7 @@ class UserRulesTest extends TestCase
 
 		$kirby = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures',
+				'site' => static::FIXTURES,
 			],
 			'user' => 'user@domain.com',
 			'users' => [
@@ -184,7 +186,7 @@ class UserRulesTest extends TestCase
 	{
 		$kirby = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures',
+				'site' => static::FIXTURES,
 			],
 			'user' => 'user1@domain.com',
 			'users' => [
@@ -204,7 +206,7 @@ class UserRulesTest extends TestCase
 
 		$kirby = new App([
 			'roots' => [
-				'site' => __DIR__ . '/fixtures',
+				'site' => static::FIXTURES,
 			],
 			'user' => 'user1@domain.com',
 			'users' => [

--- a/tests/Content/ContentStorageTest.php
+++ b/tests/Content/ContentStorageTest.php
@@ -16,17 +16,18 @@ use ReflectionMethod;
  */
 class ContentStorageTest extends TestCase
 {
-	protected $tmp = __DIR__ . '/tmp';
+	public const TMP = KIRBY_TMP_DIR . '/Content.ContentStorage';
+
 	protected $model;
 	protected $storage;
 
 	public function setUp(): void
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
 		$this->model = new Page([
 			'kirby'    => new App(),
-			'root'     => $this->tmp,
+			'root'     => static::TMP,
 			'slug'     => 'a-page',
 			'template' => 'article'
 		]);
@@ -36,7 +37,7 @@ class ContentStorageTest extends TestCase
 	public function tearDown(): void
 	{
 		App::destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -19,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 
 class FieldMethodsTest extends TestCase
 {
-	protected $tmp;
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Filesystem.FieldMethods';
 
 	public function setUp(): void
 	{
@@ -27,18 +28,19 @@ class FieldMethodsTest extends TestCase
 
 		new App([
 			'roots' => [
-				'index'   => $this->tmp = __DIR__ . '/tmp',
-				'content' => __DIR__ . '/fixtures'
+				'index'   => static::TMP,
+				'content' => static::FIXTURES
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
 		parent::tearDown();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function testFieldMethodCaseInsensitivity()
@@ -125,7 +127,7 @@ class FieldMethodsTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => [
 				'date.handler' => 'strftime'
@@ -157,6 +159,12 @@ class FieldMethodsTest extends TestCase
 
 	public function testToFile()
 	{
+		new App([
+			'roots' => [
+				'index' => static::TMP
+			]
+		]);
+
 		$page = new Page([
 			'content' => [
 				'cover'   => 'cover.jpg',
@@ -173,7 +181,6 @@ class FieldMethodsTest extends TestCase
 
 		$this->assertSame('cover.jpg', $page->cover()->toFile()->filename());
 		$this->assertSame('cover.jpg', $page->coverid()->toFile()->filename());
-		Dir::remove(__DIR__ . '/fixtures/test');
 	}
 
 	public function testToFiles()
@@ -196,7 +203,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -303,7 +310,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -331,7 +338,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -393,7 +400,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -477,7 +484,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'urls' => [
 				'index' => 'https://getkirby.com'
@@ -500,7 +507,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -547,7 +554,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'users' => [
 				['email' => 'a@company.com'],
@@ -572,7 +579,7 @@ class FieldMethodsTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'users' => [
 				['email' => 'a@company.com'],
@@ -798,7 +805,7 @@ class FieldMethodsTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => [
 				'smartypants' => true

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -18,17 +18,18 @@ use PHPUnit\Framework\TestCase;
  */
 class PlainTextContentStorageHandlerTest extends TestCase
 {
-	protected $tmp = __DIR__ . '/tmp';
+	public const TMP = KIRBY_TMP_DIR . '/Content.PlainTextContentStorage';
+
 	protected $model;
 	protected $storage;
 
 	public function setUp(): void
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
 		$this->model = new Page([
 			'kirby'    => new App(),
-			'root'     => $this->tmp,
+			'root'     => static::TMP,
 			'slug'     => 'a-page',
 			'template' => 'article'
 		]);
@@ -39,7 +40,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public function tearDown(): void
 	{
 		App::destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -53,7 +54,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		];
 
 		$this->storage->create('changes', 'en', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/_changes/article.en.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
 	/**
@@ -67,7 +68,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		];
 
 		$this->storage->create('changes', 'default', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/_changes/article.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
 	/**
@@ -81,7 +82,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		];
 
 		$this->storage->create('published', 'en', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/article.en.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
 	/**
@@ -95,7 +96,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		];
 
 		$this->storage->create('published', 'default', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/article.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
 	}
 
 	/**
@@ -116,7 +117,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		// test idempotency
 		$this->storage->delete('published', 'default');
-		$this->assertDirectoryDoesNotExist($this->tmp);
+		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
 	/**
@@ -124,14 +125,14 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testDeleteChangesMultiLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.en.txt');
-		touch($this->tmp . '/_changes/article.en.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.en.txt');
+		touch(static::TMP . '/_changes/article.en.txt');
 
 		$this->storage->delete('changes', 'en');
-		$this->assertFileDoesNotExist($this->tmp . '/_changes/article.en.txt');
-		$this->assertDirectoryDoesNotExist($this->tmp . '/_changes');
-		$this->assertDirectoryExists($this->tmp);
+		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.en.txt');
+		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
+		$this->assertDirectoryExists(static::TMP);
 	}
 
 	/**
@@ -139,13 +140,13 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testDeleteChangesSingleLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.txt');
-		touch($this->tmp . '/_changes/article.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.txt');
+		touch(static::TMP . '/_changes/article.txt');
 
 		$this->storage->delete('changes', 'default');
-		$this->assertFileDoesNotExist($this->tmp . '/_changes/article.txt');
-		$this->assertDirectoryDoesNotExist($this->tmp . '/_changes');
+		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.txt');
+		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
 	}
 
 	/**
@@ -153,13 +154,13 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testDeletePublishedMultiLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.en.txt');
-		touch($this->tmp . '/_changes/article.en.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.en.txt');
+		touch(static::TMP . '/_changes/article.en.txt');
 
 		$this->storage->delete('published', 'en');
-		$this->assertFileDoesNotExist($this->tmp . '/article.en.txt');
-		$this->assertDirectoryExists($this->tmp);
+		$this->assertFileDoesNotExist(static::TMP . '/article.en.txt');
+		$this->assertDirectoryExists(static::TMP);
 	}
 
 	/**
@@ -167,13 +168,13 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testDeletePublishedSingleLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.txt');
-		touch($this->tmp . '/_changes/article.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.txt');
+		touch(static::TMP . '/_changes/article.txt');
 
 		$this->storage->delete('published', 'default');
-		$this->assertFileDoesNotExist($this->tmp . '/article.txt');
-		$this->assertDirectoryExists($this->tmp);
+		$this->assertFileDoesNotExist(static::TMP . '/article.txt');
+		$this->assertDirectoryExists(static::TMP);
 	}
 
 	/**
@@ -202,9 +203,9 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testExistsSomeExistingMultiLang(string $id, string|null $language, array $expected)
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.txt');
-		touch($this->tmp . '/_changes/article.en.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.txt');
+		touch(static::TMP . '/_changes/article.en.txt');
 
 		new App([
 			'languages' => [
@@ -227,9 +228,9 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testExistsSomeExistingSingleLang(string $id, string|null $language, array $expected)
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.txt');
-		touch($this->tmp . '/_changes/article.en.txt');
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.txt');
+		touch(static::TMP . '/_changes/article.en.txt');
 
 		$this->assertSame($expected[1], $this->storage->exists($id, $language));
 	}
@@ -272,9 +273,9 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testModifiedSomeExisting(string $id, string $language, int|null $expected)
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/article.txt', 1234567890);
-		touch($this->tmp . '/_changes/article.en.txt', 1234567890);
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/article.txt', 1234567890);
+		touch(static::TMP . '/_changes/article.en.txt', 1234567890);
 
 		$this->assertSame($expected, $this->storage->modified($id, $language));
 	}
@@ -310,8 +311,8 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make($this->tmp . '/_changes');
-		Data::write($this->tmp . '/_changes/article.en.txt', $fields);
+		Dir::make(static::TMP . '/_changes');
+		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
 		$this->assertSame($fields, $this->storage->read('changes', 'en'));
 	}
@@ -326,8 +327,8 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make($this->tmp . '/_changes');
-		Data::write($this->tmp . '/_changes/article.txt', $fields);
+		Dir::make(static::TMP . '/_changes');
+		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
 		$this->assertSame($fields, $this->storage->read('changes', 'default'));
 	}
@@ -342,7 +343,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write($this->tmp . '/article.en.txt', $fields);
+		Data::write(static::TMP . '/article.en.txt', $fields);
 
 		$this->assertSame($fields, $this->storage->read('published', 'en'));
 	}
@@ -357,7 +358,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write($this->tmp . '/article.txt', $fields);
+		Data::write(static::TMP . '/article.txt', $fields);
 
 		$this->assertSame($fields, $this->storage->read('published', 'default'));
 	}
@@ -378,16 +379,16 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testTouchChangesMultiLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/_changes/article.en.txt', 123456);
-		$this->assertSame(123456, filemtime($this->tmp . '/_changes/article.en.txt'));
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/_changes/article.en.txt', 123456);
+		$this->assertSame(123456, filemtime(static::TMP . '/_changes/article.en.txt'));
 
 		$minTime = time();
 
 		$this->storage->touch('changes', 'en');
 
 		clearstatcache();
-		$this->assertGreaterThanOrEqual($minTime, filemtime($this->tmp . '/_changes/article.en.txt'));
+		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.en.txt'));
 	}
 
 	/**
@@ -395,16 +396,16 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testTouchChangesSingleLang()
 	{
-		Dir::make($this->tmp . '/_changes');
-		touch($this->tmp . '/_changes/article.txt', 123456);
-		$this->assertSame(123456, filemtime($this->tmp . '/_changes/article.txt'));
+		Dir::make(static::TMP . '/_changes');
+		touch(static::TMP . '/_changes/article.txt', 123456);
+		$this->assertSame(123456, filemtime(static::TMP . '/_changes/article.txt'));
 
 		$minTime = time();
 
 		$this->storage->touch('changes', 'default');
 
 		clearstatcache();
-		$this->assertGreaterThanOrEqual($minTime, filemtime($this->tmp . '/_changes/article.txt'));
+		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.txt'));
 	}
 
 	/**
@@ -412,15 +413,15 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testTouchPublishedMultiLang()
 	{
-		touch($this->tmp . '/article.en.txt', 123456);
-		$this->assertSame(123456, filemtime($this->tmp . '/article.en.txt'));
+		touch(static::TMP . '/article.en.txt', 123456);
+		$this->assertSame(123456, filemtime(static::TMP . '/article.en.txt'));
 
 		$minTime = time();
 
 		$this->storage->touch('published', 'en');
 
 		clearstatcache();
-		$this->assertGreaterThanOrEqual($minTime, filemtime($this->tmp . '/article.en.txt'));
+		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.en.txt'));
 	}
 
 	/**
@@ -428,15 +429,15 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 */
 	public function testTouchPublishedSingleLang()
 	{
-		touch($this->tmp . '/article.txt', 123456);
-		$this->assertSame(123456, filemtime($this->tmp . '/article.txt'));
+		touch(static::TMP . '/article.txt', 123456);
+		$this->assertSame(123456, filemtime(static::TMP . '/article.txt'));
 
 		$minTime = time();
 
 		$this->storage->touch('published', 'default');
 
 		clearstatcache();
-		$this->assertGreaterThanOrEqual($minTime, filemtime($this->tmp . '/article.txt'));
+		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.txt'));
 	}
 
 	/**
@@ -460,11 +461,11 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make($this->tmp . '/_changes');
-		Data::write($this->tmp . '/_changes/article.en.txt', $fields);
+		Dir::make(static::TMP . '/_changes');
+		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
 		$this->storage->update('changes', 'en', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/_changes/article.en.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
 	/**
@@ -477,11 +478,11 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make($this->tmp . '/_changes');
-		Data::write($this->tmp . '/_changes/article.txt', $fields);
+		Dir::make(static::TMP . '/_changes');
+		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
 		$this->storage->update('changes', 'default', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/_changes/article.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
 	/**
@@ -494,10 +495,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write($this->tmp . '/article.en.txt', $fields);
+		Data::write(static::TMP . '/article.en.txt', $fields);
 
 		$this->storage->update('published', 'en', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/article.en.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
 	/**
@@ -510,10 +511,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write($this->tmp . '/article.txt', $fields);
+		Data::write(static::TMP . '/article.txt', $fields);
 
 		$this->storage->update('published', 'default', $fields);
-		$this->assertSame($fields, Data::read($this->tmp . '/article.txt'));
+		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
 	}
 
 	/**
@@ -535,7 +536,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 
@@ -559,7 +560,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		};
 
 		$storage = new PlainTextContentStorageHandler($model);
-		$this->assertSame($this->tmp . '/' . $expected, $storage->contentFile($id, $language));
+		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile($id, $language));
 	}
 
 	public static function contentFileProvider(): array
@@ -592,7 +593,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 
@@ -604,7 +605,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$storage = new PlainTextContentStorageHandler($model);
-		$this->assertSame($this->tmp . '/' . $expected, $storage->contentFile('changes', $language));
+		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile('changes', $language));
 	}
 
 	/**
@@ -615,13 +616,13 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 
 		$model = new Page([
 			'kirby' => $app,
-			'root' => $this->tmp,
+			'root' => static::TMP,
 			'isDraft' => true,
 			'slug' => 'a-page',
 			'template' => 'article'
@@ -671,8 +672,8 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$this->assertSame([
-			$this->tmp . '/_changes/article.en.txt',
-			$this->tmp . '/_changes/article.de.txt'
+			static::TMP . '/_changes/article.en.txt',
+			static::TMP . '/_changes/article.de.txt'
 		], $this->storage->contentFiles('changes'));
 	}
 
@@ -682,7 +683,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public function testContentFilesChangesSingleLang()
 	{
 		$this->assertSame([
-			$this->tmp . '/_changes/article.txt'
+			static::TMP . '/_changes/article.txt'
 		], $this->storage->contentFiles('changes'));
 	}
 
@@ -704,8 +705,8 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$this->assertSame([
-			$this->tmp . '/article.en.txt',
-			$this->tmp . '/article.de.txt'
+			static::TMP . '/article.en.txt',
+			static::TMP . '/article.de.txt'
 		], $this->storage->contentFiles('published'));
 	}
 
@@ -715,7 +716,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public function testContentFilesPublishedSingleLang()
 	{
 		$this->assertSame([
-			$this->tmp . '/article.txt'
+			static::TMP . '/article.txt'
 		], $this->storage->contentFiles('published'));
 	}
 

--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -13,6 +13,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class DataTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Data.Data';
+
 	/**
 	 * @covers ::handler
 	 */
@@ -141,10 +143,7 @@ class DataTest extends TestCase
 			'email' => 'homer@simpson.com'
 		];
 
-		$file = __DIR__ . '/tmp/data.json';
-
-		// clean up first
-		@unlink($file);
+		$file = static::TMP . '/data.json';
 
 		// automatic type detection
 		Data::write($file, $data);
@@ -172,7 +171,7 @@ class DataTest extends TestCase
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
 
-		Data::read(__DIR__ . '/tmp/data.foo');
+		Data::read(static::TMP . '/data.foo');
 	}
 
 	/**
@@ -189,6 +188,6 @@ class DataTest extends TestCase
 			'email' => 'homer@simpson.com'
 		];
 
-		Data::write(__DIR__ . '/tmp/data.foo', $data);
+		Data::write(static::TMP . '/data.foo', $data);
 	}
 }

--- a/tests/Data/HandlerTest.php
+++ b/tests/Data/HandlerTest.php
@@ -12,6 +12,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class HandlerTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Data.Handler';
+
 	/**
 	 * @covers ::read
 	 * @covers ::write
@@ -23,10 +25,7 @@ class HandlerTest extends TestCase
 			'email' => 'homer@simpson.com'
 		];
 
-		$file = __DIR__ . '/tmp/data.json';
-
-		// clean up first
-		@unlink($file);
+		$file = static::TMP . '/data.json';
 
 		CustomHandler::write($file, $data);
 		$this->assertFileExists($file);
@@ -41,7 +40,7 @@ class HandlerTest extends TestCase
 	 */
 	public function testReadFileMissing()
 	{
-		$file = __DIR__ . '/tmp/does-not-exist.json';
+		$file = static::TMP . '/does-not-exist.json';
 
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('The file "' . $file . '" does not exist or cannot be read');

--- a/tests/Data/PHPTest.php
+++ b/tests/Data/PHPTest.php
@@ -11,13 +11,16 @@ use PHPUnit\Framework\TestCase;
  */
 class PHPTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/php';
+	public const TMP      = KIRBY_TMP_DIR . '/Data.PHP';
+
 	/**
 	 * @covers ::encode
 	 */
 	public function testEncode()
 	{
-		$input    = __DIR__ . '/fixtures/php/input.php';
-		$expected = __DIR__ . '/fixtures/php/expected.php';
+		$input    = static::FIXTURES . '/input.php';
+		$expected = static::FIXTURES . '/expected.php';
 		$result   = PHP::encode(include $input);
 
 		$this->assertSame(trim(file_get_contents($expected)), $result);
@@ -35,7 +38,7 @@ class PHPTest extends TestCase
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('The PHP::decode() method is not implemented');
 
-		$input  = include __DIR__ . '/fixtures/php/input.php';
+		$input  = include static::FIXTURES . '/input.php';
 		$result = PHP::decode($input);
 	}
 
@@ -44,7 +47,7 @@ class PHPTest extends TestCase
 	 */
 	public function testRead()
 	{
-		$input  = __DIR__ . '/fixtures/php/input.php';
+		$input  = static::FIXTURES . '/input.php';
 		$result = PHP::read($input);
 
 		$this->assertSame($result, include $input);
@@ -55,7 +58,7 @@ class PHPTest extends TestCase
 	 */
 	public function testReadFileMissing()
 	{
-		$file = __DIR__ . '/tmp/does-not-exist.php';
+		$file = static::TMP . '/does-not-exist.php';
 
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('The file "' . $file . '" does not exist');
@@ -68,8 +71,8 @@ class PHPTest extends TestCase
 	 */
 	public function testWrite()
 	{
-		$input = include __DIR__ . '/fixtures/php/input.php';
-		$file  = __DIR__ . '/fixtures/php/tmp.php';
+		$input = include static::FIXTURES . '/input.php';
+		$file  = static::TMP . '/tmp.php';
 
 		$this->assertTrue(PHP::write($file, $input));
 

--- a/tests/Email/PHPMailerTest.php
+++ b/tests/Email/PHPMailerTest.php
@@ -6,6 +6,8 @@ use Kirby\Exception\InvalidArgumentException;
 
 class PHPMailerTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
+
 	protected function _email($props = [], $mailer = PHPMailer::class)
 	{
 		return parent::_email($props, $mailer);
@@ -24,6 +26,7 @@ class PHPMailerTest extends TestCase
 	public function testProperties()
 	{
 		$phpunit = $this;
+		$fixtures = static::FIXTURES;
 		$beforeSend = false;
 
 		$email = $this->_email([
@@ -45,9 +48,9 @@ class PHPMailerTest extends TestCase
 				'html' => '<strong>We will never reply</strong>',
 			],
 			'attachments' => [
-				__DIR__ . '/fixtures/files/test.jpg'
+				static::FIXTURES . '/test.jpg'
 			],
-			'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend) {
+			'beforeSend' => function (\PHPMailer\PHPMailer\PHPMailer $mailer) use ($phpunit, &$beforeSend, $fixtures) {
 				$phpunit->assertInstanceOf('PHPMailer\PHPMailer\PHPMailer', $mailer);
 				$phpunit->assertSame('mail', $mailer->Mailer);
 				$phpunit->assertSame('no-reply@supercompany.com', $mailer->From);
@@ -68,7 +71,7 @@ class PHPMailerTest extends TestCase
 				], $mailer->getBccAddresses());
 				$phpunit->assertSame([
 					[
-						__DIR__ . '/fixtures/files/test.jpg',
+						$fixtures . '/test.jpg',
 						'test.jpg',
 						'test.jpg',
 						'base64',

--- a/tests/Field/FieldOptionsTest.php
+++ b/tests/Field/FieldOptionsTest.php
@@ -12,6 +12,8 @@ use Kirby\Option\OptionsQuery;
  */
 class FieldOptionsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/../Option/fixtures';
+
 	/**
 	 * @covers ::factory
 	 */
@@ -90,7 +92,7 @@ class FieldOptionsTest extends TestCase
 
 		$options = FieldOptions::factory([
 			'type'  => 'api',
-			'url'   =>  __DIR__ . '/../Option/fixtures/data-nested.json',
+			'url'   =>  static::FIXTURES . '/data-nested.json',
 			'query' => 'Directory.Companies',
 			'text'  => '{{ item.slogan }}'
 		]);
@@ -101,7 +103,7 @@ class FieldOptionsTest extends TestCase
 		$options = FieldOptions::factory(
 			[
 				'type'  => 'api',
-				'url'   =>  __DIR__ . '/../Option/fixtures/data-nested.json',
+				'url'   =>  static::FIXTURES . '/data-nested.json',
 				'query' => 'Directory.Companies',
 				'text'  => '{{ item.slogan }}'
 			],

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -15,21 +15,17 @@ use PHPUnit\Framework\TestCase as TestCase;
 class DirTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/dir';
-
-	protected $fixtures = __DIR__ . '/fixtures/dir';
-	protected $tmp = __DIR__ . '/tmp';
-	protected $moved = __DIR__ . '/moved';
+	public const TMP      = KIRBY_TMP_DIR . '/Filesystem.Dir';
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
-		Dir::remove($this->moved);
+		Dir::remove(static::TMP);
 	}
 
 	protected function create(array $items, ...$args)
 	{
 		foreach ($items as $item) {
-			$root = $this->tmp . '/' . $item;
+			$root = static::TMP . '/' . $item;
 
 			if ($extension = F::extension($item)) {
 				F::write($root, '');
@@ -38,7 +34,7 @@ class DirTest extends TestCase
 			}
 		}
 
-		return Dir::inventory($this->tmp, ...$args);
+		return Dir::inventory(static::TMP, ...$args);
 	}
 
 	/**
@@ -46,8 +42,8 @@ class DirTest extends TestCase
 	 */
 	public function testCopy()
 	{
-		$src    = $this->fixtures . '/copy';
-		$target = $this->tmp . '/copy';
+		$src    = static::FIXTURES . '/copy';
+		$target = static::TMP . '/copy';
 
 		$result = Dir::copy($src, $target);
 
@@ -63,8 +59,8 @@ class DirTest extends TestCase
 	 */
 	public function testCopyNonRecursive()
 	{
-		$src    = $this->fixtures . '/copy';
-		$target = $this->tmp . '/copy';
+		$src    = static::FIXTURES . '/copy';
+		$target = static::TMP . '/copy';
 
 		$result = Dir::copy($src, $target, false);
 
@@ -80,8 +76,8 @@ class DirTest extends TestCase
 	 */
 	public function testCopyIgnore()
 	{
-		$src    = $this->fixtures . '/copy';
-		$target = $this->tmp . '/copy';
+		$src    = static::FIXTURES . '/copy';
+		$target = static::TMP . '/copy';
 
 		$result = Dir::copy($src, $target, true, [$src . '/subfolder/b.txt']);
 
@@ -98,8 +94,8 @@ class DirTest extends TestCase
 	 */
 	public function testCopyNoIgnore()
 	{
-		$src    = $this->fixtures . '/copy';
-		$target = $this->tmp . '/copy';
+		$src    = static::FIXTURES . '/copy';
+		$target = static::TMP . '/copy';
 
 		$result = Dir::copy($src, $target, true, false);
 
@@ -120,7 +116,7 @@ class DirTest extends TestCase
 		$this->expectExceptionMessage('The directory "/does-not-exist" does not exist');
 
 		$src    = '/does-not-exist';
-		$target = $this->tmp . '/copy';
+		$target = static::TMP . '/copy';
 
 		Dir::copy($src, $target);
 	}
@@ -130,8 +126,8 @@ class DirTest extends TestCase
 	 */
 	public function testCopyExistingTarget()
 	{
-		$src    = $this->fixtures . '/copy';
-		$target = $this->fixtures . '/copy';
+		$src    = static::FIXTURES . '/copy';
+		$target = static::FIXTURES . '/copy';
 
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('The target directory "' . $target . '" exists');
@@ -144,7 +140,7 @@ class DirTest extends TestCase
 	 */
 	public function testCopyInvalidTarget()
 	{
-		$src    = $this->fixtures . '/copy';
+		$src    = static::FIXTURES . '/copy';
 		$target = '';
 
 		$this->expectException('Exception');
@@ -158,9 +154,9 @@ class DirTest extends TestCase
 	 */
 	public function testExists()
 	{
-		$this->assertFalse(Dir::exists($this->tmp));
-		Dir::make($this->tmp);
-		$this->assertTrue(Dir::exists($this->tmp));
+		$this->assertFalse(Dir::exists(static::TMP));
+		Dir::make(static::TMP);
+		$this->assertTrue(Dir::exists(static::TMP));
 	}
 
 	/**
@@ -168,11 +164,11 @@ class DirTest extends TestCase
 	 */
 	public function testIndex()
 	{
-		Dir::make($dir = $this->tmp);
-		Dir::make($this->tmp . '/sub');
+		Dir::make($dir = static::TMP);
+		Dir::make(static::TMP . '/sub');
 
-		F::write($this->tmp . '/a.txt', 'test');
-		F::write($this->tmp . '/b.txt', 'test');
+		F::write(static::TMP . '/a.txt', 'test');
+		F::write(static::TMP . '/b.txt', 'test');
 
 		$expected = [
 			'a.txt',
@@ -188,13 +184,13 @@ class DirTest extends TestCase
 	 */
 	public function testIndexRecursive()
 	{
-		Dir::make($dir = $this->tmp);
-		Dir::make($this->tmp . '/sub');
-		Dir::make($this->tmp . '/sub/sub');
+		Dir::make($dir = static::TMP);
+		Dir::make(static::TMP . '/sub');
+		Dir::make(static::TMP . '/sub/sub');
 
-		F::write($this->tmp . '/a.txt', 'test');
-		F::write($this->tmp . '/sub/b.txt', 'test');
-		F::write($this->tmp . '/sub/sub/c.txt', 'test');
+		F::write(static::TMP . '/a.txt', 'test');
+		F::write(static::TMP . '/sub/b.txt', 'test');
+		F::write(static::TMP . '/sub/sub/c.txt', 'test');
 
 		$expected = [
 			'a.txt',
@@ -214,17 +210,17 @@ class DirTest extends TestCase
 	{
 		Dir::$ignore = ['z.txt'];
 
-		Dir::make($dir = $this->tmp);
-		Dir::make($this->tmp . '/sub');
-		Dir::make($this->tmp . '/sub/sub');
+		Dir::make($dir = static::TMP);
+		Dir::make(static::TMP . '/sub');
+		Dir::make(static::TMP . '/sub/sub');
 
-		F::write($this->tmp . '/a.txt', 'test');
-		F::write($this->tmp . '/d.txt', 'test');
-		F::write($this->tmp . '/z.txt', 'test');
-		F::write($this->tmp . '/sub/a.txt', 'test');
-		F::write($this->tmp . '/sub/b.txt', 'test');
-		F::write($this->tmp . '/sub/sub/a.txt', 'test');
-		F::write($this->tmp . '/sub/sub/c.txt', 'test');
+		F::write(static::TMP . '/a.txt', 'test');
+		F::write(static::TMP . '/d.txt', 'test');
+		F::write(static::TMP . '/z.txt', 'test');
+		F::write(static::TMP . '/sub/a.txt', 'test');
+		F::write(static::TMP . '/sub/b.txt', 'test');
+		F::write(static::TMP . '/sub/sub/a.txt', 'test');
+		F::write(static::TMP . '/sub/sub/c.txt', 'test');
 
 		// only global static $ignore
 		$this->assertSame([
@@ -259,9 +255,9 @@ class DirTest extends TestCase
 			'sub/sub',
 			'sub/sub/c.txt'
 		], Dir::index($dir, true, [
-			$this->tmp . '/a.txt',
-			$this->tmp . '/sub/a.txt',
-			$this->tmp . '/sub/sub/a.txt'
+			static::TMP . '/a.txt',
+			static::TMP . '/sub/a.txt',
+			static::TMP . '/sub/sub/a.txt'
 		]));
 	}
 
@@ -270,9 +266,9 @@ class DirTest extends TestCase
 	 */
 	public function testIsWritable()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		$this->assertSame(is_writable($this->tmp), Dir::isWritable($this->tmp));
+		$this->assertSame(is_writable(static::TMP), Dir::isWritable(static::TMP));
 	}
 
 	/**
@@ -521,7 +517,7 @@ class DirTest extends TestCase
 	 */
 	public function testMake()
 	{
-		$this->assertTrue(Dir::make($this->tmp));
+		$this->assertTrue(Dir::make(static::TMP));
 		$this->assertFalse(Dir::make(''));
 	}
 
@@ -530,7 +526,7 @@ class DirTest extends TestCase
 	 */
 	public function testMakeFileExists()
 	{
-		$test = $this->tmp . '/test';
+		$test = static::TMP . '/test';
 
 		$this->expectException('Exception');
 		$this->expectExceptionMessage('A file with the name "' . $test . '" already exists');
@@ -544,9 +540,9 @@ class DirTest extends TestCase
 	 */
 	public function testModified()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		$this->assertTrue(is_int(Dir::modified($this->tmp)));
+		$this->assertTrue(is_int(Dir::modified(static::TMP)));
 	}
 
 	/**
@@ -554,9 +550,9 @@ class DirTest extends TestCase
 	 */
 	public function testMove()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP . '/1');
 
-		$this->assertTrue(Dir::move($this->tmp, $this->moved));
+		$this->assertTrue(Dir::move(static::TMP . '/1', static::TMP . '/2'));
 	}
 
 	/**
@@ -564,7 +560,7 @@ class DirTest extends TestCase
 	 */
 	public function testMoveNonExisting()
 	{
-		$this->assertFalse(Dir::move('/does-not-exist', $this->moved));
+		$this->assertFalse(Dir::move('/does-not-exist', static::TMP . '/2'));
 	}
 
 	/**
@@ -572,8 +568,8 @@ class DirTest extends TestCase
 	 */
 	public function testLink()
 	{
-		$source = $this->tmp . '/source';
-		$link   = $this->tmp . '/link';
+		$source = static::TMP . '/source';
+		$link   = static::TMP . '/link';
 
 		Dir::make($source);
 
@@ -586,8 +582,8 @@ class DirTest extends TestCase
 	 */
 	public function testLinkExistingLink()
 	{
-		$source = $this->tmp . '/source';
-		$link   = $this->tmp . '/link';
+		$source = static::TMP . '/source';
+		$link   = static::TMP . '/link';
 
 		Dir::make($source);
 		Dir::link($source, $link);
@@ -600,8 +596,8 @@ class DirTest extends TestCase
 	 */
 	public function testLinkWithoutSource()
 	{
-		$source = $this->tmp . '/source';
-		$link   = $this->tmp . '/link';
+		$source = static::TMP . '/source';
+		$link   = static::TMP . '/link';
 
 		$this->expectExceptionMessage('Expection');
 		$this->expectExceptionMessage('The directory "' . $source . '" does not exist and cannot be linked');
@@ -614,14 +610,14 @@ class DirTest extends TestCase
 	 */
 	public function testRead()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		touch($this->tmp . '/a.jpg');
-		touch($this->tmp . '/b.jpg');
-		touch($this->tmp . '/c.jpg');
+		touch(static::TMP . '/a.jpg');
+		touch(static::TMP . '/b.jpg');
+		touch(static::TMP . '/c.jpg');
 
 		// relative
-		$files    = Dir::read($this->tmp);
+		$files    = Dir::read(static::TMP);
 		$expected = [
 			'a.jpg',
 			'b.jpg',
@@ -631,17 +627,17 @@ class DirTest extends TestCase
 		$this->assertSame($expected, $files);
 
 		// absolute
-		$files    = Dir::read($this->tmp, null, true);
+		$files    = Dir::read(static::TMP, null, true);
 		$expected = [
-			$this->tmp . '/a.jpg',
-			$this->tmp . '/b.jpg',
-			$this->tmp . '/c.jpg'
+			static::TMP . '/a.jpg',
+			static::TMP . '/b.jpg',
+			static::TMP . '/c.jpg'
 		];
 
 		$this->assertSame($expected, $files);
 
 		// ignore
-		$files    = Dir::read($this->tmp, ['a.jpg']);
+		$files    = Dir::read(static::TMP, ['a.jpg']);
 		$expected = [
 			'b.jpg',
 			'c.jpg'
@@ -655,11 +651,11 @@ class DirTest extends TestCase
 	 */
 	public function testRemove()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		$this->assertDirectoryExists($this->tmp);
-		$this->assertTrue(Dir::remove($this->tmp));
-		$this->assertDirectoryDoesNotExist($this->tmp);
+		$this->assertDirectoryExists(static::TMP);
+		$this->assertTrue(Dir::remove(static::TMP));
+		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
 	/**
@@ -667,9 +663,9 @@ class DirTest extends TestCase
 	 */
 	public function testIsReadable()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		$this->assertSame(is_readable($this->tmp), Dir::isReadable($this->tmp));
+		$this->assertSame(is_readable(static::TMP), Dir::isReadable(static::TMP));
 	}
 
 	/**
@@ -678,53 +674,51 @@ class DirTest extends TestCase
 	 */
 	public function testReadDirsAndFiles()
 	{
-		Dir::make($root = $this->fixtures . '/dirs');
-		Dir::make($root . '/a');
-		Dir::make($root . '/b');
-		Dir::make($root . '/c');
+		Dir::make(static::TMP);
+		Dir::make(static::TMP . '/a');
+		Dir::make(static::TMP . '/b');
+		Dir::make(static::TMP . '/c');
 
-		touch($root . '/a.txt');
-		touch($root . '/b.jpg');
-		touch($root . '/c.doc');
+		touch(static::TMP . '/a.txt');
+		touch(static::TMP . '/b.jpg');
+		touch(static::TMP . '/c.doc');
 
-		$any = Dir::read($root);
+		$any = Dir::read(static::TMP);
 		$expected = ['a', 'a.txt', 'b', 'b.jpg', 'c', 'c.doc'];
 
 		$this->assertSame($any, $expected);
 
 		// relative dirs
-		$dirs = Dir::dirs($root);
+		$dirs = Dir::dirs(static::TMP);
 		$expected = ['a', 'b', 'c'];
 
 		$this->assertSame($expected, $dirs);
 
 		// absolute dirs
-		$dirs = Dir::dirs($root, null, true);
+		$dirs = Dir::dirs(static::TMP, null, true);
 		$expected = [
-			$root . '/a',
-			$root . '/b',
-			$root . '/c'
+			static::TMP . '/a',
+			static::TMP . '/b',
+			static::TMP . '/c'
 		];
 
 		$this->assertSame($expected, $dirs);
 
 		// relative files
-		$files = Dir::files($root);
+		$files = Dir::files(static::TMP);
 		$expected = ['a.txt', 'b.jpg', 'c.doc'];
 
 		$this->assertSame($expected, $files);
 
 		// absolute files
-		$files = Dir::files($root, null, true);
+		$files = Dir::files(static::TMP, null, true);
 		$expected = [
-			$root . '/a.txt',
-			$root . '/b.jpg',
-			$root . '/c.doc'
+			static::TMP . '/a.txt',
+			static::TMP . '/b.jpg',
+			static::TMP . '/c.doc'
 		];
 
 		$this->assertSame($expected, $files);
-
-		Dir::remove($root);
 	}
 
 	/**
@@ -733,17 +727,17 @@ class DirTest extends TestCase
 	 */
 	public function testSize()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
-		F::write($this->tmp . '/testfile-1.txt', Str::random(5));
-		F::write($this->tmp . '/testfile-2.txt', Str::random(5));
-		F::write($this->tmp . '/testfile-3.txt', Str::random(5));
+		F::write(static::TMP . '/testfile-1.txt', Str::random(5));
+		F::write(static::TMP . '/testfile-2.txt', Str::random(5));
+		F::write(static::TMP . '/testfile-3.txt', Str::random(5));
 
-		$this->assertSame(15, Dir::size($this->tmp));
-		$this->assertSame(15, Dir::size($this->tmp, false));
-		$this->assertSame('15 B', Dir::niceSize($this->tmp));
+		$this->assertSame(15, Dir::size(static::TMP));
+		$this->assertSame(15, Dir::size(static::TMP, false));
+		$this->assertSame('15 B', Dir::niceSize(static::TMP));
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -751,19 +745,19 @@ class DirTest extends TestCase
 	 */
 	public function testSizeWithNestedFolders()
 	{
-		Dir::make($this->tmp);
-		Dir::make($this->tmp . '/sub');
-		Dir::make($this->tmp . '/sub/sub');
+		Dir::make(static::TMP);
+		Dir::make(static::TMP . '/sub');
+		Dir::make(static::TMP . '/sub/sub');
 
-		F::write($this->tmp . '/testfile-1.txt', Str::random(5));
-		F::write($this->tmp . '/sub/testfile-2.txt', Str::random(5));
-		F::write($this->tmp . '/sub/sub/testfile-3.txt', Str::random(5));
+		F::write(static::TMP . '/testfile-1.txt', Str::random(5));
+		F::write(static::TMP . '/sub/testfile-2.txt', Str::random(5));
+		F::write(static::TMP . '/sub/sub/testfile-3.txt', Str::random(5));
 
-		$this->assertSame(15, Dir::size($this->tmp));
-		$this->assertSame(5, Dir::size($this->tmp, false));
-		$this->assertSame('15 B', Dir::niceSize($this->tmp));
+		$this->assertSame(15, Dir::size(static::TMP));
+		$this->assertSame(5, Dir::size(static::TMP, false));
+		$this->assertSame('15 B', Dir::niceSize(static::TMP));
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -781,34 +775,34 @@ class DirTest extends TestCase
 	{
 		$time = time();
 
-		Dir::make($this->tmp);
-		Dir::make($this->tmp . '/sub');
-		F::write($this->tmp . '/sub/test.txt', 'foo');
+		Dir::make(static::TMP);
+		Dir::make(static::TMP . '/sub');
+		F::write(static::TMP . '/sub/test.txt', 'foo');
 
 		// the modification time of the folder is already later
 		// than the given time
-		$this->assertTrue(Dir::wasModifiedAfter($this->tmp, $time - 10));
+		$this->assertTrue(Dir::wasModifiedAfter(static::TMP, $time - 10));
 
 		// ensure that the modified times are consistent
 		// to make the test more reliable
-		touch($this->tmp, $time);
-		touch($this->tmp . '/sub', $time);
-		touch($this->tmp . '/sub/test.txt', $time);
+		touch(static::TMP, $time);
+		touch(static::TMP . '/sub', $time);
+		touch(static::TMP . '/sub/test.txt', $time);
 
-		$this->assertFalse(Dir::wasModifiedAfter($this->tmp, $time));
+		$this->assertFalse(Dir::wasModifiedAfter(static::TMP, $time));
 
-		touch($this->tmp . '/sub/test.txt', $time + 1);
+		touch(static::TMP . '/sub/test.txt', $time + 1);
 
-		$this->assertTrue(Dir::wasModifiedAfter($this->tmp, $time));
+		$this->assertTrue(Dir::wasModifiedAfter(static::TMP, $time));
 
-		touch($this->tmp . '/sub', $time + 1);
-		touch($this->tmp . '/sub/test.txt', $time);
+		touch(static::TMP . '/sub', $time + 1);
+		touch(static::TMP . '/sub/test.txt', $time);
 
-		$this->assertTrue(Dir::wasModifiedAfter($this->tmp, $time));
+		$this->assertTrue(Dir::wasModifiedAfter(static::TMP, $time));
 
 		// sanity check
-		touch($this->tmp . '/sub', $time);
+		touch(static::TMP . '/sub', $time);
 
-		$this->assertFalse(Dir::wasModifiedAfter($this->tmp, $time));
+		$this->assertFalse(Dir::wasModifiedAfter(static::TMP, $time));
 	}
 }

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -15,27 +15,25 @@ require_once dirname(__DIR__) . '/Http/mocks.php';
  */
 class FTest extends TestCase
 {
-	protected $fixtures;
+	public const FIXTURES = __DIR__ . '/fixtures/f';
+	public const TMP      = KIRBY_TMP_DIR . '/Filesystem.F';
+
 	protected $hasErrorHandler = false;
 	protected $sample;
 	protected $test;
-	protected $tmp;
 
 	public function setUp(): void
 	{
-		$this->fixtures = __DIR__ . '/fixtures/f';
-		$this->sample   = $this->fixtures . '/test.txt';
-		$this->tmp      = __DIR__ . '/tmp';
-		$this->test     = $this->tmp . '/moved.txt';
+		$this->sample = static::FIXTURES . '/test.txt';
+		$this->test   = static::TMP . '/moved.txt';
 
-		Dir::remove($this->tmp);
-		Dir::make($this->tmp);
+		Dir::remove(static::TMP);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		F::unlink($this->test);
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		if ($this->hasErrorHandler === true) {
 			restore_error_handler();
@@ -70,7 +68,7 @@ class FTest extends TestCase
 	 */
 	public function testCopy()
 	{
-		$origin = $this->tmp . '/a.txt';
+		$origin = static::TMP . '/a.txt';
 		F::write($origin, 'test');
 
 		$this->assertFileDoesNotExist($this->test);
@@ -167,8 +165,8 @@ class FTest extends TestCase
 	 */
 	public function testLink()
 	{
-		$src  = $this->tmp . '/a.txt';
-		$link = $this->tmp . '/b.txt';
+		$src  = static::TMP . '/a.txt';
+		$link = static::TMP . '/b.txt';
 
 		F::write($src, 'test');
 
@@ -309,8 +307,8 @@ class FTest extends TestCase
 	 */
 	public function testLinkSymlink()
 	{
-		$src  = $this->tmp . '/a.txt';
-		$link = $this->tmp . '/b.txt';
+		$src  = static::TMP . '/a.txt';
+		$link = static::TMP . '/b.txt';
 
 		F::write($src, 'test');
 
@@ -323,8 +321,8 @@ class FTest extends TestCase
 	 */
 	public function testLinkExistingLink()
 	{
-		$src  = $this->tmp . '/a.txt';
-		$link = $this->tmp . '/b.txt';
+		$src  = static::TMP . '/a.txt';
+		$link = static::TMP . '/b.txt';
 
 		F::write($src, 'test');
 		F::link($src, $link);
@@ -337,8 +335,8 @@ class FTest extends TestCase
 	 */
 	public function testLinkWithMissingSource()
 	{
-		$src  = $this->tmp . '/a.txt';
-		$link = $this->tmp . '/b.txt';
+		$src  = static::TMP . '/a.txt';
+		$link = static::TMP . '/b.txt';
 
 		$this->expectExceptionMessage('Expection');
 		$this->expectExceptionMessage('The file "' . $src . '" does not exist and cannot be linked');
@@ -352,24 +350,24 @@ class FTest extends TestCase
 	public function testLoad()
 	{
 		// basic behavior
-		F::write($file = $this->tmp . '/test.php', '<?php return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php return "foo";');
 		$this->assertSame('foo', F::load($file));
 
 		// non-existing file
 		$this->assertSame('foo', F::load('does-not-exist.php', 'foo'));
 
 		// type mismatch
-		F::write($file = $this->tmp . '/test.php', '<?php return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php return "foo";');
 		$expected = ['a' => 'b'];
 		$this->assertSame($expected, F::load($file, $expected));
 
 		// type mismatch with overwritten $fallback
-		F::write($file = $this->tmp . '/test.php', '<?php $fallback = "test"; return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php $fallback = "test"; return "foo";');
 		$expected = ['a' => 'b'];
 		$this->assertSame($expected, F::load($file, $expected));
 
 		// with data
-		F::write($file = $this->tmp . '/test.php', '<?php return $variable;');
+		F::write($file = static::TMP . '/test.php', '<?php return $variable;');
 		$this->assertSame('foobar', F::load($file, null, ['variable' => 'foobar']));
 
 		// with overwritten $data
@@ -379,11 +377,11 @@ class FTest extends TestCase
 		$this->assertSame('foobar', F::load($file, null, ['variable' => 'foobar', 'file' => null]));
 
 		// protection against accidental output (without output)
-		F::write($file = $this->tmp . '/test.php', '<?php return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php return "foo";');
 		$this->assertSame('foo', F::load($file, allowOutput: false));
 
 		// no protection against accidental output (with output)
-		F::write($file = $this->tmp . '/test.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
 		$this->assertSame('foo', F::load($file));
 	}
 
@@ -395,7 +393,7 @@ class FTest extends TestCase
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Disallowed output from file file.php:123, possible accidental whitespace?');
 
-		F::write($file = $this->tmp . '/test.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
+		F::write($file = static::TMP . '/test.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
 
 		F::load($file, allowOutput: false);
 	}
@@ -406,13 +404,13 @@ class FTest extends TestCase
 	public function testLoadClasses()
 	{
 		F::loadClasses([
-			'ftest\\a' => __DIR__ . '/fixtures/f/load/a/a.php',
-			'ftest\\output' => __DIR__ . '/fixtures/f/load/output.php'
+			'ftest\\a' => static::FIXTURES . '/load/a/a.php',
+			'ftest\\output' => static::FIXTURES . '/load/output.php'
 		]);
 
 		F::loadClasses([
 			'FTest\\B' => 'B.php',
-		], __DIR__ . '/fixtures/f/load/B');
+		], static::FIXTURES . '/load/B');
 
 		$this->assertTrue(class_exists('FTest\\A'));
 		$this->assertTrue(class_exists('FTest\\B'));
@@ -429,18 +427,18 @@ class FTest extends TestCase
 	public function testLoadOnce()
 	{
 		// basic behavior
-		F::write($file = $this->tmp . '/test1.php', '<?php return "foo";');
+		F::write($file = static::TMP . '/test1.php', '<?php return "foo";');
 		$this->assertTrue(F::loadOnce($file));
 
 		// non-existing file
 		$this->assertFalse(F::loadOnce('does-not-exist.php'));
 
 		// protection against accidental output (without output)
-		F::write($file = $this->tmp . '/test2.php', '<?php return "foo";');
+		F::write($file = static::TMP . '/test2.php', '<?php return "foo";');
 		$this->assertTrue(F::loadOnce($file, allowOutput: false));
 
 		// no protection against accidental output (with output)
-		F::write($file = $this->tmp . '/test3.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
+		F::write($file = static::TMP . '/test3.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
 		$this->assertTrue(F::loadOnce($file));
 	}
 
@@ -452,7 +450,7 @@ class FTest extends TestCase
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Disallowed output from file file.php:123, possible accidental whitespace?');
 
-		F::write($file = $this->tmp . '/test4.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
+		F::write($file = static::TMP . '/test4.php', '<?php Kirby\Http\HeadersSent::$value = true; return "foo";');
 
 		F::loadOnce($file, allowOutput: false);
 	}
@@ -462,7 +460,7 @@ class FTest extends TestCase
 	 */
 	public function testMove()
 	{
-		F::write($origin = $this->tmp . '/a.txt', 'test');
+		F::write($origin = static::TMP . '/a.txt', 'test');
 
 		// simply move file
 		$this->assertFileDoesNotExist($this->test);
@@ -503,12 +501,12 @@ class FTest extends TestCase
 			$tmpDir = sys_get_temp_dir();
 		}
 
-		if (stat($this->tmp)['dev'] === stat($tmpDir)['dev']) {
+		if (stat(static::TMP)['dev'] === stat($tmpDir)['dev']) {
 			$this->markTestSkipped('Temporary directory "' . $tmpDir . '" is on the same filesystem');
 			return;
 		}
 
-		F::write($origin = $this->tmp . '/a.txt', 'test');
+		F::write($origin = static::TMP . '/a.txt', 'test');
 		$this->test = $tmpDir . '/kirby-test-' . uniqid();
 
 		// simply move file
@@ -586,8 +584,8 @@ class FTest extends TestCase
 	{
 		$locale = I18n::$locale;
 
-		F::write($a = $this->tmp . '/a.txt', 'test');
-		F::write($b = $this->tmp . '/b.txt', 'test');
+		F::write($a = static::TMP . '/a.txt', 'test');
+		F::write($b = static::TMP . '/b.txt', 'test');
 
 		// for file path
 		$this->assertSame('4 B', F::niceSize($a));
@@ -638,7 +636,7 @@ class FTest extends TestCase
 	 */
 	public function testRemove()
 	{
-		F::write($a = $this->tmp . '/a.jpg', '');
+		F::write($a = static::TMP . '/a.jpg', '');
 
 		$this->assertFileExists($a);
 
@@ -652,7 +650,7 @@ class FTest extends TestCase
 	 */
 	public function testRemoveAlreadyRemoved()
 	{
-		$this->assertFileDoesNotExist($a = $this->tmp . '/a.jpg');
+		$this->assertFileDoesNotExist($a = static::TMP . '/a.jpg');
 
 		$this->assertTrue(F::remove($a));
 
@@ -664,7 +662,7 @@ class FTest extends TestCase
 	 */
 	public function testRemoveDirectory()
 	{
-		Dir::make($a = $this->tmp . '/a');
+		Dir::make($a = static::TMP . '/a');
 
 		$this->assertDirectoryExists($a);
 
@@ -678,8 +676,8 @@ class FTest extends TestCase
 	 */
 	public function testRemoveLink()
 	{
-		F::write($a = $this->tmp . '/a.jpg', '');
-		symlink($a, $b = $this->tmp . '/b.jpg');
+		F::write($a = static::TMP . '/a.jpg', '');
+		symlink($a, $b = static::TMP . '/b.jpg');
 
 		$this->assertFileExists($a);
 		$this->assertTrue(is_link($b));
@@ -695,15 +693,15 @@ class FTest extends TestCase
 	 */
 	public function testRemoveGlob()
 	{
-		F::write($a = $this->tmp . '/a.jpg', '');
-		F::write($b = $this->tmp . '/a.1234.jpg', '');
-		F::write($c = $this->tmp . '/a.3456.jpg', '');
+		F::write($a = static::TMP . '/a.jpg', '');
+		F::write($b = static::TMP . '/a.1234.jpg', '');
+		F::write($c = static::TMP . '/a.3456.jpg', '');
 
 		$this->assertFileExists($a);
 		$this->assertFileExists($b);
 		$this->assertFileExists($c);
 
-		F::remove($this->tmp . '/a*.jpg');
+		F::remove(static::TMP . '/a*.jpg');
 
 		$this->assertFileDoesNotExist($a);
 		$this->assertFileDoesNotExist($b);
@@ -715,7 +713,7 @@ class FTest extends TestCase
 	 */
 	public function testRename()
 	{
-		F::write($origin = $this->tmp . '/a.txt', 'test');
+		F::write($origin = static::TMP . '/a.txt', 'test');
 
 		// simply rename file
 		$this->assertFileDoesNotExist($this->test);
@@ -814,8 +812,8 @@ class FTest extends TestCase
 	 */
 	public function testSize()
 	{
-		F::write($a = $this->tmp . '/a.txt', 'test');
-		F::write($b = $this->tmp . '/b.txt', 'test');
+		F::write($a = static::TMP . '/a.txt', 'test');
+		F::write($b = static::TMP . '/b.txt', 'test');
 
 		$this->assertSame(4, F::size($a));
 		$this->assertSame(4, F::size($b));
@@ -842,7 +840,7 @@ class FTest extends TestCase
 	 */
 	public function testTypeWithoutExtension()
 	{
-		F::write($file = $this->tmp . '/test', '<?php echo "foo"; ?>');
+		F::write($file = static::TMP . '/test', '<?php echo "foo"; ?>');
 
 		$this->assertSame('text/x-php', F::mime($file));
 		$this->assertSame('code', F::type($file));
@@ -863,17 +861,17 @@ class FTest extends TestCase
 	 */
 	public function testUnlink()
 	{
-		touch($this->tmp . '/file');
-		symlink($this->tmp . '/file', $this->tmp . '/link-exists');
-		symlink($this->tmp . '/invalid', $this->tmp . '/link-invalid');
+		touch(static::TMP . '/file');
+		symlink(static::TMP . '/file', static::TMP . '/link-exists');
+		symlink(static::TMP . '/invalid', static::TMP . '/link-invalid');
 
-		$this->assertTrue(F::unlink($this->tmp . '/file'));
-		$this->assertTrue(F::unlink($this->tmp . '/link-exists'));
-		$this->assertTrue(F::unlink($this->tmp . '/link-invalid'));
+		$this->assertTrue(F::unlink(static::TMP . '/file'));
+		$this->assertTrue(F::unlink(static::TMP . '/link-exists'));
+		$this->assertTrue(F::unlink(static::TMP . '/link-invalid'));
 
-		$this->assertFileDoesNotExist($this->tmp . '/file');
-		$this->assertFalse(is_link($this->tmp . '/link-exists'));
-		$this->assertFalse(is_link($this->tmp . '/link-invalid'));
+		$this->assertFileDoesNotExist(static::TMP . '/file');
+		$this->assertFalse(is_link(static::TMP . '/link-exists'));
+		$this->assertFalse(is_link(static::TMP . '/link-invalid'));
 	}
 
 	/**
@@ -881,7 +879,7 @@ class FTest extends TestCase
 	 */
 	public function testUnlinkAlredyDeleted()
 	{
-		$this->assertTrue(F::unlink($this->tmp . '/does-not-exist'));
+		$this->assertTrue(F::unlink(static::TMP . '/does-not-exist'));
 	}
 
 	/**
@@ -897,7 +895,7 @@ class FTest extends TestCase
 
 			$this->assertSame(E_WARNING, $errno);
 
-			$expectedPrefix = 'unlink(' . $this->tmp . '/folder): ';
+			$expectedPrefix = 'unlink(' . static::TMP . '/folder): ';
 			$expected = [
 				$expectedPrefix . 'Is a directory',
 				$expectedPrefix . 'Operation not permitted'
@@ -906,9 +904,9 @@ class FTest extends TestCase
 			$this->assertTrue(in_array($errstr, $expected, true));
 		});
 
-		mkdir($this->tmp . '/folder');
+		mkdir(static::TMP . '/folder');
 
-		$this->assertFalse(F::unlink($this->tmp . '/folder'));
+		$this->assertFalse(F::unlink(static::TMP . '/folder'));
 
 		$this->assertTrue($called);
 	}
@@ -976,9 +974,9 @@ class FTest extends TestCase
 	 */
 	public function testSimilar()
 	{
-		F::write($a = $this->tmp . '/a.jpg', '');
-		F::write($b = $this->tmp . '/a.1234.jpg', '');
-		F::write($c = $this->tmp . '/a.3456.jpg', '');
+		F::write($a = static::TMP . '/a.jpg', '');
+		F::write($b = static::TMP . '/a.1234.jpg', '');
+		F::write($c = static::TMP . '/a.3456.jpg', '');
 
 		$expected = [
 			$b,

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase as TestCase;
  */
 class MimeTest extends TestCase
 {
-	protected $fixtures = __DIR__ . '/fixtures/mime';
+	public const FIXTURES = __DIR__ . '/fixtures/mime';
 
 	/**
 	 * @covers ::fix
@@ -35,8 +35,8 @@ class MimeTest extends TestCase
 	public function testFixSvg()
 	{
 		$this->assertSame('image/svg+xml', Mime::fix('something.svg', 'image/svg', 'svg'));
-		$this->assertSame('image/svg+xml', Mime::fix($this->fixtures . '/optimized.svg', 'text/html', 'svg'));
-		$this->assertSame('image/svg+xml', Mime::fix($this->fixtures . '/unoptimized.svg', 'text/html', 'svg'));
+		$this->assertSame('image/svg+xml', Mime::fix(static::FIXTURES . '/optimized.svg', 'text/html', 'svg'));
+		$this->assertSame('image/svg+xml', Mime::fix(static::FIXTURES . '/unoptimized.svg', 'text/html', 'svg'));
 	}
 
 	/**
@@ -62,7 +62,7 @@ class MimeTest extends TestCase
 	 */
 	public function testFromSvg()
 	{
-		$mime = Mime::fromSvg(__DIR__ . '/fixtures/mime/optimized.svg');
+		$mime = Mime::fromSvg(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
@@ -137,7 +137,7 @@ class MimeTest extends TestCase
 	 */
 	public function testTypeWithOptimizedSvg()
 	{
-		$mime = Mime::type($this->fixtures . '/optimized.svg');
+		$mime = Mime::type(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
@@ -146,7 +146,7 @@ class MimeTest extends TestCase
 	 */
 	public function testTypeWithUnoptimizedSvg()
 	{
-		$mime = Mime::type($this->fixtures . '/unoptimized.svg');
+		$mime = Mime::type(static::FIXTURES . '/unoptimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
@@ -155,7 +155,7 @@ class MimeTest extends TestCase
 	 */
 	public function testTypeWithJson()
 	{
-		$mime = Mime::type($this->fixtures . '/something.json');
+		$mime = Mime::type(static::FIXTURES . '/something.json');
 		$this->assertSame('application/json', $mime);
 	}
 

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -9,13 +9,15 @@ use Kirby\Cms\User;
 
 class FilesFieldTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.Languages';
+
 	public function setUp(): void
 	{
 		parent::setUp();
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -237,7 +239,7 @@ class FilesFieldTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => ['api.allowImpersonation' => true],
 			'site' => [

--- a/tests/Form/Fields/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/FilePickerMixinTest.php
@@ -10,10 +10,22 @@ use Kirby\Form\Field;
 
 class FilePickerMixinTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.FilePickerMixin';
+
 	public function setUp(): void
 	{
-		$kirby = App::instance();
+		$kirby = new App([
+			'roots' => [
+				'index' => static::TMP
+			]
+		]);
+
 		$kirby->impersonate('kirby');
+	}
+
+	public function tearDown(): void
+	{
+		App::destroy();
 	}
 
 	public function testPageFiles()

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -7,6 +7,8 @@ use Kirby\Form\Field;
 
 class PagePickerMixinTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.PagePickerMixin';
+
 	public function setUp(): void
 	{
 		parent::setUp();

--- a/tests/Form/Fields/Mixins/UserPickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/UserPickerMixinTest.php
@@ -8,13 +8,15 @@ use Kirby\Form\Field;
 
 class UserPickerMixinTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.UserPickerMixin';
+
 	public function setUp(): void
 	{
 		parent::setUp();
 
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'roles' => [
 				['name' => 'admin'],

--- a/tests/Form/Fields/PagesFieldTest.php
+++ b/tests/Form/Fields/PagesFieldTest.php
@@ -7,13 +7,15 @@ use Kirby\Cms\Page;
 
 class PagesFieldTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.PagesField';
+
 	public function setUp(): void
 	{
 		parent::setUp();
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'site' => [
 				'children' => [
@@ -169,7 +171,7 @@ class PagesFieldTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => ['api.allowImpersonation' => true],
 			'site' => [

--- a/tests/Form/Fields/TestCase.php
+++ b/tests/Form/Fields/TestCase.php
@@ -12,18 +12,19 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		// start with a fresh set of fields
 		Field::$types = [];
 
-		Dir::make($this->tmp);
+		if ($this->hasTmp() === true) {
+			Dir::make(static::TMP);
+		}
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => $this->hasTmp() ? static::TMP : '/dev/null'
 			],
 			'urls' => [
 				'index' => 'https://getkirby.com/subfolder'
@@ -33,7 +34,9 @@ class TestCase extends BaseTestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
 	}
 
 	public function app()
@@ -45,5 +48,14 @@ class TestCase extends BaseTestCase
 	{
 		$page = new Page(['slug' => 'test']);
 		return Field::factory($type, array_merge(['model' => $page], $attr), $formFields);
+	}
+
+	/**
+	 * Checks if the test class extending this test case class
+	 * has defined a temporary directory
+	 */
+	protected function hasTmp(): bool
+	{
+		return defined(get_class($this) . '::TMP');
 	}
 }

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -11,12 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EnvironmentTest extends TestCase
 {
-	protected $config = null;
-
-	public function setUp(): void
-	{
-		$this->config = __DIR__ . '/fixtures/EnvironmentTest';
-	}
+	public const FIXTURES = __DIR__ . '/fixtures/EnvironmentTest';
 
 	public function tearDown(): void
 	{
@@ -1075,7 +1070,7 @@ class EnvironmentTest extends TestCase
 			'SERVER_NAME' => 'example.com'
 		]);
 
-		$this->assertSame('test option', $env->options($this->config)['test']);
+		$this->assertSame('test option', $env->options(static::FIXTURES)['test']);
 	}
 
 	public function testOptionsFromServerAddress()
@@ -1084,7 +1079,7 @@ class EnvironmentTest extends TestCase
 			'SERVER_ADDR' => '127.0.0.1'
 		]);
 
-		$this->assertSame('test address option', $env->options($this->config)['test']);
+		$this->assertSame('test address option', $env->options(static::FIXTURES)['test']);
 	}
 
 	public function testOptionsFromInvalidHost()
@@ -1098,7 +1093,7 @@ class EnvironmentTest extends TestCase
 			'SERVER_NAME' => 'example.com'
 		]);
 
-		$this->assertSame([], $env->options($this->config));
+		$this->assertSame([], $env->options(static::FIXTURES));
 	}
 
 	public function testOptionsFromCLI()
@@ -1107,7 +1102,7 @@ class EnvironmentTest extends TestCase
 			'cli' => true
 		]);
 
-		$this->assertSame('test cli option', $env->options($this->config)['test']);
+		$this->assertSame('test cli option', $env->options(static::FIXTURES)['test']);
 	}
 
 	/**
@@ -1607,7 +1602,7 @@ class EnvironmentTest extends TestCase
 	public function testToArray()
 	{
 		$env = new Environment([
-			'root' => $this->config,
+			'root' => static::FIXTURES,
 		], [
 			'SERVER_NAME' => 'example.com'
 		]);

--- a/tests/Http/Request/Auth/SessionAuthTest.php
+++ b/tests/Http/Request/Auth/SessionAuthTest.php
@@ -12,17 +12,17 @@ use PHPUnit\Framework\TestCase;
  */
 class SessionAuthTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Http.Request.Auth.SessionAuth';
+
 	protected $kirby;
-	protected $tmp;
 
 	public function setUp(): void
 	{
-		$this->tmp = dirname(__DIR__, 2) . '/tmp';
-		Dir::make($this->tmp . '/site/sessions');
+		Dir::make(static::TMP . '/site/sessions');
 
 		$this->kirby = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 	}
@@ -30,7 +30,7 @@ class SessionAuthTest extends TestCase
 	public function tearDown(): void
 	{
 		$this->kirby->session()->destroy();
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testInstance()

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -12,6 +12,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class ResponseTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function tearDown(): void
 	{
 		HeadersSent::$value = false;
@@ -188,7 +190,7 @@ class ResponseTest extends TestCase
 
 	public function testFile()
 	{
-		$file = __DIR__ . '/fixtures/download.json';
+		$file = static::FIXTURES . '/download.json';
 
 		$response = Response::file($file);
 
@@ -213,7 +215,7 @@ class ResponseTest extends TestCase
 
 	public function testFileInvalid()
 	{
-		$file = __DIR__ . '/fixtures/download.xyz';
+		$file = static::FIXTURES . '/download.xyz';
 
 		$response = Response::file($file);
 

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -10,27 +10,24 @@ use PHPUnit\Framework\TestCase;
  */
 class GdLibTest extends TestCase
 {
-	protected $fixtures;
-	protected $tmp;
+	public const FIXTURES = __DIR__ . '/../fixtures/image';
+	public const TMP      = KIRBY_TMP_DIR . '/Image.Darkroom.GdLib';
 
 	public function setUp(): void
 	{
-		$this->fixtures = dirname(__DIR__) . '/fixtures/image';
-		$this->tmp      = dirname(__DIR__) . '/tmp';
-
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testProcess()
 	{
 		$gd = new GdLib();
 
-		copy($this->fixtures . '/cat.jpg', $file = $this->tmp . '/cat.jpg');
+		copy(static::FIXTURES . '/cat.jpg', $file = static::TMP . '/cat.jpg');
 
 		$this->assertSame([
 			'autoOrient' => true,
@@ -54,7 +51,7 @@ class GdLibTest extends TestCase
 	public function testProcessWithFormat()
 	{
 		$gd = new GdLib(['format' => 'webp']);
-		copy($this->fixtures . '/cat.jpg', $file = $this->tmp . '/cat.jpg');
+		copy(static::FIXTURES . '/cat.jpg', $file = static::TMP . '/cat.jpg');
 		$this->assertSame('webp', $gd->process($file)['format']);
 	}
 }

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -11,27 +11,24 @@ use PHPUnit\Framework\TestCase;
  */
 class ImageMagickTest extends TestCase
 {
-	protected $fixtures;
-	protected $tmp;
+	public const FIXTURES = __DIR__ . '/../fixtures/image';
+	public const TMP      = KIRBY_TMP_DIR . '/Image.Darkroom.ImageMagick';
 
 	public function setUp(): void
 	{
-		$this->fixtures = dirname(__DIR__) . '/fixtures/image';
-		$this->tmp      = dirname(__DIR__) . '/tmp';
-
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testProcess()
 	{
 		$im = new ImageMagick();
 
-		copy($this->fixtures . '/cat.jpg', $file = $this->tmp . '/cat.jpg');
+		copy(static::FIXTURES . '/cat.jpg', $file = static::TMP . '/cat.jpg');
 
 		$this->assertSame([
 			'autoOrient' => true,
@@ -58,8 +55,8 @@ class ImageMagickTest extends TestCase
 	{
 		$im = new ImageMagick(['format' => 'webp']);
 
-		copy($this->fixtures . '/cat.jpg', $file = $this->tmp . '/cat.jpg');
-		$this->assertFalse(F::exists($webp = $this->tmp . '/cat.webp'));
+		copy(static::FIXTURES . '/cat.jpg', $file = static::TMP . '/cat.jpg');
+		$this->assertFalse(F::exists($webp = static::TMP . '/cat.webp'));
 		$im->process($file);
 		$this->assertTrue(F::exists($webp));
 	}
@@ -75,7 +72,7 @@ class ImageMagickTest extends TestCase
 			'width' => 250, // do some arbitrary transformation
 		]);
 
-		copy($this->fixtures . '/' . $basename, $file = $this->tmp . '/' . $basename);
+		copy(static::FIXTURES . '/' . $basename, $file = static::TMP . '/' . $basename);
 
 		// test if profile has been kept
 		// errors have to be redirected to /dev/null, otherwise they would be printed to stdout by ImageMagick

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -6,13 +6,15 @@ use PHPUnit\Framework\TestCase;
 
 class DarkroomTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function file(string $driver = null)
 	{
 		if ($driver !== null) {
-			return __DIR__ . '/fixtures/image/cat-' . $driver . '.jpg';
+			return static::FIXTURES . '/image/cat-' . $driver . '.jpg';
 		}
 
-		return __DIR__ . '/fixtures/image/cat.jpg';
+		return static::FIXTURES . '/image/cat.jpg';
 	}
 
 	public function testFactory()

--- a/tests/Image/DimensionsTest.php
+++ b/tests/Image/DimensionsTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
  */
 class DimensionsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	/**
 	 * @covers ::__construct
 	 * @covers ::width
@@ -168,15 +170,15 @@ class DimensionsTest extends TestCase
 	 */
 	public function testForSvg()
 	{
-		$dimensions = Dimensions::forSvg(__DIR__ . '/fixtures/dimensions/circle.svg');
+		$dimensions = Dimensions::forSvg(static::FIXTURES . '/dimensions/circle.svg');
 		$this->assertSame(50, $dimensions->width());
 		$this->assertSame(50, $dimensions->height());
 
-		$dimensions = Dimensions::forSvg(__DIR__ . '/fixtures/dimensions/circle-abs.svg');
+		$dimensions = Dimensions::forSvg(static::FIXTURES . '/dimensions/circle-abs.svg');
 		$this->assertSame(35, $dimensions->width());
 		$this->assertSame(35, $dimensions->height());
 
-		$dimensions = Dimensions::forSvg(__DIR__ . '/fixtures/dimensions/circle-offset.svg');
+		$dimensions = Dimensions::forSvg(static::FIXTURES . '/dimensions/circle-offset.svg');
 		$this->assertSame(40, $dimensions->width());
 		$this->assertSame(25, $dimensions->height());
 	}

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -13,10 +13,12 @@ use PHPUnit\Framework\TestCase as TestCase;
  */
 class ImageTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	protected function _image($file = 'cat.jpg')
 	{
 		return new Image([
-			'root' => __DIR__ . '/fixtures/image/' . $file,
+			'root' => static::FIXTURES . '/image/' . $file,
 			'url'  => 'https://foo.bar/' . $file
 		]);
 	}
@@ -89,7 +91,7 @@ class ImageTest extends TestCase
 			'content'  => ['alt' => 'Test text']
 		]);
 		$image = new Image([
-			'root'  => __DIR__ . '/fixtures/image/cat.jpg',
+			'root'  => static::FIXTURES . '/image/cat.jpg',
 			'url'   => 'https://foo.bar/cat.jpg',
 			'model' => $file
 		]);
@@ -104,7 +106,7 @@ class ImageTest extends TestCase
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Calling Image::html() requires that the URL property is not null');
-		$file = new Image(['root' => __DIR__ . '/fixtures/image/cat.jpg']);
+		$file = new Image(['root' => static::FIXTURES . '/image/cat.jpg']);
 		$file->html();
 	}
 

--- a/tests/Image/QrCodeTest.php
+++ b/tests/Image/QrCodeTest.php
@@ -12,33 +12,34 @@ use Kirby\Filesystem\F;
  */
 class QrCodeTest extends TestCase
 {
-	protected $tmp = __DIR__ . '/tmp';
+	public const FIXTURES = __DIR__ . '/fixtures/qr';
+	public const TMP      = KIRBY_TMP_DIR . '/Image.QrCode';
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public function testToDataUri()
 	{
 		$qr = new QrCode('12345678');
-		$expected = F::read(__DIR__ . '/fixtures/qr/num.txt');
+		$expected = F::read(static::FIXTURES . '/num.txt');
 		$this->assertSame($expected, $qr->toDataUri());
 
 		$qr = new QrCode('ABCDEF12345');
-		$expected = F::read(__DIR__ . '/fixtures/qr/alphanum.txt');
+		$expected = F::read(static::FIXTURES . '/alphanum.txt');
 		$this->assertSame($expected, $qr->toDataUri());
 
 		$qr = new QrCode('https://getkirby.com');
-		$expected = F::read(__DIR__ . '/fixtures/qr/url.txt');
+		$expected = F::read(static::FIXTURES . '/url.txt');
 		$this->assertSame($expected, $qr->toDataUri());
 
 		$qr = new QrCode('🥳🐨🏳️‍🌈');
-		$expected = F::read(__DIR__ . '/fixtures/qr/emoji.txt');
+		$expected = F::read(static::FIXTURES . '/emoji.txt');
 		$this->assertSame($expected, $qr->toDataUri());
 
 		$qr = new QrCode('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.');
-		$expected = F::read(__DIR__ . '/fixtures/qr/lorem.txt');
+		$expected = F::read(static::FIXTURES . '/lorem.txt');
 		$this->assertSame($expected, $qr->toDataUri());
 	}
 
@@ -47,7 +48,7 @@ class QrCodeTest extends TestCase
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage();
 		$data     = $this->imageContent($image);
-		$expected = F::read(__DIR__ . '/fixtures/qr/image.png');
+		$expected = F::read(static::FIXTURES . '/image.png');
 
 		$this->assertInstanceOf(GdImage::class, $image);
 		$this->assertSame($expected, $data);
@@ -58,7 +59,7 @@ class QrCodeTest extends TestCase
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage(750);
 		$data     = $this->imageContent($image);
-		$expected = F::read(__DIR__ . '/fixtures/qr/image-size.png');
+		$expected = F::read(static::FIXTURES . '/image-size.png');
 		$this->assertSame($expected, $data);
 	}
 
@@ -67,30 +68,30 @@ class QrCodeTest extends TestCase
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage(null, '#00ff00', '#0000ff');
 		$data     = $this->imageContent($image);
-		$expected = F::read(__DIR__ . '/fixtures/qr/image-colors.png');
+		$expected = F::read(static::FIXTURES . '/image-colors.png');
 		$this->assertSame($expected, $data);
 	}
 
 	public function testToSvg()
 	{
 		$qr = new QrCode('12345678');
-		$expected = F::read(__DIR__ . '/fixtures/qr/num.svg');
+		$expected = F::read(static::FIXTURES . '/num.svg');
 		$this->assertSame($expected, $qr->toSvg());
 
 		$qr = new QrCode('ABCDEF12345');
-		$expected = F::read(__DIR__ . '/fixtures/qr/alphanum.svg');
+		$expected = F::read(static::FIXTURES . '/alphanum.svg');
 		$this->assertSame($expected, $qr->toSvg());
 
 		$qr = new QrCode('https://getkirby.com');
-		$expected = F::read(__DIR__ . '/fixtures/qr/url.svg');
+		$expected = F::read(static::FIXTURES . '/url.svg');
 		$this->assertSame($expected, $qr->toSvg());
 
 		$qr = new QrCode('🥳🐨🏳️‍🌈');
-		$expected = F::read(__DIR__ . '/fixtures/qr/emoji.svg');
+		$expected = F::read(static::FIXTURES . '/emoji.svg');
 		$this->assertSame($expected, $qr->toSvg());
 
 		$qr = new QrCode('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.');
-		$expected = F::read(__DIR__ . '/fixtures/qr/lorem.svg');
+		$expected = F::read(static::FIXTURES . '/lorem.svg');
 		$this->assertSame($expected, $qr->toSvg());
 	}
 
@@ -120,37 +121,37 @@ class QrCodeTest extends TestCase
 	 */
 	public function testWrite()
 	{
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 
 		$qr = new QrCode('https://getkirby.com');
 
-		$qr->write($file = $this->tmp . '/test.svg');
+		$qr->write($file = static::TMP . '/test.svg');
 		$this->assertFileExists($file);
-		$this->assertFileEquals(__DIR__ . '/fixtures/qr/test.svg', $file);
+		$this->assertFileEquals(static::FIXTURES . '/test.svg', $file);
 
-		$qr->write($file = $this->tmp . '/test.png');
+		$qr->write($file = static::TMP . '/test.png');
 		$this->assertFileExists($file);
-		$this->assertFileEquals(__DIR__ . '/fixtures/qr/test.png', $file);
+		$this->assertFileEquals(static::FIXTURES . '/test.png', $file);
 
-		$qr->write($file = $this->tmp . '/test.gif');
+		$qr->write($file = static::TMP . '/test.gif');
 		$this->assertFileExists($file);
-		$this->assertFileEquals(__DIR__ . '/fixtures/qr/test.gif', $file);
+		$this->assertFileEquals(static::FIXTURES . '/test.gif', $file);
 
-		$qr->write($file = $this->tmp . '/test.webp');
+		$qr->write($file = static::TMP . '/test.webp');
 		$this->assertFileExists($file);
-		$this->assertFileEquals(__DIR__ . '/fixtures/qr/test.webp', $file);
+		$this->assertFileEquals(static::FIXTURES . '/test.webp', $file);
 
 		// test JPEG by comparing the output dynamically to avoid issues
 		// with different libraries/library versions in CI
-		$fixture      = __DIR__ . '/fixtures/qr/test.jpg';
+		$fixture      = static::FIXTURES . '/test.jpg';
 		$expectedJpeg = $this->imageContent(imagecreatefromjpeg($fixture));
 
-		$qr->write($file = $this->tmp . '/test.jpg');
+		$qr->write($file = static::TMP . '/test.jpg');
 		$this->assertFileExists($file);
 		$actualJpeg = $this->imageContent(imagecreatefromjpeg($file));
 		$this->assertSame($expectedJpeg, $actualJpeg);
 
-		$qr->write($file = $this->tmp . '/test.jpeg');
+		$qr->write($file = static::TMP . '/test.jpeg');
 		$this->assertFileExists($file);
 		$actualJpeg = $this->imageContent(imagecreatefromjpeg($file));
 		$this->assertSame($expectedJpeg, $actualJpeg);

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -11,6 +11,8 @@ use Kirby\Field\TestCase;
  */
 class OptionsApiTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	/**
 	 * @covers ::__construct
 	 */
@@ -99,7 +101,7 @@ class OptionsApiTest extends TestCase
 	public function testResolve()
 	{
 		$model   = new Page(['slug' => 'test']);
-		$options = new OptionsApi(__DIR__ . '/fixtures/data.json');
+		$options = new OptionsApi(static::FIXTURES . '/data.json');
 		$result  = $options->render($model);
 
 		$this->assertSame('A', $result[0]['text']);
@@ -114,7 +116,7 @@ class OptionsApiTest extends TestCase
 	public function testResolveSimple()
 	{
 		$model   = new Page(['slug' => 'test']);
-		$options = new OptionsApi(__DIR__ . '/fixtures/data-simple.json');
+		$options = new OptionsApi(static::FIXTURES . '/data-simple.json');
 		$result  = $options->render($model);
 
 		$this->assertSame('A', $result[0]['text']);
@@ -130,7 +132,7 @@ class OptionsApiTest extends TestCase
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data.json',
+			url: static::FIXTURES . '/data.json',
 			text: '{{ item.name }}',
 			value: '{{ item.email }}',
 		);
@@ -149,7 +151,7 @@ class OptionsApiTest extends TestCase
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data-nested.json',
+			url: static::FIXTURES . '/data-nested.json',
 			query: 'Directory.Companies'
 		);
 		$result  = $options->render($model);
@@ -167,7 +169,7 @@ class OptionsApiTest extends TestCase
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data-nested.json',
+			url: static::FIXTURES . '/data-nested.json',
 			query: 'Directory.Companies',
 			text: '{{ item.name }}',
 			value: '{{ item.email }}'
@@ -189,7 +191,7 @@ class OptionsApiTest extends TestCase
 
 		// text escaped by default
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data.json',
+			url: static::FIXTURES . '/data.json',
 			text: '{{ item.slogan }}',
 			value: '{{ item.slogan }}'
 		);
@@ -201,7 +203,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
 		// with simple array
-		$options = new OptionsApi(__DIR__ . '/fixtures/data-simple-html.json');
+		$options = new OptionsApi(static::FIXTURES . '/data-simple-html.json');
 		$result = $options->render($model);
 
 		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $result[0]['text']);
@@ -211,7 +213,7 @@ class OptionsApiTest extends TestCase
 
 		// with query
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data-nested.json',
+			url: static::FIXTURES . '/data-nested.json',
 			query: 'Directory.Companies',
 			text: '{{ item.slogan }}',
 			value: '{{ item.slogan }}'
@@ -225,7 +227,7 @@ class OptionsApiTest extends TestCase
 
 		// text unescaped using {< >}
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data.json',
+			url: static::FIXTURES . '/data.json',
 			text: '{< item.slogan >}',
 			value: '{{ item.slogan }}'
 		);
@@ -237,7 +239,7 @@ class OptionsApiTest extends TestCase
 
 		// text unescaped using {< >} (simple array)
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data-simple-html.json',
+			url: static::FIXTURES . '/data-simple-html.json',
 			text: '{< item.value >}',
 			value: '{{ item.value }}'
 		);
@@ -249,7 +251,7 @@ class OptionsApiTest extends TestCase
 
 		// test unescaped with disabled safe mode
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data.json',
+			url: static::FIXTURES . '/data.json',
 			text: '{{ item.slogan }}',
 			value: '{{ item.slogan }}'
 		);
@@ -267,7 +269,7 @@ class OptionsApiTest extends TestCase
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data.json',
+			url: static::FIXTURES . '/data.json',
 			text: '{{ item.name }}',
 			value: '{{ item.name.slug }}'
 		);
@@ -286,7 +288,7 @@ class OptionsApiTest extends TestCase
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
-			url: __DIR__ . '/fixtures/data-nested.json',
+			url: static::FIXTURES . '/data-nested.json',
 			query: 'simple',
 			text: '{{ item }}',
 			value: '{{ item.slug }}'

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -12,8 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AreaTestCase extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Areas.AreaTestCase';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function app(array $params)
 	{
@@ -178,7 +179,7 @@ abstract class AreaTestCase extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'request' => [
 				'query' => [
@@ -192,7 +193,7 @@ abstract class AreaTestCase extends TestCase
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function submit(array $data)
@@ -213,7 +214,7 @@ abstract class AreaTestCase extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear blueprint cache
 		Blueprint::$loaded = [];

--- a/tests/Panel/Areas/SystemTest.php
+++ b/tests/Panel/Areas/SystemTest.php
@@ -7,12 +7,14 @@ use Kirby\Cms\System\UpdateStatus;
 
 class SystemTest extends AreaTestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/SystemTest';
+
 	protected static $host;
 
 	public static function setUpBeforeClass(): void
 	{
 		static::$host = UpdateStatus::$host;
-		UpdateStatus::$host = 'file://' . __DIR__ . '/fixtures/SystemTest';
+		UpdateStatus::$host = 'file://' . static::FIXTURES;
 	}
 
 	public static function tearDownAfterClass(): void
@@ -326,9 +328,9 @@ class SystemTest extends AreaTestCase
 		$this->assertSame($expected, $view['props']['plugins']);
 		$this->assertSame([
 			'Could not load update data for plugin getkirby/private: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/SystemTest/plugins/getkirby/private.json',
+			static::FIXTURES . '/plugins/getkirby/private.json',
 			'Could not load update data for plugin getkirby/unknown: Couldn\'t open file ' .
-			__DIR__ . '/fixtures/SystemTest/plugins/getkirby/unknown.json',
+			static::FIXTURES . '/plugins/getkirby/unknown.json',
 		], $view['props']['exceptions']);
 	}
 

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -14,18 +14,19 @@ use PHPUnit\Framework\TestCase;
  */
 class AssetsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Assets';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -33,7 +34,7 @@ class AssetsTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];
@@ -110,8 +111,8 @@ class AssetsTest extends TestCase
 	 */
 	public function testCssWithCustomFile(): void
 	{
-		F::write($this->tmp . '/panel.css', '');
-		F::write($this->tmp . '/foo.css', '');
+		F::write(static::TMP . '/panel.css', '');
+		F::write(static::TMP . '/foo.css', '');
 
 		// single
 		$this->app->clone([
@@ -192,8 +193,8 @@ class AssetsTest extends TestCase
 		]);
 
 		// create dummy assets
-		F::write($this->tmp . '/assets/panel.css', 'test');
-		F::write($this->tmp . '/assets/panel.js', 'test');
+		F::write(static::TMP . '/assets/panel.css', 'test');
+		F::write(static::TMP . '/assets/panel.js', 'test');
 
 		$assets   = new Assets();
 		$external = $assets->external();
@@ -392,8 +393,8 @@ class AssetsTest extends TestCase
 	 */
 	public function testJsWithCustomFile(): void
 	{
-		F::write($this->tmp . '/panel.js', '');
-		F::write($this->tmp . '/foo.js', '');
+		F::write(static::TMP . '/panel.js', '');
+		F::write(static::TMP . '/foo.js', '');
 
 		// single
 		$this->app->clone([

--- a/tests/Panel/DialogTest.php
+++ b/tests/Panel/DialogTest.php
@@ -11,18 +11,19 @@ use PHPUnit\Framework\TestCase;
  */
 class DialogTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Dialog';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -30,7 +31,7 @@ class DialogTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -12,18 +12,19 @@ use PHPUnit\Framework\TestCase;
  */
 class DocumentTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Document';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -31,7 +32,7 @@ class DocumentTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -11,18 +11,19 @@ use PHPUnit\Framework\TestCase;
  */
 class DropdownTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Dropdown';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -30,7 +31,7 @@ class DropdownTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -11,18 +11,19 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Field';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -30,7 +31,7 @@ class FieldTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -23,23 +23,24 @@ class ModelFileTestForceLocked extends ModelFile
  */
 class FileTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.File';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -15,8 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 class HomeTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Home';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -27,7 +28,7 @@ class HomeTest extends TestCase
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'options' => [
 				'panel' => [
@@ -36,14 +37,14 @@ class HomeTest extends TestCase
 			],
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
 		$this->app->session()->destroy();
 		unset($_SERVER['SERVER_SOFTWARE']);
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Panel/MenuTest.php
+++ b/tests/Panel/MenuTest.php
@@ -12,18 +12,19 @@ use PHPUnit\Framework\TestCase;
  */
 class MenuTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Menu';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -31,7 +32,7 @@ class MenuTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -96,23 +96,24 @@ class ModelSiteWithImageMethod extends ModelSite
  */
 class ModelTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Model';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	protected function panel(array $props = [])
@@ -412,7 +413,7 @@ class ModelTest extends TestCase
 		$site = new ModelSiteNoLocking();
 		$this->assertFalse($site->panel()->lock());
 
-		Dir::make($this->tmp . '/content');
+		Dir::make(static::TMP . '/content');
 		$app = $this->app->clone();
 		$app->impersonate('kirby');
 

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -22,23 +22,24 @@ class ModelPageTestForceLocked extends ModelPage
  */
 class PageTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Page';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -739,7 +740,7 @@ class PageTest extends TestCase
 	{
 		$app = $this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/a' => [
@@ -805,7 +806,7 @@ class PageTest extends TestCase
 	{
 		$app = $this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/c' => [
@@ -884,7 +885,7 @@ class PageTest extends TestCase
 	{
 		$app = $this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/e' => [
@@ -963,7 +964,7 @@ class PageTest extends TestCase
 	{
 		$app = $this->app->clone([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'blueprints' => [
 				'pages/g' => [

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -15,8 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 class PanelTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Panel';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
@@ -24,16 +25,16 @@ class PanelTest extends TestCase
 
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 		// fix installation issues by creating directories
-		Dir::make($this->tmp . '/content');
-		Dir::make($this->tmp . '/media');
-		Dir::make($this->tmp . '/site/accounts');
-		Dir::make($this->tmp . '/site/sessions');
+		Dir::make(static::TMP . '/content');
+		Dir::make(static::TMP . '/media');
+		Dir::make(static::TMP . '/site/accounts');
+		Dir::make(static::TMP . '/site/sessions');
 
 		// let's pretend we are on a supported server
 		$_SERVER['SERVER_SOFTWARE'] = 'php';
@@ -44,7 +45,7 @@ class PanelTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/PluginsTest.php
+++ b/tests/Panel/PluginsTest.php
@@ -12,8 +12,9 @@ use PHPUnit\Framework\TestCase;
  */
 class PluginsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Plugins';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 	protected $cssA;
 	protected $cssB;
 	protected $cssC;
@@ -28,7 +29,7 @@ class PluginsTest extends TestCase
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			]
 		]);
 	}
@@ -37,29 +38,29 @@ class PluginsTest extends TestCase
 	{
 		$time = \time() + 2;
 
-		F::write($this->tmp . '/site/plugins/a/index.php', '<?php Kirby::plugin("test/a", []);');
-		touch($this->tmp . '/site/plugins/a/index.php', $time);
-		F::write($this->cssA = $this->tmp . '/site/plugins/a/index.css', 'a');
+		F::write(static::TMP . '/site/plugins/a/index.php', '<?php Kirby::plugin("test/a", []);');
+		touch(static::TMP . '/site/plugins/a/index.php', $time);
+		F::write($this->cssA = static::TMP . '/site/plugins/a/index.css', 'a');
 		touch($this->cssA, $time);
-		F::write($this->jsA = $this->tmp . '/site/plugins/a/index.js', 'a');
+		F::write($this->jsA = static::TMP . '/site/plugins/a/index.js', 'a');
 		touch($this->jsA, $time);
-		$this->mjsA = $this->tmp . '/site/plugins/a/index.dev.mjs';
+		$this->mjsA = static::TMP . '/site/plugins/a/index.dev.mjs';
 
-		F::write($this->tmp . '/site/plugins/b/index.php', '<?php Kirby::plugin("test/b", []);');
-		touch($this->tmp . '/site/plugins/b/index.php', $time);
-		F::write($this->cssB = $this->tmp . '/site/plugins/b/index.css', 'b');
+		F::write(static::TMP . '/site/plugins/b/index.php', '<?php Kirby::plugin("test/b", []);');
+		touch(static::TMP . '/site/plugins/b/index.php', $time);
+		F::write($this->cssB = static::TMP . '/site/plugins/b/index.css', 'b');
 		touch($this->cssB, $time);
-		F::write($this->jsB = $this->tmp . '/site/plugins/b/index.js', 'b');
+		F::write($this->jsB = static::TMP . '/site/plugins/b/index.js', 'b');
 		touch($this->jsB, $time);
-		$this->mjsB = $this->tmp . '/site/plugins/b/index.dev.mjs';
+		$this->mjsB = static::TMP . '/site/plugins/b/index.dev.mjs';
 
-		F::write($this->tmp . '/site/plugins/c/index.php', '<?php Kirby::plugin("test/c", []);');
-		touch($this->tmp . '/site/plugins/c/index.php', $time);
-		F::write($this->cssC = $this->tmp . '/site/plugins/c/index.css', 'c');
+		F::write(static::TMP . '/site/plugins/c/index.php', '<?php Kirby::plugin("test/c", []);');
+		touch(static::TMP . '/site/plugins/c/index.php', $time);
+		F::write($this->cssC = static::TMP . '/site/plugins/c/index.css', 'c');
 		touch($this->cssC, $time);
-		F::write($this->jsC = $this->tmp . '/site/plugins/c/index.js', 'c');
+		F::write($this->jsC = static::TMP . '/site/plugins/c/index.js', 'c');
 		touch($this->jsC, $time);
-		$this->mjsC = $this->tmp . '/site/plugins/c/index.dev.mjs';
+		$this->mjsC = static::TMP . '/site/plugins/c/index.dev.mjs';
 
 		if ($addDevMjs === true) {
 			F::write($this->mjsC, 'c');
@@ -71,7 +72,7 @@ class PluginsTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -13,23 +13,24 @@ use PHPUnit\Framework\TestCase;
  */
 class SiteTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Site';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	protected function panel(array $props = [])

--- a/tests/Panel/UserTotpDisableDialogTest.php
+++ b/tests/Panel/UserTotpDisableDialogTest.php
@@ -14,14 +14,15 @@ use PHPUnit\Framework\TestCase;
  */
 class UserTotpDisableDialogTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpDisableDialog';
+
 	protected App $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	protected function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'users' => [
 				[
@@ -37,7 +38,7 @@ class UserTotpDisableDialogTest extends TestCase
 			'user' => 'test@getkirby.com'
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -45,7 +46,7 @@ class UserTotpDisableDialogTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/UserTotpEnableDialogTest.php
+++ b/tests/Panel/UserTotpEnableDialogTest.php
@@ -14,14 +14,15 @@ use PHPUnit\Framework\TestCase;
  */
 class UserTotpEnableDialogTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpEnableDialog';
+
 	protected App $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	protected function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			],
 			'users' => [
 				[
@@ -31,7 +32,7 @@ class UserTotpEnableDialogTest extends TestCase
 			'user' => 'test@getkirby.com'
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -39,7 +40,7 @@ class UserTotpEnableDialogTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -15,18 +15,19 @@ use PHPUnit\Framework\TestCase;
  */
 class ViewTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Panel.View';
+
 	protected $app;
-	protected $tmp = __DIR__ . '/tmp';
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => static::TMP,
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
@@ -34,7 +35,7 @@ class ViewTest extends TestCase
 		// clear session file first
 		$this->app->session()->destroy();
 
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 
 		// clear fake json requests
 		$_GET = [];

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -21,6 +21,8 @@ class TestableParsley extends Parsley
  */
 class ParsleyTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	protected function parser(string $html = 'Test')
 	{
 		return new TestableParsley($html, new Blocks());
@@ -34,7 +36,7 @@ class ParsleyTest extends TestCase
 	 */
 	public function testBlocks()
 	{
-		$examples = glob(__DIR__ . '/fixtures/*.html');
+		$examples = glob(static::FIXTURES . '/*.html');
 
 		foreach ($examples as $example) {
 			$input    = F::read($example);

--- a/tests/Sane/DomHandlerTest.php
+++ b/tests/Sane/DomHandlerTest.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class DomHandlerTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.DomHandler';
+
 	protected static $type = 'sane';
 
 	public function testSanitize()

--- a/tests/Sane/HandlerTest.php
+++ b/tests/Sane/HandlerTest.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class HandlerTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Handler';
+
 	protected static $type = 'sane';
 
 	/**

--- a/tests/Sane/HtmlTest.php
+++ b/tests/Sane/HtmlTest.php
@@ -10,6 +10,8 @@ use Kirby\Exception\InvalidArgumentException;
  */
 class HtmlTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Html';
+
 	protected static $type = 'html';
 
 	/**

--- a/tests/Sane/SaneTest.php
+++ b/tests/Sane/SaneTest.php
@@ -14,6 +14,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class SaneTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Sane';
+
 	protected static $type = 'sane';
 
 	/**

--- a/tests/Sane/SvgTest.php
+++ b/tests/Sane/SvgTest.php
@@ -9,6 +9,8 @@ use Kirby\Exception\InvalidArgumentException;
  */
 class SvgTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Svg';
+
 	protected static $type = 'svg';
 
 	/**

--- a/tests/Sane/SvgzTest.php
+++ b/tests/Sane/SvgzTest.php
@@ -9,6 +9,8 @@ use Kirby\Exception\InvalidArgumentException;
  */
 class SvgzTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Svgz';
+
 	protected static $type = 'svgz';
 
 	/**

--- a/tests/Sane/TestCase.php
+++ b/tests/Sane/TestCase.php
@@ -12,6 +12,8 @@ use RecursiveIteratorIterator;
 
 class TestCase extends BaseTestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	protected static $type;
 
 	public function setUp(): void
@@ -26,7 +28,7 @@ class TestCase extends BaseTestCase
 	public function tearDown(): void
 	{
 		App::destroy();
-		Dir::remove(__DIR__ . '/tmp');
+		Dir::remove(static::TMP);
 	}
 
 	/**
@@ -38,13 +40,13 @@ class TestCase extends BaseTestCase
 	 */
 	protected function fixture(string $name, bool $tmp = false): string
 	{
-		$fixtureRoot = __DIR__ . '/fixtures/' . static::$type . '/' . $name;
+		$fixtureRoot = static::FIXTURES . '/' . static::$type . '/' . $name;
 
 		if ($tmp === false) {
 			return $fixtureRoot;
 		}
 
-		$tmpRoot = __DIR__ . '/tmp/' . static::$type . '/' . $name;
+		$tmpRoot = static::TMP . '/' . static::$type . '/' . $name;
 		F::copy($fixtureRoot, $tmpRoot);
 		return $tmpRoot;
 	}
@@ -61,7 +63,7 @@ class TestCase extends BaseTestCase
 		string $directory,
 		string $extension
 	): array {
-		$root = __DIR__ . '/fixtures/' . static::$type;
+		$root = static::FIXTURES . '/' . static::$type;
 
 		$directory = new RecursiveDirectoryIterator(
 			$root . '/' . $directory,

--- a/tests/Sane/XmlTest.php
+++ b/tests/Sane/XmlTest.php
@@ -9,6 +9,8 @@ use Kirby\Exception\InvalidArgumentException;
  */
 class XmlTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Sane.Xml';
+
 	protected static $type = 'xml';
 
 	public function tearDown(): void

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -14,6 +14,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class AutoSessionTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/store';
+
 	protected $store;
 
 	public function setUp(): void
@@ -46,8 +48,8 @@ class AutoSessionTest extends TestCase
 		$this->assertSame($this->store, $sessionsProperty->getValue($autoSession)->store());
 
 		// path string as store
-		$autoSession = new AutoSession(__DIR__ . '/fixtures/store');
-		$this->assertSame(__DIR__ . '/fixtures/store', $pathProperty->getValue($sessionsProperty->getValue($autoSession)->store()));
+		$autoSession = new AutoSession(static::FIXTURES);
+		$this->assertSame(static::FIXTURES, $pathProperty->getValue($sessionsProperty->getValue($autoSession)->store()));
 
 		// default cookie name
 		$autoSession = new AutoSession($this->store);

--- a/tests/Session/FileSessionStoreTest.php
+++ b/tests/Session/FileSessionStoreTest.php
@@ -17,15 +17,16 @@ require_once __DIR__ . '/mocks.php';
  */
 class FileSessionStoreTest extends TestCase
 {
-	protected $root = __DIR__ . '/fixtures/store';
+	public const TMP = KIRBY_TMP_DIR . '/Session.FileSessionStore';
+
 	protected $store;
 	protected $storeHandles;
 	protected $storeIsLocked;
 
 	public function setUp(): void
 	{
-		$this->store = new FileSessionStore($this->root);
-		$this->assertDirectoryExists($this->root);
+		$this->store = new FileSessionStore(static::TMP);
+		$this->assertDirectoryExists(static::TMP);
 
 		// make internal data accessible
 		$reflector = new ReflectionClass(FileSessionStore::class);
@@ -35,12 +36,12 @@ class FileSessionStoreTest extends TestCase
 		$this->storeIsLocked->setAccessible(true);
 
 		// demo files
-		F::write($this->root . '/.gitignore', "*\n!.gitignore");
-		F::write($this->root . '/1234567890.abcdefghijabcdefghij.sess', '1234567890');
-		F::write($this->root . '/1357913579.abcdefghijabcdefghij.sess', '1357913579');
-		F::write($this->root . '/7777777777.abcdefghijabcdefghij.sess', '7777777777');
-		F::write($this->root . '/8888888888.abcdefghijabcdefghij.sess', '');
-		F::write($this->root . '/9999999999.abcdefghijabcdefghij.sess', '9999999999');
+		F::write(static::TMP . '/.gitignore', "*\n!.gitignore");
+		F::write(static::TMP . '/1234567890.abcdefghijabcdefghij.sess', '1234567890');
+		F::write(static::TMP . '/1357913579.abcdefghijabcdefghij.sess', '1357913579');
+		F::write(static::TMP . '/7777777777.abcdefghijabcdefghij.sess', '7777777777');
+		F::write(static::TMP . '/8888888888.abcdefghijabcdefghij.sess', '');
+		F::write(static::TMP . '/9999999999.abcdefghijabcdefghij.sess', '9999999999');
 	}
 
 	public function tearDown(): void
@@ -49,15 +50,15 @@ class FileSessionStoreTest extends TestCase
 		unset($this->store);
 
 		// make sure the directory and in files are writable before trying to delete
-		chmod($this->root, 0777);
+		chmod(static::TMP, 0777);
 
-		$files = array_diff(scandir($this->root) ?? [], ['.', '..']);
+		$files = array_diff(scandir(static::TMP) ?? [], ['.', '..']);
 		foreach ($files as $file) {
-			chmod($this->root . '/' . $file, 0777);
+			chmod(static::TMP . '/' . $file, 0777);
 		}
 
-		Dir::remove($this->root);
-		$this->assertDirectoryDoesNotExist($this->root);
+		Dir::remove(static::TMP);
+		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
 	/**
@@ -68,10 +69,10 @@ class FileSessionStoreTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionCode('error.session.filestore.dirNotWritable');
 
-		Dir::make($this->root, true);
-		chmod($this->root, 0555);
+		Dir::make(static::TMP, true);
+		chmod(static::TMP, 0555);
 
-		new FileSessionStore($this->root);
+		new FileSessionStore(static::TMP);
 	}
 
 	/**
@@ -85,7 +86,7 @@ class FileSessionStoreTest extends TestCase
 
 		$this->assertStringMatchesFormat('%x', $id);
 		$this->assertSame(20, strlen($id));
-		$this->assertFileExists($this->root . '/1234567890.' . $id . '.sess');
+		$this->assertFileExists(static::TMP . '/1234567890.' . $id . '.sess');
 		$this->assertHandleExists('1234567890.' . $id);
 		$this->assertLocked('1234567890.' . $id);
 	}
@@ -166,7 +167,7 @@ class FileSessionStoreTest extends TestCase
 		// locked file that doesn't exist anymore
 		$this->store->lock(1357913579, 'abcdefghijabcdefghij');
 		$this->assertLocked('1357913579.abcdefghijabcdefghij');
-		unlink($this->root . '/1357913579.abcdefghijabcdefghij.sess');
+		unlink(static::TMP . '/1357913579.abcdefghijabcdefghij.sess');
 		$this->store->unlock(1357913579, 'abcdefghijabcdefghij');
 		$this->assertNotLocked('1357913579.abcdefghijabcdefghij');
 	}
@@ -209,7 +210,7 @@ class FileSessionStoreTest extends TestCase
 		$this->expectExceptionCode('error.session.filestore.notOpened');
 
 		// session files need to have read and write permissions even for reading
-		chmod($this->root . '/1234567890.abcdefghijabcdefghij.sess', 0444);
+		chmod(static::TMP . '/1234567890.abcdefghijabcdefghij.sess', 0444);
 		$this->store->get(1234567890, 'abcdefghijabcdefghij');
 	}
 
@@ -227,7 +228,7 @@ class FileSessionStoreTest extends TestCase
 
 		$this->assertLocked('1234567890.abcdefghijabcdefghij');
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
-		$this->assertSame('some other data', F::read($this->root . '/1234567890.abcdefghijabcdefghij.sess'));
+		$this->assertSame('some other data', F::read(static::TMP . '/1234567890.abcdefghijabcdefghij.sess'));
 		$this->assertSame('some other data', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
 	}
 
@@ -267,13 +268,13 @@ class FileSessionStoreTest extends TestCase
 	 */
 	public function testDestroy()
 	{
-		$this->assertFileExists($this->root . '/1234567890.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
 		$this->assertNotLocked('1234567890.abcdefghijabcdefghij');
 		$this->assertHandleNotExists('1234567890.abcdefghijabcdefghij');
 
 		$this->store->destroy(1234567890, 'abcdefghijabcdefghij');
 
-		$this->assertFileDoesNotExist($this->root . '/1234567890.abcdefghijabcdefghij.sess');
+		$this->assertFileDoesNotExist(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
 		$this->assertNotLocked('1234567890.abcdefghijabcdefghij');
 		$this->assertHandleNotExists('1234567890.abcdefghijabcdefghij');
 	}
@@ -291,7 +292,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
 
 		// simulate that another thread deleted the file
-		unlink($this->root . '/1234567890.abcdefghijabcdefghij.sess');
+		unlink(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
 
 		// shouldn't throw an Exception
 		$this->store->destroy(1234567890, 'abcdefghijabcdefghij');
@@ -313,7 +314,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
 
 		// simulate that another thread deleted the file
-		unlink($this->root . '/1234567890.abcdefghijabcdefghij.sess');
+		unlink(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
 
 		// now it should throw even if there is already a handle
 		$this->store->set(1234567890, 'abcdefghijabcdefghij', 'something else');
@@ -324,21 +325,21 @@ class FileSessionStoreTest extends TestCase
 	 */
 	public function testCollectGarbage()
 	{
-		$this->assertFileExists($this->root . '/.gitignore');
-		$this->assertFileExists($this->root . '/1234567890.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/1357913579.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/7777777777.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/8888888888.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/9999999999.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/.gitignore');
+		$this->assertFileExists(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/1357913579.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/7777777777.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/8888888888.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/9999999999.abcdefghijabcdefghij.sess');
 
 		$this->store->collectGarbage();
 
-		$this->assertFileExists($this->root . '/.gitignore');
-		$this->assertFileDoesNotExist($this->root . '/1234567890.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/1357913579.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/7777777777.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/8888888888.abcdefghijabcdefghij.sess');
-		$this->assertFileExists($this->root . '/9999999999.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/.gitignore');
+		$this->assertFileDoesNotExist(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/1357913579.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/7777777777.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/8888888888.abcdefghijabcdefghij.sess');
+		$this->assertFileExists(static::TMP . '/9999999999.abcdefghijabcdefghij.sess');
 	}
 
 	/**
@@ -353,7 +354,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertTrue(isset($isLocked[$name]));
 
 		// try locking the file again, which should fail
-		$path = $this->root . '/' . $name . '.sess';
+		$path = static::TMP . '/' . $name . '.sess';
 		if (is_file($path)) {
 			$handle = fopen($path, 'r+');
 			$this->assertFalse(flock($handle, LOCK_EX | LOCK_NB));
@@ -374,7 +375,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertFalse(isset($isLocked[$name]));
 
 		// try locking the file, which should work if the file is not currently locked
-		$path = $this->root . '/' . $name . '.sess';
+		$path = static::TMP . '/' . $name . '.sess';
 		if (is_file($path)) {
 			$handle = fopen($path, 'r+');
 			$this->assertTrue(flock($handle, LOCK_EX | LOCK_NB));

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -18,6 +18,8 @@ require_once __DIR__ . '/mocks.php';
  */
 class SessionsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/store';
+
 	protected $store;
 	protected $sessions;
 
@@ -45,12 +47,12 @@ class SessionsTest extends TestCase
 		$this->assertSame($this->store, $this->sessions->store());
 
 		// custom store
-		$store    = new FileSessionStore(__DIR__ . '/fixtures/store');
+		$store    = new FileSessionStore(static::FIXTURES);
 		$sessions = new Sessions($store);
 		$this->assertSame($store, $sessions->store());
 
 		// custom path
-		$path     = __DIR__ . '/fixtures/store';
+		$path     = static::FIXTURES;
 		$sessions = new Sessions($path);
 
 		$reflector = new ReflectionClass(FileSessionStore::class);
@@ -74,7 +76,7 @@ class SessionsTest extends TestCase
 	 */
 	public function testConstructorOptions()
 	{
-		$sessions = new Sessions(__DIR__ . '/fixtures/store', [
+		$sessions = new Sessions(static::FIXTURES, [
 			'mode'       => 'header',
 			'cookieName' => 'my_cookie_name'
 		]);
@@ -94,7 +96,7 @@ class SessionsTest extends TestCase
 	{
 		$this->expectException(InvalidArgumentException::class);
 
-		new Sessions(__DIR__ . '/fixtures/store', ['mode' => 'invalid']);
+		new Sessions(static::FIXTURES, ['mode' => 'invalid']);
 	}
 
 	/**
@@ -104,7 +106,7 @@ class SessionsTest extends TestCase
 	{
 		$this->expectException(TypeError::class);
 
-		new Sessions(__DIR__ . '/fixtures/store', ['cookieName' => ['foo']]);
+		new Sessions(static::FIXTURES, ['cookieName' => ['foo']]);
 	}
 
 	/**
@@ -130,7 +132,7 @@ class SessionsTest extends TestCase
 	{
 		$this->expectException(InvalidArgumentException::class);
 
-		new Sessions(__DIR__ . '/fixtures/store', ['gcInterval' => 0]);
+		new Sessions(static::FIXTURES, ['gcInterval' => 0]);
 	}
 
 	/**

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -12,6 +12,8 @@ use ReflectionProperty;
  */
 class SnippetTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	/**
 	 * @covers ::close
 	 */
@@ -35,7 +37,7 @@ class SnippetTest extends TestCase
 
 		new App([
 			'roots' => [
-				'snippets' => __DIR__ . '/fixtures'
+				'snippets' => static::FIXTURES
 			]
 		]);
 
@@ -78,12 +80,12 @@ class SnippetTest extends TestCase
 
 		new App([
 			'roots' => [
-				'snippets' => __DIR__ . '/fixtures'
+				'snippets' => static::FIXTURES
 			]
 		]);
 
-		$this->assertSame(__DIR__ . '/fixtures/simple.php', Snippet::file('simple'));
-		$this->assertSame(__DIR__ . '/fixtures/simple.php', Snippet::file(['missin', 'simple']));
+		$this->assertSame(static::FIXTURES . '/simple.php', Snippet::file('simple'));
+		$this->assertSame(static::FIXTURES . '/simple.php', Snippet::file(['missin', 'simple']));
 		$this->assertNull(Snippet::file('missin'));
 		$this->assertSame('bar.php', Snippet::file('foo'));
 	}
@@ -96,7 +98,7 @@ class SnippetTest extends TestCase
 	{
 		ob_start();
 
-		Snippet::begin(__DIR__ . '/fixtures/simple.php');
+		Snippet::begin(static::FIXTURES . '/simple.php');
 		Slot::begin();
 		echo 'Nice';
 		Slot::end();
@@ -179,8 +181,8 @@ class SnippetTest extends TestCase
 	public static function renderWithSlotsProvider(): array
 	{
 		return [
-			[__DIR__ . '/fixtures/slots.php', 'Header content' . PHP_EOL . 'Body content' . PHP_EOL . 'Footer content'],
-			[__DIR__ . '/fixtures/missin.php', ''],
+			[static::FIXTURES . '/slots.php', 'Header content' . PHP_EOL . 'Body content' . PHP_EOL . 'Footer content'],
+			[static::FIXTURES . '/missin.php', ''],
 			[null, ''],
 		];
 	}
@@ -226,7 +228,7 @@ class SnippetTest extends TestCase
 		// all output must be captured
 		$this->expectOutputString('');
 
-		$snippet = new Snippet(__DIR__ . '/fixtures/layout.php');
+		$snippet = new Snippet(static::FIXTURES . '/layout.php');
 		$snippet->open();
 		echo 'content';
 
@@ -241,7 +243,7 @@ class SnippetTest extends TestCase
 		// all output must be captured
 		$this->expectOutputString('');
 
-		$snippet = new Snippet(__DIR__ . '/fixtures/layout-with-multiple-slots.php');
+		$snippet = new Snippet(static::FIXTURES . '/layout-with-multiple-slots.php');
 
 		$snippet->slot('header');
 		echo 'Header content';
@@ -259,7 +261,7 @@ class SnippetTest extends TestCase
 	 */
 	public function testRenderWithLazySlots()
 	{
-		$snippet = new Snippet(__DIR__ . '/fixtures/slots.php');
+		$snippet = new Snippet(static::FIXTURES . '/slots.php');
 
 		$html = $snippet->render(slots: [
 			'header'  => 'Header content',
@@ -281,7 +283,7 @@ class SnippetTest extends TestCase
 	public function testRenderWithData()
 	{
 		$snippet = new Snippet(
-			file: __DIR__ . '/fixtures/data.php',
+			file: static::FIXTURES . '/data.php',
 			data: ['message' => 'hello']
 		);
 
@@ -294,7 +296,7 @@ class SnippetTest extends TestCase
 	public function testRenderWithLazyData()
 	{
 		$snippet = new Snippet(
-			file: __DIR__ . '/fixtures/data.php',
+			file: static::FIXTURES . '/data.php',
 		);
 
 		$this->assertSame('hello', $snippet->render(data: ['message' => 'hello']));
@@ -307,7 +309,7 @@ class SnippetTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'snippets' => $root = __DIR__ . '/fixtures'
+				'snippets' => $root = static::FIXTURES
 			]
 		]);
 
@@ -334,7 +336,7 @@ class SnippetTest extends TestCase
 			echo 'Scope snippet success';
 		};
 
-		$snippet = new Snippet(file: __DIR__ . '/fixtures/scope.php', data: $data = [
+		$snippet = new Snippet(file: static::FIXTURES . '/scope.php', data: $data = [
 			'message' => 'Hello',
 			'closure' => $closure
 		]);
@@ -360,7 +362,7 @@ class SnippetTest extends TestCase
 			echo 'Scope snippet success';
 		};
 
-		$snippet = new Snippet(file: __DIR__ . '/fixtures/scope.php', data: $data = [
+		$snippet = new Snippet(file: static::FIXTURES . '/scope.php', data: $data = [
 			'closure' => $closure
 		]);
 
@@ -381,7 +383,7 @@ class SnippetTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'snippets' => __DIR__ . '/fixtures'
+				'snippets' => static::FIXTURES
 			]
 		]);
 
@@ -435,7 +437,7 @@ class SnippetTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'snippets' => __DIR__ . '/fixtures'
+				'snippets' => static::FIXTURES
 			]
 		]);
 

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -9,6 +9,8 @@ use Kirby\Cms\App;
  */
 class TemplateTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	/**
 	 * @covers ::__construct
 	 * @covers ::name
@@ -35,7 +37,7 @@ class TemplateTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'templates' => __DIR__ . '/fixtures'
+				'templates' => static::FIXTURES
 			]
 		]);
 
@@ -65,7 +67,7 @@ class TemplateTest extends TestCase
 
 		new App([
 			'roots' => [
-				'templates' => __DIR__ . '/fixtures'
+				'templates' => static::FIXTURES
 			]
 		]);
 
@@ -73,10 +75,10 @@ class TemplateTest extends TestCase
 		$this->assertNull($template->file());
 
 		$template = new Template('simple');
-		$this->assertSame(__DIR__ . '/fixtures/simple.php', $template->file());
+		$this->assertSame(static::FIXTURES . '/simple.php', $template->file());
 
 		$template = new Template('simple', 'rss');
-		$this->assertSame(__DIR__ . '/fixtures/simple.rss.php', $template->file());
+		$this->assertSame(static::FIXTURES . '/simple.rss.php', $template->file());
 
 		$template = new Template('plugin');
 		$this->assertSame('plugin.php', $template->file());
@@ -105,7 +107,7 @@ class TemplateTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'templates' => $root = __DIR__ . '/fixtures'
+				'templates' => $root = static::FIXTURES
 			]
 		]);
 
@@ -121,7 +123,7 @@ class TemplateTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'templates' => $root = __DIR__ . '/fixtures'
+				'templates' => $root = static::FIXTURES
 			]
 		]);
 
@@ -136,8 +138,8 @@ class TemplateTest extends TestCase
 	{
 		new App([
 			'roots' => [
-				'snippets'  => __DIR__ . '/fixtures',
-				'templates' => __DIR__ . '/fixtures'
+				'snippets'  => static::FIXTURES,
+				'templates' => static::FIXTURES
 			]
 		]);
 
@@ -152,8 +154,8 @@ class TemplateTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'snippets'  => __DIR__ . '/fixtures',
-				'templates' => __DIR__ . '/fixtures'
+				'snippets'  => static::FIXTURES,
+				'templates' => static::FIXTURES
 			]
 		]);
 
@@ -172,8 +174,8 @@ class TemplateTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'snippets'  => __DIR__ . '/fixtures',
-				'templates' => __DIR__ . '/fixtures'
+				'snippets'  => static::FIXTURES,
+				'templates' => static::FIXTURES
 			]
 		]);
 
@@ -195,8 +197,8 @@ class TemplateTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'snippets'  => __DIR__ . '/fixtures',
-				'templates' => __DIR__ . '/fixtures'
+				'snippets'  => static::FIXTURES,
+				'templates' => static::FIXTURES
 			]
 		]);
 

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -14,30 +14,32 @@ use PHPUnit\Framework\TestCase;
  */
 class KirbyTagsTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+	public const TMP      = KIRBY_TMP_DIR . '/Text.KirbyTags';
+
 	protected $app;
-	protected $tmp;
 
 	public function setUp(): void
 	{
 		$this->app = new App([
 			'roots' => [
-				'index' => $this->tmp = __DIR__ . '/tmp'
+				'index' => static::TMP
 			]
 		]);
 
-		Dir::make($this->tmp);
+		Dir::make(static::TMP);
 	}
 
 	public function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		Dir::remove(static::TMP);
 	}
 
 	public static function dataProvider()
 	{
 		$tests = [];
 
-		foreach (Dir::read($root = __DIR__ . '/fixtures/kirbytext') as $dir) {
+		foreach (Dir::read($root = static::FIXTURES . '/kirbytext') as $dir) {
 			$kirbytext = F::read($root . '/' . $dir . '/test.txt');
 			$expected  = F::read($root . '/' . $dir . '/expected.html');
 

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -7,6 +7,8 @@ namespace Kirby\Toolkit;
  */
 class ControllerTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	/**
 	 * @covers ::call
 	 */
@@ -81,7 +83,7 @@ class ControllerTest extends TestCase
 	 */
 	public function testLoad()
 	{
-		$root       = __DIR__ . '/fixtures/controller/controller.php';
+		$root       = static::FIXTURES . '/controller/controller.php';
 		$controller = Controller::load($root);
 		$this->assertSame('loaded', $controller->call());
 	}
@@ -91,7 +93,7 @@ class ControllerTest extends TestCase
 	 */
 	public function testLoadNonExisting()
 	{
-		$root       = __DIR__ . '/fixtures/controller/does-not-exist.php';
+		$root       = static::FIXTURES . '/controller/does-not-exist.php';
 		$controller = Controller::load($root);
 		$this->assertNull($controller);
 	}
@@ -101,7 +103,7 @@ class ControllerTest extends TestCase
 	 */
 	public function testLoadInvalidController()
 	{
-		$root       = __DIR__ . '/fixtures/controller/invalid.php';
+		$root       = static::FIXTURES . '/controller/invalid.php';
 		$controller = Controller::load($root);
 		$this->assertNull($controller);
 	}

--- a/tests/Toolkit/TplTest.php
+++ b/tests/Toolkit/TplTest.php
@@ -4,21 +4,23 @@ namespace Kirby\Toolkit;
 
 class TplTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures';
+
 	public function testLoadWithGoodTemplate()
 	{
-		$tpl = Tpl::load(__DIR__ . '/fixtures/tpl/good.php', ['name' => 'Peter']);
+		$tpl = Tpl::load(static::FIXTURES . '/tpl/good.php', ['name' => 'Peter']);
 		$this->assertSame('Hello Peter', $tpl);
 	}
 
 	public function testLoadWithBadTemplate()
 	{
 		$this->expectException('Error');
-		Tpl::load(__DIR__ . '/fixtures/tpl/bad.php');
+		Tpl::load(static::FIXTURES . '/tpl/bad.php');
 	}
 
 	public function testLoadWithNonExistingFile()
 	{
-		$tpl = Tpl::load(__DIR__ . '/fixtures/tpl/imaginary.php');
+		$tpl = Tpl::load(static::FIXTURES . '/tpl/imaginary.php');
 		$this->assertSame('', $tpl);
 	}
 }

--- a/tests/Toolkit/ViewTest.php
+++ b/tests/Toolkit/ViewTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
  */
 class ViewTest extends TestCase
 {
-	protected string $fixtures = __DIR__ . '/fixtures/view';
+	public const FIXTURES = __DIR__ . '/fixtures/view';
 
 	protected function view(array $data = [])
 	{
-		return new View($this->fixtures . '/view.php', $data);
+		return new View(static::FIXTURES . '/view.php', $data);
 	}
 
 	/**
@@ -38,7 +38,7 @@ class ViewTest extends TestCase
 		$view = $this->view();
 		$this->assertTrue($view->exists());
 
-		$view = new View($this->fixtures . '/foo.php');
+		$view = new View(static::FIXTURES . '/foo.php');
 		$this->assertFalse($view->exists());
 	}
 
@@ -49,7 +49,7 @@ class ViewTest extends TestCase
 	public function testFile()
 	{
 		$view = $this->view();
-		$this->assertSame($this->fixtures . '/view.php', $view->file());
+		$this->assertSame(static::FIXTURES . '/view.php', $view->file());
 	}
 
 	/**
@@ -81,7 +81,7 @@ class ViewTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('View exception');
 
-		$view = new View($this->fixtures . '/view-with-exception.php');
+		$view = new View(static::FIXTURES . '/view-with-exception.php');
 		$view->render();
 	}
 

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
  */
 class XmlTest extends TestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/xml';
+
 	/**
 	 * @covers       ::attr
 	 * @dataProvider attrProvider
@@ -69,14 +71,13 @@ class XmlTest extends TestCase
 		$this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '    ', 1));
 		$this->assertSame('    <name>Homer</name>', Xml::create('Homer', 'name', false, '  ', 2));
 
-		$fixtures = __DIR__ . '/fixtures/xml';
 		$data = [
 			'@name'       => 'contact',
 			'@attributes' => ['type' => 'husband'],
 			'@value'      => 'Homer'
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/contact.xml')));
-		$this->assertStringEqualsFile($fixtures . '/contact.xml', Xml::create($data, 'contact'));
+		$this->assertSame($data, Xml::parse(file_get_contents(static::FIXTURES . '/contact.xml')));
+		$this->assertStringEqualsFile(static::FIXTURES . '/contact.xml', Xml::create($data, 'contact'));
 
 		$data = [
 			'@name' => 'contacts',
@@ -95,9 +96,9 @@ class XmlTest extends TestCase
 				]
 			]
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/contacts.xml')));
-		$this->assertStringEqualsFile($fixtures . '/contacts_nowrapper.xml', Xml::create($contacts, 'contact', false));
-		$this->assertStringEqualsFile($fixtures . '/contacts.xml', Xml::create($data, 'contacts'));
+		$this->assertSame($data, Xml::parse(file_get_contents(static::FIXTURES . '/contacts.xml')));
+		$this->assertStringEqualsFile(static::FIXTURES . '/contacts_nowrapper.xml', Xml::create($contacts, 'contact', false));
+		$this->assertStringEqualsFile(static::FIXTURES . '/contacts.xml', Xml::create($data, 'contacts'));
 
 		$data = [
 			'@name' => 'simpsons',
@@ -129,12 +130,12 @@ class XmlTest extends TestCase
 				]
 			]
 		];
-		$this->assertSame($data, Xml::parse(file_get_contents($fixtures . '/simpsons.xml')));
-		$this->assertStringEqualsFile($fixtures . '/simpsons.xml', Xml::create($data, 'invalid'));
-		$this->assertStringEqualsFile($fixtures . '/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
+		$this->assertSame($data, Xml::parse(file_get_contents(static::FIXTURES . '/simpsons.xml')));
+		$this->assertStringEqualsFile(static::FIXTURES . '/simpsons.xml', Xml::create($data, 'invalid'));
+		$this->assertStringEqualsFile(static::FIXTURES . '/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
 
 		unset($data['@name']);
-		$this->assertStringEqualsFile($fixtures . '/simpsons.xml', Xml::create($data, 'simpsons'));
+		$this->assertStringEqualsFile(static::FIXTURES . '/simpsons.xml', Xml::create($data, 'simpsons'));
 
 		$this->assertNull(Xml::parse('<this>is invalid</that>'));
 	}
@@ -158,7 +159,7 @@ class XmlTest extends TestCase
 	 */
 	public function testParseRecursiveEntities()
 	{
-		$xml = file_get_contents(__DIR__ . '/fixtures/xml/billion-laughs.xml');
+		$xml = file_get_contents(static::FIXTURES . '/billion-laughs.xml');
 		$this->assertNull(Xml::parse($xml));
 	}
 

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -11,6 +11,8 @@ use Kirby\Cms\File;
  */
 class FileUuidTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.FileUuid';
+
 	/**
 	 * @covers ::findByCache
 	 */
@@ -139,7 +141,7 @@ class FileUuidTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => [
 				'languages' => true

--- a/tests/Uuid/HasUuidsTest.php
+++ b/tests/Uuid/HasUuidsTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Uuid;
 
 class HasUuidsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.HasUuids';
+
 	public function testfindByUuid()
 	{
 		$app = $this->app->clone([

--- a/tests/Uuid/IdentifiableModelActionsTest.php
+++ b/tests/Uuid/IdentifiableModelActionsTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Uuid;
 
 class IdentifiableModelActionsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.IdentifiableModelActions';
+
 	public function testFileChangeName()
 	{
 		$file = $this->app->file('page-a/test.pdf');

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -11,6 +11,8 @@ use Kirby\Cms\Page;
  */
 class PageUuidTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.PageUuid';
+
 	/**
 	 * @covers ::findByCache
 	 */
@@ -128,7 +130,7 @@ class PageUuidTest extends TestCase
 	{
 		$app = new App([
 			'roots' => [
-				'index' => $this->tmp
+				'index' => static::TMP
 			],
 			'options' => [
 				'languages' => true

--- a/tests/Uuid/PermalinksTest.php
+++ b/tests/Uuid/PermalinksTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Uuid;
 
 class PermalinksTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.Permalinks';
+
 	public function testRoute()
 	{
 		$app = $this->app->clone([

--- a/tests/Uuid/SiteUuidTest.php
+++ b/tests/Uuid/SiteUuidTest.php
@@ -10,6 +10,8 @@ use Kirby\Cms\Site;
  */
 class SiteUuidTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.SiteUuid';
+
 	/**
 	 * @covers ::id
 	 */

--- a/tests/Uuid/TestCase.php
+++ b/tests/Uuid/TestCase.php
@@ -9,18 +9,22 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
 	protected $app;
-	protected $tmp;
 
 	protected function setUp(): void
 	{
-		$this->tmp = __DIR__ . '/tmp';
 		$this->app = $this->app();
-		Dir::make($this->tmp);
+
+		if ($this->hasTmp() === true) {
+			Dir::make(static::TMP);
+		}
 	}
 
 	protected function tearDown(): void
 	{
-		Dir::remove($this->tmp);
+		if ($this->hasTmp() === true) {
+			Dir::remove(static::TMP);
+		}
+
 		Uuids::cache()->flush();
 	}
 
@@ -28,7 +32,7 @@ class TestCase extends BaseTestCase
 	{
 		return new App([
 			'roots' => [
-				'index' => $this->tmp,
+				'index' => $this->hasTmp() ? static::TMP : '/dev/null',
 			],
 			'options' => [
 				'url' => 'https://getkirby.com'
@@ -119,5 +123,14 @@ class TestCase extends BaseTestCase
 				]
 			],
 		]);
+	}
+
+	/**
+	 * Checks if the test class extending this test case class
+	 * has defined a temporary directory
+	 */
+	protected function hasTmp(): bool
+	{
+		return defined(get_class($this) . '::TMP');
 	}
 }

--- a/tests/Uuid/UriTest.php
+++ b/tests/Uuid/UriTest.php
@@ -7,6 +7,8 @@ namespace Kirby\Uuid;
  */
 class UriTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uri';
+
 	public static function provider(): array
 	{
 		// Provider entries:

--- a/tests/Uuid/UserUuidTest.php
+++ b/tests/Uuid/UserUuidTest.php
@@ -10,6 +10,8 @@ use Kirby\Cms\User;
  */
 class UserUuidTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.UserUuid';
+
 	/**
 	 * @covers ::index
 	 */

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -20,6 +20,8 @@ class TestUuid extends Uuid
  */
 class UuidTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuid';
+
 	/**
 	 * @covers ::__construct
 	 */

--- a/tests/Uuid/UuidsTest.php
+++ b/tests/Uuid/UuidsTest.php
@@ -12,6 +12,8 @@ use Kirby\Exception\LogicException;
  */
 class UuidsTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuids';
+
 	/**
 	 * @covers ::cache
 	 */


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Housekeeping

- Our PHPUnit tests can now be run individually with process isolation
- Refactor PHPUnit tests to use a global tmp directory that is properly cleaned up

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
