### PR TITLE
Changes 4: Refactor PlainTextContentStorageHandler to use Language object

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -297,6 +297,7 @@ class Language implements Stringable
 
 	/**
 	 * Checks if this is the single language object
+	 * @internal
 	 */
 	public function isSingle(): bool
 	{

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -45,6 +45,7 @@ class Language implements Stringable
 	protected string $direction;
 	protected array $locale;
 	protected string $name;
+	protected bool $single;
 	protected array $slugs;
 	protected array $smartypants;
 	protected array $translations;
@@ -64,6 +65,7 @@ class Language implements Stringable
 		$this->default      = ($props['default'] ?? false) === true;
 		$this->direction    = ($props['direction'] ?? null) === 'rtl' ? 'rtl' : 'ltr';
 		$this->name         = trim($props['name'] ?? $this->code);
+		$this->single       = $props['single'] ?? false;
 		$this->slugs        = $props['slugs'] ?? [];
 		$this->smartypants  = $props['smartypants'] ?? [];
 		$this->translations = $props['translations'] ?? [];
@@ -177,8 +179,8 @@ class Language implements Stringable
 		if ($languages->count() === 0) {
 			foreach ($kirby->models() as $model) {
 				$model->storage()->convertLanguage(
-					'default',
-					$language->code()
+					Language::single(),
+					$language
 				);
 			}
 		}
@@ -225,7 +227,7 @@ class Language implements Stringable
 
 		foreach ($kirby->models() as $model) {
 			if ($this->isLast() === true) {
-				$model->storage()->convertLanguage($code, 'default');
+				$model->storage()->convertLanguage($this, Language::single());
 			} else {
 				$model->storage()->deleteLanguage($code);
 			}
@@ -273,7 +275,7 @@ class Language implements Stringable
 	public function isDeletable(): bool
 	{
 		// the default language can only be deleted if it's the last
-		if ($this->isDefault() === true && $this->isLast() === false) {
+		if ($this->isSingle() === true && $this->isDefault() === true && $this->isLast() === false) {
 			return false;
 		}
 
@@ -286,6 +288,14 @@ class Language implements Stringable
 	public function isLast(): bool
 	{
 		return App::instance()->languages()->count() === 1;
+	}
+
+	/**
+	 * Checks if this is the single language object
+	 */
+	public function isSingle(): bool
+	{
+		return $this->single;
 	}
 
 	/**
@@ -455,7 +465,8 @@ class Language implements Stringable
 		return new static([
 			'code'    => 'en',
 			'default' => true,
-			'locale'  => App::instance()->option('locale', 'en_US.utf-8')
+			'locale'  => App::instance()->option('locale', 'en_US.utf-8'),
+			'single'  => true
 		]);
 	}
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -447,6 +447,19 @@ class Language implements Stringable
 	}
 
 	/**
+	 * Create a placeholder language object in a
+	 * single-language installation
+	 */
+	public static function single(): static
+	{
+		return new static([
+			'code'    => 'en',
+			'default' => true,
+			'locale'  => App::instance()->option('locale', 'en_US.utf-8')
+		]);
+	}
+
+	/**
 	 * Returns the custom slug rules for this language
 	 */
 	public function slugs(): array

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -274,8 +274,13 @@ class Language implements Stringable
 	 */
 	public function isDeletable(): bool
 	{
+		// a single-language object cannot be deleted
+		if ($this->isSingle() === true) {
+			return false;
+		}
+
 		// the default language can only be deleted if it's the last
-		if ($this->isSingle() === true && $this->isDefault() === true && $this->isLast() === false) {
+		if ($this->isDefault() === true && $this->isLast() === false) {
 			return false;
 		}
 

--- a/src/Content/ContentStorage.php
+++ b/src/Content/ContentStorage.php
@@ -83,11 +83,8 @@ class ContentStorage
 	 * Adapts all versions when converting languages
 	 * @internal
 	 */
-	public function convertLanguage(string $from, string $to): void
+	public function convertLanguage(Language $from, Language $to): void
 	{
-		$from = $this->language($from, true);
-		$to   = $this->language($to, true);
-
 		foreach ($this->dynamicVersions() as $versionId) {
 			$this->handler->move($versionId, $from, $versionId, $to);
 		}
@@ -127,7 +124,7 @@ class ContentStorage
 	 */
 	public function deleteLanguage(string|null $lang): void
 	{
-		$lang = $this->language($lang, true);
+		$lang = $this->language($lang);
 
 		foreach ($this->dynamicVersions() as $version) {
 			$this->handler->delete($version, $lang);
@@ -217,7 +214,7 @@ class ContentStorage
 	 */
 	public function touchLanguage(string|null $lang): void
 	{
-		$lang = $this->language($lang, true);
+		$lang = $this->language($lang);
 
 		foreach ($this->dynamicVersions() as $version) {
 			if ($this->exists($version, $lang) === true) {
@@ -265,8 +262,6 @@ class ContentStorage
 	/**
 	 * Converts a "user-facing" language code to a "raw" language code to be
 	 * used for storage
-	 *
-	 * @param bool $force If set to `true`, the language code is not validated
 	 */
 	protected function language(
 		string|null $languageCode = null,

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 
 /**
@@ -25,71 +26,57 @@ interface ContentStorageHandler
 	/**
 	 * Creates a new version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 */
-	public function create(VersionId $versionId, string $lang, array $fields): void;
+	public function create(VersionId $versionId, Language $language, array $fields): void;
 
 	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function delete(VersionId $versionId, string $lang): void;
+	public function delete(VersionId $versionId, Language $language): void;
 
 	/**
 	 * Checks if a version exists
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function exists(VersionId $versionId, string $lang): bool;
+	public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
 	 * Returns the modification timestamp of a version if it exists
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function modified(VersionId $versionId, string $lang): int|null;
+	public function modified(VersionId $versionId, Language $language): int|null;
 
 	/**
 	 * Moves content from one version-language combination to another
-	 *
-	 * @param string $fromLang Code `'default'` in a single-lang installation
-	 * @param string $toLang Code `'default'` in a single-lang installation
 	 */
 	public function move(
 		VersionId $fromVersionId,
-		string $fromLang,
+		Language $fromLanguage,
 		VersionId $toVersionId,
-		string $toLang
+		Language $toLanguage
 	): void;
 
 	/**
 	 * Returns the stored content fields
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @return array<string, string>
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function read(VersionId $versionId, string $lang): array;
+	public function read(VersionId $versionId, Language $language): array;
 
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
-	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(VersionId $versionId, string $lang): void;
+	public function touch(VersionId $versionId, Language $language): void;
 
 	/**
 	 * Updates the content fields of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function update(VersionId $versionId, string $lang, array $fields): void;
+	public function update(VersionId $versionId, Language $language, array $fields): void;
 }

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -87,8 +87,7 @@ class ContentTranslation
 	{
 		return $this->contentFile = $this->parent->storage()->contentFile(
 			VersionId::default($this->parent),
-			$this->code,
-			true
+			$this->code
 		);
 	}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -117,7 +117,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * Creates a filename with extension and optional language code
 	 * in a multi-language installation
 	 */
-	public function contentFilename(string $name, Language $language): string
+	protected function contentFilename(string $name, Language $language): string
 	{
 		$kirby     = $this->model->kirby();
 		$extension = $kirby->contentExtension();

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\File;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
@@ -53,17 +54,15 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Returns the absolute path to the content file
 	 * @internal To be made `protected` when the CMS core no longer relies on it
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function contentFile(VersionId $versionId, string $lang): string
+	public function contentFile(VersionId $versionId, Language $language): string
 	{
 		// get the filename without extension and language code
 		return match (true) {
-			$this->model instanceof File => $this->contentFileForFile($this->model, $versionId, $lang),
-			$this->model instanceof Page => $this->contentFileForPage($this->model, $versionId, $lang),
-			$this->model instanceof Site => $this->contentFileForSite($this->model, $versionId, $lang),
-			$this->model instanceof User => $this->contentFileForUser($this->model, $versionId, $lang),
+			$this->model instanceof File => $this->contentFileForFile($this->model, $versionId, $language),
+			$this->model instanceof Page => $this->contentFileForPage($this->model, $versionId, $language),
+			$this->model instanceof Site => $this->contentFileForSite($this->model, $versionId, $language),
+			$this->model instanceof User => $this->contentFileForUser($this->model, $versionId, $language),
 			// @codeCoverageIgnoreStart
 			default => throw new LogicException('Cannot determine content file for model type "' . $this->model::CLASS_ALIAS . '"')
 			// @codeCoverageIgnoreEnd
@@ -72,20 +71,16 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 
 	/**
 	 * Returns the absolute path to the content file of a file model
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	protected function contentFileForFile(File $model, VersionId $versionId, string $lang): string
+	protected function contentFileForFile(File $model, VersionId $versionId, Language $language): string
 	{
-		return $this->contentDirectory($versionId) . '/' . $this->contentFilename($model->filename(), $lang);
+		return $this->contentDirectory($versionId) . '/' . $this->contentFilename($model->filename(), $language);
 	}
 
 	/**
 	 * Returns the absolute path to the content file of a page model
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	protected function contentFileForPage(Page $model, VersionId $versionId, string $lang): string
+	protected function contentFileForPage(Page $model, VersionId $versionId, Language $language): string
 	{
 		$directory = $this->contentDirectory($versionId);
 
@@ -99,42 +94,36 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 			$directory = $this->model->root();
 		}
 
-		return $directory . '/' . $this->contentFilename($model->intendedTemplate()->name(), $lang);
+		return $directory . '/' . $this->contentFilename($model->intendedTemplate()->name(), $language);
 	}
 
 	/**
 	 * Returns the absolute path to the content file of a site model
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	protected function contentFileForSite(Site $model, VersionId $versionId, string $lang): string
+	protected function contentFileForSite(Site $model, VersionId $versionId, Language $language): string
 	{
-		return $this->contentDirectory($versionId) . '/' . $this->contentFilename('site', $lang);
+		return $this->contentDirectory($versionId) . '/' . $this->contentFilename('site', $language);
 	}
 
 	/**
 	 * Returns the absolute path to the content file of a user model
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	protected function contentFileForUser(User $model, VersionId $versionId, string $lang): string
+	protected function contentFileForUser(User $model, VersionId $versionId, Language $language): string
 	{
-		return $this->contentDirectory($versionId) . '/' . $this->contentFilename('user', $lang);
+		return $this->contentDirectory($versionId) . '/' . $this->contentFilename('user', $language);
 	}
 
 	/**
 	 * Creates a filename with extension and optional language code
 	 * in a multi-language installation
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	protected function contentFilename(string $name, string $lang): string
+	public function contentFilename(string $name, Language $language): string
 	{
 		$kirby     = $this->model->kirby();
 		$extension = $kirby->contentExtension();
 
-		if ($lang !== 'default') {
-			return $name . '.' . $lang . '.' . $extension;
+		if ($kirby->multilang() === true) {
+			return $name . '.' . $language->code() . '.' . $extension;
 		}
 
 		return $name . '.' . $extension;
@@ -148,36 +137,33 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	{
 		if ($this->model->kirby()->multilang() === true) {
 			return $this->model->kirby()->languages()->values(
-				fn ($lang) => $this->contentFile($versionId, $lang)
+				fn ($language) => $this->contentFile($versionId, $language)
 			);
 		}
 
 		return [
-			$this->contentFile($versionId, 'default')
+			$this->contentFile($versionId, Language::single())
 		];
 	}
 
 	/**
 	 * Creates a new version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 *
 	 * @throws \Kirby\Exception\Exception If the file cannot be written
 	 */
-	public function create(VersionId $versionId, string $lang, array $fields): void
+	public function create(VersionId $versionId, Language $language, array $fields): void
 	{
-		$this->write($versionId, $lang, $fields);
+		$this->write($versionId, $language, $fields);
 	}
 
 	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function delete(VersionId $versionId, string $lang): void
+	public function delete(VersionId $versionId, Language $language): void
 	{
-		$contentFile = $this->contentFile($versionId, $lang);
+		$contentFile = $this->contentFile($versionId, $language);
 		$success = F::unlink($contentFile);
 
 		// @codeCoverageIgnoreStart
@@ -204,23 +190,19 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 
 	/**
 	 * Checks if a version exists
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function exists(VersionId $versionId, string $lang): bool
+	public function exists(VersionId $versionId, Language $language): bool
 	{
-		return is_file($this->contentFile($versionId, $lang)) === true;
+		return is_file($this->contentFile($versionId, $language)) === true;
 	}
 
 	/**
 	 * Returns the modification timestamp of a version
 	 * if it exists
-	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 */
-	public function modified(VersionId $versionId, string $lang): int|null
+	public function modified(VersionId $versionId, Language $language): int|null
 	{
-		$modified = F::modified($this->contentFile($versionId, $lang));
+		$modified = F::modified($this->contentFile($versionId, $language));
 
 		if (is_int($modified) === true) {
 			return $modified;
@@ -231,43 +213,37 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 
 	/**
 	 * Moves content from one version-language combination to another
-	 *
-	 * @param string $fromLang Code `'default'` in a single-lang installation
-	 * @param string $toLang Code `'default'` in a single-lang installation
 	 */
 	public function move(
 		VersionId $fromVersionId,
-		string $fromLang,
+		Language $fromLanguage,
 		VersionId $toVersionId,
-		string $toLang
+		Language $toLanguage
 	): void {
 		F::move(
-			$this->contentFile($fromVersionId, $fromLang),
-			$this->contentFile($toVersionId, $toLang)
+			$this->contentFile($fromVersionId, $fromLanguage),
+			$this->contentFile($toVersionId, $toLanguage)
 		);
 	}
 
 	/**
 	 * Returns the stored content fields
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @return array<string, string>
 	 */
-	public function read(VersionId $versionId, string $lang): array
+	public function read(VersionId $versionId, Language $language): array
 	{
-		return Data::read($this->contentFile($versionId, $lang));
+		return Data::read($this->contentFile($versionId, $language));
 	}
 
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
-	 *
 	 * @throws \Kirby\Exception\Exception If the file cannot be touched
 	 */
-	public function touch(VersionId $versionId, string $lang): void
+	public function touch(VersionId $versionId, Language $language): void
 	{
-		$success = touch($this->contentFile($versionId, $lang));
+		$success = touch($this->contentFile($versionId, $language));
 
 		// @codeCoverageIgnoreStart
 		if ($success !== true) {
@@ -279,14 +255,13 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Updates the content fields of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
 	 *
 	 * @throws \Kirby\Exception\Exception If the file cannot be written
 	 */
-	public function update(VersionId $versionId, string $lang, array $fields): void
+	public function update(VersionId $versionId, Language $language, array $fields): void
 	{
-		$this->write($versionId, $lang, $fields);
+		$this->write($versionId, $language, $fields);
 	}
 
 	/**
@@ -297,9 +272,9 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\Exception If the content cannot be written
 	 */
-	protected function write(VersionId $versionId, string $lang, array $fields): void
+	protected function write(VersionId $versionId, Language $language, array $fields): void
 	{
-		$success = Data::write($this->contentFile($versionId, $lang), $fields);
+		$success = Data::write($this->contentFile($versionId, $language), $fields);
 
 		// @codeCoverageIgnoreStart
 		if ($success !== true) {

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -122,7 +122,7 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 		$kirby     = $this->model->kirby();
 		$extension = $kirby->contentExtension();
 
-		if ($kirby->multilang() === true) {
+		if ($language->isSingle() === false) {
 			return $name . '.' . $language->code() . '.' . $extension;
 		}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -267,8 +267,8 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	/**
 	 * Writes the content fields of an existing version
 	 *
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 * @param array<string, string> $fields Content fields
+	 * @param string $lang Code `'default'` in a single-lang installation
 	 *
 	 * @throws \Kirby\Exception\Exception If the content cannot be written
 	 */

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -268,7 +268,6 @@ class PlainTextContentStorageHandler implements ContentStorageHandler
 	 * Writes the content fields of an existing version
 	 *
 	 * @param array<string, string> $fields Content fields
-	 * @param string $lang Code `'default'` in a single-lang installation
 	 *
 	 * @throws \Kirby\Exception\Exception If the content cannot be written
 	 */

--- a/tests/Cms/Languages/LanguageConversionTest.php
+++ b/tests/Cms/Languages/LanguageConversionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Data\Data;
+
+/**
+ * @coversDefaultClass \Kirby\Cms\Language
+ */
+class LanguageConversionTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageConversion';
+
+	protected $app;
+
+	public function setUp(): void
+	{
+		Dir::make(static::TMP);
+	}
+
+	public function tearDown(): void
+	{
+		Dir::remove(static::TMP);
+	}
+
+	public function testConvertFromSingleLanguageToMultiLanguage(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+		]);
+
+		// create the page model
+		Data::write($app->root('content') . '/test/test.txt', [
+			'title' => 'Title'
+		]);
+
+		$this->assertCount(0, $app->languages());
+		$this->assertFalse($app->multilang());
+
+		// get the page model
+		$page = $app->page('test');
+
+		// and check if the content is loadable
+		$this->assertSame('Title', $page->content()->title()->value());
+
+		// create a new Language to switch to multi-language mode
+		Language::create([
+			'code' => 'en',
+		]);
+
+		// make sure that Kirby actually switched to multi-language mode
+		$this->assertCount(1, $app->languages());
+		$this->assertTrue($app->multilang());
+
+		// the content file should now have been moved to .en
+		$this->assertFileExists($page->root() . '/test.en.txt');
+		$this->assertFileDoesNotExist($page->root() . '/test.txt');
+
+		// the content should still be loadable for the page
+		$this->assertSame('Title', $page->content()->title()->value());
+		$this->assertSame('Title', $page->content('en')->title()->value());
+	}
+
+	public function testConvertFromMultiLanguageToSingleLanguage(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+		]);
+
+		// create two languages
+		Data::write($app->root('languages') . '/en.php', [
+			'code'    => 'en',
+			'default' => true
+		]);
+
+		Data::write($app->root('languages') . '/de.php', [
+			'code' => 'de',
+		]);
+
+		// create some models
+		Data::write($app->root('content') . '/test/test.en.txt', [
+			'title' => 'English Title'
+		]);
+
+		Data::write($app->root('content') . '/test/test.de.txt', [
+			'title' => 'German Title'
+		]);
+
+		$this->assertCount(2, $app->languages());
+		$this->assertTrue($app->multilang());
+
+		// get the page model
+		$page = $app->page('test');
+
+		$this->assertSame('English Title', $page->content('en')->title()->value());
+		$this->assertSame('German Title', $page->content('de')->title()->value());
+
+		// delete the first language to check file removal.
+		$app->language('de')->delete();
+
+		// the .de file should now be gone
+		$this->assertFileDoesNotExist($page->root() . '/test.de.txt');
+
+		// the .en file should still be there
+		$this->assertFileExists($page->root() . '/test.en.txt');
+
+		// delete the last language to switch to single-language mode
+		$app->language('en')->delete();
+
+		// the .en file should now be gone
+		$this->assertFileDoesNotExist($page->root() . '/test.en.txt');
+
+		// … and should be replaced by the content file without language code
+		$this->assertFileExists($page->root() . '/test.txt');
+
+		// meanwhile, Kirby should have been switched to single language mode
+		$this->assertCount(0, $app->languages());
+		$this->assertFalse($app->multilang());
+
+		// the page should still load the english content
+		$this->assertSame('English Title', $page->content()->title()->value());
+	}
+
+}

--- a/tests/Cms/Languages/LanguageConversionTest.php
+++ b/tests/Cms/Languages/LanguageConversionTest.php
@@ -61,6 +61,8 @@ class LanguageConversionTest extends TestCase
 		// the content should still be loadable for the page
 		$this->assertSame('Title', $page->content()->title()->value());
 		$this->assertSame('Title', $page->content('en')->title()->value());
+
+		$this->assertSame('Title', Data::read($page->root() . '/test.en.txt')['title']);
 	}
 
 	public function testConvertFromMultiLanguageToSingleLanguage(): void
@@ -123,6 +125,7 @@ class LanguageConversionTest extends TestCase
 
 		// the page should still load the english content
 		$this->assertSame('English Title', $page->content()->title()->value());
+		$this->assertSame('English Title', Data::read($page->root() . '/test.txt')['title']);
 	}
 
 }

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -566,6 +566,17 @@ class LanguageTest extends TestCase
 	}
 
 	/**
+	 * @covers ::single
+	 */
+	public function testSingle()
+	{
+		$language = Language::single();
+
+		$this->assertSame('en', $language->code());
+		$this->assertSame('en', $language->name());
+	}
+
+	/**
 	 * @covers ::toArray
 	 * @covers ::__debugInfo
 	 */

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -281,6 +281,27 @@ class LanguageTest extends TestCase
 	}
 
 	/**
+	 * @covers ::isSingle
+	 */
+	public function testIsSingle()
+	{
+		// default
+		$language = new Language([
+			'code' => 'en'
+		]);
+
+		$this->assertFalse($language->isSingle());
+
+		// true
+		$language = new Language([
+			'code'   => 'en',
+			'single' => true
+		]);
+
+		$this->assertTrue($language->isSingle());
+	}
+
+	/**
 	 * @covers ::locale
 	 */
 	public function testLocale()

--- a/tests/Content/ContentStorageTest.php
+++ b/tests/Content/ContentStorageTest.php
@@ -77,9 +77,9 @@ class ContentStorageTest extends TestCase
 	public function testReadDoesNotExist()
 	{
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published (default)" does not already exist');
+		$this->expectExceptionMessage('Version "published" does not already exist');
 
-		$this->storage->read(VersionId::published(), 'default');
+		$this->storage->read(VersionId::published());
 	}
 
 	/**
@@ -89,9 +89,9 @@ class ContentStorageTest extends TestCase
 	public function testTouchDoesNotExist()
 	{
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published (default)" does not already exist');
+		$this->expectExceptionMessage('Version "published" does not already exist');
 
-		$this->storage->touch(VersionId::published(), 'default');
+		$this->storage->touch(VersionId::published());
 	}
 
 	/**
@@ -101,7 +101,7 @@ class ContentStorageTest extends TestCase
 	public function testUpdateDoesNotExist()
 	{
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published (default)" does not already exist');
+		$this->expectExceptionMessage('Version "published" does not already exist');
 
 		$fields = [
 			'title' => 'Foo',
@@ -113,9 +113,8 @@ class ContentStorageTest extends TestCase
 
 	/**
 	 * @covers ::language
-	 * @dataProvider languageProvider
 	 */
-	public function testLanguageMultiLang(string|null $languageCode, bool $force, array $expectedCodes)
+	public function testLanguageMultiLang()
 	{
 		$app = new App([
 			'languages' => [
@@ -129,8 +128,17 @@ class ContentStorageTest extends TestCase
 			]
 		]);
 
-		$language = $this->language($this->storage, $languageCode, $force);
-		$this->assertSame($expectedCodes[0], $language);
+		$language = $this->language($this->storage, 'en');
+		$this->assertSame('en', $language->code());
+
+		$language = $this->language($this->storage, 'de');
+		$this->assertSame('de', $language->code());
+
+		$language = $this->language($this->storage, 'default');
+		$this->assertSame('en', $language->code());
+
+		$language = $this->language($this->storage);
+		$this->assertSame('en', $language->code());
 	}
 
 	/**
@@ -158,12 +166,14 @@ class ContentStorageTest extends TestCase
 
 	/**
 	 * @covers ::language
-	 * @dataProvider languageProvider
 	 */
-	public function testLanguageSingleLang(string|null $languageCode, bool $force, array $expectedCodes)
+	public function testLanguageSingleLang()
 	{
-		$language = $this->language($this->storage, $languageCode, $force);
-		$this->assertSame($expectedCodes[1], $language);
+		$language = $this->language($this->storage, 'en');
+		$this->assertSame('en', $language->code());
+
+		$language = $this->language($this->storage, 'de');
+		$this->assertSame('en', $language->code());
 	}
 
 	/**
@@ -172,7 +182,7 @@ class ContentStorageTest extends TestCase
 	public function testLanguageSingleLangInvalid()
 	{
 		$language = $this->language($this->storage, 'fr', false);
-		$this->assertSame('default', $language);
+		$this->assertSame('en', $language->code());
 	}
 
 	public static function languageProvider(): array

--- a/tests/Content/ContentTranslationTest.php
+++ b/tests/Content/ContentTranslationTest.php
@@ -109,9 +109,18 @@ class ContentTranslationTest extends TestCase
 	public function testContentFile()
 	{
 		$app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
 			'roots' => [
 				'content' => '/content',
-			]
+			],
 		]);
 
 		$page = new Page([


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442

### Refactoring

- New `Language::single()` method to create a Language placeholder object in single language installations
- Use full language objects in `ContentStorageHandler` and `PlainTextContentStorageHandler` methods
- Refactor `ContentStorage` to always provide a full language object to the storage methods. This is only temporary to keep all the unit tests working. `ContentStorage` will be removed later, as planned.

### Outlook

- The `PlainTextContentStorageHandler` class will no longer implement the interface but extend the abstract `ContentStorageHandler` class. This change will also remove the `__construct` method, which will then be implemented by the abstract. https://github.com/getkirby/kirby/pull/6449
- The new `::write` method will later be moved to the `ContentStorageHandler` class as an abstract method. `ContentStorageHandler` will then also get a non-abstract update and create method, which will use the new write method by default. This will add the option for storage handlers to only modify the write method if no further logic is needed for create and update. https://github.com/getkirby/kirby/pull/6457

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
