### PR TITLE
Link field preview: fix overflow

### DIFF
--- a/panel/lab/components/fieldpreviews/link/index.vue
+++ b/panel/lab/components/fieldpreviews/link/index.vue
@@ -55,5 +55,15 @@
 				<!-- @code-end -->
 			</k-lab-table-cell>
 		</k-lab-example>
+
+		<k-lab-example label="URL with overflow">
+			<k-lab-table-cell>
+				<!-- @code -->
+				<k-link-field-preview
+					value="https://getkirby.com/this-is-a-super-long-link-lahsdjkahskdjahskjdhaksjdhkajshdkashdjashdkahjsdkjahsdkjashdkjahskdjhaksjhdkashjdkahjsdajshkdhjahjkd"
+				/>
+				<!-- @code-end -->
+			</k-lab-table-cell>
+		</k-lab-example>
 	</k-lab-examples>
 </template>

--- a/panel/src/components/Forms/Previews/LinkFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/LinkFieldPreview.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="k-link-field-preview">
+	<div :class="{ 'k-link-field-preview': true, 'k-url-field-preview': isLink }">
 		<template v-if="currentType === 'page' || currentType === 'file'">
 			<template v-if="model">
 				<k-tag
@@ -16,7 +16,9 @@
 		</template>
 		<template v-else-if="isLink">
 			<p class="k-text">
-				<a :href="value" target="_blank">{{ detected.link }}</a>
+				<a :href="value" target="_blank">
+					<span>{{ detected.link }}</span>
+				</a>
 			</p>
 		</template>
 		<template v-else>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Applying `k-url-field-preview` to `k-link-preview` as well, whenever value is a link.
- Now overflow is hidden with ellipsis in both previews consistently.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Link field preview: fixed overflow instead of wrapping for long links #6510

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
