### PR TITLE
Changes 13: New translation classes

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -38,6 +38,13 @@ class Helpers
 		// TODO: switch to true in v6
 		'plugin-extends-root' => false,
 
+		// The `Content\Translation` class keeps a set of methods from the old
+		// `ContentTranslation` class for compatibility that should no longer be used.
+		// Some of them can be replaced by using `Version` class methods instead
+		// (see method comments). `Content\Translation::contentFile` should be avoided
+		//  entirely and has no recommended replacement.
+		'translation-methods' => false,
+
 		// Passing a single space as value to `Xml::attr()` has been
 		// deprecated. In a future version, passing a single space won't
 		// render an empty value anymore but a single space.

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -43,7 +43,7 @@ class Helpers
 		// Some of them can be replaced by using `Version` class methods instead
 		// (see method comments). `Content\Translation::contentFile` should be avoided
 		//  entirely and has no recommended replacement.
-		'translation-methods' => false,
+		'translation-methods' => true,
 
 		// Passing a single space as value to `Xml::attr()` has been
 		// deprecated. In a future version, passing a single space won't

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -16,7 +16,7 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class Translation extends ContentTranslation
+class Translation
 {
 	/**
 	 * Creates a new translation object
@@ -40,6 +40,8 @@ class Translation extends ContentTranslation
 	/**
 	 * Returns the language code of the
 	 * translation
+	 *
+	 * @deprecated since 5.0.0 Use `::language()->code()` instead
 	 */
 	public function code(): string
 	{
@@ -49,14 +51,18 @@ class Translation extends ContentTranslation
 	/**
 	 * Returns the translation content
 	 * as plain array
+	 *
+	 * @deprecated since 5.0.0 Use `::version()->content()` instead
 	 */
-	public function content(): array
+	public function content(): Content
 	{
-		return $this->version->read($this->language);
+		return $this->version->content($this->language);
 	}
 
 	/**
 	 * Absolute path to the translation content file
+	 *
+	 * @deprecated since 5.0.0 Use `::version()->contentFile()` instead
 	 */
 	public function contentFile(): string
 	{
@@ -89,6 +95,8 @@ class Translation extends ContentTranslation
 
 	/**
 	 * Checks if the translation file exists
+	 *
+	 * @deprecated since 5.0.0 Use `::version()->exists()` instead
 	 */
 	public function exists(): bool
 	{
@@ -100,12 +108,14 @@ class Translation extends ContentTranslation
 	 */
 	public function id(): string
 	{
-		return $this->code();
+		return $this->language->code();
 	}
 
 	/**
 	 * Checks if the this is the default translation
 	 * of the model
+	 *
+	 * @deprecated since 5.0.0 Use `::language()->isDefault()` instead
 	 */
 	public function isDefault(): bool
 	{
@@ -133,22 +143,7 @@ class Translation extends ContentTranslation
 	 */
 	public function slug(): string|null
 	{
-		return $this->content()['slug'] ?? null;
-	}
-
-	/**
-	 * Merge the old and new data
-	 */
-	public function update(array|null $data = null, bool $overwrite = false): static
-	{
-		$data = array_change_key_case((array)$data);
-
-		$this->content = match ($overwrite) {
-			true    => $data,
-			default => [...$this->content(), ...$data]
-		};
-
-		return $this;
+		return $this->version->read()['slug'] ?? null;
 	}
 
 	/**
@@ -158,9 +153,9 @@ class Translation extends ContentTranslation
 	public function toArray(): array
 	{
 		return [
-			'code'    => $this->code(),
-			'content' => $this->content(),
-			'exists'  => $this->exists(),
+			'code'    => $this->language->code(),
+			'content' => $this->version->content($this->language)->toArray(),
+			'exists'  => $this->version->exists($this->language),
 			'slug'    => $this->slug(),
 		];
 	}

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -58,7 +58,7 @@ class Translation extends ContentTranslation
 	 */
 	public function content(): array
 	{
-		Helpers::deprecated('`$translation->content()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-methods');
+		Helpers::deprecated('`$translation->content()->toArray()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-methods');
 		return $this->version->content($this->language)->toArray();
 	}
 
@@ -69,7 +69,7 @@ class Translation extends ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		Helpers::deprecated('`$translation->contentFile()` has been deprecated. Use `$translation->version()->contentFile()` instead.', 'translation-methods');
+		Helpers::deprecated('Please let us know if you have a use case for a replacement.', 'translation-methods');
 		return $this->version->contentFile($this->language);
 	}
 

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * Each page, file or site can have multiple
+ * translated versions of their content,
+ * represented by this class
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Translation extends ContentTranslation
+{
+	/**
+	 * Creates a new translation object
+	 */
+	public function __construct(
+		protected ModelWithContent $model,
+		protected Version $version,
+		protected Language $language
+	) {
+	}
+
+	/**
+	 * Improve `var_dump` output
+	 * @codeCoverageIgnore
+	 */
+	public function __debugInfo(): array
+	{
+		return $this->toArray();
+	}
+
+	/**
+	 * Returns the language code of the
+	 * translation
+	 */
+	public function code(): string
+	{
+		return $this->language->code();
+	}
+
+	/**
+	 * Returns the translation content
+	 * as plain array
+	 */
+	public function content(): array
+	{
+		return $this->version->read($this->language);
+	}
+
+	/**
+	 * Absolute path to the translation content file
+	 */
+	public function contentFile(): string
+	{
+		return $this->version->contentFile($this->language);
+	}
+
+	/**
+	 * Creates a new Translation for the given model
+	 */
+	public static function create(
+		ModelWithContent $model,
+		Version $version,
+		Language $language,
+		array $fields,
+		string|null $slug = null
+	): static {
+		// add the custom slug to the fields array
+		if ($slug !== null) {
+			$fields['slug'] = $slug;
+		}
+
+		$version->create($fields, $language);
+
+		return new static(
+			model: $model,
+			version: $version,
+			language: $language,
+		);
+	}
+
+	/**
+	 * Checks if the translation file exists
+	 */
+	public function exists(): bool
+	{
+		return $this->version->exists($this->language);
+	}
+
+	/**
+	 * Returns the translation code as id
+	 */
+	public function id(): string
+	{
+		return $this->code();
+	}
+
+	/**
+	 * Checks if the this is the default translation
+	 * of the model
+	 */
+	public function isDefault(): bool
+	{
+		return $this->language->isDefault();
+	}
+
+	/**
+	 * Returns the language
+	 */
+	public function language(): Language
+	{
+		return $this->language;
+	}
+
+	/**
+	 * Returns the parent page, file or site object
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	/**
+	 * Returns the custom translation slug
+	 */
+	public function slug(): string|null
+	{
+		return $this->content()['slug'] ?? null;
+	}
+
+	/**
+	 * Merge the old and new data
+	 */
+	public function update(array|null $data = null, bool $overwrite = false): static
+	{
+		$data = array_change_key_case((array)$data);
+
+		$this->content = match ($overwrite) {
+			true    => $data,
+			default => [...$this->content(), ...$data]
+		};
+
+		return $this;
+	}
+
+	/**
+	 * Converts the most important translation
+	 * props to an array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'code'    => $this->code(),
+			'content' => $this->content(),
+			'exists'  => $this->exists(),
+			'slug'    => $this->slug(),
+		];
+	}
+
+	/**
+	 * Returns the version
+	 */
+	public function version(): Version
+	{
+		return $this->version;
+	}
+}

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\Exception;
 
 /**
  * Each page, file or site can have multiple
@@ -148,6 +149,14 @@ class Translation extends ContentTranslation
 	}
 
 	/**
+	 * @deprecated 5.0.0 Use `$translation->model()` instead
+	 */
+	public function parent(): ModelWithContent
+	{
+		throw new Exception('`$translation->parent()` has been deprecated. Please use `$translation->model()` instead');
+	}
+
+	/**
 	 * Returns the custom translation slug
 	 */
 	public function slug(): string|null
@@ -167,6 +176,14 @@ class Translation extends ContentTranslation
 			'exists'  => $this->version->exists($this->language),
 			'slug'    => $this->slug(),
 		];
+	}
+
+	/**
+	 * @deprecated 5.0.0 Use `$model->version()->update()` instead
+	 */
+	public function update(array|null $data = null, bool $overwrite = false): static
+	{
+		throw new Exception('`$translation->update()` has been deprecated. Please use `$model->version()->update()` instead');
 	}
 
 	/**

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -42,7 +42,7 @@ class Translation extends ContentTranslation
 	 * Returns the language code of the
 	 * translation
 	 *
-	 * @deprecated since 5.0.0 Use `::language()->code()` instead
+	 * @deprecated 5.0.0 Use `::language()->code()` instead
 	 */
 	public function code(): string
 	{
@@ -54,7 +54,7 @@ class Translation extends ContentTranslation
 	 * Returns the translation content
 	 * as plain array
 	 *
-	 * @deprecated since 5.0.0 Use `::version()->content()->toArray()` instead
+	 * @deprecated 5.0.0 Use `::version()->content()->toArray()` instead
 	 */
 	public function content(): array
 	{
@@ -65,7 +65,7 @@ class Translation extends ContentTranslation
 	/**
 	 * Absolute path to the translation content file
 	 *
-	 * @deprecated since 5.0.0 Use `::version()->contentFile()` instead
+	 * @deprecated 5.0.0
 	 */
 	public function contentFile(): string
 	{
@@ -100,7 +100,7 @@ class Translation extends ContentTranslation
 	/**
 	 * Checks if the translation file exists
 	 *
-	 * @deprecated since 5.0.0 Use `::version()->exists()` instead
+	 * @deprecated 5.0.0 Use `::version()->exists()` instead
 	 */
 	public function exists(): bool
 	{
@@ -120,7 +120,7 @@ class Translation extends ContentTranslation
 	 * Checks if the this is the default translation
 	 * of the model
 	 *
-	 * @deprecated since 5.0.0 Use `::language()->isDefault()` instead
+	 * @deprecated 5.0.0 Use `::language()->isDefault()` instead
 	 */
 	public function isDefault(): bool
 	{

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -16,7 +16,7 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class Translation
+class Translation extends ContentTranslation
 {
 	/**
 	 * Creates a new translation object
@@ -52,11 +52,11 @@ class Translation
 	 * Returns the translation content
 	 * as plain array
 	 *
-	 * @deprecated since 5.0.0 Use `::version()->content()` instead
+	 * @deprecated since 5.0.0 Use `::version()->content()->toArray()` instead
 	 */
-	public function content(): Content
+	public function content(): array
 	{
-		return $this->version->content($this->language);
+		return $this->version->content($this->language)->toArray();
 	}
 
 	/**

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -45,6 +45,7 @@ class Translation extends ContentTranslation
 	 */
 	public function code(): string
 	{
+		Helpers::deprecated('`$translation->code()` has been deprecated. Use `$translation->language()->code()` instead.', 'translation-code');
 		return $this->language->code();
 	}
 
@@ -56,6 +57,7 @@ class Translation extends ContentTranslation
 	 */
 	public function content(): array
 	{
+		Helpers::deprecated('`$translation->content()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-content');
 		return $this->version->content($this->language)->toArray();
 	}
 
@@ -66,6 +68,7 @@ class Translation extends ContentTranslation
 	 */
 	public function contentFile(): string
 	{
+		Helpers::deprecated('`$translation->contentFile()` has been deprecated. Use `$translation->version()->contentFile()` instead.', 'translation-contentFile');
 		return $this->version->contentFile($this->language);
 	}
 
@@ -100,6 +103,7 @@ class Translation extends ContentTranslation
 	 */
 	public function exists(): bool
 	{
+		Helpers::deprecated('`$translation->exists()` has been deprecated. Use `$translation->version()->exists()` instead.', 'translation-exists');
 		return $this->version->exists($this->language);
 	}
 
@@ -119,6 +123,7 @@ class Translation extends ContentTranslation
 	 */
 	public function isDefault(): bool
 	{
+		Helpers::deprecated('`$translation->isDefault()` has been deprecated. Use `$translation->language()->isDefault()` instead.', 'translation-isDefault');
 		return $this->language->isDefault();
 	}
 

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -149,7 +149,7 @@ class Translation extends ContentTranslation
 	 */
 	public function slug(): string|null
 	{
-		return $this->version->read($this->language)['slug'] ?? null;
+		return $this->version->content($this->language)->data()['slug'] ?? null;
 	}
 
 	/**

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -143,7 +143,7 @@ class Translation extends ContentTranslation
 	 */
 	public function slug(): string|null
 	{
-		return $this->version->read()['slug'] ?? null;
+		return $this->version->read($this->language)['slug'] ?? null;
 	}
 
 	/**

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -69,7 +69,7 @@ class Translation extends ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		Helpers::deprecated('Please let us know if you have a use case for a replacement.', 'translation-methods');
+		Helpers::deprecated('`$translation->contentFile()` has been deprecated. Please let us know if you have a use case for a replacement.', 'translation-methods');
 		return $this->version->contentFile($this->language);
 	}
 

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\Helpers;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -46,7 +46,7 @@ class Translation extends ContentTranslation
 	 */
 	public function code(): string
 	{
-		Helpers::deprecated('`$translation->code()` has been deprecated. Use `$translation->language()->code()` instead.', 'translation-code');
+		Helpers::deprecated('`$translation->code()` has been deprecated. Use `$translation->language()->code()` instead.', 'translation-methods');
 		return $this->language->code();
 	}
 
@@ -58,7 +58,7 @@ class Translation extends ContentTranslation
 	 */
 	public function content(): array
 	{
-		Helpers::deprecated('`$translation->content()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-content');
+		Helpers::deprecated('`$translation->content()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-methods');
 		return $this->version->content($this->language)->toArray();
 	}
 
@@ -69,7 +69,7 @@ class Translation extends ContentTranslation
 	 */
 	public function contentFile(): string
 	{
-		Helpers::deprecated('`$translation->contentFile()` has been deprecated. Use `$translation->version()->contentFile()` instead.', 'translation-contentFile');
+		Helpers::deprecated('`$translation->contentFile()` has been deprecated. Use `$translation->version()->contentFile()` instead.', 'translation-methods');
 		return $this->version->contentFile($this->language);
 	}
 
@@ -104,7 +104,7 @@ class Translation extends ContentTranslation
 	 */
 	public function exists(): bool
 	{
-		Helpers::deprecated('`$translation->exists()` has been deprecated. Use `$translation->version()->exists()` instead.', 'translation-exists');
+		Helpers::deprecated('`$translation->exists()` has been deprecated. Use `$translation->version()->exists()` instead.', 'translation-methods');
 		return $this->version->exists($this->language);
 	}
 
@@ -124,7 +124,7 @@ class Translation extends ContentTranslation
 	 */
 	public function isDefault(): bool
 	{
-		Helpers::deprecated('`$translation->isDefault()` has been deprecated. Use `$translation->language()->isDefault()` instead.', 'translation-isDefault');
+		Helpers::deprecated('`$translation->isDefault()` has been deprecated. Use `$translation->language()->isDefault()` instead.', 'translation-methods');
 		return $this->language->isDefault();
 	}
 

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -75,6 +75,9 @@ class Translation extends ContentTranslation
 
 	/**
 	 * Creates a new Translation for the given model
+	 *
+	 * @todo Needs to be refactored as soon as Version::create becomes static
+	 * 		 (see https://github.com/getkirby/kirby/pull/6491#discussion_r1652264408)
 	 */
 	public static function create(
 		ModelWithContent $model,

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Collection;
+use Kirby\Cms\Language;
+use Kirby\Cms\Languages;
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ *
+ * @extends \Kirby\Cms\Collection<\Kirby\Content\Translation>
+ */
+class Translations extends Collection
+{
+	/**
+	 * Creates a new Translations collection from
+	 * an array of translations properties. This is
+	 * used in LabPage::setTranslations to properly
+	 * normalize an array definition.
+	 */
+	public static function create(
+		ModelWithContent $model,
+		Version $version,
+		array $translations
+	): static {
+		foreach ($translations as $translation) {
+			Translation::create(
+				model: $model,
+				version: $version,
+				language: Language::ensure($translation['code'] ?? 'default'),
+				fields: $translation['content'] ?? [],
+				slug: $translation['slug'] ?? null
+			);
+		}
+
+		return static::load(
+			model: $model,
+			version: $version
+		);
+	}
+
+	/**
+	 * Simplifies `Translations::find` by allowing to pass
+	 * Language codes that will be properly validated here.
+	 */
+	public function findByKey(string $key): Translation|null
+	{
+		try {
+			return parent::get(Language::ensure($key)->code());
+		} catch (NotFoundException) {
+			return null;
+		}
+	}
+
+	/**
+	 * Loads all available translations for a given model
+	 */
+	public static function load(
+		ModelWithContent $model,
+		Version $version
+	): static {
+		$translations = new static();
+
+		foreach (Languages::ensure() as $language) {
+			$translation = new Translation(
+				model: $model,
+				version: $version,
+				language: $language
+			);
+
+			$translations->data[$language->code()] = $translation;
+		}
+
+		return $translations;
+	}
+}

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -61,18 +61,16 @@ class Translations extends Collection
 		ModelWithContent $model,
 		Version $version
 	): static {
-		$translations = new static();
+		$translations = [];
 
 		foreach (Languages::ensure() as $language) {
-			$translation = new Translation(
+			$translations[] = new Translation(
 				model: $model,
 				version: $version,
 				language: $language
 			);
-
-			$translations->data[$language->code()] = $translation;
 		}
 
-		return $translations;
+		return new static($translations);
 	}
 }

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -6,6 +6,7 @@ use Kirby\Cms\Collection;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\NotFoundException;
 
 /**
  * @package   Kirby Content

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -23,6 +23,9 @@ class Translations extends Collection
 	 * an array of translations properties. This is
 	 * used in LabPage::setTranslations to properly
 	 * normalize an array definition.
+	 *
+	 * @todo Needs to be refactored as soon as Version::create becomes static
+	 * 		 (see https://github.com/getkirby/kirby/pull/6491#discussion_r1652264408)
 	 */
 	public static function create(
 		ModelWithContent $model,

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -6,7 +6,6 @@ use Kirby\Cms\Collection;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Exception\NotFoundException;
 
 /**
  * @package   Kirby Content
@@ -52,11 +51,7 @@ class Translations extends Collection
 	 */
 	public function findByKey(string $key): Translation|null
 	{
-		try {
-			return parent::get(Language::ensure($key)->code());
-		} catch (NotFoundException) {
-			return null;
-		}
+		return parent::get(Language::ensure($key)->code());
 	}
 
 	/**

--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\App;
+use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase as BaseTestCase;
 
@@ -11,6 +12,66 @@ class TestCase extends BaseTestCase
 	public const TMP = KIRBY_TMP_DIR;
 
 	protected $model;
+
+	public function assertContentFileExists(string|null $language = null, VersionId|null $versionId = null)
+	{
+		$this->assertFileExists($this->contentFile($language, $versionId));
+	}
+
+	public function assertContentFileDoesNotExist(string|null $language = null, VersionId|null $versionId = null)
+	{
+		$this->assertFileDoesNotExist($this->contentFile($language, $versionId));
+	}
+
+	public function contentFile(string|null $language = null, VersionId|null $versionId = null): string
+	{
+		return
+			$this->model->root() .
+			// add the changes folder
+			($versionId?->value() === 'changes' ? '/_changes/' : '/') .
+			// template
+			'article' .
+			// language code
+			($language === null ? '' : '.' . $language) .
+			'.txt';
+	}
+
+	public function createContentMultiLanguage(): array
+	{
+		Data::write($fileEN = $this->contentFile('en'), $contentEN = [
+			'title'    => 'Title English',
+			'subtitle' => 'Subtitle English'
+		]);
+
+		Data::write($fileDE = $this->contentFile('de'), $contentDE = [
+			'title'    => 'Title Deutsch',
+			'subtitle' => 'Subtitle Deutsch'
+		]);
+
+		return [
+			'en' => [
+				'content' => $contentEN,
+				'file'    => $fileEN,
+			],
+			'de' => [
+				'content' => $contentDE,
+				'file'    => $fileDE,
+			]
+		];
+	}
+
+	public function createContentSingleLanguage(): array
+	{
+		Data::write($file = $this->contentFile(), $content = [
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle'
+		]);
+
+		return [
+			'content' => $content,
+			'file'    => $file
+		];
+	}
 
 	public function setUp(): void
 	{

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -6,7 +6,7 @@ use Kirby\Cms\Language;
 use Kirby\Data\Data;
 
 /**
- * @coversDefaultClass Kirby\Content\Translation
+ * @coversDefaultClass \Kirby\Content\Translation
  * @covers ::__construct
  */
 class TranslationTest extends TestCase

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Language;
 use Kirby\Data\Data;
+use Kirby\Exception\Exception;
 
 /**
  * @coversDefaultClass \Kirby\Content\Translation
@@ -268,6 +269,25 @@ class TranslationTest extends TestCase
 	}
 
 	/**
+	 * @covers ::parent
+	 */
+	public function testParent()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $version = $this->model->version(),
+			language: Language::ensure('default')
+		);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('`$translation->parent()` has been deprecated. Please use `$translation->model()` instead');
+
+		$translation->parent();
+	}
+
+	/**
 	 * @covers ::slug
 	 */
 	public function testSlugExists()
@@ -306,6 +326,25 @@ class TranslationTest extends TestCase
 		]);
 
 		$this->assertNull($translation->slug());
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdate()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $version = $this->model->version(),
+			language: Language::ensure('default')
+		);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('`$translation->update()` has been deprecated. Please use `$model->version()->update()` instead');
+
+		$translation->update();
 	}
 
 	/**

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -59,8 +59,8 @@ class TranslationTest extends TestCase
 
 		$expected = $this->createContentMultiLanguage();
 
-		$this->assertSame($expected['en']['content'], $translationEN->content()->toArray());
-		$this->assertSame($expected['de']['content'], $translationDE->content()->toArray());
+		$this->assertSame($expected['en']['content'], $translationEN->content());
+		$this->assertSame($expected['de']['content'], $translationDE->content());
 	}
 
 	/**
@@ -78,7 +78,7 @@ class TranslationTest extends TestCase
 
 		$expected = $this->createContentSingleLanguage();
 
-		$this->assertSame($expected['content'], $translation->content()->toArray());
+		$this->assertSame($expected['content'], $translation->content());
 	}
 
 	/**
@@ -132,7 +132,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model, $translation->model());
 		$this->assertSame($version, $translation->version());
 		$this->assertSame($language, $translation->language());
-		$this->assertSame($content, $translation->content()->toArray());
+		$this->assertSame($content, $translation->content());
 		$this->assertTrue($translation->exists());
 	}
 
@@ -153,7 +153,7 @@ class TranslationTest extends TestCase
 			slug: 'foo'
 		);
 
-		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->content()->toArray());
+		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->content());
 		$this->assertSame('foo', $translation->slug());
 	}
 

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -274,30 +274,18 @@ class TranslationTest extends TestCase
 	{
 		$this->setUpMultiLanguage();
 
-		$translationEN = new Translation(
-			model: $this->model,
-			version: $this->model->version(),
-			language: Language::ensure('en')
-		);
-
-		$translationDE = new Translation(
+		$translation = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
 			language: Language::ensure('de')
 		);
-
-		Data::write($this->contentFile('en'), [
-			'title' => 'Test',
-			'slug'  => 'english-slug'
-		]);
 
 		Data::write($this->contentFile('de'), [
 			'title' => 'Test',
 			'slug'  => 'german-slug'
 		]);
 
-		$this->assertSame('english-slug', $translationEN->slug());
-		$this->assertSame('german-slug', $translationDE->slug());
+		$this->assertSame('german-slug', $translation->slug());
 	}
 
 	/**
@@ -310,10 +298,10 @@ class TranslationTest extends TestCase
 		$translation = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
-			language: Language::ensure('en')
+			language: Language::ensure('de')
 		);
 
-		Data::write($this->contentFile('en'), [
+		Data::write($this->contentFile('de'), [
 			'title' => 'Test',
 		]);
 

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -274,18 +274,30 @@ class TranslationTest extends TestCase
 	{
 		$this->setUpMultiLanguage();
 
-		$translation = new Translation(
+		$translationEN = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
 			language: Language::ensure('en')
 		);
 
+		$translationDE = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('de')
+		);
+
 		Data::write($this->contentFile('en'), [
 			'title' => 'Test',
-			'slug'  => 'foo'
+			'slug'  => 'english-slug'
 		]);
 
-		$this->assertSame('foo', $translation->slug());
+		Data::write($this->contentFile('de'), [
+			'title' => 'Test',
+			'slug'  => 'german-slug'
+		]);
+
+		$this->assertSame('english-slug', $translationEN->slug());
+		$this->assertSame('german-slug', $translationDE->slug());
 	}
 
 	/**

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -31,10 +31,10 @@ class TranslationTest extends TestCase
 			language: Language::ensure('de')
 		);
 
-		$this->assertSame('en', $translationEN->code());
+		$this->assertSame('en', $translationEN->language()->code());
 		$this->assertSame('en', $translationEN->id());
 
-		$this->assertSame('de', $translationDE->code());
+		$this->assertSame('de', $translationDE->language()->code());
 		$this->assertSame('de', $translationDE->id());
 	}
 
@@ -48,19 +48,19 @@ class TranslationTest extends TestCase
 		$translationEN = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
-			language: Language::ensure('en')
+			language: $languageEN = Language::ensure('en')
 		);
 
 		$translationDE = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
-			language: Language::ensure('de')
+			language: $languageDE = Language::ensure('de')
 		);
 
 		$expected = $this->createContentMultiLanguage();
 
-		$this->assertSame($expected['en']['content'], $translationEN->content());
-		$this->assertSame($expected['de']['content'], $translationDE->content());
+		$this->assertSame($expected['en']['content'], $translationEN->version()->content($languageEN)->toArray());
+		$this->assertSame($expected['de']['content'], $translationDE->version()->content($languageDE)->toArray());
 	}
 
 	/**
@@ -78,7 +78,7 @@ class TranslationTest extends TestCase
 
 		$expected = $this->createContentSingleLanguage();
 
-		$this->assertSame($expected['content'], $translation->content());
+		$this->assertSame($expected['content'], $translation->version()->content()->toArray());
 	}
 
 	/**
@@ -94,7 +94,7 @@ class TranslationTest extends TestCase
 			language: Language::ensure('en')
 		);
 
-		$this->assertSame($this->model->root() . '/article.en.txt', $translation->contentFile());
+		$this->assertSame($this->model->root() . '/article.en.txt', $translation->version()->contentFile());
 	}
 
 	/**
@@ -110,7 +110,7 @@ class TranslationTest extends TestCase
 			language: Language::single()
 		);
 
-		$this->assertSame($this->model->root() . '/article.txt', $translation->contentFile());
+		$this->assertSame($this->model->root() . '/article.txt', $translation->version()->contentFile());
 	}
 
 	/**
@@ -132,8 +132,8 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model, $translation->model());
 		$this->assertSame($version, $translation->version());
 		$this->assertSame($language, $translation->language());
-		$this->assertSame($content, $translation->content());
-		$this->assertTrue($translation->exists());
+		$this->assertSame($content, $translation->version()->content()->toArray());
+		$this->assertTrue($translation->version()->exists());
 	}
 
 	/**
@@ -153,7 +153,7 @@ class TranslationTest extends TestCase
 			slug: 'foo'
 		);
 
-		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->content());
+		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->version()->content()->toArray());
 		$this->assertSame('foo', $translation->slug());
 	}
 
@@ -176,13 +176,13 @@ class TranslationTest extends TestCase
 			language: Language::ensure('de')
 		);
 
-		$this->assertFalse($translationEN->exists());
-		$this->assertFalse($translationDE->exists());
+		$this->assertFalse($translationEN->version()->exists());
+		$this->assertFalse($translationDE->version()->exists());
 
 		$this->createContentMultiLanguage();
 
-		$this->assertTrue($translationEN->exists());
-		$this->assertTrue($translationDE->exists());
+		$this->assertTrue($translationEN->version()->exists());
+		$this->assertTrue($translationDE->version()->exists());
 	}
 
 	/**
@@ -198,11 +198,11 @@ class TranslationTest extends TestCase
 			language: Language::single()
 		);
 
-		$this->assertFalse($translation->exists());
+		$this->assertFalse($translation->version()->exists());
 
 		$this->createContentSingleLanguage();
 
-		$this->assertTrue($translation->exists());
+		$this->assertTrue($translation->version()->exists());
 	}
 
 	/**
@@ -224,8 +224,8 @@ class TranslationTest extends TestCase
 			language: Language::ensure('de')
 		);
 
-		$this->assertTrue($en->isDefault());
-		$this->assertFalse($de->isDefault());
+		$this->assertTrue($en->language()->isDefault());
+		$this->assertFalse($de->language()->isDefault());
 	}
 
 	/**

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+use Kirby\Data\Data;
+
+/**
+ * @coversDefaultClass Kirby\Content\Translation
+ * @covers ::__construct
+ */
+class TranslationTest extends TestCase
+{
+	/**
+	 * @covers ::code
+	 * @covers ::id
+	 */
+	public function testCodeAndId()
+	{
+		$this->setUpMultiLanguage();
+
+		$translationEN = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$translationDE = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('de')
+		);
+
+		$this->assertSame('en', $translationEN->code());
+		$this->assertSame('en', $translationEN->id());
+
+		$this->assertSame('de', $translationDE->code());
+		$this->assertSame('de', $translationDE->id());
+	}
+
+	/**
+	 * @covers ::content
+	 */
+	public function testContentMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$translationEN = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$translationDE = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('de')
+		);
+
+		$expected = $this->createContentMultiLanguage();
+
+		$this->assertSame($expected['en']['content'], $translationEN->content()->toArray());
+		$this->assertSame($expected['de']['content'], $translationDE->content()->toArray());
+	}
+
+	/**
+	 * @covers ::content
+	 */
+	public function testContentSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::single()
+		);
+
+		$expected = $this->createContentSingleLanguage();
+
+		$this->assertSame($expected['content'], $translation->content()->toArray());
+	}
+
+	/**
+	 * @covers ::contentFile
+	 */
+	public function testContentFileMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$this->assertSame($this->model->root() . '/article.en.txt', $translation->contentFile());
+	}
+
+	/**
+	 * @covers ::contentFile
+	 */
+	public function testContentFileSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::single()
+		);
+
+		$this->assertSame($this->model->root() . '/article.txt', $translation->contentFile());
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreate()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = Translation::create(
+			model: $this->model,
+			version: $version = $this->model->version(),
+			language: $language = Language::ensure('en'),
+			fields: $content = [
+				'title' => 'Test'
+			]
+		);
+
+		$this->assertSame($this->model, $translation->model());
+		$this->assertSame($version, $translation->version());
+		$this->assertSame($language, $translation->language());
+		$this->assertSame($content, $translation->content()->toArray());
+		$this->assertTrue($translation->exists());
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateWithSlug()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = Translation::create(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en'),
+			fields: [
+				'title' => 'Test'
+			],
+			slug: 'foo'
+		);
+
+		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->content()->toArray());
+		$this->assertSame('foo', $translation->slug());
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$translationEN = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$translationDE = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('de')
+		);
+
+		$this->assertFalse($translationEN->exists());
+		$this->assertFalse($translationDE->exists());
+
+		$this->createContentMultiLanguage();
+
+		$this->assertTrue($translationEN->exists());
+		$this->assertTrue($translationDE->exists());
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::single()
+		);
+
+		$this->assertFalse($translation->exists());
+
+		$this->createContentSingleLanguage();
+
+		$this->assertTrue($translation->exists());
+	}
+
+	/**
+	 * @covers ::isDefault
+	 */
+	public function testIsDefault()
+	{
+		$this->setUpMultiLanguage();
+
+		$en = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$de = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('de')
+		);
+
+		$this->assertTrue($en->isDefault());
+		$this->assertFalse($de->isDefault());
+	}
+
+	/**
+	 * @covers ::language
+	 */
+	public function testLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$translationEN = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: $languageEN = Language::ensure('en')
+		);
+
+		$translationDE = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: $languageDE = Language::ensure('de')
+		);
+
+		$this->assertSame($languageEN, $translationEN->language());
+		$this->assertSame($languageDE, $translationDE->language());
+	}
+
+	/**
+	 * @covers ::model
+	 */
+	public function testModel()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$this->assertSame($this->model, $translation->model());
+	}
+
+	/**
+	 * @covers ::slug
+	 */
+	public function testSlugExists()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		Data::write($this->contentFile('en'), [
+			'title' => 'Test',
+			'slug'  => 'foo'
+		]);
+
+		$this->assertSame('foo', $translation->slug());
+	}
+
+	/**
+	 * @covers ::slug
+	 */
+	public function testSlugNotExists()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		Data::write($this->contentFile('en'), [
+			'title' => 'Test',
+		]);
+
+		$this->assertNull($translation->slug());
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray()
+	{
+		$this->setUpSingleLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$expected = [
+			'code'    => 'en',
+			'content' => $this->createContentSingleLanguage()['content'],
+			'exists'  => true,
+			'slug'    => null,
+		];
+
+		$this->assertSame($expected, $translation->toArray());
+	}
+
+	/**
+	 * @covers ::version
+	 */
+	public function testVersion()
+	{
+		$this->setUpMultiLanguage();
+
+		$translation = new Translation(
+			model: $this->model,
+			version: $version = $this->model->version(),
+			language: Language::ensure('en')
+		);
+
+		$this->assertSame($version, $translation->version());
+	}
+}

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -35,8 +35,8 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertCount(2, $translations);
-		$this->assertSame('en', $translations->first()->code());
-		$this->assertSame('de', $translations->last()->code());
+		$this->assertSame('en', $translations->first()->language()->code());
+		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
 	/**
@@ -67,7 +67,7 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertCount(1, $translations);
-		$this->assertSame('en', $translations->first()->code());
+		$this->assertSame('en', $translations->first()->language()->code());
 		$this->assertTrue($translations->first()->language()->isSingle());
 	}
 
@@ -83,10 +83,10 @@ class TranslationsTest extends TestCase
 			version: $this->model->version()
 		);
 
-		$this->assertSame('en', $translations->findByKey('en')->code());
-		$this->assertSame('en', $translations->findByKey('default')->code());
-		$this->assertSame('en', $translations->findByKey('current')->code());
-		$this->assertSame('de', $translations->findByKey('de')->code());
+		$this->assertSame('en', $translations->findByKey('en')->language()->code());
+		$this->assertSame('en', $translations->findByKey('default')->language()->code());
+		$this->assertSame('en', $translations->findByKey('current')->language()->code());
+		$this->assertSame('de', $translations->findByKey('de')->language()->code());
 		$this->assertNull($translations->findByKey('fr'));
 	}
 
@@ -102,9 +102,9 @@ class TranslationsTest extends TestCase
 			version: $this->model->version()
 		);
 
-		$this->assertSame('en', $translations->findByKey('en')->code());
-		$this->assertSame('en', $translations->findByKey('default')->code());
-		$this->assertSame('en', $translations->findByKey('current')->code());
+		$this->assertSame('en', $translations->findByKey('en')->language()->code());
+		$this->assertSame('en', $translations->findByKey('default')->language()->code());
+		$this->assertSame('en', $translations->findByKey('current')->language()->code());
 	}
 
 	/**
@@ -120,8 +120,8 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertCount(2, $translations);
-		$this->assertSame('en', $translations->first()->code());
-		$this->assertSame('de', $translations->last()->code());
+		$this->assertSame('en', $translations->first()->language()->code());
+		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
 	/**
@@ -137,7 +137,7 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertCount(1, $translations);
-		$this->assertSame('en', $translations->first()->code());
+		$this->assertSame('en', $translations->first()->language()->code());
 		$this->assertTrue($translations->first()->language()->isSingle());
 	}
 }

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -32,17 +32,35 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertCount(2, $translations);
+		$this->assertSame('en', $translations->first()->code());
+		$this->assertSame('de', $translations->last()->code());
 	}
 
 	public function testFindByKeyMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
+		$translations = Translations::load(
+			model: $this->model,
+			version: $this->model->version()
+		);
+
+		$this->assertSame('en', $translations->findByKey('en')->code());
+		$this->assertSame('de', $translations->findByKey('de')->code());
+		$this->assertNull($translations->findByKey('fr'));
 	}
 
 	public function testLoadMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
+		$translations = Translations::load(
+			model: $this->model,
+			version: $this->model->version()
+		);
+
+		$this->assertCount(2, $translations);
+		$this->assertSame('en', $translations->first()->code());
+		$this->assertSame('de', $translations->last()->code());
 	}
 }

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -8,7 +8,10 @@ namespace Kirby\Content;
  */
 class TranslationsTest extends TestCase
 {
-	public function testCreateMultiLanguage(): void
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
 
@@ -36,7 +39,42 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->last()->code());
 	}
 
