### PR TITLE
Support non string scalar values in where clause builder for 2 arguments

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -869,7 +869,7 @@ class Query
 					$this->bindings($args[1]);
 
 				// ->where('username like ?', 'myuser')
-				} elseif (is_string($args[0]) === true && is_string($args[1]) === true) {
+				} elseif (is_string($args[0]) === true && is_scalar($args[1]) === true) {
 					// prepared where clause
 					$result = $args[0];
 

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -481,6 +481,14 @@ class QueryTest extends TestCase
 
 		$this->assertSame(4, $count);
 
+		// numeric comparison (2 arguments)
+		$count = $this->database
+			->table('users')
+			->where('balance > ?', 0)
+			->count();
+
+		$this->assertSame(4, $count);
+
 		// boolean comparison
 		$count = $this->database
 			->table('users')
@@ -493,6 +501,14 @@ class QueryTest extends TestCase
 		$count = $this->database
 			->table('users')
 			->where('active', '=', false)
+			->count();
+
+		$this->assertSame(2, $count);
+
+		// boolean comparison (2 arguments)
+		$count = $this->database
+			->table('users')
+			->where('active = ?', false)
 			->count();
 
 		$this->assertSame(2, $count);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->
Adds support for non-string scalar values in where clause builder when using 2 arguments. Previously non-string scalar values would be silently ignored.

### Fixes
https://github.com/getkirby/kirby/issues/6291

### Breaking changes
None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
