### PR TITLE
Require PHP 8.2

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           php-version: ${{ env.php }}
           coverage: none
-          tools: php-cs-fixer:3.13.0
+          tools: php-cs-fixer:3.52.1
 
       - name: Cache analysis data
         id: finishPrepare

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        php: [ "8.1", "8.2", "8.3" ]
+        php: ["8.2", "8.3"]
     env:
       extensions: mbstring, ctype, curl, gd, apcu, memcached
       ini: apc.enabled=1, apc.enable_cli=1, pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      php: "8.1"
+      php: "8.2"
       extensions: mbstring, ctype, curl, gd, apcu, memcached
 
     steps:
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      php: "8.1"
+      php: "8.2"
 
     steps:
       - name: Checkout

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      php: "8.1"
+      php: "8.2"
 
     steps:
       - name: Checkout

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,6 +40,7 @@ return $config
 		'no_empty_statement' => true,
 		'no_leading_namespace_whitespace' => true,
 		'no_mixed_echo_print' => ['use' => 'echo'],
+		// 'no_superfluous_phpdoc_tags' => true,
 		'no_unneeded_control_parentheses' => true,
 		'no_unused_imports' => true,
 		'no_useless_return' => true,
@@ -47,11 +48,13 @@ return $config
 		// 'phpdoc_add_missing_param_annotation' => ['only_untyped' => false], // adds params in the wrong order
 		'phpdoc_align' => ['align' => 'left'],
 		'phpdoc_indent' => true,
+		'phpdoc_param_order' => true,
 		'phpdoc_scalar' => true,
 		'phpdoc_trim' => true,
 		'short_scalar_cast' => true,
 		'single_line_comment_style' => true,
 		'single_quote' => true,