-	public function testFindByKeyMultiLanguage(): void
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translations = Translations::create(
+			model: $this->model,
+			version: $this->model->version(),
+			translations: [
+				[
+					'code' 	  => 'en',
+					'content' => [
+						'title' => 'Title English'
+					]
+				],
+				// should be ignored because the matching language is not installed
+				[
+					'code' 	  => 'de',
+					'content' => [
+						'title' => 'Title Deutsch'
+					]
+				]
+			]
+		);
+
+		$this->assertCount(1, $translations);
+		$this->assertSame('en', $translations->first()->code());
+		$this->assertTrue($translations->first()->language()->isSingle());
+	}
+
+	/**
+	 * @covers ::findByKey
+	 */
+	public function testFindByKeyMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
 
@@ -46,11 +84,33 @@ class TranslationsTest extends TestCase
 		);
 
 		$this->assertSame('en', $translations->findByKey('en')->code());
+		$this->assertSame('en', $translations->findByKey('default')->code());
+		$this->assertSame('en', $translations->findByKey('current')->code());
 		$this->assertSame('de', $translations->findByKey('de')->code());
 		$this->assertNull($translations->findByKey('fr'));
 	}
 
-	public function testLoadMultiLanguage(): void
+	/**
+	 * @covers ::findByKey
+	 */
+	public function testFindByKeySingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translations = Translations::load(
+			model: $this->model,
+			version: $this->model->version()
+		);
+
+		$this->assertSame('en', $translations->findByKey('en')->code());
+		$this->assertSame('en', $translations->findByKey('default')->code());
+		$this->assertSame('en', $translations->findByKey('current')->code());
+	}
+
+	/**
+	 * @covers ::load
+	 */
+	public function testLoadMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
 
