### PR TITLE
`File::match()`: Handle missing MIME types

### DIFF
--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -277,6 +277,15 @@ class File
 		if (is_array($rules['mime'] ?? null) === true) {
 			$mime = $this->mime();
 
+			// the MIME type could not be determined, but matching
+			// to it was requested explicitly
+			if ($mime === null) {
+				throw new Exception([
+					'key'  => 'file.mime.missing',
+					'data' => ['filename' => $this->filename()]
+				]);
+			}
+
 			// determine if any pattern matches the MIME type;
 			// once any pattern matches, `$carry` is `true` and the rest is skipped
 			$matches = array_reduce(

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -375,7 +375,7 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @covers \Kirby\Filesystem\File::match
+	 * @covers ::match
 	 */
 	public function testMatchMimeException()
 	{
@@ -386,7 +386,7 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @covers \Kirby\Filesystem\File::match
+	 * @covers ::match
 	 */
 	public function testMatchExtensionException()
 	{
@@ -397,7 +397,7 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @covers \Kirby\Filesystem\File::match
+	 * @covers ::match
 	 */
 	public function testMatchTypeException()
 	{

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -377,7 +377,18 @@ class FileTest extends TestCase
 	/**
 	 * @covers ::match
 	 */
-	public function testMatchMimeException()
+	public function testMatchMimeMissing()
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('The media type for "doesnotexist.invalid" cannot be detected');
+
+		$this->_file('doesnotexist.invalid')->match(['mime' => ['image/png', 'application/pdf']]);
+	}
+
+	/**
+	 * @covers ::match
+	 */
+	public function testMatchMimeInvalid()
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid mime type: text/plain');


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Proper error message when a MIME type of a file is being validated but could not be determined from the file #6095

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] ~Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)~
