### PR TITLE
Native validaty for `date`/`time` inputs

### DIFF
--- a/panel/lab/components/inputs/calendar/index.vue
+++ b/panel/lab/components/inputs/calendar/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-calendar-input
 					name="calendar"

--- a/panel/lab/components/inputs/date/index.vue
+++ b/panel/lab/components/inputs/date/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-date-input name="date" :value="value" @input="value = $event" />
 			</k-lab-example>

--- a/panel/lab/components/inputs/time/index.vue
+++ b/panel/lab/components/inputs/time/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-time-input name="time" :value="value" @input="value = $event" />
 			</k-lab-example>
@@ -35,11 +35,11 @@
 			</k-lab-example>
 
 			<k-lab-example label="Min: 12:00">
-				<k-time-input :value="value" min="12:00" @input="value = $event" />
+				<k-time-input :value="value" min="12:00:00" @input="value = $event" />
 			</k-lab-example>
 
 			<k-lab-example label="Max: 18:00">
-				<k-time-input :value="value" max="18:00" @input="value = $event" />
+				<k-time-input :value="value" max="18:00:00" @input="value = $event" />
 			</k-lab-example>
 		</k-lab-examples>
 	</k-lab-form>

--- a/panel/lab/components/inputs/timeoptions/index.vue
+++ b/panel/lab/components/inputs/timeoptions/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-lab-form>
-		<k-lab-examples>
+		<k-lab-examples class="k-lab-input-examples">
 			<k-lab-example label="Default">
 				<k-timeoptions-input
 					name="timeoptions"
@@ -38,6 +38,22 @@
 				<k-timeoptions-input
 					:disabled="true"
 					:value="value"
+					@input="value = $event"
+				/>
+			</k-lab-example>
+
+			<k-lab-example label="Min: 12:00">
+				<k-timeoptions-input
+					:value="value"
+					min="12:00:00"
+					@input="value = $event"
+				/>
+			</k-lab-example>
+
+			<k-lab-example label="Max: 18:00">
+				<k-timeoptions-input
+					:value="value"
+					max="18:00:00"
 					@input="value = $event"
 				/>
 			</k-lab-example>

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -88,7 +88,7 @@
 
 <script>
 import { props as InputProps } from "@/mixins/input.js";
