### PR TITLE
Changes C: `panel.content.isLocked`

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -98,7 +98,7 @@ export default {
 			return this.$panel.content.hasUnpublishedChanges;
 		},
 		isLocked() {
-			return this.lockState === "lock";
+			return this.$panel.content.isLocked;
 		},
 		isUnlocked() {
 			return this.lockState === "unlock";
@@ -138,7 +138,10 @@ export default {
 		hasChanges: {
 			handler(changes, before) {
 				if (this.supportsLocking === true) {
-					if (this.isLocked === false && this.isUnlocked === false) {
+					if (
+						this.$panel.content.isLocked === false &&
+						this.isUnlocked === false
+					) {
 						if (changes === true) {
 							// unsaved changes, write lock every 30 seconds
 							this.locking();

--- a/panel/src/components/View/Buttons/SettingsButton.vue
+++ b/panel/src/components/View/Buttons/SettingsButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<k-button
-			:disabled="$panel.view.isLocked"
+			:disabled="$panel.content.isLocked"
 			:dropdown="true"
 			:title="$t('settings')"
 			icon="cog"

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -23,7 +23,7 @@ export default {
 			return this.$helper.page.status.call(
 				this,
 				this.model.status,
-				!this.permissions.changeStatus || this.$panel.view.isLocked
+				!this.permissions.changeStatus || this.$panel.content.isLocked
 			);
 		},
 		model() {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -37,7 +37,7 @@ export default {
 			return this.model.link;
 		},
 		isLocked() {
-			return this.$panel.view.isLocked;
+			return this.$panel.content.isLocked;
 		},
 		protectedFields() {
 			return [];

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -45,6 +45,14 @@ export default (panel) => {
 		isPublishing: false,
 		isSaving: false,
 		/**
+		 * Whether the content is currently locked by another user
+		 *
+		 * @returns {Boolean}
+		 */
+		get isLocked() {
+			return this.lock?.state === "lock";
+		},
+		/**
 		 * Content lock state of the model
 		 *
 		 * @returns {Object|null|false}

--- a/panel/src/panel/view.js
+++ b/panel/src/panel/view.js
@@ -22,10 +22,6 @@ export default (panel) => {
 	return {
 		...parent,
 
-		get isLocked() {
-			return this.props.lock?.state === "lock";
-		},
-
 		/**
 		 * Setting the active view state
 		 * will also change the document title


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge first: https://github.com/getkirby/kirby/pull/6513

### Summary of changes
- Added `panel.content.isLocked` getter to replace `panel.view.isLocked`


### Reasoning
- Fits thematically better to the content module
- Later on, `save` API calls might also return a lock, so it's better to keep them nearby. To be determined if the views should still receive `lock` as prop or if that's completely moved to the content module (if we could Fiber-fy it).
