### PR TITLE
Fix `v-bind` order

### DIFF
--- a/panel/src/components/Dialogs/PageMoveDialog.vue
+++ b/panel/src/components/Dialogs/PageMoveDialog.vue
@@ -1,13 +1,13 @@
 <template>
 	<k-dialog
 		ref="dialog"
+		v-bind="$props"
 		:submit-button="{
 			icon: 'parent',
 			text: $t('move')
 		}"
 		class="k-page-move-dialog"
 		size="medium"
-		v-bind="$props"
 		@cancel="$emit('cancel')"
 		@submit="$emit('submit', value)"
 	>

--- a/panel/src/components/Dialogs/SearchDialog.vue
+++ b/panel/src/components/Dialogs/SearchDialog.vue
@@ -1,11 +1,11 @@
 <template>
 	<k-dialog
+		v-bind="$props"
 		:cancel-button="false"
 		:submit-button="false"
 		class="k-search-dialog"
 		role="search"
 		size="medium"
-		v-bind="$props"
 		@cancel="$emit('cancel')"
 		@submit="submit"
 	>

--- a/panel/src/components/Drawers/FiberDrawer.vue
+++ b/panel/src/components/Drawers/FiberDrawer.vue
@@ -4,10 +4,10 @@
 			:is="drawer.component"
 			v-for="drawer in $panel.drawer.history.milestones"
 			:key="drawer.id"
+			v-bind="isCurrent(drawer.id) ? $panel.drawer.props : drawer.props"
 			:breadcrumb="$panel.drawer.breadcrumb"
 			:disabled="isCurrent(drawer.id) === false"
 			:visible="true"
-			v-bind="isCurrent(drawer.id) ? $panel.drawer.props : drawer.props"
 			v-on="isCurrent(drawer.id) ? $panel.drawer.listeners() : drawer.on"
 		/>
 	</div>

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -27,8 +27,8 @@
 			<component
 				:is="customComponent"
 				ref="editor"
-				:tabs="tabs"
 				v-bind="$props"
+				:tabs="tabs"
 				v-on="listeners"
 			/>
 		</div>

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -1,9 +1,9 @@
 <template>
 	<component
 		:is="component"
+		v-bind="attrs"
 		:data-has-icon="Boolean(icon)"
 		:data-has-text="Boolean(text || $slots.default)"
-		v-bind="attrs"
 		class="k-button"
 		@click="onClick"
 	>


### PR DESCRIPTION
Vue 3 will be strict about the order, so we can already make sure that v-bind goes first, so it can be overwritten by individual bindings that follow.