### PR TITLE
feat: `language:variables` root

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -31,7 +31,10 @@ trait AppTranslations
 				$this->multilang() === true &&
 				$language = $this->languages()->find($locale)
 			) {
-				$data = [...$data, ...$language->translations()];
+				$data = [
+					...$data,
+					...$language->variables()->toArray()
+				];
 			}
 
 
@@ -139,7 +142,10 @@ trait AppTranslations
 
 		// inject current language translations
 		if ($language = $this->language($locale)) {
-			$inject = [...$inject, ...$language->translations()];
+			$inject = [
+				...$inject,
+				...$language->variables()->toArray()
+			];
 		}
 
 		// load from disk instead
@@ -164,14 +170,14 @@ trait AppTranslations
 		// injects languages translations
 		if ($languages = $this->languages()) {
 			foreach ($languages as $language) {
-				$languageCode         = $language->code();
-				$languageTranslations = $language->translations();
+				$languageCode      = $language->code();
+				$languageVariables = $language->variables()->toArray();
 
 				// merges language translations with extensions translations
-				if (empty($languageTranslations) === false) {
+				if (empty($languageVariables) === false) {
 					$translations[$languageCode] = [
 						...$translations[$languageCode] ?? [],
-						...$languageTranslations
+						...$languageVariables
 					];
 				}
 			}

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -357,6 +357,7 @@ class Core
 			'commands'          => fn (array $roots) => $roots['site'] . '/commands',
 			'config'            => fn (array $roots) => $roots['site'] . '/config',
 			'controllers'       => fn (array $roots) => $roots['site'] . '/controllers',
+			'language:variables' => null,
 			'languages'         => fn (array $roots) => $roots['site'] . '/languages',
 			'licenses'          => fn (array $roots) => $roots['site'] . '/licenses',
 			'license'           => fn (array $roots) => $roots['config'] . '/.license',

--- a/src/Cms/LanguageVariable.php
+++ b/src/Cms/LanguageVariable.php
@@ -48,12 +48,12 @@ class LanguageVariable
 			);
 		}
 
-		$kirby        = App::instance();
-		$language     = $kirby->defaultLanguage();
-		$translations = $language->translations();
+		$kirby     = App::instance();
+		$language  = $kirby->defaultLanguage();
+		$variables = $language->variables()->toArray();
 
 		if ($kirby->translation()->get($key) !== null) {
-			if (isset($translations[$key]) === true) {
+			if (isset($variables[$key]) === true) {
 				throw new DuplicateException(
 					message: 'The variable already exists'
 				);
@@ -64,9 +64,9 @@ class LanguageVariable
 			);
 		}
 
-		$translations[$key] = $value ?? '';
+		$variables[$key] = $value ?? '';
 
-		$language = $language->update(['translations' => $translations]);
+		$language = $language->update(['variables' => $variables]);
 
 		return $language->variable($key);
 	}
@@ -80,11 +80,9 @@ class LanguageVariable
 	{
 		// go through all languages and remove the variable
 		foreach ($this->kirby->languages() as $language) {
-			$variables = $language->translations();
-
-			unset($variables[$this->key]);
-
-			$language->update(['translations' => $variables]);
+			$variables = $language->variables();
+			$variables->remove($this->key);
+			$language->update(['variables' => $variables->toArray()]);
 		}
 
 		return true;
@@ -96,7 +94,7 @@ class LanguageVariable
 	public function exists(): bool
 	{
 		$language = $this->kirby->defaultLanguage();
-		return isset($language->translations()[$this->key]) === true;
+		return $language->variables()->get($this->key) !== null;
 	}
 
 	/**
@@ -130,19 +128,19 @@ class LanguageVariable
 	 */
 	public function update(string|array|null $value = null): static
 	{
-		$translations             = $this->language->translations();
-		$translations[$this->key] = $value ?? '';
+		$variables = $this->language->variables();
+		$variables->set($this->key, $value);
 
-		$language = $this->language->update(['translations' => $translations]);
+		$language = $this->language->update(['variables' => $variables->toArray()]);
 
 		return $language->variable($this->key);
 	}
 
 	/**
-	 * Returns the value if the variable has been translated.
+	 * Returns the value if the variable has been translated
 	 */
 	public function value(): string|array|null
 	{
-		return $this->language->translations()[$this->key] ?? null;
+		return $this->language->variables()->get($this->key);
 	}
 }

