### PR TITLE
Draggable: fix footer

### DIFF
--- a/panel/src/components/Misc/Draggable.vue
+++ b/panel/src/components/Misc/Draggable.vue
@@ -3,10 +3,10 @@
 		<!-- @slot Items to be sortable via drag and drop -->
 		<slot />
 
-		<footer v-if="$slots.footer" ref="footer" class="k-draggable-footer">
+		<template v-if="$slots.footer">
 			<!-- @slot Non-sortable footer -->
 			<slot name="footer" />
-		</footer>
+		</template>
 	</component>
 </template>
 
@@ -102,6 +102,7 @@ export default {
 		}
 	},
 	mounted() {
+		this.disableFooter();
 		this.create();
 	},
 	methods: {
@@ -159,10 +160,10 @@ export default {
 				},
 
 				// Event when you move an item in the list or between lists
-				onMove: (event, originalEvent) => {
+				onMove: (event) => {
 					// ensure footer stays non-sortable at the bottom
-					if (originalEvent.target === this.$refs.footer) {
-						return -1;
+					if (event.dragged.classList.contains("k-draggable-footer")) {
+						return false;
 					}
 
 					if (this.move) {
@@ -183,6 +184,21 @@ export default {
 					return true;
 				}
 			});
+		},
+		disableFooter() {
+			if (this.$slots.footer) {
+				// get as many nodes from the back of the list
+				// as footer elements are present
+				const nodes = [...this.$el.childNodes].slice(
+					-1 * this.$slots.footer.length
+				);
+
+				// add class to any node in the footer slot
+				// to allow filtering it as non-draggable
+				for (const node of nodes) {
+					node.classList?.add("k-draggable-footer");
+				}
+			}
 		},
 		getInstance(element) {
 			// get the Vue instance from HTMLElement


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Draggable: Remove wrapping `<footer>` tag for footer slot
- Add JS logic to disable any nodes in the footer slot to be non-draggable


### Reasoning
Adding the wrapping `<footer>` tag was a breaking change that I thought initially we could make, but I encountered causes troubles, e.g. with the styling of the empty placeholder in a layout column (as there is now one more nested level). The programmatic change now is closer to our K4 behavior of `<k-draggable>`.
