### PR TITLE
Pass `languageCode` argument for some missing hooks

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -366,7 +366,19 @@ trait PageActions
 		string $title,
 		string|null $languageCode = null
 	): static {
+		// if the `$languageCode` argument is not set and is not the default language
+		// the `$languageCode` argument is sent as the current language
+		if (
+			$languageCode === null &&
+			$language = $this->kirby()->language()
+		) {
+			if ($language->isDefault() === false) {
+				$languageCode = $language->code();
+			}
+		}
+
 		$arguments = ['page' => $this, 'title' => $title, 'languageCode' => $languageCode];
+
 		return $this->commit('changeTitle', $arguments, function ($page, $title, $languageCode) {
 			$page = $page->save(['title' => $title], $languageCode);
 

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -49,16 +49,25 @@ trait SiteActions
 	 */
 	public function changeTitle(
 		string $title,
-		string $languageCode = null
+		string|null $languageCode = null
 	): static {
-		$site  = $this;
-		$title = trim($title);
+		// if the `$languageCode` argument is not set and is not the default language
+		// the `$languageCode` argument is sent as the current language
+		if (
+			$languageCode === null &&
+			$language = $this->kirby()->language()
+		) {
+			if ($language->isDefault() === false) {
+				$languageCode = $language->code();
+			}
+		}
+
+		$arguments = ['site' => $this, 'title' => trim($title), 'languageCode' => $languageCode];
 
 		return $this->commit(
 			'changeTitle',
-			compact('site', 'title', 'languageCode'),
-			fn ($site, $title, $languageCode) =>
-				$site->save(['title' => $title], $languageCode)
+			$arguments,
+			fn ($site, $title, $languageCode) => $site->save(['title' => $title], $languageCode)
 		);
 	}
 

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -1146,6 +1146,83 @@ class PageActionsTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
+	public function testChangeTitleBeforeHookDefaultLanguage()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			],
+			'hooks' => [
+				'page.changeTitle:before' => function (Page $page, $title, $languageCode) use ($phpunit, &$calls) {
+					$phpunit->assertSame('test', $page->title()->value);
+					$phpunit->assertSame('New Title', $title);
+					$phpunit->assertNull($languageCode);
+					$calls++;
+				},
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$page = new Page([
+			'slug' => 'test'
+		]);
+
+		$page->changeTitle('New Title');
+
+		$this->assertSame(1, $calls);
+	}
+
+	public function testChangeTitleBeforeHookSecondaryLanguage()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			],
+			'hooks' => [
+				'page.changeTitle:before' => function (Page $page, $title, $languageCode) use ($phpunit, &$calls) {
+					$phpunit->assertSame('test', $page->title()->value);
+					$phpunit->assertSame('New Title', $title);
+					$phpunit->assertSame('de', $languageCode);
+					$calls++;
+				},
+			]
+		]);
+
+		$app->impersonate('kirby');
+		$app->setCurrentLanguage('de');
+
+		$page = new Page([
+			'slug' => 'test'
+		]);
+
+		$page->changeTitle('New Title', 'de');
+
+		$this->assertSame(1, $calls);
+	}
+
 	public function testCreateHooks()
 	{
 		$calls = 0;

--- a/tests/Cms/Site/SiteActionsTest.php
+++ b/tests/Cms/Site/SiteActionsTest.php
@@ -121,6 +121,70 @@ class SiteActionsTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
+	public function testChangeTitleHookBeforeHookDefaultLanguage()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			],
+			'hooks' => [
+				'site.changeTitle:before' => function (Site $site, $title, $languageCode) use ($phpunit, &$calls) {
+					$phpunit->assertNull($site->title()->value());
+					$phpunit->assertSame('New Title', $title);
+					$phpunit->assertNull($languageCode);
+					$calls++;
+				}
+			]
+		]);
+
+		$app->site()->changeTitle('New Title');
+
+		$this->assertSame(1, $calls);
+	}
+
+	public function testChangeTitleHookBeforeHookSecondaryLanguage()
+	{
+		$calls = 0;
+		$phpunit = $this;
+
+		$app = $this->app->clone([
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			],
+			'hooks' => [
+				'site.changeTitle:before' => function (Site $site, $title, $languageCode) use ($phpunit, &$calls) {
+					$phpunit->assertNull($site->title()->value());
+					$phpunit->assertSame('New Title', $title);
+					$phpunit->assertSame('de', $languageCode);
+					$calls++;
+				}
+			]
+		]);
+
+		$app->site()->changeTitle('New Title', 'de');
+
+		$this->assertSame(1, $calls);
+	}
+
 	public function testUpdateHooks()
 	{
 		$calls = 0;


### PR DESCRIPTION
## This PR …

Fixes missing `$languageCode` argument for `site.changeTitle:before` and `page.changeTitle:before` hooks.

### Fixes
- Language argument doesn't passed to hooks from dialogs/areas #6117

### Breaking changes

May be `$languageCode` in `Site::changeTitle()` type hint could be a breaking change, not sure.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
