### PR TITLE
Buttons 8: Connect frontend with view button classes

### DIFF
--- a/config/areas/account.php
+++ b/config/areas/account.php
@@ -7,6 +7,7 @@ return function () {
 		'icon'      => 'account',
 		'label'     => I18n::translate('view.account'),
 		'search'    => 'users',
+		'buttons'   => require __DIR__ . '/account/buttons.php',
 		'dialogs'   => require __DIR__ . '/account/dialogs.php',
 		'drawers'   => require __DIR__ . '/account/drawers.php',
 		'dropdowns' => require __DIR__ . '/account/dropdowns.php',

--- a/config/areas/account/buttons.php
+++ b/config/areas/account/buttons.php
@@ -1,0 +1,13 @@
+<?php
+
+use Kirby\Cms\App;
+use Kirby\Cms\User;
+use Kirby\Panel\Ui\Buttons\ViewButton;
+
+return [
+	'user.theme' => function (App $kirby, User $user) {
+		if ($kirby->user()->is($user) === true) {
+			return new ViewButton(component: 'k-view-theme-button');
+		}
+	}
+];

--- a/config/areas/files/buttons.php
+++ b/config/areas/files/buttons.php
@@ -1,0 +1,14 @@
+<?php
+
+use Kirby\Cms\File;
+use Kirby\Panel\Ui\Buttons\PreviewButton;
+use Kirby\Panel\Ui\Buttons\SettingsButton;
+
+return [
+	'file.preview' => function (File $file) {
+		return new PreviewButton(link: $file->previewUrl());
+	},
+	'file.settings' => function (File $file) {
+		return new SettingsButton(model: $file);
+	}
+];

--- a/config/areas/languages.php
+++ b/config/areas/languages.php
@@ -7,6 +7,7 @@ return function ($kirby) {
 		'icon'    => 'translate',
 		'label'   => I18n::translate('view.languages'),
 		'menu'    => true,
+		'buttons' => require __DIR__ . '/languages/buttons.php',
 		'dialogs' => require __DIR__ . '/languages/dialogs.php',
 		'views'   => require __DIR__ . '/languages/views.php'
 	];

--- a/config/areas/languages/buttons.php
+++ b/config/areas/languages/buttons.php
@@ -1,0 +1,35 @@
+<?php
+
+use Kirby\Cms\Language;
+use Kirby\Panel\Ui\Buttons\PreviewButton;
+use Kirby\Panel\Ui\Buttons\ViewButton;
+use Kirby\Toolkit\I18n;
+
+return [
+	'languages.add' => function () {
+		return new ViewButton(
+			dialog: 'languages/create',
+			icon: 'add',
+			text: I18n::translate('language.create'),
+		);
+	},
+	'language.preview' => function (Language $language) {
+		return new PreviewButton(link: $language->url());
+	},
+	'language.settings' => function (Language $language) {
+		return new ViewButton(
+			dialog: 'languages/' . $language->id() . '/update',
+			icon: 'cog',
+			title: I18n::translate('settings'),
+		);
+	},
+	'language.remove' => function (Language $language) {
+		if ($language->isDeletable() === true) {
+			return new ViewButton(
+				dialog: 'languages/' . $language->id() . '/delete',
+				icon: 'trash',
+				title: I18n::translate('delete'),
+			);
+		}
+	}
+];

--- a/config/areas/languages/views.php
+++ b/config/areas/languages/views.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\App;
 use Kirby\Cms\Find;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\I18n;
 
@@ -68,11 +69,10 @@ return [
 					]
 				],
 				'props'      => [
-					'buttons' => $kirby->option('panel.viewButtons.language', [
-						'preview',
-						'settings',
-						'remove'
-					]),
+					'buttons' => fn () =>
+						ViewButtons::view('language')
+							->defaults('preview', 'settings', 'remove')
+							->render(['language' => $language]),
 					'deletable'    => $language->isDeletable(),
 					'code'         => Escape::html($language->code()),
 					'default'      => $language->isDefault(),
@@ -113,9 +113,10 @@ return [
 			return [
 				'component' => 'k-languages-view',
 				'props'     => [
-					'buttons' => $kirby->option('panel.viewButtons.languages', [
-						'add'
-					]),
+					'buttons' => fn () =>
+						ViewButtons::view('languages')
+							->defaults('add')
+							->render(),
 					'languages' => $kirby->languages()->values(fn ($language) => [
 						'deletable' => $language->isDeletable(),
 						'default'   => $language->isDefault(),

--- a/config/areas/site.php
+++ b/config/areas/site.php
@@ -12,6 +12,7 @@ return function ($kirby) {
 		'icon'      => $blueprint->icon() ?? 'home',
 		'label'     => $blueprint->title() ?? I18n::translate('view.site'),
 		'menu'      => true,
+		'buttons'   => require __DIR__ . '/site/buttons.php',
 		'dialogs'   => require __DIR__ . '/site/dialogs.php',
 		'drawers'   => require __DIR__ . '/site/drawers.php',
 		'dropdowns' => require __DIR__ . '/site/dropdowns.php',

--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -1,0 +1,33 @@
+<?php
+
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Panel\Ui\Buttons\LanguagesButton;
+use Kirby\Panel\Ui\Buttons\PageStatusButton;
+use Kirby\Panel\Ui\Buttons\PreviewButton;
+use Kirby\Panel\Ui\Buttons\SettingsButton;
+
+return [
+	'site.preview' => function (Site $site) {
+		return new PreviewButton(link: $site->url());
+	},
+	'page.preview' => function (Page $page) {
+		if ($page->permissions()->can('preview') === true) {
+			return new PreviewButton(link: $page->previewUrl());
+		}
+	},
+	'page.settings' => function (Page $page) {
+		return new SettingsButton(model: $page);
+	},
+	'page.status' => function (Page $page) {
+		return new PageStatusButton($page);
+	},
+	// `languages` button needs to be in site area, as languages area itself
+	// is only loaded when in multilang setup
+	'languages' => function () {
+		return new LanguagesButton();
+	},
+
+	// file buttons
+	...require __DIR__ . '/../files/buttons.php'
+];

--- a/config/areas/system/views.php
+++ b/config/areas/system/views.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\App;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
 
 return [
@@ -87,7 +88,8 @@ return [
 			return [
 				'component' => 'k-system-view',
 				'props'     => [
-					'buttons'     => $kirby->option('panel.viewButtons.system', []),
+					'buttons'     => fn () =>
+						ViewButtons::view('system')->render(),
 					'environment' => $environment,
 					'exceptions'  => $kirby->option('debug') === true ? $exceptions : [],
 					'info'        => $system->info(),

--- a/config/areas/users.php
+++ b/config/areas/users.php
@@ -8,6 +8,7 @@ return function ($kirby) {
 		'label'     => I18n::translate('view.users'),
 		'search'    => 'users',
 		'menu'      => true,
+		'buttons'   => require __DIR__ . '/users/buttons.php',
 		'dialogs'   => require __DIR__ . '/users/dialogs.php',
 		'drawers'   => require __DIR__ . '/users/drawers.php',
 		'dropdowns' => require __DIR__ . '/users/dropdowns.php',

--- a/config/areas/users/buttons.php
+++ b/config/areas/users/buttons.php
@@ -1,0 +1,20 @@
+<?php
+
+use Kirby\Cms\User;
+use Kirby\Panel\Ui\Buttons\SettingsButton;
+use Kirby\Panel\Ui\Buttons\ViewButton;
+use Kirby\Toolkit\I18n;
+
+return [
+	'users.add' => function (User $user, string|null $role = null) {
+		return new ViewButton(
+			dialog: 'users/create?role=' . $role,
+			disabled: $user->role()->permissions()->for('users', 'create') !== true,
+			icon: 'add',
+			text: I18n::translate('user.create'),
+		);
+	},
+	'user.settings' => function (User $user) {
+		return new SettingsButton(model: $user);
+	}
+];

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\App;
 use Kirby\Cms\Find;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\Escape;
 
 return [
@@ -18,9 +19,10 @@ return [
 			return [
 				'component' => 'k-users-view',
 				'props'     => [
-					'buttons' => $kirby->option('panel.viewButtons.users', [
-						'add'
-					]),
+					'buttons' => fn () =>
+						ViewButtons::view('users')
+							->defaults('add')
+							->render(['role' => $role]),
 					'role' => function () use ($roles, $role) {
 						if ($role) {
 							return $roles[$role] ?? null;

--- a/panel/src/components/View/Buttons/Buttons.vue
+++ b/panel/src/components/View/Buttons/Buttons.vue
@@ -1,9 +1,10 @@
 <template>
-	<k-button-group class="k-view-buttons">
+	<k-button-group v-if="buttons.length" class="k-view-buttons">
 		<component
-			:is="`k-view-${button}-button`"
+			:is="component(button)"
 			v-for="button in buttons"
-			:key="button"
+			:key="button.key"
+			v-bind="button.props"
 			@action="$emit('action', $event)"
 		/>
 	</k-button-group>
@@ -13,12 +14,27 @@
 /**
  * Wrapper button group that dynamically renders the
  * respective view button components passed as `buttons` prop.
+ *
+ * @displayName ViewButtons
+ * @since 5.0.0
  * @internal
  */
 export default {
 	props: {
-		buttons: Array
+		buttons: {
+			type: Array,
+			default: () => []
+		}
 	},
-	emits: ["action"]
+	emits: ["action"],
+	methods: {
+		component(button) {
+			if (this.$helper.isComponent(button.component)) {
+				return button.component;
+			}
+
+			return "k-view-button";
+		}
+	}
 };
 </script>

--- a/panel/src/components/View/Buttons/LanguagesButton.vue
+++ b/panel/src/components/View/Buttons/LanguagesButton.vue
@@ -1,14 +1,10 @@
 <template>
-	<k-view-button
-		:options="options"
-		:text="code"
-		icon="translate"
-		responsive="text"
-		class="k-view-languages-button k-languages-dropdown"
-	/>
+	<k-view-button v-bind="$props" :options="languages" />
 </template>
 
 <script>
+import { props as ButtonProps } from "@/components/Navigation/Button.vue";
+
 /**
  * View header button to switch between content languages
  * @displayName ViewLanguagesButton
@@ -16,37 +12,25 @@
  * @internal
  */
 export default {
+	mixins: [ButtonProps],
+	props: {
+		options: {
+			type: Array,
+			default: () => []
+		}
+	},
 	computed: {
-		code() {
-			return this.language.code.toUpperCase();
-		},
-		language() {
-			return this.$panel.language;
-		},
 		languages() {
-			return this.$panel.languages;
-		},
-		options() {
-			const options = [];
+			return this.options.map((option) => {
+				if (option === "-") {
+					return option;
+				}
 
-			// add the primary/default language first
-			const primaryLanguage = this.languages.find(
-				(language) => language.default === true
-			);
-
-			options.push(this.item(primaryLanguage));
-			options.push("-");
-
-			// add all secondary languages after the separator
-			const secondaryLanguages = this.languages.filter(
-				(language) => language.default === false
-			);
-
-			for (const language of secondaryLanguages) {
-				options.push(this.item(language));
-			}
-
-			return options;
+				return {
+					...option,
+					click: () => this.change(option)
+				};
+			});
 		}
 	},
 	methods: {
@@ -56,13 +40,6 @@ export default {
 					language: language.code
 				}
 			});
-		},
-		item(language) {
-			return {
-				click: () => this.change(language),
-				current: language.code === this.language.code,
-				text: language.name
-			};
 		}
 	}
 };

--- a/panel/src/components/View/Buttons/SettingsButton.vue
+++ b/panel/src/components/View/Buttons/SettingsButton.vue
@@ -1,34 +1,24 @@
 <template>
 	<k-view-button
+		v-bind="$props"
 		:disabled="$panel.content.isLocked"
-		:title="$t('settings')"
-		icon="cog"
-		class="k-view-settings-button k-view-options"
-		:options="hasDropdown ? dropdown : null"
-		@click="$emit('action', 'settings')"
+		@action="$emit('action', $event)"
 	/>
 </template>
 
 <script>
+import Button from "./Button.vue";
+
 /**
  * View header button to open the model's settings dropdown
  * @displayName ViewSettingsButton
  * @since 5.0.0
+ * @deprecated 5.0.0
  * @internal
+ * @todo implement fully on backend when changes feature implemented
  */
 export default {
-	inheritAttrs: false,
-	emits: ["action", "click"],
-	computed: {
-		hasDropdown() {
-			return Boolean(this.dropdown);
-		},
-		dropdown() {
-			return this.model?.link;
-		},
-		model() {
-			return this.$panel.view.props.model;
-		}
-	}
+	extends: Button,
+	emits: ["action"]
 };
 </script>

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -1,43 +1,22 @@
 <template>
 	<k-view-button
-		v-if="$panel.view.component === 'k-page-view' && status"
-		v-bind="button"
-		:responsive="true"
-		:text="status.label"
-		class="k-view-status-button k-page-status-button"
-		@click="$dialog(model.link + '/changeStatus')"
+		v-bind="$props"
+		:disabled="disabled || $panel.content.isLocked"
 	/>
 </template>
 
 <script>
+import Button from "./Button.vue";
+
 /**
  * View header button to change the page status
  * @displayName ViewStatusButton
  * @since 5.0.0
+ * @deprecated 5.0.0
  * @internal
+ * @todo implement fully on backend when changes feature implemented
  */
 export default {
-	inheritAttrs: false,
-	computed: {
-		button() {
-			return {
-				...this.$helper.page.status.call(
-					this,
-					this.model.status,
-					!this.permissions.changeStatus || this.$panel.content.isLocked
-				),
-				size: "sm"
-			};
-		},
-		model() {
-			return this.$panel.view.props.model;
-		},
-		permissions() {
-			return this.$panel.view.props.permissions;
-		},
-		status() {
-			return this.$panel.view.props.status;
-		}
-	}
+	extends: Button
 };
 </script>

--- a/panel/src/components/View/Buttons/ThemeButton.vue
+++ b/panel/src/components/View/Buttons/ThemeButton.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-view-button
-		v-if="$panel.view.id === 'account'"
 		:icon="current === 'light' ? 'sun' : 'moon'"
 		:options="options"
 		:text="$t('theme')"

--- a/panel/src/components/Views/Languages/LanguageView.vue
+++ b/panel/src/components/Views/Languages/LanguageView.vue
@@ -4,11 +4,11 @@
 			<k-prev-next :prev="prev" :next="next" />
 		</template>
 
-		<k-header :editable="true" @edit="update()">
+		<k-header :editable="true" @edit="$dialog(`languages/${id}/update`)">
 			{{ name }}
 
 			<template #buttons>
-				<k-view-buttons :buttons="buttons" @action="onAction" />
+				<k-view-buttons :buttons="buttons" />
 			</template>
 		</k-header>
 
@@ -76,12 +76,6 @@ export default {
 		createTranslation() {
 			this.$dialog(`languages/${this.id}/translations/create`);
 		},
-		onAction(action) {
-			switch (action) {
-				case "settings":
-					return this.update();
-			}
-		},
 		option(option, row) {
 			// for the compatibility of the encoded url in different environments,
 			// it is also encoded with base64 to reduce special characters
@@ -90,15 +84,6 @@ export default {
 					encodeURIComponent(row.key)
 				)}/${option}`
 			);
-		},
-		update(focus) {
-			this.$dialog(`languages/${this.id}/update`, {
-				on: {
-					ready: () => {
-						this.$panel.dialog.focus(focus);
-					}
-				}
-			});
 		},
 		updateTranslation({ row }) {
 			// for the compatibility of the encoded url in different environments,

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -40,9 +40,6 @@ import ModelView from "../ModelView.vue";
 
 export default {
 	extends: ModelView,
-	props: {
-		status: Object
-	},
 	computed: {
 		protectedFields() {
 			return ["title"];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,11 @@
 		<exclude>
 			<directory suffix=".php">./config/blocks</directory>
 			<directory suffix=".php">./config/templates</directory>
+			<file>./config/areas/account/buttons.php</file>
+			<file>./config/areas/files/buttons.php</file>
+			<file>./config/areas/languages/buttons.php</file>
+			<file>./config/areas/site/buttons.php</file>
+			<file>./config/areas/users/buttons.php</file>
 			<file>./config/aliases.php</file>
 			<file>./config/setup.php</file>
 			<file>./config/areas/account/requests.php</file>

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
 use Throwable;
 
@@ -70,13 +71,11 @@ class File extends Model
 	 */
 	public function buttons(): array
 	{
-		return
-			$this->model->blueprint()->buttons() ??
-			$this->model->kirby()->option('panel.viewButtons.file', [
-				'preview',
-				'settings',
-				'languages'
-			]);
+		return ViewButtons::view($this)->defaults(
+			'preview',
+			'settings',
+			'languages'
+		)->render(['file' => $this->model()]);
 	}
 
 	/**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -366,7 +366,7 @@ abstract class Model
 		$tab       = $blueprint->tab($request->get('tab')) ?? $tabs[0] ?? null;
 
 		$props = [
-			'buttons'     => $this->buttons(),
+			'buttons'     => fn () => $this->buttons(),
 			'lock'        => $this->lock(),
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -40,19 +41,17 @@ class Page extends Model
 	}
 
 	/**
-	 * Returns header button names which should be displayed
+	 * Returns header buttons which should be displayed
 	 * on the page view
 	 */
 	public function buttons(): array
 	{
-		return
-			$this->model->blueprint()->buttons() ??
-			$this->model->kirby()->option('panel.viewButtons.page', [
-				'preview',
-				'settings',
-				'languages',
-				'status'
-			]);
+		return ViewButtons::view($this)->defaults(
+			'preview',
+			'settings',
+			'languages',
+			'status'
+		)->render(['page' => $this->model()]);
 	}
 
 	/**
@@ -359,12 +358,7 @@ class Page extends Model
 				'status'     => $page->status(),
 				'title'      => $page->title()->toString(),
 				'uuid'       => fn () => $page->uuid()?->toString(),
-			],
-			'status' => function () use ($page) {
-				if ($status = $page->status()) {
-					return $page->blueprint()->status()[$status] ?? null;
-				}
-			},
+			]
 		];
 	}
 

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 
 /**
  * Provides information about the site model for the Panel
@@ -24,17 +25,15 @@ class Site extends Model
 	protected ModelWithContent $model;
 
 	/**
-	 * Returns header button names which should be displayed
+	 * Returns header buttons which should be displayed
 	 * on the site view
 	 */
 	public function buttons(): array
 	{
-		return
-			$this->model->blueprint()->buttons() ??
-			$this->model->kirby()->option('panel.viewButtons.site', [
-				'preview',
-				'languages'
-			]);
+		return ViewButtons::view($this)->defaults(
+			'preview',
+			'languages'
+		)->render(['site' => $this->model()]);
 	}
 
 	/**

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -7,6 +7,7 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Translation;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\Asset;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -40,18 +41,16 @@ class User extends Model
 	}
 
 	/**
-	 * Returns header button names which should be displayed
-	 * on the site view
+	 * Returns header buttons which should be displayed
+	 * on the user view
 	 */
 	public function buttons(): array
 	{
-		return
-			$this->model->blueprint()->buttons() ??
-			$this->model->kirby()->option('panel.viewButtons.user', [
-				'theme',
-				'settings',
-				'languages'
-			]);
+		return ViewButtons::view($this)->defaults(
+			'theme',
+			'settings',
+			'languages'
+		)->render(['user' => $this->model()]);
 	}
 
 	/**

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -50,9 +50,6 @@ class SiteTest extends AreaTestCase
 
 		$this->assertNull($props['next']);
 		$this->assertNull($props['prev']);
-
-		$this->assertSame('Draft', $props['status']['label']);
-		$this->assertSame('The page is in draft mode and only visible for logged in editors or via secret link', $props['status']['text']);
 	}
 
 	public function testPageFileWithoutModel(): void

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -132,10 +132,10 @@ class FileTest extends TestCase
 	public function testButtons()
 	{
 		$this->assertSame([
-			'preview',
-			'settings',
-			'languages'
-		], $this->panel()->buttons());
+			'k-view-preview-button',
+			'k-view-settings-button',
+			'k-view-languages-button',
+		], array_column($this->panel()->buttons(), 'component'));
 	}
 
 	/**

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -98,11 +98,11 @@ class PageTest extends TestCase
 	public function testButtons()
 	{
 		$this->assertSame([
-			'preview',
-			'settings',
-			'languages',
-			'status'
-		], $this->panel()->buttons());
+			'k-view-preview-button',
+			'k-view-settings-button',
+			'k-view-languages-button',
+			'k-view-status-button',
+		], array_column($this->panel()->buttons(), 'component'));
 	}
 
 	/**
@@ -542,10 +542,6 @@ class PageTest extends TestCase
 
 		$this->assertNull($props['next']());
 		$this->assertNull($props['prev']());
-		$this->assertSame([
-			'label' => 'Unlisted',
-			'text'  => 'The page is only accessible via URL'
-		], $props['status']());
 	}
 
 	/**
@@ -658,48 +654,6 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/baz?tab=test', $prevNext['next']()['link']);
 
 		$_GET = [];
-	}
-
-	/**
-	 * @covers ::props
-	 */
-	public function testPropsStatus()
-	{
-		$page = new ModelPage([
-			'slug'  => 'test',
-			'num'   => 0
-		]);
-
-		$props = (new Page($page))->props();
-		$this->assertSame([
-			'label' => 'Public',
-			'text'  => 'The page is public for anyone'
-		], $props['status']());
-
-
-		$app = $this->app->clone([
-			'blueprints' => [
-				'pages/note' => [
-					'status' => [
-						'unlisted' => 'Foo',
-					]
-				]
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'template' => 'note'
-					]
-				]
-			]
-		]);
-
-		$props = (new Page($app->page('test')))->props();
-		$this->assertSame([
-			'label' => 'Foo',
-			'text'  => null
-		], $props['status']());
 	}
 
 	/**

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -43,9 +43,9 @@ class SiteTest extends TestCase
 	public function testButtons()
 	{
 		$this->assertSame([
-			'preview',
-			'languages',
-		], $this->panel()->buttons());
+			'k-view-preview-button',
+			'k-view-languages-button',
+		], array_column($this->panel()->buttons(), 'component'));
 	}
 
 	/**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -69,10 +69,10 @@ class UserTest extends TestCase
 	public function testButtons()
 	{
 		$this->assertSame([
-			'theme',
-			'settings',
-			'languages',
-		], $this->panel()->buttons());
+			'k-view-theme-button',
+			'k-view-settings-button',
+			'k-view-languages-button',
+		], array_column($this->panel()->buttons(), 'component'));
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge https://github.com/getkirby/kirby/pull/6539
- [x] Merge https://github.com/getkirby/kirby/pull/6540
- [x] Merge https://github.com/getkirby/kirby/pull/6541
- [x] Merge https://github.com/getkirby/kirby/pull/6542
- [x] Merge https://github.com/getkirby/kirby/pull/6543
- [x] Merge https://github.com/getkirby/kirby/pull/6545

### Summary of changes
- Connect new backend classes with frontend
- Integrate in `Panel\Model` classes
- Exclude area buttons configs from code coverage

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Features
- Define custom view buttons in your blueprints or config
- Custom Panel are buttons extension


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->


As with the previous PR, view buttons can be defined by names in a model blueprint or for all views in the config. 

### Define custom button in config

However, one can now even define whole buttons by setting an array instead of a name string. The array consist of a `component` key (optional, if omitted `k-view-button` will be used) and a `props` array.

Via config:
```php
'panel' => [
	'viewButtons' => [
		'site' => [
			'preview',
			'a' => [
				'props' => [
					'icon'   => 'heart',
					'text'   => 'Kosmos',
					'theme'  => 'purple-icon',
					'target' => '_blank',
					'link'   => 'https://getkirby.com'
				]
			],
			'b-dropdown' => [
				'props' => [
					'icon'     => 'info',
					'text'     => 'Info',
					'dropdown' => 'my/dropdown/route'
				]
			],
			'c-component' => [
				'component' => 'my-custom-component',
				'props' => [
					'foo' => 'bar'
				]
			]
		]
	]
]
```

#### Shorthand for only props

If you don't pass a component-props definition, you can also just pass the props on their own, being then applied to `k-view-button`:

```php
'panel' => [
	'viewButtons' => [
		'site' => [
			'a' => [
				'icon'   => 'heart',
				'text'   => 'Kosmos',
				'theme'  => 'purple-icon',
				'target' => '_blank',
				'link'   => 'https://getkirby.com'
			]
		]
	]
]
```

### Define custom button in a blueprint

This also works in blueprints:

```yml
buttons:
  - preview
  - settings
  foo:
      text: Foo
```

### Reusable buttons: Panel area buttons extension

If you do not want to define just one button via the config, but reuse it (or even ship it as part of your plugin), you have to add them to the Panel area extension:

```php
Kirby::plugin('custom/buttons', [
	'areas' => [
		'todos' => function () {
			return [
				'buttons' => [
					'todos.add' => function () {
						return [
							'props' => [
								'icon'   => 'add',
								'dialog' => 'todos/create'
							]
						];
					}
				]
			];
		}
	]
]);
```

You have the same options for your return value: full component-props array or just props on top-level. In addition, you can also return directly a `Kirby\Panel\Ui\Button\ViewButton` object. 

See `Kirby\Panel\Ui\Button\ViewButton` properties for available `props` options (also for array notation).


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - https://github.com/getkirby/sandbox/pull/8
- [ ] Add changes & docs to release notes draft in Notion
