### PR TITLE
Allow unknown file extensions to be selected in file open dialog

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -39,7 +39,7 @@ return [
 					'template' => $template
 				]);
 
-				$uploads['accept'] = $file->blueprint()->acceptMime();
+				$uploads['accept'] = $file->blueprint()->acceptAttribute();
 			}
 
 			return $uploads;

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -47,7 +47,7 @@ return [
 					'template' => $this->template
 				]);
 
-				return $file->blueprint()->acceptMime();
+				return $file->blueprint()->acceptAttribute();
 			}
 
 			return null;

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -57,6 +57,8 @@ class FileBlueprint extends Blueprint
 	/**
 	 * Returns the list of all accepted MIME types for
 	 * file upload or `*` if all MIME types are allowed
+	 *
+	 * @deprecated 4.2.0 Use `acceptAttribute` instead
 	 */
 	public function acceptMime(): string
 	{
@@ -113,6 +115,82 @@ class FileBlueprint extends Blueprint
 		}
 
 		// no restrictions, accept everything
+		return '*';
+	}
+
+
+	/**
+	 * Returns the list of all accepted file extensions
+	 * for file upload or `*` if all extensions are allowed
+	 *
+	 * If a mime type is specified in the blueprint, the extensions and types options are ignored for the browser.
+	 * Extensions and Types, however, are still used to validate an uploaded file on the server.
+	 * This behavior might change in the future to better represent what file extensions are actually allowed.
+	 *
+	 * If no mime type is specified, the intersection between manually defined extensions and the Kirby "file types" is returned.
+	 * If the intersection is empty, an empty string is returned.
+	 * This behavior might change in the future to instead return the union of mime, extensions and types.
+	 *
+	 * @since 4.2.0
+	 * @return string
+	 */
+	public function acceptAttribute(): string
+	{
+		// don't disclose the specific default types
+		if ($this->defaultTypes === true) {
+			return '*';
+		}
+
+		$accept = $this->accept();
+
+		// get extensions from "mime" option
+		if (is_array($accept['mime']) === true) {
+			// determine the extensions for each MIME type
+			$extensions = array_map(
+				fn($pattern) => Mime::toExtensions($pattern, true),
+				$accept['mime']
+			);
+
+			$fromMime = array_unique(array_merge(...$extensions));
+
+			// return early to ignore the other options
+			return implode(',', array_map(fn($ext) => ".$ext", $fromMime));
+		}
+
+		$restrictions = [];
+
+		// get extensions from "type" option
+		if (is_array($accept['type']) === true) {
+			$extensions = array_map(
+				F::typeToExtensions(...),
+				$accept['type']
+			);
+
+			// F::typeToExtensions might return null instead of empty arrays,
+			// we need to filter those out
+			$fromType = array_merge(...array_filter($extensions));
+			$restrictions[] = $fromType;
+		}
+
+		// get extensions from "extension" option
+		if (is_array($accept['extension']) === true) {
+			$fromExtension = $accept['extension'];
+			$restrictions[] = $fromExtension;
+		}
+
+		// intersect all restrictions
+		if (count($restrictions) > 1) {
+			$list = array_intersect(...$restrictions);
+		} else {
+			$list = $restrictions[0];
+		}
+
+		$list = array_unique($list);
+
+		// format the list to include a leading dot on each extension
+		return implode(',', array_map(fn($ext) => ".$ext", $list));
+
+		// unknown restrictions, accept everything
 		return '*';
 	}
 

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -59,6 +59,7 @@ class FileBlueprint extends Blueprint
 	 * file upload or `*` if all MIME types are allowed
 	 *
 	 * @deprecated 4.2.0 Use `acceptAttribute` instead
+	 * @todo 5.0.0 Remove method
 	 */
 	public function acceptMime(): string
 	{
@@ -117,19 +118,17 @@ class FileBlueprint extends Blueprint
 		// no restrictions, accept everything
 		return '*';
 	}
