### PR TITLE
`A::random()`: exception if $count exceeds array

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -738,12 +738,18 @@ class A
 	/**
 	 * Returns a number of random elements from an array,
 	 * either in original or shuffled order
+	 *
+	 * @throws \Exception When $count is larger than array length
 	 */
 	public static function random(
 		array $array,
 		int $count = 1,
 		bool $shuffle = false
 	): array {
+		if ($count > count($array)) {
+			throw new Exception('$count is larger than available array items');
+		}
+
 		if ($shuffle === true) {
 			return array_slice(self::shuffle($array), 0, $count);
 		}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -747,7 +747,7 @@ class A
 		bool $shuffle = false
 	): array {
 		if ($count > count($array)) {
-			throw new Exception('$count is larger than available array items');
+			throw new InvalidArgumentException('$count is larger than available array items');
 		}
 
 		if ($shuffle === true) {

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -698,6 +698,16 @@ class ATest extends TestCase
 	}
 
 	/**
+	 * @covers ::random
+	 */
+	public function testRandomInvalidCount()
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('$count is larger than available array items');
+		A::random([1, 2, 3], 4);
+	}
+
+	/**
 	 * @covers ::fill
 	 */
 	public function testFill()

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -702,7 +702,7 @@ class ATest extends TestCase
 	 */
 	public function testRandomInvalidCount()
 	{
-		$this->expectException(Exception::class);
+		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('$count is larger than available array items');
 		A::random([1, 2, 3], 4);
 	}


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `A::random()` throws exception instead of error when `$count` is higher than array length


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
