### PR TITLE
Replace `get_class()` with `::class`

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -432,7 +432,7 @@ class Api
 			return $this->collection($collection, $object);
 		}
 
-		throw new NotFoundException(sprintf('The object "%s" cannot be resolved', get_class($object)));
+		throw new NotFoundException(sprintf('The object "%s" cannot be resolved', $object::class));
 	}
 
 	/**
@@ -542,7 +542,7 @@ class Api
 			'status'    => 'error',
 			'message'   => $e->getMessage(),
 			'code'      => empty($e->getCode()) === true ? 500 : $e->getCode(),
-			'exception' => get_class($e),
+			'exception' => $e::class,
 			'key'       => null,
 			'file'      => F::relativepath($e->getFile(), $docRoot),
 			'line'      => $e->getLine(),

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -61,7 +61,7 @@ class Model
 		) {
 			$class = match ($this->data) {
 				null    => 'null',
-				default => get_class($this->data),
+				default => $this->data::class,
 			};
 			throw new Exception(sprintf('Invalid model type "%s" expected: "%s"', $class, $schema['type']));
 		}

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -764,7 +764,7 @@ class App
 				return $response->code($code)->send($errorPage->render([
 					'errorCode'    => $code,
 					'errorMessage' => $message,
-					'errorType'    => get_class($input)
+					'errorType'    => $input::class
 				]));
 			}
 

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -148,7 +148,7 @@ trait AppErrors
 			if ($this->option('debug') === true) {
 				echo Response::json([
 					'status'    => 'error',
-					'exception' => get_class($exception),
+					'exception' => $exception::class,
 					'code'      => $code,
 					'message'   => $exception->getMessage(),
 					'details'   => $details,

--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -159,7 +159,7 @@ class OptionsQuery extends OptionsProvider
 		}
 
 		if ($result instanceof Collection === false) {
-			$type = is_object($result) === true ? get_class($result) : gettype($result);
+			$type = is_object($result) === true ? $result::class : gettype($result);
 
 			throw new InvalidArgumentException('Invalid query result data: ' . $type);
 		}

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -227,7 +227,7 @@ class Parsley
 		$skip = ['DOMComment', 'DOMDocumentType'];
 
 		// unwanted element types
-		if (in_array(get_class($element), $skip) === true) {
+		if (in_array($element::class, $skip) === true) {
 			return false;
 		}
 

--- a/src/Sane/Sane.php
+++ b/src/Sane/Sane.php
@@ -5,6 +5,7 @@ namespace Kirby\Sane;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\A;
 
 /**
  * The `Sane` class validates that files
@@ -123,10 +124,9 @@ class Sane
 			default:
 				// more than one matching handler;
 				// sanitizing with all handlers will not leave much in the output
-				$handlerNames = array_map('get_class', $handlers);
 				throw new LogicException(
 					'Cannot sanitize file as more than one handler applies: ' .
-					implode(', ', $handlerNames)
+					implode(', ', A::map($handlers, fn ($handler) => $handler::class))
 				);
 		}
 	}
@@ -194,7 +194,7 @@ class Sane
 
 		foreach ($options as $option) {
 			$handler      = static::handler($option, $lazy);
-			$handlerClass = $handler ? get_class($handler) : null;
+			$handlerClass = $handler ? $handler::class : null;
 
 			// ensure that each handler class is only returned once
 			if (

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -205,7 +205,7 @@ abstract class Uuid implements Stringable
 			// $seed instanceof StructureObject
 			// 	=> new StructureUuid(model: $seed, context: $context),
 			default
-			=> throw new InvalidArgumentException('UUID not supported for: ' . get_class($seed))
+			=> throw new InvalidArgumentException('UUID not supported for: ' . $seed::class)
 		};
 	}
 

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Database;
 use InvalidArgumentException;
 use Kirby\TestCase;
 use Kirby\Toolkit\Collection;
+use Kirby\Toolkit\Pagination;
 use PDOException;
 
 /**
@@ -669,7 +670,7 @@ class QueryTest extends TestCase
 
 		$this->assertCount(5, $results);
 		$this->assertSame('John', $results->first()->fname());
-		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+		$this->assertTrue($pagination instanceof Pagination);
 		$this->assertSame(1, $pagination->pages());
 		$this->assertSame(5, $pagination->total());
 		$this->assertSame(1, $pagination->page());
@@ -683,7 +684,7 @@ class QueryTest extends TestCase
 
 		$this->assertCount(1, $results);
 		$this->assertSame('George', $results->first()->fname());
-		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+		$this->assertTrue($pagination instanceof Pagination);
 		$this->assertSame(5, $pagination->pages());
 		$this->assertSame(5, $pagination->total());
 		$this->assertSame(3, $pagination->page());
@@ -697,7 +698,7 @@ class QueryTest extends TestCase
 
 		$this->assertCount(2, $results);
 		$this->assertSame('Mark', $results->first()->fname());
-		$this->assertTrue(get_class($pagination) === 'Kirby\Toolkit\Pagination');
+		$this->assertTrue($pagination instanceof Pagination);
 		$this->assertSame(2, $pagination->pages());
 		$this->assertSame(5, $pagination->total());
 		$this->assertSame(2, $pagination->page());

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -77,7 +77,7 @@ class GdLibTest extends TestCase
 	{
 		$gd = new GdLib();
 
-		$method = new ReflectionMethod(get_class($gd), 'sharpen');
+		$method = new ReflectionMethod($gd::class, 'sharpen');
 		$method->setAccessible(true);
 
 		$simpleImage = new SimpleImageMock();
@@ -96,7 +96,7 @@ class GdLibTest extends TestCase
 	{
 		$gd = new GdLib();
 
-		$method = new ReflectionMethod(get_class($gd), 'sharpen');
+		$method = new ReflectionMethod($gd::class, 'sharpen');
 		$method->setAccessible(true);
 
 		$simpleImage = new SimpleImageMock();

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -58,7 +58,7 @@ class ImageMagickTest extends TestCase
 	{
 		$im = new ImageMagick();
 
-		$method = new ReflectionMethod(get_class($im), 'sharpen');
+		$method = new ReflectionMethod($im::class, 'sharpen');
 		$method->setAccessible(true);
 
 		$result = $method->invoke($im, '', [
@@ -75,7 +75,7 @@ class ImageMagickTest extends TestCase
 	{
 		$im = new ImageMagick();
 
-		$method = new ReflectionMethod(get_class($im), 'sharpen');
+		$method = new ReflectionMethod($im::class, 'sharpen');
 		$method->setAccessible(true);
 
 		$result = $method->invoke($im, '', [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Replacing `get_class()` method with `::class` notation

### Reasoning
 Adapting modern PHP syntax

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] Tests and checks all pass