### PR TITLE
Models sections: non-mutating `items` computed

### DIFF
--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -23,23 +23,24 @@ export default {
 		},
 		items() {
 			return this.data.map((file) => {
-				file.sortable = this.options.sortable;
-				file.column = this.column;
-				file.options = this.$dropdown(file.link, {
-					query: {
-						view: "list",
-						update: this.options.sortable,
-						delete: this.data.length > this.options.min
-					}
-				});
+				const sortable = this.options.sortable;
 
-				// add data-attributes info for item
-				file.data = {
-					"data-id": file.id,
-					"data-template": file.template
+				return {
+					...file,
+					column: this.column,
+					data: {
+						"data-id": file.id,
+						"data-template": file.template
+					},
+					options: this.$dropdown(file.link, {
+						query: {
+							view: "list",
+							update: sortable,
+							delete: this.data.length > this.options.min
+						}
+					}),
+					sortable
 				};
-
-				return file;
 			});
 		},
 		type() {

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -9,36 +9,37 @@ export default {
 		},
 		items() {
 			return this.data.map((page) => {
-				const disabled = page.permissions.changeStatus === false;
-				const status = this.$helper.page.status(page.status, disabled);
-				status.click = () => this.$dialog(page.link + "/changeStatus");
+				const sortable = page.permissions.sort && this.options.sortable;
+				const deletable = this.data.length > this.options.min;
 
-				page.flag = {
-					status: page.status,
-					disabled: disabled,
-					click: () => this.$dialog(page.link + "/changeStatus")
+				return {
+					...page,
+					buttons: [
+						{
+							...this.$helper.page.status(
+								page.status,
+								page.permissions.changeStatus === false
+							),
+							click: () => this.$dialog(page.link + "/changeStatus")
+						},
+						...(page.buttons ?? [])
+					],
+					column: this.column,
+					data: {
+						"data-id": page.id,
+						"data-status": page.status,
+						"data-template": page.template
+					},
+					deletable,
+					options: this.$dropdown(page.link, {
+						query: {
+							view: "list",
+							delete: deletable,
+							sort: sortable
+						}
+					}),
+					sortable
 				};
-
-				page.sortable = page.permissions.sort && this.options.sortable;
-				page.deletable = this.data.length > this.options.min;
-				page.column = this.column;
-				page.buttons = [status, ...(page.buttons ?? [])];
-				page.options = this.$dropdown(page.link, {
-					query: {
-						view: "list",
-						delete: page.deletable,
-						sort: page.sortable
-					}
-				});
-
-				// add data-attributes info for item
-				page.data = {
-					"data-id": page.id,
-					"data-status": page.status,
-					"data-template": page.template
-				};
-
-				return page;
 			});
 		},
 		type() {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Pages and files section: make that `items` computed maps the items by returning new objects instead of mutating the model parameter directly


### Reasoning
In Vue 3 the page/file parameter inside the map closure will be reactive. So assigning new values will directly mutate the original object. Which is problematic in this case https://github.com/getkirby/kirby/compare/v5/develop...v5/refactor/nonmutating-modelssection-items-computed?expand=1#diff-97e5d0547fc36db8267a17f7b8e71ce28763c11dcba313d445cef261fce2ebc0R25 where we add the status button to other buttons. When the object is reactive, this adds an additional status button to the list, each time the computed prop code runs. By refactoring the code this is avoided.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [ ] Tests and checks all pass
