### PR TITLE
Add native validity to `range` input

### DIFF
--- a/panel/lab/components/inputs/alpha/index.vue
+++ b/panel/lab/components/inputs/alpha/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-alpha-input name="alpha" :value="value" @input="value = $event" />
 			</k-lab-example>

--- a/panel/lab/components/inputs/hue/index.vue
+++ b/panel/lab/components/inputs/hue/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-hue-input name="hue" :value="value" @input="value = $event" />
 			</k-lab-example>

--- a/panel/lab/components/inputs/range/index.vue
+++ b/panel/lab/components/inputs/range/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-range-input name="range" :value="value" @input="value = $event" />
 			</k-lab-example>

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -80,6 +80,8 @@ export const props = {
 
 /**
  * @example <k-input :value="range" @input="range = $event" name="range" type="range" />
+ *
+ * @todo remove vuelidate parts in v5 - until then we keep parrallel validation
  */
 export default {
 	mixins: [Input, props],
@@ -88,6 +90,11 @@ export default {
 			// If the minimum is below 0, the baseline should be placed at .
 			// Otherwise place the baseline at the minimum
 			return this.min < 0 ? 0 : this.min;
+		},
+		isEmpty() {
+			return (
+				this.value === "" || this.value === undefined || this.value === null
+			);
 		},
 		label() {
 			return this.required || this.value || this.value === 0
@@ -103,10 +110,14 @@ export default {
 	watch: {
 		position() {
 			this.onInvalid();
+		},
+		value() {
+			this.validate();
 		}
 	},
 	mounted() {
 		this.onInvalid();
+		this.validate();
 
 		if (this.$props.autofocus) {
 			this.focus();
@@ -129,6 +140,23 @@ export default {
 		},
 		onInput(value) {
 			this.$emit("input", value);
+		},
+		validate() {
+			const errors = [];
+
+			if (this.required && this.isEmpty === true) {
+				errors.push(this.$t("error.validation.required"));
+			}
+
+			if (this.isEmpty === false && this.min && this.value < this.min) {
+				errors.push(this.$t("error.validation.min", { min: this.min }));
+			}
+
+			if (this.isEmpty === false && this.max && this.value > this.max) {
+				errors.push(this.$t("error.validation.max", { max: this.max }));
+			}
+
+			this.$refs.range?.setCustomValidity(errors.join(", "));
 		}
 	},
 	validations() {

--- a/panel/src/components/Lab/PlaygroundView.vue
+++ b/panel/src/components/Lab/PlaygroundView.vue
@@ -133,9 +133,8 @@ export default {
 	margin-top: var(--spacing-12);
 }
 
-.k-lab-input-examples .k-lab-example-canvas:has(:invalid) {
+.k-lab-input-examples .k-lab-example:has(:invalid) {
 	outline: 2px solid var(--color-red-500);
-	outline-offset: -2px;
 }
 
 .k-lab-input-examples-focus .k-lab-example-canvas > .k-button {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

For the moment, vuelidate remains side by side with the new native validations to avoid breaking changes in v4.x. But I think this would be a good way to slowly add native validity to all inputs and fields and cut down the size of https://github.com/getkirby/kirby/pull/6099 

### Refactoring
- `range` input: added native validity in preparation to remove vuelidate library. 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
