### PR TITLE
Add language specific UUID URLs

### DIFF
--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -217,6 +217,9 @@ class LanguageRouterTest extends TestCase
 				'children' => [
 					[
 						'slug' => 'notes',
+					],
+					[
+						'slug' => 'albums',
 					]
 				]
 			],
@@ -230,5 +233,10 @@ class LanguageRouterTest extends TestCase
 
 		$this->assertSame(302, $response->code());
 		$this->assertSame('/en/notes', $response->header('Location'));
+
+		// not cached
+		$uuid = $app->page('albums')->uuid();
+		$response = $language->router()->call('@/page/' . $uuid->id());
+		$this->assertFalse($response);
 	}
 }

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -4,18 +4,21 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
 use Kirby\TestCase;
+use Kirby\Uuid\Uuid;
 
 class LanguageRouterTest extends TestCase
 {
 	protected $app;
 
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageRouter';
+
 	public function setUp(): void
 	{
-		App::destroy();
+		Dir::make(static::TMP);
 
 		$this->app = new App([
 			'roots' => [
-				'index' => '/dev/null'
+				'index' => static::TMP
 			],
 			'languages' => [
 				[
@@ -23,6 +26,12 @@ class LanguageRouterTest extends TestCase
 				]
 			]
 		]);
+	}
+
+	public function tearDown(): void
+	{
+		Dir::remove(static::TMP);
+		App::destroy();
 	}
 
 	public function testRouteForSingleLanguage()
@@ -200,5 +209,26 @@ class LanguageRouterTest extends TestCase
 
 		$language = $app->language('en');
 		$router   = $language->router()->call('notes/a/slug');
+	}
+
+	public function testUUIDRoute()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'notes',
+					]
+				]
+			],
+		]);
+
+		$uuid = $app->page('notes')->uuid()->id();
+
+		$language = $app->language('en');
+		$router   = $language->router()->call('@/page/' . $uuid);
+
+		// TODO: this should normally result in a redirect response
+		var_dump($router);
 	}
 }

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
 use Kirby\TestCase;
-use Kirby\Uuid\Uuid;
 
 class LanguageRouterTest extends TestCase
 {
@@ -223,12 +222,13 @@ class LanguageRouterTest extends TestCase
 			],
 		]);
 
-		$uuid = $app->page('notes')->uuid()->id();
+		$uuid = $app->page('notes')->uuid();
+		$uuid->populate();
 
 		$language = $app->language('en');
-		$router   = $language->router()->call('@/page/' . $uuid);
+		$response = $language->router()->call('@/page/' . $uuid->id());
 
-		// TODO: this should normally result in a redirect response
-		var_dump($router);
+		$this->assertSame(302, $response->code());
+		$this->assertSame('/en/notes', $response->header('Location'));
 	}
 }

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -50,7 +50,6 @@ class LanguageRouterTest extends TestCase
 		$router   = $language->router();
 		$routes   = $router->routes();
 
-		$this->assertCount(1, $routes);
 		$this->assertSame('(:any)', $routes[0]['pattern']);
 		$this->assertSame('en', $routes[0]['language']);
 		$this->assertSame('en', $router->call('anything'));
@@ -71,7 +70,7 @@ class LanguageRouterTest extends TestCase
 
 		$language = $app->language('en');
 
-		$this->assertCount(0, $language->router()->routes());
+		$this->assertCount(1, $language->router()->routes());
 	}
 
 	public function testRouteForMultipleLanguages()
@@ -92,7 +91,6 @@ class LanguageRouterTest extends TestCase
 		$router   = $language->router();
 		$routes   = $router->routes();
 
-		$this->assertCount(1, $routes);
 		$this->assertSame('(:any)', $routes[0]['pattern']);
 		$this->assertSame('en|de', $routes[0]['language']);
 		$this->assertSame('slug', $router->call('slug'));
@@ -116,7 +114,6 @@ class LanguageRouterTest extends TestCase
 		$router   = $language->router();
 		$routes   = $router->routes();
 
-		$this->assertCount(1, $routes);
 		$this->assertSame('(:any)', $routes[0]['pattern']);
 		$this->assertSame('*', $routes[0]['language']);
 		$this->assertSame('slug', $router->call('slug'));


### PR DESCRIPTION
## This PR …

This is an attempt to finally get parts of the multi-language UUID issues solved. (https://github.com/getkirby/kirby/issues/5551)

This adds a new route for language-specific UUID urls: 

Examples: 
```
/en/@/page/1234
/en/@/file/1234
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
