### PR TITLE
Fix `k-tabs` inline variable assignment

### DIFF
--- a/panel/lab/components/tabs/index.vue
+++ b/panel/lab/components/tabs/index.vue
@@ -6,6 +6,9 @@
 		<k-lab-example label="too many tabs">
 			<k-tabs :tabs="tabs" />
 		</k-lab-example>
+		<k-lab-example label="theme: notice">
+			<k-tabs :tabs="tabs" theme="notice" />
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -1,17 +1,17 @@
 <template>
 	<nav v-if="tabs.length > 1" class="k-tabs">
 		<k-button
-			v-for="tabBtn in visible"
+			v-for="btn in buttons"
 			ref="visible"
-			:key="tabBtn.name"
-			v-bind="(btn = button(tabBtn))"
+			:key="btn.name"
+			v-bind="btn"
 			variant="dimmed"
 			class="k-tab-button"
 		>
 			{{ btn.text }}
 
-			<span v-if="tabBtn.badge" :data-theme="theme" class="k-tabs-badge">
-				{{ tabBtn.badge }}
+			<span v-if="btn.badge" :data-theme="theme" class="k-tabs-badge">
+				{{ btn.badge }}
 			</span>
 		</k-button>
 
@@ -74,6 +74,9 @@ export default {
 		};
 	},
 	computed: {
+		buttons() {
+			return this.visible.map(this.button);
+		},
 		current() {
 			const tab =
 				this.tabs.find((tab) => tab.name === this.tab) ?? this.tabs[0];
@@ -106,9 +109,8 @@ export default {
 	methods: {
 		button(tab) {
 			return {
-				link: tab.link,
+				...tab,
 				current: tab.name === this.current,
-				icon: tab.icon,
 				title: tab.label,
 				text: tab.label ?? tab.text ?? tab.name
 			};


### PR DESCRIPTION
Vue 3 doesn't like that inline variable assignment `v-bind="(btn = button(tabBtn))"`.
It just renders each instance of the loop with the last assignment.

So moving this out of the template section into a proper computed property.