### PR TITLE
Fix border radius inconsistency

### DIFF
--- a/panel/src/components/Layout/Bubble.vue
+++ b/panel/src/components/Layout/Bubble.vue
@@ -93,7 +93,7 @@ export default {
 :root {
 	--bubble-size: 1.525rem;
 	--bubble-back: var(--color-light);
-	--bubble-rounded: var(--rounded);
+	--bubble-rounded: var(--rounded-sm);
 	--bubble-text: var(--color-black);
 }
 


### PR DESCRIPTION
## This PR …

### Fixes

- Sets the default border radius for `k-bubble` to rounded-sm to be consistent with `k-tag`. #6188 

### For review team

- [x] Add changes to release notes draft in Notion