### PR TITLE
Changes 7: Move ContentStorage methods to ContentStorageHandler

### DIFF
--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
 
 /**
  * Abstract for content storage handlers;
@@ -36,6 +37,28 @@ abstract class ContentStorageHandler
 	 * Deletes an existing version in an idempotent way if it was already deleted
 	 */
 	abstract public function delete(VersionId $versionId, Language $language): void;
+
+	/**
+	 * Returns all versions availalbe for the model that can be updated.
+	 *
+	 * @todo We might want to move this directly to the models later or work
+	 *       with a Versions class
+	 *
+	 * @internal
+	 */
+	public function dynamicVersions(): array
+	{
+		$versions = [VersionId::changes()];
+
+		if (
+			$this->model instanceof Page === false ||
+			$this->model->isDraft() === false
+		) {
+			$versions[] = VersionId::published();
+		}
+
+		return $versions;
+	}
 
 	/**
 	 * Checks if a version exists

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -102,6 +102,17 @@ abstract class ContentStorageHandler
 	): void;
 
 	/**
+	 * Adapts all versions when converting languages
+	 * @internal
+	 */
+	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
+	{
+		foreach ($this->dynamicVersions() as $versionId) {
+			$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
+		}
+	}
+
+	/**
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -140,6 +140,19 @@ abstract class ContentStorageHandler
 	abstract public function touch(VersionId $versionId, Language $language): void;
 
 	/**
+	 * Touches all versions of a language
+	 * @internal
+	 */
+	public function touchLanguage(Language $language): void
+	{
+		foreach ($this->dynamicVersions() as $version) {
+			if ($this->exists($version, $language) === true) {
+				$this->touch($version, $language);
+			}
+		}
+	}
+
+	/**
 	 * Updates the content fields of an existing version
 	 *
 	 * @param array<string, string> $fields Content fields

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -29,9 +29,9 @@ abstract class ContentStorageHandler
 
 	/**
 	 * Returns generator for all existing version-language combinations
+	 * @todo 5.0.0 Consider more descriptive name and maybe move to a different class
 	 *
 	 * @return Generator<\Kirby\Content\VersionId, \Kirby\Cms\Language>
-	 * @todo 5.0.0 Consider more descriptive name and maybe move to a different class
 	 */
 	public function all(): Generator
 	{
@@ -73,11 +73,9 @@ abstract class ContentStorageHandler
 
 	/**
 	 * Returns all versions available for the model that can be updated
-	 *
+	 * @internal
 	 * @todo We might want to move this directly to the models later or work
 	 *       with a `Versions` class
-	 *
-	 * @internal
 	 */
 	public function dynamicVersions(): array
 	{

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -30,7 +30,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Returns generator for all existing version-language combinations
 	 *
-	 * @return Generator<VersionId|Language>
+	 * @return Generator<\Kirby\Content\VersionId, \Kirby\Cms\Language>
 	 * @todo 5.0.0 Consider more descriptive name and maybe move to a different class
 	 */
 	public function all(): Generator

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -31,7 +31,7 @@ abstract class ContentStorageHandler
 	 * Returns generator for all existing versions-languages combinations
 	 *
 	 * @return Generator<VersionId|Language>
-	 * @todo 4.0.0 consider more descpritive name
+	 * @todo 4.0.0 consider more descpritive name and maybe move to a different class
 	 */
 	public function all(): Generator
 	{
@@ -62,6 +62,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Deletes all versions when deleting a language
 	 * @internal
+	 * @todo Move to Language class
 	 */
 	public function deleteLanguage(Language $language): void
 	{
@@ -115,6 +116,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Adapts all versions when converting languages
 	 * @internal
+	 * @todo Move to Language class
 	 */
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
@@ -142,6 +144,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Touches all versions of a language
 	 * @internal
+	 * @todo Move to Language class
 	 */
 	public function touchLanguage(Language $language): void
 	{

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -60,6 +60,17 @@ abstract class ContentStorageHandler
 	abstract public function delete(VersionId $versionId, Language $language): void;
 
 	/**
+	 * Deletes all versions when deleting a language
+	 * @internal
+	 */
+	public function deleteLanguage(Language $language): void
+	{
+		foreach ($this->dynamicVersions() as $version) {
+			$this->delete($version, $language);
+		}
+	}
+
+	/**
 	 * Returns all versions availalbe for the model that can be updated.
 	 *
 	 * @todo We might want to move this directly to the models later or work

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -28,10 +28,10 @@ abstract class ContentStorageHandler
 	}
 
 	/**
-	 * Returns generator for all existing versions-languages combinations
+	 * Returns generator for all existing version-language combinations
 	 *
 	 * @return Generator<VersionId|Language>
-	 * @todo 4.0.0 consider more descpritive name and maybe move to a different class
+	 * @todo 5.0.0 Consider more descriptive name and maybe move to a different class
 	 */
 	public function all(): Generator
 	{
@@ -62,7 +62,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Deletes all versions when deleting a language
 	 * @internal
-	 * @todo Move to Language class
+	 * @todo Move to `Language` class
 	 */
 	public function deleteLanguage(Language $language): void
 	{
@@ -72,10 +72,10 @@ abstract class ContentStorageHandler
 	}
 
 	/**
-	 * Returns all versions availalbe for the model that can be updated.
+	 * Returns all versions available for the model that can be updated
 	 *
 	 * @todo We might want to move this directly to the models later or work
-	 *       with a Versions class
+	 *       with a `Versions` class
 	 *
 	 * @internal
 	 */
@@ -116,7 +116,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Adapts all versions when converting languages
 	 * @internal
-	 * @todo Move to Language class
+	 * @todo Move to `Language` class
 	 */
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
@@ -144,7 +144,7 @@ abstract class ContentStorageHandler
 	/**
 	 * Touches all versions of a language
 	 * @internal
-	 * @todo Move to Language class
+	 * @todo Move to `Language` class
 	 */
 	public function touchLanguage(Language $language): void
 	{

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Generator;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
@@ -24,6 +25,26 @@ abstract class ContentStorageHandler
 {
 	public function __construct(protected ModelWithContent $model)
 	{
+	}
+
+	/**
+	 * Returns generator for all existing versions-languages combinations
+	 *
+	 * @return Generator<VersionId|Language>
+	 * @todo 4.0.0 consider more descpritive name
+	 */
+	public function all(): Generator
+	{
+		$kirby     = $this->model->kirby();
+		$languages = $kirby->multilang() === false ? [Language::single()] : $kirby->languages();
+
+		foreach ($languages as $language) {
+			foreach ($this->dynamicVersions() as $versionId) {
+				if ($this->exists($versionId, $language) === true) {
+					yield $versionId => $language;
+				}
+			}
+		}
 	}
 
 	/**

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass Kirby\Content\ContentStorageHandler
+ * @covers ::__construct
+ */
+class ContentStorageHandlerTest extends TestCase
+{
+	/**
+	 * @covers ::dynamicVersions
+	 */
+	public function testDynamicVersionsForFile()
+	{
+		$handler = new TestContentStorageHandler(
+			new File([
+				'filename' => 'test.jpg',
+				'parent'   => new Page(['slug' => 'test'])
+			])
+		);
+
+		$versions = $handler->dynamicVersions();
+
+		$this->assertCount(2, $versions);
+		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
+		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
+	}
+
+	/**
+	 * @covers ::dynamicVersions
+	 */
+	public function testDynamicVersionsForPage()
+	{
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => false])
+		);
+
+		$versions = $handler->dynamicVersions();
+
+		$this->assertCount(2, $versions);
+		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
+		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
+	}
+
+	/**
+	 * @covers ::dynamicVersions
+	 */
+	public function testDynamicVersionsForPageDraft()
+	{
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => true])
+		);
+
+		$versions = $handler->dynamicVersions();
+
+		$this->assertCount(1, $versions);
+		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
+	}
+
+	/**
+	 * @covers ::dynamicVersions
+	 */
+	public function testDynamicVersionsForSite()
+	{
+		$handler = new TestContentStorageHandler(
+			new Site()
+		);
+
+		$versions = $handler->dynamicVersions();
+
+		$this->assertCount(2, $versions);
+		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
+		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
+	}
+
+	/**
+	 * @covers ::dynamicVersions
+	 */
+	public function testDynamicVersionsForUser()
+	{
+		$handler = new TestContentStorageHandler(
+			new User(['email' => 'test@getkirby.com'])
+		);
+
+		$versions = $handler->dynamicVersions();
+
+		$this->assertCount(2, $versions);
+		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
+		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
+	}
+}

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -6,7 +6,6 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
-use Kirby\TestCase;
 
 /**
  * @coversDefaultClass Kirby\Content\ContentStorageHandler
@@ -14,6 +13,131 @@ use Kirby\TestCase;
  */
 class ContentStorageHandlerTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Content.ContentStorageHandler';
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllMultiLanguageForFile()
+	{
+		$this->setUpMultiLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new File([
+				'filename' => 'test.jpg',
+				'parent'   => new Page(['slug' => 'test'])
+			])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// The TestContentStorage handler always returns true
+		// for every version and language. Thus there should be
+		// 2 versions for every language.
+		//
+		// article.en.txt
+		// article.de.txt
+		// _changes/article.en.txt
+		// _changes/article.de.txt
+		$this->assertCount(4, $versions);
+	}
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllSingleLanguageForFile()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new File([
+				'filename' => 'test.jpg',
+				'parent'   => new Page(['slug' => 'test'])
+			])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// The TestContentStorage handler always returns true
+		// for every version and language. Thus there should be
+		// 2 versions in a single language installation.
+		//
+		// article.txt
+		// _changes/article.txt
+		$this->assertCount(2, $versions);
+	}
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllMultiLanguageForPage()
+	{
+		$this->setUpMultiLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => false])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// A page that's not in draft mode can have published and changes versions
+		// and thus should have changes and published for every language
+		$this->assertCount(4, $versions);
+	}
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllMultiLanguageForPageDraft()
+	{
+		$this->setUpMultiLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => true])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// A draft page has only changes and thus should only have
+		// a changes for every language, but no published versions
+		$this->assertCount(2, $versions);
+	}
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllSingleLanguageForPage()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => false])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// A page that's not in draft mode can have published and changes versions
+		$this->assertCount(2, $versions);
+	}
+
+	/**
+	 * @covers ::all
+	 */
+	public function testAllSingleLanguageForPageDraft()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestContentStorageHandler(
+			new Page(['slug' => 'test', 'isDraft' => true])
+		);
+
+		$versions = iterator_to_array($handler->all(), false);
+
+		// A draft page has only changes and thus should only have
+		// a single version in a single language installation
+		$this->assertCount(1, $versions);
+	}
+
 	/**
 	 * @covers ::dynamicVersions
 	 */

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
@@ -10,7 +9,6 @@ use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
-use Kirby\TestCase;
 
 /**
  * @coversDefaultClass Kirby\Content\PlainTextContentStorageHandler
@@ -20,71 +18,20 @@ class PlainTextContentStorageHandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.PlainTextContentStorage';
 
-	protected $model;
 	protected $storage;
-
-	public function setUp(): void
-	{
-		Dir::make(static::TMP);
-	}
 
 	public function setUpMultiLanguage(): void
 	{
-		$this->app = new App([
-			'languages' => [
-				[
-					'code'    => 'en',
-					'default' => true
-				],
-				[
-					'code' => 'de'
-				]
-			],
-			'roots' => [
-				'index' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'a-page',
-						'template' => 'article',
-					]
-				]
-			]
-		]);
+		parent::setUpMultiLanguage();
 
-		$this->model   = $this->app->page('a-page');
 		$this->storage = new PlainTextContentStorageHandler($this->model);
-
-		Dir::make($this->model->root());
 	}
 
 	public function setUpSingleLanguage(): void
 	{
-		$this->app = new App([
-			'roots' => [
-				'index' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'a-page',
-						'template' => 'article'
-					]
-				]
-			]
-		]);
+		parent::setUpSingleLanguage();
 
-		$this->model   = $this->app->page('a-page');
 		$this->storage = new PlainTextContentStorageHandler($this->model);
-
-		Dir::make($this->model->root());
-	}
-
-	public function tearDown(): void
-	{
-		App::destroy();
-		Dir::remove(static::TMP);
 	}
 
 	/**

--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\App;
+use Kirby\Filesystem\Dir;
+use Kirby\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+	public const TMP = KIRBY_TMP_DIR;
+
+	protected $app;
+	protected $model;
+
+	public function setUp(): void
+	{
+		Dir::make(static::TMP);
+	}
+
+	public function setUpMultiLanguage(): void
+	{
+		$this->app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'a-page',
+						'template' => 'article',
+					]
+				]
+			]
+		]);
+
+		$this->model = $this->app->page('a-page');
+
+		Dir::make($this->model->root());
+	}
+
+	public function setUpSingleLanguage(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'a-page',
+						'template' => 'article'
+					]
+				]
+			]
+		]);
+
+		$this->model = $this->app->page('a-page');
+
+		Dir::make($this->model->root());
+	}
+
+	public function tearDown(): void
+	{
+		App::destroy();
+		Dir::remove(static::TMP);
+	}
+}

--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -10,7 +10,6 @@ class TestCase extends BaseTestCase
 {
 	public const TMP = KIRBY_TMP_DIR;
 
-	protected $app;
 	protected $model;
 
 	public function setUp(): void

--- a/tests/Content/TestContentStorageHandler.php
+++ b/tests/Content/TestContentStorageHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+
+class TestContentStorageHandler extends ContentStorageHandler
+{
+	public function create(VersionId $versionId, Language $language, array $fields): void
+	{
+	}
+
+	public function delete(VersionId $versionId, Language $language): void
+	{
+	}
+
+	public function exists(VersionId $versionId, Language $language): bool
+	{
+	}
+
+	public function modified(VersionId $versionId, Language $language): int|null
+	{
+	}
+
+	public function move(
+		VersionId $fromVersionId,
+		Language $fromLanguage,
+		VersionId $toVersionId,
+		Language $toLanguage
+	): void {
+	}
+
+	public function read(VersionId $versionId, Language $language): array
+	{
+	}
+
+	public function touch(VersionId $versionId, Language $language): void
+	{
+	}
+
+	public function update(VersionId $versionId, Language $language, array $fields): void
+	{
+	}
+}

--- a/tests/Content/TestContentStorageHandler.php
+++ b/tests/Content/TestContentStorageHandler.php
@@ -16,10 +16,12 @@ class TestContentStorageHandler extends ContentStorageHandler
 
 	public function exists(VersionId $versionId, Language $language): bool
 	{
+		return true;
 	}
 
 	public function modified(VersionId $versionId, Language $language): int|null
 	{
+		return null;
 	}
 
 	public function move(
@@ -32,6 +34,7 @@ class TestContentStorageHandler extends ContentStorageHandler
 
 	public function read(VersionId $versionId, Language $language): array
 	{
+		return [];
 	}
 
 	public function touch(VersionId $versionId, Language $language): void

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -2,12 +2,9 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\App;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
-use Kirby\Filesystem\Dir;
-use Kirby\TestCase;
 
 /**
  * @coversDefaultClass Kirby\Content\Version
@@ -16,8 +13,6 @@ use Kirby\TestCase;
 class VersionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Version';
-
-	protected $model;
 
 	public function assertContentFileExists(string|null $language = null, VersionId|null $versionId = null)
 	{
@@ -40,68 +35,6 @@ class VersionTest extends TestCase
 			// language code
 			($language === null ? '' : '.' . $language) .
 			'.txt';
-	}
-
-	public function setUp(): void
-	{
-		Dir::make(static::TMP);
-	}
-
-	public function setUpMultiLanguage(): void
-	{
-		$this->app = new App([
-			'languages' => [
-				[
-					'code'    => 'en',
-					'default' => true
-				],
-				[
-					'code' => 'de'
-				]
-			],
-			'roots' => [
-				'index' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'a-page',
-						'template' => 'article',
-					]
-				]
-			]
-		]);
-
-		$this->model = $this->app->page('a-page');
-
-		Dir::make($this->model->root());
-	}
-
-	public function setUpSingleLanguage(): void
-	{
-		$this->app = new App([
-			'roots' => [
-				'index' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'a-page',
-						'template' => 'article'
-					]
-				]
-			]
-		]);
-
-		$this->model = $this->app->page('a-page');
-
-		Dir::make($this->model->root());
-	}
-
-	public function tearDown(): void
-	{
-		App::destroy();
-		Dir::remove(static::TMP);
 	}
 
 	/**


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450

### Refactoring

- Add methods from ContentStorage to ContentStorageHandler to prepare the removal of the ContentStorage class
  - `ContentStorageHandler::all`
  - `ContentStorageHandler::deleteLanguage`
  - `ContentStorageHandler::dynamicVersions`
  - `ContentStorageHandler::moveLanguage` (formerly `ContentStorage::convertLanguage`)
  - `ContentStorageHandler::touchLanguage`
- Added unit tests for …
  - `ContentStorageHandler::all`
  - `ContentStorageHandler::dynamicVersions`

The other methods are hard to test for the abstract class. We should probably add tests for the PlainTextContentStorageHandler class but so far all those tests have been missing anyway.

### Outlook 

- The `ContentStorage` class cannot be removed yet. That step would be too much. First, the new `ModelWithContent::version` method needs to be implemented, which happens here: https://github.com/getkirby/kirby/pull/6455 This PR also takes care of using `::version` instead of direct access to `$this->storage()` in all model action methods whereever possible. 
- Once the new `ModelWithContent::version()` method is implemented, https://github.com/getkirby/kirby/pull/6456 will remove the ContentStorage class. This will also require a few unit tests to be refactored and the `Language` class needs adjustments. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add changes & docs to release notes draft in Notion~ (not relevant as the changes are purely internal and temporary)