### PR TITLE
Revert: deprecating `this.$helper.object.clone`

### DIFF
--- a/panel/lab/components/stats/1_stats/index.vue
+++ b/panel/lab/components/stats/1_stats/index.vue
@@ -38,11 +38,11 @@ export default {
 			];
 		},
 		reportsWithoutTheme() {
-			return structuredClone(this.reports).map((report) => {
-				report.icon = null;
-				report.theme = null;
-				return report;
-			});
+			return this.reports.map((report) => ({
+				...report,
+				icon: null,
+				theme: null
+			}));
 		}
 	}
 };

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -337,7 +337,7 @@ export default {
 		},
 		async duplicate(block, index) {
 			const copy = {
-				...structuredClone(block),
+				...this.$helper.object.clone(block),
 				id: this.$helper.uuid()
 			};
 			this.blocks.splice(index + 1, 0, copy);
@@ -677,7 +677,7 @@ export default {
 			if (to < 0) {
 				return;
 			}
-			let blocks = structuredClone(this.blocks);
+			let blocks = this.$helper.object.clone(this.blocks);
 			blocks.splice(from, 1);
 			blocks.splice(to, 0, block);
 			this.blocks = blocks;
@@ -687,7 +687,7 @@ export default {
 		},
 		async split(block, index, contents) {
 			// prepare old block with reduced content chunk
-			const oldBlock = structuredClone(block);
+			const oldBlock = this.$helper.object.clone(block);
 			oldBlock.content = { ...oldBlock.content, ...contents[0] };
 
 			// create a new block and merge in default contents as

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -432,7 +432,7 @@ export default {
 
 				case "duplicate":
 					this.add({
-						...structuredClone(row),
+						...this.$helper.object.clone(row),
 						_id: this.$helper.uuid()
 					});
 					break;

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -141,7 +141,7 @@ export default {
 	methods: {
 		create(input) {
 			const inputs = input.split(this.separator).map((tag) => tag.trim());
-			const tags = structuredClone(this.value);
+			const tags = this.$helper.object.clone(this.value);
 
 			for (let tag of inputs) {
 				// convert input to tag object
@@ -201,7 +201,7 @@ export default {
 			}
 
 			// replace the tag at the given index
-			const tags = structuredClone(this.value);
+			const tags = this.$helper.object.clone(this.value);
 			tags.splice(index, 1, updated.value);
 			this.$emit("input", tags);
 

--- a/panel/src/components/Forms/Layouts/Layouts.vue
+++ b/panel/src/components/Forms/Layouts/Layouts.vue
@@ -135,7 +135,7 @@ export default {
 			});
 		},
 		duplicate(index, layout) {
-			const copy = structuredClone(layout);
+			const copy = this.$helper.object.clone(layout);
 
 			// replace all unique IDs for layouts, columns and blocks
 			// the method processes a single object and returns it as an array
@@ -200,7 +200,7 @@ export default {
 				// move throught the new layout rows in steps of columns per row
 				for (let i = 0; i < chunks; i += newLayout.columns.length) {
 					const copy = {
-						...structuredClone(newLayout),
+						...this.$helper.object.clone(newLayout),
 						id: this.$helper.uuid()
 					};
 

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -110,7 +110,7 @@ export default {
 			handler() {
 				// make sure values are not reactive
 				// otherwise this could have nasty side-effects
-				let tags = structuredClone(this.value);
+				let tags = this.$helper.object.clone(this.value);
 
 				// sort all tags by the available options
 				if (this.sort === true) {

--- a/panel/src/components/Views/System/SystemSecurity.vue
+++ b/panel/src/components/Views/System/SystemSecurity.vue
@@ -40,7 +40,7 @@ export default {
 	},
 	data() {
 		return {
-			issues: structuredClone(this.security)
+			issues: this.$helper.object.clone(this.security)
 		};
 	},
 	async mounted() {

--- a/panel/src/helpers/object.js
+++ b/panel/src/helpers/object.js
@@ -3,8 +3,6 @@
  *
  * @param {Object|array} value
  * @returns  {Object|array}
- *
- * @deprecated 4.1.0 Use `structuredClone` instead
  */
 export function clone(value) {
 	if (value === undefined) {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Undeprecate `$helper.object.clone`
- Use `$helper.object.clone` instead of `structuredClone`

### Reasoning
`structuredClone` cannot handle the automatic reactivity layer that Vue 3 adds on most/all objects. So we need a beefier version of `$helper.object.clone` to solve this. But therefore, we should stick to using the helper everywhere.


## Changelog

### Fix
- `$helper.object.clone` is no longer deprecated. Please use it instead of `structuredClone` as this might cause issues down the road with Vue 3.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->


- [ ] Tests and checks all pass
