### PR TITLE
Changes 10: New MemoryContentStorageHandler

### DIFF
--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -101,18 +101,18 @@ abstract class ContentStorageHandler
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function ensure(VersionId $versionId, Language $language): bool
+	public function ensure(VersionId $versionId, Language $language): void
 	{
-		if ($this->exists($versionId, $language) !== true) {
-			$message = match($this->model->kirby()->multilang()) {
-				true  => 'Version "' . $versionId . ' (' . $language->code() . ')" does not already exist',
-				false => 'Version "' . $versionId . '" does not already exist',
-			};
-
-			throw new NotFoundException($message);
+		if ($this->exists($versionId, $language) === true) {
+			return;
 		}
 
-		return true;
+		$message = match($this->model->kirby()->multilang()) {
+			true  => 'Version "' . $versionId . ' (' . $language->code() . ')" does not already exist',
+			false => 'Version "' . $versionId . '" does not already exist',
+		};
+
+		throw new NotFoundException($message);
 	}
 
 	/**

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -97,7 +97,7 @@ abstract class ContentStorageHandler
 
 	/**
 	 * Checks if a version/language combination exists and otherwise
-	 * will throw a NotFoundException
+	 * will throw a `NotFoundException`
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */

--- a/src/Content/MemoryContentStorageHandler.php
+++ b/src/Content/MemoryContentStorageHandler.php
@@ -51,19 +51,7 @@ class MemoryContentStorageHandler extends ContentStorageHandler
 	 */
 	public function exists(VersionId $versionId, Language $language): bool
 	{
-		$data = $this->cache->get($this->cacheId($versionId, $language));
-
-		// validate the cached data
-		if (
-			isset($data['fields']) === true &&
-			is_array($data['fields']) === true &&
-			isset($data['modified']) === true &&
-			is_int($data['modified']) === true
-		) {
-			return true;
-		}
-
-		return false;
+		return $this->cache->exists($this->cacheId($versionId, $language));
 	}
 
 	/**
@@ -75,7 +63,7 @@ class MemoryContentStorageHandler extends ContentStorageHandler
 			return null;
 		}
 
-		return $this->cache->get($this->cacheId($versionId, $language))['modified'];
+		return $this->cache->modified($this->cacheId($versionId, $language));
 	}
 
 	/**
@@ -88,7 +76,7 @@ class MemoryContentStorageHandler extends ContentStorageHandler
 	public function read(VersionId $versionId, Language $language): array
 	{
 		$this->ensure($versionId, $language);
-		return $this->cache->get($this->cacheId($versionId, $language))['fields'];
+		return $this->cache->get($this->cacheId($versionId, $language));
 	}
 
 	/**
@@ -122,9 +110,6 @@ class MemoryContentStorageHandler extends ContentStorageHandler
 	 */
 	protected function write(VersionId $versionId, Language $language, array $fields): void
 	{
-		$this->cache->set($this->cacheId($versionId, $language), [
-			'fields'   => $fields,
-			'modified' => time()
-		]);
+		$this->cache->set($this->cacheId($versionId, $language), $fields);
 	}
 }

