### PR TITLE
PageCreateDialog: use field defaults

### DIFF
--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -236,8 +236,12 @@ class PageCreateDialog
 			$content[$name] = $input[$name] ?? null;
 		}
 
+		// create temporary form to sanitize the input
+		// and add default values
+		$form = Form::for($this->model(), ['values' => $content]);
+
 		return [
-			'content'  => $content,
+			'content'  => $form->strings(true),
 			'slug'     => $input['slug'],
 			'template' => $this->template,
 		];

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -305,7 +305,7 @@ class PageCreateDialog
 
 	public function value(): array
 	{
-		return [
+		$value = [
 			'parent'   => $this->parentId,
 			'section'  => $this->sectionId,
 			'slug'     => $this->slug ?? '',
@@ -313,5 +313,12 @@ class PageCreateDialog
 			'title'    => $this->title ?? '',
 			'view'     => $this->viewId,
 		];
+
+		// add default values for custom fields
+		foreach ($this->customFields() as $name => $field) {
+			$value[$name] = $field['default'] ?? null;
+		}
+
+		return $value;
 	}
 }

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -316,7 +316,9 @@ class PageCreateDialog
 
 		// add default values for custom fields
 		foreach ($this->customFields() as $name => $field) {
-			$value[$name] = $field['default'] ?? null;
+			if ($default = $field['default'] ?? null) {
+				$value[$name] = $default;
+			}
 		}
 
 		return $value;

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -36,6 +36,56 @@ class PageCreateDialogTest extends AreaTestCase
 	}
 
 	/**
+	 * @covers ::sanitize
+	 */
+	public function testSanitize(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'fields' => ['foo', 'bar']
+					],
+					'fields' => [
+						'foo' => [
+							'type'     => 'text',
+							'required' => true
+						],
+						'bar' => [
+							'type'     => 'text',
+							'required' => true,
+							'default'  => 'bar'
+						]
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$input = $dialog->sanitize([
+			'slug'  => 'foo',
+			'title' => 'Foo',
+			'foo'   => 'bar'
+		]);
+
+		$this->assertSame([
+			'content'  => [
+				'foo'   => 'bar',
+				'bar'   => 'bar',
+				'title' => 'Foo',
+			],
+			'slug'     => 'foo',
+			'template' => 'test',
+		], $input);
+	}
+
+	/**
 	 * @covers ::validate
 	 */
 	public function testValidateInvalidTitle(): void
@@ -119,14 +169,13 @@ class PageCreateDialogTest extends AreaTestCase
 				'pages/test' => [
 					'fields' => [
 						'foo' => [
-							'type' => 'text',
+							'type'     => 'text',
 							'required' => true
 						]
 					]
 				]
 			]
 		]);
-
 
 		$dialog = new PageCreateDialog(
 			null,

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -191,4 +191,46 @@ class PageCreateDialogTest extends AreaTestCase
 
 		$this->assertTrue($valid);
 	}
+
+	/**
+	 * @covers ::value
+	 */
+	public function testValue(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'fields' => ['foo']
+					],
+					'fields' => [
+						'foo' => [
+							'type'     => 'text',
+							'required' => true,
+							'default'  => 'bar'
+						]
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$value = $dialog->value();
+
+		$this->assertSame([
+			'parent'   => 'site',
+			'section'  => null,
+			'slug'     => '',
+			'template' => 'test',
+			'title'    => '',
+			'view'     => null,
+			'foo'      => 'bar'
+		], $value);
+	}
 }


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Page create dialog: custom fields in dialogs are prefilled with default values
- Page create dialog: no error is thrown when directly publishing page with required fields that have a default value 
#6119


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
