### PR TITLE
Color field: fix options from query

### DIFF
--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -68,6 +68,9 @@ return [
 			}
 
 			$options = match (true) {
+				// simple array of values
+				// or value=text (from Options class)
+				is_numeric($options[0]['value']) ||
 				$options[0]['value'] === $options[0]['text']
 					=> A::map($options, fn ($option) => [
 						'value' => $option['text']

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -75,6 +75,7 @@ return [
 					=> A::map($options, fn ($option) => [
 						'value' => $option['text']
 					]),
+
 				// deprecated: name => value, flipping
 				// TODO: start throwing in warning in v5
 				$this->isColor($options[0]['text'])
@@ -82,11 +83,12 @@ return [
 						'value' => $option['text'],
 						'text'  => $option['value']
 					]),
+
 				default
-					=> A::map($options, fn ($option) => [
-						'value' => $option['value'],
-						'text'  => $option['text']
-					]),
+				=> A::map($options, fn ($option) => [
+					'value' => $option['value'],
+					'text'  => $option['text']
+				]),
 			};
 
 			return $options;

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -57,10 +57,11 @@ return [
 			// alongside api and query options
 			$props   = FieldOptions::polyfill($this->props);
 			$options = FieldOptions::factory([
-				...$props['options'],
-				'value' => '{{ item.key }}',
 				'text'  => '{{ item.value }}',
+				'value' => '{{ item.key }}',
+				...$props['options']
 			]);
+
 			$options = $options->render($this->model());
 
 			if (empty($options) === true) {

--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -159,7 +159,9 @@ class OptionsQuery extends OptionsProvider
 		}
 
 		if ($result instanceof Collection === false) {
-			throw new InvalidArgumentException('Invalid query result data: ' . get_class($result));
+			$type = is_object($result) === true ? get_class($result) : gettype($result);
+
+			throw new InvalidArgumentException('Invalid query result data: ' . $type);
 		}
 
 		// create options array

--- a/tests/Form/Fields/ColorFieldTest.php
+++ b/tests/Form/Fields/ColorFieldTest.php
@@ -52,24 +52,45 @@ class ColorFieldTest extends TestCase
 
 	public function testOptions()
 	{
+		// Only values
 		$field = $this->field('color', [
 			'options' => ['a', 'b', 'c'],
 		]);
 
 		$this->assertSame([
-			['value' => 'a', 'text' => null],
-			['value' => 'b', 'text' => null],
-			['value' => 'c', 'text' => null]
+			['value' => 'a'],
+			['value' => 'b'],
+			['value' => 'c']
 		], $field->options());
 
+		// Value => Name
 		$field = $this->field('color', [
-			'options' => ['Color a' => 'a', 'Color b' => 'b', 'Color c' => 'c'],
+			'options' => [
+				'#aaa' => 'Color a',
+				'#bbb' => 'Color b',
+				'#ccc' => 'Color c'
+			],
 		]);
 
 		$this->assertSame([
-			['value' => 'a', 'text' => 'Color a'],
-			['value' => 'b', 'text' => 'Color b'],
-			['value' => 'c', 'text' => 'Color c']
+			['value' => '#aaa', 'text' => 'Color a'],
+			['value' => '#bbb', 'text' => 'Color b'],
+			['value' => '#ccc', 'text' => 'Color c']
+		], $field->options());
+
+		// Deprecated: name => value
+		$field = $this->field('color', [
+			'options' => [
+				'Color a' => '#aaa',
+				'Color b' => '#bbb',
+				'Color c' => '#ccc'
+			],
+		]);
+
+		$this->assertSame([
+			['value' => '#aaa', 'text' => 'Color a'],
+			['value' => '#bbb', 'text' => 'Color b'],
+			['value' => '#ccc', 'text' => 'Color c']
 		], $field->options());
 	}
 }

--- a/tests/Form/Fields/ColorFieldTest.php
+++ b/tests/Form/Fields/ColorFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Fields;
 
+use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 
 class ColorFieldTest extends TestCase
@@ -54,13 +55,13 @@ class ColorFieldTest extends TestCase
 	{
 		// Only values
 		$field = $this->field('color', [
-			'options' => ['a', 'b', 'c'],
+			'options' => ['#aaa', '#bbb', '#ccc'],
 		]);
 
 		$this->assertSame([
-			['value' => 'a'],
-			['value' => 'b'],
-			['value' => 'c']
+			['value' => '#aaa'],
+			['value' => '#bbb'],
+			['value' => '#ccc']
 		], $field->options());
 
 		// Value => Name
@@ -85,6 +86,68 @@ class ColorFieldTest extends TestCase
 				'Color b' => '#bbb',
 				'Color c' => '#ccc'
 			],
+		]);
+
+		$this->assertSame([
+			['value' => '#aaa', 'text' => 'Color a'],
+			['value' => '#bbb', 'text' => 'Color b'],
+			['value' => '#ccc', 'text' => 'Color c']
+		], $field->options());
+	}
+
+	public function testOptionsFromQuery()
+	{
+		// Only values
+		$this->app = new App([
+			'options' => [
+				'foo' => ['#aaa', '#bbb', '#ccc']
+			]
+		]);
+
+		$field = $this->field('color', [
+			'options' => ['type' => 'query', 'query' => 'kirby.option("foo")'],
+		]);
+
+		$this->assertSame([
+			['value' => '#aaa'],
+			['value' => '#bbb'],
+			['value' => '#ccc']
+		], $field->options());
+
+		// Value => Name
+		$this->app = new App([
+			'options' => [
+				'foo' => [
+					'#aaa' => 'Color a',
+					'#bbb' => 'Color b',
+					'#ccc' => 'Color c'
+				]
+			]
+		]);
+
+		$field = $this->field('color', [
+			'options' => ['type' => 'query', 'query' => 'kirby.option("foo")'],
+		]);
+
+		$this->assertSame([
+			['value' => '#aaa', 'text' => 'Color a'],
+			['value' => '#bbb', 'text' => 'Color b'],
+			['value' => '#ccc', 'text' => 'Color c']
+		], $field->options());
+
+		// Deprecated: name => value
+		$this->app = new App([
+			'options' => [
+				'foo' => [
+					'Color a' => '#aaa',
+					'Color b' => '#bbb',
+					'Color c' => '#ccc'
+				],
+			]
+		]);
+
+		$field = $this->field('color', [
+			'options' => ['type' => 'query', 'query' => 'kirby.option("foo")'],
 		]);
 
 		$this->assertSame([


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixed (not for release notes as it fixes unreleased changes)
-  #6101

### Refactored
- Color field: options should be written as `$value => $name`, e.g.
```yml
options:
  "#F8B195": "Sunny rays"
  "#F67280": "First-love blush"
  "#C06C84": "Cherry blossom"
  "#6C5B7B": "Morning gloom"
  "#355C7D": "Midnight rain"
```

### Deprecated
- Color field: writing options as `$name => value` has been deprecated



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
