### PR TITLE
Changes 14: LabPage class

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -131,17 +131,19 @@ class Page extends ModelWithContent
 			throw new InvalidArgumentException('The page slug is required');
 		}
 
-		parent::__construct($props);
-
+		// the draft state needs to be set before running
+		// ::setContent or ::setTranslations
+		$this->isDraft = $props['isDraft'] ?? false;
 		$this->slug    = $props['slug'];
 		// Sets the dirname manually, which works
 		// more reliable in connection with the inventory
 		// than computing the dirname afterwards
 		$this->dirname = $props['dirname'] ?? null;
-		$this->isDraft = $props['isDraft'] ?? false;
 		$this->num     = $props['num'] ?? null;
 		$this->parent  = $props['parent'] ?? null;
 		$this->root    = $props['root'] ?? null;
+
+		parent::__construct($props);
 
 		$this->setBlueprint($props['blueprint'] ?? null);
 		$this->setChildren($props['children'] ?? null);

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -119,6 +119,25 @@ abstract class ContentStorageHandler
 	abstract public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
+	 * Creates a new storage instance with all the versions
+	 * from the given storage instance.
+	 */
+	public static function from(self $fromStorage): static
+	{
+		$toStorage = new static(
+			model: $fromStorage->model()
+		);
+
+		// copy all versions from the given storage instance
+		// and add them to the new storage instance.
+		foreach ($fromStorage->all() as $versionId => $language) {
+			$toStorage->create($versionId, $language, $fromStorage->read($versionId, $language));
+		}
+
+		return $toStorage;
+	}
+
+	/**
 	 * Returns the related model
 	 */
 	public function model(): ModelWithContent

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -119,6 +119,14 @@ abstract class ContentStorageHandler
 	abstract public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
+	 * Returns the related model
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	/**
 	 * Returns the modification timestamp of a version if it exists
 	 */
 	abstract public function modified(VersionId $versionId, Language $language): int|null;

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -46,6 +46,10 @@ class LabPage extends Page
 		return $this->version()->read($languageCode ?? 'current');
 	}
 