--- a/src/Content/MemoryContentStorageHandler.php
+++ b/src/Content/MemoryContentStorageHandler.php
@@ -91,19 +91,6 @@ class MemoryContentStorageHandler extends ContentStorageHandler
 	}
 
 	/**
-	 * Updates the content fields of an existing version
-	 *
-	 * @param array<string, string> $fields Content fields
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
-	 */
-	public function update(VersionId $versionId, Language $language, array $fields): void
-	{
-		$this->ensure($versionId, $language);
-		$this->write($versionId, $language, $fields);
-	}
-
-	/**
 	 * Writes the content fields of an existing version
 	 *
 	 * @param array<string, string> $fields Content fields

--- a/src/Content/MemoryContentStorageHandler.php
+++ b/src/Content/MemoryContentStorageHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cache\MemoryCache;
+use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class MemoryContentStorageHandler extends ContentStorageHandler
+{
+	/**
+	 * Cache instance, used to store content in memory
+	 */
+	protected MemoryCache $cache;
+
+	/**
+	 * Sets up the cache instance
+	 */
+	public function __construct(protected ModelWithContent $model)
+	{
+		parent::__construct($model);
+		$this->cache = new MemoryCache();
+	}
+
+	/**
+	 * Returns a unique id for a combination
+	 * of the version id, the language code and the model id
+	 */
+	protected function cacheId(VersionId $versionId, Language $language): string
+	{
+		return $versionId->value() . '/' . $language->code() . '/' . $this->model->id();
+	}
+
+	/**
+	 * Deletes an existing version in an idempotent way if it was already deleted
+	 */
+	public function delete(VersionId $versionId, Language $language): void
+	{
+		$this->cache->remove($this->cacheId($versionId, $language));
+	}
+
+	/**
+	 * Checks if a version exists
+	 */
+	public function exists(VersionId $versionId, Language $language): bool
+	{
+		$data = $this->cache->get($this->cacheId($versionId, $language));
+
+		// validate the cached data
+		if (
+			isset($data['fields']) === true &&
+			is_array($data['fields']) === true &&
+			isset($data['modified']) === true &&
+			is_int($data['modified']) === true
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the modification timestamp of a version if it exists
+	 */
+	public function modified(VersionId $versionId, Language $language): int|null
+	{
+		if ($this->exists($versionId, $language) === false) {
+			return null;
+		}
+
+		return $this->cache->get($this->cacheId($versionId, $language))['modified'];
+	}
+
+	/**
+	 * Returns the stored content fields
+	 *
+	 * @return array<string, string>
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function read(VersionId $versionId, Language $language): array
+	{
+		$this->ensure($versionId, $language);
+		return $this->cache->get($this->cacheId($versionId, $language))['fields'];
+	}
+
+	/**
+	 * Updates the modification timestamp of an existing version
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function touch(VersionId $versionId, Language $language): void
+	{
+		$fields = $this->read($versionId, $language);
+		$this->write($versionId, $language, $fields);
+	}
+
+	/**
+	 * Updates the content fields of an existing version
+	 *
+	 * @param array<string, string> $fields Content fields
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function update(VersionId $versionId, Language $language, array $fields): void
+	{
+		$this->ensure($versionId, $language);
+		$this->write($versionId, $language, $fields);
+	}
+
+	/**
+	 * Writes the content fields of an existing version
+	 *
+	 * @param array<string, string> $fields Content fields
+	 */
+	protected function write(VersionId $versionId, Language $language, array $fields): void
+	{
+		$this->cache->set($this->cacheId($versionId, $language), [
+			'fields'   => $fields,
+			'modified' => time()
+		]);
+	}
+}

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -142,18 +142,6 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	}
 
 	/**
-	 * Creates a new version
-	 *
-	 * @param array<string, string> $fields Content fields
-	 *
-	 * @throws \Kirby\Exception\Exception If the file cannot be written
-	 */
-	public function create(VersionId $versionId, Language $language, array $fields): void
-	{
-		$this->write($versionId, $language, $fields);
-	}
-
-	/**
 	 * Deletes an existing version in an idempotent way if it was already deleted
 	 */
 	public function delete(VersionId $versionId, Language $language): void
@@ -245,18 +233,6 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 			throw new Exception('Could not touch existing content file');
 		}
 		// @codeCoverageIgnoreEnd
