### PR TITLE
DateInput: fix `Cmd+S` in nested structures

### DIFF
--- a/panel/src/components/Forms/Input/DateInput.vue
+++ b/panel/src/components/Forms/Input/DateInput.vue
@@ -17,6 +17,8 @@
 		@keydown.down.stop.prevent="onArrowDown"
 		@keydown.up.stop.prevent="onArrowUp"
 		@keydown.enter.stop.prevent="onEnter"
+		@keydown.meta.s.stop.prevent="onEnter"
+		@keydown.ctrl.s.stop.prevent="onEnter"
 		@keydown.tab="onTab"
 	/>
 </template>
@@ -137,13 +139,6 @@ export default {
 			immediate: true
 		}
 	},
-	mounted() {
-		// make sure to commit input value when Cmd+S is hit
-		this.$events.on("keydown.cmd.s", this.onBlur);
-	},
-	destroyed() {
-		this.$events.off("keydown.cmd.s", this.onBlur);
-	},
 	methods: {
 		/**
 		 * Increment/decrement the current dayjs object based on the
@@ -244,8 +239,10 @@ export default {
 		 * but also emit additional submit event
 		 */
 		async onEnter() {
+			// ensure inout gets parsed and emitted as new value
 			this.onBlur();
 			await this.$nextTick();
+			// only thereafter emit submit so the content gets saved
 			this.$emit("submit");
 		},
 		/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `DateInput.vue` does not use anymore the global `keydown.cmd.s` event to commit unfinished input, but rather listens to the event locally, preventing propagation and only emits a `submit` event once the input value has been committed/transofrmed to a proper date time object and emitted/updated.


### Reasoning
- Using the global `keydown.cmd.s` event has been triggering the `onBlur()` method no matter whether the date input was actually being edited or just present in the current view. We only need to trigger it when the input is currently being edited (as `@blur` will take care of committing the value when the focus changes away from the input already).
- To avoid the previous race conditions, we listen locally for the event (prevent default and stop propagation), commit then the value to a real datetime object and emit the `submit` event. We do not use `this.$events.emit("keydown.cmd.s")` as this triggers a race condition, where the `input` event is still propagating up the chain when the save would also happen. Emitting `submit` ensures that this event has to travel up the same chain as the `input` event and thus they arrive in the right order.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Using `Cmd + S`/`Ctrl + S` in nested structures/objects with date fields does not corrupt data anymore
#6390



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
