### PR TITLE
DateInput: fix clearing

### DIFF
--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -136,10 +136,10 @@ export default {
 		 */
 		isEmpty() {
 			if (this.time) {
-				return this.iso.date === null && this.iso.time;
+				return !this.iso.date || !this.iso.time;
 			}
 
-			return this.iso.date === null;
+			return !this.iso.date;
 		}
 	},
 	watch: {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Two things I noticed and tried to fix:
- `iso.date` and `iso.time` might not be `null` but `undefined`
- For `isEmpty` we cannot check for date AND time, but date OR time. Since the whole field shares one DateTime object, if we clear the date part, `isEmpty` would still be false (if the time part is filled and we check for AND) and thus we would immediately fill it with the current date. Which clearly is not intended if the users clears the date part. In turn, with the new implementation, when a user clears the date input, the time input is cleared as well and vice-versa. This isn't ideal, but with the current setup of sharing one DateTime object as source of truth, we can only either have a state (and showing up in both inputs) or none.

### Fixes
- Date field: clearing the date field on backspace works now
#6392

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~~Add lab and/or sandbox examples (wherever helpful)~~ already exist
- [x] Add changes & docs to release notes draft in Notion
