### PR TITLE
`Filesystem\Mime`: more readable if logic

### DIFF
--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -270,32 +270,37 @@ class Mime
 	/**
 	 * Returns all available extensions for a given MIME type
 	 */
-	public static function toExtensions(string|null $mime = null, bool $matchWildcards = false): array
-	{
+	public static function toExtensions(
+		string|null $mime = null,
+		bool $matchWildcards = false
+	): array {
 		$extensions = [];
-		$testMime = fn (string $v) => static::matches($v, $mime);
+		$testMime   = fn (string $v): bool => static::matches($v, $mime);
 
 		foreach (static::$types as $key => $value) {
-			if (is_array($value) === true) {
-				if ($matchWildcards === true) {
-					if (A::some($value, $testMime)) {
-						$extensions[] = $key;
-					}
-				} else {
-					if (in_array($mime, $value) === true) {
-						$extensions[] = $key;
-					}
-				}
-			} else {
-				if ($matchWildcards === true) {
-					if ($testMime($value) === true) {
-						$extensions[] = $key;
-					}
-				} else {
-					if ($value === $mime) {
-						$extensions[] = $key;
-					}
-				}
+			if (
+				(
+					is_array($value) &&
+					$matchWildcards &&
+					A::some($value, $testMime)
+				) ||
+				(
+					is_array($value) &&
+					$matchWildcards === false &&
+					in_array($mime, $value)
+				) ||
+				(
+					is_array($value) === false &&
+					$matchWildcards &&
+					$testMime($value)
+				) ||
+				(
+					is_array($value) === false &&
+					$matchWildcards === false &&
+					$value === $mime
+				)
+			) {
+				$extensions[] = $key;
 			}
 		}
 

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -284,7 +284,7 @@ class Mime
 				// get corresponding MIME types as array
 				$mimes = A::wrap(static::$types[$extension]);
 
-				if ($matchWildcards) {
+				if ($matchWildcards === true) {
 					// check if at least one MIME type with wildcards matches
 					return A::some(
 						$mimes,
@@ -297,6 +297,7 @@ class Mime
 			}
 		);
 
+		// renumber array with consecutive keys
 		return array_values($extensions);
 	}
 

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -130,21 +130,31 @@ class MimeTest extends TestCase
 
 		$extensions = Mime::toExtensions('text/css');
 		$this->assertSame(['css'], $extensions);
+	}
 
-		// test matchWildcards: false (default value)
+	/**
+	 * @covers ::toExtensions
+	 */
+	public function testToExtensionsMatchWildcards()
+	{
+		// matchWildcards: false (default value)
 		$extensions = Mime::toExtensions('image/*');
 		$this->assertCount(0, $extensions);
 
-		// test matchWildcards: true
+		// matchWildcards: true
 		$extensions = Mime::toExtensions('image/*', true);
-		// use we only check for a positive and negative subset instead of a complete list,
-		// this should make sure the test doesn't break when a new image type is added
-		$shouldContain = ['jpg', 'jpeg', 'gif', 'png'];
-		$shouldNotContain = ['js', 'pdf', 'zip', 'docx'];
-		foreach ($shouldContain as $ext) {
+
+		// we only check for a positive and negative subset
+		// instead of a complete list to make sure the test
+		// doesn't break when a new image type is added
+
+		// should contain
+		foreach (['jpg', 'jpeg', 'gif', 'png'] as $ext) {
 			$this->assertContains($ext, $extensions);
 		}
-		foreach ($shouldNotContain as $ext) {
+
+		// should not contain
+		foreach (['js', 'pdf', 'zip', 'docx'] as $ext) {
 			$this->assertNotContains($ext, $extensions);
 		}
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Filesystem\Mime::toExtensions()`: refactored nested if-else into one-level if


### Reasoning
The nested if-else logic is super hard to read and keep track of the conditions for each result, which also does the same. Changing it to a one-level if is a lot easier to read, which various conditions lead to adding an extension, even if we have to list some conditions multiple times then.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Tests and CI checks all pass
