### PR TITLE
Page create dialog: hide `title` and/or `slug`

### DIFF
--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -126,18 +126,21 @@ export default (panel, key, defaults) => {
 				panel.notification.close();
 			}
 
-			// block the overflow until we can use :has for this.
-			document.documentElement.setAttribute("data-overlay", "true");
-			document.documentElement.style.setProperty(
-				"--scroll-top",
-				window.scrollY + "px"
-			);
-
 			// open the modal feature via url or with a state object
 			await parent.open.call(this, modal, options);
 
-			// mark the modal as open
-			this.isOpen = true;
+			// only mark this as open if a component has been defined
+			if (this.component) {
+				// block the overflow until we can use :has for this.
+				document.documentElement.setAttribute("data-overlay", "true");
+				document.documentElement.style.setProperty(
+					"--scroll-top",
+					window.scrollY + "px"
+				);
+
+				// mark the modal as open
+				this.isOpen = true;
+			}
 
 			return this.state();
 		},

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -354,15 +354,6 @@ export default {
 		}
 
 		/**
-		 * Toggle the dropdown
-		 */
-		if (isObject(state.dropdown) === true) {
-			this.dropdown.open(state.dropdown);
-		} else if (state.dropdown !== undefined) {
-			this.dropdown.close();
-		}
-
-		/**
 		 * Toggle modals
 		 */
 		for (const modal of modals) {
@@ -381,6 +372,15 @@ export default {
 			else if (state[modal] !== undefined) {
 				this[modal].close();
 			}
+		}
+
+		/**
+		 * Toggle the dropdown
+		 */
+		if (isObject(state.dropdown) === true) {
+			this.dropdown.open(state.dropdown);
+		} else if (state.dropdown !== undefined) {
+			this.dropdown.close();
 		}
 
 		/**

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -354,13 +354,26 @@ export default {
 		}
 
 		/**
+		 * Toggle the dropdown
+		 */
+		if (isObject(state.dropdown) === true) {
+			this.dropdown.open(state.dropdown);
+		} else if (state.dropdown !== undefined) {
+			this.dropdown.close();
+		}
+
+		/**
 		 * Toggle modals
 		 */
 		for (const modal of modals) {
 			// if there's a new state for the
 			// modal, call its state setter method
 			if (isObject(state[modal]) === true) {
-				this[modal].open(state[modal]);
+				if (state[modal].redirect) {
+					return this.open(state[modal].redirect);
+				} else {
+					this[modal].open(state[modal]);
+				}
 			}
 
 			// modals will be closed if the response is null or false.
@@ -368,15 +381,6 @@ export default {
 			else if (state[modal] !== undefined) {
 				this[modal].close();
 			}
-		}
-
-		/**
-		 * Toggle the dropdown
-		 */
-		if (isObject(state.dropdown) === true) {
-			this.dropdown.open(state.dropdown);
-		} else if (state.dropdown !== undefined) {
-			this.dropdown.close();
 		}
 
 		/**

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -216,13 +216,7 @@ class PageCreateDialog
 		// immediately submit the dialog if there is no editable field
 		if (count($visible) === 0 && count($blueprints) < 2) {
 			$input    = $this->value();
-			$response = $this->submit([
-				...$input,
-
-				// only as dummy to pass validation
-				'title' => 'New page',
-				'slug'  => 'new-page'
-			]);
+			$response = $this->submit($input);
 			$response['redirect'] ??= $this->parent->panel()->url(true);
 			Panel::go($response['redirect']);
 		}

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -259,12 +259,21 @@ class PageCreateDialog
 		$title = $this->blueprint()->create()['title'] ?? null;
 		$slug  = $this->blueprint()->create()['slug'] ?? null;
 
+		// create temporary page object
+		// to resolve the template strings
+		$page = new Page([
+			'slug'     => 'temp',
+			'template' => $input['template'],
+			'parent'   => $this->model(),
+			'content'  => $input
+		]);
+
 		if (is_string($title)) {
-			$input['title'] = $this->model()->toSafeString($title);
+			$input['title'] = $page->toSafeString($title);
 		}
 
 		if (is_string($slug)) {
-			$input['slug'] = $this->model()->toSafeString($slug);
+			$input['slug'] = $page->toSafeString($slug);
 		}
 
 		return $input;

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -107,9 +107,14 @@ class PageCreateDialog
 	{
 		$fields = [];
 
-		// title field
 		$title = $this->blueprint()->create()['title'] ?? null;
+		$slug  = $this->blueprint()->create()['slug'] ?? null;
 
+		if ($title === false || $slug === false) {
+			throw new InvalidArgumentException('Page create dialog: title and slug must not be false');
+		}
+
+		// title field
 		if ($title === null || is_array($title) === true) {
 			$label = $title['label'] ?? 'title';
 			$fields['title'] = Field::title([
@@ -121,8 +126,6 @@ class PageCreateDialog
 		}
 
 		// slug field
-		$slug = $this->blueprint()->create()['slug'] ?? null;
-
 		if ($slug === null) {
 			$fields['slug'] = Field::slug([
 				'required' => true,
@@ -262,8 +265,8 @@ class PageCreateDialog
 		// create temporary page object
 		// to resolve the template strings
 		$page = new Page([
-			'slug'     => 'temp',
-			'template' => $input['template'],
+			'slug'     => 'tmp',
+			'template' => $this->template,
 			'parent'   => $this->model(),
 			'content'  => $input
 		]);

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -216,7 +216,13 @@ class PageCreateDialog
 		// immediately submit the dialog if there is no editable field
 		if (count($visible) === 0 && count($blueprints) < 2) {
 			$input    = $this->value();
-			$response = $this->submit($input);
+			$response = $this->submit([
+				...$input,
+
+				// only as dummy to pass validation
+				'title' => 'New page',
+				'slug'  => 'new-page'
+			]);
 			$response['redirect'] ??= $this->parent->panel()->url(true);
 			Panel::go($response['redirect']);
 		}

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -31,8 +31,102 @@ class PageCreateDialogTest extends AreaTestCase
 
 		$fields = $dialog->coreFields();
 
+		$this->assertCount(6, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
+	}
+
+	/**
+	 * @covers ::coreFields
+	 */
+	public function testCoreFieldWithoutTitleSlug(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'title' => 'A simple title',
+						'slug'  => 'a-simple-slug'
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$fields = $dialog->coreFields();
+
+		$this->assertArrayNotHasKey('title', $fields);
+		$this->assertArrayNotHasKey('slug', $fields);
+	}
+
+	/**
+	 * @covers ::coreFields
+	 */
+	public function testCoreFieldInvalidTitleSlug(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'title' => false
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Page create dialog: title and slug must not be false');
+
+		$dialog->coreFields();
+	}
+
+	/**
+	 * @covers ::resolveFieldTemplates
+	 */
+	public function testResolveFieldTemplates(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'title' => 'This is a {{ page.foo }}',
+						'slug'  => 'page-{{ page.bar }}'
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$input = $dialog->resolveFieldTemplates([
+			'foo' => 'Foo',
+			'bar' => 'foo',
+		]);
+
+		$this->assertSame([
+			'foo'   => 'Foo',
+			'bar'   => 'foo',
+			'title' => 'This is a Foo',
+			'slug'  => 'page-foo',
+		], $input);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Feature
- Page create dialog now allows to hide the `title` and/or `slug` field by defining a string template that will be used instead;
```yml
create:
  title: "{{ page.location }} – {{ page.date.toDate('M Y') }}"
  slug: "{{ page.location.slug }}-{{ page.date.toDate('Y-m-d') }}"
```
Custom fields from the create dialog will be accessible through Kirby query starting with `page.` (in this example the fields `location` and `date`. If no custom fields are defined, the create dialog will be skipped and the page immediately created.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass
- [x] Add sandbox examples (but only once PR is final and approved)


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
