### PR TITLE
Changes 14: Model prop fixes

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -81,8 +81,6 @@ class File extends ModelWithContent
 	 */
 	public function __construct(array $props)
 	{
-		parent::__construct($props);
-
 		if (isset($props['filename'], $props['parent']) === false) {
 			throw new InvalidArgumentException('The filename and parent are required');
 		}
@@ -94,6 +92,8 @@ class File extends ModelWithContent
 		// auto root detection
 		$this->root     = null;
 		$this->url      = $props['url'] ?? null;
+
+		parent::__construct($props);
 
 		$this->setBlueprint($props['blueprint'] ?? null);
 	}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -131,8 +131,6 @@ class Page extends ModelWithContent
 			throw new InvalidArgumentException('The page slug is required');
 		}
 
-		parent::__construct($props);
-
 		$this->slug    = $props['slug'];
 		// Sets the dirname manually, which works
 		// more reliable in connection with the inventory
@@ -142,6 +140,8 @@ class Page extends ModelWithContent
 		$this->num     = $props['num'] ?? null;
 		$this->parent  = $props['parent'] ?? null;
 		$this->root    = $props['root'] ?? null;
+
+		parent::__construct($props);
 
 		$this->setBlueprint($props['blueprint'] ?? null);
 		$this->setChildren($props['children'] ?? null);

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -81,12 +81,12 @@ class Site extends ModelWithContent
 	 */
 	public function __construct(array $props = [])
 	{
-		parent::__construct($props);
-
 		$this->errorPageId = $props['errorPageId'] ?? 'error';
 		$this->homePageId  = $props['homePageId'] ?? 'home';
 		$this->page        = $props['page'] ?? null;
 		$this->url         = $props['url'] ?? null;
+
+		parent::__construct($props);
 
 		$this->setBlueprint($props['blueprint'] ?? null);
 		$this->setChildren($props['children'] ?? null);

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -80,14 +80,14 @@ class User extends ModelWithContent
 		// so it also gets stored in propertyData prop
 		$props['id'] ??= $this->createId();
 
-		parent::__construct($props);
-
 		$this->id       = $props['id'];
 		$this->email    = $set('email', fn ($email) => Str::lower(trim($email)));
 		$this->language = $set('language', fn ($language) => trim($language));
 		$this->name     = $set('name', fn ($name) => trim(strip_tags($name)));
 		$this->password = $props['password'] ?? null;
 		$this->role     = $set('role', fn ($role) => Str::lower(trim($role)));
+
+		parent::__construct($props);
 
 		$this->setBlueprint($props['blueprint'] ?? null);
 		$this->setFiles($props['files'] ?? null);


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [x] 🚨 Merge first: #6457
- [x] 🚨 Merge first: #6483 
- [x] 🚨 Merge first: #6490
- [x] 🚨 Merge first: #6491

### Reasoning

Our Models run `parent::__construct` before setting their props. This leads to a situation where `::setContent` and `::setTranslations` cannot access vital properties, such as `isDraft`, `slug`, `id` etc. because they are not available yet. We cannot properly switch to the Version implementation as long as this is not fixed. 

### Refactoring

- `Page::__construct` calls `parent::__construct` after setting the props
- `Site::__construct` calls `parent::__construct` after setting the props
- `User::__construct` calls `parent::__construct` after setting the props
- `File::__construct` calls `parent::__construct` after setting the props

### Breaking changes

None expected

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
