### PR TITLE
LinkField: fix dropdown for only option

### DIFF
--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -6,10 +6,12 @@
 				<k-button
 					class="k-link-input-toggle"
 					:disabled="disabled"
-					:dropdown="true"
+					:dropdown="!disabled && activeTypesOptions.length > 1"
 					:icon="currentType.icon"
 					variant="filled"
-					@click="$refs.types.toggle()"
+					@click="
+						activeTypesOptions.length > 1 ? $refs.types.toggle() : toggle()
+					"
 				>
 					{{ currentType.label }}
 				</k-button>


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Link field: no dropdown is shown if only one type option is active
#6186
- Link field: no dropdown icon is shown when field is disabled

### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