@@ -62,5 +122,22 @@ class TranslationsTest extends TestCase
 		$this->assertCount(2, $translations);
 		$this->assertSame('en', $translations->first()->code());
 		$this->assertSame('de', $translations->last()->code());
+	}
+
+	/**
+	 * @covers ::load
+	 */
+	public function testLoadSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$translations = Translations::load(
+			model: $this->model,
+			version: $this->model->version()
+		);
+
+		$this->assertCount(1, $translations);
+		$this->assertSame('en', $translations->first()->code());
+		$this->assertTrue($translations->first()->language()->isSingle());
 	}
 }

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Content;
 
+use Kirby\Exception\NotFoundException;
+
 /**
  * @coversDefaultClass \Kirby\Content\Translations
  * @covers ::__construct
@@ -87,7 +89,6 @@ class TranslationsTest extends TestCase
 		$this->assertSame('en', $translations->findByKey('default')->language()->code());
 		$this->assertSame('en', $translations->findByKey('current')->language()->code());
 		$this->assertSame('de', $translations->findByKey('de')->language()->code());
-		$this->assertNull($translations->findByKey('fr'));
 	}
 
 	/**
@@ -105,6 +106,24 @@ class TranslationsTest extends TestCase
 		$this->assertSame('en', $translations->findByKey('en')->language()->code());
 		$this->assertSame('en', $translations->findByKey('default')->language()->code());
 		$this->assertSame('en', $translations->findByKey('current')->language()->code());
+	}
+
+	/**
+	 * @covers ::findByKey
+	 */
+	public function testFindByKeyWithInvalidLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$translations = Translations::load(
+			model: $this->model,
+			version: $this->model->version()
+		);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Invalid language: fr');
+
+		$translations->findByKey('fr');
 	}
 
 	/**

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -3,7 +3,7 @@
 namespace Kirby\Content;
 
 /**
- * @coversDefaultClass Kirby\Content\Translations
+ * @coversDefaultClass \Kirby\Content\Translations
  * @covers ::__construct
  */
 class TranslationsTest extends TestCase

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Kirby\Content;
+
+/**
+ * @coversDefaultClass Kirby\Content\Translations
+ * @covers ::__construct
+ */
+class TranslationsTest extends TestCase
+{
+	public function testCreateMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$translations = Translations::create(
+			model: $this->model,
+			version: $this->model->version(),
+			translations: [
+				[
+					'code' 	  => 'en',
+					'content' => [
+						'title' => 'Title English'
+					]
+				],
+				[
+					'code' 	  => 'de',
+					'content' => [
+						'title' => 'Title Deutsch'
+					]
+				]
+			]
+		);
+
+		$this->assertCount(2, $translations);
+	}
+
+	public function testFindByKeyMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+	}
+
+	public function testLoadMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+	}
+}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -13,66 +13,6 @@ class VersionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Version';
 