+	/**
+	 * Stores the content on disk
+	 * @internal
+	 */
 	public function save(
 		array|null $data = null,
 		string|null $languageCode = null,

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -21,6 +21,10 @@ class LabPage extends Page
 	 */
 	public function clone(array $props = []): static
 	{
+		// keep the current state of the content in memory storage
+		// before creating the clone. The storage of the clone can
+		// afterwards be mutated without affecting the content in the
+		// original instance.
 		$this->storage = MemoryContentStorageHandler::from($this->storage);
 		return parent::clone($props);
 	}

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -144,6 +144,22 @@ class LabPage extends Page
 	}
 
 	/**
+	 * Returns the slug of the page
+	 */
+	public function slug(string|null $languageCode = null): string
+	{
+		if ($this->kirby()->multilang() === true) {
+			$language = Language::ensure($languageCode ?? 'current');
+
+			if ($language->isDefault() !== true) {
+				return $this->translation($language)->slug() ?? $this->slug;
+			}
+		}
+
+		return $this->slug;
+	}
+
+	/**
 	 * Returns a single translation by language code
 	 * If no code is specified the current translation is returned
 	 */

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Collection;
+use Kirby\Cms\Language;
+use Kirby\Cms\Page;
+
+/**
+ * Test Model to prototype the content and translation
+ * mechanics
+ */
+class LabPage extends Page
+{
+	/**
+	 * Creates a new instance with the same
+	 * initial properties
+	 *
+	 * @todo eventually refactor without need of propertyData
+	 */
+	public function clone(array $props = []): static
+	{
+		$this->storage = MemoryContentStorageHandler::from($this->storage);
+		return parent::clone($props);
+	}
+
+	/**
+	 * Returns the content for the default version and given language code
+	 */
+	public function content(string|null $languageCode = null): Content
+	{
+		return $this->version()->content($languageCode ?? 'current');
+	}
+
+	/**
+	 * @deprecated since 5.0.0 Use `::version()->read()` instead
+	 */
+	public function readContent(string|null $languageCode = null): array
+	{
+		return $this->version()->read($languageCode ?? 'current');
+	}
+
+	/**
+	 * @deprecated since 5.0.0 Use `::version()->save()` instead
+	 */
+	public function save(
+		array|null $data = null,
+		string|null $languageCode = null,
+		bool $overwrite = false
+	): static {
+		$clone = $this->clone();
+		$clone->version()->save($data ?? [], $languageCode ?? 'current', $overwrite);
+		return $clone;
+	}
+
+	/**
+	 * @deprecated since 5.0.0 Use `::version()->save()` instead
+	 */
+	protected function saveContent(
+		array|null $data = null,
+		bool $overwrite = false
+	): static {
+		$clone = $this->clone();
+		$clone->version()->save($data ?? [], 'current', $overwrite);
+		return $clone;
+	}
+
+	/**
+	 * @deprecated since 5.0.0 Use `::version()->save()` instead
+	 */
+	protected function saveTranslation(
+		array|null $data = null,
+		string|null $languageCode = null,
+		bool $overwrite = false
+	): static {
+		$clone = $this->clone();
+		$clone->version()->save($data ?? [], $languageCode ?? 'current', $overwrite);
+		return $clone;
+	}
+
+	/**
+	 * Sets the content when initializing a model manually.
+	 * This will switch to the in memory storage to keep the
+	 * content there instead of on disk or in a database.
+	 * The content will be created for the default version and language
+	 */
+	protected function setContent(array|null $content = null): static
+	{
+		// don't set anything if there's no content
+		if ($content === null) {
+			return $this;
+		}
+
+		$this->storage = new MemoryContentStorageHandler(
+			model: $this
+		);
+
+		Translation::create(
+			model: $this,
+			version: $this->version(),
+			language: Language::ensure('default'),
+			fields: $content
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Stores in-memory translations for the model if they
+	 * are passed to the constructor with the translations prop.
+	 */
+	protected function setTranslations(array|null $translations = null): static
+	{
+		// don't set anything if there's no content
+		if ($translations === null) {
+			return $this;
+		}
+
+		// switch to in-memory content storage
+		$this->storage = new MemoryContentStorageHandler(
+			model: $this
+		);
+
+		Translations::create(
+			model: $this,
+			version: $this->version(),
+			translations: $translations
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Returns a single translation by language code
+	 * If no code is specified the current translation is returned
+	 */
+	public function translation(
+		string|null $languageCode = null
+	): Translation|null {
+		return $this->translations()->find($languageCode ?? 'current');
+	}
+
+	/**
+	 * Returns the translations collection
+	 */
+	public function translations(): Translations
+	{
+		return Translations::load(
+			model: $this,
+			version: $this->version()
+		);
+	}
+
+	/**
+	 * @deprecated since 5.0.0 Use `::version()->save()` instead
+	 */
+	public function writeContent(array $data, string|null $languageCode = null): bool
+	{
+		$this->clone()->version()->save($data, $languageCode ?? 'default', true);
+		return true;
+	}
+}

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\Collection;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
@@ -47,16 +46,11 @@ class LabPage extends Page
 		return $this->version()->read($languageCode ?? 'current');
 	}
 
-	/**
-	 * @deprecated since 5.0.0 Use `::version()->save()` instead
-	 */
 	public function save(
 		array|null $data = null,
 		string|null $languageCode = null,
 		bool $overwrite = false
 	): static {
-		Helpers::deprecated('`$model->save()` has been deprecated. Use `$model->version()->save()` instead.', 'model-save');
-
 		$clone = $this->clone();
 		$clone->version()->save($data ?? [], $languageCode ?? 'current', $overwrite);
 		return $clone;

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -24,7 +24,7 @@ class LabPage extends Page
 		// before creating the clone. The storage of the clone can
 		// afterwards be mutated without affecting the content in the
 		// original instance.
-		$this->storage = MemoryContentStorageHandler::from($this->storage);
+		$this->storage = MemoryContentStorageHandler::from($this->storage());
 		return parent::clone($props);
 	}
 

--- a/src/Content/LabPage.php
+++ b/src/Content/LabPage.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Collection;
+use Kirby\Cms\Helpers;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 
@@ -37,6 +38,8 @@ class LabPage extends Page
 	 */
 	public function readContent(string|null $languageCode = null): array
 	{
+		Helpers::deprecated('`$model->readContent()` has been deprecated. Use `$model->version()->read()` instead.', 'model-read-content');
+
 		return $this->version()->read($languageCode ?? 'current');
 	}
 
@@ -48,6 +51,8 @@ class LabPage extends Page
 		string|null $languageCode = null,
 		bool $overwrite = false
 	): static {
+		Helpers::deprecated('`$model->save()` has been deprecated. Use `$model->version()->save()` instead.', 'model-save');
+
 		$clone = $this->clone();
 		$clone->version()->save($data ?? [], $languageCode ?? 'current', $overwrite);
 		return $clone;
@@ -60,6 +65,8 @@ class LabPage extends Page
 		array|null $data = null,
 		bool $overwrite = false
 	): static {
+		Helpers::deprecated('`$model->saveContent()` has been deprecated. Use `$model->version()->save()` instead.', 'model-save-content');
+
 		$clone = $this->clone();
 		$clone->version()->save($data ?? [], 'current', $overwrite);
 		return $clone;
@@ -73,6 +80,8 @@ class LabPage extends Page
 		string|null $languageCode = null,
 		bool $overwrite = false
 	): static {
+		Helpers::deprecated('`$model->saveTranslation()` has been deprecated. Use `$model->version()->save()` instead.', 'model-save-translation');
+
 		$clone = $this->clone();
 		$clone->version()->save($data ?? [], $languageCode ?? 'current', $overwrite);
 		return $clone;
@@ -156,7 +165,9 @@ class LabPage extends Page
 	 */
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
-		$this->clone()->version()->save($data, $languageCode ?? 'default', true);
+		Helpers::deprecated('`$model->writeContent()` has been deprecated. Use `$model->version()->save()` instead.', 'model-write-content');
+
+		$this->clone()->version()->save($data, $languageCode ?? 'current', true);
 		return true;
 	}
 }

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -148,8 +148,10 @@ class Version
 	 */
 	public function read(Language|string $language = 'default'): array
 	{
+		$language = Language::ensure($language);
+
 		try {
-			return $this->model->storage()->read($this->id, Language::ensure($language));
+			return $this->model->storage()->read($this->id, $language);
 		} catch (Throwable) {
 			return [];
 		}

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -33,9 +33,25 @@ class Version
 	 */
 	public function content(Language|string $language = 'default'): Content
 	{
+		$language = Language::ensure($language);
+		$fields   = $this->read($language);
+
+		// This is where we merge content from the default language
+		// to provide a fallback for missing/untranslated fields.
+		//
+		// @todo This is the critical point that needs to be removed/refactored
+		// in the future, to provide multi-language support with truly
+		// individual versions of pages and no longer enforce the fallback.
+		if ($language->isDefault() === false) {
+			$fields = [
+				...$this->read('default'),
+				...$fields
+			];
+		}
+
 		return new Content(
 			parent: $this->model,
-			data:   $this->read($language),
+			data:   $fields,
 		);
 	}
 

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Data\Data;
+
+class LabPageTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Content.LabeModel';
+
+	public function testContentMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.en.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $page->content('en')->toArray());
+
+		$this->markTestIncomplete('TODO: The following assertion is only correct as long as we don’t merge translated content. It’s a breaking change so far compared to the previous behavior and needs to be fixed.');
+		$this->assertSame([], $page->content('de')->toArray());
+	}
+
+	public function testContentSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $page->content()->toArray());
+	}
+
+	public function testContentNonExistingMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test'
+		]);
+
+		$this->assertSame([], $page->content('en')->toArray());
+		$this->assertSame([], $page->content('de')->toArray());
+	}
+
+	public function testContentNonExistingSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test'
+		]);
+
+		$this->assertSame([], $page->content()->toArray());
+	}
+
+	public function testSetContentMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'    => 'test',
+			'content' => $content = [
+				'title' => 'Test'
+			]
+		]);
+
+		$this->assertSame($content, $page->content()->toArray());
+		$this->assertSame($content, $page->content('en')->toArray());
+
+		$this->markTestIncomplete('TODO: The following assertion is only correct as long as we don’t merge translated content. It’s a breaking change so far compared to the previous behavior and needs to be fixed.');
+		$this->assertSame([], $page->content('de')->toArray());
+	}
+
+	public function testSetContentSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'    => 'test',
+			'content' => $content = [
+				'title' => 'Test'
+			]
+		]);
+
+		$this->assertSame($content, $page->content()->toArray());
+	}
+
+	public function testSetTranslationMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'         => 'test',
+			'translations' => [
+				[
+					'code'    => 'en',
+					'content' => $en = [
+						'title' => 'Test English'
+					]
+				],
+				[
+					'code'    => 'de',
+					'content' => $de = [
+						'title' => 'Test Deutsch'
+					]
+				]
+			]
+		]);
+
+		$this->assertSame($en, $page->content()->toArray());
+		$this->assertSame($en, $page->content('en')->toArray());
+		$this->assertSame($en, $page->translation('en')->content());
+
+		$this->assertSame($de, $page->content('de')->toArray());
+		$this->assertSame($de, $page->translation('de')->content());
+	}
+
+	public function testSetTranslationSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'         => 'test',
+			'translations' => [
+				[
+					'code'    => 'en',
+					'content' => $content = [
+						'title' => 'Test'
+					]
+				]
+			]
+		]);
+
+		$this->assertSame($content, $page->content()->toArray());
+		$this->assertSame($content, $page->translation('en')->content());
+	}
+
+	public function testTranslationMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		Data::write($page->root() . '/article.en.txt', $en = [
+			'title' => 'Test English'
+		]);
+
+		Data::write($page->root() . '/article.de.txt', $de = [
+			'title' => 'Test Deutsch'
+		]);
+
+		$this->assertSame($en, $page->translation('en')->content());
+		$this->assertSame($de, $page->translation('de')->content());
+	}
+
+	public function testTranslationSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		Data::write($page->root() . '/article.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $page->translation()->content());
+		$this->assertSame($content, $page->translation('en')->content());
+	}
+
+	public function testTranslationsMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		Data::write($page->root() . '/article.en.txt', $en = [
+			'title' => 'Test English'
+		]);
+
+		Data::write($page->root() . '/article.de.txt', $de = [
+			'title' => 'Test Deutsch'
+		]);
+
+		$translations = $page->translations();
+
+		$this->assertCount(2, $translations);
+		$this->assertSame($en, $translations->find('en')->content());
+		$this->assertSame($de, $translations->find('de')->content());
+	}
+
+	public function testTranslationsSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$translations = $page->translations();
+
+		$this->assertCount(1, $translations);
+		$this->assertSame($content, $translations->first()->content());
+	}
+
+	public function testUpdateMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// make sure to be authenticated
+		$this->app->impersonate('kirby');
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.en.txt', $en = [
+			'title' => 'Test English'
+		]);
+
+		Data::write($page->root() . '/article.de.txt', $de = [
+			'title' => 'Test Deutsch'
+		]);
+
+		$updatedPage = $page->update([
+			'title' => 'Updated Test English'
+		], 'en');
+
+		$updatedPage = $page->update([
+			'title' => 'Updated Test Deutsch'
+		], 'de');
+
+		// check if the old version is still the same
+		$this->assertSame('Test English', $page->title()->value());
+
+		$this->assertSame('Updated Test English', $updatedPage->title()->value());
+		$this->assertSame('Updated Test English', $updatedPage->content('en')->title()->value());
+		$this->assertSame('Updated Test English', Data::read($updatedPage->root() . '/article.en.txt')['title']);
+
+		$this->assertSame('Updated Test Deutsch', $updatedPage->content('de')->title()->value());
+		$this->assertSame('Updated Test Deutsch', Data::read($updatedPage->root() . '/article.de.txt')['title']);
+	}
+
+	public function testUpdateSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// make sure to be authenticated
+		$this->app->impersonate('kirby');
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$updatedPage = $page->update([
+			'title' => 'Updated title'
+		]);
+
+		// check if the old version is still the same
+		$this->assertSame('Test', $page->title()->value());
+
+		$this->assertSame('Updated title', $updatedPage->title()->value());
+		$this->assertSame('Updated title', Data::read($updatedPage->root() . '/article.txt')['title']);
+	}
+}

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -8,6 +8,23 @@ class LabPageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.LabeModel';
 
