### PR TITLE
Writer field: fix content with non-breaking space

### DIFF
--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -63,7 +63,14 @@ return [
 	'computed' => [
 		'value' => function () {
 			$value = trim($this->value ?? '');
-			return Sane::sanitize($value, 'html');
+			$value = Sane::sanitize($value, 'html');
+
+			// convert non-breaking spaces to HTML entity
+			// as that's how ProseMirror handles it internally;
+			// will allow comparing saved and current content
+			$value = str_replace(' ', '&nbsp;', $value);
+
+			return $value;
 		}
 	],
 	'validations' => [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
Enforcing conversion of a non-breaking space to `&nbsp;` as this is what ProseMirror internally will do automatically. And if the backend delivers the actual non-breaking space character but ProseMirror converts it to `&nbsp:` we have an unreasonable state where the current input value can never be the original value (and thus always shows as changed).


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Writer field: content with non-breaking changes doesn't anymore show up as changed always
#6285


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
