### PR TITLE
Remove deprecated Content methods

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -246,33 +246,6 @@ class File extends ModelWithContent
 	}
 
 	/**
-	 * Returns the directory in which
-	 * the content file is located
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileDirectory(): string
-	{
-		Helpers::deprecated('The internal $model->contentFileDirectory() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return dirname($this->root());
-	}
-
-	/**
-	 * Filename for the content file
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileName(): string
-	{
-		Helpers::deprecated('The internal $model->contentFileName() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return $this->filename();
-	}
-
-	/**
 	 * Constructs a File object
 	 * @internal
 	 */

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -34,9 +34,6 @@ class Helpers
 		// render an empty value anymore but a single space.
 		// To render an empty value, please pass an empty string.
 		'xml-attr-single-space' => true,
-
-		// The internal `$model->contentFile*()` methods have been deprecated
-		'model-content-file' => true,
 	];
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -165,47 +165,6 @@ abstract class ModelWithContent implements Identifiable
 	}
 
 	/**
-	 * Returns the absolute path to the content file;
-	 * NOTE: only supports the published content file
-	 * (use `$model->storage()->contentFile()` for other versions)
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the language for the given code does not exist
-	 */
-	public function contentFile(
-		string|null $languageCode = null,
-		bool $force = false
-	): string {
-		Helpers::deprecated('The internal $model->contentFile() method has been deprecated. You can use $model->storage()->contentFile() instead, however please note that this method is also internal and may be removed in the future.', 'model-content-file');
-
-		return $this->storage()->contentFile(
-			$this->storage()->defaultVersion(),
-			$languageCode,
-			$force
-		);
-	}
-
-	/**
-	 * Returns an array with all content files;
-	 * NOTE: only supports the published content file
-	 * (use `$model->storage()->contentFiles()` for other versions)
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFiles(): array
-	{
-		Helpers::deprecated('The internal $model->contentFiles() method has been deprecated. You can use $model->storage()->contentFiles() instead, however please note that this method is also internal and may be removed in the future.', 'model-content-file');
-
-		return $this->storage()->contentFiles(
-			$this->storage()->defaultVersion()
-		);
-	}
-
-	/**
 	 * Prepares the content that should be written
 	 * to the text file
 	 * @internal
@@ -216,43 +175,6 @@ abstract class ModelWithContent implements Identifiable
 	): array {
 		return $data;
 	}
-
-	/**
-	 * Returns the absolute path to the
-	 * folder in which the content file is
-	 * located
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileDirectory(): string|null
-	{
-		Helpers::deprecated('The internal $model->contentFileDirectory() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return $this->root();
-	}
-
-	/**
-	 * Returns the extension of the content file
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileExtension(): string
-	{
-		Helpers::deprecated('The internal $model->contentFileName() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return $this->kirby()->contentExtension();
-	}
-
-	/**
-	 * Needs to be declared by the final model
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	abstract public function contentFileName(): string;
 
 	/**
 	 * Converts model to new blueprint

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -287,20 +287,6 @@ class Page extends ModelWithContent
 	}
 
 	/**
-	 * Returns the content text file
-	 * which is found by the inventory method
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileName(string|null $languageCode = null): string
-	{
-		Helpers::deprecated('The internal $model->contentFileName() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return $this->intendedTemplate()->name();
-	}
-
-	/**
 	 * Call the page controller
 	 * @internal
 	 *

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -191,19 +191,6 @@ class Site extends ModelWithContent
 	}
 
 	/**
-	 * Filename for the content file
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileName(): string
-	{
-		Helpers::deprecated('The internal $model->contentFileName() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return 'site';
-	}
-
-	/**
 	 * Returns the error page object
 	 */
 	public function errorPage(): Page|null

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -185,20 +185,6 @@ class User extends ModelWithContent
 		return $data;
 	}
 
-	/**
-	 * Filename for the content file
-	 *
-	 * @internal
-	 * @deprecated 4.0.0
-	 * @todo Remove in v5
-	 * @codeCoverageIgnore
-	 */
-	public function contentFileName(): string
-	{
-		Helpers::deprecated('The internal $model->contentFileName() method has been deprecated. Please let us know via a GitHub issue if you need this method and tell us your use case.', 'model-content-file');
-		return 'user';
-	}
-
 	protected function credentials(): array
 	{
 		return $this->credentials ??= $this->readCredentials();
@@ -748,15 +734,6 @@ class User extends ModelWithContent
 		}
 
 		return true;
-	}
-
-	/**
-	 * @deprecated 4.0.0 Use `->secretsFile()` instead
-	 * @codeCoverageIgnore
-	 */
-	protected function passwordFile(): string
-	{
-		return $this->secretsFile();
 	}
 
 	/**

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -23,11 +23,6 @@ class ExtendedModelWithContent extends ModelWithContent
 		// nothing to commit in the test
 	}
 
-	public function contentFileName(): string
-	{
-		return 'test.txt';
-	}
-
 	public function panel(): PanelPage
 	{
 		return new PanelPage($this);


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Removed deprecated code
- `Kirby\Cms\File::contentFileDirectory()`
- `Kirby\Cms\File::contentFileName()`
- `Kirby\Cms\ModelWithContent::contentFile()`. Use `$model->storage()->contentFile()` instead.
- `Kirby\Cms\ModelWithContent::contentFiles()`. Use `$model->storage()->contentFiles()` instead.
- `Kirby\Cms\ModelWithContent::contentFileDirectory()`.
- `Kirby\Cms\ModelWithContent::contentFileName()`.
- `Kirby\Cms\ModelWithContent::contentFileExtension()`.
- `Kirby\Cms\Page::contentFileName()`
- `Kirby\Cms\Site::contentFileName()`
- `Kirby\Cms\User::contentFileName()`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
