### PR TITLE
Changes 6: Version class improvements and unit tests

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -194,7 +194,7 @@ class Version
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @param string|null $language If null, all available languages will be touched
+	 * @param Language|string|null $language If null, all available languages will be touched
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
@@ -223,7 +223,7 @@ class Version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touchLanguage(Language|string $language = 'default'): void
+	protected function touchLanguage(Language|string $language = 'default'): void
 	{
 		// make sure the version exists
 		$this->ensure($language);

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -165,6 +165,8 @@ class Version
 
 	/**
 	 * Moves the version to a new language and/or version
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function move(
 		Language|string $fromLanguage,
@@ -184,6 +186,8 @@ class Version
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function read(Language|string $language = 'default'): array
 	{
@@ -194,38 +198,10 @@ class Version
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @param Language|string|null $language If null, all available languages will be touched
-	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(Language|string|null $language = null): void
+	public function touch(Language|string $language = 'default'): void
 	{
-		// touch a single language
-		if ($this->model->kirby()->multilang() === false) {
-			$this->touchLanguage('default');
-			return;
-		}
-
-		// touch a specific language
-		if ($language !== null) {
-			$this->touchLanguage($language);
-			return;
-		}
-
-		// touch all languages
-		foreach ($this->model->kirby()->languages() as $language) {
-			$this->touchLanguage($language);
-		}
-	}
-
-	/**
-	 * Updates the modification timestamp of a specific language
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
-	 */
-	protected function touchLanguage(Language|string $language = 'default'): void
-	{
-		// make sure the version exists
 		$this->ensure($language);
 		$this->model->storage()->touch($this->id, $this->language($language));
 	}

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -154,8 +154,11 @@ class Version
 	public function modified(
 		string $language = 'default'
 	): int|null {
-		$this->ensure($language);
-		return $this->model->storage()->modified($this->id, $this->language($language));
+		if ($this->exists($language) === true) {
+			return $this->model->storage()->modified($this->id, $this->language($language));
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -70,6 +70,7 @@ class Version
 		// delete the default language in single-language mode
 		if ($this->model->kirby()->multilang() === false) {
 			$this->model->storage()->delete($this->id, $this->language('default'));
+			return;
 		}
 
 		// delete all languages

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -86,16 +86,16 @@ class Version
 	public function ensure(
 		Language|string $language = 'default'
 	): bool {
-		if ($this->exists($language) !== true) {
-			$message = match($this->model->kirby()->multilang()) {
-				true  => 'Version "' . $this->id . ' (' . $language . ')" does not already exist',
-				false => 'Version "' . $this->id . '" does not already exist',
-			};
-
-			throw new NotFoundException($message);
+		if ($this->exists($language) === true) {
+			return true;
 		}
 
-		return true;
+		$message = match($this->model->kirby()->multilang()) {
+			true  => 'Version "' . $this->id . ' (' . $language . ')" does not already exist',
+			false => 'Version "' . $this->id . '" does not already exist',
+		};
+
+		throw new NotFoundException($message);
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -62,35 +62,19 @@ class Version
 	}
 
 	/**
-	 * Deletes a version by language or for any language
-	 *
-	 * @param string|null $language If null, all available languages will be deleted
+	 * Deletes a version with all its languages
 	 */
-	public function delete(string|null $language = null): void
+	public function delete(): void
 	{
-		// delete a single language
+		// delete the default language in single-language mode
 		if ($this->model->kirby()->multilang() === false) {
-			$this->deleteLanguage('default');
-		}
-
-		// delete a specific language
-		if ($language !== null) {
-			$this->deleteLanguage($language);
-			return;
+			$this->model->storage()->delete($this->id, $this->language('default'));
 		}
 
 		// delete all languages
 		foreach ($this->model->kirby()->languages() as $language) {
-			$this->deleteLanguage($language);
+			$this->model->storage()->delete($this->id, $language);
 		}
-	}
-
-	/**
-	 * Deletes a version by a specific language
-	 */
-	public function deleteLanguage(string $language = 'default'): void
-	{
-		$this->model->storage()->delete($this->id, $this->language($language));
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -31,7 +31,7 @@ class Version
 	/**
 	 * Returns a Content object for the given language
 	 */
-	public function content(string $language = 'default'): Content
+	public function content(Language|string $language = 'default'): Content
 	{
 		return new Content(
 			parent: $this->model,
@@ -46,18 +46,17 @@ class Version
 	 *
 	 * @internal
 	 */
-	public function contentFile(string $language = 'default'): string
+	public function contentFile(Language|string $language = 'default'): string
 	{
 		return $this->model->storage()->contentFile($this->id, $this->language($language));
 	}
 
 	/**
 	 * Creates a new version for the given language
-	 * @todo Convert to a static method that creates the version initially with all relevant languages
 	 *
 	 * @param array<string, string> $fields Content fields
 	 */
-	public function create(array $fields, string $language = 'default'): void
+	public function create(array $fields, Language|string $language = 'default'): void
 	{
 		$this->model->storage()->create($this->id, $this->language($language), $fields);
 	}
@@ -70,7 +69,6 @@ class Version
 		// delete the default language in single-language mode
 		if ($this->model->kirby()->multilang() === false) {
 			$this->model->storage()->delete($this->id, $this->language('default'));
-			return;
 		}
 
 		// delete all languages
@@ -86,7 +84,7 @@ class Version
 	 * @throws \Kirby\Exception\NotFoundException if the version does not exist
 	 */
 	public function ensure(
-		string $language = 'default'
+		Language|string $language = 'default'
 	): bool {
 		if ($this->exists($language) !== true) {
 			$message = match($this->model->kirby()->multilang()) {
@@ -103,7 +101,7 @@ class Version
 	/**
 	 * Checks if a version exists for the given language
 	 */
-	public function exists(string $language = 'default'): bool
+	public function exists(Language|string $language = 'default'): bool
 	{
 		return $this->model->storage()->exists($this->id, $this->language($language));
 	}
@@ -117,12 +115,18 @@ class Version
 	}
 
 	/**
-	 * Converts a "user-facing" language code to a `Language` object
-	 * to be used in storage methods
+	 * Converts a "user-facing" language code or Language object
+	 * to a `Language` object to be used in storage methods
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException if the language code does not match a valid language
 	 */
 	protected function language(
-		string|null $languageCode = null,
+		Language|string|null $languageCode = null,
 	): Language {
+		if ($languageCode instanceof Language) {
+			return $languageCode;
+		}
+
 		// single language
 		if ($this->model->kirby()->multilang() === false) {
 			return Language::single();
@@ -150,7 +154,7 @@ class Version
 	 * if it exists
 	 */
 	public function modified(
-		string $language = 'default'
+		Language|string $language = 'default'
 	): int|null {
 		if ($this->exists($language) === true) {
 			return $this->model->storage()->modified($this->id, $this->language($language));
@@ -162,8 +166,11 @@ class Version
 	/**
 	 * Moves the version to a new language and/or version
 	 */
-	public function move(string $fromLanguage, VersionId $toVersionId, string $toLanguage): void
-	{
+	public function move(
+		Language|string $fromLanguage,
+		VersionId $toVersionId,
+		Language|string $toLanguage
+	): void {
 		$this->ensure($fromLanguage);
 		$this->model->storage()->move(
 			fromVersionId: $this->id,
@@ -178,7 +185,7 @@ class Version
 	 *
 	 * @return array<string, string>
 	 */
-	public function read(string $language = 'default'): array
+	public function read(Language|string $language = 'default'): array
 	{
 		$this->ensure($language);
 		return $this->model->storage()->read($this->id, $this->language($language));
@@ -191,7 +198,7 @@ class Version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touch(string|null $language = null): void
+	public function touch(Language|string|null $language = null): void
 	{
 		// touch a single language
 		if ($this->model->kirby()->multilang() === false) {
@@ -216,7 +223,7 @@ class Version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function touchLanguage(string $language = 'default'): void
+	public function touchLanguage(Language|string $language = 'default'): void
 	{
 		// make sure the version exists
 		$this->ensure($language);
@@ -230,7 +237,7 @@ class Version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function update(array $fields, string $language = 'default'): void
+	public function update(array $fields, Language|string $language = 'default'): void
 	{
 		$this->ensure($language);
 		$this->model->storage()->update($this->id, $this->language($language), $fields);

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -40,6 +40,18 @@ class Version
 	}
 
 	/**
+	 * Provides simplified access to the absolute content file path.
+	 * This should stay an internal method and be removed as soon as
+	 * the dependency on file storage methods is resolved more clearly.
+	 *
+	 * @internal
+	 */
+	public function contentFile(string $language = 'default'): string
+	{
+		return $this->model->storage()->contentFile($this->id, $this->language($language));
+	}
+
+	/**
 	 * Creates a new version for the given language
 	 *
 	 * @param array<string, string> $fields Content fields

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -85,9 +85,9 @@ class Version
 	 */
 	public function ensure(
 		Language|string $language = 'default'
-	): bool {
+	): void {
 		if ($this->exists($language) === true) {
-			return true;
+			return;
 		}
 
 		$message = match($this->model->kirby()->multilang()) {

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -41,7 +41,7 @@ class Version
 
 	/**
 	 * Creates a new version for the given language
-     *
+	 *
 	 * @param array<string, string> $fields Content fields
 	 */
 	public function create(array $fields, string $language = 'default'): void
@@ -120,7 +120,7 @@ class Version
 
 	/**
 	 * Converts a "user-facing" language code to a `Language` object
-     * to be used in storage methods
+	 * to be used in storage methods
 	 */
 	protected function language(
 		string|null $languageCode = null,

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -53,6 +53,7 @@ class Version
 
 	/**
 	 * Creates a new version for the given language
+	 * @todo Convert to a static method that creates the version initially with all relevant languages
 	 *
 	 * @param array<string, string> $fields Content fields
 	 */

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -11,6 +11,7 @@ use Kirby\TestCase;
 
 /**
  * @coversDefaultClass Kirby\Content\Version
+ * @covers ::__construct
  */
 class VersionTest extends TestCase
 {

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -225,15 +225,22 @@ class VersionTest extends TestCase
 		);
 
 		$this->assertContentFileDoesNotExist('de');
+		$this->assertContentFileDoesNotExist('en');
 
-		$version->create([
+		Data::write($this->contentFile('en'), [
 			'title' => 'Test'
-		], 'de');
+		]);
 
+		Data::write($this->contentFile('de'), [
+			'title' => 'Test'
+		]);
+
+		$this->assertContentFileExists('en');
 		$this->assertContentFileExists('de');
 
-		$version->delete('de');
+		$version->delete();
 
+		$this->assertContentFileDoesNotExist('en');
 		$this->assertContentFileDoesNotExist('de');
 	}
 
@@ -252,7 +259,7 @@ class VersionTest extends TestCase
 
 		$this->assertContentFileDoesNotExist();
 
-		$version->create([
+		Data::write($this->contentFile(), [
 			'title' => 'Test'
 		]);
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -128,6 +128,7 @@ class VersionTest extends TestCase
 
 		$this->assertSame('Test', $version->content('en')->get('title')->value());
 		$this->assertSame('Test', $version->content($this->app->language('en'))->get('title')->value());
+		$this->assertSame('Test', $version->content()->get('title')->value());
 		$this->assertSame('Töst', $version->content('de')->get('title')->value());
 		$this->assertSame('Töst', $version->content($this->app->language('de'))->get('title')->value());
 	}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -310,8 +310,8 @@ class VersionTest extends TestCase
 			'title' => 'Test'
 		]);
 
-		$this->assertTrue($version->ensure('de'));
-		$this->assertTrue($version->ensure($this->app->language('de')));
+		$this->assertNull($version->ensure('de'));
+		$this->assertNull($version->ensure($this->app->language('de')));
 	}
 
 	/**
@@ -330,7 +330,7 @@ class VersionTest extends TestCase
 			'title' => 'Test'
 		]);
 
-		$this->assertTrue($version->ensure());
+		$this->assertNull($version->ensure());
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -669,36 +669,6 @@ class VersionTest extends TestCase
 	 * @covers ::touchLanguage
 	 * @covers ::language
 	 */
-	public function testTouchAllLanguages(): void
-	{
-		$this->setUpMultiLanguage();
-
-		$version = new Version(
-			model: $this->model,
-			id: VersionId::published()
-		);
-
-		touch($rootEN = $this->contentFile('en'), 123456);
-		touch($rootDE = $this->contentFile('de'), 123456);
-
-		$this->assertSame(123456, filemtime($rootEN));
-		$this->assertSame(123456, filemtime($rootDE));
-
-		$minTime = time();
-
-		$version->touch();
-
-		clearstatcache();
-
-		$this->assertGreaterThanOrEqual($minTime, filemtime($rootEN));
-		$this->assertGreaterThanOrEqual($minTime, filemtime($rootDE));
-	}
-
-	/**
-	 * @covers ::touch
-	 * @covers ::touchLanguage
-	 * @covers ::language
-	 */
 	public function testTouchMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -107,13 +107,13 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$version->create([
+		Data::write($this->contentFile('en'), [
 			'title' => 'Test'
-		], 'en');
+		]);
 
-		$version->create([
+		Data::write($this->contentFile('de'), [
 			'title' => 'Töst'
-		], 'de');
+		]);
 
 		$this->assertSame('Test', $version->content('en')->get('title')->value());
 		$this->assertSame('Töst', $version->content('de')->get('title')->value());
@@ -131,7 +131,7 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$version->create([
+		Data::write($this->contentFile(), [
 			'title' => 'Test'
 		]);
 
@@ -282,7 +282,10 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$version->create([], 'de');
+		Data::write($this->contentFile('de'), [
+			'title' => 'Test'
+		]);
+
 		$this->assertTrue($version->ensure('de'));
 	}
 
@@ -298,7 +301,10 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$version->create([]);
+		Data::write($this->contentFile(), [
+			'title' => 'Test'
+		]);
+
 		$this->assertTrue($version->ensure());
 	}
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -372,6 +372,22 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::modified
 	 */
+	public function testModifiedMultiLanguageIfNotExists(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertNull($version->modified('en'));
+		$this->assertNull($version->modified('de'));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
 	public function testModifiedSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -384,6 +400,21 @@ class VersionTest extends TestCase
 		touch($this->model->root() . '/article.txt', $modified = 123456);
 
 		$this->assertSame($modified, $version->modified());
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedSingleLanguageIfNotExists(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertNull($version->modified());
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Kirby\Cms\App;
 use Kirby\Data\Data;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
@@ -366,6 +367,25 @@ class VersionTest extends TestCase
 		$this->expectExceptionMessage('Version "published" does not already exist');
 
 		$version->ensure();
+	}
+
+	/**
+	 * @covers ::ensure
+	 * @covers ::language
+	 */
+	public function testEnsureWithInvalidLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid language: fr');
+
+		$version->ensure('fr');
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -666,7 +666,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::touch
-	 * @covers ::touchLanguage
 	 * @covers ::language
 	 */
 	public function testTouchMultiLanguage(): void
@@ -700,7 +699,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::touch
-	 * @covers ::touchLanguage
 	 */
 	public function testTouchSingleLanguage(): void
 	{

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 
@@ -14,18 +15,63 @@ class VersionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Version';
 
+	protected $app;
 	protected $model;
 
 	public function setUp(): void
 	{
 		Dir::make(static::TMP);
+	}
 
-		$this->model = new Page([
-			'kirby'    => new App(),
-			'root'     => static::TMP,
-			'slug'     => 'a-page',
-			'template' => 'article'
+	public function setUpMultiLanguage(): void
+	{
+		$this->app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'a-page',
+						'template' => 'article',
+					]
+				]
+			]
 		]);
+
+		$this->model = $this->app->page('a-page');
+
+		Dir::make($this->model->root());
+	}
+
+	public function setUpSingleLanguage(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'a-page',
+						'template' => 'article'
+					]
+				]
+			]
+		]);
+
+		$this->model = $this->app->page('a-page');
+
+		Dir::make($this->model->root());
 	}
 
 	public function tearDown(): void
@@ -35,29 +81,55 @@ class VersionTest extends TestCase
 	}
 
 	/**
-	 * @covers ::create
+	 * @covers ::content
 	 */
-	public function testCreate(): void
+	public function testContentMultiLanguage(): void
 	{
+		$this->setUpMultiLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
 		);
 
-		$this->assertFalse($version->exists());
+		$version->create([
+			'title' => 'Test'
+		], 'en');
+
+		$version->create([
+			'title' => 'Töst'
+		], 'de');
+
+		$this->assertSame('Test', $version->content('en')->get('title')->value());
+		$this->assertSame('Töst', $version->content('de')->get('title')->value());
+	}
+
+	/**
+	 * @covers ::content
+	 */
+	public function testContentSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
 
 		$version->create([
 			'title' => 'Test'
 		]);
 
-		$this->assertTrue($version->exists());
+		$this->assertSame('Test', $version->content()->get('title')->value());
 	}
 
 	/**
 	 * @covers ::create
 	 */
-	public function testCreateLanguage(): void
+	public function testCreateMultiLanguage(): void
 	{
+		$this->setUpMultiLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -73,10 +145,60 @@ class VersionTest extends TestCase
 	}
 
 	/**
-	 * @covers ::delete
+	 * @covers ::create
 	 */
-	public function testDelete(): void
+	public function testCreateSingleLanguage(): void
 	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists());
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$this->assertTrue($version->exists());
+	}
+
+	/**
+	 * @covers ::delete
+	 * @covers ::deleteLanguage
+	 */
+	public function testDeleteMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists('de'));
+
+		$version->create([
+			'title' => 'Test'
+		], 'de');
+
+		$this->assertTrue($version->exists('de'));
+
+		$version->delete('de');
+
+		$this->assertFalse($version->exists('de'));
+	}
+
+	/**
+	 * @covers ::delete
+	 * @covers ::deleteLanguage
+	 */
+	public function testDeleteSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -96,10 +218,99 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::ensure
+	 */
+	public function testEnsureMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create([], 'de');
+		$this->assertTrue($version->ensure('de'));
+	}
+
+	/**
+	 * @covers ::ensure
+	 */
+	public function testEnsureSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create([]);
+		$this->assertTrue($version->ensure());
+	}
+
+	/**
+	 * @covers ::ensure
+	 */
+	public function testEnsureWhenMissingMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Version "published (de)" does not already exist');
+
+		$version->ensure('de');
+	}
+
+	/**
+	 * @covers ::ensure
+	 */
+	public function testEnsureWhenMissingSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Version "published" does not already exist');
+
+		$version->ensure();
+	}
+
+	/**
 	 * @covers ::exists
 	 */
-	public function testExists(): void
+	public function testExistsMultiLanguage(): void
 	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFalse($version->exists('de'));
+
+		$version->create([], 'de');
+
+		$this->assertTrue($version->exists('de'));
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -117,6 +328,8 @@ class VersionTest extends TestCase
 	 */
 	public function testId(): void
 	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: $id = VersionId::published()
@@ -130,6 +343,8 @@ class VersionTest extends TestCase
 	 */
 	public function testModel(): void
 	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -139,10 +354,70 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		touch($this->model->root() . '/article.de.txt', $modified = 123456);
+
+		$this->assertSame($modified, $version->modified('de'));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		touch($this->model->root() . '/article.txt', $modified = 123456);
+
+		$this->assertSame($modified, $version->modified());
+	}
+
+	/**
 	 * @covers ::read
 	 */
-	public function testRead(): void
+	public function testReadMultiLanguage(): void
 	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create($contentEN = [
+			'title' => 'Test'
+		], 'en');
+
+		$version->create($contentDE = [
+			'title' => 'Töst'
+		], 'de');
+
+		$this->assertSame($contentEN, $version->read('en'));
+		$this->assertSame($contentDE, $version->read('de'));
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testReadSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -156,10 +431,87 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::touch
+	 * @covers ::touchLanguage
+	 */
+	public function testTouchMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		touch($root = $this->model->root() . '/article.de.txt', 123456);
+		$this->assertSame(123456, filemtime($root));
+
+		$minTime = time();
+
+		$version->touch('de');
+
+		clearstatcache();
+
+		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
+	}
+
+	/**
+	 * @covers ::touch
+	 * @covers ::touchLanguage
+	 */
+	public function testTouchSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		touch($root = $this->model->root() . '/article.txt', 123456);
+		$this->assertSame(123456, filemtime($root));
+
+		$minTime = time();
+
+		$version->touch();
+
+		clearstatcache();
+
+		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
+	}
+
+	/**
 	 * @covers ::update
 	 */
