### PR TITLE
Remove MethodSignatureMismatch ignore

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -24,13 +24,6 @@
 				<directory name="config" />
 			</errorLevel>
 		</InvalidScope>
-
-		<!-- TODO: This check gets flagged by Psalm for unknown reasons in PHP 8.2 -->
-		<MethodSignatureMismatch>
-			<errorLevel type="suppress">
-				<file name="src/Toolkit/Date.php" />
-			</errorLevel>
-		</MethodSignatureMismatch>
 	</issueHandlers>
 
 	<plugins>


### PR DESCRIPTION
Psalm no longer reports this error.