### PR TITLE
Fix tab icon as emoji

### DIFF
--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -8,7 +8,7 @@
 		@click="onClick"
 	>
 		<span v-if="icon" class="k-button-icon">
-			<k-icon :type="icon" />
+			<k-icon-frame :icon="icon" back="transparent" />
 		</span>
 		<span v-if="text || $slots.default" class="k-button-text">
 			<!--


### PR DESCRIPTION
## This PR …

I preferred using `k-icon-frame` instead `k-icon` in button component. Also instead using `k-icon-frame`, we can solve putting `isEmoji` control in button component.

### Fixes
- Tab emoji icon not working #6276

### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
