### PR TITLE
File upload: fix sort number

### DIFF
--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -286,8 +286,14 @@ export default (panel) => {
 				file.error = null;
 				file.progress = 0;
 
+				// clone the attributes to ensure that
+				// each file has its own copy, e.g. of sort
+				// (otherwise all files would use the state
+				// of attributes from the last file in the loop)
+				const attributes = { ...this.attributes };
+
 				// add file to upload queue
-				files.push(async () => await this.upload(file));
+				files.push(async () => await this.upload(file, attributes));
 
 				const sort = this.attributes?.sort;
 
@@ -304,10 +310,10 @@ export default (panel) => {
 				return this.done();
 			}
 		},
-		async upload(file) {
+		async upload(file, attributes) {
 			try {
 				const response = await upload(file.src, {
-					attributes: this.attributes,
+					attributes: attributes,
 					headers: { "x-csrf": panel.system.csrf },
 					filename: file.name + "." + file.extension,
 					url: this.url,


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

We were passing `this.attributes` so far and incrementing the `sort` subkey in preparation. However, when the uploads actually start, they all point to the same object which now has the same, too-high sort number.

To fix this, we create a local copy of `attributes` that preserves the sort number for the specific file and pass it to the upload.

### Fixes
- Simultaneously uploaded files receive the correct sorting number now
#6380


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
