### PR TITLE
Changes 8: New ModelWithContent::version method

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -426,7 +426,7 @@ class File extends ModelWithContent
 	 */
 	protected function modifiedContent(string|null $languageCode = null): int
 	{
-		return $this->version(VersionId::published())->modified($languageCode ?? 'default') ?? 0;
+		return $this->version(VersionId::published())->modified($languageCode ?? 'current') ?? 0;
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -426,7 +426,7 @@ class File extends ModelWithContent
 	 */
 	protected function modifiedContent(string|null $languageCode = null): int
 	{
-		return $this->storage()->modified(VersionId::published(), $languageCode) ?? 0;
+		return $this->version(VersionId::published())->modified($languageCode ?? 'default') ?? 0;
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -755,10 +755,10 @@ abstract class ModelWithContent implements Identifiable, Stringable
 
 		try {
 			// we can only update if the version already exists
-			$this->storage()->update($id, $languageCode, $data);
+			$this->version($id)->update($data, $languageCode ?? 'default');
 		} catch (NotFoundException) {
 			// otherwise create a new version
-			$this->storage()->create($id, $languageCode, $data);
+			$this->version($id)->create($data, $languageCode ?? 'default');
 		}
 
 		return true;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -202,10 +202,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 					$content = $this->content($code)->convertTo($blueprint);
 
 					// delete the old text file
-					$this->storage()->delete(
-						$identifier,
-						$code
-					);
+					$this->version($identifier)->delete($code);
 
 					// save to re-create the translation content file
 					// with the converted/updated content
@@ -229,7 +226,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$content = $this->content()->convertTo($blueprint);
 
 		// delete the old text file
-		$this->storage()->delete($identifier, 'default');
+		$this->version($identifier)->delete('default');
 
 		return $new->save($content);
 	}

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -416,7 +416,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	public function readContent(string|null $languageCode = null): array
 	{
 		try {
-			return $this->version(VersionId::default($this))->read($languageCode ?? 'default');
+			return $this->version()->read($languageCode ?? 'default');
 		} catch (NotFoundException) {
 			// only if the content file really does not exist, it's ok
 			// to return empty content. Otherwise this could lead to
@@ -745,14 +745,16 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
 		$data = $this->contentFileData($data, $languageCode);
-		$id   = VersionId::default($this);
+
+		// update the default language, unless a specific language is passed
+		$languageCode ??= 'default';
 
 		try {
 			// we can only update if the version already exists
-			$this->version($id)->update($data, $languageCode ?? 'default');
+			$this->version()->update($data, $languageCode);
 		} catch (NotFoundException) {
 			// otherwise create a new version
-			$this->version($id)->create($data, $languageCode ?? 'default');
+			$this->version()->create($data, $languageCode);
 		}
 
 		return true;

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -419,10 +419,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	public function readContent(string|null $languageCode = null): array
 	{
 		try {
-			return $this->storage()->read(
-				VersionId::default($this),
-				$languageCode
-			);
+			return $this->version(VersionId::default($this))->read($languageCode ?? 'default');
 		} catch (NotFoundException) {
 			// only if the content file really does not exist, it's ok
 			// to return empty content. Otherwise this could lead to

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -729,11 +729,11 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 * Returns a content version instance
 	 * @since 5.0.0
 	 */
-	public function version(VersionId|string $versionId): Version
+	public function version(VersionId|string|null $versionId = null): Version
 	{
 		return new Version(
 			model: $this,
-			id: VersionId::from($versionId)
+			id: VersionId::from($versionId ?? VersionId::default($this))
 		);
 	}
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -7,6 +7,7 @@ use Kirby\Content\Content;
 use Kirby\Content\ContentStorage;
 use Kirby\Content\ContentTranslation;
 use Kirby\Content\PlainTextContentStorageHandler;
+use Kirby\Content\Version;
 use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
@@ -728,6 +729,18 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	public function uuid(): Uuid|null
 	{
 		return Uuid::for($this);
+	}
+
+	/**
+	 * Returns a content version instance
+	 * @since 5.0.0
+	 */
+	public function version(VersionId|string $versionId): Version
+	{
+		return new Version(
+			model: $this,
+			id: VersionId::from($versionId)
+		);
 	}
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -4,7 +4,6 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Content\Field;
-use Kirby\Content\VersionId;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -830,7 +830,7 @@ class Page extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false|null {
-		$modified = $this->version(VersionId::default($this))->modified(
+		$modified = $this->version()->modified(
 			$languageCode ?? 'current'
 		);
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -830,9 +830,8 @@ class Page extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false|null {
-		$modified = $this->storage()->modified(
-			VersionId::default($this),
-			$languageCode
+		$modified = $this->version(VersionId::default($this))->modified(
+			$languageCode ?? 'current'
 		);
 
 		if ($modified === null) {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -76,10 +76,7 @@ class System
 
 		switch ($folder) {
 			case 'content':
-				return $url . '/' . basename($this->app->site()->storage()->contentFile(
-					VersionId::published(),
-					'default'
-				));
+				return $url . '/' . basename($this->app->site()->version(VersionId::published())->contentFile());
 			case 'git':
 				return $url . '/config';
 			case 'kirby':

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -208,10 +208,7 @@ class User extends ModelWithContent
 	 */
 	public function exists(): bool
 	{
-		return $this->storage()->exists(
-			VersionId::published(),
-			'default'
-		);
+		return $this->version(VersionId::published())->exists('default');
 	}
 
 	/**
@@ -473,7 +470,7 @@ class User extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false {
-		$modifiedContent = $this->storage()->modified(VersionId::published(), $languageCode);
+		$modifiedContent = $this->version(VersionId::published())->modified($languageCode ?? 'current');
 		$modifiedIndex   = F::modified($this->root() . '/index.php');
 		$modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
 

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -85,7 +85,7 @@ class ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		return $this->contentFile = $this->parent->version(VersionId::default($this->parent))->contentFile($this->code);
+		return $this->contentFile = $this->parent->version()->contentFile($this->code);
 	}
 
 	/**

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -85,10 +85,7 @@ class ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		return $this->contentFile = $this->parent->storage()->contentFile(
-			VersionId::default($this->parent),
-			$this->code
-		);
+		return $this->contentFile = $this->parent->version(VersionId::default($this->parent))->contentFile($this->code);
 	}
 
 	/**

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -79,9 +79,9 @@ class VersionId implements Stringable
 	/**
 	 * Creates a VersionId instance from a simple string value
 	 */
-	public static function from(self|string $value): static
+	public static function from(VersionId|string $value): static
 	{
-		if ($value instanceof static) {
+		if ($value instanceof VersionId) {
 			return $value;
 		}
 

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -79,8 +79,12 @@ class VersionId implements Stringable
 	/**
 	 * Creates a VersionId instance from a simple string value
 	 */
-	public static function from(string $value): static
+	public static function from(self|string $value): static
 	{
+		if ($value instanceof static) {
+			return $value;
+		}
+
 		return new static($value);
 	}
 

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -104,19 +104,19 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile(VersionId::published(), 'default'), '');
+		F::write($file->version(VersionId::published())->contentFile('default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileExists($file->version(VersionId::published())->contentFile('default'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotSame($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileExists($result->version(VersionId::published())->contentFile('default'));
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileDoesNotExist($file->version(VersionId::published())->contentFile('default'));
 	}
 
 	public static function fileProviderMultiLang(): array
@@ -140,20 +140,20 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and empty content files for it
-		F::write($file->storage()->contentFile(VersionId::published(), 'en'), '');
-		F::write($file->storage()->contentFile(VersionId::published(), 'de'), '');
+		F::write($file->version(VersionId::published())->contentFile('en'), '');
+		F::write($file->version(VersionId::published())->contentFile('de'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'en'));
-		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'de'));
+		$this->assertFileExists($file->version(VersionId::published())->contentFile('en'));
+		$this->assertFileExists($file->version(VersionId::published())->contentFile('de'));
 
 		$result = $file->changeName('test');
 
 		$this->assertNotEquals($file->root(), $result->root());
 		$this->assertSame('test.csv', $result->filename());
 		$this->assertFileExists($result->root());
-		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'en'));
-		$this->assertFileExists($result->storage()->contentFile(VersionId::published(), 'de'));
+		$this->assertFileExists($result->version(VersionId::published())->contentFile('en'));
+		$this->assertFileExists($result->version(VersionId::published())->contentFile('de'));
 	}
 
 	public function testChangeTemplate()
@@ -375,9 +375,9 @@ class FileActionsTest extends TestCase
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Das ist der Text', $modified->text()->value());
 
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'en'));
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::published(), 'fr'));
+		$this->assertFileExists($modified->version(VersionId::published())->contentFile('en'));
+		$this->assertFileExists($modified->version(VersionId::published())->contentFile('de'));
+		$this->assertFileDoesNotExist($modified->version(VersionId::published())->contentFile('fr'));
 	}
 
 	public function testChangeTemplateDefault()
@@ -753,17 +753,17 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->storage()->contentFile(VersionId::published(), 'default'), '');
+		F::write($file->version(VersionId::published())->contentFile('default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileExists($file->version(VersionId::published())->contentFile('default'));
 
 		$result = $file->delete();
 
 		$this->assertTrue($result);
 
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileDoesNotExist($file->version(VersionId::published())->contentFile('default'));
 	}
 
 	/**
@@ -873,11 +873,11 @@ class FileActionsTest extends TestCase
 		F::write($file->root(), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileDoesNotExist($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileDoesNotExist($file->version(VersionId::published())->contentFile('default'));
 
 		$file = $file->clone(['content' => ['caption' => 'save']])->save();
 
-		$this->assertFileExists($file->storage()->contentFile(VersionId::published(), 'default'));
+		$this->assertFileExists($file->version(VersionId::published())->contentFile('default'));
 	}
 
 	/**

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Content\Version;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Page as PanelPage;
 use Kirby\Uuid\PageUuid;
@@ -442,5 +443,14 @@ class ModelWithContentTest extends TestCase
 
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(PageUuid::class, $model->uuid());
+	}
+
+	public function testVersion()
+	{
+		$model = new Site();
+		$this->assertInstanceOf(Version::class, $model->version('published'));
+
+		$model = new Page(['slug' => 'foo']);
+		$this->assertInstanceOf(Version::class, $model->version('published'));
 	}
 }

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -449,11 +449,11 @@ class ModelWithContentTest extends TestCase
 	{
 		$model = new Site();
 		$this->assertInstanceOf(Version::class, $model->version('published'));
-		$this->assertSame('published', $model->version()->id()->value());
+		$this->assertSame('published', $model->version('published')->id()->value());
 
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(Version::class, $model->version('published'));
-		$this->assertSame('published', $model->version()->id()->value());
+		$this->assertSame('published', $model->version('published')->id()->value());
 	}
 
 	public function testVersionFallback()

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Content\Version;
+use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Page as PanelPage;
 use Kirby\Uuid\PageUuid;
@@ -450,10 +451,12 @@ class ModelWithContentTest extends TestCase
 		$model = new Site();
 		$this->assertInstanceOf(Version::class, $model->version('published'));
 		$this->assertSame('published', $model->version('published')->id()->value());
+		$this->assertSame('published', $model->version(VersionId::published())->id()->value());
 
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(Version::class, $model->version('published'));
 		$this->assertSame('published', $model->version('published')->id()->value());
+		$this->assertSame('published', $model->version(VersionId::published())->id()->value());
 	}
 
 	public function testVersionFallback()

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -449,8 +449,21 @@ class ModelWithContentTest extends TestCase
 	{
 		$model = new Site();
 		$this->assertInstanceOf(Version::class, $model->version('published'));
+		$this->assertSame('published', $model->version()->id()->value());
 
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(Version::class, $model->version('published'));
+		$this->assertSame('published', $model->version()->id()->value());
+	}
+
+	public function testVersionFallback()
+	{
+		$model = new Page(['slug' => 'foo']);
+		$this->assertInstanceOf(Version::class, $model->version());
+		$this->assertSame('published', $model->version()->id()->value());
+
+		$model = new Page(['slug' => 'foo', 'isDraft' => true]);
+		$this->assertInstanceOf(Version::class, $model->version());
+		$this->assertSame('changes', $model->version()->id()->value());
 	}
 }

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -422,9 +422,9 @@ class PageActionsTest extends TestCase
 		$this->assertSame('article', $modified->intendedTemplate()->name());
 		$this->assertSame(2, $calls);
 
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'en'));
-		$this->assertFileExists($modified->storage()->contentFile(VersionId::published(), 'de'));
-		$this->assertFileDoesNotExist($modified->storage()->contentFile(VersionId::published(), 'fr'));
+		$this->assertFileExists($modified->version(VersionId::published())->contentFile('en'));
+		$this->assertFileExists($modified->version(VersionId::published())->contentFile('de'));
+		$this->assertFileDoesNotExist($modified->version(VersionId::published())->contentFile('fr'));
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Text', $modified->text()->value());
 		$this->assertNull($modified->content('de')->get('caption')->value());
@@ -889,15 +889,15 @@ class PageActionsTest extends TestCase
 			'parent' => $page,
 			'code'   => 'en',
 		]);
-		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'en'));
+		$this->assertFileExists($page->version(VersionId::changes())->contentFile('en'));
 
 		$drafts = $app->site()->drafts();
 		$childrenAndDrafts = $app->site()->childrenAndDrafts();
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileExists($copy->storage()->contentFile(VersionId::changes(), 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::changes(), 'de'));
+		$this->assertFileExists($copy->version(VersionId::changes())->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version(VersionId::changes())->contentFile('de'));
 
 		$this->assertIsPage($page, $drafts->find('test'));
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
@@ -929,8 +929,8 @@ class PageActionsTest extends TestCase
 			'slug'  => 'test-de'
 		], 'de');
 
-		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'en'));
-		$this->assertFileExists($page->storage()->contentFile(VersionId::changes(), 'de'));
+		$this->assertFileExists($page->version(VersionId::changes())->contentFile('en'));
+		$this->assertFileExists($page->version(VersionId::changes())->contentFile('de'));
 		$this->assertSame('test', $page->slug());
 		$this->assertSame('test-de', $page->slug('de'));
 
@@ -1044,8 +1044,8 @@ class PageActionsTest extends TestCase
 
 		$copy = $page->duplicate('test-copy', ['children' => true]);
 
-		$this->assertFileExists($copy->storage()->contentFile(VersionId::changes(), 'en'));
-		$this->assertFileDoesNotExist($copy->storage()->contentFile(VersionId::changes(), 'de'));
+		$this->assertFileExists($copy->version(VersionId::changes())->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version(VersionId::changes())->contentFile('de'));
 
 
 		$this->assertNotSame($page->uuid()->id(), $copy->uuid()->id());

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -59,10 +59,19 @@ class VersionIdTest extends TestCase
 	 * @covers ::from
 	 * @covers ::value
 	 */
-	public function testFrom()
+	public function testFromString()
 	{
 		$version = VersionId::from('published');
+		$this->assertSame('published', $version->value());
+	}
 
+	/**
+	 * @covers ::from
+	 * @covers ::value
+	 */
+	public function testFromInstance()
+	{
+		$version = VersionId::from(VersionId::published());
 		$this->assertSame('published', $version->value());
 	}
 


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454

### Features

- New `ModelWithContent::version()` method

### Refactoring

- Use new version method wherever it makes sense. 
  - `ModelWithContent::convertTo`
  - `ModelWithContent::readContent`
  - `ModelWithContent::writeContent`
  - `File::modifiedContent`
  - `Page::modified`
  - `System::exposedFileUrl`
  - `User::exists`
  - `User::modified`
  - `ContentTranslation::contentFile`
  - `FileActionsTest`
  - `PageActionsTest`

The other methods are hard to test for the abstract class. We should probably add tests for the PlainTextContentStorageHandler class but so far all those tests have been missing anyway.

### Breaking changes

- `ModelWithContent::version()` is now a reserved keyword. If you've used a field with this name, you need to use `$model->content()->get('version')` instead to work with the field.
- `Page::modified()`, `File::modifiedContent()` and `User::modified()` now use the current language instead of the default language.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
