### PR TITLE
Turn `panel` JS modules fully reactive

### DIFF
--- a/panel/src/panel/activiation.js
+++ b/panel/src/panel/activiation.js
@@ -1,18 +1,29 @@
+import { reactive } from "vue";
+import State from "./state.js";
+
+export const defaults = () => {
+	return {
+		isOpen: sessionStorage.getItem("kirby$activation$card") !== "true"
+	};
+};
+
 /**
  * @since 4.0.0
  */
 export default () => {
-	return {
+	const parent = State("activation", defaults());
+
+	return reactive({
+		...parent,
+
 		close() {
 			sessionStorage.setItem("kirby$activation$card", "true");
 			this.isOpen = false;
 		},
 
-		isOpen: sessionStorage.getItem("kirby$activation$card") !== "true",
-
 		open() {
 			sessionStorage.removeItem("kirby$activation$card");
 			this.isOpen = true;
 		}
-	};
+	});
 };

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,8 +1,10 @@
+import { reactive } from "vue";
+
 /**
  * @since 5.0.0
  */
 export default (panel) => {
-	return {
+	return reactive({
 		/**
 		 * Returns all fields and their values that
 		 * have been changed but not yet published
@@ -126,5 +128,5 @@ export default (panel) => {
 				...this.changes
 			};
 		}
-	};
+	});
 };

--- a/panel/src/panel/dialog.js
+++ b/panel/src/panel/dialog.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import Modal, { defaults as modalDefaults } from "./modal.js";
 
 export const defaults = () => {
@@ -27,7 +28,7 @@ export default (panel) => {
 
 	const parent = Modal(panel, "dialog", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -131,5 +132,5 @@ export default (panel) => {
 
 			return state;
 		}
-	};
+	});
 };

--- a/panel/src/panel/drag.js
+++ b/panel/src/panel/drag.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import State from "./state.js";
 
 export const defaults = () => {
@@ -13,7 +14,7 @@ export const defaults = () => {
 export default () => {
 	const parent = State("drag", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -44,5 +45,5 @@ export default () => {
 			this.type = null;
 			this.data = {};
 		}
-	};
+	});
 };

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -1,6 +1,6 @@
 import Modal, { defaults as modalDefaults } from "./modal.js";
 import History from "./history.js";
-import { set } from "vue";
+import { reactive, set } from "vue";
 import { uuid } from "@/helpers/string.js";
 
 export const defaults = () => {
@@ -22,11 +22,13 @@ export default (panel) => {
 		panel.drawer.submit();
 	});
 
-	return {
+	return reactive({
 		...parent,
+
 		get breadcrumb() {
 			return this.history.milestones;
 		},
+
 		/**
 		 * Closes the drawer and goes back to the
 		 * parent one if it has been stored
@@ -187,5 +189,5 @@ export default (panel) => {
 				this.focus();
 			});
 		}
-	};
+	});
 };

--- a/panel/src/panel/dropdown.js
+++ b/panel/src/panel/dropdown.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import Feature, { defaults } from "./feature.js";
 
 /**
@@ -6,7 +7,7 @@ import Feature, { defaults } from "./feature.js";
 export default (panel) => {
 	const parent = Feature(panel, "dropdown", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		close() {
@@ -85,5 +86,5 @@ export default (panel) => {
 
 			return parent.set.call(this, state);
 		}
-	};
+	});
 };

--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import { isUrl } from "@/helpers/url";
 import listeners from "./listeners.js";
 import State from "./state.js";
@@ -39,7 +40,7 @@ export const defaults = () => {
 export default (panel, key, defaults) => {
 	const parent = State(key, defaults);
 
-	return {
+	return reactive({
 		/**
 		 * Features inherit all the state methods
 		 * and reactive defaults are also merged
@@ -240,5 +241,5 @@ export default (panel, key, defaults) => {
 		url() {
 			return panel.url(this.path, this.query);
 		}
-	};
+	});
 };

--- a/panel/src/panel/history.js
+++ b/panel/src/panel/history.js
@@ -1,10 +1,10 @@
-import { set } from "vue";
+import { reactive, set } from "vue";
 
 /**
  * @since 4.0.0
  */
 export default () => {
-	return {
+	return reactive({
 		add(state) {
 			if (!state.id) {
 				throw new Error("The state needs an ID");
@@ -74,5 +74,5 @@ export default () => {
 
 			set(this.milestones, index, state);
 		}
-	};
+	});
 };

--- a/panel/src/panel/language.js
+++ b/panel/src/panel/language.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import State from "./state.js";
 
 export const defaults = () => {
@@ -16,10 +17,11 @@ export const defaults = () => {
 export default () => {
 	const parent = State("language", defaults());
 
-	return {
+	return reactive({
 		...parent,
+
 		get isDefault() {
 			return this.default;
 		}
-	};
+	});
 };

--- a/panel/src/panel/menu.js
+++ b/panel/src/panel/menu.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import State from "./state.js";
 
 export const defaults = () => {
@@ -14,7 +15,7 @@ export const defaults = () => {
 export default (panel) => {
 	const parent = State("menu", defaults());
 	const media = window.matchMedia?.("(max-width: 60rem)");
-	const menu = {
+	const menu = reactive({
 		...parent,
 
 		/**
@@ -116,7 +117,7 @@ export default (panel) => {
 				this.open();
 			}
 		}
-	};
+	});
 
 	// escape key event
 	panel.events.on("keydown.esc", menu.escape.bind(menu));

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -4,7 +4,7 @@ import { isObject } from "@/helpers/object.js";
 import Feature, { defaults as featureDefaults } from "./feature.js";
 import focus from "@/helpers/focus.js";
 import "@/helpers/array.js";
-import { set } from "vue";
+import { reactive, set } from "vue";
 import { wrap } from "@/helpers/array.js";
 
 /**
@@ -29,7 +29,7 @@ export const defaults = () => {
 export default (panel, key, defaults) => {
 	const parent = Feature(panel, key, defaults);
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -310,5 +310,5 @@ export default (panel, key, defaults) => {
 		get value() {
 			return this.props?.value;
 		}
-	};
+	});
 };

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import AuthError from "@/errors/AuthError.js";
 import JsonRequestError from "@/errors/JsonRequestError.js";
 import RequestError from "@/errors/RequestError.js";
@@ -23,7 +24,7 @@ export const defaults = () => {
 export default (panel = {}) => {
 	const parent = State("notification", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -240,5 +241,5 @@ export default (panel = {}) => {
 		 * Holds the timer object
 		 */
 		timer: Timer
-	};
+	});
 };

--- a/panel/src/panel/state.js
+++ b/panel/src/panel/state.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import { isObject } from "@/helpers/object";
 
 /**
@@ -15,7 +16,7 @@ import { isObject } from "@/helpers/object";
  * @param {Object} defaults Sets the default state
  */
 export default (key, defaults = {}) => {
-	return {
+	return reactive({
 		/**
 		 * State defaults will be reactive and
 		 * must be present immediately in the object
@@ -100,5 +101,5 @@ export default (key, defaults = {}) => {
 
 			return true;
 		}
-	};
+	});
 };

--- a/panel/src/panel/theme.js
+++ b/panel/src/panel/theme.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import State from "./state.js";
 
 export const defaults = () => {
@@ -12,7 +13,7 @@ export const defaults = () => {
 export default () => {
 	const parent = State("theme", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		get current() {
@@ -34,5 +35,5 @@ export default () => {
 				? "dark"
 				: "light";
 		}
-	};
+	});
 };

--- a/panel/src/panel/translation.js
+++ b/panel/src/panel/translation.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import { template } from "@/helpers/string.js";
 import State from "./state.js";
 
@@ -17,7 +18,7 @@ export const defaults = () => {
 export default () => {
 	const parent = State("translation", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -69,5 +70,5 @@ export default () => {
 
 			return template(string, data);
 		}
-	};
+	});
 };

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import { uuid } from "@/helpers/string";
 import State from "./state.js";
 import listeners from "./listeners.js";
@@ -32,7 +33,7 @@ export const defaults = () => {
 export default (panel) => {
 	const parent = State("upload", defaults());
 
-	return {
+	return reactive({
 		...parent,
 		...listeners(),
 		input: null,
@@ -347,5 +348,5 @@ export default (panel) => {
 				file.progress = 0;
 			}
 		}
-	};
+	});
 };

--- a/panel/src/panel/view.js
+++ b/panel/src/panel/view.js
@@ -1,3 +1,4 @@
+import { reactive } from "vue";
 import Feature, { defaults as featureDefaults } from "./feature.js";
 
 export const defaults = () => {
@@ -19,7 +20,7 @@ export const defaults = () => {
 export default (panel) => {
 	const parent = Feature(panel, "view", defaults());
 
-	return {
+	return reactive({
 		...parent,
 
 		/**
@@ -57,5 +58,5 @@ export default (panel) => {
 		async submit() {
 			throw new Error("Not yet implemented");
 		}
-	};
+	});
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Wrap all relevant `panel` JS modules in Vue's `reactive()`


### Reasoning
While in Vue 2 as it seems no problem, in Vue 3 the modules aren't fully reactive without these. In particular, when not accessed through `this.$panel` which already receives `reactive()` from the `return reactive(this)` in panel.js. When internally accessing the modules in the panel JS code, they are not going through the proxies created from `reative()` and thus Vue 3 doesn't register them as altered then.

I tired to apply it less broadly, e.g. just on `state.js` but that didn't work.