-	}
-
-	/**
-	 * Updates the content fields of an existing version
-	 *
-	 * @param array<string, string> $fields Content fields
-	 *
-	 * @throws \Kirby\Exception\Exception If the file cannot be written
-	 */
-	public function update(VersionId $versionId, Language $language, array $fields): void
-	{
-		$this->write($versionId, $language, $fields);
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -5,7 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
-use Kirby\Exception\NotFoundException;
 
 /**
  * The Version class handles all actions for a single
@@ -87,17 +86,8 @@ class Version
 	 */
 	public function ensure(
 		Language|string $language = 'default'
-	): void {
-		if ($this->exists($language) === true) {
-			return;
-		}
-
-		$message = match($this->model->kirby()->multilang()) {
-			true  => 'Version "' . $this->id . ' (' . $language . ')" does not already exist',
-			false => 'Version "' . $this->id . '" does not already exist',
-		};
-
-		throw new NotFoundException($message);
+	): bool {
+		return $this->model->storage()->ensure($this->id, $this->language($language));
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -86,8 +86,8 @@ class Version
 	 */
 	public function ensure(
 		Language|string $language = 'default'
-	): bool {
-		return $this->model->storage()->ensure($this->id, $this->language($language));
+	): void {
+		$this->model->storage()->ensure($this->id, $this->language($language));
 	}
 
 	/**

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -116,4 +116,18 @@ class MemoryCacheTest extends TestCase
 		$this->assertTrue($cache2->exists('a'));
 		$this->assertTrue($cache2->exists('b'));
 	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModified()
+	{
+		$cache = new MemoryCache();
+
+		$time = time();
+
+		$cache->set('a', 'A basic value');
+
+		$this->assertGreaterThanOrEqual($time, $cache->modified('a'));
+	}
 }

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -34,10 +34,18 @@ class ContentStorageHandlerTest extends TestCase
 
 		$versions = iterator_to_array($handler->all(), false);
 
-		// The TestContentStorage handler always returns true
-		// for every version and language. Thus there should be
-		// 2 versions for every language.
-		//
+		$this->assertCount(0, $versions);
+
+		// create all possible versions
+		$handler->create(VersionId::published(), $this->app->language('en'), []);
+		$handler->create(VersionId::published(), $this->app->language('de'), []);
+
+		$handler->create(VersionId::changes(), $this->app->language('en'), []);
+		$handler->create(VersionId::changes(), $this->app->language('de'), []);
+
+		// count again
+		$versions = iterator_to_array($handler->all(), false);
+
 		// article.en.txt
 		// article.de.txt
 		// _changes/article.en.txt
@@ -61,10 +69,15 @@ class ContentStorageHandlerTest extends TestCase
 
 		$versions = iterator_to_array($handler->all(), false);
 
-		// The TestContentStorage handler always returns true
-		// for every version and language. Thus there should be
-		// 2 versions in a single language installation.
-		//
+		$this->assertCount(0, $versions);
+
+		// create all possible versions
+		$handler->create(VersionId::published(), Language::single(), []);
+		$handler->create(VersionId::changes(), Language::single(), []);
+
+		// count again
+		$versions = iterator_to_array($handler->all(), false);
+
 		// article.txt
 		// _changes/article.txt
 		$this->assertCount(2, $versions);
@@ -81,6 +94,18 @@ class ContentStorageHandlerTest extends TestCase
 			new Page(['slug' => 'test', 'isDraft' => false])
 		);
 
+		$versions = iterator_to_array($handler->all(), false);
+
+		$this->assertCount(0, $versions);
+
+		// create all possible versions
+		$handler->create(VersionId::published(), $this->app->language('en'), []);
+		$handler->create(VersionId::published(), $this->app->language('de'), []);
+
+		$handler->create(VersionId::changes(), $this->app->language('en'), []);
+		$handler->create(VersionId::changes(), $this->app->language('de'), []);
+
+		// count again
 		$versions = iterator_to_array($handler->all(), false);
 
 		// A page that's not in draft mode can have published and changes versions
@@ -101,6 +126,17 @@ class ContentStorageHandlerTest extends TestCase
 
 		$versions = iterator_to_array($handler->all(), false);
 
+		$this->assertCount(0, $versions);
+
+		$handler->create(VersionId::published(), $this->app->language('en'), []);
+		$handler->create(VersionId::published(), $this->app->language('de'), []);
+
+		$handler->create(VersionId::changes(), $this->app->language('en'), []);
+		$handler->create(VersionId::changes(), $this->app->language('de'), []);
+
+		// count again
+		$versions = iterator_to_array($handler->all(), false);
+
 		// A draft page has only changes and thus should only have
 		// a changes for every language, but no published versions
 		$this->assertCount(2, $versions);
@@ -117,6 +153,15 @@ class ContentStorageHandlerTest extends TestCase
 			new Page(['slug' => 'test', 'isDraft' => false])
 		);
 
+		$versions = iterator_to_array($handler->all(), false);
+
+		$this->assertCount(0, $versions);
+
+		// create all possible versions
+		$handler->create(VersionId::published(), Language::single(), []);
+		$handler->create(VersionId::changes(), Language::single(), []);
+
+		// count again
 		$versions = iterator_to_array($handler->all(), false);
 
 		// A page that's not in draft mode can have published and changes versions
@@ -136,6 +181,15 @@ class ContentStorageHandlerTest extends TestCase
 
 		$versions = iterator_to_array($handler->all(), false);
 
+		$this->assertCount(0, $versions);
+
+		// create all possible versions
+		$handler->create(VersionId::published(), Language::single(), []);
+		$handler->create(VersionId::changes(), Language::single(), []);
+
+		// count again
+		$versions = iterator_to_array($handler->all(), false);
+
 		// A draft page has only changes and thus should only have
 		// a single version in a single language installation
 		$this->assertCount(1, $versions);
@@ -148,22 +202,21 @@ class ContentStorageHandlerTest extends TestCase
 	{
 		$this->setUpMultiLanguage();
 
-		// Use the plain text handler, as the abstract class and the test handler do not
-		// implement the necessary methods to test this.
-		$handler = new PlainTextContentStorageHandler(
+		$handler = new TestContentStorageHandler(
 			model: $this->model
 		);
 
-		Data::write($filePublished = $this->model->root() . '/article.de.txt', []);
-		Data::write($fileChanges   = $this->model->root() . '/_changes/article.de.txt', []);
+		// create two versions for the German language
+		$handler->create(VersionId::published(), $this->app->language('de'), []);
+		$handler->create(VersionId::changes(), $this->app->language('de'), []);
 
-		$this->assertFileExists($filePublished);
-		$this->assertFileExists($fileChanges);
+		$this->assertTrue($handler->exists(VersionId::published(), $this->app->language('de')));
+		$this->assertTrue($handler->exists(VersionId::changes(), $this->app->language('de')));
 
 		$handler->deleteLanguage($this->app->language('de'));
 
-		$this->assertFileDoesNotExist($filePublished);
-		$this->assertFileDoesNotExist($fileChanges);
+		$this->assertFalse($handler->exists(VersionId::published(), $this->app->language('de')));
+		$this->assertFalse($handler->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
 	/**
@@ -175,20 +228,23 @@ class ContentStorageHandlerTest extends TestCase
 
 		// Use the plain text handler, as the abstract class and the test handler do not
 		// implement the necessary methods to test this.
-		$handler = new PlainTextContentStorageHandler(
+		$handler = new TestContentStorageHandler(
 			model: $this->model
 		);
 
-		Data::write($filePublished = $this->model->root() . '/article.txt', []);
-		Data::write($fileChanges   = $this->model->root() . '/_changes/article.txt', []);
+		$language = Language::single();
 
-		$this->assertFileExists($filePublished);
-		$this->assertFileExists($fileChanges);
+		// create two versions
+		$handler->create(VersionId::published(), $language, []);
+		$handler->create(VersionId::changes(), $language, []);
 
-		$handler->deleteLanguage(Language::single());
+		$this->assertTrue($handler->exists(VersionId::published(), $language));
+		$this->assertTrue($handler->exists(VersionId::changes(), $language));
 
-		$this->assertFileDoesNotExist($filePublished);
-		$this->assertFileDoesNotExist($fileChanges);
+		$handler->deleteLanguage($language);
+
+		$this->assertFalse($handler->exists(VersionId::published(), $language));
+		$this->assertFalse($handler->exists(VersionId::changes(), $language));
 	}
 
 	/**
@@ -275,14 +331,67 @@ class ContentStorageHandlerTest extends TestCase
 
 	/**
 	 * @covers ::move
+	 */
+	public function testMoveMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$handler = new TestContentStorageHandler(
+			model: $this->model
+		);
+
+		$en = $this->app->language('en');
+		$de = $this->app->language('de');
+
+		$handler->create(VersionId::published(), $en, []);
+
+		$this->assertTrue($handler->exists(VersionId::published(), $en));
+		$this->assertFalse($handler->exists(VersionId::published(), $de));
+
+		$handler->move(
+			VersionId::published(),
+			$en,
+			VersionId::published(),
+			$de
+		);
+
+		$this->assertFalse($handler->exists(VersionId::published(), $en));
+		$this->assertTrue($handler->exists(VersionId::published(), $de));
+	}
+
+	public function testMoveSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestContentStorageHandler(
+			model: $this->model
+		);
+
+		$handler->create(VersionId::published(), Language::single(), []);
+
+		$this->assertTrue($handler->exists(VersionId::published(), Language::single()));
+		$this->assertFalse($handler->exists(VersionId::changes(), Language::single()));
+
+		$handler->move(
+			VersionId::published(),
+			Language::single(),
+			VersionId::changes(),
+			Language::single()
+		);
+
+		$this->assertFalse($handler->exists(VersionId::published(), Language::single()));
+		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
+	}
+
+	/**
 	 * @covers ::moveLanguage
 	 */
 	public function testMoveSingleLanguageToMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
 
