### PR TITLE
Changes D: set all values onInput

### DIFF
--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -73,12 +73,12 @@ export default {
 				this.isLoading = false;
 			}
 		},
-		onInput(values, field, fieldName) {
-			this.$panel.content.set(fieldName, values[fieldName]);
+		onInput(values) {
+			this.$panel.content.set(values);
 		},
 		onSubmit(values) {
 			// ensure that all values are actually committed to content store
-			this.$panel.content.set(values);
+			this.onInput(values);
 			this.$events.emit("keydown.cmd.s", values);
 		}
 	}

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -53,6 +53,14 @@ export default (panel) => {
 			return this.lock?.state === "lock";
 		},
 		/**
+		 * Whether the content is currently locked by another user
+		 *
+		 * @returns {Boolean}
+		 */
+		get isLocked() {
+			return this.lock?.state === "lock";
+		},
+		/**
 		 * Content lock state of the model
 		 *
 		 * @returns {Object|null|false}

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -53,14 +53,6 @@ export default (panel) => {
 			return this.lock?.state === "lock";
 		},
 		/**
-		 * Whether the content is currently locked by another user
-		 *
-		 * @returns {Boolean}
-		 */
-		get isLocked() {
-			return this.lock?.state === "lock";
-		},
-		/**
 		 * Content lock state of the model
 		 *
 		 * @returns {Object|null|false}

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -110,16 +110,12 @@ export default (panel) => {
 			this.isSaving = false;
 		},
 		/**
-		 * Updates the value of fields/a field
+		 * Updates the values of fields
 		 *
-		 * @param {String|Object} fields
+		 * @param {Object} fields
 		 * @param {any} value
 		 */
-		set(fields, value) {
-			if (typeof fields === "string") {
-				fields = { [fields]: value };
-			}
-
+		set(fields) {
 			panel.app.$store.dispatch("content/update", [null, fields]);
 		},
 		/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] First merge: https://github.com/getkirby/kirby/pull/6513
- [x] First merge: https://github.com/getkirby/kirby/pull/6515

### Summary of changes
- Fields section submit all values on input of any field now (similar to on submit) instead of updating the one field


### Reasoning
When we throttle the save call to the backend later on, we cannot just have the one updated value on the call that gets through, but always a full set of current/changed values.

Alternatively, `panel.content` would need to keep a temporary store of not-yet-saved changed values.