+	public function testCloneMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		$this->assertInstanceOf(PlainTextContentStorageHandler::class, $page->storage());
+
+		$clone = $page->clone();
+
+		$this->assertInstanceOf(MemoryContentStorageHandler::class, $page->storage());
+		$this->assertInstanceOf(PlainTextContentStorageHandler::class, $clone->storage());
+	}
+
 	public function testContentMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -169,6 +169,57 @@ class LabPageTest extends TestCase
 		$this->assertSame($content, $page->translation('en')->content());
 	}
 
+	public function testSlugMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test',
+			'translations' => [
+				[
+					'code' => 'en',
+					// should be ignored
+					'slug' => 'english-slug'
+				],
+				[
+					'code' => 'de',
+					// should be considered
+					'slug' => 'deutscher-slug'
+				]
+			]
+		]);
+
+		// the slug for the default language will always be the slug prop
+		$this->assertSame('test', $page->slug());
+		$this->assertSame('test', $page->slug('en'));
+
+		// the slug for non-default languages can be customized
+		$this->assertSame('deutscher-slug', $page->slug('de'));
+	}
+
+	public function testSlugSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test',
+			'translations' => [
+				[
+					'code' => 'en',
+					'content' => $content = [
+						'title' => 'Test'
+					],
+					// setting a custom slug should not have any effect
+					// in single language setups. The slug prop is still
+					// the dominant factor here.
+					'slug' => 'foo'
+				]
+			]
+		]);
+
+		$this->assertSame('test', $page->slug());
+	}
+
 	public function testTranslationMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -112,10 +112,11 @@ class LabPageTest extends TestCase
 			'title' => 'Test'
 		]);
 
