### PR TITLE
Remove null headers from API calls

### DIFF
--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -29,11 +29,11 @@ export default (api) => {
 		}
 
 		// remove null headers
-		Object.keys(options.headers).forEach((key) => {
+		for (const key in options.headers) {
 			if (options.headers[key] === null) {
 				delete options.headers[key];
 			}
-		});
+		}
 
 		// build the request URL
 		options.url = rtrim(api.endpoint, "/") + "/" + ltrim(path, "/");

--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -28,6 +28,13 @@ export default (api) => {
 			options.method = "POST";
 		}
 
+		// remove null headers
+		Object.keys(options.headers).forEach((key) => {
+			if (options.headers[key] === null) {
+				delete options.headers[key];
+			}
+		});
+
 		// build the request URL
 		options.url = rtrim(api.endpoint, "/") + "/" + ltrim(path, "/");
 


### PR DESCRIPTION
## This PR …

### Fixes

- Headers with null as value are no longer added to API requests. For some weird reason, JS will turn them into 'NULL' strings which is pretty annoying to work with in the backend. 

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

This is another prep PR for changes. I'm trying to extract all the no-brainers that we can already add to v4

- [ ] Add changes & docs to release notes draft in Notion
