### PR TITLE
Writer toolbar: support inline node buttons

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -158,6 +158,15 @@ export default {
 		markButtons() {
 			const available = this.editor.buttons("mark");
 
+			// add node buttons that are meant to be displayed inline
+			const nodes = this.editor.buttons("node");
+
+			for (const node in nodes) {
+				if (nodes[node].inline === true) {
+					available[node] = nodes[node];
+				}
+			}
+
 			if (this.marks === false || this.$helper.object.length(available) === 0) {
 				return {};
 			}
@@ -178,11 +187,15 @@ export default {
 
 			return buttons;
 		},
-		/**
-		 * All nodes that are available and requested based on the `nodes` prop
-		 */
-		nodeButtons() {
+		availableNodes() {
 			const available = this.editor.buttons("node");
+
+			// skip node buttons that are meant to be displayed inline
+			for (const node in available) {
+				if (available[node].inline === true) {
+					delete available[node];
+				}
+			}
 
 			if (this.nodes === false || this.$helper.object.length(available) === 0) {
 				return {};
@@ -193,15 +206,21 @@ export default {
 				delete available.paragraph;
 			}
 
+			return available;
+		},
+		/**
+		 * All nodes that are available and requested based on the `nodes` prop
+		 */
+		nodeButtons() {
 			if (this.nodes === true) {
-				return available;
+				return this.availableNodes;
 			}
 
 			const buttons = {};
 
 			for (const node of this.nodes) {
-				if (available[node]) {
-					buttons[node] = available[node];
+				if (this.availableNodes[node]) {
+					buttons[node] = this.availableNodes[node];
 				}
 			}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

TBD: Is it too confusing that in the blueprint option, it would then have to be listed under `marks` instead of `nodes` even though it's technically a custom node?

- [ ] requires bode to be added to both, marks and nodes option, currently 

### Enhancement
- Custom writer nodes: button can now set an `inline: true` option to not be listed in the toolbar dropdown but inline alongside marks

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->

```js
window.panel.plugin("your/plugin", {
  writerNodes: {
    placeholder: {
      get button() {
        return {
          icon: "wand",
          inline: true
        }
      },
 ```


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