+		$this->assertSame($content, $page->content()->toArray());
 		$this->assertSame($content, $page->content('en')->toArray());
 
-		$this->markTestIncomplete('TODO: The following assertion is only correct as long as we don’t merge translated content. It’s a breaking change so far compared to the previous behavior and needs to be fixed.');
-		$this->assertSame([], $page->content('de')->toArray());
+		// make sure that the content fallback works
+		$this->assertSame($page->content('en')->toArray(), $page->content('de')->toArray());
 	}
 
 	public function testContentSingleLanguage()
@@ -134,6 +135,25 @@ class LabPageTest extends TestCase
 		]);
 
 		$this->assertSame($content, $page->content()->toArray());
+	}
+
+	public function testContentWithFallback()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.en.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $page->content('en')->toArray());
+		$this->assertSame($page->content('en')->toArray(), $page->content('de')->toArray());
 	}
 
 	public function testContentWithInvalidLanguage()
@@ -225,8 +245,8 @@ class LabPageTest extends TestCase
 		$this->assertSame($content, $page->content()->toArray());
 		$this->assertSame($content, $page->content('en')->toArray());
 
-		$this->markTestIncomplete('TODO: The following assertion is only correct as long as we don’t merge translated content. It’s a breaking change so far compared to the previous behavior and needs to be fixed.');
-		$this->assertSame([], $page->content('de')->toArray());
+		// make sure that the content fallback works
+		$this->assertSame($page->content('en')->toArray(), $page->content('de')->toArray());
 	}
 
 	public function testSetContentSingleLanguage()

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -215,10 +215,10 @@ class LabPageTest extends TestCase
 
 		$this->assertSame($en, $page->content()->toArray());
 		$this->assertSame($en, $page->content('en')->toArray());
