### PR TITLE
Fix table column regressions

### DIFF
--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -137,12 +137,15 @@ return [
 			$form = Form::for($model)->values();
 
 			foreach ($this->columns as $columnName => $column) {
-				// don't overwrite columns
-				$item[$columnName] ??= match (empty($column['value'])) {
+				$item[$columnName] = match (empty($column['value'])) {
 					// if column value defined, resolve the query
 					false   => $model->toString($column['value']),
-					// otherwise use the form value
-					default => $form[$column['id'] ?? $columnName] ?? null,
+					// otherwise use the form value,
+					// but don't overwrite columns
+					default =>
+						$item[$columnName] ??
+						$form[$column['id'] ?? $columnName] ??
+						null,
 				};
 			}
 

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -91,10 +91,10 @@
 						<!-- Cell -->
 						<k-table-cell
 							v-for="(column, columnIndex) in columns"
+							:id="columnIndex"
 							:key="rowIndex + '-' + columnIndex"
 							:column="column"
 							:field="fields[columnIndex]"
-							:id="columnIndex"
 							:row="row"
 							:mobile="column.mobile"
 							:value="row[columnIndex]"

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -94,6 +94,7 @@
 							:key="rowIndex + '-' + columnIndex"
 							:column="column"
 							:field="fields[columnIndex]"
+							:id="columnIndex"
 							:row="row"
 							:mobile="column.mobile"
 							:value="row[columnIndex]"

--- a/panel/src/components/Layout/TableCell.vue
+++ b/panel/src/components/Layout/TableCell.vue
@@ -1,5 +1,10 @@
 <template>
-	<td :data-align="column.align" :data-mobile="mobile" class="k-table-cell">
+	<td
+		:data-align="column.align"
+		:data-column-id="id"
+		:data-mobile="mobile"
+		class="k-table-cell"
+	>
 		<!-- Table cell type component -->
 		<component
 			:is="component"
@@ -25,6 +30,7 @@ export default {
 		 * Optional corresponding field options
 		 */
 		field: Object,
+		id: String,
 		/**
 		 * Keep cell on mobile
 		 */


### PR DESCRIPTION
- [ ] Double check if the current state is actually intended, see issue reported for docs: https://github.com/getkirby/getkirby.com/issues/2291

Two fixes for 4.2.0 regressions:

- properly allowing to override column values for default ids (e.g. `text`) when explicit `value` option is set
- also apply `data-column-id` to td in table body row