### PR TITLE
Fix `focus` helper for non-native inputs

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -10,6 +10,7 @@
 					icon="add"
 					variant="filled"
 					size="xs"
+					class="input-focus"
 					@click="$refs.blocks.choose(value.length)"
 				/>
 				<k-button

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -8,6 +8,7 @@
 					icon="add"
 					variant="filled"
 					size="xs"
+					class="input-focus"
 					@click="$refs.layouts.select(0)"
 				/>
 				<k-button

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -13,7 +13,7 @@
 				ref="toggle"
 				:autofocus="autofocus"
 				:disabled="disabled"
-				class="k-tags-input-toggle k-tags-navigatable"
+				class="k-tags-input-toggle k-tags-navigatable input-focus"
 				size="xs"
 				icon="add"
 				@click="$refs.create.open()"

--- a/panel/src/helpers/focus.js
+++ b/panel/src/helpers/focus.js
@@ -26,12 +26,11 @@ export default function focus(element, field) {
 	}
 
 	const selectors = [
-		"[autofocus]",
-		"[data-autofocus]",
-		"input",
-		"textarea",
-		"select",
-		"[contenteditable=true]",
+		// prioritize elements that have set autofocus explicitly
+		":where([autofocus], [data-autofocus])",
+		// treat all types of inputs equally as second-best
+		":where(input, textarea, select, [contenteditable=true], .input-focus)",
+		// prefer submit button over other buttons
 		"[type=submit]",
 		"button"
 	];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `focus` helper treats certain groups of CSS selectors now as equals
- set `input-focus` class on non-native inputs to receive equal focus importance as input, textarea etc.


### Reasoning
In dialogs etc., the focus helper should try helping select the first input. However, if it's a non-native input (e.g. tags input), the focus selects the second field instead. Treating the set `:where(input, textarea, select, [contenteditable=true], .input-focus)` as equals, the helper should be able to always focus on the first field.



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- #6347



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