-	public function assertContentFileExists(string|null $language = null, VersionId|null $versionId = null)
-	{
-		$this->assertFileExists($this->contentFile($language, $versionId));
-	}
-
-	public function assertContentFileDoesNotExist(string|null $language = null, VersionId|null $versionId = null)
-	{
-		$this->assertFileDoesNotExist($this->contentFile($language, $versionId));
-	}
-
-	public function contentFile(string|null $language = null, VersionId|null $versionId = null): string
-	{
-		return
-			$this->model->root() .
-			// add the changes folder
-			($versionId?->value() === 'changes' ? '/_changes/' : '/') .
-			// template
-			'article' .
-			// language code
-			($language === null ? '' : '.' . $language) .
-			'.txt';
-	}
-
-	public function createContentMultiLanguage(): array
-	{
-		Data::write($fileEN = $this->contentFile('en'), $contentEN = [
-			'title'    => 'Title English',
-			'subtitle' => 'Subtitle English'
-		]);
-
-		Data::write($fileDE = $this->contentFile('de'), $contentDE = [
-			'title'    => 'Title Deutsch',
-			'subtitle' => 'Subtitle Deutsch'
-		]);
-
-		return [
-			'en' => [
-				'content' => $contentEN,
-				'file'    => $fileEN,
-			],
-			'de' => [
-				'content' => $contentDE,
-				'file'    => $fileDE,
-			]
-		];
-	}
-
-	public function createContentSingleLanguage(): array
-	{
-		Data::write($file = $this->contentFile(), $content = [
-			'title'    => 'Title',
-			'subtitle' => 'Subtitle'
-		]);
-
-		return [
-			'content' => $content,
-			'file'    => $file
-		];
-	}
-
 	/**
 	 * @covers ::content
 	 */


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [x] 🚨 Merge first: #6457
- [x] 🚨 Merge first: #6483
- [x] 🚨 Merge first: #6490

