### PR TITLE
Panel theme: allow resetting to system default

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -27,9 +27,6 @@
 	"date": "Date",
 	"date.select": "Select a date",
 
-	"dark.on": "Lights off",
-	"dark.off": "Lights on",
-
 	"day": "Day",
 	"days.fri": "Fri",
 	"days.mon": "Mon",
@@ -657,6 +654,12 @@
 	"tel": "Phone",
 	"tel.placeholder": "+49123456789",
 	"template": "Template",
+
+	"theme": "Theme",
+	"theme.light": "Lights on",
+	"theme.dark": "Lights off",
+	"theme.automatic": "Match system default",
+
 	"title": "Title",
 	"today": "Today",
 

--- a/panel/src/components/View/Buttons/ThemeButton.vue
+++ b/panel/src/components/View/Buttons/ThemeButton.vue
@@ -1,13 +1,16 @@
 <template>
-	<k-button
-		v-if="$panel.view.id === 'account'"
-		:icon="icon"
-		:text="text"
-		size="sm"
-		variant="filled"
-		class="k-view-theme-button"
-		@click="$panel.theme.toggle()"
-	/>
+	<div v-if="$panel.view.id === 'account'">
+		<k-button
+			:dropdown="true"
+			:icon="current === 'light' ? 'sun' : 'moon'"
+			:text="$t('theme')"
+			size="sm"
+			variant="filled"
+			class="k-view-theme-button"
+			@click="$refs.dropdown.toggle()"
+		/>
+		<k-dropdown-content ref="dropdown" :options="options" align-x="end" />
+	</div>
 </template>
 
 <script>
@@ -17,14 +20,33 @@
  */
 export default {
 	computed: {
-		icon() {
-			return this.isDark ? "sun" : "moon";
+		current() {
+			return this.$panel.theme.current;
 		},
-		isDark() {
-			return this.$panel.theme.current === "dark";
+		options() {
+			return [
+				{
+					text: this.$t("theme.light"),
+					icon: "sun",
+					disabled: this.setting === "light",
+					click: () => this.$panel.theme.set("light")
+				},
+				{
+					text: this.$t("theme.dark"),
+					icon: "moon",
+					disabled: this.setting === "dark",
+					click: () => this.$panel.theme.set("dark")
+				},
+				{
+					text: this.$t("theme.automatic"),
+					icon: "wand",
+					disabled: this.setting === null,
+					click: () => this.$panel.theme.reset()
+				}
+			];
 		},
-		text() {
-			return this.isDark ? this.$t("dark.off") : this.$t("dark.on");
+		setting() {
+			return this.$panel.theme.setting;
 		}
 	}
 };

--- a/panel/src/panel/theme.js
+++ b/panel/src/panel/theme.js
@@ -2,11 +2,7 @@ import State from "./state.js";
 
 export const defaults = () => {
 	return {
-		current:
-			localStorage.getItem("kirby$theme") ??
-			(window.matchMedia?.("(prefers-color-scheme: dark)").matches
-				? "dark"
-				: "light")
+		setting: localStorage.getItem("kirby$theme")
 	};
 };
 
@@ -19,14 +15,24 @@ export default () => {
 	return {
 		...parent,
 
-		toggle() {
-			if (this.current === "dark") {
-				this.current = "light";
-			} else {
-				this.current = "dark";
-			}
+		get current() {
+			return this.setting ?? this.system;
+		},
 
-			localStorage.setItem("kirby$theme", this.current);
+		reset() {
+			this.setting = null;
+			localStorage.removeItem("kirby$theme");
+		},
+
+		set(theme) {
+			this.setting = theme;
+			localStorage.setItem("kirby$theme", theme);
+		},
+
+		get system() {
+			return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+				? "dark"
+				: "light";
 		}
 	};
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Theme button: now as dropdown with additional option to reset to using system default 

<img width="452" alt="Screenshot 2024-07-13 at 12 37 23" src="https://github.com/user-attachments/assets/1b6f7c3c-9e4b-4198-b0bc-7799ff450181">


### Reasoning
Before this, there is no way to use the system default again, once set a theme (besides going into the dev tools and removing localStorage).

## Changelog

### Changes compared to alpha.1
- Theme button is now a dropdown and allows to reset to match system default color scheme