-		$this->assertSame($en, $page->translation('en')->content());
+		$this->assertSame($en, $page->translation('en')->version()->content('en')->toArray());
 
 		$this->assertSame($de, $page->content('de')->toArray());
-		$this->assertSame($de, $page->translation('de')->content());
+		$this->assertSame($de, $page->translation('de')->version()->content('de')->toArray());
 	}
 
 	public function testSetTranslationSingleLanguage()
@@ -238,7 +238,7 @@ class LabPageTest extends TestCase
 		]);
 
 		$this->assertSame($content, $page->content()->toArray());
-		$this->assertSame($content, $page->translation('en')->content());
+		$this->assertSame($content, $page->translation('en')->version()->content('en')->toArray());
 	}
 
 	public function testSlugMultiLanguage()
@@ -323,8 +323,8 @@ class LabPageTest extends TestCase
 			'title' => 'Test Deutsch'
 		]);
 
-		$this->assertSame($en, $page->translation('en')->content());
-		$this->assertSame($de, $page->translation('de')->content());
+		$this->assertSame($en, $page->translation('en')->version()->content('en')->toArray());
+		$this->assertSame($de, $page->translation('de')->version()->content('de')->toArray());
 	}
 
 	public function testTranslationSingleLanguage()
@@ -340,8 +340,8 @@ class LabPageTest extends TestCase
 			'title' => 'Test'
 		]);
 
