### PR TITLE
Throw out reviewdog from CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -270,16 +270,4 @@ jobs:
 
       - name: Check for PHP coding style violations
         if: always() && steps.finishPrepare.outcome == 'success'
-        # Use the --dry-run flag in push builds to get a failed CI status
-        run: >
-          php-cs-fixer fix --diff
-          ${{ github.event_name != 'pull_request' && '--dry-run' || '' }}
-
-      - name: Create code suggestions from the coding style changes (on PR only)
-        if: >
-          always() && steps.finishPrepare.outcome == 'success' &&
-          github.event_name == 'pull_request'
-        uses: reviewdog/action-suggester@3d7fde6859623ad6174df5fd662677a0eb63310a # pin@v1
-        with:
-          tool_name: PHP-CS-Fixer
-          fail_on_error: "true"
+        run: php-cs-fixer fix --diff --dry-run

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -108,32 +108,10 @@ jobs:
 
       - name: Check for JavaScript coding style violations (ESLint)
         if: always() && steps.finishPrepare.outcome == 'success'
-        # Use the --no-fix flag in push builds to get a failed CI status
-        run: >
-          npm run lint -- --max-warnings 0 --format stylish
-          ${{ github.event_name != 'pull_request' && '--no-fix' || '' }}
+        run: npm run lint -- --max-warnings 0 --format stylish --no-fix
         working-directory: panel
-
-      - name: Create code suggestions from the coding style changes (on PR only)
-        if: >
-          always() && steps.finishPrepare.outcome == 'success' &&
-          github.event_name == 'pull_request'
-        uses: reviewdog/action-suggester@3d7fde6859623ad6174df5fd662677a0eb63310a # pin@v1
-        with:
-          tool_name: ESLint
-          fail_on_error: "true"
 
       - name: Check for JavaScript coding style violations (Prettier)
         if: always() && steps.finishPrepare.outcome == 'success'
-        # Use the --check flag to get a failed CI status
         run: npm run format --check
         working-directory: panel
-
-      - name: Create code suggestions from the coding style changes (on PR only)
-        if: >
-          always() && steps.finishPrepare.outcome == 'success' &&
-          github.event_name == 'pull_request'
-        uses: reviewdog/action-suggester@3d7fde6859623ad6174df5fd662677a0eb63310a # pin@v1
-        with:
-          tool_name: Prettier
-          fail_on_error: "true"


### PR DESCRIPTION
Now that Prettier doesn't support check and write mode simultaneously anyway, reviewdog (the automatic suggester) is not useful anymore for Prettier. TBH I think it was annoying anyway as it spammed the PRs with comments. So I suggest we throw it out completely.

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Housekeeping

- Remove reviewdog tool from CI to reduce complexity

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->

None
### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
