### PR TITLE
`k-button`: New `theme` notations w/ `-icon` suffix for only colored icon

### DIFF
--- a/panel/lab/components/buttons/2_themes/index.php
+++ b/panel/lab/components/buttons/2_themes/index.php
@@ -7,6 +7,7 @@ return [
 		'warning',
 		'positive',
 		'info',
+		'love',
 		null,
 		'empty',
 	]

--- a/panel/lab/components/buttons/2_themes/index.php
+++ b/panel/lab/components/buttons/2_themes/index.php
@@ -2,13 +2,14 @@
 
 return [
 	'themes' => [
-		'negative',
-		'notice',
-		'warning',
-		'positive',
-		'info',
-		'love',
 		null,
-		'empty',
+		'red',
+		'orange',
+		'yellow',
+		'green',
+		'aqua',
+		'blue',
+		'purple',
+		'pink',
 	]
 ];

--- a/panel/lab/components/buttons/2_themes/index.vue
+++ b/panel/lab/components/buttons/2_themes/index.vue
@@ -27,13 +27,24 @@
 				Button
 			</k-button>
 		</k-lab-example>
+		<k-lab-example :flex="true" label="variant: filled with themed icon">
+			<k-button
+				v-for="theme in themes"
+				:key="theme"
+				:theme="theme + '-icon'"
+				variant="filled"
+				icon="edit"
+			>
+				Button
+			</k-button>
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 
 <script>
 export default {
 	props: {
-		themes: Array,
-	},
+		themes: Array
+	}
 };
 </script>

--- a/panel/lab/components/buttons/2_themes/index.vue
+++ b/panel/lab/components/buttons/2_themes/index.vue
@@ -1,11 +1,11 @@
 <template>
 	<k-lab-examples>
-		<k-lab-example :flex="true" label="default">
+		<k-lab-example :flex="true" label="theme: none">
 			<k-button v-for="theme in themes" :key="theme" :theme="theme" icon="edit">
 				Button
 			</k-button>
 		</k-lab-example>
-		<k-lab-example :flex="true" label="variant: dimmed">
+		<k-lab-example :flex="true" label="theme: none | variant: dimmed">
 			<k-button
 				v-for="theme in themes"
 				:key="theme"
@@ -16,7 +16,18 @@
 				Button
 			</k-button>
 		</k-lab-example>
-		<k-lab-example :flex="true" label="variant: filled">
+		<k-lab-example :flex="true" label="theme: ${color}-icon | variant: dimmed ">
+			<k-button
+				v-for="theme in themes"
+				:key="theme"
+				:theme="theme ? theme + '-icon' : null"
+				variant="dimmed"
+				icon="edit"
+			>
+				Button
+			</k-button>
+		</k-lab-example>
+		<k-lab-example :flex="true" label="theme: ${color} | variant: filled">
 			<k-button
 				v-for="theme in themes"
 				:key="theme"
@@ -27,16 +38,19 @@
 				Button
 			</k-button>
 		</k-lab-example>
-		<k-lab-example :flex="true" label="variant: filled with themed icon">
+		<k-lab-example :flex="true" label="theme: ${color}-icon | variant: filled">
 			<k-button
 				v-for="theme in themes"
 				:key="theme"
-				:theme="theme + '-icon'"
+				:theme="theme ? theme + '-icon' : null"
 				variant="filled"
 				icon="edit"
 			>
 				Button
 			</k-button>
+		</k-lab-example>
+		<k-lab-example :flex="true" label="theme: empty">
+			<k-button theme="empty" variant="filled" icon="edit"> Button </k-button>
 		</k-lab-example>
 	</k-lab-examples>
 </template>

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -312,21 +312,21 @@ export default {
 }
 
 /** Filled Buttons **/
