### PR TITLE
Fix to handle invalid PHP version strings

### DIFF
--- a/src/Cms/System/UpdateStatus.php
+++ b/src/Cms/System/UpdateStatus.php
@@ -158,7 +158,9 @@ class UpdateStatus
 		// collect all matching custom messages
 		$filters = [
 			'kirby' => $this->app->version(),
-			'php'   => phpversion()
+			// Some PHP version strings contain extra info that makes them
+			// invalid so we need to strip it off.
+			'php'   => preg_replace('#^([^~+-]+).*$#', '$1', phpversion())
 		];
 
 		if ($type === 'plugin') {

--- a/src/Cms/System/UpdateStatus.php
+++ b/src/Cms/System/UpdateStatus.php
@@ -158,9 +158,9 @@ class UpdateStatus
 		// collect all matching custom messages
 		$filters = [
 			'kirby' => $this->app->version(),
-			// Some PHP version strings contain extra info that makes them
-			// invalid so we need to strip it off.
-			'php'   => preg_replace('#^([^~+-]+).*$#', '$1', phpversion())
+			// some PHP version strings contain extra info that makes them
+			// invalid so we need to strip it off
+			'php'   => preg_replace('/^([^~+-]+).*$/', '$1', phpversion())
 		];
 
 		if ($type === 'plugin') {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->
Some versions of PHP have extra information in the version string that does not conform to semantic versioning and this causes a problem matching messages in UpdateStatus.

### Fixes
This fix strips off any extra info from the version string with a regex. The regex is taken from Composer where it is used to handle the same situation.

### Breaking changes
None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
