### PR TITLE
Use utf8mb4 as default charset in mysql database connections

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -566,7 +566,7 @@ Database::$types['mysql'] = [
 			$parts[] = 'dbname=' . $params['database'];
 		}
 
-		$parts[] = 'charset=' . ($params['charset'] ?? 'utf8');
+		$parts[] = 'charset=' . ($params['charset'] ?? 'utf8mb4');
 
 		return 'mysql:' . implode(';', $parts);
 	}

--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -47,7 +47,8 @@ class Db
 			'password' => Config::get('db.password', ''),
 			'database' => Config::get('db.database', ''),
 			'prefix'   => Config::get('db.prefix', ''),
-			'port'     => Config::get('db.port', '')
+			'port'     => Config::get('db.port', ''),
+			'charset'  => Config::get('db.charset', 'utf8mb4')
 		];
 
 		return static::$connection = new Database($params);

--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -48,7 +48,7 @@ class Db
 			'database' => Config::get('db.database', ''),
 			'prefix'   => Config::get('db.prefix', ''),
 			'port'     => Config::get('db.port', ''),
-			'charset'  => Config::get('db.charset', 'utf8mb4')
+			'charset'  => Config::get('db.charset')
 		];
 
 		return static::$connection = new Database($params);


### PR DESCRIPTION
## This PR …

This PR takes over from https://github.com/getkirby/kirby/pull/6153

### Enhancement

- Added support for emojis and other multi-byte characters in mysql database connections. Thanks to @degoya 

### Breaking changes

None

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
