### PR TITLE
Sanity check for the file id in the toFiles method

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -148,7 +148,7 @@ return function (App $app) {
 			$files  = new Files([]);
 
 			foreach ($field->toData($separator) as $id) {
-				if ($file = $parent->kirby()->file($id, $parent)) {
+				if (is_string($id) === true && $file = $parent->kirby()->file($id, $parent)) {
 					$files->add($file);
 				}
 			}


### PR DESCRIPTION
## This PR …

Branko sent me an issue in the Zero One theme, which boilt down to the toFiles method not properly checking for usable file ids. I think that this is a patch that's useful for a lot of cases. If the toFiles method is used on a field with yaml content, but the yaml array does actually have child arrays in each item, this would always break the entire site without the patch in the PR.

### Fixes

- More stability for the `toFiles` method by checking for valid file IDs 

### Breaking changes

None

### For review team

<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
