### PR TITLE
`content.uuid.index` option: prevent index lookup

### DIFF
--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -12,6 +12,7 @@ use Kirby\Cms\Site;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
 
 /**
@@ -217,7 +218,13 @@ abstract class Uuid
 			return (static::$generator)($length);
 		}
 
-		if (App::instance()->option('content.uuid') === 'uuid-v4') {
+		$option = App::instance()->option('content.uuid');
+
+		if (is_array($option) === true) {
+			$option = $option['format'] ?? null;
+		}
+
+		if ($option === 'uuid-v4') {
 			return Str::uuid();
 		}
 
@@ -332,6 +339,10 @@ abstract class Uuid
 		}
 
 		if ($lazy === false) {
+			if (App::instance()->option('content.uuid.index') === false) {
+				throw new NotFoundException('Model for UUID ' . $this->uri->toString() . ' could not be found without searching in the site index');
+			}
+
 			if ($this->model = $this->findByIndex()) {
 				// lazily fill cache by writing to cache
 				// whenever looked up from index to speed

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Uuid;
 use Generator;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
 
 class TestUuid extends Uuid
@@ -257,6 +258,16 @@ class UuidTest extends TestCase
 		$id = Uuid::generate();
 		$this->assertSame(36, strlen($id));
 
+		$this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => ['format' => 'uuid-v4']
+				]
+			]
+		]);
+		$id = Uuid::generate();
+		$this->assertSame(36, strlen($id));
+
 		// UUID v4 mode with custom length (no effect)
 		$id = Uuid::generate(5);
 		$this->assertSame(36, strlen($id));
@@ -426,6 +437,17 @@ class UuidTest extends TestCase
 		$this->assertNull(Uuid::for('page://something')->model());
 		$this->assertNull(Uuid::for('user://something')->model());
 		$this->assertNull(Uuid::for('file://something')->model());
+	}
+
+	/**
+	 * @covers ::model
+	 */
+	public function testModelNotFoundIndexLookupDisabled()
+	{
+		$this->app->clone(['options' => ['content' => ['uuid' => ['index' => false]]]]);
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Model for UUID page://something could not be found without searching in the site index');
+		Uuid::for('page://something')->model();
 	}
 
 	/**


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement
- `content.uuid.index` option to prevent index lookup. Will throw an exception if a UUID model cannot be looked up from the cache alone. This requires you to keep a full UUID cache at all times but can be helpful for very large sites where any index lookup would run into memory limits.
  - Use `content.uuid.format`  to specify `uuid-v4` as format.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
