### PR TITLE
`App::io()`: redirect `NotFoundException` to error

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -782,7 +782,7 @@ class App
 		if ($input instanceof Page) {
 			try {
 				$html = $input->render();
-			} catch (ErrorPageException $e) {
+			} catch (ErrorPageException|NotFoundException $e) {
 				return $this->io($e);
 			}
 


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `Kirby\Exception\NotFoundException` thrown during page rendering now redirects request to the error page (with 404); as `Kirby\Exception\ErrorPageException` already does 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] ~~In-code documentation (wherever needed)~~
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