-	public function testUpdate(): void
+	public function testUpdateMultiLanguage(): void
 	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->create([
+			'title' => 'Test'
+		], 'de');
+
+		$this->assertSame('Test', $version->read('de')['title']);
+
+		$version->update([
+			'title' => 'Updated Title'
+		], 'de');
+
+		$this->assertSame('Updated Title', $version->read('de')['title']);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -213,7 +213,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::delete
-	 * @covers ::deleteLanguage
 	 */
 	public function testDeleteMultiLanguage(): void
 	{
@@ -246,7 +245,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::delete
-	 * @covers ::deleteLanguage
 	 */
 	public function testDeleteSingleLanguage(): void
 	{

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\App;
-use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -552,6 +552,36 @@ class VersionTest extends TestCase
 	 * @covers ::touchLanguage
 	 * @covers ::language
 	 */
+	public function testTouchAllLanguages(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		touch($rootEN = $this->contentFile('en'), 123456);
+		touch($rootDE = $this->contentFile('de'), 123456);
+
+		$this->assertSame(123456, filemtime($rootEN));
+		$this->assertSame(123456, filemtime($rootDE));
+
+		$minTime = time();
+
+		$version->touch();
+
+		clearstatcache();
+
+		$this->assertGreaterThanOrEqual($minTime, filemtime($rootEN));
+		$this->assertGreaterThanOrEqual($minTime, filemtime($rootDE));
+	}
+
+	/**
+	 * @covers ::touch
+	 * @covers ::touchLanguage
+	 * @covers ::language
+	 */
 	public function testTouchMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -123,6 +123,37 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::contentFile
+	 */
+	public function testContentFileMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertSame($this->model->root() . '/article.en.txt', $version->contentFile());
+		$this->assertSame($this->model->root() . '/article.de.txt', $version->contentFile('de'));
+	}
+
+	/**
+	 * @covers ::contentFile
+	 */
+	public function testContentFileSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertSame($this->model->root() . '/article.txt', $version->contentFile());
+	}
+
+	/**
 	 * @covers ::create
 	 */
 	public function testCreateMultiLanguage(): void

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -97,6 +97,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::content
+	 * @covers ::language
 	 */
 	public function testContentMultiLanguage(): void
 	{
@@ -116,7 +117,9 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertSame('Test', $version->content('en')->get('title')->value());
+		$this->assertSame('Test', $version->content($this->app->language('en'))->get('title')->value());
 		$this->assertSame('Töst', $version->content('de')->get('title')->value());
+		$this->assertSame('Töst', $version->content($this->app->language('de'))->get('title')->value());
 	}
 
 	/**
@@ -140,6 +143,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::contentFile
+	 * @covers ::language
 	 */
 	public function testContentFileMultiLanguage(): void
 	{
@@ -151,7 +155,10 @@ class VersionTest extends TestCase
 		);
 
 		$this->assertSame($this->contentFile('en'), $version->contentFile());
