### PR TITLE
Upload dialog: fix allowed characters for filename

### DIFF
--- a/panel/src/components/Uploads/UploadItem.vue
+++ b/panel/src/components/Uploads/UploadItem.vue
@@ -13,6 +13,7 @@
 			:novalidate="true"
 			:required="true"
 			:value="name"
+			allow="a-z0-9@._-"
 			class="k-upload-item-input"
 			type="slug"
 			@input="$emit('rename', $event)"

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -210,8 +210,8 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	string = string.replace("/", separator);
 
 	// trim leading and trailing non-word-chars
-	string = string.replace(new RegExp("^[^" + allowed + "]+", "g"), "");
-	string = string.replace(new RegExp("[^" + allowed + "]+$", "g"), "");
+	string = string.replace(new RegExp("^[^a-z0-9]+", "g"), "");
+	string = string.replace(new RegExp("[^a-z0-9]+$", "g"), "");
 
 	return string;
 }

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -70,6 +70,11 @@ describe.concurrent("$helper.string.slug()", () => {
 		expect(resultB).toBe("a-b");
 	});
 
+	it("should produces safe filenames", () => {
+		const result = slug("-what a view@2x.png_", [], "a-z0-9@._-");
+		expect(result).toBe("what-a-view@2x.png");
+	});
+
 	it("should return empty string when no param sent", () => {
 		const result = slug();
 		expect(result).toBe("");

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -47,7 +47,9 @@ trait FileActions
 		string|null $extension = null
 	): static {
 		if ($sanitize === true) {
-			$name = F::safeName($name);
+			// sanitize the basename part only
+			// as the extension isn't included in $name
+			$name = F::safeBasename($name, false);
 		}
 
 		// if no extension is passed, make sure to maintain current one

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -756,20 +756,32 @@ class F
 	 * Sanitize a file's name (without extension)
 	 * @since 4.0.0
 	 */
-	public static function safeBasename(string $string): string
-	{
-		$name = static::name($string);
-		return Str::slug($name, '-', 'a-z0-9@._-');
+	public static function safeBasename(
+		string $string,
+		bool $extract = true
+	): string {
+		// extract only the name part from whole filename string
+		if ($extract === true) {
+			$string = static::name($string);
+		}
+
+		return Str::slug($string, '-', 'a-z0-9@._-');
 	}
 
 	/**
 	 * Sanitize a file's extension
 	 * @since 4.0.0
 	 */
-	public static function safeExtension(string $string): string
-	{
-		$extension = static::extension($string);
-		return Str::slug($extension);
+	public static function safeExtension(
+		string $string,
+		bool $extract = true
+	): string {
+		// extract only the extension part from whole filename string
+		if ($extract === true) {
+			$string = static::extension($string);
+		}
+
+		return Str::slug($string);
 	}
 
 	/**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -763,14 +763,17 @@ class FTest extends TestCase
 		// without extension
 		$this->assertSame('uber-genious', F::safeName('über genious'));
 
-		// with leading dash
-		$this->assertSame('super.jpg', F::safeName('-super.jpg'));
+		// with leading and trailing dash
+		$this->assertSame('super.jpg', F::safeName('-super.jpg-'));
 
-		// with leading underscore
-		$this->assertSame('super.jpg', F::safeName('_super.jpg'));
+		// with leading and trailing underscore
+		$this->assertSame('super.jpg', F::safeName('_super.jpg_'));
 
-		// with leading dot
-		$this->assertSame('super.jpg', F::safeName('.super.jpg'));
+		// with leading and trailing dot
+		$this->assertSame('super.jpg', F::safeName('.super.jpg.'));
+
+		// leave allowed characters untouched
+		$this->assertSame('file.a@b_c-d.jpg', F::safeName('file.a@b_c-d.jpg'));
 	}
 
 	/**
@@ -786,6 +789,8 @@ class FTest extends TestCase
 
 		// without extension
 		$this->assertSame('uber-genious', F::safeBasename('über genious'));
+		$this->assertSame('uber', F::safeBasename('über.genious'));
+		$this->assertSame('uber.genious', F::safeBasename('über.genious', false));
 
 		// with leading dash
 		$this->assertSame('super', F::safeBasename('-super.jpg'));
@@ -801,6 +806,7 @@ class FTest extends TestCase
 
 		$this->assertSame('txt', F::safeExtension('über genious.txt'));
 		$this->assertSame('taxt', F::safeExtension('über genious.täxt'));
+		$this->assertSame('taxt', F::safeExtension('täxt', false));
 		$this->assertSame('', F::safeExtension('über genious'));
 		$this->assertSame('jpg', F::safeExtension('-super.jpg'));
 	}

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1182,7 +1182,10 @@ class StrTest extends TestCase
 		// Allow underscores
 		$this->assertSame('a_b', Str::slug('a_b', '-', 'a-z0-9_'));
 
-		// store default defaults
+		// Trim non-alphanum characters
+		$this->assertSame('a@b-c.b', Str::slug('.a@b c.b-', '-', 'a-z0-9@._-'));
+
+		// Store default defaults
 		$defaults = Str::$defaults['slug'];
 
 		// Custom str defaults


### PR DESCRIPTION
## This PR …
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

Consistent with change filename dialog: https://github.com/getkirby/kirby/blob/c1e6ff77b056774543f201035f5dab6a02bfdb3b/config/areas/files/dialogs.php#L29

### Fixes
- Upload dialog: allows `@`, `.` and `_` in filenames to be consistent with other filename rules
https://github.com/getkirby/kirby/issues/6461
- `$file->changeName()` now sanitizes new filenames with`.` included correctly


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
