### PR TITLE
Fix `Str::excerpt()` for text without spaces

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -488,7 +488,16 @@ class Str
 			return $string;
 		}
 
-		return static::substr($string, 0, mb_strrpos(static::substr($string, 0, $chars), ' ')) . $rep;
+		// shorten the string to the specified number of characters,
+		// but make sure to not cut off in the middle of a word
+		$excerpt = static::substr($string, 0, $chars);
+		$cutoff  = mb_strrpos($excerpt, ' ');
+
+		if ($cutoff !== false) {
+			$excerpt = static::substr($string, 0, $cutoff);
+		}
+
+		return $excerpt . $rep;
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -400,6 +400,18 @@ class StrTest extends TestCase
 	/**
 	 * @covers ::excerpt
 	 */
+	public function testExcerptWithoutSpaces()
+	{
+		$string   = 'ThisIsALongTextWithSomeHtml';
+		$expected = 'ThisIsALongText …';
+		$result   = Str::excerpt($string, 15);
+
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * @covers ::excerpt
+	 */
 	public function testExcerptWithLineBreaks()
 	{
 		$string   = 'This is a long text ' . PHP_EOL . ' with some html';


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Fixed `Str::excerpt()` for texts without spaces


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