--- a/src/Cms/LanguageVariables.php
+++ b/src/Cms/LanguageVariables.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Data\Data;
+use Kirby\Exception\Exception;
+use Kirby\Filesystem\F;
+use Throwable;
+
+/**
+ * Manages the variables string for a language,
+ * either from the language file or `language:variables` root
+ * @since 5.0.0
+ *
+ * @package   Kirby Cms
+ * @author    Ahmet Bora <ahmet@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class LanguageVariables
+{
+	public function __construct(
+		protected Language $language,
+		protected array $data = []
+	) {
+		$this->data = [...$this->load(), ...$this->data];
+	}
+
+	/**
+	 * Deletes the current language variables file
+	 * if custom root defined
+	 */
+	public function delete(): void
+	{
+		if ($file = $this->root()) {
+			if (F::remove($file) !== true) {
+				throw new Exception('The language variables could not be deleted');
+			}
+		}
+	}
+
+	/**
+	 * Returns a single variable string by key
+	 */
+	public function get(string $key, string|null $default = null): string|null
+	{
+		return $this->data[$key] ?? $default;
+	}
+
+	/**
+	 * Loads the language variables based on custom roots
+	 */
+	public function load(): array
+	{
+		if ($file = static::root()) {
+			try {
+				return Data::read($file);
+			} catch (Throwable) {
+				// skip when an exception thrown
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Saves the language variables in the custom root
+	 * @return $this
+	 * @internal
+	 */
+	public function save(array $variables = []): static
+	{
+		$this->data = $variables;
+
+		if ($root = $this->root()) {
+			Data::write($root, $this->data);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Returns custom variables root path if defined
+	 */
+	public function root(): string|null
+	{
+		if ($root = App::instance()->root('language:variables')) {
+			return $root . '/' . $this->language->code() . '.php';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Removes a variable key
+	 *
+	 * @return $this
+	 */
+	public function remove(string $key): static
+	{
+		unset($this->data[$key]);
+		return $this;
+	}
+
+	/**
+	 * Sets the variable key
+	 *
+	 * @return $this
+	 */
+	public function set(string $key, string|null $value = null): static
+	{
+		$this->data[$key] = $value;
+		return $this;
+	}
+
+	/**
+	 * Returns variables
+	 */
+	public function toArray(): array
+	{
+		return $this->data;
+	}
+
+	/**
+	 * Updates the variables data
+	 */
+	public function update(array $data = []): static
+	{
+		$this->data = $data;
+		return $this;
+	}
+}

--- a/src/Panel/Controller/View/LanguageViewController.php
+++ b/src/Panel/Controller/View/LanguageViewController.php
@@ -90,7 +90,7 @@ class LanguageViewController extends ViewController
 			next:         $this->next(),
 			prev:         $this->prev(),
 			title:        $this->language->name(),
-			translations: $this->translations(),
+			translations: $this->variables(),
 			url:          $this->language->url(),
 		);
 	}
@@ -119,11 +119,11 @@ class LanguageViewController extends ViewController
 		return null;
 	}
 
-	public function translations(): array
+	public function variables(): array
 	{
 		$strings      = [];
-		$foundation   = $this->kirby->defaultLanguage()?->translations() ?? [];
-		$translations = $this->language->translations();
+		$foundation   = $this->kirby->defaultLanguage()->variables()->toArray();
+		$variables    = $this->language->variables()->toArray();
 
 		// TODO: update following line and adapt for update and
 		// delete options when `languageVariables.*` permissions available
@@ -134,7 +134,7 @@ class LanguageViewController extends ViewController
 		foreach (array_keys($foundation) as $key) {
 			$strings[] = [
 				'key'     => $key,
-				'value'   => $translations[$key] ?? null,
+				'value'   => $variables[$key] ?? null,
 				'options' => [
 					[
 						'click'    => 'update',


### PR DESCRIPTION
## This PR …
This was a more complex problem than I expected (always 🙈). Because the system should be able to read, update and delete language variables both from the language file and from a custom root. It involves a breakage change, but I wanted to remove the code complexity by creating a separate `LanguageVariables` object.

### Todos/To discuss
- [ ] Inconsistencies: Sometimes we call them variables, sometimes translations (e.g. in the `k-language-view` and the API endpoints). Do we fully want to switch to `variables`? Then we should make the changes everywhere (with legacy fallbacks for now).
- [ ] Do we need to pass `$props['translation']` to the `LanguageVariables` object? Or would it be better to keep them separate, so that `LanguageVariables` only takes care about the file and its value. And `Language` has the job to merge both arrays (`$props['translation']`) and `$this->variables->toArray()`) together. As well as filtering all keys from  `$props['translation']` to only write everything remaining to the variables file.
- [ ] Update `@since` tags
- [ ] Add unit tests for new/altered code
- [ ] Passing unit tests

## Changelog
### Fixes
- External language variables setup no longer works since K4's language views #6176

### Features
- New `language:variables` root

````php
$kirby = new Kirby([
    'roots' => [
        'language:variables' => __DIR__ . '/site/variables'
    ]
]);
````

### Breaking changes
- `Language::translations()` deprecated, use `Language::variables()` instead
- `$language->translations()` returns `LanguageVariables` object instead `array`. Use `$language->translations()->toArray()` or `$language->variables()->toArray()`.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Unit tests for fixed bug/feature
- [ ] In-code documentation (wherever needed)
- [ ] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [ ] Add changes to release notes draft in Notion
- [ ] Add to [website docs release checklist](https://github.com/getkirby/getkirby.com/pulls) (if needed)
