### PR TITLE
Fix `nodeInputRule`

### DIFF
--- a/panel/src/components/Forms/Writer/Nodes/HorizontalRule.js
+++ b/panel/src/components/Forms/Writer/Nodes/HorizontalRule.js
@@ -7,7 +7,15 @@ export default class HorizontalRule extends Node {
 	}
 
 	inputRules({ type, utils }) {
-		return [utils.nodeInputRule(/^(?:---|___\s|\*\*\*\s)$/, type)];
+		// create regular input rule for horizontal rule
+		const rule = utils.nodeInputRule(/^(?:---|___\s|\*\*\*\s)$/, type);
+
+		// extend handler to remove the leftover empty line
+		const handler = rule.handler;
+		rule.handler = (state, match, start, end) =>
+			handler(state, match, start, end).replaceWith(start - 1, start, "");
+
+		return [rule];
 	}
 
 	get name() {

--- a/panel/src/components/Forms/Writer/Utils/nodeInputRule.js
+++ b/panel/src/components/Forms/Writer/Utils/nodeInputRule.js
@@ -6,7 +6,7 @@ export default function (regexp, type, getAttrs) {
 		const { tr } = state;
 
 		if (match[0]) {
-			tr.replaceWith(start - 1, end, type.create(attrs));
+			tr.replaceWith(start, end, type.create(attrs));
 		}
 
 		return tr;


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

For the purpose of the hr node, `nodeInputRule` also deleted the previous character before the match (to remove the extra leftover empty line). This behavior doesn't make sense for other nodes, in particular inline nodes. This PR fixes the behavior of `nodeInputRule` and adds the custom behavior directly to the hr node.

### Fixes
- Editor: `nodeInputRule` only overwrites matched selection

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