+		'statement_indentation' => ['stick_comment_to_next_continuous_control_statement' => true],
 		'ternary_to_null_coalescing' => true,
 		'whitespace_after_comma_in_array' => true
 	])

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,7 +5,7 @@
  * stop at older or too recent versions
  */
 if (
-	version_compare(PHP_VERSION, '8.1.0', '>=') === false ||
+	version_compare(PHP_VERSION, '8.2.0', '>=') === false ||
 	version_compare(PHP_VERSION, '8.4.0', '<')  === false
 ) {
 	die(include __DIR__ . '/views/php.php');

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 		},
 		"optimize-autoloader": true,
 		"platform": {
-			"php": "8.1.0"
+			"php": "8.2.0"
 		},
 		"platform-check": false
 	},

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"source": "https://github.com/getkirby/kirby"
 	},
 	"require": {
-		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+		"php": "~8.2.0 || ~8.3.0",
 		"ext-SimpleXML": "*",
 		"ext-ctype": "*",
 		"ext-curl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4c8e3ce904878c2f03903e95bbfa461",
+    "content-hash": "ad38d70467f53214530c3912e0c8fd78",
     "packages": [
         {
             "name": "christian-riesen/base32",
@@ -1096,7 +1096,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.2.0 || ~8.3.0",
         "ext-simplexml": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
@@ -1111,7 +1111,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/config/components.php
+++ b/config/components.php
@@ -324,7 +324,6 @@ return [
 	 * @param string $src Root of the original file
 	 * @param string $dst Template string for the root to the desired destination
 	 * @param array $options All thumb options that should be applied: `width`, `height`, `crop`, `blur`, `grayscale`
-	 * @return string
 	 */
 	'thumb' => function (
 		App $kirby,

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -252,7 +252,7 @@ class FileRules
 	 * Validates the extension, MIME type and filename
 	 *
 	 * @param $mime If not passed, the MIME type is detected from the file,
-	 *              if `false`, the MIME type is not validated for performance reasons
+	 *             if `false`, the MIME type is not validated for performance reasons
 	 * @throws \Kirby\Exception\InvalidArgumentException If the extension, MIME type or filename is missing or forbidden
 	 */
 	public static function validFile(

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -251,8 +251,8 @@ class FileRules
 	/**
 	 * Validates the extension, MIME type and filename
 	 *
-	 * @param $mime If not passed, the MIME type is detected from the file,
-	 *             if `false`, the MIME type is not validated for performance reasons
+	 * @param string|false|null $mime If not passed, the MIME type is detected from the file,
+	 *                                if `false`, the MIME type is not validated for performance reasons
 	 * @throws \Kirby\Exception\InvalidArgumentException If the extension, MIME type or filename is missing or forbidden
 	 */
 	public static function validFile(

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -345,7 +345,7 @@ class System
 	public function php(): bool
 	{
 		return
-			version_compare(PHP_VERSION, '8.1.0', '>=') === true &&
+			version_compare(PHP_VERSION, '8.2.0', '>=') === true &&
 			version_compare(PHP_VERSION, '8.4.0', '<')  === true;
 	}
 

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -146,7 +146,7 @@ abstract class Sql
 	 * Combines an identifier (table and column)
 	 *
 	 * @param $values bool Whether the identifier is going to be used for a VALUES clause;
-	 *                only relevant for SQLite
+	 *               only relevant for SQLite
 	 */
 	public function combineIdentifier(string $table, string $column, bool $values = false): string
 	{

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -145,8 +145,8 @@ abstract class Sql
 	/**
 	 * Combines an identifier (table and column)
 	 *
-	 * @param $values bool Whether the identifier is going to be used for a VALUES clause;
-	 *               only relevant for SQLite
+	 * @param bool $values Whether the identifier is going to be used for a VALUES clause;
+	 *                    only relevant for SQLite
 	 */
 	public function combineIdentifier(string $table, string $column, bool $values = false): string
 	{

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -146,7 +146,7 @@ abstract class Sql
 	 * Combines an identifier (table and column)
 	 *
 	 * @param bool $values Whether the identifier is going to be used for a VALUES clause;
-	 *                    only relevant for SQLite
+	 *                     only relevant for SQLite
 	 */
 	public function combineIdentifier(string $table, string $column, bool $values = false): string
 	{

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -168,7 +168,7 @@ class Dom
 	public static function isAllowedAttr(
 		DOMAttr $attr,
 		array $options
-	): bool|string {
+	): true|string {
 		$options = static::normalizeSanitizeOptions($options);
 
 		$allowedTags = $options['allowedTags'];
@@ -218,7 +218,7 @@ class Dom
 	public static function isAllowedGlobalAttr(
 		DOMAttr $attr,
 		array $options
-	): bool|string {
+	): true|string {
 		$options = static::normalizeSanitizeOptions($options);
 
 		$allowedAttrs = $options['allowedAttrs'];
@@ -258,7 +258,7 @@ class Dom
 	public static function isAllowedUrl(
 		string $url,
 		array $options
-	): bool|string {
+	): true|string {
 		$options = static::normalizeSanitizeOptions($options);
 
 		$url = Str::lower($url);

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -420,7 +420,7 @@ class ClassLoader
      * @param  string    $class The name of the class
      * @return true|null True if loaded, null otherwise
      */
-    public function loadClass($class): true|null
+    public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
             $includeFile = self::$includeFile;

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -420,7 +420,7 @@ class ClassLoader
      * @param  string    $class The name of the class
      * @return true|null True if loaded, null otherwise
      */
-    public function loadClass($class)
+    public function loadClass($class): true|null
     {
         if ($file = $this->findFile($class)) {
             $includeFile = self::$includeFile;

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'getkirby/cms',
         'pretty_version' => '4.2.0-rc.1',
         'version' => '4.2.0.0-RC1',
-        'reference' => NULL,
+        'reference' => null,
         'type' => 'kirby-cms',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -49,7 +49,7 @@
         'getkirby/cms' => array(
             'pretty_version' => '4.2.0-rc.1',
             'version' => '4.2.0.0-RC1',
-            'reference' => NULL,
+            'reference' => null,
             'type' => 'kirby-cms',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

I think it's quite settled that we will release Kirby 5 somewhere around the end of future support of PHP 8.1 and we can consider raising the PHP requirement.

Main question: Do we think webhosters will keep up the tempo or could this be a problem?

Opening this PR already as I think, it's good to merge it early - only once we are certain we want to do it - so we can develop all of v5 already with the new baseline of PHP 8.2.

### Breaking changes
- Kirby requires at least PHP 8.2


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