-
-
 	/**
 	 * Returns the list of all accepted file extensions
 	 * for file upload or `*` if all extensions are allowed
 	 *
-	 * If a mime type is specified in the blueprint, the extensions and types options are ignored for the browser.
-	 * Extensions and Types, however, are still used to validate an uploaded file on the server.
-	 * This behavior might change in the future to better represent what file extensions are actually allowed.
+	 * If a MIME type is specified in the blueprint, the `extension` and `type` options are ignored for the browser.
+	 * Extensions and types, however, are still used to validate an uploaded file on the server.
+	 * This behavior might change in the future to better represent which file extensions are actually allowed.
 	 *
-	 * If no mime type is specified, the intersection between manually defined extensions and the Kirby "file types" is returned.
+	 * If no MIME type is specified, the intersection between manually defined extensions and the Kirby "file types" is returned.
 	 * If the intersection is empty, an empty string is returned.
-	 * This behavior might change in the future to instead return the union of mime, extensions and types.
+	 * This behavior might change in the future to instead return the union of `mime`, `extension` and `type`.
 	 *
 	 * @since 4.2.0
 	 */

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -189,9 +189,6 @@ class FileBlueprint extends Blueprint
 
 		// format the list to include a leading dot on each extension
 		return implode(',', array_map(fn ($ext) => ".$ext", $list));
-
-		// unknown restrictions, accept everything
-		return '*';
 	}
 
 	protected function normalizeAccept(mixed $accept = null): array

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -151,7 +151,7 @@ class FileBlueprint extends Blueprint
 				$accept['mime']
 			);
 
-			$fromMime = array_unique(array_merge(...$extensions));
+			$fromMime = array_unique(array_merge(...array_values($extensions)));
 
 			// return early to ignore the other options
 			return implode(',', array_map(fn ($ext) => ".$ext", $fromMime));
@@ -168,7 +168,7 @@ class FileBlueprint extends Blueprint
 
 			// F::typeToExtensions might return null instead of empty arrays,
 			// we need to filter those out
-			$fromType = array_merge(...array_filter($extensions));
+			$fromType = array_merge(...array_values(array_filter($extensions)));
 			$restrictions[] = $fromType;
 		}
 

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -161,7 +161,7 @@ class FileBlueprint extends Blueprint
 		// get extensions from "type" option
 		if (is_array($accept['type']) === true) {
 			$extensions = array_map(
-				fn($type) => F::typeToExtensions($type) ?? [],
+				fn ($type) => F::typeToExtensions($type) ?? [],
 				$accept['type']
 			);
 

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -118,6 +118,7 @@ class FileBlueprint extends Blueprint
 		// no restrictions, accept everything
 		return '*';
 	}
