### PR TITLE
`file` KirbyTag: fix fallback for not found file

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -62,7 +62,7 @@ return [
 		],
 		'html' => function (KirbyTag $tag): string {
 			if (!$file = $tag->file($tag->value)) {
-				return $tag->text;
+				return $tag->text ?? $tag->value;
 			}
 
 			// use filename if the text is empty and make sure to

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -480,6 +480,27 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
+	public function testFileDoesNotExist()
+	{
+		$kirby = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'a',
+						'content' => [
+							'text' => '(file: a.jpg) (file: b.jpg text: b)'
+						]
+					],
+
+				]
+			]
+		]);
+
+		$page = $kirby->page('a');
+
+		$this->assertSame('<p>a.jpg b</p>', $page->text()->kt()->value());
+	}
+
 	public function testFileWithDisabledDownloadOption()
 	{
 		$kirby = $this->app->clone([


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `file` KirbyTag that references a non-existing file does not throw an exception anymore, when not `text` attribute passed
#6177 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
