### PR TITLE
Changes 5: ContentStorageHandler Abstract

### DIFF
--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -21,7 +21,9 @@ use Kirby\Cms\ModelWithContent;
  */
 abstract class ContentStorageHandler
 {
-	abstract public function __construct(ModelWithContent $model);
+	public function __construct(protected ModelWithContent $model)
+	{
+	}
 
 	/**
 	 * Creates a new version

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -6,7 +6,7 @@ use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 
 /**
- * Interface for content storage handlers;
+ * Abstract for content storage handlers;
  * note that it is so far not viable to build custom
  * handlers because the CMS core relies on the filesystem
  * and cannot fully benefit from this abstraction yet
@@ -19,36 +19,36 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-interface ContentStorageHandler
+abstract class ContentStorageHandler
 {
-	public function __construct(ModelWithContent $model);
+	abstract public function __construct(ModelWithContent $model);
 
 	/**
 	 * Creates a new version
 	 *
 	 * @param array<string, string> $fields Content fields
 	 */
-	public function create(VersionId $versionId, Language $language, array $fields): void;
+	abstract public function create(VersionId $versionId, Language $language, array $fields): void;
 
 	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
 	 */
-	public function delete(VersionId $versionId, Language $language): void;
+	abstract public function delete(VersionId $versionId, Language $language): void;
 
 	/**
 	 * Checks if a version exists
 	 */
-	public function exists(VersionId $versionId, Language $language): bool;
+	abstract public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
 	 * Returns the modification timestamp of a version if it exists
 	 */
-	public function modified(VersionId $versionId, Language $language): int|null;
+	abstract public function modified(VersionId $versionId, Language $language): int|null;
 
 	/**
 	 * Moves content from one version-language combination to another
 	 */
-	public function move(
+	abstract public function move(
 		VersionId $fromVersionId,
 		Language $fromLanguage,
 		VersionId $toVersionId,
@@ -62,14 +62,14 @@ interface ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function read(VersionId $versionId, Language $language): array;
+	abstract public function read(VersionId $versionId, Language $language): array;
 
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(VersionId $versionId, Language $language): void;
+	abstract public function touch(VersionId $versionId, Language $language): void;
 
 	/**
 	 * Updates the content fields of an existing version
@@ -78,5 +78,5 @@ interface ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function update(VersionId $versionId, Language $language, array $fields): void;
+	abstract public function update(VersionId $versionId, Language $language, array $fields): void;
 }

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -4,7 +4,6 @@ namespace Kirby\Content;
 
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
-use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -28,10 +28,6 @@ use Kirby\Filesystem\F;
  */
 class PlainTextContentStorageHandler extends ContentStorageHandler
 {
-	public function __construct(protected ModelWithContent $model)
-	{
-	}
-
 	/**
 	 * Creates the absolute directory path for the model
 	 */

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -26,7 +26,7 @@ use Kirby\Filesystem\F;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class PlainTextContentStorageHandler implements ContentStorageHandler
+class PlainTextContentStorageHandler extends ContentStorageHandler
 {
 	public function __construct(protected ModelWithContent $model)
 	{


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448

### Refactoring

- Converts the `ContentStorageHandler` interface to an abstract class
- Define `__construct` in the abstract class and remove it from `PlainTextContentStorageHandler`

### Outlook

- The `::write` method will later be moved to the `ContentStorageHandler` class as an abstract method. `ContentStorageHandler` will then also get a non-abstract `update` and `create` method, which will use the new write method by default. This will add the option for storage handlers to only modify the write method if no further logic is needed for create and update. https://github.com/getkirby/kirby/pull/6457

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
