### PR TITLE
Fix overflowing topbar with very long breadcrumb

### DIFF
--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -102,6 +102,13 @@ export default {
 	min-width: 0;
 	transition: flex-shrink 0.1s;
 }
+.k-breadcrumb ol li:has(.k-icon) {
+	/*
+	 * without a useful min-width, the item will vanish completely on hover of a very long other item.
+	 * 2.25rem helps to keep at least the icon visible for items with icons.
+	 */
+	min-width: 2.25rem;
+}
 .k-breadcrumb ol li:not(:last-child)::after {
 	content: var(--breadcrumb-divider);
 	opacity: 0.175;

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -100,16 +100,14 @@ export default {
 	display: flex;
 	align-items: center;
 	min-width: 0;
+	transition: flex-shrink 0.1s;
 }
 .k-breadcrumb ol li:not(:last-child)::after {
 	content: var(--breadcrumb-divider);
 	opacity: 0.175;
 	flex-shrink: 0;
 }
-.k-breadcrumb ol li {
-	min-width: 0;
-	transition: flex-shrink 0.1s;
-}
+
 .k-breadcrumb .k-icon[data-type="loader"] {
 	opacity: 0.5;
 }

--- a/panel/src/components/View/Topbar.vue
+++ b/panel/src/components/View/Topbar.vue
@@ -52,6 +52,8 @@ export default {
 
 .k-topbar-breadcrumb {
 	margin-inline-start: -2px;
+	flex-shrink: 1;
+	min-width: 0;
 }
 
 .k-topbar-spacer {


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Panel topbar: fix overflow when breadcrumb gets very long
#6348


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
