### PR TITLE
Fix menu blur when not inside Panel

### DIFF
--- a/panel/src/panel/menu.js
+++ b/panel/src/panel/menu.js
@@ -23,11 +23,12 @@ export default (panel) => {
 		 * @param {Event} event
 		 */
 		blur(event) {
-			if (media.matches === false) {
+			const menu = document.querySelector(".k-panel-menu");
+
+			if (!menu || media.matches === false) {
 				return false;
 			}
 
-			const menu = document.querySelector(".k-panel-menu");
 			const toggle = document.querySelector(".k-panel-menu-proxy");
 
 			if (


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
The panel menu blur method would run for narrow screen widths, trying to close the Panel menu, even when using `<k-panel-outside>` where the menu isn't present. It now stops trying to close the menu if the menu doesn't exist anyways.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed console error from login view on small window widths #6486



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
