### PR TITLE
fix(DB): added charset to DB Params

### DIFF
--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -47,7 +47,8 @@ class Db
 			'password' => Config::get('db.password', ''),
 			'database' => Config::get('db.database', ''),
 			'prefix'   => Config::get('db.prefix', ''),
-			'port'     => Config::get('db.port', '')
+			'port'     => Config::get('db.port', ''),
+			'charset'  => Config::get('db.charset', 'utf8mb4')
 		];
 
 		return static::$connection = new Database($params);


### PR DESCRIPTION
## Fix Database Problem with Emojis like 🦉📌 

Kirby was not able to display or save Emojis like 🦉📌 to the Database. The reason was the wrong charset, the problem is that the charset is'nt loaded to params from the config.

### Fixes

loading charset from config to DB params