+		$this->assertSame($this->contentFile('en'), $version->contentFile('en'));
+		$this->assertSame($this->contentFile('en'), $version->contentFile($this->app->language('en')));
 		$this->assertSame($this->contentFile('de'), $version->contentFile('de'));
+		$this->assertSame($this->contentFile('de'), $version->contentFile($this->app->language('de')));
 	}
 
 	/**
@@ -171,6 +178,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::create
+	 * @covers ::language
 	 */
 	public function testCreateMultiLanguage(): void
 	{
@@ -181,12 +189,20 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
+		$this->assertContentFileDoesNotExist('en');
 		$this->assertContentFileDoesNotExist('de');
 
+		// with Language argument
+		$version->create([
+			'title' => 'Test'
+		], $this->app->language('en'));
+
+		// with string argument
 		$version->create([
 			'title' => 'Test'
 		], 'de');
 
+		$this->assertContentFileExists('en');
 		$this->assertContentFileExists('de');
 	}
 
@@ -270,6 +286,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::ensure
+	 * @covers ::language
 	 */
 	public function testEnsureMultiLanguage(): void
 	{
@@ -285,6 +302,7 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertTrue($version->ensure('de'));
+		$this->assertTrue($version->ensure($this->app->language('de')));
 	}
 
 	/**
@@ -344,6 +362,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::exists
+	 * @covers ::language
 	 */
 	public function testExistsMultiLanguage(): void
 	{
@@ -355,10 +374,12 @@ class VersionTest extends TestCase
 		);
 
 		$this->assertFalse($version->exists('de'));
