### PR TITLE
`Colorname` input: unset inherited props

### DIFF
--- a/panel/src/components/Forms/Input/ColornameInput.vue
+++ b/panel/src/components/Forms/Input/ColornameInput.vue
@@ -1,6 +1,8 @@
 <template>
 	<k-string-input
 		v-bind="$props"
+		:spellcheck="false"
+		autocomplete="off"
 		class="k-colorname-input"
 		type="text"
 		@blur.native="onBlur"
@@ -17,16 +19,20 @@ import StringInput, { props as StringInputProps } from "./StringInput.vue";
 export const props = {
 	mixins: [StringInputProps],
 	props: {
+		// unset props
+		autocomplete: null,
+		font: null,
+		maxlength: null,
+		minlength: null,
+		pattern: null,
+		spellcheck: null,
+
 		/**
 		 * Add the alpha value to the color name
 		 */
 		alpha: {
 			type: Boolean,
 			default: true
-		},
-		autocomplete: {
-			default: "off",
-			type: String
 		},
 		/**
 		 * @values "hex", "rgb", "hsl"
@@ -35,10 +41,6 @@ export const props = {
 			type: String,
 			default: "hex",
 			validator: (format) => ["hex", "rgb", "hsl"].includes(format)
-		},
-		spellcheck: {
-			default: false,
-			type: Boolean
 		}
 	}
 };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `colorname` input: props that were falsely exposed are now correctly unset