### PR TITLE
Fix language permissions

### DIFF
--- a/panel/src/components/Views/Languages/LanguagesView.vue
+++ b/panel/src/components/Views/Languages/LanguagesView.vue
@@ -5,6 +5,7 @@
 
 			<k-button-group slot="buttons">
 				<k-button
+					:disabled="!$panel.permissions.languages.create"
 					:text="$t('language.create')"
 					icon="add"
 					size="sm"
@@ -84,7 +85,7 @@ export default {
 					{
 						icon: "trash",
 						text: this.$t("delete"),
-						disabled: language.deletable === false,
+						disabled: language.deletable === false || !this.$panel.permissions.languages.delete,
 						click: () => this.$dialog(`languages/${language.id}/delete`)
 					}
 				]

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -6,6 +6,7 @@ use Kirby\Data\Data;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
@@ -145,8 +146,13 @@ class Language
 	 */
 	public static function create(array $props): static
 	{
+		$kirby = App::instance();
+
+		if ($kirby->user()?->role()->permissions()->for('languages', 'create') === false) {
+			throw new PermissionException('You are not allowed to create a language');
+		}
+
 		$props['code'] = Str::slug($props['code'] ?? null);
-		$kirby         = App::instance();
 		$languages     = $kirby->languages();
 
 		// make the first language the default language
@@ -205,6 +211,10 @@ class Language
 	{
 		$kirby = App::instance();
 		$code  = $this->code();
+
+		if ($kirby->user()?->role()->permissions()->for('languages', 'delete') === false) {
+			throw new PermissionException('You are not allowed to delete the language');
+		}
 
 		if ($this->isDeletable() === false) {
 			throw new Exception('The language cannot be deleted');

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
@@ -102,6 +103,39 @@ class LanguageTest extends TestCase
 	/**
 	 * @covers ::create
 	 */
+	public function testCreateNoPermissions()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'users/editor' => [
+					'name' => 'editor',
+					'permissions' => [
+						'languages' => [
+							'create' => false
+						]
+					]
+				],
+			],
+			'users' => [
+				['email' => 'test@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to create a language');
+
+		$app->impersonate('test@getkirby.com');
+		Language::create([
+			'code' => 'en'
+		]);
+	}
+
+	/**
+	 * @covers ::create
+	 */
 	public function testCreateHooks()
 	{
 		$calls = 0;
@@ -152,6 +186,39 @@ class LanguageTest extends TestCase
 	{
 		$language = Language::create(['code' => 'en']);
 		$this->assertTrue($language->delete());
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteNoPermissions()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'users/editor' => [
+					'name' => 'editor',
+					'permissions' => [
+						'languages' => [
+							'create' => true,
+							'delete' => false
+						]
+					]
+				],
+			],
+			'users' => [
+				['email' => 'test@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to delete the language');
+
+		$app->impersonate('test@getkirby.com');
+		$language = Language::create(['code' => 'en']);
+		$language->delete();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixed the issue with adding new checks to `Language::create` and `Language::delete` methods.

### Additional context

Currently users can create any language with `Language::create()` method without authenticate, so no needed to impersonate. I kept this behavior with following syntax. But I'm not sure this is correct behavior? For panel, users have to permission to create languages, for frontend users don't have to any permission. Please direct me.

````php
if ($kirby->user()?->role()->permissions()->for('languages', 'create') === false) {
  throw new PermissionException('You are not allowed to create a language');
}
````


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Language permissions not working getkirby/backlog#89


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
