### PR TITLE
Refactor the link field input event handling to improve link detection

### DIFF
--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -106,16 +106,39 @@ export default {
 	inheritAttrs: false,
 	data() {
 		return {
+			/**
+			 * Stores the currently detected link type. The currentType
+			 * object is computed from this
+			 */
 			linkType: null,
+			/**
+			 * The link value holds the value that is visible in the input
+			 * E.g. for the email type, the actually stored value would be
+			 * prefixed by mailto: but the linkValue would be without prefix
+			 */
 			linkValue: null,
+			/**
+			 * Open/close state for the file or page browser
+			 */
 			expanded: false,
+			/**
+			 * Validation state for the wrapping `k-input` component
+			 */
 			isInvalid: false
 		};
 	},
 	computed: {
+		/**
+		 * Returns all available link types as defined
+		 * by the options prop
+		 */
 		activeTypes() {
 			return this.$helper.link.types(this.options);
 		},
+		/**
+		 * Converts all active types to
+		 * dropdown options
+		 */
 		activeTypesOptions() {
 			const options = [];
 
@@ -130,6 +153,11 @@ export default {
 
 			return options;
 		},
+		/**
+		 * Returns the full type as defined in
+		 * the helpers/link.js types object. Falls back
+		 * to the first available type.
+		 */
 		currentType() {
 			return (
 				this.activeTypes[this.linkType] ?? Object.values(this.activeTypes)[0]
@@ -137,6 +165,11 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * When the value changes from the outside. E.g. by reverting
+		 * changes or mounting the field for the first time, the link type
+		 * and link value need to be detected
+		 */
 		value: {
 			async handler(value, old) {
 				if (value === old || value === this.linkValue) {

--- a/panel/src/helpers/link.js
+++ b/panel/src/helpers/link.js
@@ -101,6 +101,7 @@ export function types(keys = []) {
 		url: {
 			detect: (value) => /^(http|https):\/\//.test(value),
 			icon: "url",
+			id: "url",
 			label: window.panel.$t("url"),
 			link: (value) => value,
 			placeholder: window.panel.$t("url.placeholder"),
@@ -110,6 +111,7 @@ export function types(keys = []) {
 		page: {
 			detect: (value) => isPageUUID(value) === true,
 			icon: "page",
+			id: "page",
 			label: window.panel.$t("page"),
 			link: (value) => value,
 			placeholder: window.panel.$t("select") + " …",
@@ -119,6 +121,7 @@ export function types(keys = []) {
 		file: {
 			detect: (value) => isFileUUID(value) === true,
 			icon: "file",
+			id: "file",
 			label: window.panel.$t("file"),
 			link: (value) => value,
 			placeholder: window.panel.$t("select") + " …",
@@ -127,6 +130,7 @@ export function types(keys = []) {
 		email: {
 			detect: (value) => value.startsWith("mailto:"),
 			icon: "email",
+			id: "email",
 			label: window.panel.$t("email"),
 			link: (value) => value.replace(/^mailto:/, ""),
 			placeholder: window.panel.$t("email.placeholder"),
@@ -136,6 +140,7 @@ export function types(keys = []) {
 		tel: {
 			detect: (value) => value.startsWith("tel:"),
 			icon: "phone",
+			id: "tel",
 			label: window.panel.$t("tel"),
 			link: (value) => value.replace(/^tel:/, ""),
 			pattern: "[+]{0,1}[0-9]+",
@@ -146,6 +151,7 @@ export function types(keys = []) {
 		anchor: {
 			detect: (value) => value.startsWith("#"),
 			icon: "anchor",
+			id: "anchor",
 			label: "Anchor",
 			link: (value) => value,
 			pattern: "^#.+",
@@ -156,6 +162,7 @@ export function types(keys = []) {
 		custom: {
 			detect: () => true,
 			icon: "title",
+			id: "custom",
 			label: window.panel.$t("custom"),
 			link: (value) => value,
 			input: "text",


### PR DESCRIPTION
## This PR …

I've refactored the way that input events are handled. Detecting the link type and value in the watcher isn't ideal and also not really necessary. We need to handle inputs (url, email, tel, etc.) differently than the file and page types. This drastically simplifies how we can detect the types. 

### Fixes

- LinkField: selected option does properly update when reverting unsaved changes https://github.com/getkirby/kirby/issues/6193

### For review team

- [x] Add changes to release notes draft in Notion