-		// Use the plain text handler, as the abstract class and the test handler do not
-		// implement the necessary methods to test this.
+		// Use the plain text handler, as it offers the most
+		// realistic, testable results for this test
 		$handler = new PlainTextContentStorageHandler(
 			model: $this->model
 		);
@@ -306,15 +415,14 @@ class ContentStorageHandlerTest extends TestCase
 	}
 
 	/**
-	 * @covers ::move
 	 * @covers ::moveLanguage
 	 */
 	public function testMoveMultiLanguageToSingleLanguage()
 	{
 		$this->setUpMultiLanguage();
 
-		// Use the plain text handler, as the abstract class and the test handler do not
-		// implement the necessary methods to test this.
+		// Use the plain text handler, as it offers the most
+		// realistic, testable results for this test
 		$handler = new PlainTextContentStorageHandler(
 			model: $this->model
 		);

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -274,6 +274,7 @@ class ContentStorageHandlerTest extends TestCase
 	}
 
 	/**
+	 * @covers ::move
 	 * @covers ::moveLanguage
 	 */
 	public function testMoveSingleLanguageToMultiLanguage()
@@ -305,6 +306,7 @@ class ContentStorageHandlerTest extends TestCase
 	}
 
 	/**
+	 * @covers ::move
 	 * @covers ::moveLanguage
 	 */
 	public function testMoveMultiLanguageToSingleLanguage()

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+
+/**
+ * @coversDefaultClass Kirby\Content\MemoryContentStorageHandler
+ * @covers ::__construct
+ */
+class MemoryContentStorageHandlerTest extends TestCase
+{
+	protected $storage;
+
+	public function assertCreateAndDelete(VersionId $versionId, Language $language): void
+	{
+		$this->storage->create($versionId, $language, []);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+
+		$this->storage->delete($versionId, $language);
+
+		$this->assertFalse($this->storage->exists($versionId, $language));
+	}
+
+	public function assertCreateAndRead(VersionId $versionId, Language $language): void
+	{
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create($versionId, $language, $fields);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+		$this->assertSame($fields, $this->storage->read($versionId, $language));
+	}
+
+	public function setUpMultiLanguage(): void
+	{
+		parent::setUpMultiLanguage();
+
+		$this->storage = new MemoryContentStorageHandler($this->model);
+	}
+
+	public function setUpSingleLanguage(): void
+	{
+		parent::setUpSingleLanguage();
+
+		$this->storage = new MemoryContentStorageHandler($this->model);
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::read
+	 */
+	public function testCreateAndReadChangesMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = $this->app->language('en');
+
+		$this->assertCreateAndRead($versionId, $language);
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::read
+	 */
+	public function testCreateAndReadChangesSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = Language::single();
+
+		$this->assertCreateAndRead($versionId, $language);
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::read
+	 */
+	public function testCreateAndReadPublishedMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::published();
+		$language  = $this->app->language('en');
+
+		$this->assertCreateAndRead($versionId, $language);
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::read
+	 */
+	public function testCreateAndReadPublishedSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::published();
+		$language  = Language::single();
+
+		$this->assertCreateAndRead($versionId, $language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteNonExisting()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::published();
+		$language  = Language::single();
+
+		$this->assertFalse($this->storage->exists($versionId, $language));
+
+		// test idempotency
+		$this->storage->delete($versionId, $language);
+
+		$this->assertFalse($this->storage->exists($versionId, $language));
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteChangesMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = $this->app->language('en');
+
+		$this->assertCreateAndDelete($versionId, $language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteChangesSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = Language::single();
+
+		$this->assertCreateAndDelete($versionId, $language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeletePublishedMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::published();
+		$language  = $this->app->language('en');
+
+		$this->assertCreateAndDelete($versionId, $language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeletePublishedSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::published();
+		$language  = Language::single();
+
+		$this->assertCreateAndDelete($versionId, $language);
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsNoneExistingMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('en')));
+		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsNoneExistingSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedNoneExistingMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$this->assertNull($this->storage->modified(VersionId::changes(), $this->app->language('en')));
+		$this->assertNull($this->storage->modified(VersionId::published(), $this->app->language('en')));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedNoneExistingSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$this->assertNull($this->storage->modified(VersionId::changes(), Language::single()));
+		$this->assertNull($this->storage->modified(VersionId::published(), Language::single()));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedSomeExistingMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$changes  = VersionId::changes();
+		$language = $this->app->language('en');
+
+		$this->storage->create($changes, $language, []);
+
+		$this->assertIsInt($this->storage->modified($changes, $language));
+		$this->assertNull($this->storage->modified(VersionId::published(), $language));
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModifiedSomeExistingSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$changes  = VersionId::changes();
+		$language = Language::single();
+
+		$this->storage->create($changes, $language, []);
+
+		$this->assertIsInt($this->storage->modified($changes, $language));
+		$this->assertNull($this->storage->modified(VersionId::published(), $language));
+	}
+
+	/**
+	 * @covers ::touch
+	 */
+	public function testTouchMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = $this->app->language('en');
+
+		$time = time();
+
+		$this->storage->create($versionId, $language, []);
+		$this->storage->touch($versionId, $language);
+
+		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
+	}
+
+	/**
+	 * @covers ::touch
+	 */
+	public function testTouchSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = Language::single();
+
+		$time = time();
+
+		$this->storage->create($versionId, $language, []);
+		$this->storage->touch($versionId, $language);
+
+		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
+	}
+}

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -202,6 +202,42 @@ class MemoryContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::exists
 	 */
