### PR TITLE
Don’t throw an exception if a model for a UUID cannot be found

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -481,10 +481,9 @@ return function (App $app) {
 
 				foreach ($elements as $element) {
 					foreach ($attributes as $attribute) {
-						if ($element->hasAttribute($attribute) && $url = $element->getAttribute($attribute)) {
+						if ($element->hasAttribute($attribute) && $uuid = $element->getAttribute($attribute)) {
 							try {
-								if ($uuid = Uuid::for($url)) {
-									$url = $uuid->model()?->url();
+								if ($url = Uuid::for($uuid)?->model()?->url()) {
 									$element->setAttribute($attribute, $url);
 								}
 							} catch (InvalidArgumentException) {

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -429,6 +429,20 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('<p>This is a <a href="/a">test</a><img src="/media/pages/a/' . $hash . '/test.jpg"></p>. This should not be <a href="https://getkirby.com">affected</a>.', (string)$result);
 	}
 
+	public function testPermalinksToUrlsWithMissingUUID()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+		]);
+
+		$field  = $this->field('<p>This is a <a href="/@/page/my-page">test</a></p>.');
+		$result = $field->permalinksToUrls();
+
+		$this->assertSame('<p>This is a <a href="/@/page/my-page">test</a></p>.', (string)$result);
+	}
+
 	public function testToStructure()
 	{
 		$data = [


### PR DESCRIPTION
## This PR …

### Fixes

- Don’t throw an exception if a model for a UUID cannot be found https://github.com/getkirby/kirby/issues/6165

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
