### PR TITLE
Changes B: `panel.content`

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -186,7 +186,7 @@ export default {
 		},
 		download() {
 			let content = "";
-			const changes = this.$panel.content.changed;
+			const changes = this.$panel.content.changes;
 
 			for (const key in changes) {
 				const change = changes[key];

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -51,12 +51,12 @@ export default {
 			if (this.mode === "lock") {
 				return [
 					{
-						icon: this.$content.lock.unlockable ? "unlock" : "loader",
+						icon: this.$panel.content.lock.unlockable ? "unlock" : "loader",
 						text: this.$t("lock.isLocked", {
-							email: this.$esc(this.$content.lock.email)
+							email: this.$esc(this.$panel.content.lock.email)
 						}),
 						title: this.$t("lock.unlock"),
-						disabled: !this.$content.lock.unlockable,
+						disabled: !this.$panel.content.lock.unlockable,
 						click: () => this.unlock()
 					}
 				];
@@ -85,7 +85,7 @@ export default {
 			}
 
 			if (this.mode === "lock") {
-				return !this.$content.lock.unlockable;
+				return !this.$panel.content.lock.unlockable;
 			}
 
 			if (this.mode === "changes") {
@@ -95,7 +95,7 @@ export default {
 			return false;
 		},
 		hasChanges() {
-			return this.$content.hasUnpublishedChanges;
+			return this.$panel.content.hasUnpublishedChanges;
 		},
 		isDisabled() {
 			return this.$store.state.content.status.enabled === false;
@@ -118,10 +118,10 @@ export default {
 			return null;
 		},
 		lockState() {
-			return this.supportsLocking && this.$content.lock?.state;
+			return this.supportsLocking && this.$panel.content.lock?.state;
 		},
 		supportsLocking() {
-			return this.$content.lock !== false;
+			return this.$panel.content.lock !== false;
 		},
 		theme() {
 			if (this.mode === "lock") {
@@ -186,7 +186,7 @@ export default {
 		},
 		download() {
 			let content = "";
-			const changes = this.$content.changed;
+			const changes = this.$panel.content.changed;
 
 			for (const key in changes) {
 				const change = changes[key];
@@ -231,7 +231,7 @@ export default {
 					// If setting lock failed, a competing lock has been set between
 					// API calls. In that case, discard changes, stop setting lock
 					clearInterval(this.isLocking);
-					this.$content.discard();
+					this.$panel.content.discard();
 				}
 			}
 
@@ -244,7 +244,7 @@ export default {
 		async resolve() {
 			// remove content unlock and throw away unsaved changes
 			await this.unlock(false);
-			this.$content.discard();
+			this.$panel.content.discard();
 		},
 		revert() {
 			this.$panel.dialog.open({
@@ -258,14 +258,14 @@ export default {
 				},
 				on: {
 					submit: () => {
-						this.$content.discard();
+						this.$panel.content.discard();
 						this.$panel.dialog.close();
 					}
 				}
 			});
 		},
 		save(e) {
-			this.$content.publish(e);
+			this.$panel.content.publish(e);
 		},
 		async unlock(unlock = true) {
 			const api = [this.$panel.view.path + "/unlock", null, null, true];
@@ -279,7 +279,7 @@ export default {
 							text: this.$t("lock.unlock")
 						},
 						text: this.$t("lock.unlock.submit", {
-							email: this.$esc(this.$content.lock.email)
+							email: this.$esc(this.$panel.content.lock.email)
 						})
 					},
 					on: {

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -107,7 +107,7 @@ export default {
 			return this.lockState === "unlock";
 		},
 		mode() {
-			if (this.lockState !== null) {
+			if (this.lockState) {
 				return this.lockState;
 			}
 

--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -10,7 +10,7 @@
 			v-bind="button"
 			size="sm"
 			variant="filled"
-			:disabled="isDisabled"
+			:disabled="disabled"
 			:responsive="true"
 			:theme="theme"
 		/>
@@ -89,16 +89,13 @@ export default {
 			}
 
 			if (this.mode === "changes") {
-				return this.isDisabled;
+				return this.$panel.content.isPublishing;
 			}
 
 			return false;
 		},
 		hasChanges() {
 			return this.$panel.content.hasUnpublishedChanges;
-		},
-		isDisabled() {
-			return this.$store.state.content.status.enabled === false;
 		},
 		isLocked() {
 			return this.lockState === "lock";

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -16,7 +16,7 @@ export default {
 	},
 	computed: {
 		withBadges() {
-			const changed = Object.keys(this.$store.getters["content/changes"]());
+			const changed = Object.keys(this.$content.changed);
 
 			return this.tabs.map((tab) => {
 				// collect all fields per tab

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -16,7 +16,7 @@ export default {
 	},
 	computed: {
 		withBadges() {
-			const changed = Object.keys(this.$content.changed);
+			const changed = Object.keys(this.$panel.content.changed);
 
 			return this.tabs.map((tab) => {
 				// collect all fields per tab

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -16,7 +16,7 @@ export default {
 	},
 	computed: {
 		withBadges() {
-			const changed = Object.keys(this.$panel.content.changed);
+			const changes = Object.keys(this.$panel.content.changes);
 
 			return this.tabs.map((tab) => {
 				// collect all fields per tab
@@ -35,7 +35,7 @@ export default {
 
 				// get count of changed fields in this tab
 				tab.badge = fields.filter((field) =>
-					changed.includes(field.toLowerCase())
+					changes.includes(field.toLowerCase())
 				).length;
 
 				return tab;

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -39,7 +39,7 @@ export default {
 	},
 	computed: {
 		values() {
-			return this.$content.values;
+			return this.$panel.content.values;
 		}
 	},
 	watch: {
@@ -74,11 +74,11 @@ export default {
 			}
 		},
 		onInput(values, field, fieldName) {
-			this.$content.set(fieldName, values[fieldName]);
+			this.$panel.content.set(fieldName, values[fieldName]);
 		},
 		onSubmit(values) {
 			// ensure that all values are actually committed to content store
-			this.$content.set(values);
+			this.$panel.content.set(values);
 			this.$events.emit("keydown.cmd.s", values);
 		}
 	}

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -39,7 +39,7 @@ export default {
 	},
 	computed: {
 		values() {
-			return this.$store.getters["content/values"]();
+			return this.$content.values;
 		}
 	},
 	watch: {
@@ -74,11 +74,11 @@ export default {
 			}
 		},
 		onInput(values, field, fieldName) {
-			this.$store.dispatch("content/update", [fieldName, values[fieldName]]);
+			this.$content.set(fieldName, values[fieldName]);
 		},
 		onSubmit(values) {
 			// ensure that all values are actually committed to content store
-			this.$store.dispatch("content/update", [null, values]);
+			this.$content.set(values);
 			this.$events.emit("keydown.cmd.s", values);
 		}
 	}

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -13,7 +13,7 @@
 			:sticky="column.sticky"
 		>
 			<template v-for="(section, sectionIndex) in column.sections">
-				<template v-if="$helper.field.isVisible(section, content)">
+				<template v-if="isVisible(section)">
 					<component
 						:is="'k-' + section.type + '-section'"
 						v-if="exists(section.type)"
@@ -63,12 +63,15 @@ export default {
 	emits: ["submit"],
 	computed: {
 		content() {
-			return this.$content.values;
+			return this.$panel.content.values;
 		}
 	},
 	methods: {
 		exists(type) {
 			return this.$helper.isComponent(`k-${type}-section`);
+		},
+		isVisible(section) {
+			return this.$helper.field.isVisible(section, this.content);
 		}
 	}
 };

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -63,7 +63,7 @@ export default {
 	emits: ["submit"],
 	computed: {
 		content() {
-			return this.$store.getters["content/values"]();
+			return this.$content.values;
 		}
 	},
 	methods: {

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -19,7 +19,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" @action="onAction" />
-				<k-form-buttons :lock="lock" />
+				<k-form-buttons />
 			</template>
 		</k-header>
 
@@ -47,7 +47,7 @@ export default {
 	},
 	computed: {
 		focus() {
-			const focus = this.$store.getters["content/values"]()["focus"];
+			const focus = this.$content.values["focus"];
 
 			if (!focus) {
 				return;
@@ -73,7 +73,7 @@ export default {
 				focus = `${focus.x}% ${focus.y}%`;
 			}
 
-			this.$store.dispatch("content/update", ["focus", focus]);
+			this.$content.set("focus", focus);
 		}
 	}
 };

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -47,7 +47,7 @@ export default {
 	},
 	computed: {
 		focus() {
-			const focus = this.$content.values["focus"];
+			const focus = this.$panel.content.values["focus"];
 
 			if (!focus) {
 				return;
@@ -73,7 +73,7 @@ export default {
 				focus = `${focus.x}% ${focus.y}%`;
 			}
 
-			this.$content.set("focus", focus);
+			this.$panel.content.set("focus", focus);
 		}
 	}
 };

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -19,7 +19,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons :lock="lock" />
+				<k-form-buttons />
 			</template>
 		</k-header>
 

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -15,7 +15,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons :lock="lock" />
+				<k-form-buttons />
 			</template>
 		</k-header>
 

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -27,7 +27,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons :lock="lock" />
+				<k-form-buttons />
 			</template>
 		</k-header>
 

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -42,6 +42,8 @@ export default (panel) => {
 		get isDraft() {
 			return panel.view.props.model.status === "draft";
 		},
+		isPublishing: false,
+		isSaving: false,
 		/**
 		 * Content lock state of the model
 		 *
@@ -69,9 +71,11 @@ export default (panel) => {
 		async publish(e) {
 			e?.preventDefault?.();
 
+			this.isPublishing = true;
 			await panel.app.$store.dispatch("content/save");
 			panel.events.emit("model.update");
 			panel.notification.success();
+			this.isPublishing = false;
 		},
 		/**
 		 * Returns all fields and their already published values
@@ -84,7 +88,11 @@ export default (panel) => {
 		/**
 		 * Saves any changes
 		 */
-		async save() {},
+		async save() {
+			this.isSaving = true;
+			// …
+			this.isSaving = false;
+		},
 		/**
 		 * Updates the value of fields/a field
 		 *

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,0 +1,118 @@
+/**
+ * @since 5.0.0
+ */
+export default (panel) => {
+	return {
+		/**
+		 * Returns all fields and their values that
+		 * have been changed but not yet published
+		 *
+		 * @returns {Object}
+		 */
+		get changed() {
+			return panel.app.$store.getters["content/changes"]();
+		},
+		/**
+		 * Removes all unpublished changes
+		 */
+		discard() {
+			panel.app.$store.dispatch("content/revert");
+		},
+		/**
+		 * Whether the model has changes that haven't been saved yet
+		 *
+		 * @returns {Boolean}
+		 */
+		get hasUnsavedChanges() {
+			return false;
+		},
+		/**
+		 * Whether the model has changes that haven't been published yet
+		 *
+		 * @returns {Boolean}
+		 */
+		get hasUnpublishedChanges() {
+			return panel.app.$store.getters["content/hasChanges"]();
+		},
+		/**
+		 * Whether the model is a draft
+		 *
+		 * @returns {Boolean}
+		 */
+		get isDraft() {
+			return panel.view.props.model.status === "draft";
+		},
+		/**
+		 * Content lock state of the model
+		 *
+		 * @returns {Object|null|false}
+		 */
+		get lock() {
+			const lock = panel.view.props.lock;
+
+			if (lock === false) {
+				return false;
+			}
+
+			if (lock.state === null) {
+				return null;
+			}
+
+			return {
+				...lock.data,
+				state: lock.state
+			};
+		},
+		/**
+		 * Publishes any changes
+		 */
+		async publish(e) {
+			e?.preventDefault?.();
+
+			await panel.app.$store.dispatch("content/save");
+			panel.events.emit("model.update");
+			panel.notification.success();
+		},
+		/**
+		 * Returns all fields and their already published values
+		 *
+		 * @returns {Object}
+		 */
+		get published() {
+			return panel.app.$store.getters["content/originals"]();
+		},
+		/**
+		 * Saves any changes
+		 */
+		async save() {},
+		/**
+		 * Updates the value of fields/a field
+		 *
+		 * @param {String|Object} fields
+		 * @param {any} value
+		 */
+		set(fields, value) {
+			if (typeof fields === "string") {
+				fields = { [fields]: value };
+			}
+
+			panel.app.$store.dispatch("content/update", [null, fields]);
+		},
+		/**
+		 * Removes the content lock for the current user,
+		 * e.g. when closing/leaving the model view
+		 */
+		async unlock() {},
+		/**
+		 * Returns all fields and values incl. changes
+		 *
+		 * @returns {Object}
+		 */
+		get values() {
+			return {
+				...this.published,
+				...this.changed
+			};
+		}
+	};
+};

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -9,7 +9,7 @@ export default (panel) => {
 		 *
 		 * @returns {Object}
 		 */
-		get changed() {
+		get changes() {
 			return panel.app.$store.getters["content/changes"]();
 		},
 		/**
@@ -111,7 +111,7 @@ export default (panel) => {
 		get values() {
 			return {
 				...this.published,
-				...this.changed
+				...this.changes
 			};
 		}
 	};

--- a/panel/src/panel/legacy.js
+++ b/panel/src/panel/legacy.js
@@ -37,7 +37,6 @@ export default {
 		const polyfills = [
 			"api",
 			"config",
-			"content",
 			"direction",
 			"events",
 			"language",

--- a/panel/src/panel/legacy.js
+++ b/panel/src/panel/legacy.js
@@ -37,6 +37,7 @@ export default {
 		const polyfills = [
 			"api",
 			"config",
+			"content",
 			"direction",
 			"events",
 			"language",

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -1,5 +1,6 @@
 import Activation from "./activiation.js";
 import Api from "@/api/index.js";
+import Content from "./content.js";
 import Dialog from "./dialog.js";
 import Drag from "./drag.js";
 import Drawer from "./drawer.js";
@@ -71,6 +72,7 @@ export default {
 		this.isOffline = false;
 
 		this.activation = Activation(this);
+		this.content = Content(this);
 		this.drag = Drag(this);
 		this.events = Events(this);
 		this.theme = Theme(this);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- New `panel.content` module aimed at taking over the intermediary role between UI and API (when removing Vuex store)
- Currently serves as interface to the Vuex store
- Started to use `this.$panel.content.` methods instead of `this.$store.dispatch("content/...")`


### Reasoning
- Allows us to think about the ideal JS interface we would want for the content
- Already starts separating the Vuex store from the rest of the code, allowing us later to more easily replace it with backend API


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- New `panel.content`/`this.$content` module to access and alter the current model content (unsaved changes)



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
