### PR TITLE
Added call to parent::tearDown()

### DIFF
--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -34,6 +34,7 @@ class HelperFunctionsTest extends HelpersTestCase
 
 	public function tearDown(): void
 	{
+		parent::tearDown();
 		Dir::remove(static::TMP);
 	}
 


### PR DESCRIPTION
## This PR …
Adds missing call to parent::tearDown() so error handlers get cleaned up after tests.

### Fixes
Issue with error handler not getting cleaned up causes other tests to fail when running the full test suite.

### Breaking changes
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
