### PR TITLE
Page section: show Add based on `create` status

### DIFF
--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -236,9 +236,18 @@ return [
 				return false;
 			}
 
-			// ensure that the add button is only shown when
-			// the section is displaying pages with the same status
-			// as the status that is used for page creation
+			// form here on, we need to check with which status
+			// the pages are created and if the section can show
+			// these newly created pages
+
+			// if the section shows pages no matter what status they have,
+			// we can always show the add button
+			if ($this->status === 'all') {
+				return true;
+			}
+
+			// collect all statuses of the blueprints
+			// that are allowed to be created
 			$statuses = [];
 
 			foreach ($this->blueprintNames() as $blueprint) {
@@ -246,16 +255,16 @@ return [
 					$props      = Blueprint::load('pages/' . $blueprint);
 					$statuses[] = $props['create']['status'] ?? 'draft';
 				} catch (Throwable) {
+					$statuses[] = 'draft'; // @codeCoverageIgnore
 				}
 			}
 
 			$statuses = array_unique($statuses);
 
-			if (count($statuses) > 1 && $this->status !== 'all') {
-				return false;
-			}
-
-			if (in_array($this->status, [...$statuses, 'all']) === false) {
+			// if there are multiple statuses or if the section is showing
+			// a different status than new pages would be created with,
+			// we cannot show the add button
+			if (count($statuses) > 1 || $this->status !== $statuses[0]) {
 				return false;
 			}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Enhancement
- Page section: Show Add button also in sections only showing listed/unlisted pages when all allowed blueprints create new child pages directly as listed/unlisted https://feedback.getkirby.com/181



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful) https://github.com/getkirby/sandbox/pull/6
- [x] Add changes & docs to release notes draft in Notion
