### PR TITLE
Suppress warnings e.g. if system CA is outside of open_basedir

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -59,7 +59,9 @@ class Remote
 		// use the system CA store by default if
 		// one has been configured in php.ini
 		$cainfo = ini_get('curl.cainfo');
-		if (empty($cainfo) === false && is_file($cainfo) === true) {
+
+		// Suppress warnings e.g. if system CA is outside of open_basedir (See: issue #6236)
+		if (empty($cainfo) === false && @is_file($cainfo) === true) {
 			$defaults['ca'] = self::CA_SYSTEM;
 		}
 


### PR DESCRIPTION
## This PR …

### Fixes

- Suppress warnings in the Remote class if system CA is outside of open_basedir https://github.com/getkirby/kirby/issues/6236

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
