### PR TITLE
Fix type hint on `Panel::area()`

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -35,7 +35,7 @@ class Panel
 	/**
 	 * Normalize a panel area
 	 */
-	public static function area(string $id, array|string $area): array
+	public static function area(string $id, array $area): array
 	{
 		$area['id']                = $id;
 		$area['label']           ??= $id;


### PR DESCRIPTION
I say this isn't a breaking change but just bug fix as the code inside the method would crash if a string was passed.