### PR TITLE
Deprecate `Array.prototype` functions

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -543,7 +543,7 @@ export default {
 				return items;
 			}
 
-			return items.sortBy(this.sortBy);
+			return this.$helper.array.sortBy(this.items, this.sortBy);
 		},
 		/**
 		 * Converts field value to internal

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -88,7 +88,7 @@ export default {
 			return this.$helper.object.length(this.$panel.searches) > 0;
 		},
 		menus() {
-			return this.$panel.menu.entries.split("-");
+			return this.$helper.array.split(this.$panel.menu.entries, "-");
 		}
 	}
 };

--- a/panel/src/helpers/array.js
+++ b/panel/src/helpers/array.js
@@ -2,11 +2,12 @@ import sort from "./sort";
 import "./regex";
 
 /**
- * Array.fromObject()
+ * @param {Array|Object} object
+ * @returns {Array}
  */
-Array.fromObject = function (object) {
+export function fromObject(object) {
 	return Array.isArray(object) ? object : Object.values(object ?? {});
-};
+}
 
 /**
  * Search through an array by query
@@ -43,9 +44,11 @@ export const search = (array, query, options = {}) => {
 };
 
 /**
- * Array.sortBy()
+ * @param {Array} array
+ * @param {String} sortBy
+ * @returns {Array}
  */
-Array.prototype.sortBy = function (sortBy) {
+export function sortBy(array, sortBy) {
 	const options = sortBy.split(" ");
 	const field = options[0];
 	const direction = options[1] ?? "asc";
@@ -55,22 +58,21 @@ Array.prototype.sortBy = function (sortBy) {
 		insensitive: true
 	});
 
-	return this.sort((a, b) => {
+	return array.sort((a, b) => {
 		const valueA = String(a[field] ?? "");
 		const valueB = String(b[field] ?? "");
 		return sorter(valueA, valueB);
 	});
-};
+}
 
 /**
- * Array.split()
- *
+ * @param {Array} array
  * @param {String} delimiter
  * @returns {Array}
  *
  */
-Array.prototype.split = function (delimiter) {
-	return this.reduce(
+export function split(array, delimiter) {
+	return array.reduce(
 		(entries, entry) => {
 			if (entry === delimiter) {
 				entries.push([]);
@@ -81,15 +83,54 @@ Array.prototype.split = function (delimiter) {
 		},
 		[[]]
 	);
-};
+}
 
 /**
- * Array.wrap()
+ * @param {any} array
+ * @returns {Array}
  */
-Array.wrap = function (array) {
+export function wrap(array) {
 	return Array.isArray(array) ? array : [array];
-};
+}
+
+/**
+ * @deprecated `Array.fromObject()` will be removed in a future version. Use `this.$helper.array.fromObject()` instead.
+ */
+Array.fromObject = fromObject;
+
+/**
+ * @deprecated `myArray.sortBy()` will be removed in a future version. Use `this.$helper.array.sortBy(myArray, sortBy)` instead.
+ */
+Object.defineProperty(Array.prototype, "sortBy", {
+	value: function (sortBy) {
+		return sortBy(this, sortBy);
+	},
+	enumerable: false,
+	writable: true,
+	configurable: true
+});
+
+/**
+ * @deprecated `myArray.split()` will be removed in a future version. Use `this.$helper.array.split(myArray, delimiter)` instead.
+ */
+Object.defineProperty(Array.prototype, "split", {
+	value: function (delimiter) {
+		return split(this, delimiter);
+	},
+	enumerable: false,
+	writable: true,
+	configurable: true
+});
+
+/**
+ * @deprecated `Array.wrap()` will be removed in a future version. Use `this.$helper.array.wrap()` instead.
+ */
+Array.wrap = wrap;
 
 export default {
-	search
+	fromObject,
+	search,
+	sortBy,
+	split,
+	wrap
 };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactored
- New `this.$helper.array.` functions: `fromObject`, `sortBy`, `split`,	`wrap`

### Deprecated
- `Array.fromObject()` has been deprecated. Use `this.$helper.array.fromObject()` instead.
- `Array.wrap()` has been deprecated. Use `this.$helper.array.wrap()` instead.
- `myArray.sortBy()` has been deprecated. Use `this.$helper.array.sortBy(myArray)` instead.
- `myArray.split()` has been deprecated. Use `this.$helper.array.split(myArray)` instead.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
