### PR TITLE
Fix `new Uri()` for relative URLs with param colon

### DIFF
--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -602,13 +602,7 @@ class Environment
 	 */
 	protected function detectRequestUri(string|null $requestUri = null): Uri
 	{
-		// make sure the URL parser works properly when there's a
-		// colon in the request URI but the URI is relative
-		if (Url::isAbsolute($requestUri) === false) {
-			$requestUri = 'https://getkirby.com' . $requestUri;
-		}
-
-		$uri = new Uri($requestUri);
+		$uri = new Uri($requestUri ?? '');
 
 		// create the URI object as a combination of base uri parts
 		// and the parts from REQUEST_URI

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -88,7 +88,16 @@ class Uri
 	public function __construct(array|string $props = [], array $inject = [])
 	{
 		if (is_string($props) === true) {
-			$props = parse_url($props);
+			// make sure the URL parser works properly when there's a
+			// colon in the string but the string is a relative URL
+			if (Url::isAbsolute($props) === false) {
+				$props = 'https://getkirby.com/' . $props;
+				$props = parse_url($props);
+				unset($props['scheme'], $props['host']);
+			} else {
+				$props = parse_url($props);
+			}
+
 			$props['username'] = $props['user'] ?? null;
 			$props['password'] = $props['pass'] ?? null;
 

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -1407,7 +1407,7 @@ class EnvironmentTest extends TestCase
 			[
 				'index.php?foo=bar',
 				[
-					'path'  => '',
+					'path'  => 'index.php',
 					'query' => 'foo=bar'
 				]
 			],

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -325,6 +325,15 @@ class UriTest extends TestCase
 				'/search/page:2?q=something'
 			],
 
+			// relative path with colon + adding query
+			[
+				'/search/page:2',
+				[
+					'query' => ['q' => 'something']
+				],
+				'/search/page:2?q=something'
+			],
+
 			// path + adding params + query
 			[
 				'https://getkirby.com/search',


### PR DESCRIPTION
## Description

With this change an existing unit test for `Environment` fails. I think the test has been wrong:

`detectRequestUri()` receives `index.php?foo=bar` as input and expects

```php
'path'  => '',
'query' => 'foo=bar'
```

as result. However, before this PR `detectRequestUri` would concat the string with `https://getkirby.com` without trailing slash.

So it would actually examine `https://getkirby.comindex.php?foo=bar` for the test in question. Which seems wrong. When actually running it on `https://getkirby.com/index.php?foo=bar` as with this PR now, the result is `'path'  => 'index.php',`.

@lukasbestle @bastianallgeier Is this unexpected/a problem if we change this and adapt the test?


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed `new Http\Uri()` for relative URLs with a colon inside
#6331


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
