### PR TITLE
Fix alpha/hue input’s min/max

### DIFF
--- a/panel/src/components/Forms/Input/AlphaInput.vue
+++ b/panel/src/components/Forms/Input/AlphaInput.vue
@@ -1,6 +1,8 @@
 <template>
 	<k-range-input
 		v-bind="$props"
+		:min="0"
+		:max="1"
 		class="k-alpha-input"
 		@input="$emit('input', $event)"
 	/>
@@ -13,14 +15,10 @@ import Input from "./RangeInput.vue";
 export const props = {
 	mixins: [RangeInputProps],
 	props: {
-		max: {
-			default: 1,
-			type: Number
-		},
-		min: {
-			default: 0,
-			type: Number
-		},
+		// unset unused/fixed props
+		max: null,
+		min: null,
+
 		step: {
 			default: 0.01,
 			type: Number

--- a/panel/src/components/Forms/Input/HueInput.vue
+++ b/panel/src/components/Forms/Input/HueInput.vue
@@ -1,6 +1,8 @@
 <template>
 	<k-range-input
 		v-bind="$props"
+		:min="0"
+		:max="360"
 		class="k-hue-input"
 		@input="$emit('input', $event)"
 	/>
@@ -13,14 +15,10 @@ import Input from "./RangeInput.vue";
 export const props = {
 	mixins: [RangeInputProps],
 	props: {
-		max: {
-			default: 360,
-			type: Number
-		},
-		min: {
-			default: 0,
-			type: Number
-		},
+		// unset unused/fixed props
+		max: null,
+		min: null,
+
 		step: {
 			default: 1,
 			type: Number


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `alpha` and `hue` inputs: setting custom `min` and `max` props would break the inputs. Those props aren't falsely exposed anymore.
 #6251


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