-import { IsoProps as DateProps } from "./DateInput.vue";
+import { IsoDateProps } from "./DateInput.vue";
 
 /**
  * The Calendar component is mainly used for our `DateInput` component, but it could be used as stand-alone calendar as well with a little CSS love.
@@ -97,7 +97,7 @@ import { IsoProps as DateProps } from "./DateInput.vue";
  * @example <k-calendar-input :value="value" @input="value = $event" />
  */
 export default {
-	mixins: [InputProps, DateProps],
+	mixins: [InputProps, IsoDateProps],
 	data() {
 		return {
 			maxdate: null,

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -69,6 +69,8 @@
 				</tr>
 			</tfoot>
 		</table>
+
+		<!-- Hidden input for validation -->
 		<input
 			:id="id"
 			:disabled="disabled"
@@ -77,7 +79,7 @@
 			:name="name"
 			:required="required"
 			:value="value"
-			class="sr-only"
+			class="input-hidden"
 			tabindex="-1"
 			type="date"
 		/>
@@ -86,6 +88,7 @@
 
 <script>
 import { props as InputProps } from "@/mixins/input.js";
+import { IsoProps as DateProps } from "./DateInput.vue";
 
 /**
  * The Calendar component is mainly used for our `DateInput` component, but it could be used as stand-alone calendar as well with a little CSS love.
@@ -94,27 +97,7 @@ import { props as InputProps } from "@/mixins/input.js";
  * @example <k-calendar-input :value="value" @input="value = $event" />
  */
 export default {
-	mixins: [InputProps],
-	props: {
-		/**
-		 * The last allowed date
-		 * @example `2020-12-31`
-		 */
-		max: String,
-		/**
-		 * The first allowed date
-		 * @example `2020-01-01`
-		 */
-		min: String,
-		/**
-		 * ISO date/datetime string
-		 * @example `2020-03-05`
-		 */
-		value: {
-			default: "",
-			type: String
-		}
-	},
+	mixins: [InputProps, DateProps],
 	data() {
 		return {
 			maxdate: null,

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -1,7 +1,6 @@
 <template>
 	<input
 		:id="id"
-		ref="input"
 		v-direction
 		:autofocus="autofocus"
 		:class="`k-text-input k-${type}-input`"
@@ -25,18 +24,8 @@
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
 
-export const props = {
-	mixins: [InputProps],
+export const IsoProps = {
 	props: {
-		/**
-		 * Format to parse and display the date
-		 * @values YYYY, YY, MM, M, DD, D
-		 * @example "MM/DD/YY"
-		 */
-		display: {
-			type: String,
-			default: "DD.MM.YYYY"
-		},
 		/**
 		 * The last allowed date as ISO date string
 		 * @example "2025-12-31"
@@ -47,6 +36,27 @@ export const props = {
 		 * @example "2020-01-01"
 		 */
 		min: String,
+		/**
+		 * Value must be provided as ISO date string
+		 * @example "2012-12-12"
+		 */
+		value: String
+	}
+};
+
+export const props = {
+	mixins: [InputProps, IsoProps],
+	props: {
+		/**
+		 * Format to parse and display the date
+		 * @values YYYY, YY, MM, M, DD, D
+		 * @example "MM/DD/YY"
+		 */
+		display: {
+			type: String,
+			default: "DD.MM.YYYY"
+		},
+
 		/**
 		 * Rounding to the nearest step.
 		 * @value { unit: "second"|"minute"|"hour"|"date"|"month"|"year", size: number }
@@ -64,12 +74,7 @@ export const props = {
 		type: {
 			type: String,
 			default: "date"
-		},
-		/**
-		 * Value must be provided as ISO date string
-		 * @example "2012-12-12"
-		 */
-		value: String
+		}
 	}
 };
 
@@ -83,6 +88,8 @@ export const props = {
  * input parts via tab key).
  *
  * @example <k-input :value="date" @input="date = $event" type="date" name="date" />
+ *
+ * @todo remove vuelidate parts in v5 - until then we keep parrallel validation
  */
 export default {
 	mixins: [Input, props],
@@ -198,6 +205,7 @@ export default {
 		commit(dt) {
 			this.dt = dt;
 			this.formatted = this.pattern.format(dt);
+			this.validate();
 			this.$emit("invalid", this.$v.$invalid, this.$v);
 		},
 		/**
@@ -281,7 +289,7 @@ export default {
 		 */
 		async onTab(event) {
 			// step out of the field if it is empty
-			if (this.$refs.input.value == "") {
+			if (this.$el.value == "") {
 				return;
 			}
 
@@ -292,9 +300,9 @@ export default {
 
 			// if an exact part is selected
 			if (
-				this.$refs.input &&
-				selection.start === this.$refs.input.selectionStart &&
-				selection.end === this.$refs.input.selectionEnd - 1
+				this.$el &&
+				selection.start === this.$el.selectionStart &&
+				selection.end === this.$el.selectionEnd - 1
 			) {
 				// move backward on shift + tab
 				if (event.shiftKey) {
@@ -319,8 +327,8 @@ export default {
 			} else {
 				// nothing or no part fully selected
 				if (
-					this.$refs.input &&
-					this.$refs.input.selectionStart == selection.end + 1 &&
+					this.$el &&
+					this.$el.selectionStart == selection.end + 1 &&
 					selection.index == this.pattern.parts.length - 1
 				) {
 					// cursor at the end of the pattern, jump out
@@ -328,13 +336,10 @@ export default {
 				}
 
 				// more than one part selected, select last affected part
-				else if (
-					this.$refs.input &&
-					this.$refs.input.selectionEnd - 1 > selection.end
-				) {
+				else if (this.$el && this.$el.selectionEnd - 1 > selection.end) {
 					const last = this.pattern.at(
-						this.$refs.input.selectionEnd,
-						this.$refs.input.selectionEnd
+						this.$el.selectionEnd,
+						this.$el.selectionEnd
 					);
 
 					this.select(this.pattern.parts[last.index]);
@@ -355,9 +360,13 @@ export default {
 		 * @return {Object|null}
 		 */
 		parse() {
-			let value = this.$refs.input.value;
-			// interpret and round to nearest step
-			value = this.$library.dayjs.interpret(value, this.inputType);
+			// interpret the input value
+			const value = this.$library.dayjs.interpret(
+				this.$el.value,
+				this.inputType
+			);
+
+			// and round to nearest step
 			return this.round(value);
 		},
 		/**
@@ -376,11 +385,8 @@ export default {
 		 * @public
 		 */
 		select(part) {
-			if (!part) {
-				part = this.selection();
-			}
-
-			this.$refs.input?.setSelectionRange(part.start, part.end + 1);
+			part ??= this.selection();
+			this.$el?.setSelectionRange(part.start, part.end + 1);
 		},
 		/**
 		 * Selects the first pattern if available
@@ -417,10 +423,7 @@ export default {
 		 * @returns {Object}
 		 */
 		selection() {
-			return this.pattern.at(
-				this.$refs.input.selectionStart,
-				this.$refs.input.selectionEnd
-			);
+			return this.pattern.at(this.$el.selectionStart, this.$el.selectionEnd);
 		},
 		/**
 		 * Converts ISO string to dayjs object
@@ -437,6 +440,37 @@ export default {
 		 */
 		toISO(dt) {
 			return dt?.toISO(this.inputType);
+		},
+		validate() {
+			const errors = [];
+
+			if (this.required && !this.dt) {
+				errors.push(this.$t("error.validation.required"));
+			}
+
+			if (
+				this.min &&
+				this.dt?.validate(this.min, "min", this.rounding.unit) === false
+			) {
+				errors.push(
+					this.$t("error.validation.date.after", {
+						date: this.min
+					})
+				);
+			}
+
+			if (
+				this.max &&
+				this.dt?.validate(this.max, "max", this.rounding.unit) === false
+			) {
+				errors.push(
+					this.$t("error.validation.date.before", {
+						date: this.max
+					})
+				);
+			}
+
+			this.$el?.setCustomValidity(errors.join(", "));
 		}
 	},
 	validations() {

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -24,7 +24,7 @@
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
 
-export const IsoProps = {
+export const IsoDateProps = {
 	props: {
 		/**
 		 * The last allowed date as ISO date string
@@ -45,7 +45,7 @@ export const IsoProps = {
 };
 
 export const props = {
-	mixins: [InputProps, IsoProps],
+	mixins: [InputProps, IsoDateProps],
 	props: {
 		/**
 		 * Format to parse and display the date

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -1,7 +1,28 @@
 <script>
 import DateInput from "./DateInput.vue";
 
+export const IsoProps = {
+	props: {
+		/**
+		 * The last allowed time as ISO time string
+		 * @example `22:30:00`
+		 */
+		max: String,
+		/**
+		 * The first allowed time as ISO time string
+		 * @example `01:30:00`
+		 */
+		min: String,
+		/**
+		 * Value must be provided as ISO time string
+		 * @example `22:33:00`
+		 */
+		value: String
+	}
+};
+
 export const props = {
+	mixins: [IsoProps],
 	props: {
 		/**
 		 * Format to parse and display the time
@@ -12,18 +33,6 @@ export const props = {
 			type: String,
 			default: "HH:mm"
 		},
-		/**
-		 * The last allowed time
-		 * as ISO time string
-		 * @example `22:30:00`
-		 */
-		max: String,
-		/**
-		 * The first allowed time
-		 * as ISO time string
-		 * @example `01:30:00`
-		 */
-		min: String,
 		/**
 		 * Rounding to the nearest step.
 		 * Requires an object with a `unit`
@@ -42,12 +51,7 @@ export const props = {
 		type: {
 			type: String,
 			default: "time"
-		},
-		/**
-		 * Value must be provided as ISO time string
-		 * @example `22:33:00`
-		 */
-		value: String
+		}
 	}
 };
 

--- a/panel/src/components/Forms/Input/TimeInput.vue
+++ b/panel/src/components/Forms/Input/TimeInput.vue
@@ -1,7 +1,7 @@
 <script>
 import DateInput from "./DateInput.vue";
 
-export const IsoProps = {
+export const IsoTimeProps = {
 	props: {
 		/**
 		 * The last allowed time as ISO time string
@@ -22,7 +22,7 @@ export const IsoProps = {
 };
 
 export const props = {
-	mixins: [IsoProps],
+	mixins: [IsoTimeProps],
 	props: {
 		/**
 		 * Format to parse and display the time

--- a/panel/src/components/Forms/Input/TimeoptionsInput.vue
+++ b/panel/src/components/Forms/Input/TimeoptionsInput.vue
@@ -56,10 +56,10 @@
 
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
-import { IsoProps as TimeProps } from "./TimeInput.vue";
+import { IsoTimeProps } from "./TimeInput.vue";
 
 export const props = {
-	mixins: [InputProps, TimeProps]
+	mixins: [InputProps, IsoTimeProps]
 };
 
 /**

--- a/panel/src/components/Forms/Input/TimeoptionsInput.vue
+++ b/panel/src/components/Forms/Input/TimeoptionsInput.vue
@@ -37,14 +37,29 @@
 				</li>
 			</ul>
 		</div>
+
+		<!-- Hidden input for validation -->
+		<input
+			:id="id"
+			:disabled="disabled"
+			:min="min"
+			:max="max"
+			:name="name"
+			:required="required"
+			:value="value"
+			class="input-hidden"
+			tabindex="-1"
+			type="time"
+		/>
 	</div>
 </template>
 
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
+import { IsoProps as TimeProps } from "./TimeInput.vue";
 
 export const props = {
-	mixins: [InputProps]
+	mixins: [InputProps, TimeProps]
 };
 
 /**

--- a/panel/src/libraries/dayjs-iso.js
+++ b/panel/src/libraries/dayjs-iso.js
@@ -32,8 +32,19 @@ export default (option, Dayjs, dayjs) => {
 	 * @param {string} format
 	 * @returns {Object|null}
 	 */
-	dayjs.iso = function (string, format = "datetime") {
-		const dt = dayjs(string, dayjsISOformat(format));
+	dayjs.iso = function (string, format) {
+		if (format) {
+			format = dayjsISOformat(format);
+		}
+
+		// if no format is provided, try to parse any of the three ISO formats
+		format ??= [
+			dayjsISOformat("datetime"),
+			dayjsISOformat("date"),
+			dayjsISOformat("time")
+		];
+
+		const dt = dayjs(string, format);
 
 		if (!dt || !dt.isValid()) {
 			return null;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactored
- `calendar`, `date`, `time`, `timoptions` inputs: added native validity in preparation to remove vuelidate library.

### Fixed
- Fixed some bugs regarding parsing limits correctly in datetime validation



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
