### PR TITLE
Section api

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -26,6 +26,15 @@ return [
 		}
 	],
 	[
+		'pattern' => $filePattern . '/fields/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $parent, string $filename, string $sectionName, string $path = null) {
+			if ($file = $this->file($parent, $filename)) {
+				return $this->sectionApi($file, $sectionName, $path);
+			}
+		}
+	],
+	[
 		'pattern' => $parentPattern,
 		'method'  => 'GET',
 		'action'  => function (string $path) {

--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -8,7 +8,15 @@ $parentPattern = '(account|pages/[^/]+|site|users/[^/]+)/files';
  * Files Routes
  */
 return [
-
+	[
+		'pattern' => $filePattern . '/fields/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $parent, string $filename, string $fieldName, string|null $path = null) {
+			if ($file = $this->file($parent, $filename)) {
+				return $this->fieldApi($file, $fieldName, $path);
+			}
+		}
+	],
 	[
 		'pattern' => $filePattern . '/sections/(:any)',
 		'method'  => 'GET',
@@ -17,18 +25,9 @@ return [
 		}
 	],
 	[
-		'pattern' => $filePattern . '/fields/(:any)/(:all?)',
+		'pattern' => $filePattern . '/sections/(:any)/(:all?)',
 		'method'  => 'ALL',
-		'action'  => function (string $parent, string $filename, string $fieldName, string $path = null) {
-			if ($file = $this->file($parent, $filename)) {
-				return $this->fieldApi($file, $fieldName, $path);
-			}
-		}
-	],
-	[
-		'pattern' => $filePattern . '/fields/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $parent, string $filename, string $sectionName, string $path = null) {
+		'action'  => function (string $parent, string $filename, string $sectionName, string|null $path = null) {
 			if ($file = $this->file($parent, $filename)) {
 				return $this->sectionApi($file, $sectionName, $path);
 			}

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -4,8 +4,6 @@
 /**
  * Page Routes
  */
-
-
 return [
 	[
 		'pattern' => 'pages/(:any)',
@@ -114,6 +112,15 @@ return [
 		'action'  => function (string $id, string $fieldName, string $path = null) {
 			if ($page = $this->page($id)) {
 				return $this->fieldApi($page, $fieldName, $path);
+			}
+		}
+	],
+	[
+		'pattern' => 'pages/(:any)/sections/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $id, string $sectionName, string $path = null) {
+			if ($page = $this->page($id)) {
+				return $this->sectionApi($page, $sectionName, $path);
 			}
 		}
 	],

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -5,6 +5,7 @@
  * Page Routes
  */
 return [
+	// @codeCoverageIgnoreStart
 	[
 		'pattern' => 'pages/(:any)',
 		'method'  => 'GET',
@@ -124,4 +125,5 @@ return [
 			}
 		}
 	],
+	// @codeCoverageIgnoreEnd
 ];

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -100,6 +100,15 @@ return [
 		}
 	],
 	[
+		'pattern' => 'pages/(:any)/fields/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $id, string $fieldName, string|null $path = null) {
+			if ($page = $this->page($id)) {
+				return $this->fieldApi($page, $fieldName, $path);
+			}
+		}
+	],
+	[
 		'pattern' => 'pages/(:any)/sections/(:any)',
 		'method'  => 'GET',
 		'action'  => function (string $id, string $sectionName) {
@@ -107,18 +116,9 @@ return [
 		}
 	],
 	[
-		'pattern' => 'pages/(:any)/fields/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $id, string $fieldName, string $path = null) {
-			if ($page = $this->page($id)) {
-				return $this->fieldApi($page, $fieldName, $path);
-			}
-		}
-	],
-	[
 		'pattern' => 'pages/(:any)/sections/(:any)/(:all?)',
 		'method'  => 'ALL',
-		'action'  => function (string $id, string $sectionName, string $path = null) {
+		'action'  => function (string $id, string $sectionName, string|null $path = null) {
 			if ($page = $this->page($id)) {
 				return $this->sectionApi($page, $sectionName, $path);
 			}

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -85,6 +85,13 @@ return [
 		}
 	],
 	[
+		'pattern' => 'site/fields/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $fieldName, string|null $path = null) {
+			return $this->fieldApi($this->site(), $fieldName, $path);
+		}
+	],
+	[
 		'pattern' => 'site/sections/(:any)',
 		'method'  => 'GET',
 		'action'  => function (string $sectionName) {
@@ -92,16 +99,9 @@ return [
 		}
 	],
 	[
-		'pattern' => 'site/fields/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $fieldName, string $path = null) {
-			return $this->fieldApi($this->site(), $fieldName, $path);
-		}
-	],
-	[
 		'pattern' => 'site/sections/(:any)/(:all?)',
 		'method'  => 'ALL',
-		'action'  => function (string $sectionName, string $path = null) {
+		'action'  => function (string $sectionName, string|null $path = null) {
 			return $this->sectionApi($this->site(), $sectionName, $path);
 		}
 	],

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -97,6 +97,12 @@ return [
 		'action'  => function (string $fieldName, string $path = null) {
 			return $this->fieldApi($this->site(), $fieldName, $path);
 		}
-	]
-
+	],
+	[
+		'pattern' => 'site/sections/(:any)/(:all?)',
+		'method'  => 'ALL',
+		'action'  => function (string $sectionName, string $path = null) {
+			return $this->sectionApi($this->site(), $sectionName, $path);
+		}
+	],
 ];

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -5,7 +5,7 @@
  * Site Routes
  */
 return [
-
+	// @codeCoverageIgnoreStart
 	[
 		'pattern' => 'site',
 		'action'  => function () {
@@ -105,4 +105,5 @@ return [
 			return $this->sectionApi($this->site(), $sectionName, $path);
 		}
 	],
+	// @codeCoverageIgnoreEnd
 ];

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -208,4 +208,14 @@ return [
 			return $this->fieldApi($this->user($id), $fieldName, $path);
 		}
 	],
+	[
+		'pattern' => [
+			'(account)/sections/(:any)/(:all?)',
+			'users/(:any)/sections/(:any)/(:all?)',
+		],
+		'method'  => 'ALL',
+		'action'  => function (string $id, string $sectionName, string $path = null) {
+			return $this->sectionApi($this->user($id), $sectionName, $path);
+		}
+	],
 ];

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -6,6 +6,7 @@ use Kirby\Filesystem\F;
  * User Routes
  */
 return [
+	// @codeCoverageIgnoreStart
 	[
 		'pattern' => 'users',
 		'method'  => 'GET',
@@ -218,4 +219,5 @@ return [
 			return $this->sectionApi($this->user($id), $sectionName, $path);
 		}
 	],
+	// @codeCoverageIgnoreEnd
 ];

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -188,6 +188,16 @@ return [
 	],
 	[
 		'pattern' => [
+			'(account)/fields/(:any)/(:all?)',
+			'users/(:any)/fields/(:any)/(:all?)',
+		],
+		'method'  => 'ALL',
+		'action'  => function (string $id, string $fieldName, string|null $path = null) {
+			return $this->fieldApi($this->user($id), $fieldName, $path);
+		}
+	],
+	[
+		'pattern' => [
 			'(account)/sections/(:any)',
 			'users/(:any)/sections/(:any)',
 		],
@@ -200,21 +210,11 @@ return [
 	],
 	[
 		'pattern' => [
-			'(account)/fields/(:any)/(:all?)',
-			'users/(:any)/fields/(:any)/(:all?)',
-		],
-		'method'  => 'ALL',
-		'action'  => function (string $id, string $fieldName, string $path = null) {
-			return $this->fieldApi($this->user($id), $fieldName, $path);
-		}
-	],
-	[
-		'pattern' => [
 			'(account)/sections/(:any)/(:all?)',
 			'users/(:any)/sections/(:any)/(:all?)',
 		],
 		'method'  => 'ALL',
-		'action'  => function (string $id, string $sectionName, string $path = null) {
+		'action'  => function (string $id, string $sectionName, string|null $path = null) {
 			return $this->sectionApi($this->user($id), $sectionName, $path);
 		}
 	],

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -205,6 +205,21 @@ return [
 			];
 		}
 	],
+	'api' => function () {
+		return [
+			[
+				'pattern' => 'sort',
+				'action'  => function () {
+					$this->section()->model()->files()->changeSort(
+						$this->requestBody('files'),
+						$this->requestBody('index')
+					);
+
+					return true;
+				}
+			]
+		];
+	},
 	'toArray' => function () {
 		return [
 			'data'    => $this->data,

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -209,6 +209,7 @@ return [
 		return [
 			[
 				'pattern' => 'sort',
+				'method'  => 'PATCH',
 				'action'  => function () {
 					$this->section()->model()->files()->changeSort(
 						$this->requestBody('files'),
@@ -226,7 +227,7 @@ return [
 			'errors'  => $this->errors,
 			'options' => [
 				'accept'   => $this->accept,
-				'apiUrl'   => $this->parent->apiUrl(true),
+				'apiUrl'   => $this->parent->apiUrl(true) . '/sections/' . $this->name,
 				'columns'  => $this->columnsWithTypes(),
 				'empty'    => $this->empty,
 				'headline' => $this->headline,

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -205,6 +205,7 @@ return [
 			];
 		}
 	],
+	// @codeCoverageIgnoreStart
 	'api' => function () {
 		return [
 			[
@@ -221,6 +222,7 @@ return [
 			]
 		];
 	},
+	// @codeCoverageIgnoreEnd
 	'toArray' => function () {
 		return [
 			'data'    => $this->data,

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -89,7 +89,7 @@ export default {
 			this.isProcessing = true;
 
 			try {
-				await this.$api.patch(this.options.apiUrl + "/files/sort", {
+				await this.$api.patch(this.options.apiUrl + "/sort", {
 					files: items.map((item) => item.id),
 					index: this.pagination.offset
 				});

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -193,7 +193,6 @@ class Api extends BaseApi
 		string $name,
 		string|null $path = null
 	): mixed {
-
 		$section = $model->blueprint()?->section($name);
 
 		$sectionApi = $this->clone([

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -71,7 +71,7 @@ class Api extends BaseApi
 		$field = Form::for($model)->field($name);
 
 		$fieldApi = $this->clone([
-			'data'   => array_merge($this->data(), ['field' => $field]),
+			'data'   => [...$this->data(), 'field' => $field],
 			'routes' => $field->api(),
 		]);
 
@@ -196,7 +196,7 @@ class Api extends BaseApi
 		$section = $model->blueprint()?->section($name);
 
 		$sectionApi = $this->clone([
-			'data'   => array_merge($this->data(), ['section' => $section]),
+			'data'   => [...$this->data(), 'section' => $section],
 			'routes' => $section->api(),
 		]);
 

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -186,6 +186,29 @@ class Api extends BaseApi
 	}
 
 	/**
+	 * @throws \Kirby\Exception\NotFoundException if the section type cannot be found or the section cannot be loaded
+	 */
+	public function sectionApi(
+		ModelWithContent $model,
+		string $name,
+		string|null $path = null
+	): mixed {
+
+		$section = $model->blueprint()?->section($name);
+
+		$sectionApi = $this->clone([
+			'data'   => array_merge($this->data(), ['section' => $section]),
+			'routes' => $section->api(),
+		]);
+
+		return $sectionApi->call(
+			$path,
+			$this->requestMethod(),
+			$this->requestData()
+		);
+	}
+
+	/**
 	 * Returns the current Session instance
 	 *
 	 * @param array $options Additional options, see the session component

--- a/src/Cms/Api.php
+++ b/src/Cms/Api.php
@@ -193,7 +193,9 @@ class Api extends BaseApi
 		string $name,
 		string|null $path = null
 	): mixed {
-		$section = $model->blueprint()?->section($name);
+		if (!$section = $model->blueprint()?->section($name)) {
+			throw new NotFoundException('The section "' . $name . '" could not be found');
+		}
 
 		$sectionApi = $this->clone([
 			'data'   => [...$this->data(), 'section' => $section],

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -659,6 +659,11 @@ trait AppPlugins
 	 */
 	protected function extensionsFromSystem(): void
 	{
+		// Always start with fresh fields and sections
+		// from the core and add plugins on top of that
+		FormField::$types = [];
+		Section::$types   = [];
+
 		// mixins
 		FormField::$mixins = $this->core->fieldMixins();
 		Section::$mixins   = $this->core->sectionMixins();
@@ -674,8 +679,8 @@ trait AppPlugins
 		$this->extendCacheTypes($this->core->cacheTypes());
 		$this->extendComponents($this->core->components());
 		$this->extendBlueprints($this->core->blueprints());
-		$this->extendFields($this->core->fields());
 		$this->extendFieldMethods($this->core->fieldMethods());
+		$this->extendFields($this->core->fields());
 		$this->extendSections($this->core->sections());
 		$this->extendSnippets($this->core->snippets());
 		$this->extendTags($this->core->kirbyTags());

--- a/src/Cms/Section.php
+++ b/src/Cms/Section.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Component;
 
@@ -44,6 +45,21 @@ class Section extends Component
 		$attrs['type']   = $type;
 
 		parent::__construct($type, $attrs);
+	}
+
+	/**
+	 * Returns field api call
+	 */
+	public function api(): mixed
+	{
+		if (
+			isset($this->options['api']) === true &&
+			$this->options['api'] instanceof Closure
+		) {
+			return $this->options['api']->call($this);
+		}
+
+		return null;
 	}
 
 	public function errors(): array

--- a/tests/Cms/Sections/SectionTest.php
+++ b/tests/Cms/Sections/SectionTest.php
@@ -28,6 +28,39 @@ class SectionTest extends TestCase
 		Section::$types = $this->sectionTypes;
 	}
 
+	public function testApi()
+	{
+		// no defined as default
+		Section::$types = [
+			'test' => []
+		];
+
+		$model = new Page(['slug' => 'test']);
+
+		$section = new Section('test', [
+			'model' => $model,
+		]);
+
+		$this->assertNull($section->api());
+
+		// return simple string
+		Section::$types = [
+			'test' => [
+				'api' => function () {
+					return 'Hello World';
+				}
+			]
+		];
+
+		$model = new Page(['slug' => 'test']);
+
+		$section = new Section('test', [
+			'model' => $model,
+		]);
+
+		$this->assertSame('Hello World', $section->api());
+	}
+
 	public function testMissingModel()
 	{
 		Section::$types['test'] = [];

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Form\Fields;
 
 use Kirby\Cms\Page;
-use Kirby\Form\Field;
 
 class PagePickerMixinTest extends TestCase
 {

--- a/tests/Form/Fields/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/PagePickerMixinTest.php
@@ -19,18 +19,17 @@ class PagePickerMixinTest extends TestCase
 
 	public function testPagesWithoutParent()
 	{
-		Field::$types = [
-			'test' => [
-				'mixins'  => ['pagepicker'],
-				'methods' => [
-					'pages' => function () {
-						return $this->pagepicker();
-					}
-				]
-			]
-		];
-
 		$app = $this->app->clone([
+			'fields' => [
+				'test' => [
+					'mixins'  => ['pagepicker'],
+					'methods' => [
+						'pages' => function () {
+							return $this->pagepicker();
+						}
+					]
+				]
+			],
 			'site' => [
 				'children' => [
 					['slug' => 'a'],
@@ -65,20 +64,19 @@ class PagePickerMixinTest extends TestCase
 
 	public function testPagesWithParent()
 	{
-		Field::$types = [
-			'test' => [
-				'mixins'  => ['pagepicker'],
-				'methods' => [
-					'pages' => function () {
-						return $this->pagepicker([
-							'parent' => 'a'
-						]);
-					}
-				]
-			]
-		];
-
 		$app = $this->app->clone([
+			'fields' => [
+				'test' => [
+					'mixins'  => ['pagepicker'],
+					'methods' => [
+						'pages' => function () {
+							return $this->pagepicker([
+								'parent' => 'a'
+							]);
+						}
+					]
+				]
+			],
 			'site' => [
 				'children' => [
 					[
@@ -116,18 +114,20 @@ class PagePickerMixinTest extends TestCase
 
 	public function testPageChildren()
 	{
-		Field::$types = [
-			'test' => [
-				'mixins'  => ['pagepicker'],
-				'methods' => [
-					'pages' => function () {
-						return $this->pagepicker([
-							'query' => 'page.children'
-						]);
-					}
+		$this->app->clone([
+			'fields' => [
+				'test' => [
+					'mixins'  => ['pagepicker'],
+					'methods' => [
+						'pages' => function () {
+							return $this->pagepicker([
+								'query' => 'page.children'
+							]);
+						}
+					]
 				]
-			]
-		];
+			],
+		]);
 
 		$page = new Page([
 			'slug' => 'test',
@@ -166,19 +166,21 @@ class PagePickerMixinTest extends TestCase
 
 	public function testPageChildrenWithoutSubpages()
 	{
-		Field::$types = [
-			'test' => [
-				'mixins'  => ['pagepicker'],
-				'methods' => [
-					'pages' => function () {
-						return $this->pagepicker([
-							'query'    => 'page.children',
-							'subpages' => false
-						]);
-					}
+		$this->app->clone([
+			'fields' => [
+				'test' => [
+					'mixins'  => ['pagepicker'],
+					'methods' => [
+						'pages' => function () {
+							return $this->pagepicker([
+								'query'    => 'page.children',
+								'subpages' => false
+							]);
+						}
+					]
 				]
-			]
-		];
+			],
+		]);
 
 		$page = new Page([
 			'slug' => 'test',
@@ -213,21 +215,23 @@ class PagePickerMixinTest extends TestCase
 
 	public function testMap()
 	{
-		Field::$types = [
-			'test' => [
-				'mixins'  => ['pagepicker'],
-				'methods' => [
-					'pages' => function () {
-						return $this->pagepicker([
-							'query' => 'page.children',
-							'map'   => function ($page) {
-								return $page->id();
-							}
-						]);
-					}
+		$this->app->clone([
+			'fields' => [
+				'test' => [
+					'mixins'  => ['pagepicker'],
+					'methods' => [
+						'pages' => function () {
+							return $this->pagepicker([
+								'query' => 'page.children',
+								'map'   => function ($page) {
+									return $page->id();
+								}
+							]);
+						}
+					]
 				]
-			]
-		];
+			],
+		]);
 
 		$page = new Page([
 			'slug' => 'test',


### PR DESCRIPTION
## This PR …

### Features

- The new section api lets you define API endpoints for your panel sections. Just like for fields, sections can now have their own routes. https://github.com/getkirby/kirby/issues/6244

```php 
// my section
return [
  'api' => function() {
    return [
      [ 
        'pattern' => '/say-hello', 
        'action' => function () {
          return [
            'message' => 'Hello, World!'
          ];
        }
      ]
    ];
  }
];
```

With the route defined on the backend, you can now access it in the panel with the API library. 

```js
const response = await this.$api.get('/pages/blog+article-a/sections/sectionName/say-hello');

alert(response.message);
```

### Enhancements

- Use the new section API in the files section to sort files.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
