### PR TITLE
Make `contentToken` independent from `num` in root

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -435,10 +435,11 @@ class App
 	 */
 	public function contentToken(mixed $model, string $value): string
 	{
-		$default = match (method_exists($model, 'root')) {
-			true  => $model->root(),
-			false => $this->root('content')
-		};
+		$default = $this->root('content');
+
+		if (method_exists($model, 'id') === true) {
+			$default .= '/' . $model->id();
+		}
 
 		$salt = $this->option('content.salt', $default);
 

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -274,7 +274,7 @@ class AppTest extends TestCase
 			]
 		]);
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken('model', 'test'));
-		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null'), $app->contentToken($app, 'test'));
+		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken($app, 'test'));
 
 		// with custom static salt
 		$app = new App([

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -636,7 +636,11 @@ class PageTest extends TestCase
 		]);
 
 		if ($draft === true && $expected !== null) {
-			$expected = str_replace('{token}', 'token=' . hash_hmac('sha1', $page->id() . $page->template(), $page->root()), $expected);
+			$expected = str_replace(
+				'{token}',
+				'token=' . hash_hmac('sha1', $page->id() . $page->template(), $page->kirby()->root('content') . '/' . $page->id()),
+				$expected
+			);
 		}
 
 		$this->assertSame($expected, $page->previewUrl());
@@ -650,16 +654,25 @@ class PageTest extends TestCase
 
 	public function testToken()
 	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			]
+		]);
+
 		$page = new Page([
 			'slug'     => 'test',
-			'root'     => '/var/www/content/test',
 			'template' => 'default'
 		]);
 
 		$method = new ReflectionMethod(Page::class, 'token');
 		$method->setAccessible(true);
 
-		$expected = hash_hmac('sha1', 'test' . 'default', '/var/www/content/test');
+		$expected = hash_hmac(
+			'sha1',
+			'testdefault',
+			'/dev/null/content/test'
+		);
 		$this->assertSame($expected, $method->invoke($page));
 	}
 


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

See discussion at #5102.
Please have a close look at it. I think I implemented it as discussed, but e.g. not sure where best to add a unit test.

### Enhancements
- Thumbnails don't need to be regenerated when page sorting changes


### Breaking changes
- All thumbnails will regenerate


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
