### PR TITLE
File: fix not creating PDF as different format

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -139,8 +139,8 @@ trait FileActions
 
 			// rename and/or resize the file if configured by new blueprint
 			$create = $file->blueprint()->create();
+			$file = $file->manipulate($create);
 			$file = $file->changeExtension($file, $create['format'] ?? null);
-			$file->manipulate($create);
 
 			return $file;
 		});
@@ -266,7 +266,6 @@ trait FileActions
 		// we need to already rename it so that the correct file rules
 		// are applied
 		$create = $file->blueprint()->create();
-		$file = $file->changeExtension($file, $create['format'] ?? null);
 
 		// run the hook
 		$arguments = compact('file', 'upload');
@@ -284,6 +283,7 @@ trait FileActions
 
 			// resize the file on upload if configured
 			$file = $file->manipulate($create);
+			$file = $file->changeExtension($file, $create['format'] ?? null);
 
 			// store the content if necessary
 			// (always create files in the default language)
@@ -384,8 +384,8 @@ trait FileActions
 
 			// apply the resizing/crop options from the blueprint
 			$create = $file->blueprint()->create();
-			$file   = $file->changeExtension($file, $create['format'] ?? null);
 			$file   = $file->manipulate($create);
+			$file   = $file->changeExtension($file, $create['format'] ?? null);
 
 			// return a fresh clone
 			return $file->clone();


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

If we change the extension first, `$file->isResizable()` will test for the new/target format, not the original one (e.g. PDF).

### Fixes
- File `create` `format` option is not applied to non-images anymore 
#6268

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
