### PR TITLE
Select field: remove undocumented empty prop

### DIFF
--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -20,7 +20,8 @@ return [
 	],
 	'computed' => [
 		'default' => function () {
-			return $this->sanitizeOption($this->default);
+			$default = $this->model()->toString($this->default);
+			return $this->sanitizeOption($default);
 		},
 		'value' => function () {
 			return $this->sanitizeOption($this->value) ?? '';

--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -17,7 +17,7 @@ return [
 			return $icon;
 		},
 		/**
-		 * Custom placeholder string for empty option.
+		 * Text shown when no option is selected yet
 		 */
 		'placeholder' => function (string $placeholder = '—') {
 			return $placeholder;

--- a/panel/lab/components/inputs/select/index.vue
+++ b/panel/lab/components/inputs/select/index.vue
@@ -56,13 +56,8 @@
 				/>
 			</k-lab-example>
 
-			<k-lab-example label="Empty: false">
-				<k-select-input
-					:empty="false"
-					:options="options"
-					:value="value"
-					@input="value = $event"
-				/>
+			<k-lab-example label="No empty option">
+				<k-select-input :required="true" :options="options" value="b" />
 			</k-lab-example>
 
 			<k-lab-example label="Multiple: true">

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -13,13 +13,13 @@
 			:disabled="disabled"
 			:name="name"
 			:required="required"
-			:value="selected"
+			:value="value"
 			class="k-select-input-native"
-			@change="onInput($event.target.value)"
+			@change="$emit('input', $event.target.value)"
 			@click="onClick"
 		>
 			<option v-if="hasEmptyOption" :disabled="required" value="">
-				{{ emptyOption }}
+				{{ empty }}
 			</option>
 			<option
 				v-for="option in options"
@@ -42,7 +42,6 @@ export const props = {
 	mixins: [InputProps, options, placeholder],
 	props: {
 		ariaLabel: String,
-		default: String,
 		value: {
 			type: [String, Number, Boolean],
 			default: ""
@@ -53,39 +52,28 @@ export const props = {
 export default {
 	mixins: [Input, props],
 	emits: ["click", "input"],
-	data() {
-		return {
-			selected: this.value
-		};
-	},
 	computed: {
-		emptyOption() {
+		empty() {
 			return this.placeholder ?? "—";
 		},
 		hasEmptyOption() {
-			// empty option is only hidden if the field is both required and has a default
-			return !(this.required && this.default);
+			// empty option is only displayed if the field is
+			// not required or currently has no value yet
+			return !this.required || this.isEmpty;
 		},
 		isEmpty() {
 			return (
-				this.selected === null ||
-				this.selected === undefined ||
-				this.selected === ""
+				this.value === null || this.value === undefined || this.value === ""
 			);
 		},
 		label() {
-			const label = this.text(this.selected);
+			const label = this.text(this.value);
 
-			if (this.selected === "" || this.selected === null || label === null) {
-				return this.emptyOption;
+			if (this.isEmpty || label === null) {
+				return this.empty;
 			}
 
 			return label;
-		}
-	},
-	watch: {
-		value(value) {
-			this.selected = value;
 		}
 	},
 	mounted() {
@@ -100,10 +88,6 @@ export default {
 		onClick(event) {
 			event.stopPropagation();
 			this.$emit("click", event);
-		},
-		onInput(value) {
-			this.selected = value;
-			this.$emit("input", this.selected);
 		},
 		select() {
 			this.focus();

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -63,6 +63,7 @@ export default {
 			return this.placeholder ?? "—";
 		},
 		hasEmptyOption() {
+			// empty option is only hidden if the field is both required and has a default
 			return !(this.required && this.default);
 		},
 		isEmpty() {

--- a/panel/src/components/Forms/Input/SelectInput.vue
+++ b/panel/src/components/Forms/Input/SelectInput.vue
@@ -43,13 +43,6 @@ export const props = {
 	props: {
 		ariaLabel: String,
 		default: String,
-		/**
-		 * The text, that is shown as the first empty option, when the field is not required.
-		 */
-		empty: {
-			type: [Boolean, String],
-			default: true
-		},
 		value: {
 			type: [String, Number, Boolean],
 			default: ""
@@ -70,10 +63,6 @@ export default {
 			return this.placeholder ?? "—";
 		},
 		hasEmptyOption() {
-			if (this.empty === false) {
-				return false;
-			}
-
 			return !(this.required && this.default);
 		},
 		isEmpty() {


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Revives https://github.com/getkirby/kirby/pull/3373. Presented breaking case inside structure fields works by now.

By now the empty prop is redundant. Everything can be replicated by required, default and placeholder props.

### Enhancements
- `default` prop supports Kirby queries in radio and select field

### Breaking changes
- Select field: `empty` prop was removed. Use combination of `required`, `placeholder` and `default` to replicate functionality.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