+
 	/**
 	 * Returns the list of all accepted file extensions
 	 * for file upload or `*` if all extensions are allowed

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -132,7 +132,6 @@ class FileBlueprint extends Blueprint
 	 * This behavior might change in the future to instead return the union of mime, extensions and types.
 	 *
 	 * @since 4.2.0
-	 * @return string
 	 */
 	public function acceptAttribute(): string
 	{
@@ -162,28 +161,25 @@ class FileBlueprint extends Blueprint
 		// get extensions from "type" option
 		if (is_array($accept['type']) === true) {
 			$extensions = array_map(
-				F::typeToExtensions(...),
+				fn($type) => F::typeToExtensions($type) ?? [],
 				$accept['type']
 			);
 
-			// F::typeToExtensions might return null instead of empty arrays,
-			// we need to filter those out
-			$fromType = array_merge(...array_values(array_filter($extensions)));
+			$fromType = array_merge(...array_values($extensions));
 			$restrictions[] = $fromType;
 		}
 
 		// get extensions from "extension" option
 		if (is_array($accept['extension']) === true) {
-			$fromExtension = $accept['extension'];
-			$restrictions[] = $fromExtension;
+			$restrictions[] = $accept['extension'];
 		}
 
 		// intersect all restrictions
-		if (count($restrictions) > 1) {
-			$list = array_intersect(...$restrictions);
-		} else {
-			$list = $restrictions[0];
-		}
+		$list = match (count($restrictions)) {
+			0 => [],
+			1 => $restrictions[0],
+			default => array_intersect(...$restrictions)
+		};
 
 		$list = array_unique($list);
 

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -147,14 +147,14 @@ class FileBlueprint extends Blueprint
 		if (is_array($accept['mime']) === true) {
 			// determine the extensions for each MIME type
 			$extensions = array_map(
-				fn($pattern) => Mime::toExtensions($pattern, true),
+				fn ($pattern) => Mime::toExtensions($pattern, true),
 				$accept['mime']
 			);
 
 			$fromMime = array_unique(array_merge(...$extensions));
 
 			// return early to ignore the other options
-			return implode(',', array_map(fn($ext) => ".$ext", $fromMime));
+			return implode(',', array_map(fn ($ext) => ".$ext", $fromMime));
 		}
 
 		$restrictions = [];
@@ -188,7 +188,7 @@ class FileBlueprint extends Blueprint
 		$list = array_unique($list);
 
 		// format the list to include a leading dot on each extension
-		return implode(',', array_map(fn($ext) => ".$ext", $list));
+		return implode(',', array_map(fn ($ext) => ".$ext", $list));
 
 		// unknown restrictions, accept everything
 		return '*';

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Filesystem;
 
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 use SimpleXMLElement;
 
@@ -268,17 +269,31 @@ class Mime
 	/**
 	 * Returns all available extensions for a given MIME type
 	 */
-	public static function toExtensions(string $mime = null): array
+	public static function toExtensions(string $mime = null, bool $matchWildcards = false): array
 	{
 		$extensions = [];
+		$testMime = fn (string $v) => static::matches($v, $mime);
 
 		foreach (static::$types as $key => $value) {
-			if (is_array($value) === true && in_array($mime, $value) === true) {
-				$extensions[] = $key;
+			$isArray = is_array($value) === true;
+
+			if ($matchWildcards === true) {
+				if ($isArray === true && A::some($value, $testMime)) {
+					$extensions[] = $key;
+				}
+
+				if ($isArray === false && $testMime($value) === true) {
+					$extensions[] = $key;
+				}
+
 				continue;
 			}
 
-			if ($value === $mime) {
+			if ($isArray === true && in_array($mime, $value) === true) {
+				$extensions[] = $key;
+			}
+
+			if ($isArray === false && $value === $mime) {
 				$extensions[] = $key;
 			}
 		}

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -275,26 +275,26 @@ class Mime
 		$testMime = fn (string $v) => static::matches($v, $mime);
 
 		foreach (static::$types as $key => $value) {
-			$isArray = is_array($value) === true;
-
-			if ($matchWildcards === true) {
-				if ($isArray === true && A::some($value, $testMime)) {
-					$extensions[] = $key;
+			if (is_array($value) === true) {
+				if ($matchWildcards === true) {
+					if (A::some($value, $testMime)) {
+						$extensions[] = $key;
+					}
+				} else {
+					if (in_array($mime, $value) === true) {
+						$extensions[] = $key;
+					}
 				}
-
-				if ($isArray === false && $testMime($value) === true) {
-					$extensions[] = $key;
+			} else {
+				if ($matchWildcards === true) {
+					if($testMime($value) === true) {
+						$extensions[] = $key;
+					}
+				} else {
+					if ($value === $mime) {
+						$extensions[] = $key;
+					}
 				}
-
-				continue;
-			}
-
-			if ($isArray === true && in_array($mime, $value) === true) {
-				$extensions[] = $key;
-			}
-
-			if ($isArray === false && $value === $mime) {
-				$extensions[] = $key;
 			}
 		}
 

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -287,7 +287,7 @@ class Mime
 				}
 			} else {
 				if ($matchWildcards === true) {
-					if($testMime($value) === true) {
+					if ($testMime($value) === true) {
 						$extensions[] = $key;
 					}
 				} else {

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Kirby\Cms\Blueprint;
+use Kirby\Cms\File;
+use Kirby\Cms\FileBlueprint;
+use Kirby\Cms\Page;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Cms\FileBlueprint
+ */
+class FileBlueprintTest extends TestCase
+{
+	protected ?Page $parent;
+	protected array $acceptCases;
+
+	protected function setUp(): void {
+		$this->parent = Page::factory([
+			'slug' => 'test'
+		]);
+
+		$this->acceptCases = [
+			'acceptWildcard' => [
+				'accept' => 'image/*',
+				'expected' => ['.jpg', '.jpeg', '.gif', '.png'],
+				'notExpected' => ['.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptMimeAsString' => [
+				'accept' => 'image/jpeg, image/png',
+				'expected' => ['.jpg', '.jpeg', '.png'],
+				'notExpected' => ['.gif', '.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptMimeAsProperty' => [
+				'accept' => [
+					'mime' => 'image/jpeg, image/png'
+				],
+				'expected' => ['.jpg', '.jpeg', '.png'],
+				'notExpected' => ['.gif', '.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptExtensions' => [
+				'accept' => [
+					'extension' => 'jpg, png'
+				],
+				'expected' => ['.jpg', '.png'],
+				'notExpected' => ['.gif', '.jpeg', '.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptExtensionsAndMime' => [
+				'accept' => [
+					'extension' => 'foo, bar', // when mime is present, extensions are ignored
+					'mime' => 'image/jpeg, image/png'
+				],
+				'expected' => ['.jpg', '.jpeg', '.png'],
+				'notExpected' => ['.gif', '.js', '.pdf', '.docx', '.zip', '.foo', '.bar']
+			],
+			'acceptType' => [
+				'accept' => [
+					'type' => 'image'
+				],
+				'expected' => ['.jpg', '.jpeg', '.gif', '.png'],
+				'notExpected' => ['.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptTypeAndMime' => [
+				'accept' => [
+					'type' => 'document', // when mime is present, type is ignored
+					'mime' => 'image/jpeg, image/png'
+				],
+				'expected' => ['.jpg', '.jpeg', '.png'],
+				'notExpected' => ['.gif', '.js', '.pdf', '.docx', '.zip']
+			],
+			'acceptInteresect' => [
+				'accept' => [
+					'type' => 'image',
+					'extension' => 'jpg, png, foo, bar', // foo bar should be ignored
+				],
+				'expected' => ['.jpg', '.png'],
+				'notExpected' => ['.gif', '.js', '.pdf', '.docx', '.zip', '.foo', '.bar']
+			],
+		];
+
+		// set up the blueprint files
+		foreach ($this->acceptCases as $name => $case) {
+			Blueprint::$loaded['files/' . $name] = [
+				'accept' => $case['accept']
+			];
+		}
+	}
+
+	protected function tearDown(): void {
+		Blueprint::$loaded = [];
+		$this->parent = null;
+	}
+
+	/**
+	 * @covers ::acceptAttribute
+	 */
+	public function testAcceptAttribute() {
+		foreach($this->acceptCases as $name => $case) {
+			$file = new File([
+				'filename' => 'tmp',
+				'parent'   => $this->parent,
+				'template' => $name
+			]);
+			$acceptAttribute = $file->blueprint()->acceptAttribute();
+
+			$expected = $case['expected'];
+			$notExpected = $case['notExpected'];
+
+			foreach ($expected as $extension) {
+				$this->assertStringContainsString($extension, $acceptAttribute, "Case $name: $extension should be accepted");
+			}
+
+			foreach ($notExpected as $extension) {
+				$this->assertStringNotContainsString($extension, $acceptAttribute, "Case $name: $extension should not be accepted");
+			}
+		}
+	}
+}

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -14,7 +14,8 @@ class FileBlueprintTest extends TestCase
 	protected ?Page $parent;
 	protected array $acceptCases;
 
-	protected function setUp(): void {
+	protected function setUp(): void
+	{
 		$this->parent = Page::factory([
 			'slug' => 'test'
 		]);
@@ -85,7 +86,8 @@ class FileBlueprintTest extends TestCase
 		}
 	}
 
-	protected function tearDown(): void {
+	protected function tearDown(): void
+	{
 		Blueprint::$loaded = [];
 		$this->parent = null;
 	}
@@ -93,8 +95,9 @@ class FileBlueprintTest extends TestCase
 	/**
 	 * @covers ::acceptAttribute
 	 */
-	public function testAcceptAttribute() {
-		foreach($this->acceptCases as $name => $case) {
+	public function testAcceptAttribute()
+	{
+		foreach ($this->acceptCases as $name => $case) {
 			$file = new File([
 				'filename' => 'tmp',
 				'parent'   => $this->parent,

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -13,50 +13,42 @@ class FileBlueprintTest extends TestCase
 	public static function acceptAttributeProvider()
 	{
 		return [
-			[
-				'wildcard', // case name
+			'wildcard' => [ // case name
 				'image/*', // accept option in blueprint
 				['.jpg', '.jpeg', '.gif', '.png'], // expected extensions
 				['.js', '.pdf', '.docx', '.zip'] // not expected extensions
 			],
-			[
-				'mimeAsString',
+			'mimeAsString' => [
 				'image/jpeg, image/png',
 				['.jpg', '.jpeg', '.png'],
 				['.gif', '.js', '.pdf', '.docx', '.zip']
 			],
-			[
-				'mimeAsProperty',
+			'mimeAsProperty' => [
 				['mime' => 'image/jpeg, image/png'],
 				['.jpg', '.jpeg', '.png'],
 				['.gif', '.js', '.pdf', '.docx', '.zip']
 			],
-			[
-				'extensions',
+			'extensions' => [
 				['extension' => 'jpg, png'],
 				['.jpg', '.png'],
 				['.gif', '.jpeg', '.js', '.pdf', '.docx', '.zip']
 			],
-			[
-				'extensionsAndMime',
+			'extensionsAndMime' => [
 				['extension' => 'foo, bar', 'mime' => 'image/jpeg, image/png'],
 				['.jpg', '.jpeg', '.png'],
 				['.gif', '.js', '.pdf', '.docx', '.zip', '.foo', '.bar']
 			],
-			[
-				'type',
+			'type' => [
 				['type' => 'image'],
 				['.jpg', '.jpeg', '.gif', '.png'],
 				['.js', '.pdf', '.docx', '.zip']
 			],
-			[
-				'typeAndMime',
+			'typeAndMime' => [
 				['type' => 'document', 'mime' => 'image/jpeg, image/png'],
 				['.jpg', '.jpeg', '.png'],
 				['.gif', '.js', '.pdf', '.docx', '.zip']
 			],
-			[
-				'intersect',
+			'intersect' => [
 				['type' => 'image', 'extension' => 'jpg, png, foo, bar'],
 				['.jpg', '.png'],
 				['.gif', '.js', '.pdf', '.docx', '.zip', '.foo', '.bar']
@@ -64,32 +56,35 @@ class FileBlueprintTest extends TestCase
 		];
 	}
 
+	public function tearDown(): void
+	{
+		unset(Blueprint::$loaded['files/acceptAttribute']);
+	}
+
 	/**
 	 * @covers ::acceptAttribute
 	 * @dataProvider acceptAttributeProvider
 	 */
-	public function testAcceptAttribute($name, $accept, $expected, $notExpected)
+	public function testAcceptAttribute($accept, $expected, $notExpected)
 	{
-		Blueprint::$loaded['files/' . $name] = [
+		Blueprint::$loaded['files/acceptAttribute'] = [
 			'accept' => $accept
 		];
 
 		$file = new File([
 			'filename' => 'tmp',
 			'parent'   => $this->createMock(Page::class),
-			'template' => $name
+			'template' => 'acceptAttribute'
 		]);
 
 		$acceptAttribute = $file->blueprint()->acceptAttribute();
 
 		foreach ($expected as $extension) {
-			$this->assertStringContainsString($extension, $acceptAttribute, "Case $name: $extension should be accepted");
+			$this->assertStringContainsString($extension, $acceptAttribute);
 		}
 
 		foreach ($notExpected as $extension) {
-			$this->assertStringNotContainsString($extension, $acceptAttribute, "Case $name: $extension should not be accepted");
+			$this->assertStringNotContainsString($extension, $acceptAttribute);
 		}
-
-		unset(Blueprint::$loaded['files/' . $name]);
 	}
 }

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -10,7 +10,8 @@ use Kirby\TestCase;
  */
 class FileBlueprintTest extends TestCase
 {
-	public static function acceptAttributeProvider() {
+	public static function acceptAttributeProvider()
+	{
 		return [
 			[
 				'wildcard', // case name
@@ -61,7 +62,6 @@ class FileBlueprintTest extends TestCase
 				['.gif', '.js', '.pdf', '.docx', '.zip', '.foo', '.bar']
 			],
 		];
-
 	}
 
 	/**
@@ -79,6 +79,7 @@ class FileBlueprintTest extends TestCase
 			'parent'   => $this->createMock(Page::class),
 			'template' => $name
 		]);
+
 		$acceptAttribute = $file->blueprint()->acceptAttribute();
 
 		foreach ($expected as $extension) {

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\Blueprint;
 use Kirby\Cms\File;
-use Kirby\Cms\FileBlueprint;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
 

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -130,6 +130,23 @@ class MimeTest extends TestCase
 
 		$extensions = Mime::toExtensions('text/css');
 		$this->assertSame(['css'], $extensions);
+
+		// test matchWildcards: false (default value)
+		$extensions = Mime::toExtensions('image/*');
+		$this->assertSame(0, count($extensions));
+
+		// test matchWildcards: true
+		$extensions = Mime::toExtensions('image/*', true);
+		// use we only check for a positive and negative subset instead of a complete list,
+		// this should make sure the test doesn't break when a new image type is added
+		$shouldContain = ['jpg', 'jpeg', 'gif', 'png'];
+		$shouldNotContain = ['js', 'pdf', 'zip', 'docx'];
+		foreach ($shouldContain as $ext) {
+			$this->assertContains($ext, $extensions);
+		}
+		foreach ($shouldNotContain as $ext) {
+			$this->assertNotContains($ext, $extensions);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

Resumes the work of #4344, but without merge conflicts. 

It:
 - Implements the `acceptAttribute` method in the `FileBlueprint` class. 
 - deprecates the `acceptMime` method
 - adds a `$matchWildcard` attribute to the `Kirby\Filesystem\Mime::toTemplates()` method. 
 - changes the `upload` field mixin and the `files` section config to use `acceptAttribute` instead of `acceptMime`. 

The new `acceptAttribute` function returns a list of extensions, instead of the list of mime types. 

The primary merit is that this allows files to be uploaded which are unknown to Kirby, but without forwading an all allowing `*` to the browser file open dialog. Because Kirby and the browser no longer need to know a mime type for those files. 

The modified `Mime::toTemplates` method can now produce an array of extensions also for a mime type like `image/*`. 

### Breaking changes
I'm not sure if the deprecation is a breaking change, in which case we could just not deprecate the no longer used `toMime()` method. 

## Docs

acceptAttribute also has a clearer docblock which mentions how the list of file extensions is actually built: 
 - If there is a mime type, the "extension" and "type" options are ignored. 
 - If there is no mime type, only the intersection between the "extension" and "type" is returned (not their union). 
The reproduces how acceptMime worked. 

## Ready?
I think so :)

- [X] In-code documentation (wherever needed)
- [X] Unit tests for fixed bug/feature
- [X] Tests and checks all pass


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion