### PR TITLE
Changes 11: Language::ensure & Languages::ensure

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -6,6 +6,7 @@ use Kirby\Data\Data;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
@@ -250,6 +251,29 @@ class Language implements Stringable
 	public function direction(): string
 	{
 		return $this->direction;
+	}
+
+	/**
+	 * Converts a "user-facing" language code to a `Language` object
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the language does not exist
+	 */
+	public static function ensure(string|null $code = null): static
+	{
+		$kirby = App::instance();
+
+		// single language
+		if ($kirby->multilang() === false) {
+			return static::single();
+		}
+
+		// look up the actual language object if possible
+		if ($language = $kirby->language($code)) {
+			return $language;
+		}
+
+		// validate the language code
+		throw new NotFoundException('Invalid language: ' . $code);
 	}
 
 	/**

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -258,8 +258,12 @@ class Language implements Stringable
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the language does not exist
 	 */
-	public static function ensure(string|null $code = null): static
+	public static function ensure(self|string|null $code = null): static
 	{
+		if ($code instanceof self) {
+			return $code;
+		}
+
 		$kirby = App::instance();
 
 		// single language

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -71,6 +71,22 @@ class Languages extends Collection
 	}
 
 	/**
+	 * Provides a collection of installed languages, even
+	 * if in single-language mode. In single-language mode
+	 * `Language::single()` is used to create the default language
+	 */
+	public static function ensure(): static
+	{
+		$kirby = App::instance();
+
+		if ($kirby->multilang() === true) {
+			return $kirby->languages();
+		}
+
+		return new static([Language::single()]);
+	}
+
+	/**
 	 * Convert all defined languages to a collection
 	 * @internal
 	 */

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -644,15 +644,14 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	/**
 	 * Returns a single translation by language code
 	 * If no code is specified the current translation is returned
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the language does not exist
 	 */
 	public function translation(
 		string|null $languageCode = null
 	): ContentTranslation|null {
-		if ($language = $this->kirby()->language($languageCode)) {
-			return $this->translations()->find($language->code());
-		}
-
-		return null;
+		$language = Language::ensure($languageCode ?? 'current');
+		return $this->translations()->find($language->code());
 	}
 
 	/**

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Generator;
 use Kirby\Cms\Language;
+use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
@@ -36,10 +37,7 @@ abstract class ContentStorageHandler
 	 */
 	public function all(): Generator
 	{
-		$kirby     = $this->model->kirby();
-		$languages = $kirby->multilang() === false ? [Language::single()] : $kirby->languages();
-
-		foreach ($languages as $language) {
+		foreach (Languages::ensure() as $language) {
 			foreach ($this->dynamicVersions() as $versionId) {
 				if ($this->exists($versionId, $language) === true) {
 					yield $versionId => $language;

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -117,18 +117,7 @@ class Version
 			return $languageCode;
 		}
 
-		// single language
-		if ($this->model->kirby()->multilang() === false) {
-			return Language::single();
-		}
-
-		// look up the actual language object if possible
-		if ($language = $this->model->kirby()->language($languageCode)) {
-			return $language;
-		}
-
-		// validate the language code
-		throw new InvalidArgumentException('Invalid language: ' . $languageCode);
+		return Language::ensure($languageCode);
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -113,10 +113,6 @@ class Version
 	protected function language(
 		Language|string|null $languageCode = null,
 	): Language {
-		if ($languageCode instanceof Language) {
-			return $languageCode;
-		}
-
 		return Language::ensure($languageCode);
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -4,7 +4,6 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Exception\InvalidArgumentException;
 
 /**
  * The Version class handles all actions for a single

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -225,6 +225,42 @@ class LanguageTest extends TestCase
 		$this->assertSame('ltr', $language->direction());
 	}
 
+	public function testEnsureInMultiLanguageMode()
+	{
+		new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true,
+				],
+				[
+					'code'    => 'de',
+				],
+			]
+		]);
+
+		$language = Language::ensure();
+
+		$this->assertSame('en', $language->code());
+
+		$language = Language::ensure('de');
+
+		$this->assertSame('de', $language->code());
+	}
+
+	public function testEnsureInSingleLanguageMode()
+	{
+		new App([
+			'roots' => [
+				'index' => static::TMP,
+			]
+		]);
+
+		$language = Language::ensure();
+
+		$this->assertSame('en', $language->code());
+	}
+
 	/**
 	 * @covers ::exists
 	 */

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -79,6 +79,29 @@ class LanguagesTest extends TestCase
 		$this->assertSame(['default'], $app->languages()->codes());
 	}
 
+	public function testEnsureInMultiLanguageMode()
+	{
+		new App([
+			'roots' => [
+				'index' => static::TMP,
+			]
+		]);
+
+		$languages = Languages::ensure();
+
+		$this->assertCount(1, $languages);
+		$this->assertSame('en', $languages->first()->code());
+	}
+
+	public function testEnsureInSingleLanguageMode()
+	{
+		$languages = Languages::ensure();
+
+		$this->assertCount(2, $languages);
+		$this->assertSame('en', $languages->first()->code());
+		$this->assertSame('de', $languages->last()->code());
+	}
+
 	public function testLoad()
 	{
 		$this->assertCount(2, $this->languages);

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -81,6 +81,15 @@ class LanguagesTest extends TestCase
 
 	public function testEnsureInMultiLanguageMode()
 	{
+		$languages = Languages::ensure();
+
+		$this->assertCount(2, $languages);
+		$this->assertSame('en', $languages->first()->code());
+		$this->assertSame('de', $languages->last()->code());
+	}
+
+	public function testEnsureInSingleLanguageMode()
+	{
 		new App([
 			'roots' => [
 				'index' => static::TMP,
@@ -91,15 +100,6 @@ class LanguagesTest extends TestCase
 
 		$this->assertCount(1, $languages);
 		$this->assertSame('en', $languages->first()->code());
-	}
-
-	public function testEnsureInSingleLanguageMode()
-	{
-		$languages = Languages::ensure();
-
-		$this->assertCount(2, $languages);
-		$this->assertSame('en', $languages->first()->code());
-		$this->assertSame('de', $languages->last()->code());
 	}
 
 	public function testLoad()

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Content;
 
 use Kirby\Data\Data;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 
 /**
@@ -315,7 +314,7 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Invalid language: fr');
 
 		$version->ensure('fr');


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [ ] 🚨 Merge first: #6450
- [ ] 🚨 Merge first: #6454
- [ ] 🚨 Merge first: #6455
- [ ] 🚨 Merge first: #6456
- [ ] 🚨 Merge first: #6457

### Features

- New `Language::ensure` method to always return a Language object - even in single-language mode
- New `Languages::ensure` method to always return a Languages collection - even in single-language mode

### Refactor

- Use new methods in ModelWithContent, ContentStorageHandler & Version classes

### Breaking changes

`ModelWithContent::translation` throws a NotFoundException if the requested language does not exist. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
