### PR TITLE
Make `Api\Upload` readonly

### DIFF
--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -29,7 +29,7 @@ use Kirby\Toolkit\Str;
  * @since     5.0.0
  * @internal
  */
-class Upload
+readonly class Upload
 {
 	public function __construct(
 		protected Api $api,


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Marked `Api\Upload` class as readonly.


### Reasoning
More a point of `Discussion`. But I thought it would be good to start embracing these newer PHP features. Since the `Upload` class is brand-new in v5, it seemed like a good starting point for the discussion and testing. In general, I think it's a good thought exercise and safety measure to consider if all/any of the class properties should ever change after initialization.

If we agree that this is a direction forward for us, we can see where/hwo to introduce this to more parts of our code step by step.

### Additional context
https://stitcher.io/blog/php-81-readonly-properties
https://stitcher.io/blog/readonly-classes-in-php-82