### PR TITLE
Object field: no inline edit when field disabled

### DIFF
--- a/panel/lab/components/fieldpreviews/toggle/index.vue
+++ b/panel/lab/components/fieldpreviews/toggle/index.vue
@@ -27,6 +27,14 @@
 				<!-- @code-end -->
 			</k-lab-table-cell>
 		</k-lab-example>
+
+		<k-lab-example label="Disabled">
+			<k-lab-table-cell>
+				<!-- @code -->
+				<k-toggle-field-preview :field="{ disabled: true }" />
+				<!-- @code-end -->
+			</k-lab-table-cell>
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -17,6 +17,9 @@ export default {
 	mixins: [FieldPreview],
 	emits: ["input"],
 	computed: {
+		isEditable() {
+			return this.field.disabled !== true;
+		},
 		text() {
 			return this.column.text !== false ? this.field.text : null;
 		}

--- a/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ToggleFieldPreview.vue
@@ -1,10 +1,11 @@
 <template>
 	<div class="k-toggle-field-preview">
 		<k-toggle-input
+			:disabled="!isEditable"
 			:text="text"
 			:value="value"
 			@input="$emit('input', $event)"
-			@click.native.stop
+			@click.native="isEditable ? $event.stopPropagation() : null"
 		/>
 	</div>
 </template>

--- a/panel/src/mixins/forms/fieldPreview.js
+++ b/panel/src/mixins/forms/fieldPreview.js
@@ -10,5 +10,10 @@ export default {
 			type: Object
 		},
 		value: {}
+	},
+	computed: {
+		isEditable() {
+			return this.field.disabled !== true;
+		}
 	}
 };

--- a/panel/src/mixins/forms/fieldPreview.js
+++ b/panel/src/mixins/forms/fieldPreview.js
@@ -10,10 +10,5 @@ export default {
 			type: Object
 		},
 		value: {}
-	},
-	computed: {
-		isEditable() {
-			return this.field.disabled !== true;
-		}
 	}
 };


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Fixes
- Object field: inline previews are not editable anymore when the subfield is disabled
#6346

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
