### PR TITLE
Changes 2: Plain Text Handler Refactoring

### DIFF
--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -156,18 +156,13 @@ class ContentStorage
 	/**
 	 * Checks if a version exists
 	 *
-	 * @param string|null $lang Code `'default'` in a single-lang installation;
-	 *                          checks for "any language" if not provided
+	 * @param string|null $lang Code `'default'` in a single-lang installation
 	 */
 	public function exists(
 		VersionId $versionId,
-		string|null $lang
+		string $lang
 	): bool {
-		if ($lang !== null) {
-			$lang = $this->language($lang);
-		}
-
-		return $this->handler->exists($versionId, $lang);
+		return $this->handler->exists($versionId, $this->language($lang));
 	}
 
 	/**

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -156,7 +156,7 @@ class ContentStorage
 	/**
 	 * Checks if a version exists
 	 *
-	 * @param string|null $lang Code `'default'` in a single-lang installation
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
 	public function exists(
 		VersionId $versionId,

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -40,10 +40,9 @@ interface ContentStorageHandler
 	/**
 	 * Checks if a version exists
 	 *
-	 * @param string|null $lang Code `'default'` in a single-lang installation;
-	 *                          checks for "any language" if not provided
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function exists(VersionId $versionId, string|null $lang): bool;
+	public function exists(VersionId $versionId, string $lang): bool;
 
 	/**
 	 * Returns the modification timestamp of a version if it exists

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -205,21 +205,10 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Checks if a version exists
 	 *
-	 * @param string|null $lang Code `'default'` in a single-lang installation;
-	 *                          checks for "any language" if not provided
+	 * @param string|null $lang Code `'default'` in a single-lang installation
 	 */
-	public function exists(VersionId $versionId, string|null $lang): bool
+	public function exists(VersionId $versionId, string $lang): bool
 	{
-		if ($lang === null) {
-			foreach ($this->contentFiles($versionId) as $file) {
-				if (is_file($file) === true) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
 		return is_file($this->contentFile($versionId, $lang)) === true;
 	}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -34,7 +34,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Creates the absolute directory path for the model
 	 */
-	public function contentDirectory(VersionId $versionId): string
+	protected function contentDirectory(VersionId $versionId): string
 	{
 		$directory = match (true) {
 			$this->model instanceof File
@@ -128,7 +128,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function contentFilename(string $name, string $lang): string
+	protected function contentFilename(string $name, string $lang): string
 	{
 		$kirby     = $this->model->kirby();
 		$extension = $kirby->contentExtension();

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -205,7 +205,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Checks if a version exists
 	 *
-	 * @param string|null $lang Code `'default'` in a single-lang installation
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
 	public function exists(VersionId $versionId, string $lang): bool
 	{
@@ -292,6 +292,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Writes the content fields of an existing version
 	 *
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 *
 	 * @throws \Kirby\Exception\Exception If the content cannot be written

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -169,56 +169,16 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	 * @covers ::exists
 	 * @dataProvider existsProvider
 	 */
-	public function testExistsNoneExisting(VersionId $id, string|null $language)
+	public function testExistsNoneExisting(VersionId $id, string $language)
 	{
 		$this->assertFalse($this->storage->exists($id, $language));
-	}
-
-	/**
-	 * @covers ::exists
-	 * @dataProvider existsProvider
-	 */
-	public function testExistsSomeExistingMultiLang(VersionId $id, string|null $language, array $expected)
-	{
-		Dir::make(static::TMP . '/_changes');
-		touch(static::TMP . '/article.txt');
-		touch(static::TMP . '/_changes/article.en.txt');
-
-		new App([
-			'languages' => [
-				[
-					'code' => 'en',
-					'default' => true
-				],
-				[
-					'code' => 'de'
-				]
-			]
-		]);
-
-		$this->assertSame($expected[0], $this->storage->exists($id, $language));
-	}
-
-	/**
-	 * @covers ::exists
-	 * @dataProvider existsProvider
-	 */
-	public function testExistsSomeExistingSingleLang(VersionId $id, string|null $language, array $expected)
-	{
-		Dir::make(static::TMP . '/_changes');
-		touch(static::TMP . '/article.txt');
-		touch(static::TMP . '/_changes/article.en.txt');
-
-		$this->assertSame($expected[1], $this->storage->exists($id, $language));
 	}
 
 	public static function existsProvider(): array
 	{
 		return [
-			[VersionId::changes(), null, [true, false]],
 			[VersionId::changes(), 'default', [false, false]],
 			[VersionId::changes(), 'en', [true, true]],
-			[VersionId::published(), null, [false, true]],
 			[VersionId::published(), 'default', [true, true]],
 			[VersionId::published(), 'en', [false, false]]
 		];


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436

### Refactoring

- New internal `PlainTextContentStorageHandler::write` method
- New `contentFile` methods to split logic per model type and make use of type hinting
- Remove option to pass null as language to `ContentStorageHandler::exists` to avoid unwanted logic in handler methods.
- Alphabetically sorted methods

### Outlook

- All `$lang` arguments in handler methods will be converted to full `Language` objects instead of strings in a later PR. I did not solve all of this at once to keep the PR more straight forward. https://github.com/getkirby/kirby/pull/6448
- The `PlainTextContentStorageHandler` class will no longer implement the interface but extend the abstract `ContentStorageHandler` class. This change will also remove the `__construct` method, which will then be implemented by the abstract. https://github.com/getkirby/kirby/pull/6449
- The new `::write` method will later be moved to the `ContentStorageHandler` class as an abstract method. `ContentStorageHandler` will then also get a non-abstract update and create method, which will use the new write method by default. This will add the option for storage handlers to only modify the write method if no further logic is needed for create and update. https://github.com/getkirby/kirby/pull/6457

### Breaking changes

None

## Ready?

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team

- [x] Add changes & docs to release notes draft in Notion
