### PR TITLE
Disable license dialog in demo mode

### DIFF
--- a/src/Cms/LicenseStatus.php
+++ b/src/Cms/LicenseStatus.php
@@ -62,10 +62,11 @@ enum LicenseStatus: string
 	/**
 	 * Returns the dialog according to the status
 	 */
-	public function dialog(): string
+	public function dialog(): string|null
 	{
 		return match ($this) {
 			static::Missing => 'registration',
+			static::Demo    => null,
 			default         => 'license'
 		};
 	}


### PR DESCRIPTION
Otherwise the stats widget would open an empty license dialog in the online demo

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes

- Fix demo license in the online demo to avoid an empty license dialog

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
