### PR TITLE
Structure: Fix regressions from `Items` refactoring

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -257,7 +257,7 @@ return function (App $app) {
 			try {
 				return Structure::factory(
 					Data::decode($field->value, 'yaml'),
-					['parent' => $field->parent()]
+					['parent' => $field->parent(), 'field' => $field]
 				);
 			} catch (Exception) {
 				$message = 'Invalid structure data for "' . $field->key() . '" field';

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -33,13 +33,17 @@ class Structure extends Items
 		array $items = null,
 		array $params = []
 	): static {
-		// Bake-in index as ID for all items
-		// TODO: remove when adding UUID supports to Structures
 		if (is_array($items) === true) {
 			$items = array_map(function ($item, $index) {
 				if (is_array($item) === true) {
+					// pass a clean content array without special `Item` keys
+					$item['content'] = $item;
+
+					// bake-in index as ID for all items
+					// TODO: remove when adding UUID supports to Structures
 					$item['id'] ??= $index;
 				}
+
 				return $item;
 			}, $items, array_keys($items));
 		}

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -29,14 +29,16 @@ class StructureTest extends TestCase
 	public function testToArray()
 	{
 		$data = [
-			['name' => 'A'],
-			['name' => 'B']
+			['name' => 'A', 'field' => 'C'],
+			['name' => 'B', 'field' => 'D']
 		];
 		$structure = Structure::factory($data)->toArray();
 
 		$this->assertSame('A', $structure[0]['name']);
+		$this->assertSame('C', $structure[0]['field']);
 		$this->assertArrayHasKey('id', $structure[0]);
 		$this->assertSame('B', $structure[1]['name']);
+		$this->assertSame('D', $structure[1]['field']);
 		$this->assertArrayHasKey('id', $structure[1]);
 	}
 

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -435,6 +435,8 @@ class FieldMethodsTest extends TestCase
 		$structure = $field->toStructure();
 
 		$this->assertCount(2, $structure);
+		$this->assertEquals($field, $structure->field()); // Field object gets cloned by the `Field` class
+		$this->assertEquals($field, $structure->first()->field()); // Field object gets cloned by the `Field` class
 		$this->assertSame('a', $structure->first()->title()->value());
 		$this->assertSame('a', $structure->first()->content()->title()->value());
 		$this->assertSame('c', $structure->first()->content()->field()->value());

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -425,8 +425,8 @@ class FieldMethodsTest extends TestCase
 	public function testToStructure()
 	{
 		$data = [
-			['title' => 'a'],
-			['title' => 'b']
+			['title' => 'a', 'field' => 'c'],
+			['title' => 'b', 'field' => 'd']
 		];
 
 		$yaml = Yaml::encode($data);
@@ -436,7 +436,11 @@ class FieldMethodsTest extends TestCase
 
 		$this->assertCount(2, $structure);
 		$this->assertSame('a', $structure->first()->title()->value());
+		$this->assertSame('a', $structure->first()->content()->title()->value());
+		$this->assertSame('c', $structure->first()->content()->field()->value());
 		$this->assertSame('b', $structure->last()->title()->value());
+		$this->assertSame('b', $structure->last()->content()->title()->value());
+		$this->assertSame('d', $structure->last()->content()->field()->value());
 	}
 
 	public function testToStructureWithInvalidData()


### PR DESCRIPTION
I keep running into Structure issues in v4, now breaking my Downloads Block plugin (which uses a `field` field inside a structure field).

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- It is possible again to use the field names `field`, `options`, `parent`, `siblings` and `params` inside structure fields
- `$field->toStructure()->field()` now returns a copy of the structure field object as intended

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
