### PR TITLE
Use `magick ` as default for ImageMagick driver

### DIFF
--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -75,7 +75,7 @@ class ImageMagick extends Darkroom
 	protected function defaults(): array
 	{
 		return parent::defaults() + [
-			'bin'       => 'convert',
+			'bin'       => 'magick',
 			'interlace' => false,
 			'threads'   => 1,
 		];
@@ -150,7 +150,7 @@ class ImageMagick extends Darkroom
 
 		// log broken commands
 		if ($return !== 0) {
-			throw new Exception('The imagemagick convert command could not be executed: ' . $command);
+			throw new Exception('The imagemagick magick command could not be executed: ' . $command);
 		}
 
 		return $options;

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -43,7 +43,7 @@ class ImageMagickTest extends TestCase
 			'scaleWidth' => 1.0,
 			'sharpen' => null,
 			'width' => 500,
-			'bin' => 'convert',
+			'bin' => 'magick',
 			'interlace' => false,
 			'threads' => 1,
 			'sourceWidth' => 500,
@@ -104,7 +104,7 @@ class ImageMagickTest extends TestCase
 	public function testKeepColorProfileStripMeta(string $basename, bool $crop)
 	{
 		$im = new ImageMagick([
-			'bin' => 'convert',
+			'bin' => 'magick',
 			'crop' => $crop,
 			'width' => 250, // do some arbitrary transformation
 		]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Switch out deprecated `convert` with `magick` in ImageMagick driver


### Reasoning
Deprecation and checking if `magick` also works for older IM versions.

EDIT: Doesn't work with older IM versions.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- https://github.com/getkirby/kirby/issues/6534



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

Replace `convert` with `magick` in IM docs

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
