### PR TITLE
Syntax preparations for PHP 8.4

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -49,6 +49,7 @@ return $config
 		'no_useless_return' => true,
 		'no_whitespace_before_comma_in_array' => true,
 		'nullable_type_declaration' => ['syntax' => 'union'],
+		'nullable_type_declaration_for_default_null_value' => true,
 		'object_operator_without_whitespace' => true,
 		'operator_linebreak' => ['position' => 'end', 'only_booleans' => true],
 		'ordered_imports' => ['sort_algorithm' => 'alpha'],

--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -8,7 +8,7 @@ return [
 	'pages' => [
 		'label' => I18n::translate('pages'),
 		'icon'  => 'page',
-		'query' => function (string $query = null, int $limit, int $page) {
+		'query' => function (string|null $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$pages = $kirby->site()
 				->index(true)
@@ -31,7 +31,7 @@ return [
 	'files' => [
 		'label' => I18n::translate('files'),
 		'icon'  => 'image',
-		'query' => function (string $query = null, int $limit, int $page) {
+		'query' => function (string|null $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$files = $kirby->site()
 				->index(true)

--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -8,7 +8,7 @@ return [
 	'pages' => [
 		'label' => I18n::translate('pages'),
 		'icon'  => 'page',
-		'query' => function (string|null $query = null, int $limit, int $page) {
+		'query' => function (string|null $query, int $limit, int $page) {
 			$kirby = App::instance();
 			$pages = $kirby->site()
 				->index(true)
@@ -31,7 +31,7 @@ return [
 	'files' => [
 		'label' => I18n::translate('files'),
 		'icon'  => 'image',
-		'query' => function (string|null $query = null, int $limit, int $page) {
+		'query' => function (string|null $query, int $limit, int $page) {
 			$kirby = App::instance();
 			$files = $kirby->site()
 				->index(true)

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -8,7 +8,7 @@ return [
 	'users' => [
 		'label' => I18n::translate('users'),
 		'icon'  => 'users',
-		'query' => function (string|null $query = null, int $limit, int $page) {
+		'query' => function (string|null $query, int $limit, int $page) {
 			$kirby = App::instance();
 			$users = $kirby->users()
 				->search($query)

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -8,7 +8,7 @@ return [
 	'users' => [
 		'label' => I18n::translate('users'),
 		'icon'  => 'users',
-		'query' => function (string $query = null, int $limit, int $page) {
+		'query' => function (string|null $query = null, int $limit, int $page) {
 			$kirby = App::instance();
 			$users = $kirby->users()
 				->search($query)

--- a/config/components.php
+++ b/config/components.php
@@ -119,7 +119,7 @@ return [
 	 */
 	'markdown' => function (
 		App $kirby,
-		string $text = null,
+		string|null $text = null,
 		array $options = []
 	): string {
 		static $markdown;
@@ -271,7 +271,7 @@ return [
 	 */
 	'smartypants' => function (
 		App $kirby,
-		string $text = null,
+		string|null $text = null,
 		array $options = []
 	): string {
 		static $smartypants;
@@ -354,7 +354,7 @@ return [
 	 */
 	'url' => function (
 		App $kirby,
-		string $path = null,
+		string|null $path = null,
 		$options = null
 	): string {
 		$language = null;

--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -29,13 +29,13 @@ return [
 		/**
 		 * Maximum number of checked boxes
 		 */
-		'max' => function (int $max = null) {
+		'max' => function (int|null $max = null) {
 			return $max;
 		},
 		/**
 		 * Minimum number of checked boxes
 		 */
-		'min' => function (int $min = null) {
+		'min' => function (int|null $min = null) {
 			return $min;
 		},
 		'value' => function ($value = null) {

--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -24,7 +24,7 @@ return [
 		/**
 		 * Default date when a new page/file/user gets created
 		 */
-		'default' => function (string $default = null): string {
+		'default' => function (string|null $default = null): string {
 			return $this->toDatetime($default) ?? '';
 		},
 
@@ -46,13 +46,13 @@ return [
 		/**
 		 * Latest date, which can be selected/saved (Y-m-d)
 		 */
-		'max' => function (string $max = null): string|null {
+		'max' => function (string|null $max = null): string|null {
 			return Date::optional($max);
 		},
 		/**
 		 * Earliest date, which can be selected/saved (Y-m-d)
 		 */
-		'min' => function (string $min = null): string|null {
+		'min' => function (string|null $min = null): string|null {
 			return Date::optional($min);
 		},
 

--- a/config/fields/info.php
+++ b/config/fields/info.php
@@ -26,7 +26,7 @@ return [
 		/**
 		 * Change the design of the info box
 		 */
-		'theme' => function (string $theme = null) {
+		'theme' => function (string|null $theme = null) {
 			return $theme;
 		}
 	],

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -7,7 +7,7 @@ return [
 		/**
 		 * Defines a custom format that is used when the field is saved
 		 */
-		'format' => function (string $format = null) {
+		'format' => function (string|null $format = null) {
 			return $format;
 		}
 	],

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -22,7 +22,7 @@ return [
 		/**
 		 * Info text for each item
 		 */
-		'info' => function (string $info = null) {
+		'info' => function (string|null $info = null) {
 			return $info;
 		},
 
@@ -36,14 +36,14 @@ return [
 		/**
 		 * The minimum number of required selected
 		 */
-		'min' => function (int $min = null) {
+		'min' => function (int|null $min = null) {
 			return $min;
 		},
 
 		/**
 		 * The maximum number of allowed selected
 		 */
-		'max' => function (int $max = null) {
+		'max' => function (int|null $max = null) {
 			return $max;
 		},
 
@@ -57,7 +57,7 @@ return [
 		/**
 		 * Query for the items to be included in the picker
 		 */
-		'query' => function (string $query = null) {
+		'query' => function (string|null $query = null) {
 			return $query;
 		},
 
@@ -81,7 +81,7 @@ return [
 		/**
 		 * Main text for each item
 		 */
-		'text' => function (string $text = null) {
+		'text' => function (string|null $text = null) {
 			return $text;
 		},
 	],

--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -70,7 +70,7 @@ return [
 				return $map($file, $parent);
 			});
 		},
-		'uploadParent' => function (string $parentQuery = null) {
+		'uploadParent' => function (string|null $parentQuery = null) {
 			$parent = $this->model();
 
 			if ($parentQuery) {

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -13,13 +13,13 @@ return [
 		/**
 		 * The lowest allowed number
 		 */
-		'min' => function (float $min = null) {
+		'min' => function (float|null $min = null) {
 			return $min;
 		},
 		/**
 		 * The highest allowed number
 		 */
-		'max' => function (float $max = null) {
+		'max' => function (float|null $max = null) {
 			return $max;
 		},
 		/**

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -31,7 +31,7 @@ return [
 		/**
 		 * Optional query to select a specific set of pages
 		 */
-		'query' => function (string $query = null) {
+		'query' => function (string|null $query = null) {
 			return $query;
 		},
 

--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -13,7 +13,7 @@ return [
 		/**
 		 * Custom icon to replace the arrow down.
 		 */
-		'icon' => function (string $icon = null) {
+		'icon' => function (string|null $icon = null) {
 			return $icon;
 		},
 		/**

--- a/config/fields/slug.php
+++ b/config/fields/slug.php
@@ -28,7 +28,7 @@ return [
 		/**
 		 * Set prefix for the help text
 		 */
-		'path'  => function (string $path = null) {
+		'path'  => function (string|null $path = null) {
 			return $path;
 		},
 
@@ -36,7 +36,7 @@ return [
 		 * Name of another field that should be used to
 		 * automatically update this field's value
 		 */
-		'sync'  => function (string $sync = null) {
+		'sync'  => function (string|null $sync = null) {
 			return $sync;
 		},
 

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -45,7 +45,7 @@ return [
 		/**
 		 * Set the default rows for the structure
 		 */
-		'default' => function (array $default = null) {
+		'default' => function (array|null $default = null) {
 			return $default;
 		},
 
@@ -58,38 +58,38 @@ return [
 		/**
 		 * The number of entries that will be displayed on a single page. Afterwards pagination kicks in.
 		 */
-		'limit' => function (int $limit = null) {
+		'limit' => function (int|null $limit = null) {
 			return $limit;
 		},
 		/**
 		 * Maximum allowed entries in the structure. Afterwards the "Add" button will be switched off.
 		 */
-		'max' => function (int $max = null) {
+		'max' => function (int|null $max = null) {
 			return $max;
 		},
 		/**
 		 * Minimum required entries in the structure
 		 */
-		'min' => function (int $min = null) {
+		'min' => function (int|null $min = null) {
 			return $min;
 		},
 		/**
 		 * Toggles adding to the top or bottom of the list
 		 */
-		'prepend' => function (bool $prepend = null) {
+		'prepend' => function (bool|null $prepend = null) {
 			return $prepend;
 		},
 		/**
 		 * Toggles drag & drop sorting
 		 */
-		'sortable' => function (bool $sortable = null) {
+		'sortable' => function (bool|null $sortable = null) {
 			return $sortable;
 		},
 		/**
 		 * Sorts the entries by the given field and order (i.e. `title desc`)
 		 * Drag & drop is disabled in this case
 		 */
-		'sortBy' => function (string $sort = null) {
+		'sortBy' => function (string|null $sort = null) {
 			return $sort;
 		}
 	],

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -37,13 +37,13 @@ return [
 		/**
 		 * Minimum number of required entries/tags
 		 */
-		'min' => function (int $min = null) {
+		'min' => function (int|null $min = null) {
 			return $min;
 		},
 		/**
 		 * Maximum number of allowed entries/tags
 		 */
-		'max' => function (int $max = null) {
+		'max' => function (int|null $max = null) {
 			return $max;
 		},
 		/**
@@ -93,7 +93,7 @@ return [
 			return $value;
 		}
 	],
-	'save' => function (array $value = null): string {
+	'save' => function (array|null $value = null): string {
 		return A::join(
 			$value,
 			$this->separator() . ' '

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -30,28 +30,28 @@ return [
 		/**
 		 * Sets the font family (sans or monospace)
 		 */
-		'font' => function (string $font = null) {
+		'font' => function (string|null $font = null) {
 			return $font === 'monospace' ? 'monospace' : 'sans-serif';
 		},
 
 		/**
 		 * Maximum number of allowed characters
 		 */
-		'maxlength' => function (int $maxlength = null) {
+		'maxlength' => function (int|null $maxlength = null) {
 			return $maxlength;
 		},
 
 		/**
 		 * Minimum number of required characters
 		 */
-		'minlength' => function (int $minlength = null) {
+		'minlength' => function (int|null $minlength = null) {
 			return $minlength;
 		},
 
 		/**
 		 * A regular expression, which will be used to validate the input
 		 */
-		'pattern' => function (string $pattern = null) {
+		'pattern' => function (string|null $pattern = null) {
 			return $pattern;
 		},
 

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -26,7 +26,7 @@ return [
 		/**
 		 * Sets the default text when a new page/file/user is created
 		 */
-		'default' => function (string $default = null) {
+		'default' => function (string|null $default = null) {
 			return trim($default ?? '');
 		},
 
@@ -48,28 +48,28 @@ return [
 		/**
 		 * Sets the font family (sans or monospace)
 		 */
-		'font' => function (string $font = null) {
+		'font' => function (string|null $font = null) {
 			return $font === 'monospace' ? 'monospace' : 'sans-serif';
 		},
 
 		/**
 		 * Maximum number of allowed characters
 		 */
-		'maxlength' => function (int $maxlength = null) {
+		'maxlength' => function (int|null $maxlength = null) {
 			return $maxlength;
 		},
 
 		/**
 		 * Minimum number of required characters
 		 */
-		'minlength' => function (int $minlength = null) {
+		'minlength' => function (int|null $minlength = null) {
 			return $minlength;
 		},
 
 		/**
 		 * Changes the size of the textarea. Available sizes: `small`, `medium`, `large`, `huge`
 		 */
-		'size' => function (string $size = null) {
+		'size' => function (string|null $size = null) {
 			return $size;
 		},
 
@@ -80,7 +80,7 @@ return [
 			return $spellcheck;
 		},
 
-		'value' => function (string $value = null) {
+		'value' => function (string|null $value = null) {
 			return trim($value ?? '');
 		}
 	],

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -36,13 +36,13 @@ return [
 		/**
 		 * Latest time, which can be selected/saved (H:i or H:i:s)
 		 */
-		'max' => function (string $max = null): string|null {
+		'max' => function (string|null $max = null): string|null {
 			return Date::optional($max);
 		},
 		/**
 		 * Earliest time, which can be selected/saved (H:i or H:i:s)
 		 */
-		'min' => function (string $min = null): string|null {
+		'min' => function (string|null $min = null): string|null {
 			return Date::optional($min);
 		},
 

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -36,14 +36,14 @@ return [
 		/**
 		 * Maximum number of allowed characters
 		 */
-		'maxlength' => function (int $maxlength = null) {
+		'maxlength' => function (int|null $maxlength = null) {
 			return $maxlength;
 		},
 
 		/**
 		 * Minimum number of required characters
 		 */
-		'minlength' => function (int $minlength = null) {
+		'minlength' => function (int|null $minlength = null) {
 			return $minlength;
 		},
 		/**

--- a/config/methods.php
+++ b/config/methods.php
@@ -115,7 +115,7 @@ return function (App $app) {
 		'toDate' => function (
 			Field $field,
 			string|IntlDateFormatter|null $format = null,
-			string $fallback = null
+			string|null $fallback = null
 		) use ($app): string|int|null {
 			if (empty($field->value) === true && $fallback === null) {
 				return null;
@@ -504,7 +504,7 @@ return function (App $app) {
 		 */
 		'query' => function (
 			Field $field,
-			string $expect = null
+			string|null $expect = null
 		) use ($app): mixed {
 			if ($parent = $field->parent()) {
 				return $parent->query($field->value, $expect);

--- a/config/routes.php
+++ b/config/routes.php
@@ -33,7 +33,7 @@ return function (App $kirby) {
 			'pattern' => $api . '/(:all)',
 			'method'  => 'ALL',
 			'env'     => 'api',
-			'action'  => function (string $path = null) use ($kirby) {
+			'action'  => function (string|null $path = null) use ($kirby) {
 				if ($kirby->option('api') === false) {
 					return null;
 				}
@@ -125,7 +125,7 @@ return function (App $kirby) {
 			'pattern' => $panel . '/(:all?)',
 			'method'  => 'ALL',
 			'env'     => 'panel',
-			'action'  => function (string $path = null) {
+			'action'  => function (string|null $path = null) {
 				return Panel::router($path);
 			}
 		],

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -28,7 +28,7 @@ return [
 		/**
 		 * Filters all files by template and also sets the template, which will be used for all uploads
 		 */
-		'template' => function (string $template = null) {
+		'template' => function (string|null $template = null) {
 			return $template;
 		},
 		/**

--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -7,13 +7,13 @@ return [
 		'headline',
 	],
 	'props' => [
-		'icon' => function (string $icon = null) {
+		'icon' => function (string|null $icon = null) {
 			return $icon;
 		},
 		'text' => function ($text = null) {
 			return I18n::translate($text, $text);
 		},
-		'theme' => function (string $theme = null) {
+		'theme' => function (string|null $theme = null) {
 			return $theme;
 		}
 	],

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -10,7 +10,7 @@ return [
 		/**
 		 * Columns config for `layout: table`
 		 */
-		'columns' => function (array $columns = null) {
+		'columns' => function (array|null $columns = null) {
 			return $columns ?? [];
 		},
 		/**

--- a/config/sections/mixins/max.php
+++ b/config/sections/mixins/max.php
@@ -5,7 +5,7 @@ return [
 		/**
 		 * Sets the maximum number of allowed entries in the section
 		 */
-		'max' => function (int $max = null) {
+		'max' => function (int|null $max = null) {
 			return $max;
 		}
 	],

--- a/config/sections/mixins/min.php
+++ b/config/sections/mixins/min.php
@@ -5,7 +5,7 @@ return [
 		/**
 		 * Sets the minimum number of required entries in the section
 		 */
-		'min' => function (int $min = null) {
+		'min' => function (int|null $min = null) {
 			return $min;
 		}
 	],

--- a/config/sections/mixins/pagination.php
+++ b/config/sections/mixins/pagination.php
@@ -14,7 +14,7 @@ return [
 		/**
 		 * Sets the default page for the pagination. This will overwrite default pagination.
 		 */
-		'page' => function (int $page = null) {
+		'page' => function (int|null $page = null) {
 			return App::instance()->request()->get('page', $page);
 		},
 	],

--- a/config/sections/mixins/parent.php
+++ b/config/sections/mixins/parent.php
@@ -11,7 +11,7 @@ return [
 		/**
 		 * Sets the query to a parent to find items for the list
 		 */
-		'parent' => function (string $parent = null) {
+		'parent' => function (string|null $parent = null) {
 			return $parent;
 		}
 	],

--- a/config/sections/mixins/sort.php
+++ b/config/sections/mixins/sort.php
@@ -17,7 +17,7 @@ return [
 		/**
 		 * Overwrites manual sorting and sorts by the given field and sorting direction (i.e. `date desc`)
 		 */
-		'sortBy' => function (string $sortBy = null) {
+		'sortBy' => function (string|null $sortBy = null) {
 			return $sortBy;
 		},
 	],

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -53,7 +53,7 @@ return [
 		/**
 		 * Filters the list by single template.
 		 */
-		'template' => function (string|array $template = null) {
+		'template' => function (string|array|null $template = null) {
 			return $template;
 		},
 		/**

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -592,7 +592,7 @@ class Api
 	 * @return $this
 	 */
 	protected function setRequestMethod(
-		string $requestMethod = null
+		string|null $requestMethod = null
 	): static {
 		$this->requestMethod = $requestMethod ?? 'GET';
 		return $this;

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -299,7 +299,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function bakeRoots(array $roots = null): static
+	protected function bakeRoots(array|null $roots = null): static
 	{
 		$roots = [...$this->core->roots(), ...$roots ?? []];
 		$this->roots = Ingredients::bake($roots);
@@ -311,7 +311,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function bakeUrls(array $urls = null): static
+	protected function bakeUrls(array|null $urls = null): static
 	{
 		$urls = [...$this->core->urls(), ...$urls ?? []];
 		$this->urls = Ingredients::bake($urls);
@@ -345,7 +345,7 @@ class App
 	/**
 	 * Calls any Kirby route
 	 */
-	public function call(string $path = null, string $method = null): mixed
+	public function call(string|null $path = null, string|null $method = null): mixed
 	{
 		$path   ??= $this->path();
 		$method ??= $this->request()->method();
@@ -705,7 +705,7 @@ class App
 	 * @psalm-return ($lazy is false ? static : static|null)
 	 */
 	public static function instance(
-		self $instance = null,
+		self|null $instance = null,
 		bool $lazy = false
 	): static|null {
 		if ($instance !== null) {
@@ -856,7 +856,7 @@ class App
 	 *
 	 * @internal
 	 */
-	public function kirbytags(string $text = null, array $data = []): string
+	public function kirbytags(string|null $text = null, array $data = []): string
 	{
 		$data['kirby']  ??= $this;
 		$data['site']   ??= $data['kirby']->site();
@@ -876,7 +876,7 @@ class App
 	 *
 	 * @internal
 	 */
-	public function kirbytext(string $text = null, array $options = []): string
+	public function kirbytext(string|null $text = null, array $options = []): string
 	{
 		$text = $this->apply('kirbytext:before', compact('text'), 'text');
 		$text = $this->kirbytags($text, $options);
@@ -894,7 +894,7 @@ class App
 	/**
 	 * Returns the current language
 	 */
-	public function language(string $code = null): Language|null
+	public function language(string|null $code = null): Language|null
 	{
 		if ($this->multilang() === false) {
 			return null;
@@ -920,7 +920,7 @@ class App
 	 *
 	 * @internal
 	 */
-	public function languageCode(string $languageCode = null): string|null
+	public function languageCode(string|null $languageCode = null): string|null
 	{
 		return $this->language($languageCode)?->code();
 	}
@@ -966,7 +966,7 @@ class App
 	 *
 	 * @internal
 	 */
-	public function markdown(string $text = null, array $options = null): string
+	public function markdown(string|null $text = null, array|null $options = null): string
 	{
 		// merge global options with local options
 		$options = [
@@ -1206,8 +1206,8 @@ class App
 	 * current request
 	 */
 	public function render(
-		string $path = null,
-		string $method = null
+		string|null $path = null,
+		string|null $method = null
 	): Response|null {
 		if (($_ENV['KIRBY_RENDER'] ?? true) === false) {
 			return null;
@@ -1239,7 +1239,7 @@ class App
 	 * @internal
 	 * @throws \Kirby\Exception\NotFoundException if the home page cannot be found
 	 */
-	public function resolve(string $path = null, string $language = null): mixed
+	public function resolve(string|null $path = null, string|null $language = null): mixed
 	{
 		// set the current translation
 		$this->setCurrentTranslation($language);
@@ -1442,7 +1442,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function setLanguages(array $languages = null): static
+	protected function setLanguages(array|null $languages = null): static
 	{
 		if ($languages !== null) {
 			$objects = [];
@@ -1463,7 +1463,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function setPath(string $path = null): static
+	protected function setPath(string|null $path = null): static
 	{
 		$this->path = $path !== null ? trim($path, '/') : null;
 		return $this;
@@ -1474,7 +1474,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function setRequest(array $request = null): static
+	protected function setRequest(array|null $request = null): static
 	{
 		if ($request !== null) {
 			$this->request = new Request($request);
@@ -1488,7 +1488,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function setRoles(array $roles = null): static
+	protected function setRoles(array|null $roles = null): static
 	{
 		if ($roles !== null) {
 			$this->roles = Roles::factory($roles);
@@ -1502,7 +1502,7 @@ class App
 	 *
 	 * @return $this
 	 */
-	protected function setSite(Site|array $site = null): static
+	protected function setSite(Site|array|null $site = null): static
 	{
 		if (is_array($site) === true) {
 			$site = new Site($site);
@@ -1529,7 +1529,7 @@ class App
 	 *
 	 * @internal
 	 */
-	public function smartypants(string $text = null): string
+	public function smartypants(string|null $text = null): string
 	{
 		$options = $this->option('smartypants', []);
 

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -99,7 +99,7 @@ trait AppPlugins
 	 */
 	public function extend(
 		array $extensions,
-		Plugin $plugin = null
+		Plugin|null $plugin = null
 	): array {
 		foreach ($this->extensions as $type => $registered) {
 			if (isset($extensions[$type]) === true) {
@@ -456,7 +456,7 @@ trait AppPlugins
 	 */
 	protected function extendOptions(
 		array $options,
-		Plugin $plugin = null
+		Plugin|null $plugin = null
 	): array {
 		if ($plugin !== null) {
 			$options = [$plugin->prefix() => $options];
@@ -518,7 +518,7 @@ trait AppPlugins
 	 */
 	protected function extendPermissions(
 		array $permissions,
-		Plugin $plugin = null
+		Plugin|null $plugin = null
 	): array {
 		if ($plugin !== null) {
 			$permissions = [$plugin->prefix() => $permissions];
@@ -718,7 +718,7 @@ trait AppPlugins
 	 *
 	 * @internal
 	 */
-	public function extensions(string $type = null): array
+	public function extensions(string|null $type = null): array
 	{
 		if ($type === null) {
 			return $this->extensions;
@@ -848,7 +848,7 @@ trait AppPlugins
 	 */
 	public static function plugin(
 		string $name,
-		array $extends = null
+		array|null $extends = null
 	): PLugin|null {
 		if ($extends === null) {
 			return static::$plugins[$name] ?? null;
@@ -874,7 +874,7 @@ trait AppPlugins
 	 * @internal
 	 * @param array|null $plugins Can be used to overwrite the plugins registry
 	 */
-	public function plugins(array $plugins = null): array
+	public function plugins(array|null $plugins = null): array
 	{
 		// overwrite the existing plugins registry
 		if ($plugins !== null) {

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -111,7 +111,7 @@ trait AppTranslations
 	 * @internal
 	 */
 	public function setCurrentLanguage(
-		string $languageCode = null
+		string|null $languageCode = null
 	): Language|null {
 		if ($this->multilang() === false) {
 			Locale::set($this->option('locale', 'en_US.utf-8'));
@@ -136,7 +136,7 @@ trait AppTranslations
 	 *
 	 * @internal
 	 */
-	public function setCurrentTranslation(string $translationCode = null): void
+	public function setCurrentTranslation(string|null $translationCode = null): void
 	{
 		I18n::$locale = $translationCode ?? 'en';
 	}

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -72,7 +72,7 @@ trait AppUsers
 	 *
 	 * @return $this
 	 */
-	protected function setUser(User|string $user = null): static
+	protected function setUser(User|string|null $user = null): static
 	{
 		$this->user = $user;
 		return $this;
@@ -83,7 +83,7 @@ trait AppUsers
 	 *
 	 * @return $this
 	 */
-	protected function setUsers(array $users = null): static
+	protected function setUsers(array|null $users = null): static
 	{
 		if ($users !== null) {
 			$this->users = Users::factory($users);

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -201,7 +201,7 @@ class Auth
 	 * @throws \Kirby\Exception\InvalidArgumentException if the authorization header is invalid
 	 * @throws \Kirby\Exception\PermissionException if basic authentication is not allowed
 	 */
-	public function currentUserFromBasicAuth(BasicAuth $auth = null): User|null
+	public function currentUserFromBasicAuth(BasicAuth|null $auth = null): User|null
 	{
 		if ($this->kirby->option('api.basicAuth', false) !== true) {
 			throw new PermissionException('Basic authentication is not activated');
@@ -253,7 +253,7 @@ class Auth
 	 * valid user id in there
 	 */
 	public function currentUserFromSession(
-		Session|array $session = null
+		Session|array|null $session = null
 	): User|null {
 		$session = $this->session($session);
 
@@ -444,7 +444,7 @@ class Auth
 	 *                                 logged in user will be returned
 	 */
 	public function status(
-		Session|array $session = null,
+		Session|array|null $session = null,
 		bool $allowImpersonation = true
 	): Status {
 		// try to return from cache
@@ -732,7 +732,7 @@ class Auth
 	 * @throws \Throwable If an authentication error occurred
 	 */
 	public function user(
-		Session|array $session = null,
+		Session|array|null $session = null,
 		bool $allowImpersonation = true
 	): User|null {
 		if ($allowImpersonation === true && $this->impersonate !== null) {
@@ -898,7 +898,7 @@ class Auth
 	 */
 	protected function fail(
 		Throwable $exception,
-		Throwable $fallback = null
+		Throwable|null $fallback = null
 	): void {
 		$debug = $this->kirby->option('auth.debug', 'log');
 
@@ -922,7 +922,7 @@ class Auth
 	/**
 	 * Creates a session object from the passed options
 	 */
-	protected function session(Session|array $session = null): Session
+	protected function session(Session|array|null $session = null): Session
 	{
 		// use passed session options or session object if set
 		if (is_array($session) === true) {

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -56,7 +56,7 @@ class Blocks extends Items
 	 * catch blocks from layouts
 	 */
 	public static function factory(
-		array $items = null,
+		array|null $items = null,
 		array $params = []
 	): static {
 		$items = static::extractFromLayouts($items);

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -39,7 +39,7 @@ class Blueprint
 	/**
 	 * Magic getter/caller for any blueprint prop
 	 */
-	public function __call(string $key, array $arguments = null): mixed
+	public function __call(string $key, array|null $arguments = null): mixed
 	{
 		return $this->props[$key] ?? null;
 	}
@@ -102,7 +102,7 @@ class Blueprint
 	 * Gathers what file templates are allowed in
 	 * this model based on the blueprint
 	 */
-	public function acceptedFileTemplates(string $inSection = null): array
+	public function acceptedFileTemplates(string|null $inSection = null): array
 	{
 		// get cached results for the current file model
 		// (except when collecting for a specific section)
@@ -323,7 +323,7 @@ class Blueprint
 	 */
 	public static function factory(
 		string $name,
-		string $fallback = null,
+		string|null $fallback = null,
 		ModelWithContent $model
 	): static|null {
 		try {

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -323,7 +323,7 @@ class Blueprint
 	 */
 	public static function factory(
 		string $name,
-		string|null $fallback = null,
+		string|null $fallback,
 		ModelWithContent $model
 	): static|null {
 		try {

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -366,7 +366,7 @@ class Collection extends BaseCollection
 	 * Searches the collection
 	 */
 	public function search(
-		string $query = null,
+		string|null $query = null,
 		string|array $params = []
 	): static {
 		return Search::collection($this, $query, $params);
@@ -377,7 +377,7 @@ class Collection extends BaseCollection
 	 * to an array. This can also take a callback
 	 * function to further modify the array result.
 	 */
-	public function toArray(Closure $map = null): array
+	public function toArray(Closure|null $map = null): array
 	{
 		return parent::toArray($map ?? fn ($object) => $object->toArray());
 	}

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -122,7 +122,7 @@ class Email
 	/**
 	 * Returns an email template by name and type
 	 */
-	protected function getTemplate(string $name, string $type = null): Template
+	protected function getTemplate(string $name, string|null $type = null): Template
 	{
 		return App::instance()->template('emails/' . $name, $type, 'text');
 	}
@@ -160,7 +160,7 @@ class Email
 		string $prop,
 		string $class,
 		string $contentValue,
-		string $contentKey = null
+		string|null $contentKey = null
 	): array {
 		$value = $this->props[$prop] ?? [];
 

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -76,7 +76,7 @@ class Fieldsets extends Items
 	}
 
 	public static function factory(
-		array $items = null,
+		array|null $items = null,
 		array $params = []
 	): static {
 		$items ??= App::instance()->option('blocks.fieldsets', [

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -159,7 +159,7 @@ class File extends ModelWithContent
 	 * Returns an array with all blueprints that are available for the file
 	 * by comparing files sections and files fields of the parent model
 	 */
-	public function blueprints(string $inSection = null): array
+	public function blueprints(string|null $inSection = null): array
 	{
 		// get cached results for the current file model
 		// (except when collecting for a specific section)
@@ -231,7 +231,7 @@ class File extends ModelWithContent
 	 */
 	public function contentFileData(
 		array $data,
-		string $languageCode = null
+		string|null $languageCode = null
 	): array {
 		// only add the template in, if the $data array
 		// doesn't explicitly unsets it
@@ -450,7 +450,7 @@ class File extends ModelWithContent
 	 * Timestamp of the last modification
 	 * of the content file
 	 */
-	protected function modifiedContent(string $languageCode = null): int
+	protected function modifiedContent(string|null $languageCode = null): int
 	{
 		return $this->storage()->modified('published', $languageCode) ?? 0;
 	}
@@ -555,7 +555,7 @@ class File extends ModelWithContent
 	 *
 	 * @return $this
 	 */
-	protected function setBlueprint(array $blueprint = null): static
+	protected function setBlueprint(array|null $blueprint = null): static
 	{
 		if ($blueprint !== null) {
 			$blueprint['model'] = $this;

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -397,8 +397,8 @@ trait FileActions
 	 * @internal
 	 */
 	public function save(
-		array $data = null,
-		string $languageCode = null,
+		array|null $data = null,
+		string|null $languageCode = null,
 		bool $overwrite = false
 	): static {
 		$file = parent::save($data, $languageCode, $overwrite);
@@ -437,8 +437,8 @@ trait FileActions
 	 * @throws \Kirby\Exception\InvalidArgumentException If the input array contains invalid values
 	 */
 	public function update(
-		array $input = null,
-		string $languageCode = null,
+		array|null $input = null,
+		string|null $languageCode = null,
 		bool $validate = false
 	): static {
 		// delete all public media versions when focus field gets changed

--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -38,7 +38,7 @@ trait FileModifications
 	 */
 	public function crop(
 		int $width,
-		int $height = null,
+		int|null $height = null,
 		$options = null
 	): FileVersion|File|Asset {
 		$quality = null;
@@ -94,9 +94,9 @@ trait FileModifications
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public function resize(
-		int $width = null,
-		int $height = null,
-		int $quality = null
+		int|null $width = null,
+		int|null $height = null,
+		int|null $quality = null
 	): FileVersion|File|Asset {
 		return $this->thumb([
 			'width'   => $width,

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -312,7 +312,7 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the MIME type is missing or forbidden
 	 */
-	public static function validMime(File $file, string $mime = null): bool
+	public static function validMime(File $file, string|null $mime = null): bool
 	{
 		// make it easier to compare the mime
 		$mime = strtolower($mime);

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -142,7 +142,7 @@ class Find
 	 * @param string|null $id User's id
 	 * @throws \Kirby\Exception\NotFoundException if the user for the given id cannot be found
 	 */
-	public static function user(string $id = null): User|null
+	public static function user(string|null $id = null): User|null
 	{
 		// account is a reserved word to find the current
 		// user. It's used in various API and area routes.

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -176,7 +176,7 @@ trait HasChildren
 	 *
 	 * @return $this
 	 */
-	protected function setChildren(array $children = null): static
+	protected function setChildren(array|null $children = null): static
 	{
 		if ($children !== null) {
 			$this->children = Pages::factory($children, $this);
@@ -190,7 +190,7 @@ trait HasChildren
 	 *
 	 * @return $this
 	 */
-	protected function setDrafts(array $drafts = null): static
+	protected function setDrafts(array|null $drafts = null): static
 	{
 		if ($drafts !== null) {
 			$this->drafts = Pages::factory($drafts, $this, true);

--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -64,7 +64,7 @@ trait HasFiles
 	 * Returns a specific file by filename or the first one
 	 */
 	public function file(
-		string $filename = null,
+		string|null $filename = null,
 		string $in = 'files'
 	): File|null {
 		if ($filename === null) {
@@ -153,7 +153,7 @@ trait HasFiles
 	/**
 	 * Returns a specific image by filename or the first one
 	 */
-	public function image(string $filename = null): File|null
+	public function image(string|null $filename = null): File|null
 	{
 		return $this->file($filename, 'images');
 	}
@@ -171,7 +171,7 @@ trait HasFiles
 	 *
 	 * @return $this
 	 */
-	protected function setFiles(array $files = null): static
+	protected function setFiles(array|null $files = null): static
 	{
 		if ($files !== null) {
 			$this->files = Files::factory($files, $this);

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -23,7 +23,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function hasNext(Collection $collection = null): bool
+	public function hasNext(Collection|null $collection = null): bool
 	{
 		return $this->next($collection) !== null;
 	}
@@ -33,7 +33,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function hasPrev(Collection $collection = null): bool
+	public function hasPrev(Collection|null $collection = null): bool
 	{
 		return $this->prev($collection) !== null;
 	}
@@ -43,7 +43,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function indexOf(Collection $collection = null): int|false
+	public function indexOf(Collection|null $collection = null): int|false
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->indexOf($this);
@@ -54,7 +54,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function isFirst(Collection $collection = null): bool
+	public function isFirst(Collection|null $collection = null): bool
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->first()->is($this);
@@ -65,7 +65,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function isLast(Collection $collection = null): bool
+	public function isLast(Collection|null $collection = null): bool
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->last()->is($this);
@@ -76,7 +76,7 @@ trait HasSiblings
 	 *
 	 * @param TCollection|null $collection
 	 */
-	public function isNth(int $n, Collection $collection = null): bool
+	public function isNth(int $n, Collection|null $collection = null): bool
 	{
 		return $this->indexOf($collection) === $n;
 	}
@@ -102,7 +102,7 @@ trait HasSiblings
 	 * @param TCollection|null $collection
 	 * @return TCollection
 	 */
-	public function nextAll(Collection $collection = null): Collection
+	public function nextAll(Collection|null $collection = null): Collection
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->slice($this->indexOf($collection) + 1);
@@ -117,7 +117,7 @@ trait HasSiblings
 	 * @param TCollection|null $collection
 	 * @return static|null
 	 */
-	public function prev(Collection $collection = null)
+	public function prev(Collection|null $collection = null)
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->nth($this->indexOf($collection) - 1);
@@ -129,7 +129,7 @@ trait HasSiblings
 	 * @param TCollection|null $collection
 	 * @return TCollection
 	 */
-	public function prevAll(Collection $collection = null): Collection
+	public function prevAll(Collection|null $collection = null): Collection
 	{
 		$collection ??= $this->siblingsCollection();
 		return $collection->slice(0, $this->indexOf($collection));

--- a/src/Cms/Html.php
+++ b/src/Cms/Html.php
@@ -79,7 +79,7 @@ class Html extends \Kirby\Toolkit\Html
 	 */
 	public static function link(
 		string|null $href = null,
-		string|array $text = null,
+		string|array|null $text = null,
 		array $attr = []
 	): string {
 		return parent::link(Url::to($href), $text, $attr);

--- a/src/Cms/Ingredients.php
+++ b/src/Cms/Ingredients.php
@@ -34,7 +34,7 @@ class Ingredients
 	/**
 	 * Magic getter for single ingredients
 	 */
-	public function __call(string $method, array $args = null): mixed
+	public function __call(string $method, array|null $args = null): mixed
 	{
 		return $this->ingredients[$method] ?? null;
 	}

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -51,7 +51,7 @@ class Items extends Collection
 	 * an array of item props
 	 */
 	public static function factory(
-		array $items = null,
+		array|null $items = null,
 		array $params = []
 	): static {
 		if (empty($items) === true || is_array($items) === false) {
@@ -96,7 +96,7 @@ class Items extends Collection
 	/**
 	 * Convert the items to an array
 	 */
-	public function toArray(Closure $map = null): array
+	public function toArray(Closure|null $map = null): array
 	{
 		return array_values(parent::toArray($map));
 	}

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -329,7 +329,7 @@ class Language
 	 *
 	 * @param int $category If passed, returns the locale for the specified category (e.g. LC_ALL) as string
 	 */
-	public function locale(int $category = null): array|string|null
+	public function locale(int|null $category = null): array|string|null
 	{
 		if ($category !== null) {
 			return $this->locale[$category] ?? $this->locale[LC_ALL] ?? null;
@@ -500,7 +500,7 @@ class Language
 	 * Update language properties and save them
 	 * @internal
 	 */
-	public function update(array $props = null): static
+	public function update(array|null $props = null): static
 	{
 		// don't change the language code
 		unset($props['code']);

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -28,7 +28,7 @@ class Layouts extends Items
 	public static array $methods = [];
 
 	public static function factory(
-		array $items = null,
+		array|null $items = null,
 		array $params = []
 	): static {
 		// convert single layout to layouts array

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -27,7 +27,7 @@ class Media
 	 * and to copy it to the media folder.
 	 */
 	public static function link(
-		Page|Site|User $model = null,
+		Page|Site|User|null $model = null,
 		string $hash,
 		string $filename
 	): Response|false {

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -27,7 +27,7 @@ class Media
 	 * and to copy it to the media folder.
 	 */
 	public static function link(
-		Page|Site|User|null $model = null,
+		Page|Site|User|null $model,
 		string $hash,
 		string $filename
 	): Response|false {

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -83,7 +83,7 @@ abstract class Model
 	 *
 	 * @return $this
 	 */
-	protected function setKirby(App $kirby = null)
+	protected function setKirby(App|null $kirby = null)
 	{
 		static::$kirby = $kirby;
 		return $this;
@@ -95,7 +95,7 @@ abstract class Model
 	 * @internal
 	 * @return $this
 	 */
-	public function setSite(Site $site = null)
+	public function setSite(Site|null $site = null)
 	{
 		$this->site = $site;
 		return $this;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -71,7 +71,7 @@ abstract class ModelWithContent implements Identifiable
 	/**
 	 * Returns an array with all blueprints that are available
 	 */
-	public function blueprints(string $inSection = null): array
+	public function blueprints(string|null $inSection = null): array
 	{
 		// helper function
 		$toBlueprints = function (array $sections): array {
@@ -176,7 +176,7 @@ abstract class ModelWithContent implements Identifiable
 	 * @throws \Kirby\Exception\InvalidArgumentException If the language for the given code does not exist
 	 */
 	public function contentFile(
-		string $languageCode = null,
+		string|null $languageCode = null,
 		bool $force = false
 	): string {
 		Helpers::deprecated('The internal $model->contentFile() method has been deprecated. You can use $model->storage()->contentFile() instead, however please note that this method is also internal and may be removed in the future.', 'model-content-file');
@@ -212,7 +212,7 @@ abstract class ModelWithContent implements Identifiable
 	 */
 	public function contentFileData(
 		array $data,
-		string $languageCode = null
+		string|null $languageCode = null
 	): array {
 		return $data;
 	}
@@ -371,7 +371,7 @@ abstract class ModelWithContent implements Identifiable
 	public function increment(
 		string $field,
 		int $by = 1,
-		int $max = null
+		int|null $max = null
 	): static {
 		$value = (int)$this->content()->get($field)->value() + $by;
 
@@ -462,8 +462,8 @@ abstract class ModelWithContent implements Identifiable
 	 * @internal
 	 */
 	public function query(
-		string $query = null,
-		string $expect = null
+		string|null $query = null,
+		string|null $expect = null
 	): mixed {
 		if ($query === null) {
 			return null;
@@ -491,7 +491,7 @@ abstract class ModelWithContent implements Identifiable
 	 * Read the content from the content file
 	 * @internal
 	 */
-	public function readContent(string $languageCode = null): array
+	public function readContent(string|null $languageCode = null): array
 	{
 		try {
 			return $this->storage()->read(
@@ -531,7 +531,7 @@ abstract class ModelWithContent implements Identifiable
 	 * Save the single language content
 	 */
 	protected function saveContent(
-		array $data = null,
+		array|null $data = null,
 		bool $overwrite = false
 	): static {
 		// create a clone to avoid modifying the original
@@ -552,8 +552,8 @@ abstract class ModelWithContent implements Identifiable
 	 * @throws \Kirby\Exception\InvalidArgumentException If the language for the given code does not exist
 	 */
 	protected function saveTranslation(
-		array $data = null,
-		string $languageCode = null,
+		array|null $data = null,
+		string|null $languageCode = null,
 		bool $overwrite = false
 	): static {
 		// create a clone to not touch the original
@@ -603,7 +603,7 @@ abstract class ModelWithContent implements Identifiable
 	 *
 	 * @return $this
 	 */
-	protected function setContent(array $content = null): static
+	protected function setContent(array|null $content = null): static
 	{
 		if ($content !== null) {
 			$content = new Content($content, $this);
@@ -618,7 +618,7 @@ abstract class ModelWithContent implements Identifiable
 	 *
 	 * @return $this
 	 */
-	protected function setTranslations(array $translations = null): static
+	protected function setTranslations(array|null $translations = null): static
 	{
 		if ($translations !== null) {
 			$this->translations = new Collection();
@@ -675,7 +675,7 @@ abstract class ModelWithContent implements Identifiable
 	 *                              (`null` to keep the original token)
 	 */
 	public function toSafeString(
-		string $template = null,
+		string|null $template = null,
 		array $data = [],
 		string|null $fallback = ''
 	): string {
@@ -691,7 +691,7 @@ abstract class ModelWithContent implements Identifiable
 	 * @param string $handler For internal use
 	 */
 	public function toString(
-		string $template = null,
+		string|null $template = null,
 		array $data = [],
 		string|null $fallback = '',
 		string $handler = 'template'
@@ -728,7 +728,7 @@ abstract class ModelWithContent implements Identifiable
 	 * If no code is specified the current translation is returned
 	 */
 	public function translation(
-		string $languageCode = null
+		string|null $languageCode = null
 	): ContentTranslation|null {
 		if ($language = $this->kirby()->language($languageCode)) {
 			return $this->translations()->find($language->code());
@@ -766,8 +766,8 @@ abstract class ModelWithContent implements Identifiable
 	 * @throws \Kirby\Exception\InvalidArgumentException If the input array contains invalid values
 	 */
 	public function update(
-		array $input = null,
-		string $languageCode = null,
+		array|null $input = null,
+		string|null $languageCode = null,
 		bool $validate = false
 	): static {
 		$form = Form::for($this, [
@@ -811,7 +811,7 @@ abstract class ModelWithContent implements Identifiable
 	 * to store the given data on disk or anywhere else
 	 * @internal
 	 */
-	public function writeContent(array $data, string $languageCode = null): bool
+	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
 		$data = $this->contentFileData($data, $languageCode);
 		$id   = $this->storage()->defaultVersion();

--- a/src/Cms/NestCollection.php
+++ b/src/Cms/NestCollection.php
@@ -23,7 +23,7 @@ class NestCollection extends BaseCollection
 	 * to an array. This can also take a callback
 	 * function to further modify the array result.
 	 */
-	public function toArray(Closure $map = null): array
+	public function toArray(Closure|null $map = null): array
 	{
 		return parent::toArray($map ?? fn ($object) => $object->toArray());
 	}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -778,7 +778,7 @@ class Page extends ModelWithContent
 	 * This is only used for drafts so far.
 	 * @internal
 	 */
-	public function isVerified(string $token = null): bool
+	public function isVerified(string|null $token = null): bool
 	{
 		if (
 			$this->isPublished() === true &&
@@ -1093,7 +1093,7 @@ class Page extends ModelWithContent
 	 *
 	 * @return $this
 	 */
-	protected function setBlueprint(array $blueprint = null): static
+	protected function setBlueprint(array|null $blueprint = null): static
 	{
 		if ($blueprint !== null) {
 			$blueprint['model'] = $this;
@@ -1108,7 +1108,7 @@ class Page extends ModelWithContent
 	 *
 	 * @return $this
 	 */
-	protected function setTemplate(string $template = null): static
+	protected function setTemplate(string|null $template = null): static
 	{
 		if ($template !== null) {
 			$this->intendedTemplate = $this->kirby()->template($template);
@@ -1122,7 +1122,7 @@ class Page extends ModelWithContent
 	 *
 	 * @return $this
 	 */
-	protected function setUrl(string $url = null): static
+	protected function setUrl(string|null $url = null): static
 	{
 		if (is_string($url) === true) {
 			$url = rtrim($url, '/');
@@ -1135,7 +1135,7 @@ class Page extends ModelWithContent
 	/**
 	 * Returns the slug of the page
 	 */
-	public function slug(string $languageCode = null): string
+	public function slug(string|null $languageCode = null): string
 	{
 		if ($this->kirby()->multilang() === true) {
 			$languageCode      ??= $this->kirby()->languageCode();
@@ -1248,7 +1248,7 @@ class Page extends ModelWithContent
 	 * The uri is the same as the id, except
 	 * that it will be translated in multi-language setups
 	 */
-	public function uri(string $languageCode = null): string
+	public function uri(string|null $languageCode = null): string
 	{
 		// set the id, depending on the parent
 		if ($parent = $this->parent()) {
@@ -1304,7 +1304,7 @@ class Page extends ModelWithContent
 	 */
 	public function urlForLanguage(
 		$language = null,
-		array $options = null
+		array|null $options = null
 	): string {
 		if ($options !== null) {
 			return Url::to($this->urlForLanguage($language), $options);

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -577,7 +577,7 @@ trait PageActions
 	 * Create the sorting number for the page
 	 * depending on the blueprint settings
 	 */
-	public function createNum(int $num = null): int
+	public function createNum(int|null $num = null): int
 	{
 		$mode = $this->blueprint()->num();
 
@@ -825,7 +825,7 @@ trait PageActions
 	/**
 	 * @throws \Kirby\Exception\LogicException If the page is not included in the siblings collection
 	 */
-	protected function resortSiblingsAfterListing(int $position = null): bool
+	protected function resortSiblingsAfterListing(int|null $position = null): bool
 	{
 		// get all siblings including the current page
 		$siblings = $this

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -80,7 +80,7 @@ class PagePicker extends Picker
 	 * parent model that is currently selected
 	 * in the page picker.
 	 */
-	public function modelToArray(Page|Site $model = null): array|null
+	public function modelToArray(Page|Site|null $model = null): array|null
 	{
 		if ($model === null) {
 			return null;

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -25,7 +25,7 @@ class PageRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the given number is invalid
 	 */
-	public static function changeNum(Page $page, int $num = null): bool
+	public static function changeNum(Page $page, int|null $num = null): bool
 	{
 		if ($num !== null && $num < 0) {
 			throw new InvalidArgumentException(['key' => 'page.num.invalid']);
@@ -86,7 +86,7 @@ class PageRules
 	public static function changeStatus(
 		Page $page,
 		string $status,
-		int $position = null
+		int|null $position = null
 	): bool {
 		if (isset($page->blueprint()->status()[$status]) === false) {
 			throw new InvalidArgumentException(['key' => 'page.status.invalid']);

--- a/src/Cms/PageSiblings.php
+++ b/src/Cms/PageSiblings.php
@@ -17,7 +17,7 @@ trait PageSiblings
 	 * Checks if there's a next listed
 	 * page in the siblings collection
 	 */
-	public function hasNextListed(Collection $collection = null): bool
+	public function hasNextListed(Collection|null $collection = null): bool
 	{
 		return $this->nextListed($collection) !== null;
 	}
@@ -26,7 +26,7 @@ trait PageSiblings
 	 * Checks if there's a next unlisted
 	 * page in the siblings collection
 	 */
-	public function hasNextUnlisted(Collection $collection = null): bool
+	public function hasNextUnlisted(Collection|null $collection = null): bool
 	{
 		return $this->nextUnlisted($collection) !== null;
 	}
@@ -35,7 +35,7 @@ trait PageSiblings
 	 * Checks if there's a previous listed
 	 * page in the siblings collection
 	 */
-	public function hasPrevListed(Collection $collection = null): bool
+	public function hasPrevListed(Collection|null $collection = null): bool
 	{
 		return $this->prevListed($collection) !== null;
 	}
@@ -44,7 +44,7 @@ trait PageSiblings
 	 * Checks if there's a previous unlisted
 	 * page in the siblings collection
 	 */
-	public function hasPrevUnlisted(Collection $collection = null): bool
+	public function hasPrevUnlisted(Collection|null $collection = null): bool
 	{
 		return $this->prevUnlisted($collection) !== null;
 	}
@@ -52,7 +52,7 @@ trait PageSiblings
 	/**
 	 * Returns the next listed page if it exists
 	 */
-	public function nextListed(Collection $collection = null): Page|null
+	public function nextListed(Collection|null $collection = null): Page|null
 	{
 		return $this->nextAll($collection)->listed()->first();
 	}
@@ -60,7 +60,7 @@ trait PageSiblings
 	/**
 	 * Returns the next unlisted page if it exists
 	 */
-	public function nextUnlisted(Collection $collection = null): Page|null
+	public function nextUnlisted(Collection|null $collection = null): Page|null
 	{
 		return $this->nextAll($collection)->unlisted()->first();
 	}
@@ -68,7 +68,7 @@ trait PageSiblings
 	/**
 	 * Returns the previous listed page
 	 */
-	public function prevListed(Collection $collection = null): Page|null
+	public function prevListed(Collection|null $collection = null): Page|null
 	{
 		return $this->prevAll($collection)->listed()->last();
 	}
@@ -76,7 +76,7 @@ trait PageSiblings
 	/**
 	 * Returns the previous unlisted page
 	 */
-	public function prevUnlisted(Collection $collection = null): Page|null
+	public function prevUnlisted(Collection|null $collection = null): Page|null
 	{
 		return $this->prevAll($collection)->unlisted()->last();
 	}

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -145,8 +145,8 @@ class Pages extends Collection
 	 */
 	public static function factory(
 		array $pages,
-		Page|Site $model = null,
-		bool $draft = null
+		Page|Site|null $model = null,
+		bool|null $draft = null
 	): static {
 		$model  ??= App::instance()->site();
 		$children = new static([], $model);
@@ -249,7 +249,7 @@ class Pages extends Collection
 	 */
 	protected function findByKeyRecursive(
 		string $id,
-		string $startAt = null,
+		string|null $startAt = null,
 		bool $multiLang = false
 	): Page|null {
 		$path       = explode('/', $id);

--- a/src/Cms/Pagination.php
+++ b/src/Cms/Pagination.php
@@ -125,7 +125,7 @@ class Pagination extends BasePagination
 	 * If the `$page` variable is set, the URL
 	 * for that page will be returned.
 	 */
-	public function pageUrl(int $page = null): string|null
+	public function pageUrl(int|null $page = null): string|null
 	{
 		if ($page === null) {
 			return $this->pageUrl($this->page());

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -109,7 +109,7 @@ class Permissions
 		}
 	}
 
-	public function for(string $category = null, string $action = null): bool
+	public function for(string|null $category = null, string|null $action = null): bool
 	{
 		if ($action === null) {
 			if ($this->hasCategory($category) === false) {

--- a/src/Cms/Picker.php
+++ b/src/Cms/Picker.php
@@ -68,7 +68,7 @@ abstract class Picker
 	 * array that is already optimized for the
 	 * panel picker component.
 	 */
-	public function itemsToArray(Collection $items = null): array
+	public function itemsToArray(Collection|null $items = null): array
 	{
 		if ($items === null) {
 			return [];

--- a/src/Cms/Plugin.php
+++ b/src/Cms/Plugin.php
@@ -55,7 +55,7 @@ class Plugin
 	/**
 	 * Allows access to any composer.json field by method call
 	 */
-	public function __call(string $key, array $arguments = null): mixed
+	public function __call(string $key, array|null $arguments = null): mixed
 	{
 		return $this->info()[$key] ?? null;
 	}

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -75,7 +75,7 @@ class Responder
 	 *
 	 * @return $this|string|null
 	 */
-	public function body(string $body = null): static|string|null
+	public function body(string|null $body = null): static|string|null
 	{
 		if ($body === null) {
 			return $this->body;
@@ -210,7 +210,7 @@ class Responder
 	 *
 	 * @return int|$this
 	 */
-	public function code(int $code = null)
+	public function code(int|null $code = null)
 	{
 		if ($code === null) {
 			return $this->code;
@@ -266,7 +266,7 @@ class Responder
 	 *
 	 * @return array|$this
 	 */
-	public function headers(array $headers = null)
+	public function headers(array|null $headers = null)
 	{
 		if ($headers === null) {
 			$injectedHeaders = [];
@@ -305,7 +305,7 @@ class Responder
 	 *
 	 * @return string|$this
 	 */
-	public function json(array $json = null)
+	public function json(array|null $json = null)
 	{
 		if ($json !== null) {
 			$this->body(json_encode($json));
@@ -334,7 +334,7 @@ class Responder
 	/**
 	 * Creates and returns the response object from the config
 	 */
-	public function send(string $body = null): Response
+	public function send(string|null $body = null): Response
 	{
 		if ($body !== null) {
 			$this->body($body);
@@ -365,7 +365,7 @@ class Responder
 	 *
 	 * @return string|$this
 	 */
-	public function type(string $type = null)
+	public function type(string|null $type = null)
 	{
 		if ($type === null) {
 			return $this->type;

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -92,7 +92,7 @@ class Roles extends Collection
 		return $collection->sort('name', 'asc');
 	}
 
-	public static function load(string $root = null, array $inject = []): static
+	public static function load(string|null $root = null, array $inject = []): static
 	{
 		$kirby = App::instance();
 		$roles = new static();

--- a/src/Cms/Search.php
+++ b/src/Cms/Search.php
@@ -17,7 +17,7 @@ namespace Kirby\Cms;
 class Search
 {
 	public static function files(
-		string $query = null,
+		string|null $query = null,
 		array $params = []
 	): Files {
 		return App::instance()->site()->index()->files()->search($query, $params);
@@ -36,14 +36,14 @@ class Search
 	}
 
 	public static function pages(
-		string $query = null,
+		string|null $query = null,
 		array $params = []
 	): Pages {
 		return App::instance()->site()->index()->search($query, $params);
 	}
 
 	public static function users(
-		string $query = null,
+		string|null $query = null,
 		array $params = []
 	): Users {
 		return App::instance()->users()->search($query, $params);

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -32,7 +32,7 @@ class Structure extends Items
 	 * an array of item props
 	 */
 	public static function factory(
-		array $items = null,
+		array|null $items = null,
 		array $params = []
 	): static {
 		if (is_array($items) === true) {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -367,7 +367,7 @@ class System
 	 * @throws \Kirby\Exception\Exception
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public function register(string $license = null, string $email = null): bool
+	public function register(string|null $license = null, string|null $email = null): bool
 	{
 		$license = new License(
 			code: $license,

--- a/src/Cms/Translation.php
+++ b/src/Cms/Translation.php
@@ -88,7 +88,7 @@ class Translation
 	 * Returns a single translation
 	 * string by key
 	 */
-	public function get(string $key, string $default = null): string|null
+	public function get(string $key, string|null $default = null): string|null
 	{
 		return $this->data[$key] ?? $default;
 	}

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -244,7 +244,7 @@ class User extends ModelWithContent
 	 */
 	public static function hashPassword(
 		#[SensitiveParameter]
-		string $password = null
+		string|null $password = null
 	): string|null {
 		if ($password !== null) {
 			$password = password_hash($password, PASSWORD_DEFAULT);
@@ -284,7 +284,7 @@ class User extends ModelWithContent
 	/**
 	 * Compares the current object with the given user object
 	 */
-	public function is(User $user = null): bool
+	public function is(User|null $user = null): bool
 	{
 		if ($user === null) {
 			return false;
@@ -639,7 +639,7 @@ class User extends ModelWithContent
 	 *
 	 * @return $this
 	 */
-	protected function setBlueprint(array $blueprint = null): static
+	protected function setBlueprint(array|null $blueprint = null): static
 	{
 		if ($blueprint !== null) {
 			$blueprint['model'] = $this;
@@ -698,7 +698,7 @@ class User extends ModelWithContent
 	 *                              (`null` to keep the original token)
 	 */
 	public function toString(
-		string $template = null,
+		string|null $template = null,
 		array $data = [],
 		string|null $fallback = '',
 		string $handler = 'template'
@@ -726,7 +726,7 @@ class User extends ModelWithContent
 	 */
 	public function validatePassword(
 		#[SensitiveParameter]
-		string $password = null
+		string|null $password = null
 	): bool {
 		if (empty($this->password()) === true) {
 			throw new NotFoundException(['key' => 'user.password.undefined']);

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -209,7 +209,7 @@ trait UserActions
 	/**
 	 * Creates a new User from the given props and returns a new User object
 	 */
-	public static function create(array $props = null): User
+	public static function create(array|null $props = null): User
 	{
 		$data = $props;
 
@@ -364,8 +364,8 @@ trait UserActions
 	 * Updates the user data
 	 */
 	public function update(
-		array $input = null,
-		string $languageCode = null,
+		array|null $input = null,
+		string|null $languageCode = null,
 		bool $validate = false
 	): static {
 		$user = parent::update($input, $languageCode, $validate);
@@ -411,7 +411,7 @@ trait UserActions
 	 */
 	protected function writePassword(
 		#[SensitiveParameter]
-		string $password = null
+		string|null $password = null
 	): bool {
 		return $this->writeSecret('password', $password);
 	}

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -54,7 +54,7 @@ class Content
 	 */
 	public function __construct(
 		array $data = [],
-		ModelWithContent $parent = null,
+		ModelWithContent|null $parent = null,
 		bool $normalize = true
 	) {
 		if ($normalize === true) {
@@ -149,7 +149,7 @@ class Content
 	 * Returns either a single field object
 	 * or all registered fields
 	 */
-	public function get(string $key = null): Field|array
+	public function get(string|null $key = null): Field|array
 	{
 		if ($key === null) {
 			return $this->fields();
@@ -234,7 +234,7 @@ class Content
 	 * @return $this
 	 */
 	public function update(
-		array $content = null,
+		array|null $content = null,
 		bool $overwrite = false
 	): static {
 		$content = array_change_key_case((array)$content, CASE_LOWER);

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -145,7 +145,7 @@ class ContentTranslation
 	 *
 	 * @return $this
 	 */
-	public function update(array $data = null, bool $overwrite = false): static
+	public function update(array|null $data = null, bool $overwrite = false): static
 	{
 		$data = array_change_key_case((array)$data);
 

--- a/src/Content/Field.php
+++ b/src/Content/Field.php
@@ -202,7 +202,7 @@ class Field
 	 * the modified field will be returned. Otherwise it
 	 * will return the field value.
 	 */
-	public function value(string|Closure $value = null): mixed
+	public function value(string|Closure|null $value = null): mixed
 	{
 		if ($value === null) {
 			return $this->value;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -420,7 +420,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function order(string $order = null)
+	public function order(string|null $order = null)
 	{
 		$this->order = $order;
 		return $this;

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -112,7 +112,7 @@ abstract class Sql
 	public function columnName(string $table, string $column, bool $enforceQualified = false): string|null
 	{
 		// ensure we have clean $table and $column values without qualified identifiers
-		list($table, $column) = $this->splitIdentifier($table, $column);
+		[$table, $column] = $this->splitIdentifier($table, $column);
 
 		// combine the identifiers again
 		if ($this->database->validateColumn($table, $column) === true) {
@@ -624,7 +624,7 @@ abstract class Sql
 			$result = [];
 
 			foreach ($columns as $column) {
-				list($table, $columnPart) = $this->splitIdentifier($table, $column);
+				[$table, $columnPart] = $this->splitIdentifier($table, $column);
 
 				if ($this->validateColumn($table, $columnPart) === true) {
 					$result[] = $this->combineIdentifier($table, $columnPart);

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -149,7 +149,7 @@ class Dir
 		string $dir,
 		bool $recursive = false,
 		array|false|null $ignore = [],
-		string $path = null
+		string|null $path = null
 	): array {
 		$result = [];
 		$dir    = realpath($dir);
@@ -434,7 +434,7 @@ class Dir
 	 */
 	public static function modified(
 		string $dir,
-		string $format = null,
+		string|null $format = null,
 		string|null $handler = null
 	): int|string {
 		$modified = filemtime($dir);

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -59,8 +59,8 @@ class File
 	 * @throws \Kirby\Exception\InvalidArgumentException When the model does not use the `Kirby\Filesystem\IsFile` trait
 	 */
 	public function __construct(
-		array|string $props = null,
-		string $url = null
+		array|string|null $props = null,
+		string|null $url = null
 	) {
 		// Legacy support for old constructor of
 		// the `Kirby\Image\Image` class

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -251,7 +251,7 @@ class Mime
 	/**
 	 * Returns the extension for a given MIME type
 	 */
-	public static function toExtension(string $mime = null): string|false
+	public static function toExtension(string|null $mime = null): string|false
 	{
 		foreach (static::$types as $key => $value) {
 			if (is_array($value) === true && in_array($mime, $value) === true) {
@@ -269,7 +269,7 @@ class Mime
 	/**
 	 * Returns all available extensions for a given MIME type
 	 */
-	public static function toExtensions(string $mime = null, bool $matchWildcards = false): array
+	public static function toExtensions(string|null $mime = null, bool $matchWildcards = false): array
 	{
 		$extensions = [];
 		$testMime = fn (string $v) => static::matches($v, $mime);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -127,7 +127,7 @@ class Field extends Component
 				/**
 				 * Sets the focus on this field when the form loads. Only the first field with this label gets
 				 */
-				'autofocus' => function (bool $autofocus = null): bool {
+				'autofocus' => function (bool|null $autofocus = null): bool {
 					return $autofocus ?? false;
 				},
 				/**
@@ -145,7 +145,7 @@ class Field extends Component
 				/**
 				 * If `true`, the field is no longer editable and will not be saved
 				 */
-				'disabled' => function (bool $disabled = null): bool {
+				'disabled' => function (bool|null $disabled = null): bool {
 					return $disabled ?? false;
 				},
 				/**
@@ -157,7 +157,7 @@ class Field extends Component
 				/**
 				 * Optional icon that will be shown at the end of the field
 				 */
-				'icon' => function (string $icon = null) {
+				'icon' => function (string|null $icon = null) {
 					return $icon;
 				},
 				/**
@@ -175,7 +175,7 @@ class Field extends Component
 				/**
 				 * If `true`, the field has to be filled in correctly to be saved.
 				 */
-				'required' => function (bool $required = null): bool {
+				'required' => function (bool|null $required = null): bool {
 					return $required ?? false;
 				},
 				/**

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -214,7 +214,7 @@ class BlocksField extends FieldClass
 				'action'  => function (
 					string $fieldsetType,
 					string $fieldName,
-					string $path = null
+					string|null $path = null
 				) use ($field) {
 					$fields = $field->fields($fieldsetType);
 					$field  = $field->form($fields)->field($fieldName);
@@ -276,7 +276,7 @@ class BlocksField extends FieldClass
 		);
 	}
 
-	protected function setGroup(string $group = null): void
+	protected function setGroup(string|null $group = null): void
 	{
 		$this->group = $group;
 	}

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -174,7 +174,7 @@ class LayoutField extends BlocksField
 			'method'  => 'ALL',
 			'action'  => function (
 				string $fieldName,
-				string $path = null
+				string|null $path = null
 			) use ($field): array {
 				$form  = $field->attrsForm();
 				$field = $form->field($fieldName);

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -613,7 +613,7 @@ abstract class FieldClass
 	}
 
 	protected function valueToJson(
-		array $value = null,
+		array|null $value = null,
 		bool $pretty = false
 	): string {
 		$constants = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
@@ -625,7 +625,7 @@ abstract class FieldClass
 		return json_encode($value, $constants);
 	}
 
-	protected function valueToYaml(array $value = null): string
+	protected function valueToYaml(array|null $value = null): string
 	{
 		return Data::encode($value, 'yaml');
 	}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -41,7 +41,7 @@ class Fields extends Collection
 	 * array and also does that for every
 	 * included field.
 	 */
-	public function toArray(Closure $map = null): array
+	public function toArray(Closure|null $map = null): array
 	{
 		$array = [];
 

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -11,7 +11,7 @@ trait Max
 		return $this->max;
 	}
 
-	protected function setMax(int $max = null)
+	protected function setMax(int|null $max = null)
 	{
 		$this->max = $max;
 	}

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -11,7 +11,7 @@ trait Min
 		return $this->min;
 	}
 
-	protected function setMin(int $min = null)
+	protected function setMin(int|null $min = null)
 	{
 		$this->min = $min;
 	}

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -153,8 +153,8 @@ class Environment
 	 * @param array|null $info Optional override for `$_SERVER`
 	 */
 	public function detect(
-		array $options = null,
-		array $info = null
+		array|null $options = null,
+		array|null $info = null
 	): array {
 		$options = [
 			'cli'     => null,

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -63,7 +63,7 @@ class Route
 	/**
 	 * Magic getter for route attributes
 	 */
-	public function __call(string $key, array $args = null): mixed
+	public function __call(string $key, array|null $args = null): mixed
 	{
 		return $this->attributes[$key] ?? null;
 	}

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -220,7 +220,7 @@ class Url
 	 */
 	public static function to(
 		string|null $path = null,
-		array $options = null
+		array|null $options = null
 	): string {
 		// make sure $path is string
 		$path ??= '';

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -25,7 +25,7 @@ class Expression
 	/**
 	 * Parses an expression string into its parts
 	 */
-	public static function factory(string $expression, Query $parent = null): static|Segments
+	public static function factory(string $expression, Query|null $parent = null): static|Segments
 	{
 		// split into different expression parts and operators
 		$parts = static::parse($expression);

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -131,12 +131,12 @@ Query::$entries['site'] = function (): Site {
 
 Query::$entries['t'] = function (
 	string $key,
-	string|array $fallback = null,
-	string $locale = null
+	string|array|null $fallback = null,
+	string|null $locale = null
 ): string|null {
 	return I18n::translate($key, $fallback, $locale);
 };
 
-Query::$entries['user'] = function (string $id = null): User|null {
+Query::$entries['user'] = function (string|null $id = null): User|null {
 	return App::instance()->user($id);
 };

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -30,7 +30,7 @@ class Segments extends Collection
 	 * Split query string into segments by dot
 	 * but not inside (nested) parens
 	 */
-	public static function factory(string $query, Query $parent = null): static
+	public static function factory(string $query, Query|null $parent = null): static
 	{
 		$segments = static::parse($query);
 		$position = 0;

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -149,7 +149,7 @@ class Session
 	 * @param string|null $mode Optional new transmission mode
 	 * @return string Transmission mode
 	 */
-	public function mode(string $mode = null): string
+	public function mode(string|null $mode = null): string
 	{
 		if ($mode !== null) {
 			// only allow this if this is a new session, otherwise the change
@@ -214,7 +214,7 @@ class Session
 	 * @param int|null $duration Optional new duration in seconds to set
 	 * @return int Number of seconds
 	 */
-	public function duration(int $duration = null): int
+	public function duration(int|null $duration = null): int
 	{
 		if ($duration !== null) {
 			// verify that the duration is at least 1 second

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -105,7 +105,7 @@ class Sessions
 	 * @param string $token Session token, either including or without the key
 	 * @param string|null $mode Optional transmission mode override
 	 */
-	public function get(string $token, string $mode = null): Session
+	public function get(string $token, string|null $mode = null): Session
 	{
 		return $this->cache[$token] ??= new Session(
 			$this,

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -189,7 +189,7 @@ class Collection extends Iterator implements Countable
 	 *
 	 * @return array|$this
 	 */
-	public function data(array $data = null): array|static
+	public function data(array|null $data = null): array|static
 	{
 		if ($data === null) {
 			return $this->data;
@@ -708,7 +708,7 @@ class Collection extends Iterator implements Countable
 	 */
 	public function pluck(
 		string $field,
-		string $split = null,
+		string|null $split = null,
 		bool $unique = false
 	): array {
 		$result = [];
@@ -884,7 +884,7 @@ class Collection extends Iterator implements Countable
 	 * @return $this|static
 	 * @psalm-return ($offset is 0 && $limit is null ? $this : static)
 	 */
-	public function slice(int $offset = 0, int $limit = null): static
+	public function slice(int $offset = 0, int|null $limit = null): static
 	{
 		if ($offset === 0 && $limit === null) {
 			return $this;
@@ -1050,7 +1050,7 @@ class Collection extends Iterator implements Countable
 	/**
 	 * Converts the object into an array
 	 */
-	public function toArray(Closure $map = null): array
+	public function toArray(Closure|null $map = null): array
 	{
 		if ($map !== null) {
 			return array_map($map, $this->data);
@@ -1080,7 +1080,7 @@ class Collection extends Iterator implements Countable
 	 * with all values. If a mapping Closure is passed,
 	 * all values are processed by the Closure.
 	 */
-	public function values(Closure $map = null): array
+	public function values(Closure|null $map = null): array
 	{
 		$data = $map === null ? $this->data : array_map($map, $this->data);
 		return array_values($data);
@@ -1098,7 +1098,7 @@ class Collection extends Iterator implements Countable
 	public function when(
 		$condition,
 		Closure $callback,
-		Closure $fallback = null
+		Closure|null $fallback = null
 	) {
 		if ($condition) {
 			return $callback->call($this, $condition);

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -464,7 +464,7 @@ class Dom
 			$namespaceUri = null;
 			$itemLocal    = $item;
 			if (Str::contains($item, ':') === true) {
-				list($namespaceName, $itemLocal) = explode(':', $item);
+				[$namespaceName, $itemLocal] = explode(':', $item);
 				$namespaceUri = $allowedNamespaces[$namespaceName] ?? null;
 			} else {
 				// list items without namespace are from the default namespace

--- a/src/Toolkit/Facade.php
+++ b/src/Toolkit/Facade.php
@@ -23,7 +23,7 @@ abstract class Facade
 	/**
 	 * Proxy for all public instance calls
 	 */
-	public static function __callStatic(string $method, array $args = null)
+	public static function __callStatic(string $method, array|null $args = null)
 	{
 		return static::instance()->$method(...$args);
 	}

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -414,7 +414,7 @@ class Html extends Xml
 		string $name,
 		array|string|null $content = '',
 		array $attr = [],
-		string $indent = null,
+		string|null $indent = null,
 		int $level = 0
 	): string {
 		// treat an explicit `null` value as an empty tag

--- a/src/Toolkit/I18n.php
+++ b/src/Toolkit/I18n.php
@@ -78,7 +78,7 @@ class I18n
 	/**
 	 * Formats a number
 	 */
-	public static function formatNumber(int|float $number, string $locale = null): string
+	public static function formatNumber(int|float $number, string|null $locale = null): string
 	{
 		$locale  ??= static::locale();
 		$formatter = static::decimalNumberFormatter($locale);
@@ -108,7 +108,7 @@ class I18n
 	 */
 	public static function template(
 		string $key,
-		string|array $fallback = null,
+		string|array|null $fallback = null,
 		array|null $replace = null,
 		string|null $locale = null
 	): string {
@@ -130,8 +130,8 @@ class I18n
 	 */
 	public static function translate(
 		string|array|null $key,
-		string|array $fallback = null,
-		string $locale = null
+		string|array|null $fallback = null,
+		string|null $locale = null
 	): string|array|Closure|null {
 		// use current locale if no specific is passed
 		$locale ??= static::locale();
@@ -242,7 +242,7 @@ class I18n
 	 * by locale. If the translation does not exist
 	 * yet, the loader will try to load it, if defined.
 	 */
-	public static function translation(string $locale = null): array
+	public static function translation(string|null $locale = null): array
 	{
 		$locale ??= static::locale();
 
@@ -304,7 +304,7 @@ class I18n
 	public static function translateCount(
 		string $key,
 		int $count,
-		string $locale = null,
+		string|null $locale = null,
 		bool $formatNumber = true
 	) {
 		$locale    ??= static::locale();

--- a/src/Toolkit/Properties.php
+++ b/src/Toolkit/Properties.php
@@ -95,7 +95,7 @@ trait Properties
 		}
 	}
 
-	protected function setProperties($props, array $keys = null)
+	protected function setProperties($props, array|null $keys = null)
 	{
 		foreach (get_object_vars($this) as $name => $default) {
 			if ($name === 'propertyData') {

--- a/src/Toolkit/Silo.php
+++ b/src/Toolkit/Silo.php
@@ -30,7 +30,7 @@ class Silo
 		return static::$data;
 	}
 
-	public static function get(string|array $key = null, $default = null)
+	public static function get(string|array|null $key = null, $default = null)
 	{
 		if ($key === null) {
 			return static::$data;
@@ -42,7 +42,7 @@ class Silo
 	/**
 	 * Removes an item from the data array
 	 */
-	public static function remove(string $key = null): array
+	public static function remove(string|null $key = null): array
 	{
 		// reset the entire array
 		if ($key === null) {

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -388,7 +388,7 @@ class Str
 		for ($i = 0; $i < static::length($string); $i++) {
 			$char = static::substr($string, $i, 1);
 			$char = mb_convert_encoding($char, 'UCS-4BE', 'UTF-8');
-			list(, $code) = unpack('N', $char);
+			[, $code] = unpack('N', $char);
 			$encoded .= rand(1, 2) === 1 ? '&#' . $code . ';' : '&#x' . dechex($code) . ';';
 		}
 

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -275,7 +275,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function camel(string|null $value = null): string
+	public static function camel(string|null $value): string
 	{
 		return lcfirst(static::studly($value));
 	}
@@ -286,7 +286,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function camelToKebab(string|null $value = null): string
+	public static function camelToKebab(string|null $value): string
 	{
 		return static::lower(preg_replace('!([a-z0-9])([A-Z])!', '$1-$2', $value));
 	}
@@ -504,9 +504,8 @@ class Str
 	 * Convert the value to a float with a decimal
 	 * point, no matter what the locale setting is
 	 */
-	public static function float(
-		string|int|float|null $value = null
-	): string {
+	public static function float(string|int|float|null $value): string
+	{
 		// make sure $value is not null
 		$value ??= '';
 
@@ -571,7 +570,7 @@ class Str
 	/**
 	 * Convert a string to kebab case.
 	 */
-	public static function kebab(string|null $value = null): string
+	public static function kebab(string|null $value): string
 	{
 		return static::snake($value, '-');
 	}
@@ -579,7 +578,7 @@ class Str
 	/**
 	 * Convert a kebab case string to camel case.
 	 */
-	public static function kebabToCamel(string|null $value = null): string
+	public static function kebabToCamel(string|null $value): string
 	{
 		return ucfirst(preg_replace_callback(
 			'/-(.)/',
@@ -591,7 +590,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strlen()
 	 */
-	public static function length(string|null $string = null): int
+	public static function length(string|null $string): int
 	{
 		return mb_strlen($string ?? '', 'UTF-8');
 	}
@@ -599,7 +598,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strtolower()
 	 */
-	public static function lower(string|null $string = null): string
+	public static function lower(string|null $string): string
 	{
 		return mb_strtolower($string ?? '', 'UTF-8');
 	}
@@ -964,7 +963,7 @@ class Str
 	 * @return string The filled-in and partially escaped string
 	 */
 	public static function safeTemplate(
-		string|null $string = null,
+		string|null $string,
 		array $data = [],
 		array $options = []
 	): string {
@@ -1021,7 +1020,7 @@ class Str
 	 * @return string The shortened string
 	 */
 	public static function short(
-		string|null $string = null,
+		string|null $string,
 		int $length = 0,
 		string $appendix = '…'
 	): string {
@@ -1126,7 +1125,7 @@ class Str
 	 * @return string The safe string
 	 */
 	public static function slug(
-		string|null $string = null,
+		string|null $string,
 		string|null $separator = null,
 		string|null $allowed = null,
 		int $maxlength = 128
@@ -1169,7 +1168,7 @@ class Str
 	 * Convert a string to snake case.
 	 */
 	public static function snake(
-		string|null $value = null,
+		string|null $value,
 		string $delimiter = '_'
 	): string {
 		if (ctype_lower($value) === false) {
@@ -1240,7 +1239,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function studly(string|null $value = null): string
+	public static function studly(string|null $value): string
 	{
 		$value = str_replace(['-', '_'], ' ', $value);
 		$value = ucwords($value);
@@ -1251,7 +1250,7 @@ class Str
 	 * A UTF-8 safe version of substr()
 	 */
 	public static function substr(
-		string|null $string = null,
+		string|null $string,
 		int $start = 0,
 		int|null $length = null
 	): string {
@@ -1280,7 +1279,7 @@ class Str
 	 * @return string The filled-in string
 	 */
 	public static function template(
-		string|null $string = null,
+		string|null $string,
 		array $data = [],
 		array $options = []
 	): string {
@@ -1377,7 +1376,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of ucfirst()
 	 */
-	public static function ucfirst(string|null $string = null): string
+	public static function ucfirst(string|null $string): string
 	{
 		$first = static::substr($string, 0, 1);
 		$rest  = static::substr($string, 1);
@@ -1387,7 +1386,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of ucwords()
 	 */
-	public static function ucwords(string|null $string = null): string
+	public static function ucwords(string|null $string): string
 	{
 		return mb_convert_case($string ?? '', MB_CASE_TITLE, 'UTF-8');
 	}
@@ -1402,7 +1401,7 @@ class Str
 	 *
 	 * </code>
 	 */
-	public static function unhtml(string|null $string = null): string
+	public static function unhtml(string|null $string): string
 	{
 		return Html::decode($string);
 	}
@@ -1427,7 +1426,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strotoupper()
 	 */
-	public static function upper(string|null $string = null): string
+	public static function upper(string|null $string): string
 	{
 		return mb_strtoupper($string ?? '', 'UTF-8');
 	}
@@ -1465,7 +1464,7 @@ class Str
 	 * typographical widows at the end of a paragraph –
 	 * that's a single word in the last line
 	 */
-	public static function widont(string|null $string = null): string
+	public static function widont(string|null $string): string
 	{
 		// make sure $string is string
 		$string ??= '';

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -263,7 +263,7 @@ class Str
 	 * Returns everything between two strings from the first occurrence of a given string
 	 */
 	public static function between(
-		string|null $string = null,
+		string|null $string,
 		string $start,
 		string $end
 	): string {
@@ -295,7 +295,7 @@ class Str
 	 * Checks if a str contains another string
 	 */
 	public static function contains(
-		string|null $string = null,
+		string|null $string,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {
@@ -315,7 +315,7 @@ class Str
 	 *                                               for the globally configured one
 	 */
 	public static function date(
-		int|null $time = null,
+		int|null $time,
 		string|IntlDateFormatter|null $format = null,
 		string|null $handler = null
 	): string|int|false {
@@ -411,7 +411,7 @@ class Str
 	 * Checks if a string ends with the passed needle
 	 */
 	public static function endsWith(
-		string|null $string = null,
+		string|null $string,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {
@@ -704,7 +704,7 @@ class Str
 	 * @throws \Kirby\Exception\InvalidArgumentException for empty $needle
 	 */
 	public static function position(
-		string|null $string = null,
+		string|null $string,
 		string $needle,
 		bool $caseInsensitive = false
 	): int|false {
@@ -1223,7 +1223,7 @@ class Str
 	 * Checks if a string starts with the passed needle
 	 */
 	public static function startsWith(
-		string|null $string = null,
+		string|null $string,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -263,7 +263,7 @@ class Str
 	 * Returns everything between two strings from the first occurrence of a given string
 	 */
 	public static function between(
-		string $string = null,
+		string|null $string = null,
 		string $start,
 		string $end
 	): string {
@@ -275,7 +275,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function camel(string $value = null): string
+	public static function camel(string|null $value = null): string
 	{
 		return lcfirst(static::studly($value));
 	}
@@ -286,7 +286,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function camelToKebab(string $value = null): string
+	public static function camelToKebab(string|null $value = null): string
 	{
 		return static::lower(preg_replace('!([a-z0-9])([A-Z])!', '$1-$2', $value));
 	}
@@ -295,7 +295,7 @@ class Str
 	 * Checks if a str contains another string
 	 */
 	public static function contains(
-		string $string = null,
+		string|null $string = null,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {
@@ -316,7 +316,7 @@ class Str
 	 */
 	public static function date(
 		int|null $time = null,
-		string|IntlDateFormatter $format = null,
+		string|IntlDateFormatter|null $format = null,
 		string|null $handler = null
 	): string|int|false {
 		if (is_null($format) === true) {
@@ -365,7 +365,7 @@ class Str
 	public static function convert(
 		string $string,
 		string $targetEncoding,
-		string $sourceEncoding = null
+		string|null $sourceEncoding = null
 	): string {
 		// detect the source encoding if not passed as third argument
 		$sourceEncoding ??= static::encoding($string);
@@ -411,7 +411,7 @@ class Str
 	 * Checks if a string ends with the passed needle
 	 */
 	public static function endsWith(
-		string $string = null,
+		string|null $string = null,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {
@@ -571,7 +571,7 @@ class Str
 	/**
 	 * Convert a string to kebab case.
 	 */
-	public static function kebab(string $value = null): string
+	public static function kebab(string|null $value = null): string
 	{
 		return static::snake($value, '-');
 	}
@@ -579,7 +579,7 @@ class Str
 	/**
 	 * Convert a kebab case string to camel case.
 	 */
-	public static function kebabToCamel(string $value = null): string
+	public static function kebabToCamel(string|null $value = null): string
 	{
 		return ucfirst(preg_replace_callback(
 			'/-(.)/',
@@ -591,7 +591,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strlen()
 	 */
-	public static function length(string $string = null): int
+	public static function length(string|null $string = null): int
 	{
 		return mb_strlen($string ?? '', 'UTF-8');
 	}
@@ -599,7 +599,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strtolower()
 	 */
-	public static function lower(string $string = null): string
+	public static function lower(string|null $string = null): string
 	{
 		return mb_strtolower($string ?? '', 'UTF-8');
 	}
@@ -704,7 +704,7 @@ class Str
 	 * @throws \Kirby\Exception\InvalidArgumentException for empty $needle
 	 */
 	public static function position(
-		string $string = null,
+		string|null $string = null,
 		string $needle,
 		bool $caseInsensitive = false
 	): int|false {
@@ -736,7 +736,7 @@ class Str
 	 * @param string $type Pool type (type of allowed characters)
 	 */
 	public static function random(
-		int $length = null,
+		int|null $length = null,
 		string $type = 'alphaNum'
 	): string|false {
 		$length ??= random_int(5, 10);
@@ -964,7 +964,7 @@ class Str
 	 * @return string The filled-in and partially escaped string
 	 */
 	public static function safeTemplate(
-		string $string = null,
+		string|null $string = null,
 		array $data = [],
 		array $options = []
 	): string {
@@ -1021,7 +1021,7 @@ class Str
 	 * @return string The shortened string
 	 */
 	public static function short(
-		string $string = null,
+		string|null $string = null,
 		int $length = 0,
 		string $appendix = '…'
 	): string {
@@ -1126,9 +1126,9 @@ class Str
 	 * @return string The safe string
 	 */
 	public static function slug(
-		string $string = null,
-		string $separator = null,
-		string $allowed = null,
+		string|null $string = null,
+		string|null $separator = null,
+		string|null $allowed = null,
 		int $maxlength = 128
 	): string {
 		$separator ??= static::$defaults['slug']['separator'];
@@ -1169,7 +1169,7 @@ class Str
 	 * Convert a string to snake case.
 	 */
 	public static function snake(
-		string $value = null,
+		string|null $value = null,
 		string $delimiter = '_'
 	): string {
 		if (ctype_lower($value) === false) {
@@ -1223,7 +1223,7 @@ class Str
 	 * Checks if a string starts with the passed needle
 	 */
 	public static function startsWith(
-		string $string = null,
+		string|null $string = null,
 		string $needle,
 		bool $caseInsensitive = false
 	): bool {
@@ -1240,7 +1240,7 @@ class Str
 	 *
 	 * @param string $value The string to convert
 	 */
-	public static function studly(string $value = null): string
+	public static function studly(string|null $value = null): string
 	{
 		$value = str_replace(['-', '_'], ' ', $value);
 		$value = ucwords($value);
@@ -1251,9 +1251,9 @@ class Str
 	 * A UTF-8 safe version of substr()
 	 */
 	public static function substr(
-		string $string = null,
+		string|null $string = null,
 		int $start = 0,
-		int $length = null
+		int|null $length = null
 	): string {
 		return mb_substr($string ?? '', $start, $length, 'UTF-8');
 	}
@@ -1280,7 +1280,7 @@ class Str
 	 * @return string The filled-in string
 	 */
 	public static function template(
-		string $string = null,
+		string|null $string = null,
 		array $data = [],
 		array $options = []
 	): string {
@@ -1377,7 +1377,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of ucfirst()
 	 */
-	public static function ucfirst(string $string = null): string
+	public static function ucfirst(string|null $string = null): string
 	{
 		$first = static::substr($string, 0, 1);
 		$rest  = static::substr($string, 1);
@@ -1387,7 +1387,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of ucwords()
 	 */
-	public static function ucwords(string $string = null): string
+	public static function ucwords(string|null $string = null): string
 	{
 		return mb_convert_case($string ?? '', MB_CASE_TITLE, 'UTF-8');
 	}
@@ -1402,7 +1402,7 @@ class Str
 	 *
 	 * </code>
 	 */
-	public static function unhtml(string $string = null): string
+	public static function unhtml(string|null $string = null): string
 	{
 		return Html::decode($string);
 	}
@@ -1427,7 +1427,7 @@ class Str
 	/**
 	 * A UTF-8 safe version of strotoupper()
 	 */
-	public static function upper(string $string = null): string
+	public static function upper(string|null $string = null): string
 	{
 		return mb_strtoupper($string ?? '', 'UTF-8');
 	}
@@ -1465,7 +1465,7 @@ class Str
 	 * typographical widows at the end of a paragraph –
 	 * that's a single word in the last line
 	 */
-	public static function widont(string $string = null): string
+	public static function widont(string|null $string = null): string
 	{
 		// make sure $string is string
 		$string ??= '';
@@ -1497,7 +1497,7 @@ class Str
 	public static function wrap(
 		string $string,
 		string $before,
-		string $after = null
+		string|null $after = null
 	): string {
 		return $before . $string . ($after ?? $before);
 	}

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -474,28 +474,28 @@ V::$validators = [
 	/**
 	 * Checks if the number of characters in the value equals or is below the given maximum
 	 */
-	'maxLength' => function (string|null $value = null, $max): bool {
+	'maxLength' => function (string|null $value, $max): bool {
 		return Str::length(trim($value)) <= $max;
 	},
 
 	/**
 	 * Checks if the number of characters in the value equals or is greater than the given minimum
 	 */
-	'minLength' => function (string|null $value = null, $min): bool {
+	'minLength' => function (string|null $value, $min): bool {
 		return Str::length(trim($value)) >= $min;
 	},
 
 	/**
 	 * Checks if the number of words in the value equals or is below the given maximum
 	 */
-	'maxWords' => function (string|null $value = null, $max): bool {
+	'maxWords' => function (string|null $value, $max): bool {
 		return V::max(explode(' ', trim($value)), $max) === true;
 	},
 
 	/**
 	 * Checks if the number of words in the value equals or is below the given maximum
 	 */
-	'minWords' => function (string|null $value = null, $min): bool {
+	'minWords' => function (string|null $value, $min): bool {
 		return V::min(explode(' ', trim($value)), $min) === true;
 	},
 

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -306,7 +306,7 @@ V::$validators = [
 	 * Pass an operator as second argument and another date as
 	 * third argument to compare them.
 	 */
-	'date' => function (string|null $value, string $operator = null, string $test = null): bool {
+	'date' => function (string|null $value, string|null $operator = null, string|null $test = null): bool {
 		// make sure $value is a string
 		$value ??= '';
 
@@ -474,28 +474,28 @@ V::$validators = [
 	/**
 	 * Checks if the number of characters in the value equals or is below the given maximum
 	 */
-	'maxLength' => function (string $value = null, $max): bool {
+	'maxLength' => function (string|null $value = null, $max): bool {
 		return Str::length(trim($value)) <= $max;
 	},
 
 	/**
 	 * Checks if the number of characters in the value equals or is greater than the given minimum
 	 */
-	'minLength' => function (string $value = null, $min): bool {
+	'minLength' => function (string|null $value = null, $min): bool {
 		return Str::length(trim($value)) >= $min;
 	},
 
 	/**
 	 * Checks if the number of words in the value equals or is below the given maximum
 	 */
-	'maxWords' => function (string $value = null, $max): bool {
+	'maxWords' => function (string|null $value = null, $max): bool {
 		return V::max(explode(' ', trim($value)), $max) === true;
 	},
 
 	/**
 	 * Checks if the number of words in the value equals or is below the given maximum
 	 */
-	'minWords' => function (string $value = null, $min): bool {
+	'minWords' => function (string|null $value = null, $min): bool {
 		return V::min(explode(' ', trim($value)), $min) === true;
 	},
 
@@ -628,7 +628,7 @@ V::$validators = [
 	/**
 	 * Checks for a valid Uuid, optionally for specific model type
 	 */
-	'uuid' => function (string $value, string $type = null): bool {
+	'uuid' => function (string $value, string|null $type = null): bool {
 		return Uuid::is($value, $type);
 	}
 ];

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -373,7 +373,7 @@ class Xml
 		string $name,
 		array|string|null $content = '',
 		array $attr = [],
-		string $indent = null,
+		string|null $indent = null,
 		int $level = 0
 	): string {
 		$attr       = static::attr($attr);

--- a/src/Uuid/Uri.php
+++ b/src/Uuid/Uri.php
@@ -61,7 +61,7 @@ class Uri extends BaseUri
 	 * Returns the ID part of the UUID string
 	 * (and sets it when new one passed)
 	 */
-	public function host(string $host = null): string|null
+	public function host(string|null $host = null): string|null
 	{
 		if ($host !== null) {
 			return $this->host = $host;

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -68,7 +68,7 @@ class FileCacheTest extends TestCase
 			'root' => $root = static::TMP
 		]);
 
-		chmod($root, 0444);
+		chmod($root, 0o444);
 
 		$this->assertFalse($cache->enabled());
 	}

--- a/tests/Cache/mocks.php
+++ b/tests/Cache/mocks.php
@@ -22,7 +22,7 @@ class TestCache extends Cache
 {
 	public $store = [];
 
-	public function set(string $key, $value, int $minutes = 0, int $created = null): bool
+	public function set(string $key, $value, int $minutes = 0, int|null $created = null): bool
 	{
 		$value = new Value($value, $minutes, $created);
 		$this->store[$key] = $value;

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -159,7 +159,7 @@ class AppComponentsTest extends TestCase
 	{
 		$this->kirby = $this->kirby->clone([
 			'components' => [
-				'markdown' => function (App $kirby, string $text = null, array $options = []) {
+				'markdown' => function (App $kirby, string|null $text = null, array $options = []) {
 					$result = Html::encode($text);
 
 					if (($options['inline'] ?? false) === false) {

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -972,7 +972,7 @@ class AppPluginsTest extends TestCase
 		]);
 
 		$plugins = $kirby->plugins();
-		$this->assertSame(1, count($plugins));
+		$this->assertCount(1, $plugins);
 
 		$plugin = array_pop($plugins);
 		$this->assertSame('plugins/test5', $plugin->name());

--- a/tests/Cms/Content/ContentLockTest.php
+++ b/tests/Cms/Content/ContentLockTest.php
@@ -54,7 +54,7 @@ class ContentLockTest extends TestCase
 		$this->assertTrue($page->lock()->create());
 		$this->assertTrue($page->lock()->create());
 
-		$this->assertFalse(empty($app->locks()->get($page)));
+		$this->assertNotEmpty($app->locks()->get($page));
 	}
 
 	public function testCreateWithExistingLock()
@@ -258,7 +258,7 @@ class ContentLockTest extends TestCase
 		$this->assertTrue($page->lock()->isUnlocked());
 		$this->assertTrue($page->lock()->resolve());
 		$this->assertFalse($page->lock()->isUnlocked());
-		$this->assertTrue(empty($app->locks()->get($page)['unlock']));
+		$this->assertArrayNotHasKey('unlock', $app->locks()->get($page));
 	}
 
 	public function testResolveWithRemainingUnlocks()

--- a/tests/Cms/Sections/mixins/LayoutMixinTest.php
+++ b/tests/Cms/Sections/mixins/LayoutMixinTest.php
@@ -22,10 +22,10 @@ class LayoutMixinTest extends TestCase
 		Section::$types['test'] = Section::$types['pages'] = [
 			'mixins' => ['layout'],
 			'props'  => $props = [
-				'info' => function (string $info = null) {
+				'info' => function (string|null $info = null) {
 					return $info;
 				},
-				'text' => function (string $text = null) {
+				'text' => function (string|null $text = null) {
 					return $text;
 				}
 			]

--- a/tests/Cms/Sections/mixins/SortMixinTest.php
+++ b/tests/Cms/Sections/mixins/SortMixinTest.php
@@ -22,7 +22,7 @@ class SortMixinTest extends TestCase
 		Section::$types['test'] = [
 			'mixins' => ['sort'],
 			'props'  => [
-				'query' => function (string $query = null) {
+				'query' => function (string|null $query = null) {
 					return $query;
 				}
 			]
@@ -31,7 +31,7 @@ class SortMixinTest extends TestCase
 		Section::$types['pages'] = [
 			'mixins' => ['sort'],
 			'props'  => [
-				'status' => function (string $status = null) {
+				'status' => function (string|null $status = null) {
 					return $status;
 				},
 			]

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -44,7 +44,7 @@ class SystemTest extends TestCase
 	public function tearDown(): void
 	{
 		if ($this->subTmp !== null) {
-			chmod($this->subTmp, 0755);
+			chmod($this->subTmp, 0o755);
 			Dir::remove($this->subTmp);
 		}
 
@@ -329,7 +329,7 @@ class SystemTest extends TestCase
 		Dir::make($this->subTmp);
 
 		// set no writable
-		chmod($this->subTmp, 0444);
+		chmod($this->subTmp, 0o444);
 
 		// /site/accounts
 		$this->expectException(PermissionException::class);

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -56,7 +56,7 @@ class TestCase extends BaseTestCase
 		return $this->site()->children();
 	}
 
-	public function page(string $id = null)
+	public function page(string|null $id = null)
 	{
 		if ($id !== null) {
 			return $this->site()->find($id);

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -256,7 +256,7 @@ class FieldMethodsTest extends TestCase
 	public function testToInt()
 	{
 		$this->assertSame(1, $this->field('1')->toInt());
-		$this->assertTrue(is_int($this->field('1')->toInt()));
+		$this->assertIsInt($this->field('1')->toInt());
 	}
 
 	public function testToLink()

--- a/tests/Database/Sql/SqliteTest.php
+++ b/tests/Database/Sql/SqliteTest.php
@@ -91,7 +91,7 @@ class SqliteTest extends TestCase
 			'\)$/m',
 			$table['query']
 		);
-		$this->assertSame(2, count($table['bindings']));
+		$this->assertCount(2, $table['bindings']);
 		$this->assertSame('test default', A::first($table['bindings']));
 		$this->assertSame('another default', A::last($table['bindings']));
 

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -244,7 +244,7 @@ class SqlTest extends TestCase
 			'another' => ['type' => 'varchar', 'default' => 'another default']
 		]);
 		$this->assertMatchesRegularExpression('/^`test` varchar\(255\) NULL DEFAULT :(.*?),' . PHP_EOL . '`another` varchar\(255\) NULL DEFAULT :(.*)$/m', $inner['query']);
-		$this->assertSame(2, count($inner['bindings']));
+		$this->assertCount(2, $inner['bindings']);
 		$this->assertSame('test default', A::first($inner['bindings']));
 		$this->assertSame('another default', A::last($inner['bindings']));
 		$this->assertSame([], $inner['keys']);
@@ -309,7 +309,7 @@ class SqlTest extends TestCase
 			'\)$/m',
 			$table['query']
 		);
-		$this->assertSame(2, count($table['bindings']));
+		$this->assertCount(2, $table['bindings']);
 		$this->assertSame('test default', A::first($table['bindings']));
 		$this->assertSame('another default', A::last($table['bindings']));
 

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -550,7 +550,7 @@ class DirTest extends TestCase
 	{
 		Dir::make(static::TMP);
 
-		$this->assertTrue(is_int(Dir::modified(static::TMP)));
+		$this->assertIsInt(Dir::modified(static::TMP));
 	}
 
 	/**

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -37,7 +37,7 @@ class FileTest extends TestCase
 	public function tearDown(): void
 	{
 		if (file_exists(static::TMP . '/unreadable.txt') === true) {
-			chmod(static::TMP . '/unreadable.txt', 0755);
+			chmod(static::TMP . '/unreadable.txt', 0o755);
 		}
 
 		static::$block = [];
@@ -619,7 +619,7 @@ class FileTest extends TestCase
 	{
 		$file = new File(static::TMP . '/unreadable.txt');
 		$file->write('test');
-		chmod($file->root(), 0000);
+		chmod($file->root(), 0o000);
 		$this->assertFalse($file->read());
 	}
 
@@ -873,7 +873,7 @@ class FileTest extends TestCase
 
 		$file = new File(static::TMP . '/unwritable.txt');
 		$file->write('test');
-		chmod($file->root(), 0555);
+		chmod($file->root(), 0o555);
 		$file->write('kirby');
 	}
 

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -133,7 +133,7 @@ class MimeTest extends TestCase
 
 		// test matchWildcards: false (default value)
 		$extensions = Mime::toExtensions('image/*');
-		$this->assertSame(0, count($extensions));
+		$this->assertCount(0, $extensions);
 
 		// test matchWildcards: true
 		$extensions = Mime::toExtensions('image/*', true);

--- a/tests/Form/Fields/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Fields/Mixins/FilePickerMixinTest.php
@@ -169,7 +169,7 @@ class FilePickerMixinTest extends TestCase
 			'test' => [
 				'mixins'  => ['filepicker'],
 				'props' => [
-					'query' => function (string $query = null) {
+					'query' => function (string|null $query = null) {
 						return $query;
 					}
 				],
@@ -213,7 +213,7 @@ class FilePickerMixinTest extends TestCase
 			'test' => [
 				'mixins'  => ['filepicker'],
 				'props' => [
-					'query' => function (string $query = null) {
+					'query' => function (string|null $query = null) {
 						return $query;
 					}
 				],

--- a/tests/Form/Fields/StructureFieldTest.php
+++ b/tests/Form/Fields/StructureFieldTest.php
@@ -296,7 +296,7 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertTrue(is_float($field->data()[0]['number']));
+		$this->assertIsFloat($field->data()[0]['number']);
 	}
 
 	public function testEmpty()

--- a/tests/Http/mocks.php
+++ b/tests/Http/mocks.php
@@ -15,7 +15,7 @@ class IniStore
 /**
  * Mock for the PHP headers_sent() function (otherwise not available on CLI)
  */
-function headers_sent(string &$file = null, int &$line = null): bool
+function headers_sent(string|null &$file = null, int|null &$line = null): bool
 {
 	if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
 		throw new Exception('Mock headers_sent() was loaded outside of the test environment. This should never happen.');

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -8,7 +8,7 @@ class DarkroomTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	public function file(string $driver = null)
+	public function file(string|null $driver = null)
 	{
 		if ($driver !== null) {
 			return static::FIXTURES . '/image/cat-' . $driver . '.jpg';

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -155,7 +155,7 @@ abstract class AreaTestCase extends TestCase
 		$this->app->impersonate($user);
 	}
 
-	public function response(string $path = null, bool $toJson = false)
+	public function response(string|null $path = null, bool $toJson = false)
 	{
 		$response = Panel::router($path);
 
@@ -221,7 +221,7 @@ abstract class AreaTestCase extends TestCase
 		App::destroy();
 	}
 
-	public function view(string $path = null): array
+	public function view(string|null $path = null): array
 	{
 		return $this->response($path, true)['$view'];
 	}

--- a/tests/Panel/Areas/PluginSearchesTest.php
+++ b/tests/Panel/Areas/PluginSearchesTest.php
@@ -22,7 +22,7 @@ class PluginSearchesTest extends AreaTestCase
 					'search' => 'test',
 					'searches' => [
 						'test' => [
-							'query' => function (string $query = null) {
+							'query' => function (string|null $query = null) {
 								return [['a'], ['b'], ['c']];
 							},
 						]

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -405,7 +405,7 @@ class FileTest extends TestCase
 
 		// fallback to model itself
 		$image = (new File($page->file()))->image('foo.bar');
-		$this->assertFalse(empty($image));
+		$this->assertNotEmpty($image);
 	}
 
 	/**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -202,7 +202,7 @@ class UserTest extends TestCase
 
 		// fallback to model itself
 		$image = (new User($user))->image('foo.bar');
-		$this->assertFalse(empty($image));
+		$this->assertNotEmpty($image);
 	}
 
 	/**

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -269,7 +269,7 @@ class ViewTest extends TestCase
 		$this->assertSame([], $view['breadcrumb']);
 		$this->assertSame(200, $view['code']);
 		$this->assertSame('', $view['path']);
-		$this->assertTrue(is_int($view['timestamp']));
+		$this->assertIsInt($view['timestamp']);
 		$this->assertSame([], $view['props']);
 		$this->assertSame('pages', $view['search']);
 

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -28,10 +28,10 @@ class BlocksTest extends TestCase
 	public function testBlockquote()
 	{
 		$html = <<<HTML
-            <blockquote>
-                Test
-            </blockquote>
-        HTML;
+			<blockquote>
+				Test
+			</blockquote>
+			HTML;
 
 		$element  = $this->element($html, '//blockquote');
 		$expected = [
@@ -48,10 +48,10 @@ class BlocksTest extends TestCase
 	public function testBlockquoteWithMarks()
 	{
 		$html = <<<HTML
-            <blockquote>
-                <p><b>Bold</b> <i>Italic</i></p>
-            </blockquote>
-        HTML;
+			<blockquote>
+				<p><b>Bold</b> <i>Italic</i></p>
+			</blockquote>
+			HTML;
 
 		$element  = $this->element($html, '//blockquote');
 		$expected = [
@@ -68,11 +68,11 @@ class BlocksTest extends TestCase
 	public function testBlockquoteWithParagraphs()
 	{
 		$html = <<<HTML
-            <blockquote>
-                <p>A</p>
-                <p>B</p>
-            </blockquote>
-        HTML;
+			<blockquote>
+				<p>A</p>
+				<p>B</p>
+			</blockquote>
+			HTML;
 
 		$element  = $this->element($html, '//blockquote');
 		$expected = [
@@ -89,11 +89,11 @@ class BlocksTest extends TestCase
 	public function testBlockquoteWithFooter()
 	{
 		$html = <<<HTML
-            <blockquote>
-                Test
-                <footer>Albert Einstein</footer>
-            </blockquote>
-        HTML;
+			<blockquote>
+				Test
+				<footer>Albert Einstein</footer>
+			</blockquote>
+			HTML;
 
 		$element  = $this->element($html, '//blockquote');
 		$expected = [
@@ -189,10 +189,10 @@ class BlocksTest extends TestCase
 	public function testHeading()
 	{
 		$html = <<<HTML
-            <h1>
-                Test
-            </h1>
-        HTML;
+			<h1>
+				Test
+			</h1>
+			HTML;
 
 		$element  = $this->element($html, '//h1');
 		$expected = [
@@ -219,10 +219,10 @@ class BlocksTest extends TestCase
 	public function testHeadingLevel($level)
 	{
 		$html = <<<HTML
-            <$level>
-                Test
-            </$level>
-        HTML;
+			<$level>
+				Test
+			</$level>
+			HTML;
 
 		$element  = $this->element($html, '//' . $level);
 		$expected = [
@@ -239,10 +239,10 @@ class BlocksTest extends TestCase
 	public function testHeadingId()
 	{
 		$html = <<<HTML
-            <h1 id="test">
-                Test
-            </h1>
-        HTML;
+			<h1 id="test">
+				Test
+			</h1>
+			HTML;
 
 		$element  = $this->element($html, '//h1');
 		$expected = [
@@ -260,8 +260,8 @@ class BlocksTest extends TestCase
 	public function testIframe()
 	{
 		$html = <<<HTML
-            <iframe src="https://getkirby.com"></iframe>
-        HTML;
+			<iframe src="https://getkirby.com"></iframe>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -277,8 +277,8 @@ class BlocksTest extends TestCase
 	public function testIframeWithVimeoVideo()
 	{
 		$html = <<<HTML
-            <iframe src="https://player.vimeo.com/video/1"></iframe>
-        HTML;
+			<iframe src="https://player.vimeo.com/video/1"></iframe>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -295,8 +295,8 @@ class BlocksTest extends TestCase
 	public function testIframeWithYoutubeVideo()
 	{
 		$html = <<<HTML
-            <iframe src="https://youtube.com/embed/1"></iframe>
-        HTML;
+			<iframe src="https://youtube.com/embed/1"></iframe>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -313,8 +313,8 @@ class BlocksTest extends TestCase
 	public function testIframeWithYoutubeNoCookieVideo()
 	{
 		$html = <<<HTML
-            <iframe src="https://youtube-nocookie.com/embed/1"></iframe>
-        HTML;
+			<iframe src="https://youtube-nocookie.com/embed/1"></iframe>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -331,11 +331,11 @@ class BlocksTest extends TestCase
 	public function testIframeWithCaption()
 	{
 		$html = <<<HTML
-            <figure>
-                <iframe src="https://youtube.com/embed/1"></iframe>
-                <figcaption>Test</figcaption>
-            </figure>
-        HTML;
+			<figure>
+				<iframe src="https://youtube.com/embed/1"></iframe>
+				<figcaption>Test</figcaption>
+			</figure>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -352,11 +352,11 @@ class BlocksTest extends TestCase
 	public function testIframeWithCaptionAndMarks()
 	{
 		$html = <<<HTML
-            <figure>
-                <iframe src="https://youtube.com/embed/1"></iframe>
-                <figcaption><b>Bold</b><i>Italic</i></figcaption>
-            </figure>
-        HTML;
+			<figure>
+				<iframe src="https://youtube.com/embed/1"></iframe>
+				<figcaption><b>Bold</b><i>Italic</i></figcaption>
+			</figure>
+			HTML;
 
 		$element  = $this->element($html, '//iframe');
 		$expected = [
@@ -373,8 +373,8 @@ class BlocksTest extends TestCase
 	public function testImg()
 	{
 		$html = <<<HTML
-            <img src="https://getkirby.com/image.jpg">
-        HTML;
+			<img src="https://getkirby.com/image.jpg">
+			HTML;
 
 		$element  = $this->element($html, '//img');
 		$expected = [
@@ -394,8 +394,8 @@ class BlocksTest extends TestCase
 	public function testImgWithAlt()
 	{
 		$html = <<<HTML
-            <img src="https://getkirby.com/image.jpg" alt="Test">
-        HTML;
+			<img src="https://getkirby.com/image.jpg" alt="Test">
+			HTML;
 
 		$element  = $this->element($html, '//img');
 		$expected = [
@@ -415,10 +415,10 @@ class BlocksTest extends TestCase
 	public function testImgWithLink()
 	{
 		$html = <<<HTML
-            <a href="https://getkirby.com">
-                <img src="https://getkirby.com/image.jpg" alt="Test">
-            </a>
-        HTML;
+			<a href="https://getkirby.com">
+				<img src="https://getkirby.com/image.jpg" alt="Test">
+			</a>
+			HTML;
 
 		$element  = $this->element($html, '//img');
 		$expected = [
@@ -438,11 +438,11 @@ class BlocksTest extends TestCase
 	public function testImgWithCaption()
 	{
 		$html = <<<HTML
-            <figure>
-                <img src="https://getkirby.com/image.jpg" alt="Test">
-                <figcaption>Test</figcaption>
-            </figure>
-        HTML;
+			<figure>
+				<img src="https://getkirby.com/image.jpg" alt="Test">
+				<figcaption>Test</figcaption>
+			</figure>
+			HTML;
 
 		$element  = $this->element($html, '//img');
 		$expected = [
@@ -462,13 +462,13 @@ class BlocksTest extends TestCase
 	public function testImgWithLinkAndCaption()
 	{
 		$html = <<<HTML
-            <figure>
-                <a href="https://getkirby.com">
-                    <img src="https://getkirby.com/image.jpg" alt="Test">
-                    <figcaption>Test</figcaption>
-                </a>
-            </figure>
-        HTML;
+			<figure>
+				<a href="https://getkirby.com">
+					<img src="https://getkirby.com/image.jpg" alt="Test">
+					<figcaption>Test</figcaption>
+				</a>
+			</figure>
+			HTML;
 
 		$element  = $this->element($html, '//img');
 		$expected = [
@@ -488,12 +488,12 @@ class BlocksTest extends TestCase
 	public function testList()
 	{
 		$html = <<<HTML
-            <ul>
-                <li>A</li>
-                <li>B</li>
-                <li>C</li>
-            </ul>
-        HTML;
+			<ul>
+				<li>A</li>
+				<li>B</li>
+				<li>C</li>
+			</ul>
+			HTML;
 
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li>A</li><li>B</li><li>C</li></ul>';
@@ -504,10 +504,10 @@ class BlocksTest extends TestCase
 	public function testListWithMarks()
 	{
 		$html = <<<HTML
-            <ul>
-                <li><b>Bold</b><i>Italic</i></li>
-            </ul>
-        HTML;
+			<ul>
+				<li><b>Bold</b><i>Italic</i></li>
+			</ul>
+			HTML;
 
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li><b>Bold</b><i>Italic</i></li></ul>';
@@ -518,18 +518,18 @@ class BlocksTest extends TestCase
 	public function testListNested()
 	{
 		$html = <<<HTML
-            <ul>
-                <li>A</li>
-                <li>
-                    <ol>
-                        <li>1</li>
-                        <li>2</li>
-                        <li>3</li>
-                    </ol>
-                </li>
-                <li>C</li>
-            </ul>
-        HTML;
+			<ul>
+				<li>A</li>
+				<li>
+					<ol>
+						<li>1</li>
+						<li>2</li>
+						<li>3</li>
+					</ol>
+				</li>
+				<li>C</li>
+			</ul>
+			HTML;
 
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li>A</li><li><ol><li>1</li><li>2</li><li>3</li></ol></li><li>C</li></ul>';
@@ -540,8 +540,8 @@ class BlocksTest extends TestCase
 	public function testPre()
 	{
 		$html = <<<HTML
-            <pre>Code</pre>
-        HTML;
+			<pre>Code</pre>
+			HTML;
 
 		$element  = $this->element($html, '//pre');
 		$expected = [
@@ -558,8 +558,8 @@ class BlocksTest extends TestCase
 	public function testPreWithCode()
 	{
 		$html = <<<HTML
-            <pre><code>Code</code></pre>
-        HTML;
+			<pre><code>Code</code></pre>
+			HTML;
 
 		$element  = $this->element($html, '//pre');
 		$expected = [
@@ -576,8 +576,8 @@ class BlocksTest extends TestCase
 	public function testPreWithLanguage()
 	{
 		$html = <<<HTML
-            <pre><code class="language-php">Code</code></pre>
-        HTML;
+			<pre><code class="language-php">Code</code></pre>
+			HTML;
 
 		$element  = $this->element($html, '//pre');
 		$expected = [
@@ -609,8 +609,8 @@ class BlocksTest extends TestCase
 	public function testTable()
 	{
 		$html = <<<HTML
-            <table></table>
-        HTML;
+			<table></table>
+			HTML;
 
 		$element  = $this->element($html, '//table');
 		$expected = [

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -17,7 +17,7 @@ class ExpressionTest extends TestCase
 	public function testFactory()
 	{
 		$expression = Expression::factory('a ? b : c');
-		$this->assertSame(5, count($expression->parts));
+		$this->assertCount(5, $expression->parts);
 		$this->assertInstanceOf(Argument::class, $expression->parts[0]);
 		$this->assertIsString($expression->parts[1]);
 		$this->assertInstanceOf(Argument::class, $expression->parts[2]);

--- a/tests/Session/FileSessionStoreTest.php
+++ b/tests/Session/FileSessionStoreTest.php
@@ -48,11 +48,11 @@ class FileSessionStoreTest extends TestCase
 		unset($this->store);
 
 		// make sure the directory and in files are writable before trying to delete
-		chmod(static::TMP, 0777);
+		chmod(static::TMP, 0o777);
 
 		$files = array_diff(scandir(static::TMP) ?? [], ['.', '..']);
 		foreach ($files as $file) {
-			chmod(static::TMP . '/' . $file, 0777);
+			chmod(static::TMP . '/' . $file, 0o777);
 		}
 
 		Dir::remove(static::TMP);
@@ -68,7 +68,7 @@ class FileSessionStoreTest extends TestCase
 		$this->expectExceptionCode('error.session.filestore.dirNotWritable');
 
 		Dir::make(static::TMP, true);
-		chmod(static::TMP, 0555);
+		chmod(static::TMP, 0o555);
 
 		new FileSessionStore(static::TMP);
 	}
@@ -208,7 +208,7 @@ class FileSessionStoreTest extends TestCase
 		$this->expectExceptionCode('error.session.filestore.notOpened');
 
 		// session files need to have read and write permissions even for reading
-		chmod(static::TMP . '/1234567890.abcdefghijabcdefghij.sess', 0444);
+		chmod(static::TMP . '/1234567890.abcdefghijabcdefghij.sess', 0o444);
 		$this->store->get(1234567890, 'abcdefghijabcdefghij');
 	}
 

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -92,12 +92,12 @@ class ATest extends TestCase
 	{
 		// The value should be passed to the callback
 		A::every(['foo', 'bar'], function ($value) {
-			$this->assertTrue(is_string($value), 'The value should be passed to the callback');
+			$this->assertIsString($value, 'The value should be passed to the callback');
 		});
 
 		// The key should be passed to the callback
 		A::every(['foo' => 1, 'bar' => 2], function ($value, $key = null) {
-			$this->assertTrue(is_string($key), 'The key should be passed to the callback');
+			$this->assertIsString($key, 'The key should be passed to the callback');
 		});
 
 		// the array should be passed to the callback
@@ -593,12 +593,12 @@ class ATest extends TestCase
 	{
 		// The value should be passed to the callback
 		A::some(['foo', 'bar'], function ($value = null) {
-			$this->assertTrue(is_string($value), 'The value should be passed to the callback');
+			$this->assertIsString($value, 'The value should be passed to the callback');
 		});
 
 		// The key should be passed to the callback
 		A::some(['foo' => 1, 'bar' => 2], function ($value = null, $key = null) {
-			$this->assertTrue(is_string($key), 'The key should be passed to the callback');
+			$this->assertIsString($key, 'The key should be passed to the callback');
 		});
 
 		// the array should be passed to the callback
@@ -681,7 +681,7 @@ class ATest extends TestCase
 		// Assert existence and correctness of keys
 		$random1 = A::random($array, 1);
 		$this->assertTrue(in_array(array_values($random1)[0], $array));
-		$this->assertTrue(array_key_exists(array_key_first($random1), $array));
+		$this->assertArrayHasKey(array_key_first($random1), $array);
 
 		// Assert order of keys in non-shuffled random
 		$random2 = A::random($array, 2);

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -151,7 +151,7 @@ class CollectionTest extends TestCase
 	public function testCount()
 	{
 		$this->assertSame(3, $this->collection->count());
-		$this->assertSame(3, count($this->collection));
+		$this->assertCount(3, $this->collection);
 	}
 
 	/**

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -219,7 +219,7 @@ class DomTest extends TestCase
 	 * @covers ::exportHtml
 	 * @covers ::exportXml
 	 */
-	public function testParseSave(string $type, string $code, string $expected = null)
+	public function testParseSave(string $type, string $code, string|null $expected = null)
 	{
 		$dom = new Dom($code, $type);
 		$this->assertSame($expected ?? $code, $dom->toString());
@@ -356,7 +356,7 @@ class DomTest extends TestCase
 	 * @covers ::exportHtml
 	 * @covers ::exportXml
 	 */
-	public function testParseSaveNormalize(string $type, string $code, string $expected = null)
+	public function testParseSaveNormalize(string $type, string $code, string|null $expected = null)
 	{
 		$dom = new Dom($code, $type);
 		$this->assertSame($expected ?? $code, $dom->toString(true));

--- a/tests/Toolkit/LazyValueTest.php
+++ b/tests/Toolkit/LazyValueTest.php
@@ -20,7 +20,7 @@ class LazyValueTest extends TestCase
 		$value    = new LazyValue(fn () => $expected);
 		$this->assertInstanceOf(LazyValue::class, $value);
 		$this->assertNotInstanceOf(Closure::class, $value);
-		$this->assertFalse(is_callable($value));
+		$this->assertIsNotCallable($value);
 		$this->assertSame($expected, $value->resolve());
 	}
 

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1539,7 +1539,6 @@ EOT;
 		$this->assertSame('Omelette du&nbsp;fromage.', Str::widont('Omelette du fromage.'));
 		$this->assertSame('Omelette du&nbsp;fromage?', Str::widont('Omelette du fromage?'));
 		$this->assertSame('Omelette du&nbsp;fromage&nbsp;?', Str::widont('Omelette du fromage ?'));
-		$this->assertSame('', Str::widont());
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -613,10 +613,10 @@ class StrTest extends TestCase
 	public function testMatchAll()
 	{
 		$longText = <<<TEXT
-		This is line with "one" and something else to match.
-		This is line with "two" and another thing to match.
-		This is line with "three" and yet another match.
-		TEXT;
+			This is line with "one" and something else to match.
+			This is line with "two" and another thing to match.
+			This is line with "three" and yet another match.
+			TEXT;
 
 		$matches = Str::matchAll($longText, '/"(.*)" and (.*).$/m');
 
@@ -1232,11 +1232,11 @@ class StrTest extends TestCase
 
 		// custom separator with line-breaks
 		$string = <<<EOT
-            ---
-            -abc-
-            ---
-            -def-
-EOT;
+			---
+			-abc-
+			---
+			-def-
+			EOT;
 		$this->assertSame(['-abc-', '-def-'], Str::split($string, '---'));
 
 		// input is already an array

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -38,8 +38,8 @@ class VTest extends TestCase
 	 */
 	public function testValidators()
 	{
-		$this->assertFalse(empty(V::$validators));
-		$this->assertFalse(empty(V::validators()));
+		$this->assertNotEmpty(V::$validators);
+		$this->assertNotEmpty(V::validators());
 	}
 
 	/**


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Refactoring

- Use more modern PHP syntax and PHPUnit assertions where applicable

### Breaking changes

- `Str::camel()`, `Str::camelToKebab()`, `Str::float()`, `Str::kebab()`, `Str::kebabToCamel()`, `Str::length()`, `Str::lower()`, `Str::safeTemplate()`, `Str::short()`, `Str::slug()`, `Str::snake()`, `Str::studly()`, `Str::substr()`, `Str::template()`, `Str::ucfirst()`, `Str::ucwords()`, `Str::unhtml()`, `Str::upper()` and `Str::widont()` can no longer be called without a value argument (passing a `null` value still works)

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
