### PR TITLE
Fix `A::prepend()`

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -588,7 +588,7 @@ class A
 	 */
 	public static function prepend(array $array, array $prepend): array
 	{
-		return $prepend + $array;
+		return static::merge($prepend, $array, A::MERGE_APPEND);
 	}
 
 	/**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -497,6 +497,30 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::prepend
+	 */
+	public function testPrepend()
+	{
+		// associative
+		$one    = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
+		$two    = ['d' => 'D', 'e' => 'E', 'f' => 'F'];
+		$result = A::prepend($one, $two);
+		$this->assertSame(['d' => 'D', 'e' => 'E', 'f' => 'F', 'a' => 'A', 'b' => 'B', 'c' => 'C'], $result);
+
+		// numeric
+		$one    = ['a', 'b', 'c'];
+		$two    = ['d', 'e', 'f'];
+		$result = A::prepend($one, $two);
+		$this->assertSame(['d', 'e', 'f', 'a', 'b', 'c'], $result);
+
+		// mixed
+		$one    = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
+		$two    = ['d', 'e', 'f'];
+		$result = A::prepend($one, $two);
+		$this->assertSame(['d', 'e', 'f', 'a' => 'A', 'b' => 'B', 'c' => 'C'], $result);
+	}
+
+	/**
 	 * @covers ::pluck
 	 */
 	public function testPluck()


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

With the previous code, non-associative arrays would not be prepended.

### Fixes
- `A::prepend()` now behaves the same as `A::append()` (just opposite side) for non-associative arrays


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Unit tests for fixed bug/feature
- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass


### For review team
<!-- 
We will take care of the following before merging the PR.
-->

- [x] Add changes to release notes draft in Notion
