### PR TITLE
Changes 1: Refactor content storage to use new VersionId class

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -426,7 +426,7 @@ class File extends ModelWithContent
 	 */
 	protected function modifiedContent(string|null $languageCode = null): int
 	{
-		return $this->storage()->modified(VersionId::PUBLISHED, $languageCode) ?? 0;
+		return $this->storage()->modified(VersionId::published(), $languageCode) ?? 0;
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Exception;
 use IntlDateFormatter;
+use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\IsFile;
@@ -425,7 +426,7 @@ class File extends ModelWithContent
 	 */
 	protected function modifiedContent(string|null $languageCode = null): int
 	{
-		return $this->storage()->modified('published', $languageCode) ?? 0;
+		return $this->storage()->modified(VersionId::PUBLISHED, $languageCode) ?? 0;
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -7,6 +7,7 @@ use Kirby\Content\Content;
 use Kirby\Content\ContentStorage;
 use Kirby\Content\ContentTranslation;
 use Kirby\Content\PlainTextContentStorageHandler;
+use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Form\Form;
@@ -187,7 +188,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$new = $this->clone(['template' => $blueprint]);
 
 		// temporary compatibility change (TODO: also convert changes)
-		$identifier = $this->storage()->defaultVersion();
+		$identifier = VersionId::default($this);
 
 		// for multilang, we go through all translations and
 		// covnert the content for each of them, remove the content file
@@ -418,7 +419,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	{
 		try {
 			return $this->storage()->read(
-				$this->storage()->defaultVersion(),
+				VersionId::default($this),
 				$languageCode
 			);
 		} catch (NotFoundException) {
@@ -737,7 +738,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
 		$data = $this->contentFileData($data, $languageCode);
-		$id   = $this->storage()->defaultVersion();
+		$id   = VersionId::default($this);
 
 		try {
 			// we can only update if the version already exists

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -827,7 +827,7 @@ class Page extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false|null {
-		$identifier = $this->isDraft() === true ? VersionId::CHANGES : VersionId::PUBLISHED;
+		$identifier = $this->isDraft() === true ? VersionId::changes() : VersionId::published();
 
 		$modified = $this->storage()->modified(
 			$identifier,

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -827,10 +827,8 @@ class Page extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false|null {
-		$identifier = $this->isDraft() === true ? VersionId::changes() : VersionId::published();
-
 		$modified = $this->storage()->modified(
-			$identifier,
+			VersionId::default($this),
 			$languageCode
 		);
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Content\Field;
+use Kirby\Content\VersionId;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
@@ -826,7 +827,7 @@ class Page extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false|null {
-		$identifier = $this->isDraft() === true ? 'changes' : 'published';
+		$identifier = $this->isDraft() === true ? VersionId::CHANGES : VersionId::PUBLISHED;
 
 		$modified = $this->storage()->modified(
 			$identifier,

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Content\VersionId;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
@@ -471,8 +472,8 @@ trait PageActions
 				$ignore[] = $file->root();
 
 				// append all content files
-				array_push($ignore, ...$file->storage()->contentFiles('published'));
-				array_push($ignore, ...$file->storage()->contentFiles('changes'));
+				array_push($ignore, ...$file->storage()->contentFiles(VersionId::published()));
+				array_push($ignore, ...$file->storage()->contentFiles(VersionId::changes()));
 			}
 		}
 

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Cms\System\UpdateStatus;
+use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
@@ -76,7 +77,7 @@ class System
 		switch ($folder) {
 			case 'content':
 				return $url . '/' . basename($this->app->site()->storage()->contentFile(
-					'published',
+					VersionId::PUBLISHED,
 					'default'
 				));
 			case 'git':

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -77,7 +77,7 @@ class System
 		switch ($folder) {
 			case 'content':
 				return $url . '/' . basename($this->app->site()->storage()->contentFile(
-					VersionId::PUBLISHED,
+					VersionId::published(),
 					'default'
 				));
 			case 'git':

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -205,7 +205,7 @@ class User extends ModelWithContent
 	public function exists(): bool
 	{
 		return $this->storage()->exists(
-			VersionId::PUBLISHED,
+			VersionId::published(),
 			'default'
 		);
 	}
@@ -469,7 +469,7 @@ class User extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false {
-		$modifiedContent = $this->storage()->modified(VersionId::PUBLISHED, $languageCode);
+		$modifiedContent = $this->storage()->modified(VersionId::published(), $languageCode);
 		$modifiedIndex   = F::modified($this->root() . '/index.php');
 		$modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Exception;
 use Kirby\Content\Field;
+use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
@@ -204,7 +205,7 @@ class User extends ModelWithContent
 	public function exists(): bool
 	{
 		return $this->storage()->exists(
-			'published',
+			VersionId::PUBLISHED,
 			'default'
 		);
 	}
@@ -468,7 +469,7 @@ class User extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false {
-		$modifiedContent = $this->storage()->modified('published', $languageCode);
+		$modifiedContent = $this->storage()->modified(VersionId::PUBLISHED, $languageCode);
 		$modifiedIndex   = F::modified($this->root() . '/index.php');
 		$modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
 

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -258,7 +258,7 @@ class ContentStorage
 		string $lang
 	): void {
 		if ($this->exists($versionId, $lang) !== true) {
-			throw new NotFoundException('Version "' . $versionId->value . ' (' . $lang . ')" does not already exist');
+			throw new NotFoundException('Version "' . $versionId . ' (' . $lang . ')" does not already exist');
 		}
 	}
 

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -109,22 +109,6 @@ class ContentStorage
 	}
 
 	/**
-	 * Returns the default version identifier for the model
-	 * @internal
-	 */
-	public function defaultVersion(): VersionId
-	{
-		if (
-			$this->model instanceof Page === true &&
-			$this->model->isDraft() === true
-		) {
-			return VersionId::changes();
-		}
-
-		return VersionId::published();
-	}
-
-	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -53,9 +53,9 @@ class ContentStorage
 	public function all(): Generator
 	{
 		foreach ($this->model->kirby()->languages()->codes() as $lang) {
-			foreach ($this->dynamicVersions() as $version) {
-				if ($this->exists($version, $lang) === true) {
-					yield $version => $lang;
+			foreach ($this->dynamicVersions() as $versionId) {
+				if ($this->exists($versionId, $lang) === true) {
+					yield $versionId => $lang;
 				}
 			}
 		}
@@ -71,12 +71,12 @@ class ContentStorage
 	 * @throws \Kirby\Exception\LogicException If the model type doesn't have a known content filename
 	 */
 	public function contentFile(
-		string $version,
+		VersionId $versionId,
 		string $lang,
 		bool $force = false
 	): string {
 		$lang = $this->language($lang, $force);
-		return $this->handler->contentFile($version, $lang);
+		return $this->handler->contentFile($versionId, $lang);
 	}
 
 	/**
@@ -88,8 +88,8 @@ class ContentStorage
 		$from = $this->language($from, true);
 		$to   = $this->language($to, true);
 
-		foreach ($this->dynamicVersions() as $version) {
-			$this->handler->move($version, $from, $version, $to);
+		foreach ($this->dynamicVersions() as $versionId) {
+			$this->handler->move($versionId, $from, $versionId, $to);
 		}
 	}
 
@@ -100,28 +100,28 @@ class ContentStorage
 	 * @param array<string, string> $fields Content fields
 	 */
 	public function create(
-		string $versionType,
+		VersionId $versionId,
 		string|null $lang,
 		array $fields
 	): void {
 		$lang = $this->language($lang);
-		$this->handler->create($versionType, $lang, $fields);
+		$this->handler->create($versionId, $lang, $fields);
 	}
 
 	/**
 	 * Returns the default version identifier for the model
 	 * @internal
 	 */
-	public function defaultVersion(): string
+	public function defaultVersion(): VersionId
 	{
 		if (
 			$this->model instanceof Page === true &&
 			$this->model->isDraft() === true
 		) {
-			return 'changes';
+			return VersionId::CHANGES;
 		}
 
-		return 'published';
+		return VersionId::PUBLISHED;
 	}
 
 	/**
@@ -130,12 +130,12 @@ class ContentStorage
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
 	public function delete(
-		string $version,
+		VersionId $versionId,
 		string|null $lang = null,
 		bool $force = false
 	): void {
 		$lang = $this->language($lang, $force);
-		$this->handler->delete($version, $lang);
+		$this->handler->delete($versionId, $lang);
 	}
 
 	/**
@@ -157,13 +157,13 @@ class ContentStorage
 	 */
 	public function dynamicVersions(): array
 	{
-		$versions = ['changes'];
+		$versions = [VersionId::CHANGES];
 
 		if (
 			$this->model instanceof Page === false ||
 			$this->model->isDraft() === false
 		) {
-			$versions[] = 'published';
+			$versions[] = VersionId::PUBLISHED;
 		}
 
 		return $versions;
@@ -176,14 +176,14 @@ class ContentStorage
 	 *                          checks for "any language" if not provided
 	 */
 	public function exists(
-		string $version,
+		VersionId $versionId,
 		string|null $lang
 	): bool {
 		if ($lang !== null) {
 			$lang = $this->language($lang);
 		}
 
-		return $this->handler->exists($version, $lang);
+		return $this->handler->exists($versionId, $lang);
 	}
 
 	/**
@@ -193,11 +193,11 @@ class ContentStorage
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
 	public function modified(
-		string $version,
+		VersionId $versionId,
 		string|null $lang = null
 	): int|null {
 		$lang = $this->language($lang);
-		return $this->handler->modified($version, $lang);
+		return $this->handler->modified($versionId, $lang);
 	}
 
 	/**
@@ -209,12 +209,12 @@ class ContentStorage
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function read(
-		string $version,
+		VersionId $versionId,
 		string|null $lang = null
 	): array {
 		$lang = $this->language($lang);
-		$this->ensureExistingVersion($version, $lang);
-		return $this->handler->read($version, $lang);
+		$this->ensureExistingVersion($versionId, $lang);
+		return $this->handler->read($versionId, $lang);
 	}
 
 	/**
@@ -225,12 +225,12 @@ class ContentStorage
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function touch(
-		string $version,
+		VersionId $versionId,
 		string|null $lang = null
 	): void {
 		$lang = $this->language($lang);
-		$this->ensureExistingVersion($version, $lang);
-		$this->handler->touch($version, $lang);
+		$this->ensureExistingVersion($versionId, $lang);
+		$this->handler->touch($versionId, $lang);
 	}
 
 	/**
@@ -257,24 +257,24 @@ class ContentStorage
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function update(
-		string $version,
+		VersionId $versionId,
 		string|null $lang = null,
 		array $fields = []
 	): void {
 		$lang = $this->language($lang);
-		$this->ensureExistingVersion($version, $lang);
-		$this->handler->update($version, $lang, $fields);
+		$this->ensureExistingVersion($versionId, $lang);
+		$this->handler->update($versionId, $lang, $fields);
 	}
 
 	/**
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	protected function ensureExistingVersion(
-		string $version,
+		VersionId $versionId,
 		string $lang
 	): void {
-		if ($this->exists($version, $lang) !== true) {
-			throw new NotFoundException('Version "' . $version . ' (' . $lang . ')" does not already exist');
+		if ($this->exists($versionId, $lang) !== true) {
+			throw new NotFoundException('Version "' . $versionId->value . ' (' . $lang . ')" does not already exist');
 		}
 	}
 

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -118,10 +118,10 @@ class ContentStorage
 			$this->model instanceof Page === true &&
 			$this->model->isDraft() === true
 		) {
-			return VersionId::CHANGES;
+			return VersionId::changes();
 		}
 
-		return VersionId::PUBLISHED;
+		return VersionId::published();
 	}
 
 	/**
@@ -157,13 +157,13 @@ class ContentStorage
 	 */
 	public function dynamicVersions(): array
 	{
-		$versions = [VersionId::CHANGES];
+		$versions = [VersionId::changes()];
 
 		if (
 			$this->model instanceof Page === false ||
 			$this->model->isDraft() === false
 		) {
-			$versions[] = VersionId::PUBLISHED;
+			$versions[] = VersionId::published();
 		}
 
 		return $versions;

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -28,14 +28,14 @@ interface ContentStorageHandler
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 */
-	public function create(string $versionType, string $lang, array $fields): void;
+	public function create(VersionId $versionId, string $lang, array $fields): void;
 
 	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function delete(string $version, string $lang): void;
+	public function delete(VersionId $versionId, string $lang): void;
 
 	/**
 	 * Checks if a version exists
@@ -43,14 +43,14 @@ interface ContentStorageHandler
 	 * @param string|null $lang Code `'default'` in a single-lang installation;
 	 *                          checks for "any language" if not provided
 	 */
-	public function exists(string $version, string|null $lang): bool;
+	public function exists(VersionId $versionId, string|null $lang): bool;
 
 	/**
 	 * Returns the modification timestamp of a version if it exists
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function modified(string $version, string $lang): int|null;
+	public function modified(VersionId $versionId, string $lang): int|null;
 
 	/**
 	 * Moves content from one version-language combination to another
@@ -59,9 +59,9 @@ interface ContentStorageHandler
 	 * @param string $toLang Code `'default'` in a single-lang installation
 	 */
 	public function move(
-		string $fromVersion,
+		VersionId $fromVersionId,
 		string $fromLang,
-		string $toVersion,
+		VersionId $toVersionId,
 		string $toLang
 	): void;
 
@@ -73,7 +73,7 @@ interface ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function read(string $version, string $lang): array;
+	public function read(VersionId $versionId, string $lang): array;
 
 	/**
 	 * Updates the modification timestamp of an existing version
@@ -82,7 +82,7 @@ interface ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(string $version, string $lang): void;
+	public function touch(VersionId $versionId, string $lang): void;
 
 	/**
 	 * Updates the content fields of an existing version
@@ -92,5 +92,5 @@ interface ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function update(string $version, string $lang, array $fields): void;
+	public function update(VersionId $versionId, string $lang, array $fields): void;
 }

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -85,13 +85,8 @@ class ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		// temporary compatibility change (TODO: take this from the parent `ModelVersion` object)
-		$versionId = $this->parent::CLASS_ALIAS === 'page' && $this->parent->isDraft() === true ?
-			VersionId::changes() :
-			VersionId::published();
-
 		return $this->contentFile = $this->parent->storage()->contentFile(
-			$versionId,
+			VersionId::default($this->parent),
 			$this->code,
 			true
 		);

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -87,8 +87,8 @@ class ContentTranslation
 	{
 		// temporary compatibility change (TODO: take this from the parent `ModelVersion` object)
 		$versionId = $this->parent::CLASS_ALIAS === 'page' && $this->parent->isDraft() === true ?
-			VersionId::CHANGES :
-			VersionId::PUBLISHED;
+			VersionId::changes() :
+			VersionId::published();
 
 		return $this->contentFile = $this->parent->storage()->contentFile(
 			$versionId,

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -86,12 +86,12 @@ class ContentTranslation
 	public function contentFile(): string
 	{
 		// temporary compatibility change (TODO: take this from the parent `ModelVersion` object)
-		$identifier = $this->parent::CLASS_ALIAS === 'page' && $this->parent->isDraft() === true ?
-			'changes' :
-			'published';
+		$versionId = $this->parent::CLASS_ALIAS === 'page' && $this->parent->isDraft() === true ?
+			VersionId::CHANGES :
+			VersionId::PUBLISHED;
 
 		return $this->contentFile = $this->parent->storage()->contentFile(
-			$identifier,
+			$versionId,
 			$this->code,
 			true
 		);

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -32,6 +32,8 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
+     *
+	 * @throws \Kirby\Exception\Exception If the file cannot be written
 	 */
 	public function create(VersionId $versionId, string $lang, array $fields): void
 	{
@@ -146,6 +148,8 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
+	 *
+	 * @throws \Kirby\Exception\Exception If the file cannot be written
 	 */
 	public function update(VersionId $versionId, string $lang, array $fields): void
 	{

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -32,7 +32,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
-     *
+	 *
 	 * @throws \Kirby\Exception\Exception If the file cannot be written
 	 */
 	public function create(VersionId $versionId, string $lang, array $fields): void

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -131,6 +131,8 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * Updates the modification timestamp of an existing version
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
+	 *
+	 * @throws \Kirby\Exception\Exception If the file cannot be touched
 	 */
 	public function touch(VersionId $versionId, string $lang): void
 	{

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -190,10 +190,10 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 			// changes versions don't need anything extra
 			// (drafts already have the `_drafts` prefix in their root),
 			// but a published version is not possible
-			if ($versionId === VersionId::PUBLISHED) {
+			if ($versionId->is(VersionId::PUBLISHED)) {
 				throw new LogicException('Drafts cannot have a published content file');
 			}
-		} elseif ($versionId === VersionId::CHANGES) {
+		} elseif ($versionId->is(VersionId::CHANGES)) {
 			// other model type or published page that has a changes subfolder
 			$directory .= '/_changes';
 		}

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -5,7 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;
 use Kirby\Exception\Exception;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -34,9 +34,9 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 */
-	public function create(string $versionType, string $lang, array $fields): void
+	public function create(VersionId $versionId, string $lang, array $fields): void
 	{
-		$success = Data::write($this->contentFile($versionType, $lang), $fields);
+		$success = Data::write($this->contentFile($versionId, $lang), $fields);
 
 		// @codeCoverageIgnoreStart
 		if ($success !== true) {
@@ -50,9 +50,9 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function delete(string $version, string $lang): void
+	public function delete(VersionId $versionId, string $lang): void
 	{
-		$contentFile = $this->contentFile($version, $lang);
+		$contentFile = $this->contentFile($versionId, $lang);
 		$success = F::unlink($contentFile);
 
 		// @codeCoverageIgnoreStart
@@ -83,10 +83,10 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * @param string|null $lang Code `'default'` in a single-lang installation;
 	 *                          checks for "any language" if not provided
 	 */
-	public function exists(string $version, string|null $lang): bool
+	public function exists(VersionId $versionId, string|null $lang): bool
 	{
 		if ($lang === null) {
-			foreach ($this->contentFiles($version) as $file) {
+			foreach ($this->contentFiles($versionId) as $file) {
 				if (is_file($file) === true) {
 					return true;
 				}
@@ -95,7 +95,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 			return false;
 		}
 
-		return is_file($this->contentFile($version, $lang)) === true;
+		return is_file($this->contentFile($versionId, $lang)) === true;
 	}
 
 	/**
@@ -104,9 +104,9 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function modified(string $version, string $lang): int|null
+	public function modified(VersionId $versionId, string $lang): int|null
 	{
-		$modified = F::modified($this->contentFile($version, $lang));
+		$modified = F::modified($this->contentFile($versionId, $lang));
 
 		if (is_int($modified) === true) {
 			return $modified;
@@ -120,24 +120,20 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @return array<string, string>
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function read(string $version, string $lang): array
+	public function read(VersionId $versionId, string $lang): array
 	{
-		return Data::read($this->contentFile($version, $lang));
+		return Data::read($this->contentFile($versionId, $lang));
 	}
 
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(string $version, string $lang): void
+	public function touch(VersionId $versionId, string $lang): void
 	{
-		$success = touch($this->contentFile($version, $lang));
+		$success = touch($this->contentFile($versionId, $lang));
 
 		// @codeCoverageIgnoreStart
 		if ($success !== true) {
@@ -151,12 +147,10 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function update(string $version, string $lang, array $fields): void
+	public function update(VersionId $versionId, string $lang, array $fields): void
 	{
-		$success = Data::write($this->contentFile($version, $lang), $fields);
+		$success = Data::write($this->contentFile($versionId, $lang), $fields);
 
 		// @codeCoverageIgnoreStart
 		if ($success !== true) {
@@ -173,12 +167,8 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\LogicException If the model type doesn't have a known content filename
 	 */
-	public function contentFile(string $version, string $lang): string
+	public function contentFile(VersionId $versionId, string $lang): string
 	{
-		if (in_array($version, ['published', 'changes']) !== true) {
-			throw new InvalidArgumentException('Invalid version identifier "' . $version . '"');
-		}
-
 		$extension = $this->model->kirby()->contentExtension();
 		$directory = $this->model->root();
 
@@ -201,10 +191,10 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 			// changes versions don't need anything extra
 			// (drafts already have the `_drafts` prefix in their root),
 			// but a published version is not possible
-			if ($version === 'published') {
+			if ($versionId === VersionId::PUBLISHED) {
 				throw new LogicException('Drafts cannot have a published content file');
 			}
-		} elseif ($version === 'changes') {
+		} elseif ($versionId === VersionId::CHANGES) {
 			// other model type or published page that has a changes subfolder
 			$directory .= '/_changes';
 		}
@@ -220,16 +210,16 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * Returns an array with content files of all languages
 	 * @internal To be made `protected` when the CMS core no longer relies on it
 	 */
-	public function contentFiles(string $version): array
+	public function contentFiles(VersionId $versionId): array
 	{
 		if ($this->model->kirby()->multilang() === true) {
 			return $this->model->kirby()->languages()->values(
-				fn ($lang) => $this->contentFile($version, $lang)
+				fn ($lang) => $this->contentFile($versionId, $lang)
 			);
 		}
 
 		return [
-			$this->contentFile($version, 'default')
+			$this->contentFile($versionId, 'default')
 		];
 	}
 
@@ -240,14 +230,14 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * @param string $toLang Code `'default'` in a single-lang installation
 	 */
 	public function move(
-		string $fromVersion,
+		VersionId $fromVersionId,
 		string $fromLang,
-		string $toVersion,
+		VersionId $toVersionId,
 		string $toLang
 	): void {
 		F::move(
-			$this->contentFile($fromVersion, $fromLang),
-			$this->contentFile($toVersion, $toLang)
+			$this->contentFile($fromVersionId, $fromLang),
+			$this->contentFile($toVersionId, $toLang)
 		);
 	}
 }

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -25,12 +25,12 @@ class VersionId implements Stringable
 	/**
 	 * Latest stable version of the content
 	 */
-	const PUBLISHED = 'published';
+	public const PUBLISHED = 'published';
 
 	/**
 	 * Latest changes to the content (optional)
 	 */
-	const CHANGES   = 'changes';
+	public const CHANGES   = 'changes';
 
 	/**
 	 * @throws \Kirby\Exception\InvalidArgumentException If the version ID is not valid
@@ -41,6 +41,14 @@ class VersionId implements Stringable
 		if (in_array($value, [static::CHANGES, static::PUBLISHED]) === false) {
 			throw new InvalidArgumentException('Invalid Version ID');
 		}
+	}
+
+	/**
+	 * Converts the VersionId instance to a simple string value
+	 */
+	public function __toString(): string
+	{
+		return $this->value;
 	}
 
 	/**
@@ -76,9 +84,9 @@ class VersionId implements Stringable
 	}
 
 	/**
-	 * Converts the VersionId instance to a simple string value
+	 * Returns the ID value
 	 */
-	public function __toString(): string
+	public function value(): string
 	{
 		return $this->value;
 	}

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kirby\Content;
+
+enum VersionId: string
+{
+	case PUBLISHED = 'published';
+	case CHANGES   = 'changes';
+}

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -2,8 +2,84 @@
 
 namespace Kirby\Content;
 
-enum VersionId: string
+use Kirby\Exception\InvalidArgumentException;
+use Stringable;
+
+/**
+ * The Version ID identifies a version of content.
+ * This can be the currently published version or changes
+ * to the content. In the future, we also plan to use this
+ * for older revisions of the content.
+ *
+ * @internal
+ * @since 5.0.0
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class VersionId implements Stringable
 {
-	case PUBLISHED = 'published';
-	case CHANGES   = 'changes';
+	/**
+	 * Latest stable version of the content
+	 */
+	const PUBLISHED = 'published';
+
+	/**
+	 * Latest changes to the content (optional)
+	 */
+	const CHANGES   = 'changes';
+
+	/**
+	 * @throws \Kirby\Exception\InvalidArgumentException If the version ID is not valid
+	 */
+	public function __construct(
+		public string $value
+	) {
+		if (in_array($value, [static::CHANGES, static::PUBLISHED]) === false) {
+			throw new InvalidArgumentException('Invalid Version ID');
+		}
+	}
+
+	/**
+	 * Creates a VersionId instance for the latest content changes
+	 */
+	public static function changes(): static
+	{
+		return new static(static::CHANGES);
+	}
+
+	/**
+	 * Creates a VersionId instance from a simple string value
+	 */
+	public static function from(string $value): static
+	{
+		return new static($value);
+	}
+
+	/**
+	 * Compares a string value with the id value
+	 */
+	public function is(string $value): bool
+	{
+		return $value === $this->value;
+	}
+
+	/**
+	 * Creates a VersionId instance for the latest stable version of the content
+	 */
+	public static function published(): static
+	{
+		return new static(static::PUBLISHED);
+	}
+
+	/**
+	 * Converts the VersionId instance to a simple string value
+	 */
+	public function __toString(): string
+	{
+		return $this->value;
+	}
 }

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Stringable;
 
@@ -57,6 +59,21 @@ class VersionId implements Stringable
 	public static function changes(): static
 	{
 		return new static(static::CHANGES);
+	}
+
+	/**
+	 * Returns the default version id for the model
+	 */
+	public static function default(ModelWithContent $model): static
+	{
+		if (
+			$model instanceof Page === true &&
+			$model->isDraft() === true
+		) {
+			return VersionId::changes();
+		}
+
+		return VersionId::published();
 	}
 
 	/**

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Content\VersionId;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -105,19 +106,19 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile('published', 'default'), '');
+		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile('published', 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotSame($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile('published', 'default'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile('published', 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 	}
 
 	public static function fileProviderMultiLang(): array
@@ -141,20 +142,20 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and empty content files for it
-		F::write($file->storage()->contentFile('published', 'en'), '');
-		F::write($file->storage()->contentFile('published', 'de'), '');
+		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'en'), '');
+		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'de'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile('published', 'en'));
-		$this->assertFileExists($file->storage()->contentFile('published', 'de'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'en'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'de'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotEquals($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile('published', 'en'));
-		$this->assertFileExists($result->storage()->contentFile('published', 'de'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'en'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'de'));
 	}
 
 	public function testChangeTemplate()
@@ -376,9 +377,9 @@ class FileActionsTest extends TestCase
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Das ist der Text', $modified->text()->value());
 
-		$this->assertFileExists($modified->storage()->contentFile('published', 'en'));
-		$this->assertFileExists($modified->storage()->contentFile('published', 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile('published', 'fr'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'en'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'de'));
+		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::PUBLISHED, 'fr'));
 	}
 
 	public function testChangeTemplateDefault()
@@ -754,17 +755,17 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile('published', 'default'), '');
+		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile('published', 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 
 		$result = $file->delete();
 
 		$this->assertTrue($result);
 
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile('published', 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 	}
 
 	/**
@@ -874,11 +875,11 @@ class FileActionsTest extends TestCase
 		F::write($file->root(), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile('published', 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 
 		$file = $file->clone(['content' => ['caption' => 'save']])->save();
 
-		$this->assertFileExists($file->storage()->contentFile('published', 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
 	}
 
 	/**

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -106,19 +106,19 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'default'), '');
+		F::write($file->storage()->contentFile(VersionId::published(), 'default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotSame($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'default'));
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
 	}
 
 	public static function fileProviderMultiLang(): array
@@ -142,20 +142,20 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and empty content files for it
-		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'en'), '');
-		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'de'), '');
+		F::write($file->storage()->contentFile(VersionId::published(), 'en'), '');
+		F::write($file->storage()->contentFile(VersionId::published(), 'de'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'en'));
-		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'de'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'en'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'de'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotEquals($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'en'));
-		$this->assertFileExists($result->storage()->contentFile(VersionId::PUBLISHED, 'de'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'en'));
+		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'de'));
 	}
 
 	public function testChangeTemplate()
@@ -377,9 +377,9 @@ class FileActionsTest extends TestCase
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Das ist der Text', $modified->text()->value());
 
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'en'));
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::PUBLISHED, 'fr'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'en'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'de'));
+		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::published(), 'fr'));
 	}
 
 	public function testChangeTemplateDefault()
@@ -755,17 +755,17 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile(VersionId::PUBLISHED, 'default'), '');
+		F::write($file->storage()->contentFile(VersionId::published(), 'default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
 
 		$result = $file->delete();
 
 		$this->assertTrue($result);
 
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
 	}
 
 	/**
@@ -875,11 +875,11 @@ class FileActionsTest extends TestCase
 		F::write($file->root(), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
 
 		$file = $file->clone(['content' => ['caption' => 'save']])->save();
 
-		$this->assertFileExists($file->storage()->contentFile(VersionId::PUBLISHED, 'default'));
+		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
 	}
 
 	/**

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Content\ContentTranslation;
+use Kirby\Content\VersionId;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
@@ -423,9 +424,9 @@ class PageActionsTest extends TestCase
 		$this->assertSame('article', $modified->intendedTemplate()->name());
 		$this->assertSame(2, $calls);
 
-		$this->assertFileExists($modified->storage()->contentFile('published', 'en'));
-		$this->assertFileExists($modified->storage()->contentFile('published', 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile('published', 'fr'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'en'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'de'));
+		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::PUBLISHED, 'fr'));
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Text', $modified->text()->value());
 		$this->assertNull($modified->content('de')->get('caption')->value());
@@ -890,15 +891,15 @@ class PageActionsTest extends TestCase
 			'parent' => $page,
 			'code'   => 'en',
 		]);
-		$this->assertFileExists($page->storage()->contentFile('changes', 'en'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'en'));
 
 		$drafts = $app->site()->drafts();
 		$childrenAndDrafts = $app->site()->childrenAndDrafts();
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileExists($copy->storage()->contentFile('changes', 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile('changes', 'de'));
+		$this->assertFileExists($copy->storage()->contentFile(VersionId::CHANGES, 'en'));
+		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::CHANGES, 'de'));
 
 		$this->assertIsPage($page, $drafts->find('test'));
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
@@ -930,8 +931,8 @@ class PageActionsTest extends TestCase
 			'slug'  => 'test-de'
 		], 'de');
 
-		$this->assertFileExists($page->storage()->contentFile('changes', 'en'));
-		$this->assertFileExists($page->storage()->contentFile('changes', 'de'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'en'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'de'));
 		$this->assertSame('test', $page->slug());
 		$this->assertSame('test-de', $page->slug('de'));
 
@@ -1045,8 +1046,8 @@ class PageActionsTest extends TestCase
 
 		$copy = $page->duplicate('test-copy', ['children' => true]);
 
-		$this->assertFileExists($copy->storage()->contentFile('changes', 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile('changes', 'de'));
+		$this->assertFileExists($copy->storage()->contentFile(VersionId::CHANGES, 'en'));
+		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::CHANGES, 'de'));
 
 
 		$this->assertNotSame($page->uuid()->id(), $copy->uuid()->id());

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -424,9 +424,9 @@ class PageActionsTest extends TestCase
 		$this->assertSame('article', $modified->intendedTemplate()->name());
 		$this->assertSame(2, $calls);
 
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'en'));
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::PUBLISHED, 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::PUBLISHED, 'fr'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'en'));
+		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'de'));
+		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::published(), 'fr'));
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Text', $modified->text()->value());
 		$this->assertNull($modified->content('de')->get('caption')->value());
@@ -891,15 +891,15 @@ class PageActionsTest extends TestCase
 			'parent' => $page,
 			'code'   => 'en',
 		]);
-		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'en'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'en'));
 
 		$drafts = $app->site()->drafts();
 		$childrenAndDrafts = $app->site()->childrenAndDrafts();
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileExists($copy->storage()->contentFile(VersionId::CHANGES, 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::CHANGES, 'de'));
+		$this->assertFileExists($copy->storage()->contentFile(VersionId::changes(), 'en'));
+		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::changes(), 'de'));
 
 		$this->assertIsPage($page, $drafts->find('test'));
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
@@ -931,8 +931,8 @@ class PageActionsTest extends TestCase
 			'slug'  => 'test-de'
 		], 'de');
 
-		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'en'));
-		$this->assertFileExists($page->storage()->contentFile(VersionId::CHANGES, 'de'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'en'));
+		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'de'));
 		$this->assertSame('test', $page->slug());
 		$this->assertSame('test-de', $page->slug('de'));
 
@@ -1046,8 +1046,8 @@ class PageActionsTest extends TestCase
 
 		$copy = $page->duplicate('test-copy', ['children' => true]);
 
-		$this->assertFileExists($copy->storage()->contentFile(VersionId::CHANGES, 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::CHANGES, 'de'));
+		$this->assertFileExists($copy->storage()->contentFile(VersionId::changes(), 'en'));
+		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::changes(), 'de'));
 
 
 		$this->assertNotSame($page->uuid()->id(), $copy->uuid()->id());

--- a/tests/Content/ContentStorageTest.php
+++ b/tests/Content/ContentStorageTest.php
@@ -50,9 +50,9 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->assertFalse($this->storage->exists('changes', 'en'));
-		$this->storage->create('changes', 'en', $fields);
-		$this->assertTrue($this->storage->exists('changes', 'en'));
+		$this->assertFalse($this->storage->exists(VersionId::CHANGES, 'en'));
+		$this->storage->create(VersionId::CHANGES, 'en', $fields);
+		$this->assertTrue($this->storage->exists(VersionId::CHANGES, 'en'));
 	}
 
 	/**
@@ -65,9 +65,9 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->assertFalse($this->storage->exists('changes', 'default'));
-		$this->storage->create('changes', 'default', $fields);
-		$this->assertTrue($this->storage->exists('changes', 'default'));
+		$this->assertFalse($this->storage->exists(VersionId::CHANGES, 'default'));
+		$this->storage->create(VersionId::CHANGES, 'default', $fields);
+		$this->assertTrue($this->storage->exists(VersionId::CHANGES, 'default'));
 	}
 
 	/**
@@ -79,7 +79,7 @@ class ContentStorageTest extends TestCase
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Version "published (default)" does not already exist');
 
-		$this->storage->read('published', 'default');
+		$this->storage->read(VersionId::PUBLISHED, 'default');
 	}
 
 	/**
@@ -91,7 +91,7 @@ class ContentStorageTest extends TestCase
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Version "published (default)" does not already exist');
 
-		$this->storage->touch('published', 'default');
+		$this->storage->touch(VersionId::PUBLISHED, 'default');
 	}
 
 	/**
@@ -108,7 +108,7 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->update('published', 'default', $fields);
+		$this->storage->update(VersionId::PUBLISHED, 'default', $fields);
 	}
 
 	/**

--- a/tests/Content/ContentStorageTest.php
+++ b/tests/Content/ContentStorageTest.php
@@ -50,9 +50,9 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->assertFalse($this->storage->exists(VersionId::CHANGES, 'en'));
-		$this->storage->create(VersionId::CHANGES, 'en', $fields);
-		$this->assertTrue($this->storage->exists(VersionId::CHANGES, 'en'));
+		$this->assertFalse($this->storage->exists(VersionId::changes(), 'en'));
+		$this->storage->create(VersionId::changes(), 'en', $fields);
+		$this->assertTrue($this->storage->exists(VersionId::changes(), 'en'));
 	}
 
 	/**
@@ -65,9 +65,9 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->assertFalse($this->storage->exists(VersionId::CHANGES, 'default'));
-		$this->storage->create(VersionId::CHANGES, 'default', $fields);
-		$this->assertTrue($this->storage->exists(VersionId::CHANGES, 'default'));
+		$this->assertFalse($this->storage->exists(VersionId::changes(), 'default'));
+		$this->storage->create(VersionId::changes(), 'default', $fields);
+		$this->assertTrue($this->storage->exists(VersionId::changes(), 'default'));
 	}
 
 	/**
@@ -79,7 +79,7 @@ class ContentStorageTest extends TestCase
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Version "published (default)" does not already exist');
 
-		$this->storage->read(VersionId::PUBLISHED, 'default');
+		$this->storage->read(VersionId::published(), 'default');
 	}
 
 	/**
@@ -91,7 +91,7 @@ class ContentStorageTest extends TestCase
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Version "published (default)" does not already exist');
 
-		$this->storage->touch(VersionId::PUBLISHED, 'default');
+		$this->storage->touch(VersionId::published(), 'default');
 	}
 
 	/**
@@ -108,7 +108,7 @@ class ContentStorageTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->update(VersionId::PUBLISHED, 'default', $fields);
+		$this->storage->update(VersionId::published(), 'default', $fields);
 	}
 
 	/**

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -7,7 +7,6 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -52,7 +52,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create(VersionId::CHANGES, 'en', $fields);
+		$this->storage->create(VersionId::changes(), 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
@@ -66,7 +66,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create(VersionId::CHANGES, 'default', $fields);
+		$this->storage->create(VersionId::changes(), 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
@@ -80,7 +80,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create(VersionId::PUBLISHED, 'en', $fields);
+		$this->storage->create(VersionId::published(), 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
@@ -94,7 +94,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create(VersionId::PUBLISHED, 'default', $fields);
+		$this->storage->create(VersionId::published(), 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
 	}
 
@@ -104,7 +104,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public function testDeleteNonExisting()
 	{
 		// test idempotency
-		$this->storage->delete(VersionId::PUBLISHED, 'default');
+		$this->storage->delete(VersionId::published(), 'default');
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
@@ -117,7 +117,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.en.txt');
 		touch(static::TMP . '/_changes/article.en.txt');
 
-		$this->storage->delete(VersionId::CHANGES, 'en');
+		$this->storage->delete(VersionId::changes(), 'en');
 		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.en.txt');
 		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
 		$this->assertDirectoryExists(static::TMP);
@@ -132,7 +132,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.txt');
 		touch(static::TMP . '/_changes/article.txt');
 
-		$this->storage->delete(VersionId::CHANGES, 'default');
+		$this->storage->delete(VersionId::changes(), 'default');
 		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.txt');
 		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
 	}
@@ -146,7 +146,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.en.txt');
 		touch(static::TMP . '/_changes/article.en.txt');
 
-		$this->storage->delete(VersionId::PUBLISHED, 'en');
+		$this->storage->delete(VersionId::published(), 'en');
 		$this->assertFileDoesNotExist(static::TMP . '/article.en.txt');
 		$this->assertDirectoryExists(static::TMP);
 	}
@@ -160,7 +160,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.txt');
 		touch(static::TMP . '/_changes/article.txt');
 
-		$this->storage->delete(VersionId::PUBLISHED, 'default');
+		$this->storage->delete(VersionId::published(), 'default');
 		$this->assertFileDoesNotExist(static::TMP . '/article.txt');
 		$this->assertDirectoryExists(static::TMP);
 	}
@@ -215,12 +215,12 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function existsProvider(): array
 	{
 		return [
-			[VersionId::CHANGES, null, [true, false]],
-			[VersionId::CHANGES, 'default', [false, false]],
-			[VersionId::CHANGES, 'en', [true, true]],
-			[VersionId::PUBLISHED, null, [false, true]],
-			[VersionId::PUBLISHED, 'default', [true, true]],
-			[VersionId::PUBLISHED, 'en', [false, false]]
+			[VersionId::changes(), null, [true, false]],
+			[VersionId::changes(), 'default', [false, false]],
+			[VersionId::changes(), 'en', [true, true]],
+			[VersionId::published(), null, [false, true]],
+			[VersionId::published(), 'default', [true, true]],
+			[VersionId::published(), 'en', [false, false]]
 		];
 	}
 
@@ -249,10 +249,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function modifiedProvider(): array
 	{
 		return [
-			[VersionId::CHANGES, 'default', null],
-			[VersionId::CHANGES, 'en', 1234567890],
-			[VersionId::PUBLISHED, 'default', 1234567890],
-			[VersionId::PUBLISHED, 'en', null]
+			[VersionId::changes(), 'default', null],
+			[VersionId::changes(), 'en', 1234567890],
+			[VersionId::published(), 'default', 1234567890],
+			[VersionId::published(), 'en', null]
 		];
 	}
 
@@ -269,7 +269,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read(VersionId::CHANGES, 'en'));
+		$this->assertSame($fields, $this->storage->read(VersionId::changes(), 'en'));
 	}
 
 	/**
@@ -285,7 +285,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read(VersionId::CHANGES, 'default'));
+		$this->assertSame($fields, $this->storage->read(VersionId::changes(), 'default'));
 	}
 
 	/**
@@ -300,7 +300,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.en.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read(VersionId::PUBLISHED, 'en'));
+		$this->assertSame($fields, $this->storage->read(VersionId::published(), 'en'));
 	}
 
 	/**
@@ -315,7 +315,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read(VersionId::PUBLISHED, 'default'));
+		$this->assertSame($fields, $this->storage->read(VersionId::published(), 'default'));
 	}
 
 	/**
@@ -329,7 +329,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch(VersionId::CHANGES, 'en');
+		$this->storage->touch(VersionId::changes(), 'en');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.en.txt'));
@@ -346,7 +346,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch(VersionId::CHANGES, 'default');
+		$this->storage->touch(VersionId::changes(), 'default');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.txt'));
@@ -362,7 +362,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch(VersionId::PUBLISHED, 'en');
+		$this->storage->touch(VersionId::published(), 'en');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.en.txt'));
@@ -378,7 +378,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch(VersionId::PUBLISHED, 'default');
+		$this->storage->touch(VersionId::published(), 'default');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.txt'));
@@ -397,7 +397,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
-		$this->storage->update(VersionId::CHANGES, 'en', $fields);
+		$this->storage->update(VersionId::changes(), 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
@@ -414,7 +414,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
-		$this->storage->update(VersionId::CHANGES, 'default', $fields);
+		$this->storage->update(VersionId::changes(), 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
@@ -430,7 +430,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.en.txt', $fields);
 
-		$this->storage->update(VersionId::PUBLISHED, 'en', $fields);
+		$this->storage->update(VersionId::published(), 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
@@ -446,7 +446,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.txt', $fields);
 
-		$this->storage->update(VersionId::PUBLISHED, 'default', $fields);
+		$this->storage->update(VersionId::published(), 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
 	}
 
@@ -488,22 +488,22 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function contentFileProvider(): array
 	{
 		return [
-			['file', VersionId::CHANGES, 'default', 'content/_changes/image.jpg.txt'],
-			['file', VersionId::CHANGES, 'en', 'content/_changes/image.jpg.en.txt'],
-			['file', VersionId::PUBLISHED, 'default', 'content/image.jpg.txt'],
-			['file', VersionId::PUBLISHED, 'en', 'content/image.jpg.en.txt'],
-			['page', VersionId::CHANGES, 'default', 'content/a-page/_changes/article.txt'],
-			['page', VersionId::CHANGES, 'en', 'content/a-page/_changes/article.en.txt'],
-			['page', VersionId::PUBLISHED, 'default', 'content/a-page/article.txt'],
-			['page', VersionId::PUBLISHED, 'en', 'content/a-page/article.en.txt'],
-			['site', VersionId::CHANGES, 'default', 'content/_changes/site.txt'],
-			['site', VersionId::CHANGES, 'en', 'content/_changes/site.en.txt'],
-			['site', VersionId::PUBLISHED, 'default', 'content/site.txt'],
-			['site', VersionId::PUBLISHED, 'en', 'content/site.en.txt'],
-			['user', VersionId::CHANGES, 'default', 'site/accounts/abcdefgh/_changes/user.txt'],
-			['user', VersionId::CHANGES, 'en', 'site/accounts/abcdefgh/_changes/user.en.txt'],
-			['user', VersionId::PUBLISHED, 'default', 'site/accounts/abcdefgh/user.txt'],
-			['user', VersionId::PUBLISHED, 'en', 'site/accounts/abcdefgh/user.en.txt'],
+			['file', VersionId::changes(), 'default', 'content/_changes/image.jpg.txt'],
+			['file', VersionId::changes(), 'en', 'content/_changes/image.jpg.en.txt'],
+			['file', VersionId::published(), 'default', 'content/image.jpg.txt'],
+			['file', VersionId::published(), 'en', 'content/image.jpg.en.txt'],
+			['page', VersionId::changes(), 'default', 'content/a-page/_changes/article.txt'],
+			['page', VersionId::changes(), 'en', 'content/a-page/_changes/article.en.txt'],
+			['page', VersionId::published(), 'default', 'content/a-page/article.txt'],
+			['page', VersionId::published(), 'en', 'content/a-page/article.en.txt'],
+			['site', VersionId::changes(), 'default', 'content/_changes/site.txt'],
+			['site', VersionId::changes(), 'en', 'content/_changes/site.en.txt'],
+			['site', VersionId::published(), 'default', 'content/site.txt'],
+			['site', VersionId::published(), 'en', 'content/site.en.txt'],
+			['user', VersionId::changes(), 'default', 'site/accounts/abcdefgh/_changes/user.txt'],
+			['user', VersionId::changes(), 'en', 'site/accounts/abcdefgh/_changes/user.en.txt'],
+			['user', VersionId::published(), 'default', 'site/accounts/abcdefgh/user.txt'],
+			['user', VersionId::published(), 'en', 'site/accounts/abcdefgh/user.en.txt'],
 		];
 	}
 
@@ -527,7 +527,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$storage = new PlainTextContentStorageHandler($model);
-		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile(VersionId::CHANGES, $language));
+		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile(VersionId::changes(), $language));
 	}
 
 	/**
@@ -554,7 +554,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Drafts cannot have a published content file');
-		$storage->contentFile(VersionId::PUBLISHED, $language);
+		$storage->contentFile(VersionId::published(), $language);
 	}
 
 	public static function contentFileDraftProvider(): array
@@ -584,7 +584,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertSame([
 			static::TMP . '/_changes/article.en.txt',
 			static::TMP . '/_changes/article.de.txt'
-		], $this->storage->contentFiles(VersionId::CHANGES));
+		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
 	/**
@@ -594,7 +594,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$this->assertSame([
 			static::TMP . '/_changes/article.txt'
-		], $this->storage->contentFiles(VersionId::CHANGES));
+		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
 	/**
@@ -617,7 +617,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertSame([
 			static::TMP . '/article.en.txt',
 			static::TMP . '/article.de.txt'
-		], $this->storage->contentFiles(VersionId::PUBLISHED));
+		], $this->storage->contentFiles(VersionId::published()));
 	}
 
 	/**
@@ -627,6 +627,6 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$this->assertSame([
 			static::TMP . '/article.txt'
-		], $this->storage->contentFiles(VersionId::PUBLISHED));
+		], $this->storage->contentFiles(VersionId::published()));
 	}
 }

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -53,7 +53,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create('changes', 'en', $fields);
+		$this->storage->create(VersionId::CHANGES, 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
@@ -67,7 +67,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create('changes', 'default', $fields);
+		$this->storage->create(VersionId::CHANGES, 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
@@ -81,7 +81,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create('published', 'en', $fields);
+		$this->storage->create(VersionId::PUBLISHED, 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
@@ -95,19 +95,8 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		$this->storage->create('published', 'default', $fields);
+		$this->storage->create(VersionId::PUBLISHED, 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
-	}
-
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateInvalidType()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->create('invalid', 'default', []);
 	}
 
 	/**
@@ -116,7 +105,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public function testDeleteNonExisting()
 	{
 		// test idempotency
-		$this->storage->delete('published', 'default');
+		$this->storage->delete(VersionId::PUBLISHED, 'default');
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
@@ -129,7 +118,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.en.txt');
 		touch(static::TMP . '/_changes/article.en.txt');
 
-		$this->storage->delete('changes', 'en');
+		$this->storage->delete(VersionId::CHANGES, 'en');
 		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.en.txt');
 		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
 		$this->assertDirectoryExists(static::TMP);
@@ -144,7 +133,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.txt');
 		touch(static::TMP . '/_changes/article.txt');
 
-		$this->storage->delete('changes', 'default');
+		$this->storage->delete(VersionId::CHANGES, 'default');
 		$this->assertFileDoesNotExist(static::TMP . '/_changes/article.txt');
 		$this->assertDirectoryDoesNotExist(static::TMP . '/_changes');
 	}
@@ -158,7 +147,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.en.txt');
 		touch(static::TMP . '/_changes/article.en.txt');
 
-		$this->storage->delete('published', 'en');
+		$this->storage->delete(VersionId::PUBLISHED, 'en');
 		$this->assertFileDoesNotExist(static::TMP . '/article.en.txt');
 		$this->assertDirectoryExists(static::TMP);
 	}
@@ -172,27 +161,16 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		touch(static::TMP . '/article.txt');
 		touch(static::TMP . '/_changes/article.txt');
 
-		$this->storage->delete('published', 'default');
+		$this->storage->delete(VersionId::PUBLISHED, 'default');
 		$this->assertFileDoesNotExist(static::TMP . '/article.txt');
 		$this->assertDirectoryExists(static::TMP);
-	}
-
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->delete('invalid', 'default');
 	}
 
 	/**
 	 * @covers ::exists
 	 * @dataProvider existsProvider
 	 */
-	public function testExistsNoneExisting(string $id, string|null $language)
+	public function testExistsNoneExisting(VersionId $id, string|null $language)
 	{
 		$this->assertFalse($this->storage->exists($id, $language));
 	}
@@ -201,7 +179,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 * @covers ::exists
 	 * @dataProvider existsProvider
 	 */
-	public function testExistsSomeExistingMultiLang(string $id, string|null $language, array $expected)
+	public function testExistsSomeExistingMultiLang(VersionId $id, string|null $language, array $expected)
 	{
 		Dir::make(static::TMP . '/_changes');
 		touch(static::TMP . '/article.txt');
@@ -226,7 +204,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 * @covers ::exists
 	 * @dataProvider existsProvider
 	 */
-	public function testExistsSomeExistingSingleLang(string $id, string|null $language, array $expected)
+	public function testExistsSomeExistingSingleLang(VersionId $id, string|null $language, array $expected)
 	{
 		Dir::make(static::TMP . '/_changes');
 		touch(static::TMP . '/article.txt');
@@ -238,31 +216,20 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function existsProvider(): array
 	{
 		return [
-			['changes', null, [true, false]],
-			['changes', 'default', [false, false]],
-			['changes', 'en', [true, true]],
-			['published', null, [false, true]],
-			['published', 'default', [true, true]],
-			['published', 'en', [false, false]]
+			[VersionId::CHANGES, null, [true, false]],
+			[VersionId::CHANGES, 'default', [false, false]],
+			[VersionId::CHANGES, 'en', [true, true]],
+			[VersionId::PUBLISHED, null, [false, true]],
+			[VersionId::PUBLISHED, 'default', [true, true]],
+			[VersionId::PUBLISHED, 'en', [false, false]]
 		];
-	}
-
-	/**
-	 * @covers ::exists
-	 */
-	public function testExistsInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->exists('invalid', 'default');
 	}
 
 	/**
 	 * @covers ::modified
 	 * @dataProvider modifiedProvider
 	 */
-	public function testModifiedNoneExisting(string $id, string $language)
+	public function testModifiedNoneExisting(VersionId $id, string $language)
 	{
 		$this->assertNull($this->storage->modified($id, $language));
 	}
@@ -271,7 +238,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 * @covers ::modified
 	 * @dataProvider modifiedProvider
 	 */
-	public function testModifiedSomeExisting(string $id, string $language, int|null $expected)
+	public function testModifiedSomeExisting(VersionId $id, string $language, int|null $expected)
 	{
 		Dir::make(static::TMP . '/_changes');
 		touch(static::TMP . '/article.txt', 1234567890);
@@ -283,22 +250,11 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function modifiedProvider(): array
 	{
 		return [
-			['changes', 'default', null],
-			['changes', 'en', 1234567890],
-			['published', 'default', 1234567890],
-			['published', 'en', null]
+			[VersionId::CHANGES, 'default', null],
+			[VersionId::CHANGES, 'en', 1234567890],
+			[VersionId::PUBLISHED, 'default', 1234567890],
+			[VersionId::PUBLISHED, 'en', null]
 		];
-	}
-
-	/**
-	 * @covers ::modified
-	 */
-	public function testModifiedInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->modified('invalid', 'default');
 	}
 
 	/**
@@ -314,7 +270,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read('changes', 'en'));
+		$this->assertSame($fields, $this->storage->read(VersionId::CHANGES, 'en'));
 	}
 
 	/**
@@ -330,7 +286,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read('changes', 'default'));
+		$this->assertSame($fields, $this->storage->read(VersionId::CHANGES, 'default'));
 	}
 
 	/**
@@ -345,7 +301,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.en.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read('published', 'en'));
+		$this->assertSame($fields, $this->storage->read(VersionId::PUBLISHED, 'en'));
 	}
 
 	/**
@@ -360,18 +316,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.txt', $fields);
 
-		$this->assertSame($fields, $this->storage->read('published', 'default'));
-	}
-
-	/**
-	 * @covers ::read
-	 */
-	public function testReadInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->read('invalid', 'default');
+		$this->assertSame($fields, $this->storage->read(VersionId::PUBLISHED, 'default'));
 	}
 
 	/**
@@ -385,7 +330,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch('changes', 'en');
+		$this->storage->touch(VersionId::CHANGES, 'en');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.en.txt'));
@@ -402,7 +347,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch('changes', 'default');
+		$this->storage->touch(VersionId::CHANGES, 'default');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/_changes/article.txt'));
@@ -418,7 +363,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch('published', 'en');
+		$this->storage->touch(VersionId::PUBLISHED, 'en');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.en.txt'));
@@ -434,21 +379,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$minTime = time();
 
-		$this->storage->touch('published', 'default');
+		$this->storage->touch(VersionId::PUBLISHED, 'default');
 
 		clearstatcache();
 		$this->assertGreaterThanOrEqual($minTime, filemtime(static::TMP . '/article.txt'));
-	}
-
-	/**
-	 * @covers ::touch
-	 */
-	public function testTouchInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->touch('invalid', 'default');
 	}
 
 	/**
@@ -464,7 +398,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
 
-		$this->storage->update('changes', 'en', $fields);
+		$this->storage->update(VersionId::CHANGES, 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
 	}
 
@@ -481,7 +415,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Dir::make(static::TMP . '/_changes');
 		Data::write(static::TMP . '/_changes/article.txt', $fields);
 
-		$this->storage->update('changes', 'default', $fields);
+		$this->storage->update(VersionId::CHANGES, 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
 	}
 
@@ -497,7 +431,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.en.txt', $fields);
 
-		$this->storage->update('published', 'en', $fields);
+		$this->storage->update(VersionId::PUBLISHED, 'en', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
 	}
 
@@ -513,26 +447,15 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		Data::write(static::TMP . '/article.txt', $fields);
 
-		$this->storage->update('published', 'default', $fields);
+		$this->storage->update(VersionId::PUBLISHED, 'default', $fields);
 		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
-	}
-
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->update('invalid', 'default', []);
 	}
 
 	/**
 	 * @covers ::contentFile
 	 * @dataProvider contentFileProvider
 	 */
-	public function testContentFile(string $type, string $id, string $language, string $expected)
+	public function testContentFile(string $type, VersionId $id, string $language, string $expected)
 	{
 		$app = new App([
 			'roots' => [
@@ -566,22 +489,22 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	public static function contentFileProvider(): array
 	{
 		return [
-			['file', 'changes', 'default', 'content/_changes/image.jpg.txt'],
-			['file', 'changes', 'en', 'content/_changes/image.jpg.en.txt'],
-			['file', 'published', 'default', 'content/image.jpg.txt'],
-			['file', 'published', 'en', 'content/image.jpg.en.txt'],
-			['page', 'changes', 'default', 'content/a-page/_changes/article.txt'],
-			['page', 'changes', 'en', 'content/a-page/_changes/article.en.txt'],
-			['page', 'published', 'default', 'content/a-page/article.txt'],
-			['page', 'published', 'en', 'content/a-page/article.en.txt'],
-			['site', 'changes', 'default', 'content/_changes/site.txt'],
-			['site', 'changes', 'en', 'content/_changes/site.en.txt'],
-			['site', 'published', 'default', 'content/site.txt'],
-			['site', 'published', 'en', 'content/site.en.txt'],
-			['user', 'changes', 'default', 'site/accounts/abcdefgh/_changes/user.txt'],
-			['user', 'changes', 'en', 'site/accounts/abcdefgh/_changes/user.en.txt'],
-			['user', 'published', 'default', 'site/accounts/abcdefgh/user.txt'],
-			['user', 'published', 'en', 'site/accounts/abcdefgh/user.en.txt'],
+			['file', VersionId::CHANGES, 'default', 'content/_changes/image.jpg.txt'],
+			['file', VersionId::CHANGES, 'en', 'content/_changes/image.jpg.en.txt'],
+			['file', VersionId::PUBLISHED, 'default', 'content/image.jpg.txt'],
+			['file', VersionId::PUBLISHED, 'en', 'content/image.jpg.en.txt'],
+			['page', VersionId::CHANGES, 'default', 'content/a-page/_changes/article.txt'],
+			['page', VersionId::CHANGES, 'en', 'content/a-page/_changes/article.en.txt'],
+			['page', VersionId::PUBLISHED, 'default', 'content/a-page/article.txt'],
+			['page', VersionId::PUBLISHED, 'en', 'content/a-page/article.en.txt'],
+			['site', VersionId::CHANGES, 'default', 'content/_changes/site.txt'],
+			['site', VersionId::CHANGES, 'en', 'content/_changes/site.en.txt'],
+			['site', VersionId::PUBLISHED, 'default', 'content/site.txt'],
+			['site', VersionId::PUBLISHED, 'en', 'content/site.en.txt'],
+			['user', VersionId::CHANGES, 'default', 'site/accounts/abcdefgh/_changes/user.txt'],
+			['user', VersionId::CHANGES, 'en', 'site/accounts/abcdefgh/_changes/user.en.txt'],
+			['user', VersionId::PUBLISHED, 'default', 'site/accounts/abcdefgh/user.txt'],
+			['user', VersionId::PUBLISHED, 'en', 'site/accounts/abcdefgh/user.en.txt'],
 		];
 	}
 
@@ -605,7 +528,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$storage = new PlainTextContentStorageHandler($model);
-		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile('changes', $language));
+		$this->assertSame(static::TMP . '/' . $expected, $storage->contentFile(VersionId::CHANGES, $language));
 	}
 
 	/**
@@ -632,7 +555,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Drafts cannot have a published content file');
-		$storage->contentFile('published', $language);
+		$storage->contentFile(VersionId::PUBLISHED, $language);
 	}
 
 	public static function contentFileDraftProvider(): array
@@ -642,18 +565,6 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			['en', 'content/_drafts/a-page/article.en.txt'],
 		];
 	}
-
-	/**
-	 * @covers ::contentFile
-	 */
-	public function testContentFileInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->contentFile('invalid', 'default');
-	}
-
 	/**
 	 * @covers ::contentFiles
 	 */
@@ -674,7 +585,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertSame([
 			static::TMP . '/_changes/article.en.txt',
 			static::TMP . '/_changes/article.de.txt'
-		], $this->storage->contentFiles('changes'));
+		], $this->storage->contentFiles(VersionId::CHANGES));
 	}
 
 	/**
@@ -684,7 +595,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$this->assertSame([
 			static::TMP . '/_changes/article.txt'
-		], $this->storage->contentFiles('changes'));
+		], $this->storage->contentFiles(VersionId::CHANGES));
 	}
 
 	/**
@@ -707,7 +618,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertSame([
 			static::TMP . '/article.en.txt',
 			static::TMP . '/article.de.txt'
-		], $this->storage->contentFiles('published'));
+		], $this->storage->contentFiles(VersionId::PUBLISHED));
 	}
 
 	/**
@@ -717,17 +628,6 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$this->assertSame([
 			static::TMP . '/article.txt'
-		], $this->storage->contentFiles('published'));
-	}
-
-	/**
-	 * @covers ::contentFiles
-	 */
-	public function testContentFilesInvalidId()
-	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid version identifier "invalid"');
-
-		$this->storage->contentFiles('invalid');
+		], $this->storage->contentFiles(VersionId::PUBLISHED));
 	}
 }

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass Kirby\Content\VersionId
+ * @covers ::__construct
+ */
+class VersionIdTest extends TestCase
+{
+	/**
+	 * @covers ::changes
+	 * @covers ::value
+	 */
+	public function testChanges()
+	{
+		$version = VersionId::changes();
+
+		$this->assertSame('changes', $version->value());
+	}
+
+	/**
+	 * @covers ::from
+	 * @covers ::value
+	 */
+	public function testFrom()
+	{
+		$version = VersionId::from('published');
+
+		$this->assertSame('published', $version->value());
+	}
+
+	/**
+	 * @covers ::is
+	 */
+	public function testIs()
+	{
+		$version = VersionId::published();
+
+		$this->assertTrue($version->is('published'));
+		$this->assertTrue($version->is(VersionId::PUBLISHED));
+		$this->assertFalse($version->is('something-else'));
+		$this->assertFalse($version->is(VersionId::CHANGES));
+	}
+
+	/**
+	 * @covers ::published
+	 * @covers ::value
+	 */
+	public function testPublished()
+	{
+		$version = VersionId::published();
+
+		$this->assertSame('published', $version->value());
+	}
+}

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 
@@ -30,6 +32,27 @@ class VersionIdTest extends TestCase
 		$this->expectExceptionMessage('Invalid Version ID');
 
 		new VersionId('foo');
+	}
+
+	/**
+	 * @covers ::default
+	 */
+	public function testDefault()
+	{
+		$draft   = new Page(['slug' => 'test', 'isDraft' => true]);
+		$version = VersionId::default($draft);
+
+		$this->assertTrue($version->is(VersionId::CHANGES));
+
+		$unlisted = new Page(['slug' => 'test', 'isDraft' => false]);
+		$version  = VersionId::default($unlisted);
+
+		$this->assertTrue($version->is(VersionId::PUBLISHED));
+
+		$file    = new File(['filename' => 'foo.jpg', 'parent' => $unlisted]);
+		$version = VersionId::default($file);
+
+		$this->assertTrue($version->is(VersionId::PUBLISHED));
 	}
 
 	/**

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -2,11 +2,11 @@
 
 namespace Kirby\Content;
 
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 
 /**
  * @coversDefaultClass Kirby\Content\VersionId
- * @covers ::__construct
  */
 class VersionIdTest extends TestCase
 {
@@ -19,6 +19,17 @@ class VersionIdTest extends TestCase
 		$version = VersionId::changes();
 
 		$this->assertSame('changes', $version->value());
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructWithInvalidId()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid Version ID');
+
+		new VersionId('foo');
 	}
 
 	/**
@@ -54,5 +65,14 @@ class VersionIdTest extends TestCase
 		$version = VersionId::published();
 
 		$this->assertSame('published', $version->value());
+	}
+
+	/**
+	 * @covers ::__toString
+	 */
+	public function testToString()
+	{
+		$this->assertSame('published', (string)VersionId::published());
+		$this->assertSame('changes', (string)VersionId::changes());
 	}
 }


### PR DESCRIPTION
## This PR …

This is the first bigger step in a series of PRs that will hopefully lead to our new changes system one day :)

### Refactored

- New `Kirby\Content\VersionId` class to represent versions
- Refactored all content storage classes and models to use the new `VersionId`.

### Breaking changes

- All content storage methods must now use the `VersionId` instead of a simple string. 

## Reason

With the new VersionId class, we can reduce quite some logic and get proper type hinting here. This feels like a much stronger/clearer path for already complex classes and methods. 

## Code coverage

We have a minor reduction in code coverage, but it's only in the ContentStorage class which will be gone in a later step anyway. That's why I think we should ignore it. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
