### PR TITLE
Changes 12: More Version class improvements

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -415,14 +415,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function readContent(string|null $languageCode = null): array
 	{
-		try {
-			return $this->version()->read($languageCode ?? 'default');
-		} catch (NotFoundException) {
-			// only if the content file really does not exist, it's ok
-			// to return empty content. Otherwise this could lead to
-			// content loss in case of file reading issues
-			return [];
-		}
+		return $this->version()->read($languageCode ?? 'default') ?? [];
 	}
 
 	/**

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -213,9 +213,11 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
+	 * @throws \Kirby\Exception\NotFoundException If the content file is missing
 	 */
 	public function read(VersionId $versionId, Language $language): array
 	{
+		$this->ensure($versionId, $language);
 		return Data::read($this->contentFile($versionId, $language));
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -48,7 +48,7 @@ class Version
 	 */
 	public function contentFile(Language|string $language = 'default'): string
 	{
-		return $this->model->storage()->contentFile($this->id, $this->language($language));
+		return $this->model->storage()->contentFile($this->id, Language::ensure($language));
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Version
 	 */
 	public function create(array $fields, Language|string $language = 'default'): void
 	{
-		$this->model->storage()->create($this->id, $this->language($language), $fields);
+		$this->model->storage()->create($this->id, Language::ensure($language), $fields);
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Version
 	public function ensure(
 		Language|string $language = 'default'
 	): void {
-		$this->model->storage()->ensure($this->id, $this->language($language));
+		$this->model->storage()->ensure($this->id, Language::ensure($language));
 	}
 
 	/**
@@ -89,7 +89,7 @@ class Version
 	 */
 	public function exists(Language|string $language = 'default'): bool
 	{
-		return $this->model->storage()->exists($this->id, $this->language($language));
+		return $this->model->storage()->exists($this->id, Language::ensure($language));
 	}
 
 	/**
@@ -98,18 +98,6 @@ class Version
 	public function id(): VersionId
 	{
 		return $this->id;
-	}
-
-	/**
-	 * Converts a "user-facing" language code or Language object
-	 * to a `Language` object to be used in storage methods
-	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if the language code does not match a valid language
-	 */
-	protected function language(
-		Language|string|null $languageCode = null,
-	): Language {
-		return Language::ensure($languageCode);
 	}
 
 	/**
@@ -128,7 +116,7 @@ class Version
 		Language|string $language = 'default'
 	): int|null {
 		if ($this->exists($language) === true) {
-			return $this->model->storage()->modified($this->id, $this->language($language));
+			return $this->model->storage()->modified($this->id, Language::ensure($language));
 		}
 
 		return null;
@@ -147,9 +135,9 @@ class Version
 		$this->ensure($fromLanguage);
 		$this->model->storage()->move(
 			fromVersionId: $this->id,
-			fromLanguage: $this->language($fromLanguage),
+			fromLanguage: Language::ensure($fromLanguage),
 			toVersionId: $toVersionId,
-			toLanguage: $this->language($toLanguage)
+			toLanguage: Language::ensure($toLanguage)
 		);
 	}
 
@@ -161,7 +149,7 @@ class Version
 	public function read(Language|string $language = 'default'): array
 	{
 		try {
-			return $this->model->storage()->read($this->id, $this->language($language));
+			return $this->model->storage()->read($this->id, Language::ensure($language));
 		} catch (Throwable) {
 			return [];
 		}
@@ -177,7 +165,7 @@ class Version
 	public function replace(array $fields, string $language = 'default'): void
 	{
 		$this->ensure($language);
-		$this->model->storage()->update($this->id, $this->language($language), $fields);
+		$this->model->storage()->update($this->id, Language::ensure($language), $fields);
 	}
 
 	/**
@@ -188,7 +176,7 @@ class Version
 	public function touch(Language|string $language = 'default'): void
 	{
 		$this->ensure($language);
-		$this->model->storage()->touch($this->id, $this->language($language));
+		$this->model->storage()->touch($this->id, Language::ensure($language));
 	}
 
 	/**
@@ -206,6 +194,6 @@ class Version
 		// update to a complete version
 		$fields = [...$this->read($language), ...$fields];
 
-		$this->model->storage()->update($this->id, $this->language($language), $fields);
+		$this->model->storage()->update($this->id, Language::ensure($language), $fields);
 	}
 }

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -162,10 +162,28 @@ class Version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
-	public function replace(array $fields, string $language = 'default'): void
+	public function replace(array $fields, Language|string $language = 'default'): void
 	{
 		$this->ensure($language);
 		$this->model->storage()->update($this->id, Language::ensure($language), $fields);
+	}
+
+	/**
+	 * Convenience wrapper around ::create, ::replace and ::update.
+	 */
+	public function save(
+		array $fields,
+		Language|string $language = 'default',
+		bool $overwrite = false
+	): void {
+		match (true) {
+			$this->exists() === false
+				=> $this->create($fields, $language),
+			$overwrite === true
+				=> $this->replace($fields, $language),
+			default
+			=> $this->update($fields, $language)
+		};
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -5,7 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
-use Throwable;
+use Kirby\Exception\NotFoundException;
 
 /**
  * The Version class handles all actions for a single
@@ -34,7 +34,7 @@ class Version
 	public function content(Language|string $language = 'default'): Content
 	{
 		$language = Language::ensure($language);
-		$fields   = $this->read($language);
+		$fields   = $this->read($language) ?? [];
 
 		// This is where we merge content from the default language
 		// to provide a fallback for missing/untranslated fields.
@@ -44,7 +44,7 @@ class Version
 		// individual versions of pages and no longer enforce the fallback.
 		if ($language->isDefault() === false) {
 			$fields = [
-				...$this->read('default'),
+				...$this->read('default') ?? [],
 				...$fields
 			];
 		}
@@ -214,9 +214,9 @@ class Version
 	/**
 	 * Returns the stored content fields
 	 *
-	 * @return array<string, string>
+	 * @return array<string, string>|null
 	 */
-	public function read(Language|string $language = 'default'): array
+	public function read(Language|string $language = 'default'): array|null
 	{
 		$language = Language::ensure($language);
 
@@ -224,8 +224,8 @@ class Version
 			$fields = $this->model->storage()->read($this->id, $language);
 			$fields = $this->prepareFieldsAfterRead($fields, $language);
 			return $fields;
-		} catch (Throwable) {
-			return [];
+		} catch (NotFoundException) {
+			return null;
 		}
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -177,7 +177,7 @@ class Version
 		bool $overwrite = false
 	): void {
 		match (true) {
-			$this->exists() === false
+			$this->exists($language) === false
 				=> $this->create($fields, $language),
 			$overwrite === true
 				=> $this->replace($fields, $language),

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -168,6 +168,19 @@ class Version
 	}
 
 	/**
+	 * Replaces the content of the current version with the given fields
+	 *
+	 * @param array<string, string> $fields Content fields
+	 *
+	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 */
+	public function replace(array $fields, string $language = 'default'): void
+	{
+		$this->ensure($language);
+		$this->model->storage()->update($this->id, $this->language($language), $fields);
+	}
+
+	/**
 	 * Updates the modification timestamp of an existing version
 	 *
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -148,8 +148,10 @@ class Version
 	 */
 	public function read(Language|string $language = 'default'): array
 	{
+		$language = Language::ensure($language);
+
 		try {
-			return $this->model->storage()->read($this->id, Language::ensure($language));
+			return $this->model->storage()->read($this->id, $language);
 		} catch (Throwable) {
 			return [];
 		}

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -201,6 +201,11 @@ class Version
 	public function update(array $fields, Language|string $language = 'default'): void
 	{
 		$this->ensure($language);
+
+		// merge the previous state with the new state to always
+		// update to a complete version
+		$fields = [...$this->read($language), ...$fields];
+
 		$this->model->storage()->update($this->id, $this->language($language), $fields);
 	}
 }

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -35,7 +35,7 @@ class Version
 	{
 		return new Content(
 			parent: $this->model,
-			data:   $this->model->storage()->read($this->id, $this->language($language)),
+			data:   $this->read($language),
 		);
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
+use Throwable;
 
 /**
  * The Version class handles all actions for a single
@@ -156,13 +157,14 @@ class Version
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
-	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	public function read(Language|string $language = 'default'): array
 	{
-		$this->ensure($language);
-		return $this->model->storage()->read($this->id, $this->language($language));
+		try {
+			return $this->model->storage()->read($this->id, $this->language($language));
+		} catch (Throwable) {
+			return [];
+		}
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -257,14 +257,17 @@ class Version
 		Language|string $language = 'default',
 		bool $overwrite = false
 	): void {
-		match (true) {
-			$this->exists($language) === false
-				=> $this->create($fields, $language),
-			$overwrite === true
-				=> $this->replace($fields, $language),
-			default
-			=> $this->update($fields, $language)
-		};
+		if ($this->exists($language) === false) {
+			$this->create($fields, $language);
+			return;
+		}
+
+		if ($overwrite === true) {
+			$this->replace($fields, $language);
+			return;
+		}
+
+		$this->update($fields, $language);
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -295,7 +295,7 @@ class Version
 		// update to a complete version
 		$fields = [
 			...$this->read($language),
-			...$this->convertFieldNamesToLowerCase($fields)
+			...$fields
 		];
 
 		$this->model->storage()->update(

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -33,9 +33,25 @@ class Version
 	 */
 	public function content(Language|string $language = 'default'): Content
 	{
+		$language = Language::ensure($language);
+		$fields   = $this->read($language);
+
+		// This is where we merge content from the default language
+		// to provide a fallback for missing/untranslated fields.
+		//
+		// @todo This is the critical point that needs to be removed/refactored
+		// in the future, to provide multi-language support with truly
+		// individual versions of pages and no longer enforce the fallback.
+		if ($language->isDefault() === false) {
+			$fields = [
+				...$this->read('default'),
+				...$fields
+			];
+		}
+
 		return new Content(
 			parent: $this->model,
-			data:   $this->read($language),
+			data:   $fields,
 		);
 	}
 

--- a/tests/Content/MemoryContentStorageHandlerTest.php
+++ b/tests/Content/MemoryContentStorageHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use Kirby\Exception\NotFoundException;
 
 /**
  * @coversDefaultClass Kirby\Content\MemoryContentStorageHandler
@@ -308,6 +309,19 @@ class MemoryContentStorageHandlerTest extends TestCase
 
 		$this->assertIsInt($this->storage->modified($changes, $language));
 		$this->assertNull($this->storage->modified(VersionId::published(), $language));
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testReadWhenMissing()
+	{
+		$this->setUpSingleLanguage();
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Version "changes" does not already exist');
+
+		$this->storage->read(VersionId::changes(), Language::single());
 	}
 
 	/**

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 
 /**
@@ -314,6 +315,19 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		Data::write($this->model->root() . '/article.txt', $fields);
 
 		$this->assertSame($fields, $this->storage->read(VersionId::published(), Language::single()));
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testReadWhenMissing()
+	{
+		$this->setUpSingleLanguage();
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Version "changes" does not already exist');
+
+		$this->storage->read(VersionId::changes(), Language::single());
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -223,7 +223,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::create
 	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::removeUnwantedFields
+	 * @covers ::prepareFieldsBeforeWrite
 	 */
 	public function testCreateWithDirtyFields(): void
 	{
@@ -653,6 +653,8 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsAfterRead
 	 */
 	public function testReadMultiLanguage(): void
 	{
@@ -673,6 +675,8 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsAfterRead
 	 */
 	public function testReadSingleLanguage(): void
 	{
@@ -691,6 +695,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::read
 	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsAfterRead
 	 */
 	public function testReadWithDirtyFields(): void
 	{
@@ -713,6 +718,8 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsAfterRead
 	 */
 	public function testReadWithInvalidLanguage(): void
 	{
@@ -731,6 +738,8 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::replace
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsBeforeWrite
 	 */
 	public function testReplaceMultiLanguage(): void
 	{
@@ -759,6 +768,8 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::replace
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::prepareFieldsBeforeWrite
 	 */
 	public function testReplaceSingleLanguage(): void
 	{
@@ -781,7 +792,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::replace
 	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::removeUnwantedFields
+	 * @covers ::prepareFieldsBeforeWrite
 	 */
 	public function testReplaceWithDirtyFields(): void
 	{
@@ -1099,7 +1110,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::update
 	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::removeUnwantedFields
+	 * @covers ::prepareFieldsBeforeWrite
 	 */
 	public function testUpdateWithDirtyFields(): void
 	{

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -38,7 +38,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::content
-	 * @covers ::language
 	 */
 	public function testContentMultiLanguage(): void
 	{
@@ -86,7 +85,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::contentFile
-	 * @covers ::language
 	 */
 	public function testContentFileMultiLanguage(): void
 	{
@@ -121,7 +119,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::create
-	 * @covers ::language
 	 */
 	public function testCreateMultiLanguage(): void
 	{
@@ -229,7 +226,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::ensure
-	 * @covers ::language
 	 */
 	public function testEnsureMultiLanguage(): void
 	{
@@ -305,7 +301,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::ensure
-	 * @covers ::language
 	 */
 	public function testEnsureWithInvalidLanguage(): void
 	{
@@ -324,7 +319,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::exists
-	 * @covers ::language
 	 */
 	public function testExistsMultiLanguage(): void
 	{
@@ -395,7 +389,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::modified
-	 * @covers ::language
 	 */
 	public function testModifiedMultiLanguage(): void
 	{
@@ -414,7 +407,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::modified
-	 * @covers ::language
 	 */
 	public function testModifiedMultiLanguageIfNotExists(): void
 	{
@@ -554,7 +546,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
-	 * @covers ::language
 	 */
 	public function testReadMultiLanguage(): void
 	{
@@ -600,7 +591,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::touch
-	 * @covers ::language
 	 */
 	public function testTouchMultiLanguage(): void
 	{
@@ -657,7 +647,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::update
-	 * @covers ::language
 	 */
 	public function testUpdateMultiLanguage(): void
 	{

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -590,6 +590,66 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::replace
+	 */
+	public function testReplaceMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		Data::write($fileEN = $this->contentFile('en'), [
+			'title'    => 'Test English',
+			'subtitle' => 'Subtitle English'
+		]);
+
+		Data::write($fileDE = $this->contentFile('de'), [
+			'title'    => 'Test Deutsch',
+			'subtitle' => 'Subtitle Deutsch'
+		]);
+
+		// with Language argument
+		$version->replace([
+			'title' => 'Updated Title English'
+		], $this->app->language('en'));
+
+		// with string argument
+		$version->replace([
+			'title' => 'Updated Title Deutsch',
+		], 'de');
+
+		$this->assertSame(['title' => 'Updated Title English'], Data::read($fileEN));
+		$this->assertSame(['title' => 'Updated Title Deutsch'], Data::read($fileDE));
+	}
+
+	/**
+	 * @covers ::replace
+	 */
+	public function testReplaceSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		Data::write($file = $this->contentFile(), $content = [
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle'
+		]);
+
+		$version->replace([
+			'title' => 'Updated Title'
+		]);
+
+		$this->assertSame(['title' => 'Updated Title'], Data::read($file));
+	}
+
+	/**
 	 * @covers ::touch
 	 */
 	public function testTouchMultiLanguage(): void
@@ -658,11 +718,13 @@ class VersionTest extends TestCase
 		);
 
 		Data::write($fileEN = $this->contentFile('en'), [
-			'title' => 'Test English'
+			'title'    => 'Test English',
+			'subtitle' => 'Subtitle English'
 		]);
 
 		Data::write($fileDE = $this->contentFile('de'), [
-			'title' => 'Test Deutsch'
+			'title'    => 'Test Deutsch',
+			'subtitle' => 'Subtitle Deutsch'
 		]);
 
 		// with Language argument
@@ -672,11 +734,13 @@ class VersionTest extends TestCase
 
 		// with string argument
 		$version->update([
-			'title' => 'Updated Title Deutsch'
+			'title' => 'Updated Title Deutsch',
 		], 'de');
 
 		$this->assertSame('Updated Title English', Data::read($fileEN)['title']);
+		$this->assertSame('Subtitle English', Data::read($fileEN)['subtitle']);
 		$this->assertSame('Updated Title Deutsch', Data::read($fileDE)['title']);
+		$this->assertSame('Subtitle Deutsch', Data::read($fileDE)['subtitle']);
 	}
 
 	/**
@@ -692,7 +756,8 @@ class VersionTest extends TestCase
 		);
 
 		Data::write($file = $this->contentFile(), $content = [
-			'title' => 'Test'
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle'
 		]);
 
 		$version->update([
@@ -700,5 +765,6 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertSame('Updated Title', Data::read($file)['title']);
+		$this->assertSame('Subtitle', Data::read($file)['subtitle']);
 	}
 }

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -65,7 +65,6 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::content
-	 * @covers ::language
 	 */
 	public function testContentSingleLanguage(): void
 	{

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -196,6 +196,63 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::create
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::removeUnwantedFields
+	 */
+	public function testCreateWithDirtyFields(): void
+	{
+		$this->setUpMultiLanguage();
+
+		// add a blueprint with an untranslatable field
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/article' => [
+					'fields' => [
+						'date' => [
+							'type'      => 'date',
+							'translate' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		// primary language
+		$version->create([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'en');
+
+		// secondary language
+		$version->create([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'de');
+
+		// check for lower case field names
+		$this->assertArrayHasKey('subtitle', $version->read('en'));
+		$this->assertArrayHasKey('subtitle', $version->read('de'));
+
+		// check for removed uuid field in secondary language
+		$this->assertArrayHasKey('uuid', $version->read('en'));
+		$this->assertArrayNotHasKey('uuid', $version->read('de'));
+
+		// check for untranslatable fields
+		$this->assertArrayHasKey('date', $version->read('en'));
+		$this->assertArrayNotHasKey('date', $version->read('de'));
+	}
+
+	/**
 	 * @covers ::delete
 	 */
 	public function testDeleteMultiLanguage(): void
@@ -608,6 +665,29 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 * @covers ::convertFieldNamesToLowerCase
+	 */
+	public function testReadWithDirtyFields(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		Data::write($this->contentFile(), [
+			'Title'    => 'Dirty title',
+			'subTitle' => 'Dirty subtitle'
+		]);
+
+		// check for lower case field names
+		$this->assertArrayHasKey('title', $version->read());
+		$this->assertArrayHasKey('subtitle', $version->read());
+	}
+
+	/**
+	 * @covers ::read
 	 */
 	public function testReadWithInvalidLanguage(): void
 	{
@@ -671,6 +751,65 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertSame(['title' => 'Updated Title'], Data::read($expected['file']));
+	}
+
+	/**
+	 * @covers ::replace
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::removeUnwantedFields
+	 */
+	public function testReplaceWithDirtyFields(): void
+	{
+		$this->setUpMultiLanguage();
+
+		// add a blueprint with an untranslatable field
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/article' => [
+					'fields' => [
+						'date' => [
+							'type'      => 'date',
+							'translate' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->createContentMultiLanguage();
+
+		// primary language
+		$version->replace([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'en');
+
+		// secondary language
+		$version->replace([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'de');
+
+		// check for lower case field names
+		$this->assertArrayHasKey('subtitle', $version->read('en'));
+		$this->assertArrayHasKey('subtitle', $version->read('de'));
+
+		// check for removed uuid field in secondary language
+		$this->assertArrayHasKey('uuid', $version->read('en'));
+		$this->assertArrayNotHasKey('uuid', $version->read('de'));
+
+		// check for untranslatable fields
+		$this->assertArrayHasKey('date', $version->read('en'));
+		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 
 	/**
@@ -930,5 +1069,64 @@ class VersionTest extends TestCase
 
 		$this->assertSame('Updated Title', Data::read($expected['file'])['title']);
 		$this->assertSame('Subtitle', Data::read($expected['file'])['subtitle']);
+	}
+
+	/**
+	 * @covers ::update
+	 * @covers ::convertFieldNamesToLowerCase
+	 * @covers ::removeUnwantedFields
+	 */
+	public function testUpdateWithDirtyFields(): void
+	{
+		$this->setUpMultiLanguage();
+
+		// add a blueprint with an untranslatable field
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/article' => [
+					'fields' => [
+						'date' => [
+							'type'      => 'date',
+							'translate' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->createContentMultiLanguage();
+
+		// primary language
+		$version->update([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'en');
+
+		// secondary language
+		$version->update([
+			'title'    => 'Test',
+			'uuid'     => '12345',
+			'Subtitle' => 'Subtitle',
+			'date'     => '2012-12-12'
+		], 'de');
+
+		// check for lower case field names
+		$this->assertArrayHasKey('subtitle', $version->read('en'));
+		$this->assertArrayHasKey('subtitle', $version->read('de'));
+
+		// check for removed uuid field in secondary language
+		$this->assertArrayHasKey('uuid', $version->read('en'));
+		$this->assertArrayNotHasKey('uuid', $version->read('de'));
+
+		// check for untranslatable fields
+		$this->assertArrayHasKey('date', $version->read('en'));
+		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 }

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -694,6 +694,22 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::read
+	 */
+	public function testReadWhenMissing(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->assertFileDoesNotExist($this->contentFile());
+		$this->assertNull($version->read());
+	}
+
+	/**
+	 * @covers ::read
 	 * @covers ::convertFieldNamesToLowerCase
 	 * @covers ::prepareFieldsAfterRead
 	 */

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -607,6 +607,24 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::read
+	 */
+	public function testReadWithInvalidLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Invalid language: fr');
+
+		$version->read('fr');
+	}
+
+	/**
 	 * @covers ::replace
 	 */
 	public function testReplaceMultiLanguage(): void

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -112,6 +112,31 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::content
+	 */
+	public function testContentWithFallback(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($this->model->root() . '/article.en.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $version->content()->toArray());
+		$this->assertSame($content, $version->content('en')->toArray());
+
+		// make sure that the content fallback works
+		$this->assertSame($version->content('en')->toArray(), $version->content('de')->toArray());
+	}
+
+	/**
 	 * @covers ::contentFile
 	 */
 	public function testContentFileMultiLanguage(): void


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [x] 🚨 Merge first: #6457
- [x] 🚨 Merge first: #6483

### Reasoning

While working on the next steps (following PRs) I realised that the Version class still needs additional adjustments to help us tackle the problems in the ModelWithContent class later. 

One of the most important changes is to move field normalization and field removal to the Version class. If we don't do that, developers could call e.g. `$model->version()->update()` with fields that should actually not be stored at all. Moving this part of the logic to the ContentStorageHandler classes would be too much and Version seems like the perfect place for it. It will also reduce the logic in the Model classes. 

With this change, we can also simplify the Content class later. It is no longer responsible to normalize field names afterwards. 

### Features

- New `Version::replace` method as a dedicated way to replace all existing fields in a version with the given array. This helps to clean up the `$overwrite` logic in `ModelWithContent::save` and `ModelWithContent::update`
- New `Version::save` method to provide a reliable way to always save the version, no matter if it already exists or not. This is a wrapper around `Version::create`, `Version::update` and `Version::replace` and prepares to deprecate
  - `ModelWithContent::save` 
  - `ModelWithContent::saveContent`
  - `ModelWithContent::saveTranslation`
  - `ModelWithContent::writeContent`
- New protected `Version::convertFieldNamesToLowerCase` method to normalize field names on read and write. 
- New protected `Version::prepareFieldsBeforeWrite` method to remove untranslatable fields and the uuid field for non-default languages.
- New protected `Version::prepareFieldsAfterRead` to clean field names after fields have been read from storage.

### Refactor

- `Version::read` returns null if the version does not exist and throws an exception if the language does not exist.
- `Version::content` will now use `Version::read` to always return a Content object, even if a version does not exist. It also implements the content fallback merge with the default language for non-default languages. 
- `Version::update` will now read the last state and merge fields with the given array to make sure that the end result will always be a full set with all fields and no fields get lost.
- The protected `Version::language` method can now be removed since `Language::ensure` is available.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
