### PR TITLE
Changes 16: ModelWithContent simplifications

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -735,19 +735,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
-		$data = $this->contentFileData($data, $languageCode);
-
-		// update the default language, unless a specific language is passed
-		$languageCode ??= 'default';
-
-		try {
-			// we can only update if the version already exists
-			$this->version()->update($data, $languageCode);
-		} catch (NotFoundException) {
-			// otherwise create a new version
-			$this->version()->create($data, $languageCode);
-		}
-
+		$this->version()->save($data, $languageCode ?? 'current', true);
 		return true;
 	}
 }

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -724,7 +724,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
-		$this->version()->save($data, $languageCode ?? 'current', true);
+		$this->version()->save($data, $languageCode ?? 'default', true);
 		return true;
 	}
 }

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -10,7 +10,6 @@ use Kirby\Content\PlainTextContentStorageHandler;
 use Kirby\Content\Version;
 use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
-use Kirby\Exception\NotFoundException;
 use Kirby\Form\Form;
 use Kirby\Panel\Model;
 use Kirby\Toolkit\Str;
@@ -132,21 +131,11 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	{
 		// single language support
 		if ($this->kirby()->multilang() === false) {
-			if ($this->content instanceof Content) {
-				return $this->content;
-			}
-
-			// don't normalize field keys (already handled by the `Data` class)
-			return $this->content = new Content($this->readContent(), $this, false);
+			return $this->content ??= $this->version()->content('default');
 		}
 
 		// get the targeted language
-		$language = $this->kirby()->language($languageCode);
-
-		// stop if the language does not exist
-		if ($language === null) {
-			throw new InvalidArgumentException('Invalid language: ' . $languageCode);
-		}
+		$language = Language::ensure($languageCode);
 
 		// only fetch from cache for the current language
 		if ($languageCode === null && $this->content instanceof Content) {

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -5,7 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Content\Version;
 use Kirby\Content\VersionId;
-use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Page as PanelPage;
 use Kirby\Uuid\PageUuid;
 use Kirby\Uuid\SiteUuid;
@@ -155,7 +155,7 @@ class ModelWithContentTest extends TestCase
 			]
 		]);
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Invalid language: fr');
 
 		$app->page('foo')->content('fr');


### PR DESCRIPTION
## This PR …

- [x] 🚨 Merge first: #6436
- [x] 🚨 Merge first: #6439
- [x] 🚨 Merge first: #6442
- [x] 🚨 Merge first: #6448
- [x] 🚨 Merge first: #6449
- [x] 🚨 Merge first: #6450
- [x] 🚨 Merge first: #6454
- [x] 🚨 Merge first: #6455
- [x] 🚨 Merge first: #6456
- [x] 🚨 Merge first: #6457
- [x] 🚨 Merge first: #6483 
- [x] 🚨 Merge first: #6490
- [x] 🚨 Merge first: #6491
- [x] 🚨 Merge first: #6499
- [x] 🚨 Merge first: #6500

### Reasoning

I'm trying to already use the improvements and changes from the last PRs in ModelWithContent without taking too many steps at once. The full conversion will be still a lot of complicated, potentially breaking steps. Taking it easy will help to keep our mental load in check. 

### Refactoring

- Simplify `ModelWithContent::writeContent` by using the new `Version::save()` method.
- Simplify `ModelWithContent::content` by using `Language::ensure()` and `Version::content()`

### Breaking changes

None expected

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
