### PR TITLE
Type hinting for collections

### DIFF
--- a/src/Blueprint/Collection.php
+++ b/src/Blueprint/Collection.php
@@ -16,6 +16,8 @@ use TypeError;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Blueprint\Node>
+ *
  * // TODO: include in test coverage once blueprint refactoring is done
  * @codeCoverageIgnore
  */

--- a/src/Blueprint/Collection.php
+++ b/src/Blueprint/Collection.php
@@ -16,7 +16,7 @@ use TypeError;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Blueprint\Node>
+ * @extends \Kirby\Cms\Collection<\Kirby\Blueprint\Node>
  *
  * // TODO: include in test coverage once blueprint refactoring is done
  * @codeCoverageIgnore

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -19,6 +19,8 @@ use Throwable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Item<\Kirby\Cms\Blocks>
  */
 class Block extends Item
 {

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -20,6 +20,8 @@ use Throwable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Block>
  */
 class Blocks extends Items
 {

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -21,7 +21,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Block>
+ * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Block>
  */
 class Blocks extends Items
 {

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -21,7 +21,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Block>
+ * @extends \Kirby\Cms\Items<\Kirby\Cms\Block>
  */
 class Blocks extends Items
 {

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -22,26 +22,24 @@ use Kirby\Uuid\Uuid;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template TValue
+ * @template-extends \Kirby\Toolkit\Collection<TValue>
  */
 class Collection extends BaseCollection
 {
 	use HasMethods;
 
 	/**
-	 * Stores the parent object, which is needed
-	 * in some collections to get the finder methods right.
-	 *
-	 * @var object
+	 * @var \Kirby\Cms\Pagination|null
 	 */
-	protected $parent;
+	protected $pagination;
 
 	/**
-	 * Magic getter function
-	 *
-	 * @param string $key
-	 * @param mixed $arguments
-	 * @return mixed
+	 * Stores the parent object, which is needed
+	 * in some collections to get the finder methods right.
 	 */
+
 	public function __call(string $key, $arguments)
 	{
 		// collection methods
@@ -53,13 +51,14 @@ class Collection extends BaseCollection
 	/**
 	 * Creates a new Collection with the given objects
 	 *
-	 * @param array $objects
-	 * @param object|null $parent
+	 * @param object|null $parent Stores the parent object,
+	 *                            which is needed in some collections
+	 *                            to get the finder methods right
 	 */
-	public function __construct($objects = [], $parent = null)
-	{
-		$this->parent = $parent;
-
+	public function __construct(
+		iterable $objects = [],
+		protected object|null $parent = null
+	) {
 		foreach ($objects as $object) {
 			$this->add($object);
 		}
@@ -72,7 +71,7 @@ class Collection extends BaseCollection
 	 * child classes can override it again to add validation
 	 * and custom behavior depending on the object type
 	 *
-	 * @param object $object
+	 * @param TValue $object
 	 */
 	public function __set(string $id, $object): void
 	{
@@ -84,7 +83,7 @@ class Collection extends BaseCollection
 	 * override from the Toolkit Collection is needed to
 	 * make the CMS collections case-sensitive
 	 */
-	public function __unset($id)
+	public function __unset(string $id)
 	{
 		unset($this->data[$id]);
 	}
@@ -94,9 +93,10 @@ class Collection extends BaseCollection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param mixed $object
+	 * @param TValue|self|array $object
+	 * @return $this
 	 */
-	public function add($object)
+	public function add($object): static
 	{
 		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
@@ -115,12 +115,18 @@ class Collection extends BaseCollection
 	/**
 	 * Appends an element to the data array
 	 *
-	 * @param mixed ...$args
-	 * @param mixed $key Optional collection key, will be determined from the item if not given
-	 * @param mixed $item
-	 * @return \Kirby\Cms\Collection
+	 * ```php
+	 * $collection->append($object);
+	 * $collection->append('key', $object);
+	 * $collection->append([$object1, $object2]);
+	 * ```
+	 *
+	 * If not collection key is passed, it will be determined from the item (id)
+	 *
+	 * @param array|string|TValue ...$args
+	 * @return $this
 	 */
-	public function append(...$args)
+	public function append(...$args): static
 	{
 		if (count($args) === 1) {
 			// try to determine the key from the provided item
@@ -141,7 +147,7 @@ class Collection extends BaseCollection
 	 * Find a single element by an attribute and its value
 	 *
 	 * @param mixed $value
-	 * @return mixed|null
+	 * @return TValue|null
 	 */
 	public function findBy(string $attribute, $value)
 	{
@@ -158,13 +164,15 @@ class Collection extends BaseCollection
 	 * Groups the items by a given field or callback. Returns a collection
 	 * with an item for each group and a collection for each group.
 	 *
-	 * @param string|Closure $field
+	 * @param string|\Closure $field
 	 * @param bool $caseInsensitive Ignore upper/lowercase for group names
-	 * @return \Kirby\Cms\Collection
+	 * @return self
 	 * @throws \Kirby\Exception\Exception
 	 */
-	public function group($field, bool $caseInsensitive = true)
-	{
+	public function group(
+		$field,
+		bool $caseInsensitive = true
+	): self {
 		if (is_string($field) === true) {
 			$groups = new Collection([], $this->parent());
 
@@ -202,7 +210,7 @@ class Collection extends BaseCollection
 	 * Checks if the given object or id
 	 * is in the collection
 	 *
-	 * @param string|object $key
+	 * @param string|TValue $key
 	 */
 	public function has($key): bool
 	{
@@ -218,7 +226,7 @@ class Collection extends BaseCollection
 	 * The method will automatically detect objects
 	 * or ids and then search accordingly.
 	 *
-	 * @param string|object $needle
+	 * @param string|TValue $needle
 	 */
 	public function indexOf($needle): int|false
 	{
@@ -232,10 +240,10 @@ class Collection extends BaseCollection
 	/**
 	 * Returns a Collection without the given element(s)
 	 *
-	 * @param mixed ...$keys any number of keys, passed as individual arguments
-	 * @return \Kirby\Cms\Collection
+	 * @param string|array|object ...$keys any number of keys,
+	 *                                     passed as individual arguments
 	 */
-	public function not(...$keys)
+	public function not(string|array|object ...$keys): static
 	{
 		$collection = $this->clone();
 
@@ -262,7 +270,7 @@ class Collection extends BaseCollection
 	 * @param mixed ...$arguments
 	 * @return $this|static
 	 */
-	public function paginate(...$arguments)
+	public function paginate(...$arguments): static
 	{
 		$this->pagination = Pagination::for($this, ...$arguments);
 
@@ -274,11 +282,9 @@ class Collection extends BaseCollection
 	}
 
 	/**
-	 * Get the pagination object
-	 *
-	 * @return \Kirby\Cms\Pagination|null
+	 * Get the previously added pagination object
 	 */
-	public function pagination()
+	public function pagination(): Pagination|null
 	{
 		return $this->pagination;
 	}
@@ -286,7 +292,7 @@ class Collection extends BaseCollection
 	/**
 	 * Returns the parent model
 	 */
-	public function parent()
+	public function parent(): object|null
 	{
 		return $this->parent;
 	}
@@ -294,12 +300,18 @@ class Collection extends BaseCollection
 	/**
 	 * Prepends an element to the data array
 	 *
-	 * @param mixed ...$args
-	 * @param mixed $key Optional collection key, will be determined from the item if not given
-	 * @param mixed $item
-	 * @return \Kirby\Cms\Collection
+	 * ```php
+	 * $collection->prepend($object);
+	 * $collection->prepend('key', $object);
+	 * $collection->prepend([$object1, $object2]);
+	 * ```
+	 *
+	 * If not collection key is passed, it will be determined from the item (id)
+	 *
+	 * @param array|string|TValue ...$args
+	 * @return $this
 	 */
-	public function prepend(...$args)
+	public function prepend(...$args): static
 	{
 		if (count($args) === 1) {
 			// try to determine the key from the provided item
@@ -320,10 +332,8 @@ class Collection extends BaseCollection
 	 * Runs a combination of filter, sort, not,
 	 * offset, limit, search and paginate on the collection.
 	 * Any part of the query is optional.
-	 *
-	 * @return static
 	 */
-	public function query(array $arguments = [])
+	public function query(array $arguments = []): static
 	{
 		$paginate = $arguments['paginate'] ?? null;
 		$search   = $arguments['search'] ?? null;
@@ -350,9 +360,9 @@ class Collection extends BaseCollection
 	/**
 	 * Removes an object
 	 *
-	 * @param mixed $key the name of the key
+	 * @param string|TValue $key the name of the key
 	 */
-	public function remove($key)
+	public function remove(string|object $key): static
 	{
 		if (is_object($key) === true) {
 			$key = $key->id();

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -36,19 +36,6 @@ class Collection extends BaseCollection
 	protected $pagination;
 
 	/**
-	 * Stores the parent object, which is needed
-	 * in some collections to get the finder methods right.
-	 */
-
-	public function __call(string $key, $arguments)
-	{
-		// collection methods
-		if ($this->hasMethod($key) === true) {
-			return $this->callMethod($key, $arguments);
-		}
-	}
-
-	/**
 	 * Creates a new Collection with the given objects
 	 *
 	 * @param object|null $parent Stores the parent object,
@@ -61,6 +48,14 @@ class Collection extends BaseCollection
 	) {
 		foreach ($objects as $object) {
 			$this->add($object);
+		}
+	}
+
+	public function __call(string $key, $arguments)
+	{
+		// collection methods
+		if ($this->hasMethod($key) === true) {
+			return $this->callMethod($key, $arguments);
 		}
 	}
 

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -88,7 +88,7 @@ class Collection extends BaseCollection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param TValue|self|array $object
+	 * @param static|TValue|array $object
 	 * @return $this
 	 */
 	public function add($object): static

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -115,9 +115,7 @@ class Collection extends BaseCollection
 	 * $collection->append('key', $object);
 	 * ```
 	 *
-	 * If not collection key is passed, it will be determined from the item (id)
-	 *
-	 * @param array|string|TValue ...$args
+	 * @param string|TValue ...$args
 	 * @return $this
 	 */
 	public function append(...$args): static
@@ -299,9 +297,7 @@ class Collection extends BaseCollection
 	 * $collection->prepend('key', $object);
 	 * ```
 	 *
-	 * If not collection key is passed, it will be determined from the item (id)
-	 *
-	 * @param array|string|TValue ...$args
+	 * @param string|TValue ...$args
 	 * @return $this
 	 */
 	public function prepend(...$args): static

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -158,7 +158,6 @@ class Collection extends BaseCollection
 	 *
 	 * @param string|\Closure $field
 	 * @param bool $caseInsensitive Ignore upper/lowercase for group names
-	 * @return self
 	 * @throws \Kirby\Exception\Exception
 	 */
 	public function group(
@@ -166,7 +165,7 @@ class Collection extends BaseCollection
 		bool $caseInsensitive = true
 	): self {
 		if (is_string($field) === true) {
-			$groups = new Collection([], $this->parent());
+			$groups = new self([], $this->parent());
 
 			foreach ($this->data as $key => $item) {
 				$value = $this->getAttribute($item, $field);
@@ -195,7 +194,12 @@ class Collection extends BaseCollection
 			return $groups;
 		}
 
-		return parent::group($field, $caseInsensitive);
+		// use the parent method but unwrap the Toolkit collection
+		// and rewrap it as a Cms collection
+		return new self(
+			parent::group($field, $caseInsensitive)->data,
+			$this->parent()
+		);
 	}
 
 	/**

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -113,7 +113,6 @@ class Collection extends BaseCollection
 	 * ```php
 	 * $collection->append($object);
 	 * $collection->append('key', $object);
-	 * $collection->append([$object1, $object2]);
 	 * ```
 	 *
 	 * If not collection key is passed, it will be determined from the item (id)
@@ -298,7 +297,6 @@ class Collection extends BaseCollection
 	 * ```php
 	 * $collection->prepend($object);
 	 * $collection->prepend('key', $object);
-	 * $collection->prepend([$object1, $object2]);
 	 * ```
 	 *
 	 * If not collection key is passed, it will be determined from the item (id)

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -24,7 +24,7 @@ use Kirby\Uuid\Uuid;
  * @license   https://getkirby.com/license
  *
  * @template TValue
- * @template-extends \Kirby\Toolkit\Collection<TValue>
+ * @extends \Kirby\Toolkit\Collection<TValue>
  */
 class Collection extends BaseCollection
 {

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -16,6 +16,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Item<\Kirby\Cms\Fieldsets>
  */
 class Fieldset extends Item
 {

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -17,7 +17,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Fieldset>
+ * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Fieldset>
  */
 class Fieldsets extends Items
 {

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -17,7 +17,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Fieldset>
+ * @extends \Kirby\Cms\Items<\Kirby\Cms\Fieldset>
  */
 class Fieldsets extends Items
 {

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -16,6 +16,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Fieldset>
  */
 class Fieldsets extends Items
 {

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -36,7 +36,7 @@ class File extends ModelWithContent
 	use FileModifications;
 	use HasMethods;
 	/**
-	 * @use HasSiblings<\Kirby\Cms\Files>
+	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Files>
 	 */
 	use HasSiblings;
 	use IsFile;

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -35,6 +35,9 @@ class File extends ModelWithContent
 	use FileActions;
 	use FileModifications;
 	use HasMethods;
+	/**
+	 * @use HasSiblings<\Kirby\Cms\Files>
+	 */
 	use HasSiblings;
 	use IsFile;
 
@@ -564,7 +567,6 @@ class File extends ModelWithContent
 
 	/**
 	 * Returns the parent Files collection
-	 * @internal
 	 */
 	protected function siblingsCollection(): Files
 	{

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -41,14 +41,14 @@ class Files extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Files|\Kirby\Cms\File|string $object
+	 * @param static|\Kirby\Cms\File|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `File` or `Files` object or an ID of an existing file is passed
 	 */
 	public function add($object): static
 	{
 		// add a files collection
-		if ($object instanceof Files) {
+		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
 		// add a file by id

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -20,7 +20,7 @@ use Kirby\Uuid\HasUuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\File>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\File>
  */
 class Files extends Collection
 {

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -19,6 +19,8 @@ use Kirby\Uuid\HasUuids;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\File>
  */
 class Files extends Collection
 {
@@ -28,6 +30,11 @@ class Files extends Collection
 	 * All registered files methods
 	 */
 	public static array $methods = [];
+
+	/**
+	 * @var \Kirby\Cms\Page|\Kirby\Cms\Site|\Kirby\Cms\User
+	 */
+	protected object|null $parent = null;
 
 	/**
 	 * Adds a single file or
@@ -41,7 +48,7 @@ class Files extends Collection
 	public function add($object): static
 	{
 		// add a files collection
-		if ($object instanceof self) {
+		if ($object instanceof Files) {
 			$this->data = [...$this->data, ...$object->data];
 
 		// add a file by id
@@ -87,8 +94,10 @@ class Files extends Collection
 	/**
 	 * Creates a files collection from an array of props
 	 */
-	public static function factory(array $files, Page|Site|User $parent): static
-	{
+	public static function factory(
+		array $files,
+		Page|Site|User $parent
+	): static {
 		$collection = new static([], $parent);
 
 		foreach ($files as $props) {
@@ -126,7 +135,7 @@ class Files extends Collection
 	 *                                  `null` for the current locale,
 	 *                                  `false` to disable number formatting
 	 */
-	public function niceSize($locale = null): string
+	public function niceSize(string|null|false $locale = null): string
 	{
 		return F::niceSize($this->size(), $locale);
 	}

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Toolkit\Collection;
+
 /**
  * This trait is used by pages, files and users
  * to handle navigation through parent collections
@@ -11,18 +13,72 @@ namespace Kirby\Cms;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template TCollection of \Kirby\Toolkit\Collection
  */
 trait HasSiblings
 {
 	/**
+	 * Checks if there's a next item in the collection
+	 *
+	 * @param TCollection|null $collection
+	 */
+	public function hasNext(Collection $collection = null): bool
+	{
+		return $this->next($collection) !== null;
+	}
+
+	/**
+	 * Checks if there's a previous item in the collection
+	 *
+	 * @param TCollection|null $collection
+	 */
+	public function hasPrev(Collection $collection = null): bool
+	{
+		return $this->prev($collection) !== null;
+	}
+
+	/**
 	 * Returns the position / index in the collection
 	 *
-	 * @param \Kirby\Cms\Collection|null $collection
+	 * @param TCollection|null $collection
 	 */
-	public function indexOf($collection = null): int|false
+	public function indexOf(Collection $collection = null): int|false
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->indexOf($this);
+	}
+
+	/**
+	 * Checks if the item is the first in the collection
+	 *
+	 * @param TCollection|null $collection
+	 */
+	public function isFirst(Collection $collection = null): bool
+	{
+		$collection ??= $this->siblingsCollection();
+		return $collection->first()->is($this);
+	}
+
+	/**
+	 * Checks if the item is the last in the collection
+	 *
+	 * @param TCollection|null $collection
+	 */
+	public function isLast(Collection $collection = null): bool
+	{
+		$collection ??= $this->siblingsCollection();
+		return $collection->last()->is($this);
+	}
+
+	/**
+	 * Checks if the item is at a certain position
+	 *
+	 * @param TCollection|null $collection
+	 */
+	public function isNth(int $n, Collection $collection = null): bool
+	{
+		return $this->indexOf($collection) === $n;
 	}
 
 	/**
@@ -31,8 +87,7 @@ trait HasSiblings
 	 *       quirks in the `Form` classes; would break if enforced
 	 *       (https://github.com/getkirby/kirby/pull/5175)
 	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
+	 * @param TCollection|null $collection
 	 * @return static|null
 	 */
 	public function next($collection = null)
@@ -44,11 +99,10 @@ trait HasSiblings
 	/**
 	 * Returns the end of the collection starting after the current item
 	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Collection
+	 * @param TCollection|null $collection
+	 * @return TCollection
 	 */
-	public function nextAll($collection = null)
+	public function nextAll(Collection $collection = null): Collection
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->slice($this->indexOf($collection) + 1);
@@ -60,11 +114,10 @@ trait HasSiblings
 	 *       quirks in the `Form` classes; would break if enforced
 	 *       (https://github.com/getkirby/kirby/pull/5175)
 	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
+	 * @param TCollection|null $collection
 	 * @return static|null
 	 */
-	public function prev($collection = null)
+	public function prev(Collection $collection = null)
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->nth($this->indexOf($collection) - 1);
@@ -73,11 +126,10 @@ trait HasSiblings
 	/**
 	 * Returns the beginning of the collection before the current item
 	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Collection
+	 * @param TCollection|null $collection
+	 * @return TCollection
 	 */
-	public function prevAll($collection = null)
+	public function prevAll(Collection $collection = null): Collection
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->slice(0, $this->indexOf($collection));
@@ -86,9 +138,9 @@ trait HasSiblings
 	/**
 	 * Returns all sibling elements
 	 *
-	 * @return \Kirby\Cms\Collection
+	 * @return TCollection
 	 */
-	public function siblings(bool $self = true)
+	public function siblings(bool $self = true): Collection
 	{
 		$siblings = $this->siblingsCollection();
 
@@ -100,54 +152,8 @@ trait HasSiblings
 	}
 
 	/**
-	 * Checks if there's a next item in the collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
+	 * Returns the collection of siblings
+	 * @return TCollection
 	 */
-	public function hasNext($collection = null): bool
-	{
-		return $this->next($collection) !== null;
-	}
-
-	/**
-	 * Checks if there's a previous item in the collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 */
-	public function hasPrev($collection = null): bool
-	{
-		return $this->prev($collection) !== null;
-	}
-
-	/**
-	 * Checks if the item is the first in the collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 */
-	public function isFirst($collection = null): bool
-	{
-		$collection ??= $this->siblingsCollection();
-		return $collection->first()->is($this);
-	}
-
-	/**
-	 * Checks if the item is the last in the collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 */
-	public function isLast($collection = null): bool
-	{
-		$collection ??= $this->siblingsCollection();
-		return $collection->last()->is($this);
-	}
-
-	/**
-	 * Checks if the item is at a certain position
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 */
-	public function isNth(int $n, $collection = null): bool
-	{
-		return $this->indexOf($collection) === $n;
-	}
+	abstract protected function siblingsCollection(): Collection;
 }

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -23,6 +23,9 @@ use Kirby\Toolkit\Str;
  */
 class Item
 {
+	/**
+	 * @use HasSiblings<self::ITEMS_CLASS>
+	 */
 	use HasSiblings;
 
 	public const ITEMS_CLASS = Items::class;

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -20,11 +20,13 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template TCollection of \Kirby\Cms\Items
  */
 class Item
 {
 	/**
-	 * @use HasSiblings<self::ITEMS_CLASS>
+	 * @use \Kirby\Cms\HasSiblings<TCollection>
 	 */
 	use HasSiblings;
 

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -17,7 +17,7 @@ use Kirby\Exception\InvalidArgumentException;
  * @license   https://getkirby.com/license
  *
  * @template TValue of \Kirby\Cms\Item
- * @template-extends \Kirby\Cms\Collection<TValue>
+ * @extends \Kirby\Cms\Collection<TValue>
  */
 class Items extends Collection
 {

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -16,7 +16,8 @@ use Kirby\Exception\InvalidArgumentException;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Item>
+ * @template TValue of \Kirby\Cms\Item
+ * @template-extends \Kirby\Cms\Collection<TValue>
  */
 class Items extends Collection
 {

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -15,6 +15,8 @@ use Kirby\Exception\InvalidArgumentException;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Item>
  */
 class Items extends Collection
 {
@@ -32,7 +34,7 @@ class Items extends Collection
 	/**
 	 * @var \Kirby\Cms\ModelWithContent
 	 */
-	protected $parent;
+	protected object|null $parent = null;
 
 	public function __construct($objects = [], array $options = [])
 	{

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -30,7 +30,7 @@ use Throwable;
 class Language
 {
 	/**
-	 * @use HasSiblings<\Kirby\Cms\Languages>
+	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Languages>
 	 */
 	use HasSiblings;
 
@@ -439,7 +439,6 @@ class Language
 
 	/**
 	 * Private siblings collector
-	 * @internal
 	 */
 	protected function siblingsCollection(): Languages
 	{

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -29,6 +29,9 @@ use Throwable;
  */
 class Language
 {
+	/**
+	 * @use HasSiblings<\Kirby\Cms\Languages>
+	 */
 	use HasSiblings;
 
 	/**
@@ -436,8 +439,9 @@ class Language
 
 	/**
 	 * Private siblings collector
+	 * @internal
 	 */
-	protected function siblingsCollection(): Collection
+	protected function siblingsCollection(): Languages
 	{
 		return App::instance()->languages();
 	}

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -14,7 +14,7 @@ use Kirby\Filesystem\F;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Language>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\Language>
  */
 class Languages extends Collection
 {

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -13,6 +13,8 @@ use Kirby\Filesystem\F;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Language>
  */
 class Languages extends Collection
 {

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -14,6 +14,8 @@ use Kirby\Content\Content;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Item<\Kirby\Cms\Layouts>
  */
 class Layout extends Item
 {

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Item<\Kirby\Cms\LayoutColumns>
  */
 class LayoutColumn extends Item
 {

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -12,7 +12,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\LayoutColumn>
+ * @template-extends \Kirby\Cms\Items<\Kirby\Cms\LayoutColumn>
  */
 class LayoutColumns extends Items
 {

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -12,7 +12,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Items<\Kirby\Cms\LayoutColumn>
+ * @extends \Kirby\Cms\Items<\Kirby\Cms\LayoutColumn>
  */
 class LayoutColumns extends Items
 {

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -11,6 +11,8 @@ namespace Kirby\Cms;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\LayoutColumn>
  */
 class LayoutColumns extends Items
 {

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -15,6 +15,8 @@ use Throwable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Layout>
  */
 class Layouts extends Items
 {

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -16,7 +16,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Layout>
+ * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Layout>
  */
 class Layouts extends Items
 {

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -16,7 +16,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Items<\Kirby\Cms\Layout>
+ * @extends \Kirby\Cms\Items<\Kirby\Cms\Layout>
  */
 class Layouts extends Items
 {

--- a/src/Cms/NestCollection.php
+++ b/src/Cms/NestCollection.php
@@ -14,7 +14,7 @@ use Kirby\Toolkit\Collection as BaseCollection;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Toolkit\Collection<\Kirby\Cms\NestObject|\Kirby\Content\Field>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Cms\NestObject|\Kirby\Content\Field>
  */
 class NestCollection extends BaseCollection
 {

--- a/src/Cms/NestCollection.php
+++ b/src/Cms/NestCollection.php
@@ -13,6 +13,8 @@ use Kirby\Toolkit\Collection as BaseCollection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Toolkit\Collection<\Kirby\Cms\NestObject|\Kirby\Content\Field>
  */
 class NestCollection extends BaseCollection
 {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -34,6 +34,9 @@ class Page extends ModelWithContent
 	use HasChildren;
 	use HasFiles;
 	use HasMethods;
+	/**
+	 * @use HasSiblings<\Kirby\Cms\Pages>
+	 */
 	use HasSiblings;
 	use PageActions;
 	use PageSiblings;

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -35,7 +35,7 @@ class Page extends ModelWithContent
 	use HasFiles;
 	use HasMethods;
 	/**
-	 * @use HasSiblings<\Kirby\Cms\Pages>
+	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Pages>
 	 */
 	use HasSiblings;
 	use PageActions;

--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -16,10 +16,8 @@ trait PageSiblings
 	/**
 	 * Checks if there's a next listed
 	 * page in the siblings collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
 	 */
-	public function hasNextListed($collection = null): bool
+	public function hasNextListed(Collection $collection = null): bool
 	{
 		return $this->nextListed($collection) !== null;
 	}
@@ -27,10 +25,8 @@ trait PageSiblings
 	/**
 	 * Checks if there's a next unlisted
 	 * page in the siblings collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
 	 */
-	public function hasNextUnlisted($collection = null): bool
+	public function hasNextUnlisted(Collection $collection = null): bool
 	{
 		return $this->nextUnlisted($collection) !== null;
 	}
@@ -38,10 +34,8 @@ trait PageSiblings
 	/**
 	 * Checks if there's a previous listed
 	 * page in the siblings collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
 	 */
-	public function hasPrevListed($collection = null): bool
+	public function hasPrevListed(Collection $collection = null): bool
 	{
 		return $this->prevListed($collection) !== null;
 	}
@@ -49,68 +43,48 @@ trait PageSiblings
 	/**
 	 * Checks if there's a previous unlisted
 	 * page in the siblings collection
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
 	 */
-	public function hasPrevUnlisted($collection = null): bool
+	public function hasPrevUnlisted(Collection $collection = null): bool
 	{
 		return $this->prevUnlisted($collection) !== null;
 	}
 
 	/**
 	 * Returns the next listed page if it exists
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Page|null
 	 */
-	public function nextListed($collection = null)
+	public function nextListed(Collection $collection = null): Page|null
 	{
 		return $this->nextAll($collection)->listed()->first();
 	}
 
 	/**
 	 * Returns the next unlisted page if it exists
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Page|null
 	 */
-	public function nextUnlisted($collection = null)
+	public function nextUnlisted(Collection $collection = null): Page|null
 	{
 		return $this->nextAll($collection)->unlisted()->first();
 	}
 
 	/**
 	 * Returns the previous listed page
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Page|null
 	 */
-	public function prevListed($collection = null)
+	public function prevListed(Collection $collection = null): Page|null
 	{
 		return $this->prevAll($collection)->listed()->last();
 	}
 
 	/**
 	 * Returns the previous unlisted page
-	 *
-	 * @param \Kirby\Cms\Collection|null $collection
-	 *
-	 * @return \Kirby\Cms\Page|null
 	 */
-	public function prevUnlisted($collection = null)
+	public function prevUnlisted(Collection $collection = null): Page|null
 	{
 		return $this->prevAll($collection)->unlisted()->last();
 	}
 
 	/**
 	 * Private siblings collector
-	 *
-	 * @return \Kirby\Cms\Collection
 	 */
-	protected function siblingsCollection()
+	protected function siblingsCollection(): Pages
 	{
 		if ($this->isDraft() === true) {
 			return $this->parentModel()->drafts();
@@ -121,10 +95,8 @@ trait PageSiblings
 
 	/**
 	 * Returns siblings with the same template
-	 *
-	 * @return \Kirby\Cms\Pages
 	 */
-	public function templateSiblings(bool $self = true)
+	public function templateSiblings(bool $self = true): Pages
 	{
 		return $this->siblings($self)->filter('intendedTemplate', $this->intendedTemplate()->name());
 	}

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -21,7 +21,7 @@ use Kirby\Uuid\HasUuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Page>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\Page>
  */
 class Pages extends Collection
 {

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -61,7 +61,7 @@ class Pages extends Collection
 		$site = App::instance()->site();
 
 		// add a pages collection
-		if ($object instanceof Pages) {
+		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
 		// add a page by id
@@ -295,10 +295,8 @@ class Pages extends Collection
 	/**
 	 * Custom getter that is able to find
 	 * extension pages
-	 *
-	 * @param mixed $default
 	 */
-	public function get(string $key, $default = null): Page|null
+	public function get(string $key, mixed $default = null): Page|null
 	{
 		if ($key === null) {
 			return null;

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -20,7 +20,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\PluginAsset>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\PluginAsset>
  */
 class PluginAssets extends Collection
 {

--- a/src/Cms/PluginAssets.php
+++ b/src/Cms/PluginAssets.php
@@ -19,6 +19,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\PluginAsset>
  */
 class PluginAssets extends Collection
 {

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -15,6 +15,8 @@ namespace Kirby\Cms;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Role>
  */
 class Roles extends Collection
 {

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -16,7 +16,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Role>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\Role>
  */
 class Roles extends Collection
 {

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -16,7 +16,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Items<\Kirby\Cms\StructureObject>
+ * @extends \Kirby\Cms\Items<\Kirby\Cms\StructureObject>
  */
 class Structure extends Items
 {

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -16,7 +16,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\StructureObject>
+ * @template-extends \Kirby\Cms\Items<\Kirby\Cms\StructureObject>
  */
 class Structure extends Items
 {

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -15,6 +15,8 @@ namespace Kirby\Cms;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\StructureObject>
  */
 class Structure extends Items
 {

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -19,6 +19,8 @@ use Kirby\Content\Content;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Item<\Kirby\Cms\Structure>
  */
 class StructureObject extends Item
 {

--- a/src/Cms/Translations.php
+++ b/src/Cms/Translations.php
@@ -16,6 +16,8 @@ use Kirby\Filesystem\F;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Translation>
  */
 class Translations extends Collection
 {

--- a/src/Cms/Translations.php
+++ b/src/Cms/Translations.php
@@ -17,7 +17,7 @@ use Kirby\Filesystem\F;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\Translation>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\Translation>
  */
 class Translations extends Collection
 {

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -30,7 +30,7 @@ class User extends ModelWithContent
 	use HasFiles;
 	use HasMethods;
 	/**
-	 * @use HasSiblings<\Kirby\Cms\Users>
+	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Users>
 	 */
 	use HasSiblings;
 	use UserActions;
@@ -667,7 +667,6 @@ class User extends ModelWithContent
 
 	/**
 	 * Returns the parent Users collection
-	 * @internal
 	 */
 	protected function siblingsCollection(): Users
 	{

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -29,6 +29,9 @@ class User extends ModelWithContent
 {
 	use HasFiles;
 	use HasMethods;
+	/**
+	 * @use HasSiblings<\Kirby\Cms\Users>
+	 */
 	use HasSiblings;
 	use UserActions;
 
@@ -664,6 +667,7 @@ class User extends ModelWithContent
 
 	/**
 	 * Returns the parent Users collection
+	 * @internal
 	 */
 	protected function siblingsCollection(): Users
 	{

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -41,7 +41,7 @@ class Users extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param self\Kirby\Cms\Users|\Kirby\Cms\User|string $object
+	 * @param \Kirby\Cms\Users|\Kirby\Cms\User|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `User` or `Users` object or an ID of an existing user is passed
 	 */

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -48,7 +48,7 @@ class Users extends Collection
 	public function add($object): static
 	{
 		// add a users collection
-		if ($object instanceof Users) {
+		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
 		// add a user by id

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -20,7 +20,7 @@ use Kirby\Uuid\HasUuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\User>
+ * @extends \Kirby\Cms\Collection<\Kirby\Cms\User>
  */
 class Users extends Collection
 {

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -19,6 +19,8 @@ use Kirby\Uuid\HasUuids;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template-extends \Kirby\Cms\Collection<\Kirby\Cms\User>
  */
 class Users extends Collection
 {
@@ -39,14 +41,14 @@ class Users extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Users|\Kirby\Cms\User|string $object
+	 * @param self\Kirby\Cms\Users|\Kirby\Cms\User|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `User` or `Users` object or an ID of an existing user is passed
 	 */
 	public function add($object): static
 	{
 		// add a users collection
-		if ($object instanceof self) {
+		if ($object instanceof Users) {
 			$this->data = [...$this->data, ...$object->data];
 
 		// add a user by id

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -25,6 +25,9 @@ use Throwable;
  */
 abstract class FieldClass
 {
+	/**
+	 * @use HasSiblings<\Kirby\Form\Fields>
+	 */
 	use HasSiblings;
 
 	protected string|null $after;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -26,7 +26,7 @@ use Throwable;
 abstract class FieldClass
 {
 	/**
-	 * @use HasSiblings<\Kirby\Form\Fields>
+	 * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
 	 */
 	use HasSiblings;
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -14,7 +14,7 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @extends \Kirby\Toolkit\Collection<\Kirby\Form\Field>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Form\Field|\Kirby\Form\FieldClass>
  */
 class Fields extends Collection
 {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -13,6 +13,8 @@ use Kirby\Toolkit\Collection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template-extends \Kirby\Toolkit\Collection<\Kirby\Form\Field>
  */
 class Fields extends Collection
 {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -14,7 +14,7 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Toolkit\Collection<\Kirby\Form\Field>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Form\Field>
  */
 class Fields extends Collection
 {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -23,7 +23,7 @@ class Fields extends Collection
 	 * This takes care of validation and of setting
 	 * the collection prop on each object correctly.
 	 *
-	 * @param object|array $field
+	 * @param \Kirby\Form\Field|\Kirby\Form\FieldClass|array $field
 	 */
 	public function __set(string $name, $field): void
 	{

--- a/src/Http/Path.php
+++ b/src/Http/Path.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Toolkit\Collection<string>
+ * @extends \Kirby\Toolkit\Collection<string>
  */
 class Path extends Collection
 {

--- a/src/Http/Path.php
+++ b/src/Http/Path.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template-extends \Kirby\Toolkit\Collection<string>
  */
 class Path extends Collection
 {

--- a/src/Option/Options.php
+++ b/src/Option/Options.php
@@ -15,7 +15,7 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Toolkit\Collection<\Kirby\Option\Option>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Option\Option>
  */
 class Options extends Collection
 {

--- a/src/Option/Options.php
+++ b/src/Option/Options.php
@@ -14,6 +14,8 @@ use Kirby\Cms\ModelWithContent;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template-extends \Kirby\Toolkit\Collection<\Kirby\Option\Option>
  */
 class Options extends Collection
 {

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
  */
 class Arguments extends Collection
 {

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\Collection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template-extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
  */
 class Arguments extends Collection
 {

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\Collection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template-extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
  */
 class Segments extends Collection
 {

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @template-extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
+ * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
  */
 class Segments extends Collection
 {

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -125,7 +125,7 @@ class Collection extends Iterator implements Countable
 	 *
 	 * ```php
 	 * $collection->append('key', $value);
-	 * $collection->append([$value1, $value2]);
+	 * $collection->append($value);
 	 * ```
 	 *
 	 * @param array|string|TValue ...$args
@@ -741,7 +741,7 @@ class Collection extends Iterator implements Countable
 	 *
 	 * ```php
 	 * $collection->prepend('key', $value);
-	 * $collection->prepend([$value1, $value2]);
+	 * $collection->prepend($value);
 	 * ```
 	 *
 	 * @param array|string|TValue ...$args

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -18,7 +18,7 @@ use Exception;
  * @license   https://opensource.org/licenses/MIT
  *
  * @template TValue
- * @template-extends \Kirby\Toolkit\Iterator<string, TValue>
+ * @extends \Kirby\Toolkit\Iterator<string, TValue>
  */
 class Collection extends Iterator implements Countable
 {

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -432,8 +432,9 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Getter
 	 *
-	 * @param mixed $default
-	 * @return mixed
+	 * @template TDefault
+	 * @param TDefault $default
+	 * @return TValue|TDefault|null
 	 */
 	public function get(string $key, $default = null)
 	{
@@ -1115,8 +1116,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * @see \Kirby\Toolkit\Collection::not()
-	 *
-	 * @param string ...$keys any number of keys, passed as individual arguments
 	 */
 	public function without(string ...$keys): static
 	{

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -436,7 +436,7 @@ class Collection extends Iterator implements Countable
 	 * @param TDefault $default
 	 * @return TValue|TDefault|null
 	 */
-	public function get(string $key, $default = null)
+	public function get(string $key, mixed $default = null)
 	{
 		return $this->__get($key) ?? $default;
 	}

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -42,18 +42,9 @@ class Collection extends Iterator implements Countable
 	protected $pagination;
 
 	/**
-	 * Magic getter function
-	 *
-	 * @return TValue|null
-	 */
-	public function __call(string $key, $arguments)
-	{
-		return $this->__get($key);
-	}
-
-	/**
 	 * Constructor
 	 *
+	 * @param array<string, TValue> $data
 	 * @param bool $caseSensitive Whether the collection keys should be
 	 *                            treated as case-sensitive
 	 */
@@ -61,6 +52,16 @@ class Collection extends Iterator implements Countable
 	{
 		$this->caseSensitive = $caseSensitive;
 		$this->set($data);
+	}
+
+	/**
+	 * Magic getter function
+	 *
+	 * @return TValue|null
+	 */
+	public function __call(string $key, $arguments)
+	{
+		return $this->__get($key);
 	}
 
 	/**
@@ -128,7 +129,7 @@ class Collection extends Iterator implements Countable
 	 * $collection->append($value);
 	 * ```
 	 *
-	 * @param array|string|TValue ...$args
+	 * @param string|TValue ...$args
 	 * @return $this
 	 */
 	public function append(...$args): static
@@ -744,7 +745,7 @@ class Collection extends Iterator implements Countable
 	 * $collection->prepend($value);
 	 * ```
 	 *
-	 * @param array|string|TValue ...$args
+	 * @param string|TValue ...$args
 	 * @return $this
 	 */
 	public function prepend(...$args): static

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -16,15 +16,16 @@ use Exception;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @template TValue
+ * @template-extends \Kirby\Toolkit\Iterator<string, TValue>
  */
 class Collection extends Iterator implements Countable
 {
 	/**
 	 * All registered collection filters
-	 *
-	 * @var array
 	 */
-	public static $filters = [];
+	public static array $filters = [];
 
 	/**
 	 * Whether the collection keys should be
@@ -32,23 +33,18 @@ class Collection extends Iterator implements Countable
 	 *
 	 * @todo 5.0 Check if case-sensitive can become the
 	 * default mode, see https://github.com/getkirby/kirby/pull/5635
-	 *
-	 * @var bool
 	 */
-	protected $caseSensitive = false;
+	protected bool $caseSensitive = false;
 
 	/**
-	 * Pagination object
-	 * @var \Kirby\Toolkit\Pagination
+	 * @var \Kirby\Toolkit\Pagination|null
 	 */
 	protected $pagination;
 
 	/**
 	 * Magic getter function
 	 *
-	 * @param string $key
-	 * @param mixed $arguments
-	 * @return mixed
+	 * @return TValue|null
 	 */
 	public function __call(string $key, $arguments)
 	{
@@ -58,7 +54,6 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Constructor
 	 *
-	 * @param array $data
 	 * @param bool $caseSensitive Whether the collection keys should be
 	 *                            treated as case-sensitive
 	 */
@@ -80,10 +75,9 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Low-level getter for elements
 	 *
-	 * @param mixed $key
-	 * @return mixed
+	 * @return TValue|null
 	 */
-	public function __get($key)
+	public function __get(string $key)
 	{
 		if ($this->caseSensitive === true) {
 			return $this->data[$key] ?? null;
@@ -95,9 +89,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Low-level setter for elements
 	 *
-	 * @param string $key string or array
-	 * @param mixed $value
-	 * @return void
+	 * @param TValue $value
 	 */
 	public function __set(string $key, $value): void
 	{
@@ -110,8 +102,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Makes it possible to echo the entire object
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{
@@ -120,10 +110,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Low-level element remover
-	 *
-	 * @param mixed $key the name of the key
 	 */
-	public function __unset($key)
+	public function __unset(string $key)
 	{
 		if ($this->caseSensitive !== true) {
 			$key = strtolower($key);
@@ -135,12 +123,15 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Appends an element
 	 *
-	 * @param mixed $key
-	 * @param mixed $item
-	 * @param mixed ...$args
+	 * ```php
+	 * $collection->append('key', $value);
+	 * $collection->append([$value1, $value2]);
+	 * ```
+	 *
+	 * @param array|string|TValue ...$args
 	 * @return $this
 	 */
-	public function append(...$args)
+	public function append(...$args): static
 	{
 		if (count($args) === 1) {
 			$this->data[] = $args[0];
@@ -159,7 +150,7 @@ class Collection extends Iterator implements Countable
 	 * @return static A new collection with an element for each chunk and
 	 *                a sub collection in each chunk
 	 */
-	public function chunk(int $size)
+	public function chunk(int $size): static
 	{
 		// create a multidimensional array that is chunked with the given
 		// chunk size keep keys of the elements
@@ -186,10 +177,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Returns a cloned instance of the collection
-	 *
-	 * @return $this
 	 */
-	public function clone()
+	public function clone(): static
 	{
 		return clone $this;
 	}
@@ -197,10 +186,9 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Getter and setter for the data
 	 *
-	 * @param array|null $data
 	 * @return array|$this
 	 */
-	public function data(array $data = null)
+	public function data(array $data = null): array|static
 	{
 		if ($data === null) {
 			return $this->data;
@@ -217,10 +205,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Clone and remove all elements from the collection
-	 *
-	 * @return static
 	 */
-	public function empty()
+	public function empty(): static
 	{
 		$collection = clone $this;
 		$collection->data = [];
@@ -229,12 +215,11 @@ class Collection extends Iterator implements Countable
 	}
 
 	/**
-	 * Adds all elements to the collection
+	 * Adds all elements to a cloned collection
 	 *
 	 * @param mixed $items
-	 * @return static
 	 */
-	public function extend($items)
+	public function extend($items): static
 	{
 		$collection = clone $this;
 		return $collection->set($items);
@@ -244,12 +229,8 @@ class Collection extends Iterator implements Countable
 	 * Filters elements by one of the
 	 * predefined filter methods, by a
 	 * custom filter function or an array of filters
-	 *
-	 * @param string|array|\Closure $field
-	 * @param mixed ...$args
-	 * @return static
 	 */
-	public function filter($field, ...$args)
+	public function filter(string|array|Closure $field, ...$args): static
 	{
 		$operator = '==';
 		$test     = $args[0] ?? null;
@@ -318,20 +299,18 @@ class Collection extends Iterator implements Countable
 	}
 
 	/**
-	 * Alias for `Kirby\Toolkit\Collection::filter`
-	 *
-	 * @param string|array|\Closure $field
-	 * @param mixed ...$args
-	 * @return static
+	 * @see \Kirby\Toolkit\Collection::filter()
 	 */
-	public function filterBy(...$args)
+	public function filterBy(...$args): static
 	{
 		return $this->filter(...$args);
 	}
 
-
-	protected function filterMatchesAny($validator, $values, $test): bool
-	{
+	protected function filterMatchesAny(
+		callable $validator,
+		array $values,
+		$test
+	): bool {
 		foreach ($values as $value) {
 			if ($validator($value, $test) !== false) {
 				return true;
@@ -341,14 +320,11 @@ class Collection extends Iterator implements Countable
 		return false;
 	}
 
-	/**
-	 * @param string $validator
-	 * @param array $values
-	 * @param mixed $test
-	 * @return bool
-	 */
-	protected function filterMatchesAll($validator, $values, $test): bool
-	{
+	protected function filterMatchesAll(
+		callable $validator,
+		array $values,
+		$test
+	): bool {
 		foreach ($values as $value) {
 			if ($validator($value, $test) === false) {
 				return false;
@@ -358,13 +334,11 @@ class Collection extends Iterator implements Countable
 		return true;
 	}
 
-	/**
-	 * @param string $validator
-	 * @param array $values
-	 * @param mixed $test
-	 * @return bool
-	 */
-	protected function filterMatchesNone($validator, $values, $test): bool
+	protected function filterMatchesNone(
+		callable $validator,
+		array $values,
+		$test
+	): bool
 	{
 		$matches = 0;
 
@@ -381,7 +355,7 @@ class Collection extends Iterator implements Countable
 	 * Find one or multiple elements by id
 	 *
 	 * @param string ...$keys
-	 * @return mixed
+	 * @return TValue|static
 	 */
 	public function find(...$keys)
 	{
@@ -412,9 +386,8 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Find a single element by an attribute and its value
 	 *
-	 * @param string $attribute
 	 * @param mixed $value
-	 * @return mixed|null
+	 * @return TValue|null
 	 */
 	public function findBy(string $attribute, $value)
 	{
@@ -429,8 +402,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Find a single element by key (id)
 	 *
-	 * @param string $key
-	 * @return mixed
+	 * @return TValue|null
 	 */
 	public function findByKey(string $key)
 	{
@@ -440,7 +412,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Returns the first element
 	 *
-	 * @return mixed
+	 * @return TValue
 	 */
 	public function first()
 	{
@@ -450,10 +422,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Returns the elements in reverse order
-	 *
-	 * @return static
 	 */
-	public function flip()
+	public function flip(): static
 	{
 		$collection = clone $this;
 		$collection->data = array_reverse($this->data, true);
@@ -463,11 +433,10 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Getter
 	 *
-	 * @param mixed $key
 	 * @param mixed $default
 	 * @return mixed
 	 */
-	public function get($key, $default = null)
+	public function get(string $key, $default = null)
 	{
 		return $this->__get($key) ?? $default;
 	}
@@ -478,14 +447,15 @@ class Collection extends Iterator implements Countable
 	 * might be objects, arrays or anything else and you need to
 	 * get the value independently from that. We use it for `filter`.
 	 *
-	 * @param array|object $item
-	 * @param string $attribute
-	 * @param bool $split
 	 * @param mixed $related
 	 * @return mixed
 	 */
-	public function getAttribute($item, string $attribute, $split = false, $related = null)
-	{
+	public function getAttribute(
+		array|object $item,
+		string $attribute,
+		bool $split = false,
+		$related = null
+	) {
 		$value = $this->{'getAttributeFrom' . gettype($item)}($item, $attribute);
 
 		if ($split !== false) {
@@ -499,37 +469,33 @@ class Collection extends Iterator implements Countable
 		return $value;
 	}
 
-	/**
-	 * @param array $array
-	 * @param string $attribute
-	 * @return mixed
-	 */
-	protected function getAttributeFromArray(array $array, string $attribute)
-	{
+	protected function getAttributeFromArray(
+		array $array,
+		string $attribute
+	): mixed {
 		return $array[$attribute] ?? null;
 	}
 
-	/**
-	 * @param object $object
-	 * @param string $attribute
-	 * @return mixed
-	 */
-	protected function getAttributeFromObject($object, string $attribute)
-	{
+	protected function getAttributeFromObject(
+		object $object,
+		string $attribute
+	): mixed {
 		return $object->{$attribute}();
 	}
 
 	/**
 	 * Groups the elements by a given field or callback function
 	 *
-	 * @param string|Closure $field
-	 * @return \Kirby\Toolkit\Collection A new collection with an element for
-	 *                                   each group and a subcollection in
-	 *                                   each group
+	 * @param string|\Closure $field
+	 * @return self A new collection with an element for
+	 *              each group and a subcollection in
+	 *              each group
 	 * @throws \Exception if $field is not a string nor a callback function
 	 */
-	public function group($field, bool $caseInsensitive = true)
-	{
+	public function group(
+		$field,
+		bool $caseInsensitive = true
+	): self {
 		// group by field name
 		if (is_string($field) === true) {
 			return $this->group(function ($item) use ($field, $caseInsensitive) {
@@ -579,21 +545,14 @@ class Collection extends Iterator implements Countable
 				}
 			}
 
-			return new Collection($groups);
+			return new self($groups);
 		}
 
 		throw new Exception('Can only group by string values or by providing a callback function');
 	}
 
 	/**
-	 * Alias for `Kirby\Toolkit\Collection::group`
-	 *
-	 * @param string|Closure $field
-	 * @param bool $i
-	 * @return \Kirby\Toolkit\Collection A new collection with an element for
-	 *                                   each group and a sub collection in
-	 *                                   each group
-	 * @throws \Exception
+	 * @see \Kirby\Toolkit\Collection::group()
 	 */
 	public function groupBy(...$args)
 	{
@@ -603,11 +562,8 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Returns a Collection with the intersection of the given elements
 	 * @since 3.3.0
-	 *
-	 * @param \Kirby\Toolkit\Collection $other
-	 * @return static
 	 */
-	public function intersection($other)
+	public function intersection(Collection $other): static
 	{
 		return $other->find($this->keys());
 	}
@@ -615,11 +571,8 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Checks if there is an intersection between the given collection and this collection
 	 * @since 3.3.0
-	 *
-	 * @param \Kirby\Toolkit\Collection $other
-	 * @return bool
 	 */
-	public function intersects($other): bool
+	public function intersects(Collection $other): bool
 	{
 		foreach ($this->keys() as $key) {
 			if ($other->has($key)) {
@@ -632,8 +585,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Checks if the number of elements is zero
-	 *
-	 * @return bool
 	 */
 	public function isEmpty(): bool
 	{
@@ -642,8 +593,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Checks if the number of elements is even
-	 *
-	 * @return bool
 	 */
 	public function isEven(): bool
 	{
@@ -652,8 +601,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Checks if the number of elements is more than zero
-	 *
-	 * @return bool
 	 */
 	public function isNotEmpty(): bool
 	{
@@ -662,8 +609,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Checks if the number of elements is odd
-	 *
-	 * @return bool
 	 */
 	public function isOdd(): bool
 	{
@@ -673,7 +618,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Returns the last element
 	 *
-	 * @return mixed
+	 * @return TValue
 	 */
 	public function last()
 	{
@@ -685,9 +630,8 @@ class Collection extends Iterator implements Countable
 	 * Returns a new object with a limited number of elements
 	 *
 	 * @param int $limit The number of elements to return
-	 * @return static
 	 */
-	public function limit(int $limit)
+	public function limit(int $limit): static
 	{
 		return $this->slice(0, $limit);
 	}
@@ -695,10 +639,9 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Map a function to each element
 	 *
-	 * @param callable $callback
 	 * @return $this
 	 */
-	public function map(callable $callback)
+	public function map(callable $callback): static
 	{
 		$this->data = array_map($callback, $this->data);
 		return $this;
@@ -707,8 +650,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Returns the nth element from the collection
 	 *
-	 * @param int $n
-	 * @return mixed
+	 * @return TValue|null
 	 */
 	public function nth(int $n)
 	{
@@ -719,9 +661,8 @@ class Collection extends Iterator implements Countable
 	 * Returns a Collection without the given element(s)
 	 *
 	 * @param string ...$keys any number of keys, passed as individual arguments
-	 * @return static
 	 */
-	public function not(...$keys)
+	public function not(string ...$keys): static
 	{
 		$collection = clone $this;
 		foreach ($keys as $key) {
@@ -734,20 +675,21 @@ class Collection extends Iterator implements Countable
 	 * Returns a new object starting from the given offset
 	 *
 	 * @param int $offset The index to start from
-	 * @return static
+	 * @return static|$this
+	 * @psalm-return ($offset is 0 ? $this : static)
 	 */
-	public function offset(int $offset)
+	public function offset(int $offset): static
 	{
 		return $this->slice($offset);
 	}
 
 	/**
-	 * Add pagination
+	 * Add pagination and return a sliced set of data
 	 *
-	 * @param array ...$arguments
-	 * @return $this|static a sliced set of data
+	 * @param mixed ...$arguments
+	 * @return $this|static
 	 */
-	public function paginate(...$arguments)
+	public function paginate(...$arguments): static
 	{
 		$this->pagination = Pagination::for($this, ...$arguments);
 
@@ -760,10 +702,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Get the previously added pagination object
-	 *
-	 * @return \Kirby\Toolkit\Pagination|null
 	 */
-	public function pagination()
+	public function pagination(): Pagination|null
 	{
 		return $this->pagination;
 	}
@@ -771,14 +711,12 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Extracts all values for a single field into
 	 * a new array
-	 *
-	 * @param string $field
-	 * @param string|null $split
-	 * @param bool $unique
-	 * @return array
 	 */
-	public function pluck(string $field, string $split = null, bool $unique = false): array
-	{
+	public function pluck(
+		string $field,
+		string $split = null,
+		bool $unique = false
+	): array {
 		$result = [];
 
 		foreach ($this->data as $item) {
@@ -801,12 +739,15 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Prepends an element to the data array
 	 *
-	 * @param mixed $key
-	 * @param mixed $item
-	 * @param mixed ...$args
+	 * ```php
+	 * $collection->prepend('key', $value);
+	 * $collection->prepend([$value1, $value2]);
+	 * ```
+	 *
+	 * @param array|string|TValue ...$args
 	 * @return $this
 	 */
-	public function prepend(...$args)
+	public function prepend(...$args): static
 	{
 		if (count($args) === 1) {
 			array_unshift($this->data, $args[0]);
@@ -824,11 +765,8 @@ class Collection extends Iterator implements Countable
 	 * Runs a combination of filter, sort, not,
 	 * offset, limit and paginate on the collection.
 	 * Any part of the query is optional.
-	 *
-	 * @param array $arguments
-	 * @return static
 	 */
-	public function query(array $arguments = [])
+	public function query(array $arguments = []): static
 	{
 		$result = clone $this;
 
@@ -883,12 +821,8 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Returns a new collection consisting of random elements,
 	 * from the original collection, shuffled or ordered
-	 *
-	 * @param int $count
-	 * @param bool $shuffle
-	 * @return static
 	 */
-	public function random(int $count = 1, bool $shuffle = false)
+	public function random(int $count = 1, bool $shuffle = false): static
 	{
 		if ($shuffle) {
 			return $this->shuffle()->slice(0, $count);
@@ -902,10 +836,10 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Removes an element from the array by key
 	 *
-	 * @param mixed $key the name of the key
+	 * @param string $key the name of the key
 	 * @return $this
 	 */
-	public function remove($key)
+	public function remove(string $key): static
 	{
 		$this->__unset($key);
 		return $this;
@@ -914,11 +848,10 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Adds a new element to the collection
 	 *
-	 * @param mixed $key string or array
-	 * @param mixed $value
+	 * @param TValue|null $value
 	 * @return $this
 	 */
-	public function set($key, $value = null)
+	public function set(string|array $key, $value = null): static
 	{
 		if (is_array($key)) {
 			foreach ($key as $k => $v) {
@@ -932,10 +865,8 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Shuffle all elements
-	 *
-	 * @return static
 	 */
-	public function shuffle()
+	public function shuffle(): static
 	{
 		$data = $this->data;
 		$keys = $this->keys();
@@ -957,8 +888,9 @@ class Collection extends Iterator implements Countable
 	 * @param int $offset The optional index to start the slice from
 	 * @param int|null $limit The optional number of elements to return
 	 * @return $this|static
+	 * @psalm-return ($offset is 0 && $limit is null ? $this : static)
 	 */
-	public function slice(int $offset = 0, int $limit = null)
+	public function slice(int $offset = 0, int $limit = null): static
 	{
 		if ($offset === 0 && $limit === null) {
 			return $this;
@@ -971,9 +903,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Get sort arguments from a string
-	 *
-	 * @param string $sort
-	 * @return array
 	 */
 	public static function sortArgs(string $sort): array
 	{
@@ -997,12 +926,19 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Sorts the elements by any number of fields
 	 *
+	 * ```php
+	 * $collection->sort('fieldName');
+	 * $collection->sort('fieldName', 'desc');
+	 * $collection->sort('fieldName', 'asc', SORT_REGULAR);
+	 * $collection->sort(fn ($a) => ...);
+	 * ```
+	 *
 	 * @param string|callable $field Field name or value callback to sort by
 	 * @param string $direction asc or desc
 	 * @param int $method The sort flag, SORT_REGULAR, SORT_NUMERIC etc.
 	 * @return $this|static
 	 */
-	public function sort()
+	public function sort(): static
 	{
 		// there is no need to sort empty collections
 		if (empty($this->data) === true) {
@@ -1110,12 +1046,7 @@ class Collection extends Iterator implements Countable
 	}
 
 	/**
-	 * Alias for `Kirby\Toolkit\Collection::sort`
-	 *
-	 * @param string|callable $field Field name or value callback to sort by
-	 * @param string $direction asc or desc
-	 * @param int $method The sort flag, SORT_REGULAR, SORT_NUMERIC etc.
-	 * @return $this|static
+	 * @see \Kirby\Toolkit\Collection::sort()
 	 */
 	public function sortBy(...$args)
 	{
@@ -1124,9 +1055,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Converts the object into an array
-	 *
-	 * @param \Closure|null $map
-	 * @return array
 	 */
 	public function toArray(Closure $map = null): array
 	{
@@ -1139,8 +1067,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Converts the object into a JSON string
-	 *
-	 * @return string
 	 */
 	public function toJson(): string
 	{
@@ -1149,8 +1075,6 @@ class Collection extends Iterator implements Countable
 
 	/**
 	 * Converts the object to a string
-	 *
-	 * @return string
 	 */
 	public function toString(): string
 	{
@@ -1161,9 +1085,6 @@ class Collection extends Iterator implements Countable
 	 * Returns a non-associative array
 	 * with all values. If a mapping Closure is passed,
 	 * all values are processed by the Closure.
-	 *
-	 * @param Closure|null $map
-	 * @return array
 	 */
 	public function values(Closure $map = null): array
 	{
@@ -1178,13 +1099,14 @@ class Collection extends Iterator implements Countable
 	 * This Closure will execute if the first parameter evaluates as false
 	 *
 	 * @since 3.3.0
-	 * @param mixed $condition
-	 * @param \Closure $callback
-	 * @param \Closure|null $fallback
+	 * @param mixed $condition a truthy or falsy value
 	 * @return mixed
 	 */
-	public function when($condition, Closure $callback, Closure $fallback = null)
-	{
+	public function when(
+		$condition,
+		Closure $callback,
+		Closure $fallback = null
+	) {
 		if ($condition) {
 			return $callback->call($this, $condition);
 		}
@@ -1193,12 +1115,11 @@ class Collection extends Iterator implements Countable
 	}
 
 	/**
-	 * Alias for $this->not()
+	 * @see \Kirby\Toolkit\Collection::not()
 	 *
 	 * @param string ...$keys any number of keys, passed as individual arguments
-	 * @return static
 	 */
-	public function without(...$keys)
+	public function without(string ...$keys): static
 	{
 		return $this->not(...$keys);
 	}
@@ -1206,14 +1127,13 @@ class Collection extends Iterator implements Countable
 
 /**
  * Equals Filter
- *
- * @param \Kirby\Toolkit\Collection $collection
- * @param mixed $field
- * @param mixed $test
- * @param bool $split
- * @return mixed
  */
-Collection::$filters['=='] = function ($collection, $field, $test, $split = false) {
+Collection::$filters['=='] = function (
+	Collection $collection,
+	string $field,
+	$test,
+	bool $split = false
+): Collection {
 	foreach ($collection->data as $key => $item) {
 		$value = $collection->getAttribute($item, $field, $split, $test);
 
@@ -1231,14 +1151,13 @@ Collection::$filters['=='] = function ($collection, $field, $test, $split = fals
 
 /**
  * Not Equals Filter
- *
- * @param \Kirby\Toolkit\Collection $collection
- * @param mixed $field
- * @param mixed $test
- * @param bool $split
- * @return mixed
  */
-Collection::$filters['!='] = function ($collection, $field, $test, $split = false) {
+Collection::$filters['!='] = function (
+	Collection $collection,
+	string $field,
+	$test,
+	bool $split = false
+): Collection {
 	foreach ($collection->data as $key => $item) {
 		$value = $collection->getAttribute($item, $field, $split, $test);
 

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -338,8 +338,7 @@ class Collection extends Iterator implements Countable
 		callable $validator,
 		array $values,
 		$test
-	): bool
-	{
+	): bool {
 		$matches = 0;
 
 		foreach ($values as $value) {

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -20,9 +20,16 @@ use IteratorAggregate;
  * 										in this class would require
  * 										implementing them throughout
  * 										the code base: https://github.com/getkirby/kirby/pull/4886#pullrequestreview-1203577545
+ *
+ * @template TKey of array-key
+ * @template TValue
+ * @template-implements \IteratorAggregate<TKey, TValue>
  */
 class Iterator implements IteratorAggregate
 {
+	/**
+     * @var array<TKey, TValue>
+	 */
 	public array $data = [];
 
 	public function __construct(array $data = [])
@@ -32,6 +39,7 @@ class Iterator implements IteratorAggregate
 
 	/**
 	 * Get an iterator for the items.
+	 * @return \ArrayIterator<TKey, TValue>
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -56,6 +64,7 @@ class Iterator implements IteratorAggregate
 
 	/**
 	 * Returns the current element
+	 * @return TValue
 	 */
 	public function current(): mixed
 	{
@@ -65,6 +74,7 @@ class Iterator implements IteratorAggregate
 	/**
 	 * Moves the cursor to the previous element
 	 * and returns it
+	 * @return TValue
 	 */
 	public function prev(): mixed
 	{
@@ -74,6 +84,7 @@ class Iterator implements IteratorAggregate
 	/**
 	 * Moves the cursor to the next element
 	 * and returns it
+	 * @return TValue
 	 */
 	public function next(): mixed
 	{
@@ -107,7 +118,7 @@ class Iterator implements IteratorAggregate
 	/**
 	 * Tries to find the index number for the given element
 	 *
-	 * @param mixed $needle the element to search for
+	 * @param TValue $needle the element to search for
 	 * @return int|false the index (int) of the element or false
 	 */
 	public function indexOf(mixed $needle): int|false
@@ -118,7 +129,7 @@ class Iterator implements IteratorAggregate
 	/**
 	 * Tries to find the key for the given element
 	 *
-	 * @param mixed $needle the element to search for
+	 * @param TValue $needle the element to search for
 	 * @return int|string|false the name of the key or false
 	 */
 	public function keyOf(mixed $needle): int|string|false
@@ -128,6 +139,7 @@ class Iterator implements IteratorAggregate
 
 	/**
 	 * Checks by key if an element is included
+	 * @param TKey $key
 	 */
 	public function has(mixed $key): bool
 	{
@@ -136,6 +148,7 @@ class Iterator implements IteratorAggregate
 
 	/**
 	 * Checks if the current key is set
+	 * @param TKey $key
 	 */
 	public function __isset(mixed $key): bool
 	{

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -17,9 +17,9 @@ use IteratorAggregate;
  * @license   https://opensource.org/licenses/MIT
  *
  * @psalm-suppress MissingTemplateParam Implementing template params
- * 										in this class would require
- * 										implementing them throughout
- * 										the code base: https://github.com/getkirby/kirby/pull/4886#pullrequestreview-1203577545
+ *                                      in this class would require
+ *                                      implementing them throughout
+ *                                      the code base: https://github.com/getkirby/kirby/pull/4886#pullrequestreview-1203577545
  *
  * @template TKey of array-key
  * @template TValue

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -23,7 +23,7 @@ use IteratorAggregate;
  *
  * @template TKey of array-key
  * @template TValue
- * @template-implements \IteratorAggregate<TKey, TValue>
+ * @implements \IteratorAggregate<TKey, TValue>
  */
 class Iterator implements IteratorAggregate
 {

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -28,7 +28,7 @@ use IteratorAggregate;
 class Iterator implements IteratorAggregate
 {
 	/**
-     * @var array<TKey, TValue>
+	 * @var array<TKey, TValue>
 	 */
 	public array $data = [];
 

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Toolkit;
 
+use Exception;
+
 class StringObject
 {
 	protected $value;
@@ -440,7 +442,7 @@ class CollectionTest extends TestCase
 	{
 		$collection = new Collection(['a' => 'A']);
 
-		$this->expectException('Exception');
+		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Can only group by string values or by providing a callback function');
 
 		$collection->group(1);


### PR DESCRIPTION
## TBD
- [ ] How can we resolve the type templates in our docs?

## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- Improved support for IDE autocompletion and type hints for collection items ($pages, $files...)


### Breaking change
- PHP (return) type hints have been added to many collection methods. If you are extending any collection classes, you might need to add the same to your methods.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
