### PR TITLE
Don’t redeclare the dump helper if it already exists

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -109,7 +109,7 @@ if (Helpers::hasOverride('deprecated') === false) { // @codeCoverageIgnore
 	}
 }
 
-if (Helpers::hasOverride('dump') === false) { // @codeCoverageIgnore
+if (Helpers::hasOverride('dump') === false && function_exists('dump') === false) { // @codeCoverageIgnore
 	/**
 	 * Simple object and variable dumper
 	 * to help with debugging.


### PR DESCRIPTION
## This PR …

### Fixes

- Don't redeclare the dump helper if it already exists. This fixes Kirby for Herd Pro users and other cases where dump is already defined by the environment https://github.com/getkirby/kirby/issues/6250

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
