### PR TITLE
Only apply responsive rules to tables with data-mobile attributes

### DIFF
--- a/panel/lab/components/tables/4_mobile/index.vue
+++ b/panel/lab/components/tables/4_mobile/index.vue
@@ -1,8 +1,14 @@
 <template>
 	<k-lab-examples>
 		<k-lab-example label="Horizontal">
+			<k-toggle-input
+				:text="['Scrolling', 'Responsive']"
+				v-model="responsive"
+				label="Responsive"
+			/>
+			<br />
 			<div class="k-table">
-				<table>
+				<table :data-responsive="responsive">
 					<thead>
 						<tr>
 							<th data-mobile="true">TH 1</th>
@@ -27,6 +33,11 @@
 
 <script>
 export default {
+	data() {
+		return {
+			responsive: true
+		};
+	},
 	computed: {
 		options() {
 			return [

--- a/panel/lab/components/tables/4_mobile/index.vue
+++ b/panel/lab/components/tables/4_mobile/index.vue
@@ -1,0 +1,50 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Horizontal">
+			<div class="k-table">
+				<table>
+					<thead>
+						<tr>
+							<th data-mobile="true">TH 1</th>
+							<th data-mobile="true" style="width: 6rem">TH 2</th>
+							<th>TH 3</th>
+							<th>TH 4</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="i in 2" :key="i">
+							<td data-mobile="true">TD 1</td>
+							<td data-mobile="true" style="width: 6rem">TD 2</td>
+							<td>TD 3</td>
+							<td>TD 4</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	computed: {
+		options() {
+			return [
+				{
+					text: "Edit",
+					icon: "edit"
+				},
+				{
+					text: "Duplicate",
+					icon: "copy"
+				},
+				"-",
+				{
+					text: "Delete",
+					icon: "trash"
+				}
+			];
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -32,13 +32,12 @@
 							:key="field.name"
 							@click="open(field.name)"
 						>
-							<th data-has-button data-mobile="true">
+							<th data-has-button>
 								<button type="button">{{ field.label }}</button>
 							</th>
 							<k-table-cell
 								:column="field"
 								:field="field"
-								:mobile="true"
 								:value="object[field.name]"
 								@input="cell(field.name, $event)"
 							/>

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -1,6 +1,10 @@
 <template>
 	<div :aria-disabled="disabled" class="k-table">
-		<table :data-disabled="disabled" :data-indexed="hasIndexColumn">
+		<table
+			:data-disabled="disabled"
+			:data-indexed="hasIndexColumn"
+			:data-responsive="isResponsive"
+		>
 			<!-- Header row -->
 			<thead>
 				<tr>
@@ -183,6 +187,10 @@ export default {
 			default: 1
 		},
 		/**
+		 * Enables hiding of columns on mobile
+		 */
+		responsive: Boolean,
+		/**
 		 * Array of table rows
 		 */
 		rows: Array,
@@ -261,6 +269,19 @@ export default {
 				this.options?.length > 0 ||
 				Object.values(this.values).filter((row) => row?.options).length > 0
 			);
+		},
+		isResponsive() {
+			if (this.responsive === true) {
+				return true;
+			}
+
+			if (
+				Object.values(this.columns).find((column) => column.mobile === true)
+			) {
+				return true;
+			}
+
+			return false;
 		}
 	},
 	watch: {
@@ -542,14 +563,17 @@ export default {
 	}
 
 	/**	Reset any custom column widths **/
-	.k-table:has([data-mobile])
+	.k-table
+		table[data-responsive="true"]
 		:where(th, td):not(.k-table-index-column):not(.k-table-options-column):not(
 			[style*="width:"]
 		) {
 		width: auto !important;
 	}
 
-	.k-table:has([data-mobile]) :where(th, td):not([data-mobile="true"]) {
+	.k-table
+		table[data-responsive="true"]
+		:where(th, td):not([data-mobile="true"]) {
 		display: none;
 	}
 }

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -542,12 +542,14 @@ export default {
 	}
 
 	/**	Reset any custom column widths **/
-	.k-table
-		:where(th, td):not(.k-table-index-column):not(.k-table-options-column) {
+	.k-table:has([data-mobile])
+		:where(th, td):not(.k-table-index-column):not(.k-table-options-column):not(
+			[style*="width:"]
+		) {
 		width: auto !important;
 	}
 
-	.k-table :where(th, td):not([data-mobile="true"]) {
+	.k-table:has([data-mobile]) :where(th, td):not([data-mobile="true"]) {
 		display: none;
 	}
 }


### PR DESCRIPTION
## This PR …

### Fixes

- Only apply responsive rules to tables with data-mobile attributes #6307 (partially also fixes #6228)

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