-		$this->assertSame($content, $page->translation()->content());
-		$this->assertSame($content, $page->translation('en')->content());
+		$this->assertSame($content, $page->translation()->version()->content()->toArray());
+		$this->assertSame($content, $page->translation('en')->version()->content('en')->toArray());
 	}
 
 	public function testTranslationsMultiLanguage()
@@ -364,8 +364,8 @@ class LabPageTest extends TestCase
 		$translations = $page->translations();
 
 		$this->assertCount(2, $translations);
-		$this->assertSame($en, $translations->find('en')->content());
-		$this->assertSame($de, $translations->find('de')->content());
+		$this->assertSame($en, $translations->find('en')->version()->content('en')->toArray());
+		$this->assertSame($de, $translations->find('de')->version()->content('de')->toArray());
 	}
 
 	public function testTranslationsSingleLanguage()
@@ -386,7 +386,7 @@ class LabPageTest extends TestCase
 		$translations = $page->translations();
 
 		$this->assertCount(1, $translations);
-		$this->assertSame($content, $translations->first()->content());
+		$this->assertSame($content, $translations->first()->version()->content('en')->toArray());
 	}
 
 	public function testUpdateMultiLanguage()
@@ -403,11 +403,11 @@ class LabPageTest extends TestCase
 
 		// write something to the content file to make sure it
 		// can be read from disk for the test.
-		Data::write($page->root() . '/article.en.txt', $en = [
+		Data::write($page->root() . '/article.en.txt', [
 			'title' => 'Test English'
 		]);
 
-		Data::write($page->root() . '/article.de.txt', $de = [
+		Data::write($page->root() . '/article.de.txt', [
 			'title' => 'Test Deutsch'
 		]);
 

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Content;
 
 use Kirby\Data\Data;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 
 class LabPageTest extends TestCase

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -196,6 +196,21 @@ class LabPageTest extends TestCase
 		$this->assertSame([], $page->content()->toArray());
 	}
 
+	public function testHardcopy()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article',
+		]);
+
+		$clone = $page->hardcopy();
+
+		$this->assertInstanceOf(MemoryContentStorageHandler::class, $page->storage());
+		$this->assertInstanceOf(PlainTextContentStorageHandler::class, $clone->storage());
+	}
+
 	public function testSetContentMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Data\Data;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 
 class LabPageTest extends TestCase
