### PR TITLE
BlockTitle: use `label` as fallback for `name`

### DIFF
--- a/panel/lab/components/block/4_title/index.vue
+++ b/panel/lab/components/block/4_title/index.vue
@@ -14,19 +14,19 @@
 				:fieldset="{
 					icon: 'image',
 					name: 'image',
-					label: 'This is an image block',
+					label: 'This is an image block'
 				}"
 			/>
 		</k-lab-example>
 		<k-lab-example label="Label template">
 			<k-block-title
 				:content="{
-					title: 'Test',
+					title: 'Test'
 				}"
 				:fieldset="{
 					icon: 'image',
 					name: 'image',
-					label: 'This is a {{title}}',
+					label: 'This is a {{title}}'
 				}"
 			/>
 		</k-lab-example>
@@ -35,7 +35,15 @@
 				:fieldset="{
 					icon: 'image',
 					name: 'image',
-					label: 'This <b>has</b> some HTML',
+					label: 'This <b>has</b> some HTML'
+				}"
+			/>
+		</k-lab-example>
+		<k-lab-example label="No name, but label (fallback)">
+			<k-block-title
+				:fieldset="{
+					icon: 'image',
+					label: 'image'
 				}"
 			/>
 		</k-lab-example>

--- a/panel/src/components/Forms/Blocks/Elements/BlockTitle.vue
+++ b/panel/src/components/Forms/Blocks/Elements/BlockTitle.vue
@@ -43,7 +43,7 @@ export default {
 				return false;
 			}
 
-			if (this.fieldset.label === this.fieldset.name) {
+			if (this.fieldset.label === this.name) {
 				return false;
 			}
 
@@ -60,7 +60,7 @@ export default {
 			return this.$helper.string.unescapeHTML(label);
 		},
 		name() {
-			return this.fieldset.name;
+			return this.fieldset.name ?? this.fieldset.label;
 		}
 	}
 };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- When a block fieldset doesn't set a `name`, the `label` is now used as fallback
 #6137


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add example to Lab
- [x] Add changes to release notes draft in Notion
- [x] Add task to document `name` on website