### PR TITLE
Add option to change number of threads for imagemagick convert

### DIFF
--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -63,7 +63,7 @@ class ImageMagick extends Darkroom
 		$command = escapeshellarg($options['bin']);
 
 		// default is limiting to single-threading to keep CPU usage sane
-		$command .= ' -limit thread ' . escapeshellarg($options['thread']);
+		$command .= ' -limit thread ' . escapeshellarg($options['threads']);
 
 		// add JPEG size hint to optimize CPU and memory usage
 		if (F::mime($file) === 'image/jpeg') {
@@ -85,7 +85,7 @@ class ImageMagick extends Darkroom
 		return parent::defaults() + [
 			'bin'       => 'convert',
 			'interlace' => false,
-			'thread'    => 1,
+			'threads'    => 1,
 		];
 	}
 

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -62,8 +62,8 @@ class ImageMagick extends Darkroom
 	{
 		$command = escapeshellarg($options['bin']);
 
-		// limit to single-threading to keep CPU usage sane
-		$command .= ' -limit thread 1';
+		// default is limiting to single-threading to keep CPU usage sane
+		$command .= ' -limit thread ' . escapeshellarg($options['thread']);
 
 		// add JPEG size hint to optimize CPU and memory usage
 		if (F::mime($file) === 'image/jpeg') {
@@ -85,6 +85,7 @@ class ImageMagick extends Darkroom
 		return parent::defaults() + [
 			'bin'       => 'convert',
 			'interlace' => false,
+			'thread'    => 1,
 		];
 	}
 

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -85,7 +85,7 @@ class ImageMagick extends Darkroom
 		return parent::defaults() + [
 			'bin'       => 'convert',
 			'interlace' => false,
-			'threads'    => 1,
+			'threads'   => 1,
 		];
 	}
 

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -45,7 +45,7 @@ class ImageMagickTest extends TestCase
 			'width' => 500,
 			'bin' => 'convert',
 			'interlace' => false,
-			'thread' => 1,
+			'threads' => 1,
 			'sourceWidth' => 500,
 			'sourceHeight' => 500
 		], $im->process($file));

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -45,6 +45,7 @@ class ImageMagickTest extends TestCase
 			'width' => 500,
 			'bin' => 'convert',
 			'interlace' => false,
+			'thread' => 1,
 			'sourceWidth' => 500,
 			'sourceHeight' => 500
 		], $im->process($file));


### PR DESCRIPTION
## This PR …
If you are converting a lot of big images with imagemagick it can get really slow.

This PR adds an option to configure the threads imagemagick can use.  (default is 1)
So you can benefit from capable hardware.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
- [x] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
