### PR TITLE
`Permissions::for()`: new `$default` argument

### DIFF
--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -43,6 +43,12 @@ abstract class ModelPermissions
 		return $this->toArray();
 	}
 
+	/**
+	 * Returns whether the current user is allowed to do
+	 * a certain action on the model
+	 *
+	 * @param bool $default Will be returned if $action does not exist
+	 */
 	public function can(
 		string $action,
 		bool $default = false
@@ -100,11 +106,17 @@ abstract class ModelPermissions
 		return $this->permissions->for($this->category, $action, $default);
 	}
 
+	/**
+	 * Returns whether the current user is not allowed to do
+	 * a certain action on the model
+	 *
+	 * @param bool $default Will be returned if $action does not exist
+	 */
 	public function cannot(
 		string $action,
-		bool $default = false
+		bool $default = true
 	): bool {
-		return $this->can($action, $default) === false;
+		return $this->can($action, !$default) === false;
 	}
 
 	public function toArray(): array

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -43,8 +43,10 @@ abstract class ModelPermissions
 		return $this->toArray();
 	}
 
-	public function can(string $action): bool
-	{
+	public function can(
+		string $action,
+		bool $default = false
+	): bool {
 		$user = $this->user->id();
 		$role = $this->user->role()->id();
 
@@ -95,12 +97,14 @@ abstract class ModelPermissions
 			}
 		}
 
-		return $this->permissions->for($this->category, $action);
+		return $this->permissions->for($this->category, $action, $default);
 	}
 
-	public function cannot(string $action): bool
-	{
-		return $this->can($action) === false;
+	public function cannot(
+		string $action,
+		bool $default = false
+	): bool {
+		return $this->can($action, $default) === false;
 	}
 
 	public function toArray(): array

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -109,18 +109,21 @@ class Permissions
 		}
 	}
 
-	public function for(string $category = null, string $action = null): bool
-	{
+	public function for(
+		string|null $category = null,
+		string|null $action = null,
+		bool $default = false
+	): bool {
 		if ($action === null) {
 			if ($this->hasCategory($category) === false) {
-				return false;
+				return $default;
 			}
 
 			return $this->actions[$category];
 		}
 
 		if ($this->hasAction($category, $action) === false) {
-			return false;
+			return $default;
 		}
 
 		return $this->actions[$category][$action];

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -393,6 +393,22 @@ class PagePermissionsTest extends TestCase
 	/**
 	 * @covers ::canSort
 	 */
+	public function testCanNotFoundDefault()
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page([
+			'slug' => 'test',
+			'num'  => 1
+		]);
+
+		$this->assertFalse($page->permissions()->can('foo'));
+		$this->assertTrue($page->permissions()->can('foo', true));
+	}
+
+	/**
+	 * @covers ::canSort
+	 */
 	public function testCannotSortUnlistedPages()
 	{
 		$this->app->impersonate('kirby');
@@ -464,5 +480,21 @@ class PagePermissionsTest extends TestCase
 		]);
 
 		$this->assertFalse($page->permissions()->can('sort'));
+	}
+
+	/**
+	 * @covers ::canSort
+	 */
+	public function testCannotNotFoundDefault()
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page([
+			'slug' => 'test',
+			'num'  => 1
+		]);
+
+		$this->assertTrue($page->permissions()->cannot('foo'));
+		$this->assertFalse($page->permissions()->cannot('foo', true));
 	}
 }

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -391,7 +391,7 @@ class PagePermissionsTest extends TestCase
 	}
 
 	/**
-	 * @covers ::canSort
+	 * @covers ::can
 	 */
 	public function testCanNotFoundDefault()
 	{
@@ -483,7 +483,7 @@ class PagePermissionsTest extends TestCase
 	}
 
 	/**
-	 * @covers ::canSort
+	 * @covers ::cannot
 	 */
 	public function testCannotNotFoundDefault()
 	{
@@ -495,6 +495,6 @@ class PagePermissionsTest extends TestCase
 		]);
 
 		$this->assertTrue($page->permissions()->cannot('foo'));
-		$this->assertFalse($page->permissions()->cannot('foo', true));
+		$this->assertFalse($page->permissions()->cannot('foo', false));
 	}
 }

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -4,6 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\Permissions
+ */
 class PermissionsTest extends TestCase
 {
 	public function tearDown(): void
@@ -131,5 +134,31 @@ class PermissionsTest extends TestCase
 		];
 
 		new Permissions();
+	}
+
+	/**
+	 * @covers ::for
+	 */
+	public function testForDefault()
+	{
+		// exists
+		$p = new Permissions();
+		$this->assertTrue($p->for('access', 'site'));
+
+		// category does not exist
+		$p = new Permissions();
+		$this->assertFalse($p->for('foo'));
+
+		// category does not exist with custom default
+		$p = new Permissions();
+		$this->assertTrue($p->for('foo', default:true));
+
+		// action does not exist
+		$p = new Permissions();
+		$this->assertFalse($p->for('access', 'foo'));
+
+		// action does not exist with custom default
+		$p = new Permissions();
+		$this->assertTrue($p->for('access', 'foo', default:true));
 	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Permissions::for()` has a new `$default` parameter specifying what is returned when the permission category or action is not found
- Implemented `$default` also for `ModelPermissions::can()` and `::cannot()`


### Reasoning
Currently, if one wants to check for a permission but by default wants to grant it, there is no easy way. Instead one has to go through `->toArray()` which isn't ideal. Allowing to also use `->for()` improves this.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- `$permissions->for()`, `$modelpermissions->can()` and `$modelpermissions->cannot()` accept a new `$default` parameter


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
