### PR TITLE
Files section: fix `NaN` after file sort

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -191,13 +191,14 @@ return [
 				'multiple'   => $multiple,
 				'max'        => $max,
 				'api'        => $this->parent->apiUrl(true) . '/files',
-				'attributes' => array_filter([
+				'attributes' => [
 					// TODO: an edge issue that needs to be solved:
-					//		 if multiple users load the same section at the same time
-					// 		 and upload a file, uploaded files have the same sort number
+					//		 if multiple users load the same section
+					//       at the same time and upload a file,
+					//       uploaded files have the same sort number
 					'sort'     => $this->sortable === true ? $this->total + 1 : null,
 					'template' => $template
-				])
+				]
 			];
 		}
 	],


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

> https://github.com/getkirby/kirby/blob/main/panel/src/panel/upload.js#L293
> 
> When there is no template and not sortable, attributes is actually empty (see https://github.com/getkirby/kirby/blob/main/config/sections/files.php#L194-L200). In turn, attributes is not an empty object but actually ends up as an empty array in JS world. And .sort on an array is a method, which is why the if statement gets entered and then NaN is the result.

### Fixes
- Files section: fixed `NaN` value after sorting files
#6067


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] ~~Unit tests for fixed bug/feature~~
- [x] ~~In-code documentation (wherever needed)~~
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~~
