### PR TITLE
Custom Panel view buttons

### DIFF
--- a/config/areas/languages/views.php
+++ b/config/areas/languages/views.php
@@ -12,10 +12,11 @@ return [
 			return App::instance()->option('languages.variables', true) !== false;
 		},
 		'action'  => function (string $code) {
+			$kirby        = App::instance();
 			$language     = Find::language($code);
 			$link         = '/languages/' . $language->code();
 			$strings      = [];
-			$foundation   = App::instance()->defaultLanguage()->translations();
+			$foundation   = $kirby->defaultLanguage()->translations();
 			$translations = $language->translations();
 
 			ksort($foundation);
@@ -67,6 +68,11 @@ return [
 					]
 				],
 				'props'      => [
+					'buttons' => $kirby->option('panel.viewButtons.language', [
+						'preview',
+						'settings',
+						'remove'
+					]),
 					'deletable'    => $language->isDeletable(),
 					'code'         => Escape::html($language->code()),
 					'default'      => $language->isDefault(),
@@ -107,6 +113,9 @@ return [
 			return [
 				'component' => 'k-languages-view',
 				'props'     => [
+					'buttons' => $kirby->option('panel.viewButtons.languages', [
+						'add'
+					]),
 					'languages' => $kirby->languages()->values(fn ($language) => [
 						'deletable' => $language->isDeletable(),
 						'default'   => $language->isDefault(),

--- a/config/areas/system/views.php
+++ b/config/areas/system/views.php
@@ -87,6 +87,7 @@ return [
 			return [
 				'component' => 'k-system-view',
 				'props'     => [
+					'buttons'     => $kirby->option('panel.viewButtons.system', []),
 					'environment' => $environment,
 					'exceptions'  => $kirby->option('debug') === true ? $exceptions : [],
 					'info'        => $system->info(),

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -18,7 +18,10 @@ return [
 			return [
 				'component' => 'k-users-view',
 				'props'     => [
-					'role' => function () use ($kirby, $roles, $role) {
+					'buttons' => $kirby->option('panel.viewButtons.users', [
+						'add'
+					]),
+					'role' => function () use ($roles, $role) {
 						if ($role) {
 							return $roles[$role] ?? null;
 						}

--- a/panel/public/js/plugins.js
+++ b/panel/public/js/plugins.js
@@ -7,6 +7,7 @@ window.panel.plugins = {
 	textareaButtons: {},
 	thirdParty: {},
 	use: [],
+	viewButtons: {},
 	views: {},
 	writerMarks: {},
 	writerNodes: {}
@@ -46,6 +47,11 @@ window.panel.plugin = function (plugin, extensions) {
 			...options,
 			mixins: ["section", ...(options.mixins ?? [])]
 		};
+	});
+
+	// View Buttons
+	resolve(extensions, "viewButtons", (name, options) => {
+		window.panel.plugins.components[`k-view-${name}-button`] = options;
 	});
 
 	// `Vue.use`

--- a/panel/src/components/Dropdowns/index.js
+++ b/panel/src/components/Dropdowns/index.js
@@ -1,7 +1,6 @@
 import DropdownContent from "./DropdownContent.vue";
 import DropdownItem from "./DropdownItem.vue";
 
-import LanguagesDropdown from "./LanguagesDropdown.vue";
 import OptionsDropdown from "./OptionsDropdown.vue";
 import PicklistDropdown from "./PicklistDropdown.vue";
 
@@ -10,7 +9,6 @@ export default {
 		app.component("k-dropdown-content", DropdownContent);
 		app.component("k-dropdown-item", DropdownItem);
 
-		app.component("k-languages-dropdown", LanguagesDropdown);
 		app.component("k-options-dropdown", OptionsDropdown);
 		app.component("k-picklist-dropdown", PicklistDropdown);
 	}

--- a/panel/src/components/View/Buttons/AddButton.vue
+++ b/panel/src/components/View/Buttons/AddButton.vue
@@ -1,0 +1,28 @@
+<template>
+	<component :is="component" v-if="component" />
+	<k-button
+		v-else
+		:text="$t('add')"
+		icon="add"
+		size="sm"
+		variant="filled"
+		@click="$emit('action', 'add')"
+	/>
+</template>
+
+<script>
+export default {
+	computed: {
+		component() {
+			const view = this.$panel.view.component.match(/^^k-(.*)-view$/)[1];
+			const component = `k-view-add-${view}-button`;
+
+			if (this.$helper.isComponent(component)) {
+				return component;
+			}
+
+			return null;
+		}
+	}
+};
+</script>

--- a/panel/src/components/View/Buttons/AddLanguagesButton.vue
+++ b/panel/src/components/View/Buttons/AddLanguagesButton.vue
@@ -1,0 +1,9 @@
+<template>
+	<k-button
+		:text="$t('language.create')"
+		icon="add"
+		size="sm"
+		variant="filled"
+		@click="$dialog('languages/create')"
+	/>
+</template>

--- a/panel/src/components/View/Buttons/AddUsersButton.vue
+++ b/panel/src/components/View/Buttons/AddUsersButton.vue
@@ -1,0 +1,16 @@
+<template>
+	<k-button
+		:disabled="!$panel.permissions.users.create"
+		:text="$t('user.create')"
+		icon="add"
+		size="sm"
+		variant="filled"
+		@click="
+			$dialog('users/create', {
+				query: {
+					role: $panel.view.props.role?.id
+				}
+			})
+		"
+	/>
+</template>

--- a/panel/src/components/View/Buttons/AddUsersButton.vue
+++ b/panel/src/components/View/Buttons/AddUsersButton.vue
@@ -1,5 +1,6 @@
 <template>
 	<k-button
+		v-if="$panel.view.component === 'k-users-view'"
 		:disabled="!$panel.permissions.users.create"
 		:text="$t('user.create')"
 		icon="add"

--- a/panel/src/components/View/Buttons/Buttons.vue
+++ b/panel/src/components/View/Buttons/Buttons.vue
@@ -1,0 +1,24 @@
+<template>
+	<k-button-group class="k-view-buttons">
+		<component
+			:is="`k-view-${button}-button`"
+			v-for="button in buttons"
+			:key="button"
+			@action="$emit('action', $event)"
+		/>
+	</k-button-group>
+</template>
+
+<script>
+/**
+ * Wrapper button group that dynamically renders the
+ * respective view button components passed as `buttons` prop.
+ * @internal
+ */
+export default {
+	props: {
+		buttons: Array
+	},
+	emits: ["action"]
+};
+</script>

--- a/panel/src/components/View/Buttons/LanguagesButton.vue
+++ b/panel/src/components/View/Buttons/LanguagesButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<div v-if="languages.length > 1" class="k-languages-dropdown">
+	<div
+		v-if="languages.length > 1"
+		class="k-view-languages-button k-languages-dropdown"
+	>
 		<k-button
 			:dropdown="true"
 			:text="code"
@@ -15,6 +18,7 @@
 
 <script>
 /**
+ * View header button to switch between content languages
  * @since 4.0.0
  */
 export default {

--- a/panel/src/components/View/Buttons/PreviewButton.vue
+++ b/panel/src/components/View/Buttons/PreviewButton.vue
@@ -1,0 +1,44 @@
+<template>
+	<k-button
+		v-if="isAvailable"
+		:link="link"
+		:title="$t('open')"
+		icon="open"
+		size="sm"
+		target="_blank"
+		variant="filled"
+		class="k-view-preview-button"
+	/>
+</template>
+
+<script>
+/**
+ * View header button to open the model's preview in a new tab
+ * @since 5.0.0
+ */
+export default {
+	computed: {
+		isAvailable() {
+			if (!this.link) {
+				return false;
+			}
+
+			if (Object.hasOwn(this.permissions, "preview") === false) {
+				return true;
+			}
+
+			return this.permissions.preview;
+		},
+		link() {
+			return (
+				this.$panel.view.props.model?.previewUrl ??
+				this.$panel.view.props.preview?.url ??
+				this.$panel.view.props.url
+			);
+		},
+		permissions() {
+			return this.$panel.view.props.permissions ?? {};
+		}
+	}
+};
+</script>

--- a/panel/src/components/View/Buttons/RemoveButton.vue
+++ b/panel/src/components/View/Buttons/RemoveButton.vue
@@ -1,0 +1,28 @@
+<template>
+	<component :is="component" v-if="component" />
+	<k-button
+		v-else
+		:text="$t('delete')"
+		icon="trash"
+		size="sm"
+		variant="filled"
+		@click="$emit('action', 'remove')"
+	/>
+</template>
+
+<script>
+export default {
+	computed: {
+		component() {
+			const view = this.$panel.view.component.match(/^^k-(.*)-view$/)[1];
+			const component = `k-view-remove-${view}-button`;
+
+			if (this.$helper.isComponent(component)) {
+				return component;
+			}
+
+			return null;
+		}
+	}
+};
+</script>

--- a/panel/src/components/View/Buttons/RemoveLanguageButton.vue
+++ b/panel/src/components/View/Buttons/RemoveLanguageButton.vue
@@ -1,0 +1,10 @@
+<template>
+	<k-button
+		v-if="$panel.view.props.deletable"
+		:title="$t('delete')"
+		icon="trash"
+		size="sm"
+		variant="filled"
+		@click="$dialog(`languages/${$panel.view.props.id}/delete`)"
+	/>
+</template>

--- a/panel/src/components/View/Buttons/RemoveLanguageButton.vue
+++ b/panel/src/components/View/Buttons/RemoveLanguageButton.vue
@@ -1,6 +1,8 @@
 <template>
 	<k-button
-		v-if="$panel.view.props.deletable"
+		v-if="
+			$panel.view.component === 'k-language-view' && $panel.view.props.deletable
+		"
 		:title="$t('delete')"
 		icon="trash"
 		size="sm"

--- a/panel/src/components/View/Buttons/SettingsButton.vue
+++ b/panel/src/components/View/Buttons/SettingsButton.vue
@@ -1,0 +1,49 @@
+<template>
+	<div>
+		<k-button
+			:disabled="$panel.view.isLocked"
+			:dropdown="true"
+			:title="$t('settings')"
+			icon="cog"
+			variant="filled"
+			size="sm"
+			class="k-view-settings-button k-view-options"
+			@click="onClick"
+		/>
+		<k-dropdown-content
+			v-if="dropdown"
+			ref="dropdown"
+			:options="$dropdown(dropdown)"
+			align-x="end"
+			@action="$emit('action', $event)"
+		/>
+	</div>
+</template>
+
+<script>
+/**
+ * View header button to open the model's settings dropdown
+ * @since 5.0.0
+ */
+export default {
+	inheritAttrs: false,
+	emits: ["action"],
+	computed: {
+		dropdown() {
+			return this.model?.link;
+		},
+		model() {
+			return this.$panel.view.props.model;
+		}
+	},
+	methods: {
+		onClick() {
+			if (this.dropdown) {
+				return this.$refs.dropdown.toggle();
+			}
+
+			this.$emit("action", "settings");
+		}
+	}
+};
+</script>

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -1,0 +1,47 @@
+<template>
+	<k-button
+		v-if="status"
+		v-bind="button"
+		:responsive="true"
+		:text="status.label"
+		size="sm"
+		variant="filled"
+		class="k-view-status-button k-page-status-button"
+		@click="$dialog(model.link + '/changeStatus')"
+	/>
+</template>
+
+<script>
+/**
+ * View header button to change the page status
+ * @since 5.0.0
+ */
+export default {
+	inheritAttrs: false,
+	computed: {
+		button() {
+			return this.$helper.page.status.call(
+				this,
+				this.model.status,
+				!this.permissions.changeStatus || this.$panel.view.isLocked
+			);
+		},
+		model() {
+			return this.$panel.view.props.model;
+		},
+		permissions() {
+			return this.$panel.view.props.permissions;
+		},
+		status() {
+			return this.$panel.view.props.status;
+		}
+	},
+	mounted() {
+		if (this.$panel.view.component !== "k-page-view") {
+			console.error(
+				"The status view button should only be used for the page view."
+			);
+		}
+	}
+};
+</script>

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-button
-		v-if="status"
+		v-if="$panel.view.component === 'k-page-view' && status"
 		v-bind="button"
 		:responsive="true"
 		:text="status.label"
@@ -34,13 +34,6 @@ export default {
 		},
 		status() {
 			return this.$panel.view.props.status;
-		}
-	},
-	mounted() {
-		if (this.$panel.view.component !== "k-page-view") {
-			console.error(
-				"The status view button should only be used for the page view."
-			);
 		}
 	}
 };

--- a/panel/src/components/View/Buttons/ThemeButton.vue
+++ b/panel/src/components/View/Buttons/ThemeButton.vue
@@ -1,14 +1,20 @@
 <template>
 	<k-button
+		v-if="$panel.view.id === 'account'"
 		:icon="icon"
 		:text="text"
 		size="sm"
 		variant="filled"
+		class="k-view-theme-button"
 		@click="$panel.theme.toggle()"
 	/>
 </template>
 
 <script>
+/**
+ * View header button to toggle the Panel theme
+ * @since 5.0.0
+ */
 export default {
 	computed: {
 		icon() {

--- a/panel/src/components/View/Buttons/index.js
+++ b/panel/src/components/View/Buttons/index.js
@@ -1,0 +1,32 @@
+import Add from "./AddButton.vue";
+import AddLanguages from "./AddLanguagesButton.vue";
+import AddUsers from "./AddUsersButton.vue";
+import Languages from "./LanguagesButton.vue";
+import Preview from "./PreviewButton.vue";
+import Remove from "./RemoveButton.vue";
+import RemoveLanguage from "./RemoveLanguageButton.vue";
+import Settings from "./SettingsButton.vue";
+import Status from "./StatusButton.vue";
+import Theme from "./ThemeButton.vue";
+
+import Buttons from "./Buttons.vue";
+
+export default {
+	install(app) {
+		app.component("k-view-add-button", Add);
+		app.component("k-view-add-languages-button", AddLanguages);
+		app.component("k-view-add-users-button", AddUsers);
+		app.component("k-view-languages-button", Languages);
+		app.component("k-view-preview-button", Preview);
+		app.component("k-view-remove-button", Remove);
+		app.component("k-view-remove-language-button", RemoveLanguage);
+		app.component("k-view-settings-button", Settings);
+		app.component("k-view-status-button", Status);
+		app.component("k-view-theme-button", Theme);
+
+		app.component("k-view-buttons", Buttons);
+
+		// @deprecated
+		app.component("k-languages-dropdown", Languages);
+	}
+};

--- a/panel/src/components/View/index.js
+++ b/panel/src/components/View/index.js
@@ -1,4 +1,5 @@
 import Activation from "./Activation.vue";
+import Buttons from "./Buttons/index.js";
 import Inside from "./Inside.vue";
 import Menu from "./Menu.vue";
 import Outside from "./Outside.vue";
@@ -7,6 +8,8 @@ import Topbar from "./Topbar.vue";
 
 export default {
 	install(app) {
+		app.use(Buttons);
+
 		app.component("k-activation", Activation);
 		app.component("k-panel", Panel);
 		app.component("k-panel-inside", Inside);

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -16,39 +16,9 @@
 			@edit="$dialog(id + '/changeName')"
 		>
 			{{ model.filename }}
+
 			<template #buttons>
-				<k-button-group>
-					<k-button
-						:link="preview.url"
-						:responsive="true"
-						:title="$t('open')"
-						class="k-file-view-options"
-						icon="open"
-						size="sm"
-						target="_blank"
-						variant="filled"
-					/>
-
-					<k-button
-						:disabled="isLocked"
-						:dropdown="true"
-						:title="$t('settings')"
-						icon="cog"
-						size="sm"
-						variant="filled"
-						class="k-file-view-options"
-						@click="$refs.settings.toggle()"
-					/>
-					<k-dropdown-content
-						ref="settings"
-						:options="$dropdown(id)"
-						align-x="end"
-						@action="action"
-					/>
-
-					<k-languages-dropdown />
-				</k-button-group>
-
+				<k-view-buttons :buttons="buttons" @action="onAction" />
 				<k-form-buttons :lock="lock" />
 			</template>
 		</k-header>
@@ -89,7 +59,7 @@ export default {
 		}
 	},
 	methods: {
-		action(action) {
+		onAction(action) {
 			switch (action) {
 				case "replace":
 					return this.$panel.upload.replace({

--- a/panel/src/components/Views/Languages/LanguageView.vue
+++ b/panel/src/components/Views/Languages/LanguageView.vue
@@ -8,31 +8,7 @@
 			{{ name }}
 
 			<template #buttons>
-				<k-button-group>
-					<k-button
-						:link="url"
-						:title="$t('open')"
-						icon="open"
-						size="sm"
-						target="_blank"
-						variant="filled"
-					/>
-					<k-button
-						:title="$t('settings')"
-						icon="cog"
-						size="sm"
-						variant="filled"
-						@click="update()"
-					/>
-					<k-button
-						v-if="deletable"
-						:title="$t('delete')"
-						icon="trash"
-						size="sm"
-						variant="filled"
-						@click="remove()"
-					/>
-				</k-button-group>
+				<k-view-buttons :buttons="buttons" @action="onAction" />
 			</template>
 		</k-header>
 
@@ -84,6 +60,7 @@
  */
 export default {
 	props: {
+		buttons: Array,
 		code: String,
 		deletable: Boolean,
 		direction: String,
@@ -99,6 +76,12 @@ export default {
 		createTranslation() {
 			this.$dialog(`languages/${this.id}/translations/create`);
 		},
+		onAction(action) {
+			switch (action) {
+				case "settings":
+					return this.update();
+			}
+		},
 		option(option, row) {
 			// for the compatibility of the encoded url in different environments,
 			// it is also encoded with base64 to reduce special characters
@@ -107,9 +90,6 @@ export default {
 					encodeURIComponent(row.key)
 				)}/${option}`
 			);
-		},
-		remove() {
-			this.$dialog(`languages/${this.id}/delete`);
 		},
 		update(focus) {
 			this.$dialog(`languages/${this.id}/update`, {

--- a/panel/src/components/Views/Languages/LanguagesView.vue
+++ b/panel/src/components/Views/Languages/LanguagesView.vue
@@ -3,15 +3,9 @@
 		<k-header>
 			{{ $t("view.languages") }}
 
-			<k-button-group slot="buttons">
-				<k-button
-					:text="$t('language.create')"
-					icon="add"
-					size="sm"
-					variant="filled"
-					@click="$dialog('languages/create')"
-				/>
-			</k-button-group>
+			<template #buttons>
+				<k-view-buttons :buttons="buttons" />
+			</template>
 		</k-header>
 
 		<template v-if="languages.length > 0">
@@ -44,6 +38,7 @@
  */
 export default {
 	props: {
+		buttons: Array,
 		languages: {
 			type: Array,
 			default: () => []

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -5,6 +5,7 @@
 export default {
 	props: {
 		blueprint: String,
+		buttons: Array,
 		next: Object,
 		prev: Object,
 		permissions: {
@@ -36,7 +37,7 @@ export default {
 			return this.model.link;
 		},
 		isLocked() {
-			return this.lock?.state === "lock";
+			return this.$panel.view.isLocked;
 		},
 		protectedFields() {
 			return [];

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -16,45 +16,9 @@
 			@edit="$dialog(id + '/changeTitle')"
 		>
 			{{ model.title }}
+
 			<template #buttons>
-				<k-button-group>
-					<k-button
-						v-if="permissions.preview && model.previewUrl"
-						:link="model.previewUrl"
-						:title="$t('open')"
-						icon="open"
-						target="_blank"
-						variant="filled"
-						size="sm"
-						class="k-page-view-preview"
-					/>
-
-					<k-button
-						:disabled="isLocked === true"
-						:dropdown="true"
-						:title="$t('settings')"
-						icon="cog"
-						variant="filled"
-						size="sm"
-						class="k-page-view-options"
-						@click="$refs.settings.toggle()"
-					/>
-					<k-dropdown-content
-						ref="settings"
-						:options="$dropdown(id)"
-						align-x="end"
-					/>
-
-					<k-languages-dropdown />
-
-					<k-button
-						v-if="status"
-						v-bind="statusBtn"
-						class="k-page-view-status"
-						@click="$dialog(id + '/changeStatus')"
-					/>
-				</k-button-group>
-
+				<k-view-buttons :buttons="buttons" />
 				<k-form-buttons :lock="lock" />
 			</template>
 		</k-header>
@@ -82,19 +46,6 @@ export default {
 	computed: {
 		protectedFields() {
 			return ["title"];
-		},
-		statusBtn() {
-			return {
-				...this.$helper.page.status.call(
-					this,
-					this.model.status,
-					!this.permissions.changeStatus || this.isLocked
-				),
-				responsive: true,
-				size: "sm",
-				text: this.status.label,
-				variant: "filled"
-			};
 		}
 	}
 };

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -12,20 +12,9 @@
 			@edit="$dialog('site/changeTitle')"
 		>
 			{{ model.title }}
-			<template #buttons>
-				<k-button-group>
-					<k-button
-						:link="model.previewUrl"
-						:title="$t('open')"
-						icon="open"
-						target="_blank"
-						variant="filled"
-						size="sm"
-						class="k-site-view-preview"
-					/>
-					<k-languages-dropdown />
-				</k-button-group>
 
+			<template #buttons>
+				<k-view-buttons :buttons="buttons" />
 				<k-form-buttons :lock="lock" />
 			</template>
 		</k-header>

--- a/panel/src/components/Views/System/SystemView.vue
+++ b/panel/src/components/Views/System/SystemView.vue
@@ -2,6 +2,10 @@
 	<k-panel-inside class="k-system-view">
 		<k-header>
 			{{ $t("view.system") }}
+
+			<template #buttons>
+				<k-view-buttons :buttons="buttons" />
+			</template>
 		</k-header>
 
 		<k-section
@@ -36,6 +40,7 @@ export default {
 		Security
 	},
 	props: {
+		buttons: Array,
 		environment: Array,
 		exceptions: Array,
 		info: Object,

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -26,27 +26,7 @@
 			</template>
 
 			<template #buttons>
-				<k-account-theme-button v-if="$panel.view.id === 'account'" />
-
-				<k-button-group>
-					<k-button
-						:disabled="isLocked"
-						:dropdown="true"
-						:title="$t('settings')"
-						icon="cog"
-						size="sm"
-						variant="filled"
-						class="k-user-view-options"
-						@click="$refs.settings.toggle()"
-					/>
-					<k-dropdown-content
-						ref="settings"
-						align-x="end"
-						:options="$dropdown(id)"
-					/>
-					<k-languages-dropdown />
-				</k-button-group>
-
+				<k-view-buttons :buttons="buttons" />
 				<k-form-buttons :lock="lock" />
 			</template>
 		</k-header>

--- a/panel/src/components/Views/Users/UsersView.vue
+++ b/panel/src/components/Views/Users/UsersView.vue
@@ -4,14 +4,7 @@
 			{{ $t("view.users") }}
 
 			<template #buttons>
-				<k-button
-					:disabled="!$panel.permissions.users.create"
-					:text="$t('user.create')"
-					icon="add"
-					size="sm"
-					variant="filled"
-					@click="create"
-				/>
+				<k-view-buttons :buttons="buttons" />
 			</template>
 		</k-header>
 		<k-tabs :tab="role?.id ?? 'all'" :tabs="tabs" />
@@ -30,6 +23,7 @@
  */
 export default {
 	props: {
+		buttons: Array,
 		role: Object,
 		roles: Array,
 		search: String,

--- a/panel/src/components/Views/index.js
+++ b/panel/src/components/Views/index.js
@@ -20,7 +20,6 @@ import SystemView from "./System/SystemView.vue";
 import TableUpdateStatusCell from "./System/TableUpdateStatusCell.vue";
 
 import AccountView from "./Users/AccountView.vue";
-import AccountThemeButton from "./Users/AccountThemeButton.vue";
 import UserAvatar from "./Users/UserAvatar.vue";
 import UserProfile from "./Users/UserProfile.vue";
 import UserView from "./Users/UserView.vue";
@@ -50,7 +49,6 @@ export default {
 		app.component("k-table-update-status-cell", TableUpdateStatusCell);
 
 		app.component("k-account-view", AccountView);
-		app.component("k-account-theme-button", AccountThemeButton);
 		app.component("k-user-avatar", UserAvatar);
 		app.component("k-user-profile", UserProfile);
 		app.component("k-user-view", UserView);

--- a/panel/src/helpers/page.js
+++ b/panel/src/helpers/page.js
@@ -8,7 +8,6 @@
  */
 export function status(status, disabled = false) {
 	const button = {
-		class: "k-status-icon",
 		icon: "status-" + status,
 		title:
 			window.panel.$t("page.status") +

--- a/panel/src/panel/plugins.js
+++ b/panel/src/panel/plugins.js
@@ -166,8 +166,9 @@ export default (app, plugins = {}) => {
 		icons: {},
 		login: null,
 		textareaButtons: {},
-		use: [],
 		thirdParty: {},
+		use: [],
+		viewButtons: {},
 		writerMarks: {},
 		writerNodes: {},
 		...plugins

--- a/panel/src/panel/plugins.test.js
+++ b/panel/src/panel/plugins.test.js
@@ -19,8 +19,9 @@ describe.concurrent("panel.plugins", () => {
 			icons: {},
 			login: null,
 			textareaButtons: {},
-			use: [],
 			thirdParty: {},
+			use: [],
+			viewButtons: {},
 			writerMarks: {},
 			writerNodes: {}
 		};

--- a/panel/src/panel/view.js
+++ b/panel/src/panel/view.js
@@ -22,6 +22,10 @@ export default (panel) => {
 	return {
 		...parent,
 
+		get isLocked() {
+			return this.props.lock?.state === "lock";
+		},
+
 		/**
 		 * Setting the active view state
 		 * will also change the document title

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -211,6 +211,14 @@ class Blueprint
 	}
 
 	/**
+	 * Gathers custom config for Panel view buttons
+	 */
+	public function buttons(): array|null
+	{
+		return $this->props['buttons'] ?? null;
+	}
+
+	/**
 	 * Converts all column definitions, that
 	 * are not wrapped in a tab, into a generic tab
 	 */

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -65,6 +65,21 @@ class File extends Model
 	}
 
 	/**
+	 * Returns header button names which should be displayed
+	 * on the file view
+	 */
+	public function buttons(): array
+	{
+		return
+			$this->model->blueprint()->buttons() ??
+			$this->model->kirby()->option('panel.viewButtons.file', [
+				'preview',
+				'settings',
+				'languages'
+			]);
+	}
+
+	/**
 	 * Provides a kirbytag or markdown
 	 * tag for the file, which will be
 	 * used in the panel, when the file

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -28,6 +28,11 @@ abstract class Model
 	}
 
 	/**
+	 * Returns header button names which should be displayed
+	 */
+	abstract public function buttons(): array;
+
+	/**
 	 * Get the content values for the model
 	 */
 	public function content(): array
@@ -352,6 +357,7 @@ abstract class Model
 		$tab       = $blueprint->tab($request->get('tab')) ?? $tabs[0] ?? null;
 
 		$props = [
+			'buttons'     => $this->buttons(),
 			'lock'        => $this->lock(),
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -40,6 +40,22 @@ class Page extends Model
 	}
 
 	/**
+	 * Returns header button names which should be displayed
+	 * on the page view
+	 */
+	public function buttons(): array
+	{
+		return
+			$this->model->blueprint()->buttons() ??
+			$this->model->kirby()->option('panel.viewButtons.page', [
+				'preview',
+				'settings',
+				'languages',
+				'status'
+			]);
+	}
+
+	/**
 	 * Provides a kirbytag or markdown
 	 * tag for the page, which will be
 	 * used in the panel, when the page

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -24,6 +24,20 @@ class Site extends Model
 	protected ModelWithContent $model;
 
 	/**
+	 * Returns header button names which should be displayed
+	 * on the site view
+	 */
+	public function buttons(): array
+	{
+		return
+			$this->model->blueprint()->buttons() ??
+			$this->model->kirby()->option('panel.viewButtons.site', [
+				'preview',
+				'languages'
+			]);
+	}
+
+	/**
 	 * Returns the setup for a dropdown option
 	 * which is used in the changes dropdown
 	 * for example.

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -40,6 +40,21 @@ class User extends Model
 	}
 
 	/**
+	 * Returns header button names which should be displayed
+	 * on the site view
+	 */
+	public function buttons(): array
+	{
+		return
+			$this->model->blueprint()->buttons() ??
+			$this->model->kirby()->option('panel.viewButtons.user', [
+				'theme',
+				'settings',
+				'languages'
+			]);
+	}
+
+	/**
 	 * Provides options for the user dropdown
 	 */
 	public function dropdown(array $options = []): array

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -339,6 +339,20 @@ class BlueprintTest extends TestCase
 	}
 
 	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'name'  => 'default',
+			'buttons' => ['foo', 'bar']
+		]);
+
+		$this->assertSame(['foo', 'bar'], $blueprint->buttons());
+	}
+
+	/**
 	 * @covers ::__debugInfo
 	 */
 	public function testDebugInfo()

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -43,6 +43,17 @@ class FileTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
+	protected function panel(array $props = [])
+	{
+		$page = new ModelPage([
+			'slug'  => 'test',
+			'files' => [
+				['filename' => 'test.jpg', ...$props],
+			]
+		]);
+		return new File($page->file('test.jpg'));
+	}
+
 	/**
 	 * @covers ::breadcrumb
 	 */
@@ -115,6 +126,18 @@ class FileTest extends TestCase
 				'link'  => '/users/test/files/test.jpg'
 			]
 		], $file->breadcrumb());
+	}
+
+	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$this->assertSame([
+			'preview',
+			'settings',
+			'languages'
+		], $this->panel()->buttons());
 	}
 
 	/**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -67,6 +67,11 @@ class ModelSiteTestForceUnlocked extends ModelSite
 
 class CustomPanelModel extends Model
 {
+	public function buttons(): array
+	{
+		return [];
+	}
+
 	public function path(): string
 	{
 		return 'custom';

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -42,6 +42,12 @@ class PageTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
+	protected function panel(array $props = [])
+	{
+		$page = new ModelPage(['slug' => 'test', ...$props]);
+		return new Page($page);
+	}
+
 	/**
 	 * @covers ::breadcrumb
 	 */
@@ -86,6 +92,19 @@ class PageTest extends TestCase
 				'link'  => '/pages/a+b+c'
 			]
 		], $page->breadcrumb());
+	}
+
+	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$this->assertSame([
+			'preview',
+			'settings',
+			'languages',
+			'status'
+		], $this->panel()->buttons());
 	}
 
 	/**

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -40,6 +40,17 @@ class SiteTest extends TestCase
 	}
 
 	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$this->assertSame([
+			'preview',
+			'languages',
+		], $this->panel()->buttons());
+	}
+
+	/**
 	 * @covers ::dropdownOption
 	 */
 	public function testDropdownOption(): void

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -45,6 +45,12 @@ class UserTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
+	protected function panel(array $props = [])
+	{
+		$user = new ModelUser(['id' => 'test', ...$props]);
+		return new User($user);
+	}
+
 	/**
 	 * @covers ::breadcrumb
 	 */
@@ -57,6 +63,18 @@ class UserTest extends TestCase
 		$breadcrumb = (new User($model))->breadcrumb();
 		$this->assertSame('test@getkirby.com', $breadcrumb[0]['label']);
 		$this->assertStringStartsWith('/users/', $breadcrumb[0]['link']);
+	}
+
+	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$this->assertSame([
+			'theme',
+			'settings',
+			'languages',
+		], $this->panel()->buttons());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Feature
- Panel view buttons extension
https://feedback.getkirby.com/411

```js
panel.plugin("getkirby/custom-view-buttons", {
  viewButtons: {
    applause: {
      template: `<k-button icon="heart" variant="filled" theme="love" size="sm" @click="applause">Applause</k-button>`,
      methods: {
        applause() {
           alert("👏");
         },
       },
    },
  },
});
```

Global config options:

```php
return [
  'panel' => [
    'viewButtons' => [
      'page' => ['preview', 'settings', 'applause', 'status']
    ]
  ]
}
  ```

Blueprint:

```yml
buttons:
  - preview
  - settings
  - applause
  - status
  ```
  
<img width="1229" alt="Screenshot 2024-04-25 at 13 06 19" src="https://github.com/getkirby/kirby/assets/3788865/a9ed21bb-798e-45e9-8a1c-086c0679db57">


### Deprecated
- `<k-languages-dropdown>` has been renamed to `<k-view-languages-button>`. `k-languages-dropdown` alias will be removed in a future version

### Breaking changes
- When overwriting/extending any model view, ensure to include new `<k-view-buttons :buttons="buttons">` component


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful): https://github.com/getkirby/sandbox/pull/5
- [x] Add changes & docs to release notes draft in Notion
