### PR TITLE
fix line break when label in block preview fields is too long

### DIFF
--- a/panel/src/components/Forms/Blocks/Types/Fields.vue
+++ b/panel/src/components/Forms/Blocks/Types/Fields.vue
@@ -99,6 +99,7 @@ export default {
 .k-block-type-fields-header .k-block-title {
 	padding-block: var(--spacing-3);
 	cursor: pointer;
+	white-space: nowrap;
 }
 
 .k-block-type-fields-form {


### PR DESCRIPTION
## This PR …
fixes this
![CleanShot 2024-05-20 at 12 22 07@2x](https://github.com/getkirby/kirby/assets/29142128/6529a2b3-2ad9-4721-82b4-81fda124983d)

### Fixes
Above

### Breaking changes
None


## Docs
None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