+		$this->assertFalse($version->exists($this->app->language('de')));
 
 		Data::write($this->contentFile('de'), []);
 
 		$this->assertTrue($version->exists('de'));
+		$this->assertTrue($version->exists($this->app->language('de')));
 	}
 
 	/**
@@ -412,6 +433,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::modified
+	 * @covers ::language
 	 */
 	public function testModifiedMultiLanguage(): void
 	{
@@ -425,10 +447,12 @@ class VersionTest extends TestCase
 		touch($this->contentFile('de'), $modified = 123456);
 
 		$this->assertSame($modified, $version->modified('de'));
+		$this->assertSame($modified, $version->modified($this->app->language('de')));
 	}
 
 	/**
 	 * @covers ::modified
+	 * @covers ::language
 	 */
 	public function testModifiedMultiLanguageIfNotExists(): void
 	{
@@ -440,7 +464,9 @@ class VersionTest extends TestCase
 		);
 
 		$this->assertNull($version->modified('en'));
+		$this->assertNull($version->modified($this->app->language('en')));
 		$this->assertNull($version->modified('de'));
+		$this->assertNull($version->modified($this->app->language('de')));
 	}
 
 	/**
@@ -477,6 +503,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 * @covers ::language
 	 */
 	public function testReadMultiLanguage(): void
 	{
@@ -496,7 +523,9 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertSame($contentEN, $version->read('en'));
+		$this->assertSame($contentEN, $version->read($this->app->language('en')));
 		$this->assertSame($contentDE, $version->read('de'));
+		$this->assertSame($contentDE, $version->read($this->app->language('de')));
 	}
 
 	/**
@@ -521,6 +550,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::touch
 	 * @covers ::touchLanguage
+	 * @covers ::language
 	 */
 	public function testTouchMultiLanguage(): void
 	{
@@ -531,16 +561,24 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		touch($root = $this->contentFile('de'), 123456);
-		$this->assertSame(123456, filemtime($root));
+		touch($rootEN = $this->contentFile('en'), 123456);
+		touch($rootDE = $this->contentFile('de'), 123456);
+
+		$this->assertSame(123456, filemtime($rootEN));
+		$this->assertSame(123456, filemtime($rootDE));
 
 		$minTime = time();
 
+		// with Language argument
+		$version->touch($this->app->language('en'));
+
+		// with string argument
 		$version->touch('de');
 
 		clearstatcache();
 
-		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
+		$this->assertGreaterThanOrEqual($minTime, filemtime($rootEN));
+		$this->assertGreaterThanOrEqual($minTime, filemtime($rootDE));
 	}
 
 	/**
@@ -570,6 +608,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::update
+	 * @covers ::language
 	 */
 	public function testUpdateMultiLanguage(): void
 	{
@@ -580,15 +619,26 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		Data::write($file = $this->contentFile('de'), $content = [
-			'title' => 'Test'
+		Data::write($fileEN = $this->contentFile('en'), [
+			'title' => 'Test English'
 		]);
 
+		Data::write($fileDE = $this->contentFile('de'), [
+			'title' => 'Test Deutsch'
+		]);
+
+		// with Language argument
 		$version->update([
-			'title' => 'Updated Title'
+			'title' => 'Updated Title English'
+		], $this->app->language('en'));
+
+		// with string argument
+		$version->update([
+			'title' => 'Updated Title Deutsch'
 		], 'de');
 
-		$this->assertSame('Updated Title', Data::read($file)['title']);
+		$this->assertSame('Updated Title English', Data::read($fileEN)['title']);
+		$this->assertSame('Updated Title Deutsch', Data::read($fileDE)['title']);
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -135,6 +135,7 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::content
+	 * @covers ::language
 	 */
 	public function testContentSingleLanguage(): void
 	{


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449

### Refactoring

- Move more logic from `ContentStorage` to `Version` where it makes sense
  - `Version::contentFile`
  - Modified `Version::delete` to always delete all languages 
  - `Version::touchLanguage`
- Pass `Language` objects to storage methods
- Return null in `::modified` if a version does not exist.
- Add unit tests

### Outlook

- The new `VersionTest::setUpSingleLanguage` and `VersionTest::setUpMultiLanguage` methods turn out to be super useful. https://github.com/getkirby/kirby/pull/6454 will implement a new `Kirby\Content\TestCase` class with those setup methods and the `PlainTextContentStorageHandlerTest` and `VersionTest` classes will both extend them, which makes the tests a lot easier. We will also be able to use this for the `MemoryContentStorageHandlerTest` class later https://github.com/getkirby/kirby/pull/6457

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add changes & docs to release notes draft in Notion~ (not relevant as the `Version` class is added in v5 alpha 1)
