### PR TITLE
Changes 15: More ContentStorageHandler class methods

### DIFF
--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -119,6 +119,25 @@ abstract class ContentStorageHandler
 	abstract public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
+	 * Creates a new storage instance with all the versions
+	 * from the given storage instance.
+	 */
+	public static function from(self $fromStorage): static
+	{
+		$toStorage = new static(
+			model: $fromStorage->model()
+		);
+
+		// copy all versions from the given storage instance
+		// and add them to the new storage instance.
+		foreach ($fromStorage->all() as $versionId => $language) {
+			$toStorage->create($versionId, $language, $fromStorage->read($versionId, $language));
+		}
+
+		return $toStorage;
+	}
+
+	/**
 	 * Returns the related model
 	 */
 	public function model(): ModelWithContent

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -119,6 +119,14 @@ abstract class ContentStorageHandler
 	abstract public function exists(VersionId $versionId, Language $language): bool;
 
 	/**
+	 * Returns the related model
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	/**
 	 * Returns the modification timestamp of a version if it exists
 	 */
 	abstract public function modified(VersionId $versionId, Language $language): int|null;

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -366,6 +366,8 @@ class ContentStorageHandlerTest extends TestCase
 		// create a new handler with all the versions from the first one
 		$handlerB = TestContentStorageHandler::from($handlerA);
 
+		$this->assertNotSame($handlerA, $handlerB);
+
 		$this->assertSame($publishedEN, $handlerB->read($versionPublished, $en));
 		$this->assertSame($publishedDE, $handlerB->read($versionPublished, $de));
 

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -330,6 +330,50 @@ class ContentStorageHandlerTest extends TestCase
 	}
 
 	/**
+	 * @covers ::from
+	 */
+	public function testFrom()
+	{
+		$this->setUpMultiLanguage();
+
+		$handlerA = new PlainTextContentStorageHandler(
+			model: $this->model
+		);
+
+		$versionPublished = VersionId::published();
+		$versionChanges   = VersionId::changes();
+
+		$en = $this->app->language('en');
+		$de = $this->app->language('de');
+
+		// create all possible versions
+		$handlerA->create($versionPublished, $en, $publishedEN = [
+			'title' => 'Published EN'
+		]);
+
+		$handlerA->create($versionPublished, $de, $publishedDE = [
+			'title' => 'Published DE'
+		]);
+
+		$handlerA->create($versionChanges, $en, $changesEN = [
+			'title' => 'Changes EN'
+		]);
+
+		$handlerA->create($versionChanges, $de, $changesDE = [
+			'title' => 'Changes DE'
+		]);
+
+		// create a new handler with all the versions from the first one
+		$handlerB = TestContentStorageHandler::from($handlerA);
+
+		$this->assertSame($publishedEN, $handlerB->read($versionPublished, $en));
+		$this->assertSame($publishedDE, $handlerB->read($versionPublished, $de));
+
+		$this->assertSame($changesEN, $handlerB->read($versionChanges, $en));
+		$this->assertSame($changesDE, $handlerB->read($versionChanges, $de));
+	}
+
+	/**
 	 * @covers ::model
 	 */
 	public function testModel()

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -330,6 +330,20 @@ class ContentStorageHandlerTest extends TestCase
 	}
 
 	/**
+	 * @covers ::model
+	 */
+	public function testModel()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestContentStorageHandler(
+			model: $this->model
+		);
+
+		$this->assertSame($this->model, $handler->model());
+	}
+
+	/**
 	 * @covers ::move
 	 */
 	public function testMoveMultiLanguage()


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [x] 🚨 Merge first: #6457
- [x] 🚨 Merge first: #6483 
- [x] 🚨 Merge first: #6490
- [x] 🚨 Merge first: #6491
- [x] 🚨 Merge first: #6499

### Reasoning

This PR is grouping together additional `ContentStorageHandler` changes that are needed in later steps. It just tries to keep future PRs more manageable and also helps to keep code coverage and unit tests under control. 

### Features

- New `ContentStorageHandler::model` method to access the parent model. We need this later when working with clones in model actions. 
- New `ContentStorageHandler::from` method. This method will take an existing `ContentStorageHandler` instance and create a new instance by copying over the same versions. This is needed later when we convert a model from `PlainTextContentStorageHandler` to `MemoryContentStorageHandler` for example. 

### Breaking changes

None expected

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