@@ -136,7 +137,7 @@ class LabPageTest extends TestCase
 		$this->assertSame($content, $page->content()->toArray());
 	}
 
-	public function testContentNonExistingMultiLanguage()
+	public function testContentWithInvalidLanguage()
 	{
 		$this->setUpMultiLanguage();
 
@@ -144,19 +145,10 @@ class LabPageTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$this->assertSame([], $page->content('en')->toArray());
-		$this->assertSame([], $page->content('de')->toArray());
-	}
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Invalid language: fr');
 
-	public function testContentNonExistingSingleLanguage()
-	{
-		$this->setUpSingleLanguage();
-
-		$page = new LabPage([
-			'slug' => 'test'
-		]);
-
-		$this->assertSame([], $page->content()->toArray());
+		$page->content('fr');
 	}
 
 	public function testContentWithNonDefaultCurrentLanguage()
@@ -180,6 +172,29 @@ class LabPageTest extends TestCase
 		$this->assertSame($content, $page->content()->toArray());
 		$this->assertSame($content, $page->content('current')->toArray());
 		$this->assertSame($content, $page->content('de')->toArray());
+	}
+
+	public function testContentWithoutFieldsMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test'
+		]);
+
+		$this->assertSame([], $page->content('en')->toArray());
+		$this->assertSame([], $page->content('de')->toArray());
+	}
+
+	public function testContentWithoutFieldsSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$page = new LabPage([
+			'slug' => 'test'
+		]);
+
+		$this->assertSame([], $page->content()->toArray());
 	}
 
 	public function testSetContentMultiLanguage()

--- a/tests/Content/LabPageTest.php
+++ b/tests/Content/LabPageTest.php
@@ -159,6 +159,29 @@ class LabPageTest extends TestCase
 		$this->assertSame([], $page->content()->toArray());
 	}
 
+	public function testContentWithNonDefaultCurrentLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		// switch to German as the current language
+		$this->app->setCurrentLanguage('de');
+
+		$page = new LabPage([
+			'slug'     => 'test',
+			'template' => 'article'
+		]);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($page->root() . '/article.de.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $page->content()->toArray());
+		$this->assertSame($content, $page->content('current')->toArray());
+		$this->assertSame($content, $page->content('de')->toArray());
+	}
+
 	public function testSetContentMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -52,6 +52,31 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::content
+	 */
+	public function testContentWithFallback(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		// write something to the content file to make sure it
+		// can be read from disk for the test.
+		Data::write($this->model->root() . '/article.en.txt', $content = [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame($content, $version->content()->toArray());
+		$this->assertSame($content, $version->content('en')->toArray());
+
+		// make sure that the content fallback works
+		$this->assertSame($version->content('en')->toArray(), $version->content('de')->toArray());
+	}
+
+	/**
 	 * @covers ::contentFile
 	 */
 	public function testContentFileMultiLanguage(): void


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [ ] 🚨 Merge first: #6457
- [ ] 🚨 Merge first: #6483
- [ ] 🚨 Merge first: #6490
- [ ] 🚨 Merge first: #6491

### Reasoning

The LabPage class extends the Page class and serves as a playground for all the methods that need to be changed in order to get Versions properly implemented. It really helped to untangle the content vs. translation mess in a more isolated state without all the other methods. Afterwards I also took care of save/update, etc. It starts to come along really nicely, but there are still some elements missing. 

### Deprecated

- `::readContent` Use `::version()->read()` instead
- `::save` Use `::version()->save()` instead
- `::saveContent` Use `::version()->save()` instead
- `::saveTranslation` Use `::version()->save()` instead
- `::writeContent` Use `::version()->save()` instead

### Breaking changes

- `::translations` will now always return a `Translations` collection with at least the `Language::single` object in single language mode.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.

More details: https://contribute.getkirby.com
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
