### PR TITLE
ImageMagick: remove optimization that breaks focus

### DIFF
--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -65,14 +65,6 @@ class ImageMagick extends Darkroom
 		// limit to single-threading to keep CPU usage sane
 		$command .= ' -limit thread 1';
 
-		// add JPEG size hint to optimize CPU and memory usage
-		if (F::mime($file) === 'image/jpeg') {
-			// add hint only when downscaling
-			if ($options['scaleWidth'] < 1 && $options['scaleHeight'] < 1) {
-				$command .= ' -define ' . escapeshellarg(sprintf('jpeg:size=%dx%d', $options['width'], $options['height']));
-			}
-		}
-
 		// append input file
 		return $command . ' ' . escapeshellarg($file);
 	}


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

The optimization step only loads a minimized version of the image into memory which is why cropping (esp. focus cropping) fails as it is done in reference to the original sized image.

Without an apparent fix, I think it would be good to remove this optimize step for now.

### Fixes
- https://github.com/getkirby/kirby/issues/5855