### PR TITLE
Update searches.php: Fixing panel search when uuids are disabled

### DIFF
--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -22,7 +22,7 @@ return [
 					'text' => Escape::html($page->title()->value()),
 					'link' => $page->panel()->url(true),
 					'info' => Escape::html($page->id()),
-					'uuid' => $page->uuid()->toString(),
+					'uuid' => $page->uuid()?->toString(),
 				]),
 				'pagination' => $pages->pagination()->toArray()
 			];


### PR DESCRIPTION
## This PR fixes a bug that would break the panel search when uuids are disabled

I couldn't find an open issue about this (which surprised me quite a bit). If UUIDs are disabled, the panel search is completely broken since 4.0. This is a quick fix that I think fixes this, but this is my first time contributing to Kirby, so I'm not too sure...

Explanation of the fix: `$page->uuid()` returns `null` when uuids are disabled. Calling `toString()` on null throws an exception. With the fix, `toString()` is not called and `null` is used instead.

### Fixes
- Panel search fixed when UUIDs are disabled

## Ready?
- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and checks all pass

### For review team
- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
