### PR TITLE
Use `mounted` lifecycle hook

### DIFF
--- a/panel/src/components/Dialogs/ModelsDialog.vue
+++ b/panel/src/components/Dialogs/ModelsDialog.vue
@@ -104,7 +104,7 @@ export default {
 			}
 		}
 	},
-	created() {
+	mounted() {
 		this.fetch();
 	},
 	methods: {

--- a/panel/src/components/Dropdowns/Dropdown.vue
+++ b/panel/src/components/Dropdowns/Dropdown.vue
@@ -9,7 +9,7 @@
  * @deprecated 4.0.0 Use `<k-dropdown-content>` as standalone.
  */
 export default {
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			"<k-dropdown> will be removed in a future version. Since Kirby 4.0, you don't need it anymore as wrapper element. Use `<k-dropdown-content>` as standalone instead."
 		);

--- a/panel/src/components/Dropdowns/DropdownContent.vue
+++ b/panel/src/components/Dropdowns/DropdownContent.vue
@@ -117,7 +117,7 @@ export default {
 			opener: null
 		};
 	},
-	created() {
+	mounted() {
 		if (this.align) {
 			window.panel.deprecated(
 				"<k-dropdown-content>: `align` prop will be removed in a future version. Use the `alignX` prop instead."

--- a/panel/src/components/Forms/Autocomplete.vue
+++ b/panel/src/components/Forms/Autocomplete.vue
@@ -75,7 +75,7 @@ export default {
 			selected: { text: null }
 		};
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			"<k-autocomplete> will be removed in a future version."
 		);

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -112,7 +112,7 @@ export default {
 			return this.$helper.keyboard.metaKey() + "+v";
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("paste", this.paste);
 	},
 	destroyed() {

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -159,7 +159,12 @@ export default {
 			this.blocks = this.value;
 		}
 	},
-	created() {
+	mounted() {
+		// focus first block
+		if (this.$props.autofocus === true) {
+			setTimeout(this.focus, 100);
+		}
+
 		this.$events.on("blur", this.onBlur);
 		this.$events.on("click", this.onClickGlobal);
 		this.$events.on("copy", this.onCopy);
@@ -174,12 +179,6 @@ export default {
 		this.$events.off("keydown", this.onKey);
 		this.$events.off("keyup", this.onKey);
 		this.$events.off("paste", this.onPaste);
-	},
-	mounted() {
-		// focus first block
-		if (this.$props.autofocus === true) {
-			setTimeout(this.focus, 100);
-		}
 	},
 	methods: {
 		async add(type = "text", index) {

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -57,7 +57,7 @@ export default {
 			};
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("file.delete", this.removeById);
 	},
 	destroyed() {

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -187,7 +187,7 @@ export default {
 			immediate: true
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("click", this.onOutsideClick);
 	},
 	destroyed() {

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -167,7 +167,7 @@ export default {
 			}
 		}
 	},
-	created() {
+	mounted() {
 		// refresh lock data every 10 seconds
 		if (this.supportsLocking) {
 			this.isLoading = setInterval(this.check, 10000);

--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -137,7 +137,7 @@ export default {
 			immediate: true
 		}
 	},
-	created() {
+	mounted() {
 		// make sure to commit input value when Cmd+S is hit
 		this.$events.on("keydown.cmd.s", this.onBlur);
 	},

--- a/panel/src/components/Layout/AspectRatio.vue
+++ b/panel/src/components/Layout/AspectRatio.vue
@@ -23,7 +23,7 @@ export default {
 			return this.$helper.ratio(this.ratio);
 		}
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			"<k-aspect-ratio> will be removed in a future version. Use the <k-frame> instead."
 		);

--- a/panel/src/components/Layout/Bubble.vue
+++ b/panel/src/components/Layout/Bubble.vue
@@ -74,7 +74,7 @@ export default {
 		 */
 		text: String
 	},
-	created() {
+	mounted() {
 		if (this.back) {
 			window.panel.deprecated(
 				"<k-bubble>: `back` prop will be removed in a future version. Use the `--bubble-back` CSS property instead."

--- a/panel/src/components/Layout/Grid.vue
+++ b/panel/src/components/Layout/Grid.vue
@@ -24,7 +24,7 @@ export default {
 		 */
 		variant: String
 	},
-	created() {
+	mounted() {
 		if (this.gutter) {
 			window.panel.deprecated(
 				'<k-grid>: the `gutter` prop will be removed in a future version. Use `style="gap: "` or `variant` prop instead.'

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -73,7 +73,7 @@ export default {
 		tabs: Array
 	},
 	emits: ["edit"],
-	created() {
+	mounted() {
 		if (this.tabs) {
 			window.panel.deprecated(
 				"<k-header>: `tabs` prop isn't supported anymore and has no effect. Use `<k-tabs>` as standalone component instead."

--- a/panel/src/components/Layout/View.vue
+++ b/panel/src/components/Layout/View.vue
@@ -17,7 +17,7 @@ export default {
 		 */
 		align: String
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated("<k-view> will be removed in a future version.");
 	}
 };

--- a/panel/src/components/Misc/Loader.vue
+++ b/panel/src/components/Misc/Loader.vue
@@ -9,7 +9,7 @@
  * @deprecated 4.0.0 Use `<k-icon type="loader" />` instead
  */
 export default {
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			'<k-loader> will be removed in a future version. Use <k-icon type="loader" /> instead.'
 		);

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -74,7 +74,7 @@ export default {
 			return [...segments, ...this.crumbs];
 		}
 	},
-	created() {
+	mounted() {
 		if (this.view) {
 			window.panel.deprecated(
 				"<k-breadcrumb>: `view` prop will be removed in a future version. Use `crumbs` instead."

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -199,7 +199,7 @@ export default {
 			return "button";
 		}
 	},
-	created() {
+	mounted() {
 		if (this.tooltip) {
 			window.panel.deprecated(
 				"<k-button>: the `tooltip` prop will be removed in a future version. Use the `title` prop instead."

--- a/panel/src/components/Navigation/ButtonDisabled.vue
+++ b/panel/src/components/Navigation/ButtonDisabled.vue
@@ -25,7 +25,7 @@ export default {
 		theme: String,
 		tooltip: String
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			'<k-button-disabled> will be removed in a future version. Use <k-button :disabled="true"> instead.'
 		);

--- a/panel/src/components/Navigation/ButtonLink.vue
+++ b/panel/src/components/Navigation/ButtonLink.vue
@@ -38,7 +38,7 @@ export default {
 		theme: String,
 		tooltip: String
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			'<k-button-link> will be removed in a future version. Use <k-button link="https//getkirby.com"> instead.'
 		);

--- a/panel/src/components/Navigation/ButtonNative.vue
+++ b/panel/src/components/Navigation/ButtonNative.vue
@@ -42,7 +42,7 @@ export default {
 			default: "button"
 		}
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			"<k-button-native> will be removed in a future version. Use <k-button> instead."
 		);

--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -26,7 +26,7 @@ export default {
 			state: []
 		};
 	},
-	async created() {
+	async mounted() {
 		if (this.items) {
 			this.state = this.items;
 		} else {

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -48,7 +48,7 @@ export default {
 			this.fetch();
 		}
 	},
-	created() {
+	mounted() {
 		this.onInput = debounce(this.onInput, 50);
 		this.fetch();
 	},

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -57,7 +57,7 @@ export default {
 			};
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("model.update", this.reload);
 		this.$events.on("file.sort", this.reload);
 	},

--- a/panel/src/components/Sections/InfoSection.vue
+++ b/panel/src/components/Sections/InfoSection.vue
@@ -17,7 +17,7 @@ export default {
 			theme: null
 		};
 	},
-	async created() {
+	async mounted() {
 		const response = await this.load();
 		this.icon = response.icon;
 		this.label = response.label;

--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -184,7 +184,7 @@ export default {
 			this.reload();
 		}
 	},
-	created() {
+	mounted() {
 		this.search = debounce(this.search, 200);
 		this.load();
 	},

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -45,7 +45,7 @@ export default {
 			return "pages";
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("page.changeStatus", this.reload);
 		this.$events.on("page.sort", this.reload);
 	},

--- a/panel/src/components/Sections/StatsSection.vue
+++ b/panel/src/components/Sections/StatsSection.vue
@@ -22,7 +22,7 @@ export default {
 			size: null
 		};
 	},
-	async created() {
+	async mounted() {
 		const section = await this.load();
 		this.isLoading = false;
 		this.headline = section.headline;

--- a/panel/src/components/Text/Headline.vue
+++ b/panel/src/components/Text/Headline.vue
@@ -52,7 +52,7 @@ export default {
 		}
 	},
 	emits: ["click"],
-	created() {
+	mounted() {
 		if (this.size) {
 			window.panel.deprecated(
 				"<k-headline>: the `size` prop will be removed in a future version. Use the `tag` prop instead."

--- a/panel/src/components/Text/Text.vue
+++ b/panel/src/components/Text/Text.vue
@@ -49,7 +49,7 @@ export default {
 			};
 		}
 	},
-	created() {
+	mounted() {
 		if (this.theme) {
 			window.panel.deprecated(
 				'<k-text>: the `theme` prop will be removed in a future version. For help text, add `.k-help "` CSS class instead.'

--- a/panel/src/components/Views/LegacyPluginView.vue
+++ b/panel/src/components/Views/LegacyPluginView.vue
@@ -13,7 +13,7 @@ export default {
 	props: {
 		id: String
 	},
-	created() {
+	mounted() {
 		window.panel.deprecated(
 			"<k-plugin-view> will be removed in a future version."
 		);

--- a/panel/src/components/Views/Login/LoginView.vue
+++ b/panel/src/components/Views/Login/LoginView.vue
@@ -53,7 +53,7 @@ export default {
 			return "k-login-view";
 		}
 	},
-	created() {
+	mounted() {
 		this.$store.dispatch("content/clear");
 	},
 	methods: {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -55,7 +55,7 @@ export default {
 			immediate: true
 		}
 	},
-	created() {
+	mounted() {
 		this.$events.on("model.reload", this.$reload);
 		this.$events.on("keydown.left", this.toPrev);
 		this.$events.on("keydown.right", this.toNext);

--- a/panel/src/components/Views/System/SystemSecurity.vue
+++ b/panel/src/components/Views/System/SystemSecurity.vue
@@ -43,7 +43,7 @@ export default {
 			issues: structuredClone(this.security)
 		};
 	},
-	async created() {
+	async mounted() {
 		console.info(
 			"Running system health checks for the Panel system view; failed requests in the following console output are expected behavior."
 		);

--- a/panel/src/components/Views/System/SystemView.vue
+++ b/panel/src/components/Views/System/SystemView.vue
@@ -32,7 +32,7 @@ export default {
 		security: Array,
 		urls: Object
 	},
-	created() {
+	mounted() {
 		// print exceptions from the backend's update check
 		// to console for debugging
 		if (this.exceptions.length > 0) {


### PR DESCRIPTION
As `destroyed` will be renamed to `unmounted` in Vue 3 and I think it makes sense to consistently use `mounted`/`unmounted` then.