+	public function testExistsMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::published();
+
+		$this->assertFalse($this->storage->exists($versionId, $this->app->language('en')));
+		$this->assertFalse($this->storage->exists($versionId, $this->app->language('de')));
+
+		$this->storage->create($versionId, $this->app->language('en'), []);
+		$this->storage->create($versionId, $this->app->language('de'), []);
+
+		$this->assertTrue($this->storage->exists($versionId, $this->app->language('en')));
+		$this->assertTrue($this->storage->exists($versionId, $this->app->language('de')));
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::published();
+		$language  = Language::single();
+
+		$this->assertFalse($this->storage->exists($versionId, $language));
+
+		$this->storage->create($versionId, $language, []);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+	}
+
+	/**
+	 * @covers ::exists
+	 */
 	public function testExistsNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -7,11 +7,18 @@ use Kirby\Cms\Language;
 /**
  * @coversDefaultClass Kirby\Content\MemoryContentStorageHandler
  * @covers ::__construct
+ * @covers ::cacheId
  */
 class MemoryContentStorageHandlerTest extends TestCase
 {
 	protected $storage;
 
+	/**
+	 * @covers ::create
+	 * @covers ::delete
+	 * @covers ::exists
+	 * @covers ::write
+	 */
 	public function assertCreateAndDelete(VersionId $versionId, Language $language): void
 	{
 		$this->storage->create($versionId, $language, []);
@@ -23,6 +30,12 @@ class MemoryContentStorageHandlerTest extends TestCase
 		$this->assertFalse($this->storage->exists($versionId, $language));
 	}
 
+	/**
+	 * @covers ::create
+	 * @covers ::exists
+	 * @covers ::read
+	 * @covers ::write
+	 */
 	public function assertCreateAndRead(VersionId $versionId, Language $language): void
 	{
 		$fields = [
@@ -31,6 +44,30 @@ class MemoryContentStorageHandlerTest extends TestCase
 		];
 
 		$this->storage->create($versionId, $language, $fields);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+		$this->assertSame($fields, $this->storage->read($versionId, $language));
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::exists
+	 * @covers ::read
+	 * @covers ::update
+	 * @covers ::write
+	 */
+	public function assertCreateAndUpdate(VersionId $versionId, Language $language): void
+	{
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create($versionId, $language, []);
+
+		$this->assertSame([], $this->storage->read($versionId, $language));
+
+		$this->storage->update($versionId, $language, $fields);
 
 		$this->assertTrue($this->storage->exists($versionId, $language));
 		$this->assertSame($fields, $this->storage->read($versionId, $language));
@@ -108,6 +145,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 
 	/**
 	 * @covers ::delete
+	 * @covers ::exists
 	 */
 	public function testDeleteNonExisting()
 	{
@@ -285,5 +323,31 @@ class MemoryContentStorageHandlerTest extends TestCase
 		$this->storage->touch($versionId, $language);
 
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateMultiLang()
+	{
+		$this->setUpMultiLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = $this->app->language('en');
+
+		$this->assertCreateAndUpdate($versionId, $language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateSingleLang()
+	{
+		$this->setUpSingleLanguage();
+
+		$versionId = VersionId::changes();
+		$language  = Language::single();
+
+		$this->assertCreateAndUpdate($versionId, $language);
 	}
 }

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -13,12 +13,6 @@ class MemoryContentStorageHandlerTest extends TestCase
 {
 	protected $storage;
 
-	/**
-	 * @covers ::create
-	 * @covers ::delete
-	 * @covers ::exists
-	 * @covers ::write
-	 */
 	public function assertCreateAndDelete(VersionId $versionId, Language $language): void
 	{
 		$this->storage->create($versionId, $language, []);
@@ -30,12 +24,6 @@ class MemoryContentStorageHandlerTest extends TestCase
 		$this->assertFalse($this->storage->exists($versionId, $language));
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::exists
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function assertCreateAndRead(VersionId $versionId, Language $language): void
 	{
 		$fields = [
@@ -49,13 +37,6 @@ class MemoryContentStorageHandlerTest extends TestCase
 		$this->assertSame($fields, $this->storage->read($versionId, $language));
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::exists
-	 * @covers ::read
-	 * @covers ::update
-	 * @covers ::write
-	 */
 	public function assertCreateAndUpdate(VersionId $versionId, Language $language): void
 	{
 		$fields = [

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -71,6 +71,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::create
 	 * @covers ::read
+	 * @covers ::write
 	 */
 	public function testCreateAndReadChangesMultiLang()
 	{
@@ -85,6 +86,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::create
 	 * @covers ::read
+	 * @covers ::write
 	 */
 	public function testCreateAndReadChangesSingleLang()
 	{
@@ -99,6 +101,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::create
 	 * @covers ::read
+	 * @covers ::write
 	 */
 	public function testCreateAndReadPublishedMultiLang()
 	{
@@ -113,6 +116,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::create
 	 * @covers ::read
+	 * @covers ::write
 	 */
 	public function testCreateAndReadPublishedSingleLang()
 	{
@@ -308,6 +312,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 
 	/**
 	 * @covers ::update
+	 * @covers ::write
 	 */
 	public function testUpdateMultiLang()
 	{
@@ -321,6 +326,7 @@ class MemoryContentStorageHandlerTest extends TestCase
 
 	/**
 	 * @covers ::update
+	 * @covers ::write
 	 */
 	public function testUpdateSingleLang()
 	{

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -410,11 +410,11 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make(static::TMP . '/_changes');
-		Data::write(static::TMP . '/_changes/article.en.txt', $fields);
+		Dir::make($this->model->root() . '/_changes');
+		Data::write($this->model->root() . '/_changes/article.en.txt', $fields);
 
 		$this->storage->update(VersionId::changes(), $this->app->language('en'), $fields);
-		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.en.txt'));
+		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
 	/**
@@ -429,11 +429,11 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Dir::make(static::TMP . '/_changes');
-		Data::write(static::TMP . '/_changes/article.txt', $fields);
+		Dir::make($this->model->root() . '/_changes');
+		Data::write($this->model->root() . '/_changes/article.txt', $fields);
 
 		$this->storage->update(VersionId::changes(), Language::single(), $fields);
-		$this->assertSame($fields, Data::read(static::TMP . '/_changes/article.txt'));
+		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
 	/**
@@ -448,10 +448,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write(static::TMP . '/article.en.txt', $fields);
+		Data::write($this->model->root() . '/article.en.txt', $fields);
 
 		$this->storage->update(VersionId::published(), $this->app->language('en'), $fields);
-		$this->assertSame($fields, Data::read(static::TMP . '/article.en.txt'));
+		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
 	/**
@@ -466,10 +466,10 @@ class PlainTextContentStorageHandlerTest extends TestCase
 			'text'  => 'Bar'
 		];
 
-		Data::write(static::TMP . '/article.txt', $fields);
+		Data::write($this->model->root() . '/article.txt', $fields);
 
 		$this->storage->update(VersionId::published(), Language::single(), $fields);
-		$this->assertSame($fields, Data::read(static::TMP . '/article.txt'));
+		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
 	/**

--- a/tests/Content/TestContentStorageHandler.php
+++ b/tests/Content/TestContentStorageHandler.php
@@ -2,34 +2,51 @@
 
 namespace Kirby\Content;
 
+use Exception;
 use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
 
 class TestContentStorageHandler extends ContentStorageHandler
 {
+	public array $store = [];
+
+	public function __construct(protected ModelWithContent $model)
+	{
+		$this->store = [];
+	}
+
 	public function delete(VersionId $versionId, Language $language): void
 	{
+		unset($this->store[$this->key($versionId, $language)]);
 	}
 
 	public function exists(VersionId $versionId, Language $language): bool
 	{
-		return true;
+		return isset($this->store[$this->key($versionId, $language)]);
+	}
+
+	public function key(VersionId $versionId, Language $language): string
+	{
+		return $versionId . '/' . $language;
 	}
 
 	public function modified(VersionId $versionId, Language $language): int|null
 	{
-		return null;
+		throw new Exception('Not implemented');
 	}
 
 	public function read(VersionId $versionId, Language $language): array
 	{
-		return [];
+		return $this->store[$this->key($versionId, $language)] ?? [];
 	}
 
 	public function touch(VersionId $versionId, Language $language): void
 	{
+		throw new Exception('Not implemented');
 	}
 
 	public function write(VersionId $versionId, Language $language, array $fields): void
 	{
+		$this->store[$this->key($versionId, $language)] = $fields;
 	}
 }

--- a/tests/Content/TestContentStorageHandler.php
+++ b/tests/Content/TestContentStorageHandler.php
@@ -6,10 +6,6 @@ use Kirby\Cms\Language;
 
 class TestContentStorageHandler extends ContentStorageHandler
 {
-	public function create(VersionId $versionId, Language $language, array $fields): void
-	{
-	}
-
 	public function delete(VersionId $versionId, Language $language): void
 	{
 	}
@@ -24,14 +20,6 @@ class TestContentStorageHandler extends ContentStorageHandler
 		return null;
 	}
 
-	public function move(
-		VersionId $fromVersionId,
-		Language $fromLanguage,
-		VersionId $toVersionId,
-		Language $toLanguage
-	): void {
-	}
-
 	public function read(VersionId $versionId, Language $language): array
 	{
 		return [];
@@ -41,7 +29,7 @@ class TestContentStorageHandler extends ContentStorageHandler
 	{
 	}
 
-	public function update(VersionId $versionId, Language $language, array $fields): void
+	public function write(VersionId $versionId, Language $language, array $fields): void
 	{
 	}
 }

--- a/tests/Content/mocks.php
+++ b/tests/Content/mocks.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirby\Content;
+
+use Exception;
+
+/**
+ * Mock for the PHP time() function to ensure reliable testing
+ *
+ * @return int A fake timestamp
+ */
+function time(): int
+{
+	if (defined('KIRBY_TESTING') !== true || KIRBY_TESTING !== true) {
+		throw new Exception('Mock time() function was loaded outside of the test environment. This should never happen.');
+	}
+
+	return 1337;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/Cache/mocks.php';
 require_once __DIR__ . '/Cms/mocks.php';
 require_once __DIR__ . '/Cms/Auth/mocks.php';
 require_once __DIR__ . '/Cms/System/mocks.php';
+require_once __DIR__ . '/Content/mocks.php';
 require_once __DIR__ . '/Data/mocks.php';
 require_once __DIR__ . '/Database/mocks.php';
 require_once __DIR__ . '/Filesystem/mocks.php';


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456

### Features

- New `MemoryContentStorageHandler` class (see outlook for details what this class is supposed to do)

### Refactor

- Move `::write` and `::ensure` into `ContentStorageHandler` class and make them abstract
- Turn `ContentStorageHandler::update` and `ContentStorageHandler::create` into non-abstract methods that use `::write` under the hood. 
- Use `ContentStorageHandler::ensure` in `Version::ensure`

### Outlook

- The new `MemoryContentStorageHandler` class will be used in `ModelWithContent::setContent` and `ModelWithContent::setTranslation`. It will replace the `PlainTextContentStorageHandler` instance with an in-memory version of the content or translation that is passed via array. This will (hopefully) keep our virtual pages, files and users working, while still making use of the underlying storage implementation. It should also help to untie the content vs. translations knot. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
