### PR TITLE
`(image:)` escape alt text for smartypants

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -154,7 +154,7 @@ return [
 				'height' => $tag->height,
 				'class'  => $tag->imgclass,
 				'title'  => $tag->title,
-				'alt'    => $tag->alt ?? ''
+				'alt'    => Str::esc($tag->alt ?? '')
 			]);
 
 			if ($tag->kirby()->option('kirbytext.image.figure', true) === false) {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- `(image: )` KirbyTag: escape `alt` text for proper value, e.g. when smartypants option is activated
#6344



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
