### PR TITLE
Plugin registration: named arguments

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -714,18 +714,17 @@ trait AppPlugins
 	public static function plugin(
 		string $name,
 		array $extends = null,
-		string|null $version = null
+		string|null $version = null,
+		string|null $root = null
 	): PLugin|null {
 		if ($extends === null) {
 			return static::$plugins[$name] ?? null;
 		}
 
-		// get the correct root for the plugin
-		$extends['root'] ??= dirname(debug_backtrace()[0]['file']);
-
 		$plugin = new Plugin(
 			name:    $name,
 			extends: $extends,
+			root:    $root,
 			version: $version
 		);
 
@@ -798,7 +797,11 @@ trait AppPlugins
 				// register as anonymous plugin (without actual extensions)
 				// to be picked up by the Panel\Document class when
 				// rendering the Panel view
-				static::plugin('plugins/' . $dirname, ['root' => $dir]);
+				static::plugin(
+					name: 'plugins/' . $dirname,
+					extends: [],
+					root: $dir
+				);
 			} else {
 				continue;
 			}

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -714,7 +714,7 @@ trait AppPlugins
 	public static function plugin(
 		string $name,
 		array $extends = null,
-		string|null $version = null,
+		array $info = [],
 		string|null $root = null
 	): PLugin|null {
 		if ($extends === null) {
@@ -724,8 +724,8 @@ trait AppPlugins
 		$plugin = new Plugin(
 			name:    $name,
 			extends: $extends,
+			info:    $info,
 			root:    $root ?? dirname(debug_backtrace()[0]['file']),
-			version: $version
 		);
 
 		$name = $plugin->name();

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -715,7 +715,8 @@ trait AppPlugins
 		string $name,
 		array $extends = null,
 		array $info = [],
-		string|null $root = null
+		string|null $root = null,
+		string|null $version = null
 	): PLugin|null {
 		if ($extends === null) {
 			return static::$plugins[$name] ?? null;
@@ -725,7 +726,9 @@ trait AppPlugins
 			name:    $name,
 			extends: $extends,
 			info:    $info,
-			root:    $root ?? dirname(debug_backtrace()[0]['file']),
+			// TODO: Remove fallback to $extends in v5
+			root:    $root ?? $extends['root'] ?? dirname(debug_backtrace()[0]['file']),
+			version: $version
 		);
 
 		$name = $plugin->name();

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -724,7 +724,7 @@ trait AppPlugins
 		$plugin = new Plugin(
 			name:    $name,
 			extends: $extends,
-			root:    $root,
+			root:    $root ?? dirname(debug_backtrace()[0]['file']),
 			version: $version
 		);
 

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -713,7 +713,8 @@ trait AppPlugins
 	 */
 	public static function plugin(
 		string $name,
-		array $extends = null
+		array $extends = null,
+		string|null $version = null
 	): PLugin|null {
 		if ($extends === null) {
 			return static::$plugins[$name] ?? null;
@@ -722,8 +723,13 @@ trait AppPlugins
 		// get the correct root for the plugin
 		$extends['root'] ??= dirname(debug_backtrace()[0]['file']);
 
-		$plugin = new Plugin($name, $extends);
-		$name   = $plugin->name();
+		$plugin = new Plugin(
+			name:    $name,
+			extends: $extends,
+			version: $version
+		);
+
+		$name = $plugin->name();
 
 		if (isset(static::$plugins[$name]) === true) {
 			throw new DuplicateException('The plugin "' . $name . '" has already been registered');

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -29,14 +29,18 @@ class Helpers
 	 * ```
 	 */
 	public static $deprecations = [
+		// The internal `$model->contentFile*()` methods have been deprecated
+		'model-content-file' => true,
+
+		// Passing an `info` array inside the `extends` array has been deprecated.
+		// Pass the individual entries directly as named arguments.
+		'plugin-extends-root' => false,
+
 		// Passing a single space as value to `Xml::attr()` has been
 		// deprecated. In a future version, passing a single space won't
 		// render an empty value anymore but a single space.
 		// To render an empty value, please pass an empty string.
 		'xml-attr-single-space' => true,
-
-		// The internal `$model->contentFile*()` methods have been deprecated
-		'model-content-file' => true,
 	];
 
 	/**

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -26,7 +26,6 @@ use Throwable;
 class Plugin
 {
 	protected PluginAssets $assets;
-	protected string $root;
 
 	// caches
 	protected array|null $info = null;
@@ -41,12 +40,25 @@ class Plugin
 	public function __construct(
 		protected string $name,
 		protected array $extends = [],
+
+		protected string|null $root = null,
 		protected string|null $version = null
 	) {
 		static::validateName($name);
 
-		$this->root = $extends['root'] ?? dirname(debug_backtrace()[0]['file']);
-		$this->info = empty($extends['info']) === false && is_array($extends['info']) ? $extends['info'] : null;
+		// TODO: Remove in v5
+		if ($root = $extends['root'] ?? null) {
+			Helpers::deprecated('Plugin "' . $name . '": Passing the `root` inside the `extends` array has been deprecated. Pass it directly as named argument `root`.', 'plugin-extends-root');
+			$this->root ??= $root;
+		}
+
+		$this->root ??= dirname(debug_backtrace()[0]['file']);
+
+		// TODO: Remove info property in v5
+		if ($info = $extends['info'] ?? null) {
+			Helpers::deprecated('Plugin "' . $name . '": Passing an `info` array inside the `extends` array has been deprecated. Pass the individual entries directly as named arguments.', 'plugin-extends-root');
+			$this->info = empty($info) === false && is_array($info) ? $info : null;
+		}
 
 		unset($this->extends['root'], $this->extends['info']);
 	}
@@ -120,6 +132,7 @@ class Plugin
 	 */
 	public function info(): array
 	{
+		// TODO: remove info prop in v5
 		if (is_array($this->info) === true) {
 			return $this->info;
 		}

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -52,7 +52,7 @@ class Plugin
 
 		$this->root ??= dirname(debug_backtrace()[0]['file']);
 
-		// TODO: Remove info property in v5
+		// TODO: Remove in v5
 		if ($info = $extends['info'] ?? null) {
 			Helpers::deprecated('Plugin "' . $name . '": Passing an `info` array inside the `extends` array has been deprecated. Pass the individual entries directly as named `info` argument.', 'plugin-extends-root');
 

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -48,6 +48,7 @@ class Plugin
 
 		// TODO: Remove in v5
 		if ($root = $extends['root'] ?? null) {
+			Helpers::deprecated('Plugin "' . $name . '": Passing the `root` inside the `extends` array has been deprecated. Pass it directly as named argument `root`.', 'plugin-extends-root');
 			$this->root ??= $root;
 		}
 
@@ -55,6 +56,7 @@ class Plugin
 
 		// TODO: Remove info property in v5
 		if ($info = $extends['info'] ?? null) {
+			Helpers::deprecated('Plugin "' . $name . '": Passing an `info` array inside the `extends` array has been deprecated. Pass the individual entries directly as named arguments.', 'plugin-extends-root');
 			$this->info = empty($info) === false && is_array($info) ? $info : null;
 		}
 

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -38,7 +38,8 @@ class Plugin
 		protected string $name,
 		protected array $extends = [],
 		protected array $info = [],
-		protected string|null $root = null
+		protected string|null $root = null,
+		protected string|null $version = null,
 	) {
 		static::validateName($name);
 
@@ -70,7 +71,7 @@ class Plugin
 			$info = [];
 		}
 
-		$this->info   = [...$info, ...$this->info];
+		$this->info = [...$info, ...$this->info];
 	}
 
 	/**
@@ -315,9 +316,9 @@ class Plugin
 			$version = null;
 		}
 
-		// fallback to the version provided in the plugin's index.php,
-		// or from the composer.json file
-		$version ??= $this->info()['version'] ?? null;
+		// fallback to the version provided in the plugin's index.php: as named
+		// argument, entry in the info array or from the composer.json file
+		$version ??= $this->version ?? $this->info()['version'] ?? null;
 
 		if (
 			is_string($version) !== true ||

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -42,13 +42,12 @@ class Plugin
 		protected array $extends = [],
 
 		protected string|null $root = null,
-		protected string|null $version = null
+ 		protected string|null $version = null
 	) {
 		static::validateName($name);
 
 		// TODO: Remove in v5
 		if ($root = $extends['root'] ?? null) {
-			Helpers::deprecated('Plugin "' . $name . '": Passing the `root` inside the `extends` array has been deprecated. Pass it directly as named argument `root`.', 'plugin-extends-root');
 			$this->root ??= $root;
 		}
 
@@ -56,7 +55,6 @@ class Plugin
 
 		// TODO: Remove info property in v5
 		if ($info = $extends['info'] ?? null) {
-			Helpers::deprecated('Plugin "' . $name . '": Passing an `info` array inside the `extends` array has been deprecated. Pass the individual entries directly as named arguments.', 'plugin-extends-root');
 			$this->info = empty($info) === false && is_array($info) ? $info : null;
 		}
 

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -26,8 +26,6 @@ use Throwable;
 class Plugin
 {
 	protected PluginAssets $assets;
-	protected array $extends;
-	protected string $name;
 	protected string $root;
 
 	// caches
@@ -40,14 +38,15 @@ class Plugin
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the plugin name has an invalid format
 	 */
-	public function __construct(string $name, array $extends = [])
-	{
+	public function __construct(
+		protected string $name,
+		protected array $extends = [],
+		protected string|null $version = null
+	) {
 		static::validateName($name);
 
-		$this->name    = $name;
-		$this->extends = $extends;
-		$this->root    = $extends['root'] ?? dirname(debug_backtrace()[0]['file']);
-		$this->info    = empty($extends['info']) === false && is_array($extends['info']) ? $extends['info'] : null;
+		$this->root = $extends['root'] ?? dirname(debug_backtrace()[0]['file']);
+		$this->info = empty($extends['info']) === false && is_array($extends['info']) ? $extends['info'] : null;
 
 		unset($this->extends['root'], $this->extends['info']);
 	}
@@ -295,8 +294,8 @@ class Plugin
 	 */
 	public function version(): string|null
 	{
-		$composerName = $this->info()['name'] ?? null;
-		$version      = $this->info()['version'] ?? null;
+		$composerName = $this->info()['name']    ?? null;
+		$version      = $this->info()['version'] ?? $this->version ?? null;
 
 		try {
 			// if plugin doesn't have version key in composer.json file

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -40,9 +40,8 @@ class Plugin
 	public function __construct(
 		protected string $name,
 		protected array $extends = [],
-
 		protected string|null $root = null,
- 		protected string|null $version = null
+		protected string|null $version = null
 	) {
 		static::validateName($name);
 

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -307,16 +307,19 @@ class Plugin
 	 */
 	public function version(): string|null
 	{
-		$composerName = $this->info()['name']    ?? null;
-		$version      = $this->info()['version'] ?? $this->version ?? null;
+		$name = $this->info()['name'] ?? null;
 
 		try {
-			// if plugin doesn't have version key in composer.json file
-			// try to get version from "vendor/composer/installed.php"
-			$version ??= InstalledVersions::getPrettyVersion($composerName);
+			// try to get version from "vendor/composer/installed.php",
+			// this is the most reliable source for the version
+			$version = InstalledVersions::getPrettyVersion($name);
 		} catch (Throwable) {
-			return null;
+			$version = null;
 		}
+
+		// fallback to the version provided in the plugin's index.php,
+		// then from the composer.json file
+		$version ??= $this->version ?? $this->info()['version'] ?? null;
 
 		if (
 			is_string($version) !== true ||

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -406,9 +406,10 @@ class PluginTest extends TestCase
 	 */
 	public function testToArray()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $root = static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: $root = static::FIXTURES . '/plugin-version'
+		);
 
 		$expected = [
 			'authors' => [
@@ -431,9 +432,10 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatus()
 	{
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertInstanceOf(UpdateStatus::class, $updateStatus);
@@ -453,9 +455,10 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusWithPrefix()
 	{
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version-prefix'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version-prefix'
+		);
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertInstanceOf(UpdateStatus::class, $updateStatus);
@@ -475,9 +478,11 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusWithoutVersion()
 	{
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin'
+		);
+
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertInstanceOf(UpdateStatus::class, $updateStatus);
@@ -498,9 +503,11 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusUnknownPlugin()
 	{
-		$plugin = new Plugin('getkirby/unknown', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/unknown',
+			root: static::FIXTURES . '/plugin-version'
+		);
+
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertInstanceOf(UpdateStatus::class, $updateStatus);
@@ -532,9 +539,10 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertNull($updateStatus);
@@ -558,9 +566,11 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
+
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertNull($updateStatus);
@@ -577,9 +587,11 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
+
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertNull($updateStatus);
@@ -600,9 +612,11 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
+
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertNull($updateStatus);
@@ -623,9 +637,10 @@ class PluginTest extends TestCase
 			]
 		]);
 
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
 		$updateStatus = $plugin->updateStatus();
 
 		$this->assertInstanceOf(UpdateStatus::class, $updateStatus);
@@ -645,9 +660,11 @@ class PluginTest extends TestCase
 	 */
 	public function testUpdateStatusCustomData()
 	{
-		$plugin = new Plugin('getkirby/public', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/public',
+			root: static::FIXTURES . '/plugin-version'
+		);
+
 		$updateStatus = $plugin->updateStatus([
 			'latest' => '87654.3.2',
 			'versions' => [
@@ -730,9 +747,10 @@ class PluginTest extends TestCase
 	 */
 	public function testVersionComposer()
 	{
-		$plugin = new Plugin('getkirby/test-plugin-composer', [
-			'root' => static::FIXTURES . '/plugin-version-composer'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin-composer',
+			root: static::FIXTURES . '/plugin-version-composer'
+		);
 
 		$this->assertSame('5.2.3', $plugin->version());
 	}
@@ -742,9 +760,10 @@ class PluginTest extends TestCase
 	 */
 	public function testVersionComposerNoVersionSet()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin-version-composer-noversionset'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version-composer-noversionset'
+		);
 
 		$this->assertNull($plugin->version());
 	}
@@ -754,10 +773,11 @@ class PluginTest extends TestCase
 	 */
 	public function testVersionComposerOverride()
 	{
-		$plugin = new Plugin('getkirby/test-plugin-composer', [
-			'root' => static::FIXTURES . '/plugin-version-composer-override'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin-composer',
+			root: static::FIXTURES . '/plugin-version-composer-override'
+		);
 
-		$this->assertSame('3.1.2', $plugin->version());
+		$this->assertSame('5.2.3', $plugin->version());
 	}
 }

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -170,7 +170,7 @@ class PluginTest extends TestCase
 	 */
 	public function testId()
 	{
-		$plugin = new Plugin( $id = 'abc-1234/DEF-56789');
+		$plugin = new Plugin($id = 'abc-1234/DEF-56789');
 		$this->assertSame($id, $plugin->id());
 	}
 
@@ -216,6 +216,23 @@ class PluginTest extends TestCase
 		);
 
 		$this->assertSame('MIT', $plugin->info()['license']);
+	}
+
+	/**
+	 * @covers ::info
+	 */
+	public function testInfoFromPropAndManifest()
+	{
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version',
+			info: [
+				'version' => '2.1.0'
+			]
+		);
+
+		$this->assertSame('MIT', $plugin->info()['license']);
+		$this->assertSame('2.1.0', $plugin->info()['version']);
 	}
 
 	/**

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -61,9 +61,10 @@ class PluginTest extends TestCase
 	 */
 	public function test__call()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin'
+		);
 
 		$this->assertSame('MIT', $plugin->license());
 	}
@@ -73,13 +74,16 @@ class PluginTest extends TestCase
 	 */
 	public function testAsset()
 	{
-		$root = static::FIXTURES . '/plugin-assets';
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'assets' => [
-				'c.css' => $a = $root . '/a.css',
-				'd.css' => $b = $root . '/foo/b.css'
+		$root   = static::FIXTURES . '/plugin-assets';
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			extends: [
+				'assets' => [
+					'c.css' => $a = $root . '/a.css',
+					'd.css' => $b = $root . '/foo/b.css'
+				]
 			]
-		]);
+		);
 
 		$this->assertSame($a, $plugin->asset('c.css')->root());
 		$this->assertSame($b, $plugin->asset('d.css')->root());
@@ -93,12 +97,15 @@ class PluginTest extends TestCase
 		$root = static::FIXTURES . '/plugin-assets';
 
 		// assets defined in plugin config
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root'   => $root,
-			'assets' => [
-				'c.css' => $root . '/a.css',
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: $root,
+			extends: [
+				'assets' => [
+					'c.css' => $root . '/a.css',
+				]
 			]
-		]);
+		);
 
 		$this->assertInstanceOf(PluginAssets::class, $plugin->assets());
 		$this->assertSame($root . '/a.css', $plugin->asset('c.css')->root());
@@ -109,9 +116,10 @@ class PluginTest extends TestCase
 	 */
 	public function testAuthors()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root:  static::FIXTURES . '/plugin'
+		);
 
 		$authors = [
 			[
@@ -132,9 +140,10 @@ class PluginTest extends TestCase
 	 */
 	public function testAuthorsNames()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin'
+		);
 
 		$this->assertSame('A, B', $plugin->authorsNames());
 	}
@@ -144,11 +153,14 @@ class PluginTest extends TestCase
 	 */
 	public function testExtends()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', $extends = [
-			'fields' => [
-				'test' => []
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			extends: $extends = [
+				'fields' => [
+					'test' => []
+				]
 			]
-		]);
+		);
 
 		$this->assertSame($extends, $plugin->extends());
 	}
@@ -158,8 +170,7 @@ class PluginTest extends TestCase
 	 */
 	public function testId()
 	{
-		$plugin = new Plugin($id = 'abc-1234/DEF-56789', []);
-
+		$plugin = new Plugin( $id = 'abc-1234/DEF-56789');
 		$this->assertSame($id, $plugin->id());
 	}
 
@@ -168,9 +179,10 @@ class PluginTest extends TestCase
 	 */
 	public function testInfo()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version'
+		);
 
 		$authors = [
 			[
@@ -196,11 +208,12 @@ class PluginTest extends TestCase
 	 */
 	public function testInfoFromProps()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'info' => [
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			info: [
 				'license' => 'MIT'
 			]
-		]);
+		);
 
 		$this->assertSame('MIT', $plugin->info()['license']);
 	}
@@ -210,9 +223,10 @@ class PluginTest extends TestCase
 	 */
 	public function testInfoWhenEmpty()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: __DIR__
+		);
 
 		$this->assertSame([], $plugin->info());
 	}
@@ -222,11 +236,12 @@ class PluginTest extends TestCase
 	 */
 	public function testLinkFromHomepage()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'info' => [
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			info: [
 				'homepage' => 'https://getkirby.com'
 			]
-		]);
+		);
 
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
@@ -236,11 +251,12 @@ class PluginTest extends TestCase
 	 */
 	public function testLinkFromInvalidHomepage()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'info' => [
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			info: [
 				'homepage' => 'test'
 			]
-		]);
+		);
 
 		$this->assertNull($plugin->link());
 	}
@@ -250,13 +266,14 @@ class PluginTest extends TestCase
 	 */
 	public function testLinkFromSupportDocs()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'info' => [
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			info: [
 				'support' => [
 					'docs' => 'https://getkirby.com'
 				]
 			]
-		]);
+		);
 
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
@@ -266,13 +283,14 @@ class PluginTest extends TestCase
 	 */
 	public function testLinkFromSupportSource()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'info' => [
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			info: [
 				'support' => [
 					'source' => 'https://getkirby.com'
 				]
 			]
-		]);
+		);
 
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
@@ -323,9 +341,10 @@ class PluginTest extends TestCase
 	 */
 	public function testManifest()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => __DIR__
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: __DIR__
+		);
 
 		$this->assertSame(__DIR__ . '/composer.json', $plugin->manifest());
 	}
@@ -336,8 +355,7 @@ class PluginTest extends TestCase
 	 */
 	public function testName()
 	{
-		$plugin = new Plugin($name = 'abc-1234/DEF-56789', []);
-
+		$plugin = new Plugin($name = 'abc-1234/DEF-56789');
 		$this->assertSame($name, $plugin->name());
 	}
 
@@ -348,8 +366,7 @@ class PluginTest extends TestCase
 	public function testNameWithInvalidInput()
 	{
 		$this->expectException(InvalidArgumentException::class);
-
-		new Plugin('äöü/!!!', []);
+		new Plugin('äöü/!!!');
 	}
 
 	/**
@@ -357,11 +374,14 @@ class PluginTest extends TestCase
 	 */
 	public function testOption()
 	{
-		App::plugin('developer/plugin', [
-			'options' => [
-				'foo' => 'bar'
+		App::plugin(
+			name: 'developer/plugin',
+			extends: [
+				'options' => [
+					'foo' => 'bar'
+				]
 			]
-		]);
+		);
 
 		$app = $this->app->clone();
 
@@ -374,8 +394,7 @@ class PluginTest extends TestCase
 	 */
 	public function testPrefix()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', []);
-
+		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertSame('getkirby.test-plugin', $plugin->prefix());
 	}
 
@@ -385,7 +404,6 @@ class PluginTest extends TestCase
 	public function testRoot()
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
-
 		$this->assertSame(__DIR__, $plugin->root());
 	}
 
@@ -394,9 +412,10 @@ class PluginTest extends TestCase
 	 */
 	public function testRootWithCustomSetup()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => $custom = __DIR__ . '/test',
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: $custom = __DIR__ . '/test'
+		);
 
 		$this->assertSame($custom, $plugin->root());
 	}
@@ -699,9 +718,10 @@ class PluginTest extends TestCase
 	 */
 	public function testVersion()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin-version'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version'
+		);
 
 		$this->assertSame('1.0.0', $plugin->version());
 	}
@@ -709,11 +729,28 @@ class PluginTest extends TestCase
 	/**
 	 * @covers ::version
 	 */
+	public function testVersionFromInfo()
+	{
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version',
+			info: [
+				'version' => '1.1.0'
+			]
+		);
+
+		$this->assertSame('1.1.0', $plugin->version());
+	}
+
+	/**
+	 * @covers ::version
+	 */
 	public function testVersionMissing()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin'
+		);
 
 		$this->assertNull($plugin->version());
 	}
@@ -723,9 +760,10 @@ class PluginTest extends TestCase
 	 */
 	public function testVersionPrefixed()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin-version-prefix'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version-prefix'
+		);
 
 		$this->assertSame('1.0.0', $plugin->version());
 	}
@@ -735,9 +773,10 @@ class PluginTest extends TestCase
 	 */
 	public function testVersionInvalid()
 	{
-		$plugin = new Plugin('getkirby/test-plugin', [
-			'root' => static::FIXTURES . '/plugin-version-invalid'
-		]);
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version-invalid'
+		);
 
 		$this->assertNull($plugin->version());
 	}

--- a/tests/Cms/Plugins/PluginTest.php
+++ b/tests/Cms/Plugins/PluginTest.php
@@ -228,11 +228,13 @@ class PluginTest extends TestCase
 			root: static::FIXTURES . '/plugin-version',
 			info: [
 				'version' => '2.1.0'
-			]
+			],
+			version: '5.3.0'
 		);
 
 		$this->assertSame('MIT', $plugin->info()['license']);
 		$this->assertSame('2.1.0', $plugin->info()['version']);
+		$this->assertSame('5.3.0', $plugin->version());
 	}
 
 	/**
@@ -741,6 +743,20 @@ class PluginTest extends TestCase
 		);
 
 		$this->assertSame('1.0.0', $plugin->version());
+	}
+
+	/**
+	 * @covers ::version
+	 */
+	public function testVersionFromArgument()
+	{
+		$plugin = new Plugin(
+			name: 'getkirby/test-plugin',
+			root: static::FIXTURES . '/plugin-version',
+			version: '1.2.0'
+		);
+
+		$this->assertSame('1.2.0', $plugin->version());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Background: https://github.com/getkirby/kirby/pull/5764

### Enhancement
- Plugin registration with named arguments
- Allow passing plugin info, e.g. version, as argument that gets merged with the info from composer.json
```php
Kirby::plugin(
    name: 'my/plugin',
    extends: [],
    info: [
        'homepage' => 'https://my-plugin.example.com'
    ],
    version: '1.0.0'
);
```



### Deprecated
- Plugin registration: Passing `info` or `root` in plugin extends array. Instead pass these as standalone named arguments.



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->

- Update examples of how to register a plugin throughout getkirby.com to use named arguments

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
