### PR TITLE
Fix email dialog title prop translation 

### DIFF
--- a/panel/src/components/Dialogs/EmailDialog.vue
+++ b/panel/src/components/Dialogs/EmailDialog.vue
@@ -24,7 +24,7 @@ export default {
 					icon: "email"
 				},
 				title: {
-					label: window.panel.$t("link.text"),
+					label: window.panel.$t("title"),
 					type: "text",
 					icon: "title"
 				}

--- a/panel/src/components/Forms/Toolbar/EmailDialog.vue
+++ b/panel/src/components/Forms/Toolbar/EmailDialog.vue
@@ -3,6 +3,23 @@ import EmailDialog from "@/components/Dialogs/EmailDialog.vue";
 
 export default {
 	extends: EmailDialog,
+	props: {
+		// eslint-disable-next-line vue/require-prop-types
+		fields: {
+			default: () => ({
+				href: {
+					label: window.panel.$t("email"),
+					type: "email",
+					icon: "email"
+				},
+				title: {
+					label: window.panel.$t("link.text"),
+					type: "text",
+					icon: "title"
+				}
+			})
+		},
+	},
 	methods: {
 		submit() {
 			const email = this.values.href ?? "";

--- a/panel/src/components/Forms/Toolbar/EmailDialog.vue
+++ b/panel/src/components/Forms/Toolbar/EmailDialog.vue
@@ -6,19 +6,15 @@ export default {
 	props: {
 		// eslint-disable-next-line vue/require-prop-types
 		fields: {
-			default: () => ({
-				href: {
-					label: window.panel.$t("email"),
-					type: "email",
-					icon: "email"
-				},
-				title: {
-					label: window.panel.$t("link.text"),
-					type: "text",
-					icon: "title"
-				}
-			})
-		},
+			default: () => {
+				const fields = EmailDialog.props.fields.default();
+
+				// change the label to "Link Text"
+				fields.title.label = window.panel.$t("link.text");
+
+				return fields;
+			}
+		}
 	},
 	methods: {
 		submit() {


### PR DESCRIPTION
## This PR …

Fixes `Title` and `Link text` translations for the different usages:

- Writer field email dialog has`Title` field
- Textarea field email dialog has `Link text` field

### Few notes to team
- Maybe we should move to 4.3 instead 4.2.1, not sure
- I couldn't find a solution that simply define `label` prop in `Toolbar/EmailDialog.vue` and merge with extended dialog component. Maybe you've better solution for this.

### Fixes
- Fix email dialog title prop translation #6402

### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snipptets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
