### PR TITLE
Vite: make HTTPS default

### DIFF
--- a/panel/.env.example
+++ b/panel/.env.example
@@ -1,1 +1,1 @@
-SERVER = "http://sandbox.test"
+SERVER = "https://sandbox.test"

--- a/panel/vite.config.mjs
+++ b/panel/vite.config.mjs
@@ -102,7 +102,7 @@ export default defineConfig(({ mode }) => {
 	};
 
 	const proxy = {
-		target: process.env.SERVER ?? "http://sandbox.test",
+		target: process.env.SERVER ?? "https://sandbox.test",
 		changeOrigin: true,
 		secure: false
 	};


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Vite: Make dev server by default `https://sandbox.test` instead of `http://sandbox.test`


### Reasoning
- Didn't get Vue 3 running without it and thought it's good to move that change even earlier then

