### PR TITLE
Fix the help text position in block and layout fields

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -30,15 +30,23 @@
 			v-on="$listeners"
 		/>
 
-		<footer v-if="!disabled && !isEmpty && !isFull && hasFieldsets">
-			<k-button
-				:title="$t('add')"
-				icon="add"
-				size="xs"
-				variant="filled"
-				@click="$refs.blocks.choose(value.length)"
-			/>
-		</footer>
+		<template #footer>
+			<footer
+				v-if="hasFooter"
+				:data-has-help="Boolean(help)"
+				class="k-field-footer"
+			>
+				<k-text v-if="help" class="k-help k-field-help" :html="help" />
+				<k-button
+					v-if="hasMoreButton"
+					:title="$t('add')"
+					icon="add"
+					size="xs"
+					variant="filled"
+					@click="$refs.blocks.choose(value.length)"
+				/>
+			</footer>
+		</template>
 	</k-field>
 </template>
 
@@ -57,6 +65,18 @@ export default {
 	computed: {
 		hasFieldsets() {
 			return this.$helper.object.length(this.fieldsets) > 0;
+		},
+		hasFooter() {
+			if (this.help) {
+				return true;
+			}
+
+			return this.hasMoreButton;
+		},
+		hasMoreButton() {
+			return (
+				!this.disabled && !this.isEmpty && !this.isFull && this.hasFieldsets
+			);
 		},
 		isEmpty() {
 			return this.value.length === 0;
@@ -100,10 +120,11 @@ export default {
 .k-blocks-field {
 	position: relative;
 }
-/** TODO: .k-blocks-field > :has(+ footer) { margin-bottom: var(--spacing-3);} */
-.k-blocks-field > footer {
+.k-blocks-field .k-field-footer {
 	display: flex;
 	justify-content: center;
-	margin-top: var(--spacing-3);
+}
+.k-blocks-field .k-field-footer[data-has-help="true"] {
+	justify-content: space-between;
 }
 </style>

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -22,15 +22,23 @@
 
 		<k-layouts ref="layouts" v-bind="$props" @input="$emit('input', $event)" />
 
-		<footer v-if="!disabled && hasFieldsets">
-			<k-button
-				:title="$t('add')"
-				icon="add"
-				size="xs"
-				variant="filled"
-				@click="$refs.layouts.select(value.length)"
-			/>
-		</footer>
+		<template #footer>
+			<footer
+				v-if="hasFooter"
+				:data-has-help="Boolean(help)"
+				class="k-field-footer"
+			>
+				<k-text v-if="help" class="k-help k-field-help" :html="help" />
+				<k-button
+					v-if="hasMoreButton"
+					:title="$t('add')"
+					icon="add"
+					size="xs"
+					variant="filled"
+					@click="$refs.layouts.select(value.length)"
+				/>
+			</footer>
+		</template>
 	</k-field>
 </template>
 
@@ -45,6 +53,16 @@ export default {
 	computed: {
 		hasFieldsets() {
 			return this.$helper.object.length(this.fieldsets) > 0;
+		},
+		hasFooter() {
+			if (this.help) {
+				return true;
+			}
+
+			return this.hasMoreButton;
+		},
+		hasMoreButton() {
+			return !this.disabled && !this.isEmpty && this.hasFieldsets;
 		},
 		isEmpty() {
 			return this.value.length === 0;
@@ -76,10 +94,12 @@ export default {
 </script>
 
 <style>
-/** TODO: .k-layout-field > :has(+ footer) { margin-bottom: var(--spacing-3);} */
-.k-layout-field > footer {
+.k-layout-field .k-field-footer {
 	display: flex;
 	justify-content: center;
-	margin-top: var(--spacing-3);
+}
+.k-layout-field .k-field-footer[data-has-help="true"] {
+	display: flex;
+	justify-content: space-between;
 }
 </style>


### PR DESCRIPTION
## This PR …

The most sensibel fix is to move the button over to the right if there's help text – at least in my opinion :)

![Screenshot 2024-01-17 at 16 22 55](https://github.com/getkirby/kirby/assets/24532/5844f11a-2c1a-4b91-9c3c-97e6da4c657e)


### Fixes

- https://github.com/getkirby/kirby/issues/6041


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