-.k-button:where([data-variant="filled"], [data-variant="filled-icon"]) {
+.k-button:where([data-variant="filled"]) {
 	--button-color-back: var(--color-gray-300);
 }
 .k-button:where([data-variant="filled"]):not([aria-disabled]):hover {
 	filter: brightness(97%);
 }
-.k-button:where([data-theme][data-variant="filled"]) {
+.k-button:where([data-theme$="-icon"][data-variant="filled"]) {
+	--button-color-icon: var(--theme-color-600);
+}
+.k-button:where([data-theme][data-variant="filled"]):not(
+		[data-theme$="-icon"]
+	) {
 	--button-color-icon: var(--theme-color-700);
 	--button-color-back: var(--theme-color-back);
 	--button-color-text: var(--theme-color-text);
-}
-
-.k-button:where([data-theme][data-variant="filled-icon"]) {
-	--button-color-back: var(--color-gray-300);
-	--button-color-icon: var(--theme-color-600);
 }
 
 /** Icon Buttons **/

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -307,6 +307,7 @@ export default {
 	--button-color-text: var(--button-color-dimmed-off);
 }
 .k-button:where([data-theme][data-variant="dimmed"]) {
+	--button-color-icon: var(--theme-color-icon);
 	--button-color-dimmed-on: var(--theme-color-text-dimmed);
 	--button-color-dimmed-off: var(--theme-color-text);
 }

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -292,6 +292,9 @@ export default {
 	--button-color-icon: var(--theme-color-icon);
 	--button-color-text: var(--theme-color-text);
 }
+.k-button[data-theme$="-icon"] {
+	--button-color-text: currentColor;
+}
 
 /** Dimmed Buttons **/
 .k-button:where([data-variant="dimmed"]) {

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -307,13 +307,12 @@ export default {
 	--button-color-text: var(--button-color-dimmed-off);
 }
 .k-button:where([data-theme][data-variant="dimmed"]) {
-	--button-color-icon: var(--theme-color-icon);
 	--button-color-dimmed-on: var(--theme-color-text-dimmed);
 	--button-color-dimmed-off: var(--theme-color-text);
 }
 
 /** Filled Buttons **/
-.k-button:where([data-variant="filled"]) {
+.k-button:where([data-variant="filled"], [data-variant="filled-icon"]) {
 	--button-color-back: var(--color-gray-300);
 }
 .k-button:where([data-variant="filled"]):not([aria-disabled]):hover {
@@ -323,6 +322,11 @@ export default {
 	--button-color-icon: var(--theme-color-700);
 	--button-color-back: var(--theme-color-back);
 	--button-color-text: var(--theme-color-text);
+}
+
+.k-button:where([data-theme][data-variant="filled-icon"]) {
+	--button-color-back: var(--color-gray-300);
+	--button-color-icon: var(--theme-color-600);
 }
 
 /** Icon Buttons **/

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -318,11 +318,9 @@ export default {
 .k-button:where([data-variant="filled"]):not([aria-disabled]):hover {
 	filter: brightness(97%);
 }
-.k-button:where([data-theme$="-icon"][data-variant="filled"]) {
-	--button-color-icon: var(--theme-color-600);
-}
-.k-button:where([data-theme][data-variant="filled"]):not(
-		[data-theme$="-icon"]
+
+.k-button:where([data-theme]):not([data-theme$="-icon"]):where(
+		[data-variant="filled"]
 	) {
 	--button-color-icon: var(--theme-color-700);
 	--button-color-back: var(--theme-color-back);

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -292,27 +292,28 @@ export default {
 	--button-color-icon: var(--theme-color-icon);
 	--button-color-text: var(--theme-color-text);
 }
-.k-button[data-theme$="-icon"] {
+.k-button:where([data-theme$="-icon"]) {
 	--button-color-text: currentColor;
 }
 
 /** Dimmed Buttons **/
 .k-button:where([data-variant="dimmed"]) {
 	--button-color-icon: var(--color-text);
-	--button-color-dimmed-on: var(--color-text-dimmed);
-	--button-color-dimmed-off: var(--color-text);
-	--button-color-text: var(--button-color-dimmed-on);
+	--button-color-text: var(--color-text-dimmed);
 }
 .k-button:where([data-variant="dimmed"]):not([aria-disabled]):is(
 		:hover,
 		[aria-current]
-	) {
-	--button-color-text: var(--button-color-dimmed-off);
+	)
+	.k-button-text {
+	filter: brightness(75%);
 }
-.k-button:where([data-theme][data-variant="dimmed"]) {
+.k-button:where([data-variant="dimmed"][data-theme]) {
 	--button-color-icon: var(--theme-color-icon);
-	--button-color-dimmed-on: var(--theme-color-text-dimmed);
-	--button-color-dimmed-off: var(--theme-color-text);
+	--button-color-text: var(--theme-color-text-dimmed);
+}
+.k-button:where([data-variant="dimmed"][data-theme$="-icon"]) {
+	--button-color-text: var(--color-text-dimmed);
 }
 
 /** Filled Buttons **/
@@ -322,13 +323,16 @@ export default {
 .k-button:where([data-variant="filled"]):not([aria-disabled]):hover {
 	filter: brightness(97%);
 }
-
-.k-button:where([data-theme]):not([data-theme$="-icon"]):where(
-		[data-variant="filled"]
-	) {
+.k-button:where([data-variant="filled"][data-theme]) {
 	--button-color-icon: var(--theme-color-700);
 	--button-color-back: var(--theme-color-back);
-	--button-color-text: var(--theme-color-text);
+}
+.k-button:where([data-theme$="-icon"][data-variant="filled"]) {
+	--button-color-icon: hsl(
+		var(--theme-color-hs),
+		57%
+	); /* slightly improve the contrast */
+	--button-color-back: var(--color-gray-300);
 }
 
 /** Icon Buttons **/

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -51,7 +51,6 @@
 						v-if="status"
 						v-bind="statusBtn"
 						class="k-page-view-status"
-						variant="filled"
 						@click="$dialog(id + '/changeStatus')"
 					/>
 				</k-button-group>
@@ -105,11 +104,5 @@ export default {
 /** TODO: .k-page-view:has(.k-tabs) .k-page-view-header */
 .k-page-view[data-has-tabs="true"] .k-page-view-header {
 	margin-bottom: 0;
-}
-
-.k-page-view-status {
-	--button-color-back: var(--color-gray-300);
-	--button-color-icon: var(--theme-color-600);
-	--button-color-text: initial;
 }
 </style>

--- a/panel/src/helpers/page.js
+++ b/panel/src/helpers/page.js
@@ -24,11 +24,11 @@ export function status(status, disabled = false) {
 	}
 
 	if (status === "draft") {
-		button.theme = "negative";
+		button.theme = "negative-icon";
 	} else if (status === "unlisted") {
-		button.theme = "info";
+		button.theme = "info-icon";
 	} else {
-		button.theme = "positive";
+		button.theme = "positive-icon";
 	}
 
 	return button;

--- a/panel/src/styles/utilities/theme.css
+++ b/panel/src/styles/utilities/theme.css
@@ -32,63 +32,63 @@
 }
 
 /* Color themes */
-[data-theme="red"],
-[data-theme="error"],
-[data-theme="negative"] {
+[data-theme^="red"],
+[data-theme^="error"],
+[data-theme^="negative"] {
 	--theme-color-h: var(--color-red-h);
 	--theme-color-s: var(--color-red-s);
 	--theme-color-boost: var(--color-red-boost);
 }
 
-[data-theme="orange"],
-[data-theme="notice"] {
+[data-theme^="orange"],
+[data-theme^="notice"] {
 	--theme-color-h: var(--color-orange-h);
 	--theme-color-s: var(--color-orange-s);
 	--theme-color-boost: var(--color-orange-boost);
 }
 
-[data-theme="yellow"],
-[data-theme="warning"] {
+[data-theme^="yellow"],
+[data-theme^="warning"] {
 	--theme-color-h: var(--color-yellow-h);
 	--theme-color-s: var(--color-yellow-s);
 	--theme-color-boost: var(--color-yellow-boost);
 }
 
-[data-theme="blue"],
-[data-theme="info"] {
+[data-theme^="blue"],
+[data-theme^="info"] {
 	--theme-color-h: var(--color-blue-h);
 	--theme-color-s: var(--color-blue-s);
 	--theme-color-boost: var(--color-blue-boost);
 }
 
-[data-theme="pink"],
-[data-theme="love"] {
+[data-theme^="pink"],
+[data-theme^="love"] {
 	--theme-color-h: var(--color-pink-h);
 	--theme-color-s: var(--color-pink-s);
 	--theme-color-boost: var(--color-pink-boost);
 }
 
-[data-theme="green"],
-[data-theme="positive"] {
+[data-theme^="green"],
+[data-theme^="positive"] {
 	--theme-color-h: var(--color-green-h);
 	--theme-color-s: var(--color-green-s);
 	--theme-color-boost: var(--color-green-boost);
 }
 
-[data-theme="aqua"] {
+[data-theme^="aqua"] {
 	--theme-color-h: var(--color-aqua-h);
 	--theme-color-s: var(--color-aqua-s);
 	--theme-color-boost: var(--color-aqua-boost);
 }
 
-[data-theme="purple"] {
+[data-theme^="purple"] {
 	--theme-color-h: var(--color-purple-h);
 	--theme-color-s: var(--color-purple-s);
 	--theme-color-boost: var(--color-purple-boost);
 }
 
-[data-theme="gray"],
-[data-theme="passive"] {
+[data-theme^="gray"],
+[data-theme^="passive"] {
 	--theme-color-h: var(--color-gray-h);
 	--theme-color-s: var(--color-gray-s);
 	--theme-color-boost: 10%;
@@ -103,7 +103,7 @@
 }
 
 /* Special Themes */
-[data-theme="dark"] {
+[data-theme^="dark"] {
 	--theme-color-h: var(--color-gray-h);
 	--theme-color-s: var(--color-gray-s);
 	--theme-color-boost: var(--color-gray-boost);

--- a/panel/src/styles/utilities/theme.css
+++ b/panel/src/styles/utilities/theme.css
@@ -25,7 +25,11 @@
 	--theme-color-900: hsl(var(--theme-color-hs), var(--theme-color-l-900));
 
 	--theme-color-text: var(--theme-color-900);
-	--theme-color-text-dimmed: var(--theme-color-700);
+	--theme-color-text-dimmed: hsl(
+		var(--theme-color-h),
+		calc(var(--theme-color-s) - 60%),
+		50%
+	);
 	--theme-color-back: var(--theme-color-400);
 	--theme-color-hover: var(--theme-color-500);
 	--theme-color-icon: var(--theme-color-600);
@@ -94,8 +98,8 @@
 	--theme-color-boost: 10%;
 }
 
-[data-theme="white"],
-[data-theme="text"] {
+[data-theme^="white"],
+[data-theme^="text"] {
 	--theme-color-back: var(--color-white);
 	--theme-color-icon: var(--color-gray-800);
 	--theme-color-text: var(--color-text);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- `<k-button>`: `theme` supports values suffixed with `-icon` now, e.g. `positive-icon` for filled buttons with only the icon colored
https://feedback.getkirby.com/635


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->


```html
<k-button icon="heart" theme="negative-icon" variant="filled">Love</k-button>
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
