### PR TITLE
Pages section table: add field types for columns

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -55,7 +55,7 @@ return [
 		'parent' => function () {
 			return $this->parentModel();
 		},
-		'files' => function () {
+		'models' => function () {
 			if ($this->query !== null) {
 				$files = $this->parent->query($this->query, Files::class) ?? new Files([]);
 			} else {
@@ -99,6 +99,9 @@ return [
 
 			return $files;
 		},
+		'files' => function () {
+			return $this->models;
+		},
 		'data' => function () {
 			$data = [];
 
@@ -106,7 +109,7 @@ return [
 			// a different parent model
 			$dragTextAbsolute = $this->model->is($this->parent) === false;
 
-			foreach ($this->files as $file) {
+			foreach ($this->models as $file) {
 				$panel = $file->panel();
 
 				$item = [
@@ -137,7 +140,7 @@ return [
 			return $data;
 		},
 		'total' => function () {
-			return $this->files->pagination()->total();
+			return $this->models->pagination()->total();
 		},
 		'errors' => function () {
 			$errors = [];
@@ -208,7 +211,7 @@ return [
 			'options' => [
 				'accept'   => $this->accept,
 				'apiUrl'   => $this->parent->apiUrl(true),
-				'columns'  => $this->columns,
+				'columns'  => $this->columnsWithTypes(),
 				'empty'    => $this->empty,
 				'headline' => $this->headline,
 				'help'     => $this->help,

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -100,7 +100,11 @@ return [
 
 			// add the type to the columns for the table layout
 			if ($this->layout === 'table') {
-				$blueprint = $this->models->first()->blueprint();
+				$blueprint = $this->models->first()?->blueprint();
+
+				if ($blueprint === null) {
+					return $columns;
+				}
 
 				foreach ($columns as $columnName => $column) {
 					if ($id = $column['id'] ?? null) {

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cms\ModelWithContent;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -28,7 +29,7 @@ return [
 	],
 	'computed' => [
 		'columns' => function () {
-			$columns = [];
+			$columns   = [];
 
 			if ($this->layout !== 'table') {
 				return [];
@@ -94,7 +95,23 @@ return [
 		},
 	],
 	'methods' => [
-		'columnsValues' => function (array $item, $model) {
+		'columnsWithTypes' => function () {
+			$columns = $this->columns;
+
+			// add the type to the columns for the table layout
+			if ($this->layout === 'table') {
+				$blueprint = $this->models->first()->blueprint();
+
+				foreach ($columns as $columnName => $column) {
+					if ($id = $column['id'] ?? null) {
+						$columns[$columnName]['type'] ??= $blueprint->field($id)['type'] ?? null;
+					}
+				}
+			}
+
+			return $columns;
+		},
+		'columnsValues' => function (array $item, ModelWithContent $model) {
 			$item['title'] = [
 				// override toSafeString() coming from `$item`
 				// because the table cells don't use v-html

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -82,7 +82,7 @@ return [
 
 			return $parent;
 		},
-		'pages' => function () {
+		'models' => function () {
 			if ($this->query !== null) {
 				$pages = $this->parent->query($this->query, Pages::class) ?? new Pages([]);
 			} else {
@@ -156,13 +156,16 @@ return [
 
 			return $pages;
 		},
+		'pages' => function () {
+			return $this->models;
+		},
 		'total' => function () {
-			return $this->pages->pagination()->total();
+			return $this->models->pagination()->total();
 		},
 		'data' => function () {
 			$data = [];
 
-			foreach ($this->pages as $page) {
+			foreach ($this->models as $page) {
 				$panel       = $page->panel();
 				$permissions = $page->permissions();
 
@@ -284,7 +287,7 @@ return [
 			'errors'  => $this->errors,
 			'options' => [
 				'add'      => $this->add,
-				'columns'  => $this->columns,
+				'columns'  => $this->columnsWithTypes(),
 				'empty'    => $this->empty,
 				'headline' => $this->headline,
 				'help'     => $this->help,

--- a/panel/src/components/Collection/Collection.vue
+++ b/panel/src/components/Collection/Collection.vue
@@ -9,13 +9,16 @@
 
 		<k-items
 			v-else
-			:columns="columns"
-			:items="items"
-			:layout="layout"
-			:link="link"
-			:size="size"
-			:sortable="sortable"
-			:theme="theme"
+			v-bind="{
+				columns,
+				fields,
+				items,
+				layout,
+				link,
+				size,
+				sortable,
+				theme
+			}"
 			@change="$emit('change', $event)"
 			@item="$emit('item', $event)"
 			@option="onOption"

--- a/panel/src/components/Collection/Items.vue
+++ b/panel/src/components/Collection/Items.vue
@@ -71,6 +71,14 @@ export const props = {
 			default: () => ({})
 		},
 		/**
+		 * Optional fields configuration that is used for table layout
+		 * @internal
+		 */
+		fields: {
+			type: Object,
+			default: () => ({})
+		},
+		/**
 		 * Array of item definitions. See `k-item` for available options.
 		 */
 		items: {
@@ -128,6 +136,7 @@ export default {
 		table() {
 			return {
 				columns: this.columns,
+				fields: this.fields,
 				rows: this.items,
 				sortable: this.sortable
 			};

--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -123,6 +123,7 @@ export default {
 			return {
 				columns: this.options.columns,
 				empty: this.emptyPropsWithSearch,
+				fields: this.options.fields,
 				layout: this.options.layout,
 				help: this.options.help,
 				items: this.items,


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- Page and files section with table layout will now try to infer the column type from the blueprint of the first model when no type has been provided explicitly


### Breaking changes
I think none as `columnsWithTypes` is a new function that our pages/files section uses - but any plugin extending those sections can still use `columns` like before. 

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