### Reasoning

The `ContentTranslation` class is one of our internal classes that still uses array props in the constructor and also has some logic that shouldn't be in there. To untangle the translation knot, it really helps to refactor this class to named properties and turn most of its methods into proxies to access the underlying version or language objects. 

In order to turn this into a smooth transition, I've decided to extend the `ContentTranslation` class for now. This way, we can use it as a replacement for `ContentTranslation` in many parts already before we replace it later. We can also change methods more freely without affecting the CMS Models and their unit tests too drastically for now. 

### Features

- New `Kirby\Content\Translation` class (to eventually replace `Kirby\Content\ContentTranslation`)
- New `Kirby\Content\Translations` class to help in `ModelWithContent::translations` later and to provide a more type-safe collection for all translations. 

The following changes to `Translation` will be new features as soon as it replaces the `ContentTranslation` class. 

- New `Translation::version` method to return the parent `Version` instance
- New `Translation::create` method to setup a new translation from an array of fields.

### Deprecated

- `Translation::code` Use `::language()->code()` instead
- `Translation::content` Use `::version()->content()->toArray()` instead
- `Translation::contentFile` Use `::version()->contentFile()` instead
- `Translation::exists` Use `::version()->exists()` instead
- `Translation::isDefault` Use `::language()->isDefault()` instead

### Breaking changes

The following changes to the `Translation` class will be breaking changes as soon as it will replace the `ContentTranslation` class. 

- `Translation::parent` has been replace with `Translation::model`
- `Translation::update` has been removed

### Code coverage

No matter what I do, `Translations::load` is simply not covered and I don't know why. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
