### PR TITLE
Changes 3: New Version class

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -65,12 +65,12 @@ class Version
 
 		// delete a single language
 		$this->model->storage()->delete($this->id, $language);
-		return;
+
 	}
 
 	/**
 	 * Ensure that the version exists and otherwise
-     * throw an exception
+	 * throw an exception
 	 *
 	 * @throws \Kirby\Exception\NotFoundException if the version does not exist
 	 */
@@ -130,7 +130,7 @@ class Version
 
 	/**
 	 * Returns the stored content fields
-     *
+	 *
 	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @return array<string, string>
 	 */
@@ -172,8 +172,8 @@ class Version
 	/**
 	 * Updates the content fields of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * The Version class handles all actions for a single
+ * version and is identified by a VersionId instance
+ *
+ * @internal
+ * @since 5.0.0
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Version
+{
+	public function __construct(
+		protected ModelWithContent $model,
+		protected VersionId $id
+	) {
+	}
+
+	/**
+	 * Returns a Content object for the given language
+	 */
+	public function content(string $language = 'default'): Content
+	{
+		return new Content(
+			parent: $this->model,
+			data:   $this->model->storage()->read($this->id, $language),
+		);
+	}
+
+	/**
+	 * Creates a new version for the given language
+	 */
+	public function create(string $language, array $fields): void
+	{
+		$this->model->storage()->create($this->id, $language, $fields);
+	}
+
+	/**
+	 * Deletes a version by language or for any language
+	 */
+	public function delete(string|null $language = null): void
+	{
+		// delete a single language
+		if ($language !== null) {
+			$this->model->storage()->delete($this->id, $language);
+			return;
+		}
+
+		// delete all languages
+		foreach ($this->model->kirby()->languages() as $language) {
+			$this->model->storage()->delete($this->id, $language->code());
+		}
+	}
+
+	/**
+	 * Checks if a version exists for the given language
+	 */
+	public function exists(string $language = 'default'): bool
+	{
+		return $this->model->storage()->exists($this->id, $language);
+	}
+
+	/**
+	 * Returns the VersionId instance for this version
+	 */
+	public function id(): VersionId
+	{
+		return $this->id;
+	}
+
+	/**
+	 * Returns the parent model
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	public function move(string $fromLanguage, VersionId $toVersionId, string $toLanguage): void
+	{
+		$this->model->storage()->move($this->id, $fromLanguage, $toVersionId, $toLanguage);
+	}
+
+	/**
+	 * Returns the stored content fields
+     *
+	 * @param string $lang Code `'default'` in a single-lang installation
+	 * @return array<string, string>
+	 */
+	public function read(string $language = 'default'): array
+	{
+		return $this->model->storage()->read($this->id, $language);
+	}
+
+	/**
+	 * Updates the modification timestamp of an existing version
+	 *
+	 * @param string $lang Code `'default'` in a single-lang installation
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function touch(string $language): void
+	{
+		$this->model->storage()->touch($this->id, $language);
+	}
+
+	/**
+	 * Updates the content fields of an existing version
+	 *
+	 * @param string $lang Code `'default'` in a single-lang installation
+	 * @param array<string, string> $fields Content fields
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function update(string $language, array $fields): void
+	{
+		$this->model->storage()->update($this->id, $language, $fields);
+	}
+}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Page;
+use Kirby\Filesystem\Dir;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass Kirby\Content\Version
+ */
+class VersionTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Content.Version';
+
+	protected $model;
+
+	public function setUp(): void
+	{
+		Dir::make(static::TMP);
+
+		$this->model = new Page([
+			'kirby'    => new App(),
+			'root'     => static::TMP,
+			'slug'     => 'a-page',
+			'template' => 'article'
+		]);
+	}
+
+	public function tearDown(): void
+	{
+		App::destroy();
+		Dir::remove(static::TMP);
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreate(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists());
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$this->assertTrue($version->exists());
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateLanguage(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists('de'));
+
+		$version->create([
+			'title' => 'Test'
+		], 'de');
+
+		$this->assertTrue($version->exists('de'));
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDelete(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists());
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$this->assertTrue($version->exists());
+
+		$version->delete();
+
+		$this->assertFalse($version->exists());
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExists(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists());
+
+		$version->create([]);
+
+		$this->assertTrue($version->exists());
+	}
+
+	/**
+	 * @covers ::id
+	 */
+	public function testId(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: $id = VersionId::published()
+		);
+
+		$this->assertSame($id, $version->id());
+	}
+
+	/**
+	 * @covers ::model
+	 */
+	public function testModel(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertSame($this->model, $version->model());
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testRead(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create($content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $version->read());
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdate(): void
+	{
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$this->assertSame('Test', $version->read()['title']);
+
+		$version->create([
+			'title' => 'Updated Title'
+		]);
+
+		$this->assertSame('Updated Title', $version->read()['title']);
+	}
+}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -171,7 +171,7 @@ class VersionTest extends TestCase
 
 		$this->assertSame('Test', $version->read()['title']);
 
-		$version->create([
+		$version->update([
 			'title' => 'Updated Title'
 		]);
 


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439

### Refactoring

- New `Version` class which inherits most of the logic from the `ContentStorage` handler and will eventually replace it. 

### Outlook

- This PR will be followed by a later PR to improve the `Version` class and add additional unit tests (https://github.com/getkirby/kirby/pull/6450) The steps are separated to make sure that all other unit tests always keep passing. It's sometimes a bit of a chicken and egg situation here.
- Once the `ContentStorageHandler` methods accept a `Language` object instead of a string (https://github.com/getkirby/kirby/pull/6448) the `Version` class also needs to pass a `Language` object instead of language codes. It will therefor get a new protected `Version::language()` method that is mostly adapted from `ContentStorage::language()` but will always return a `Language` object - even in a single-language installation. There's a new `Language::single()` method coming up in https://github.com/getkirby/kirby/pull/6448 for that. 
- The `Version` class will also inherit a few more specific logic methods from `ContentStorage` in preparation of removing `ContentStorage` entirely 
  - `::deleteLanguage`
  - `::touchLanguage`
  - `::contentFile`
- `Version::modified` will later return null if the version does not exist.
- `Version::ensure` will later use `ContentStorageHandler::ensure` https://github.com/getkirby/kirby/pull/6457

### Breaking changes

None

## Ready?

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team

- [x] Add changes & docs to release notes draft in Notion
