### PR TITLE
Replace bubbles components with tags

### DIFF
--- a/panel/lab/components/fieldpreviews/tags/index.php
+++ b/panel/lab/components/fieldpreviews/tags/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-tags-field-preview',
+];

--- a/panel/lab/components/fieldpreviews/tags/index.vue
+++ b/panel/lab/components/fieldpreviews/tags/index.vue
@@ -1,0 +1,45 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Default">
+			<k-lab-table-cell>
+				<!-- @code -->
+				<k-tags-field-preview
+					:value="[
+						{
+							text: 'A'
+						},
+						{
+							text: 'B'
+						}
+					]"
+				/>
+				<!-- @code-end -->
+			</k-lab-table-cell>
+		</k-lab-example>
+
+		<k-lab-example label="Overlow">
+			<k-lab-table-cell>
+				<!-- @code -->
+				<k-tags-field-preview
+					:value="[
+						{
+							text: 'Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+						},
+						{
+							text: 'Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+						}
+					]"
+				/>
+				<!-- @code-end -->
+			</k-lab-table-cell>
+		</k-lab-example>
+
+		<k-lab-example label="Empty">
+			<k-lab-table-cell>
+				<!-- @code -->
+				<k-tags-field-preview />
+				<!-- @code-end -->
+			</k-lab-table-cell>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/lab/components/tags/1_tag/index.vue
+++ b/panel/lab/components/tags/1_tag/index.vue
@@ -1,45 +1,89 @@
 <template>
 	<k-lab-examples>
+		<k-toggles-input
+			:labels="true"
+			:options="[
+				{ value: 'dark', text: 'Dark', icon: 'moon' },
+				{ value: 'light', text: 'Light', icon: 'sun' }
+			]"
+			:value="theme"
+			@input="theme = $event"
+		/>
+
 		<k-lab-example label="Slot">
-			<k-tag>Foo</k-tag>
+			<k-tag :theme="theme">Foo</k-tag>
 		</k-lab-example>
 		<k-lab-example label="Text">
-			<k-tag text="Foo" />
+			<k-tag :theme="theme" text="Foo" />
 		</k-lab-example>
 		<k-lab-example label="HTML">
-			<k-tag :html="true" text="Tag with <i>HTML</i>" />
+			<k-tag :html="true" :theme="theme" text="Tag with <i>HTML</i>" />
 		</k-lab-example>
 		<k-lab-example label="Removable">
-			<k-tag :removable="true" text="Foo" />
+			<k-tag :removable="true" :theme="theme" text="Foo" />
 		</k-lab-example>
 		<k-lab-example label="Disabled">
-			<k-tag :disabled="true" :removable="true" text="Foo" />
+			<k-tag :disabled="true" :removable="true" :theme="theme" text="Foo" />
 		</k-lab-example>
 		<k-lab-example :flex="true" label="Icon">
-			<k-tag :image="{ icon: 'heart' }" />
-			<k-tag :image="{ icon: 'heart' }" text="Foo" />
-			<k-tag :image="{ icon: 'heart' }" :removable="true" text="Foo" />
+			<k-tag :image="{ icon: 'heart' }" :theme="theme" />
+			<k-tag :image="{ icon: 'heart' }" :theme="theme" text="Foo" />
+			<k-tag
+				:image="{ icon: 'heart' }"
+				:removable="true"
+				:theme="theme"
+				text="Foo"
+			/>
 			<k-tag
 				:disabled="true"
 				:image="{ icon: 'heart' }"
 				:removable="true"
+				:theme="theme"
 				text="Foo"
 			/>
 		</k-lab-example>
 		<k-lab-example :flex="true" label="Image">
-			<k-tag :image="{ src: 'https://picsum.photos/100/100/', crop: true }" />
-			<k-tag :image="{ src: 'https://picsum.photos/100/100/', crop: true }" text="Foo" />
+			<k-tag
+				:image="{ src: 'https://picsum.photos/100/100/', crop: true }"
+				:theme="theme"
+			/>
+			<k-tag
+				:image="{ src: 'https://picsum.photos/100/100/', crop: true }"
+				:theme="theme"
+				text="Foo"
+			/>
 			<k-tag
 				:image="{ src: 'https://picsum.photos/100/100/', crop: true }"
 				:removable="true"
+				:theme="theme"
 				text="Foo"
-			>
+			/>
 			<k-tag
 				:disabled="true"
 				:image="{ src: 'https://picsum.photos/100/100/', crop: true }"
 				:removable="true"
+				:theme="theme"
 				text="Foo"
 			/>
 		</k-lab-example>
 	</k-lab-examples>
 </template>
+
+<script>
+export default {
+	data() {
+		return {
+			theme: "dark"
+		};
+	}
+};
+</script>
+
+<style>
+.k-lab-examples .k-toggles-input {
+	margin-bottom: var(--spacing-12);
+}
+.k-lab-example-canvas {
+	background: white;
+}
+</style>

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -334,12 +334,9 @@ export default {
 	overflow: auto;
 }
 .k-link-field .k-bubbles-field-preview {
-	--bubble-rounded: var(--rounded-sm);
-	--bubble-size: var(--height-sm);
+	--tag-rounded: var(--rounded-sm);
+	--tag-size: var(--height-sm);
 	padding-inline: 0;
-}
-.k-link-field .k-bubbles-field-preview .k-bubble {
-	font-size: var(--text-sm);
 }
 
 .k-link-field[data-disabled="true"] .k-link-input-model-placeholder {

--- a/panel/src/components/Forms/Input/TagsInput.vue
+++ b/panel/src/components/Forms/Input/TagsInput.vue
@@ -7,6 +7,7 @@
 			<k-tags
 				ref="tags"
 				v-bind="$props"
+				:removable="true"
 				@edit="edit"
 				@input="$emit('input', $event)"
 				@click.native.stop="$refs.toggle?.$el?.click()"

--- a/panel/src/components/Forms/Previews/ArrayFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ArrayFieldPreview.vue
@@ -1,12 +1,12 @@
 <script>
-import BubblesFieldPreview from "./BubblesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 
 export default {
-	extends: BubblesFieldPreview,
+	extends: TagsFieldPreview,
 	inheritAttrs: false,
 	class: "k-array-field-preview",
 	computed: {
-		bubbles() {
+		tags() {
 			return [
 				{
 					text:

--- a/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/BubblesFieldPreview.vue
@@ -11,6 +11,9 @@
 import FieldPreview from "@/mixins/forms/fieldPreview.js";
 import { props as BubblesProps } from "@/components/Layout/Bubbles.vue";
 
+/**
+ * @deprecated 5.0.0 Use `<k-tags-field-preview>` instead
+ */
 export default {
 	mixins: [FieldPreview, BubblesProps],
 	props: {
@@ -47,6 +50,11 @@ export default {
 				return bubble;
 			});
 		}
+	},
+	mounted() {
+		window.panel.deprecated(
+			"<k-bubbles-field-preview> will be removed in a future version. Use <k-tags-field-preview> instead."
+		);
 	}
 };
 </script>

--- a/panel/src/components/Forms/Previews/FilesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/FilesFieldPreview.vue
@@ -1,8 +1,8 @@
 <script>
-import BubblesFieldPreview from "./BubblesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 
 export default {
-	extends: BubblesFieldPreview,
+	extends: TagsFieldPreview,
 	class: "k-files-field-preview",
 	props: {
 		html: {
@@ -11,7 +11,7 @@ export default {
 		}
 	},
 	computed: {
-		bubbles() {
+		tags() {
 			return this.value.map((file) => ({
 				text: file.filename,
 				link: file.link,

--- a/panel/src/components/Forms/Previews/ObjectFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ObjectFieldPreview.vue
@@ -1,14 +1,14 @@
 <script>
-import BubblesFieldPreview from "./BubblesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 
 export default {
-	extends: BubblesFieldPreview,
+	extends: TagsFieldPreview,
 	class: "k-object-field-preview",
 	props: {
 		value: [Array, Object]
 	},
 	computed: {
-		bubbles() {
+		tags() {
 			if (!this.value) {
 				return [];
 			}

--- a/panel/src/components/Forms/Previews/PagesFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/PagesFieldPreview.vue
@@ -1,8 +1,8 @@
 <script>
-import BubblesFieldPreview from "./BubblesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 
 export default {
-	extends: BubblesFieldPreview,
+	extends: TagsFieldPreview,
 	inheritAttrs: false,
 	class: "k-pages-field-preview",
 	props: {

--- a/panel/src/components/Forms/Previews/TagsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TagsFieldPreview.vue
@@ -4,6 +4,7 @@
 		:style="$attrs.style"
 	>
 		<k-tags
+			:draggable="false"
 			:html="html"
 			:value="tags"
 			element="ul"

--- a/panel/src/components/Forms/Previews/TagsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TagsFieldPreview.vue
@@ -1,0 +1,68 @@
+<template>
+	<div
+		:class="['k-tags-field-preview', $options.class, $attrs.class]"
+		:style="$attrs.style"
+	>
+		<k-tags
+			:html="html"
+			:value="tags"
+			element="ul"
+			element-tag="li"
+			theme="light"
+		/>
+	</div>
+</template>
+
+<script>
+import FieldPreview from "@/mixins/forms/fieldPreview.js";
+import { props as TagsProps } from "@/components/Navigation/Tags.vue";
+
+export default {
+	mixins: [FieldPreview, TagsProps],
+	props: {
+		value: {
+			default: () => [],
+			type: [Array, String]
+		}
+	},
+	computed: {
+		tags() {
+			let tags = this.value;
+
+			// predefined options
+			const options = this.column.options ?? this.field.options ?? [];
+
+			if (typeof tags === "string") {
+				tags = tags.split(",");
+			}
+
+			return (tags ?? []).map((tag) => {
+				if (typeof tag === "string") {
+					tag = { value: tag, text: tag };
+				}
+
+				for (const option of options) {
+					if (option.value === tag.value) {
+						tag.text = option.text;
+					}
+				}
+
+				return tag;
+			});
+		}
+	}
+};
+</script>
+
+<style>
+.k-tags-field-preview {
+	--tags-gap: 0.25rem;
+	--tag-text-size: var(--text-xs);
+
+	padding: 0.375rem var(--table-cell-padding);
+	overflow: hidden;
+}
+.k-tags-field-preview .k-tags {
+	flex-wrap: nowrap;
+}
+</style>

--- a/panel/src/components/Forms/Previews/UsersFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/UsersFieldPreview.vue
@@ -1,8 +1,8 @@
 <script>
-import BubblesFieldPreview from "./BubblesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 
 export default {
-	extends: BubblesFieldPreview,
+	extends: TagsFieldPreview,
 	class: "k-users-field-preview",
 	computed: {
 		bubble() {

--- a/panel/src/components/Forms/Previews/index.js
+++ b/panel/src/components/Forms/Previews/index.js
@@ -46,7 +46,6 @@ export default {
 		app.component("k-multiselect-field-preview", BubblesFieldPreview);
 		app.component("k-radio-field-preview", BubblesFieldPreview);
 		app.component("k-select-field-preview", BubblesFieldPreview);
-		app.component("k-tags-field-preview", BubblesFieldPreview);
 		app.component("k-toggles-field-preview", BubblesFieldPreview);
 	}
 };

--- a/panel/src/components/Forms/Previews/index.js
+++ b/panel/src/components/Forms/Previews/index.js
@@ -10,6 +10,7 @@ import ImageFieldPreview from "./ImageFieldPreview.vue";
 import LinkFieldPreview from "./LinkFieldPreview.vue";
 import ObjectFieldPreview from "./ObjectFieldPreview.vue";
 import PagesFieldPreview from "./PagesFieldPreview.vue";
+import TagsFieldPreview from "./TagsFieldPreview.vue";
 import TextFieldPreview from "./TextFieldPreview.vue";
 import TimeFieldPreview from "./TimeFieldPreview.vue";
 import ToggleFieldPreview from "./ToggleFieldPreview.vue";
@@ -30,6 +31,7 @@ export default {
 		app.component("k-link-field-preview", LinkFieldPreview);
 		app.component("k-object-field-preview", ObjectFieldPreview);
 		app.component("k-pages-field-preview", PagesFieldPreview);
+		app.component("k-tags-field-preview", TagsFieldPreview);
 		app.component("k-text-field-preview", TextFieldPreview);
 		app.component("k-toggle-field-preview", ToggleFieldPreview);
 		app.component("k-time-field-preview", TimeFieldPreview);

--- a/panel/src/components/Layout/Bubble.vue
+++ b/panel/src/components/Layout/Bubble.vue
@@ -30,6 +30,7 @@
  * Bubble to display content in an inline context,
  * e.g. the structure preview table
  * @since 3.7.0
+ * @deprecated 5.0.0 Use `<k-tags>` instead
  *
  * @example <k-bubble text="Hello" />
  */
@@ -76,16 +77,9 @@ export default {
 		text: String
 	},
 	mounted() {
-		if (this.back) {
-			window.panel.deprecated(
-				"<k-bubble>: `back` prop will be removed in a future version. Use the `--bubble-back` CSS property instead."
-			);
-		}
-		if (this.color) {
-			window.panel.deprecated(
-				"<k-bubble>: `color` prop will be removed in a future version. Use the `--bubble-text` CSS property instead."
-			);
-		}
+		window.panel.deprecated(
+			"<k-bubble> will be removed in a future version. Use <k-tag> instead."
+		);
 	}
 };
 </script>

--- a/panel/src/components/Layout/Bubbles.vue
+++ b/panel/src/components/Layout/Bubbles.vue
@@ -22,6 +22,7 @@ export const props = {
 /**
  * Display a list of `<k-bubble>`
  * @since 3.7.0
+ * @deprecated 5.0.0 Use `<k-tags>` instead
  *
  * @example <k-bubbles :bubbles="['Hello', 'World']" />
  */
@@ -46,6 +47,11 @@ export default {
 				bubble === "string" ? { text: bubble } : bubble
 			);
 		}
+	},
+	mounted() {
+		window.panel.deprecated(
+			"<k-bubbles> will be removed in a future version. Use <k-tags> instead."
+		);
 	}
 };
 </script>

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -129,8 +129,8 @@ export default {
 .k-tag[data-theme="light"] {
 	--tag-color-back: var(--color-light);
 	--tag-color-text: var(--color-black);
-	--tag-color-disabled-back: var(--color-gray-400);
-	--tag-color-disabled-text: var(--tag-color-text);
+	--tag-color-disabled-back: var(--color-gray-200);
+	--tag-color-disabled-text: var(--color-gray-600);
 }
 
 .k-tag {
@@ -146,7 +146,7 @@ export default {
 	border-radius: var(--tag-rounded);
 	user-select: none;
 }
-button.k-tag {
+button.k-tag:not([aria-disabled="true"]) {
 	cursor: pointer;
 }
 .k-tag:not([aria-disabled="true"]):focus {

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -1,9 +1,10 @@
 <template>
-	<button
-		ref="button"
+	<component
+		:is="element"
 		:aria-disabled="disabled"
 		:data-has-image="Boolean(image)"
 		:data-has-toggle="isRemovable"
+		:data-theme="theme"
 		class="k-tag"
 		type="button"
 		@keydown.delete.prevent="remove"
@@ -32,16 +33,11 @@
 			icon="cancel-small"
 			@click.native.stop="remove"
 		/>
-	</button>
+	</component>
 </template>
 
 <script>
-/**
- * A simple tag button with optional image/icon and remove button
- *
- * @example <k-tag>Design</k-tag>
- */
-export default {
+export const props = {
 	props: {
 		/**
 		 * Dims the tag and hides the remove button
@@ -55,15 +51,41 @@ export default {
 			type: Boolean
 		},
 		/**
+		 * Enables the remove button
+		 */
+		removable: Boolean,
+		/**
+		 * @values "dark"|"light"
+		 * @since 5.0.0
+		 */
+		theme: {
+			type: String,
+			default: "dark"
+		}
+	}
+};
+
+/**
+ * A simple tag button with optional image/icon and remove button
+ *
+ * @example <k-tag>Design</k-tag>
+ */
+export default {
+	mixins: [props],
+	props: {
+		/**
+		 * HTML element to use
+		 */
+		element: {
+			type: String,
+			default: "button"
+		},
+		/**
 		 * See `k-image-frame` or `k-icon-frame` for available options
 		 */
 		image: {
 			type: Object
 		},
-		/**
-		 * Enables the remove button
-		 */
-		removable: Boolean,
 		/**
 		 * Text to display in the bubble
 		 */
@@ -86,7 +108,7 @@ export default {
 			}
 		},
 		focus() {
-			this.$refs.button.focus();
+			this.$el.focus();
 		}
 	}
 };
@@ -101,6 +123,14 @@ export default {
 	--tag-color-disabled-text: var(--tag-color-text);
 	--tag-height: var(--height-xs);
 	--tag-rounded: var(--rounded-sm);
+	--tag-text-size: var(--text-sm);
+}
+
+.k-tag[data-theme="light"] {
+	--tag-color-back: var(--color-light);
+	--tag-color-text: var(--color-black);
+	--tag-color-disabled-back: var(--color-gray-400);
+	--tag-color-disabled-text: var(--tag-color-text);
 }
 
 .k-tag {
@@ -109,13 +139,15 @@ export default {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	font-size: var(--text-sm);
+	font-size: var(--tag-text-size);
 	line-height: 1;
 	color: var(--tag-color-text);
 	background-color: var(--tag-color-back);
 	border-radius: var(--tag-rounded);
-	cursor: pointer;
 	user-select: none;
+}
+button.k-tag {
+	cursor: pointer;
 }
 .k-tag:not([aria-disabled="true"]):focus {
 	outline: var(--outline);

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -7,6 +7,7 @@
 		<k-draggable
 			:class="['k-tags', $attrs.class]"
 			:data-layout="layout"
+			:element="element"
 			:list="tags"
 			:options="dragOptions"
 			:style="$attrs.style"
@@ -16,8 +17,11 @@
 				v-for="(item, itemIndex) in tags"
 				:key="item.id ?? item.value ?? item.text"
 				:disabled="disabled"
+				:element="elementTag"
+				:html="html"
 				:image="item.image"
-				:removable="!disabled"
+				:removable="removable && !disabled"
+				:theme="theme"
 				name="tag"
 				@click.native.stop
 				@keypress.native.enter="edit(itemIndex, item, $event)"
@@ -36,12 +40,24 @@
 </template>
 
 <script>
-import { disabled, id, options } from "@/mixins/props.js";
+import { id, options } from "@/mixins/props.js";
+import { props as TagProps } from "@/components/Navigation/Tag.vue";
 
 export const props = {
-	mixins: [disabled, id, options],
+	mixins: [TagProps, id, options],
 	inheritAttrs: false,
 	props: {
+		/**
+		 * HTML element to use for the tags list
+		 */
+		element: {
+			type: String,
+			default: "div"
+		},
+		/**
+		 * HTML element to use for each tag
+		 */
+		elementTag: String,
 		/**
 		 * You can set the layout to `"list"` to extend the width of each tag
 		 * to 100% and show them in a list. This is handy in narrow columns


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Reasoning
Time to fade out those bubble components. We don't need two type of components that basically do the same.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- `<k-tag>`: new `element` and `theme` props
- `<k-tags>`: new `element`, `element-tag` and `theme` props
- New `<k-tags-field-preview>` component



### Deprecated
- `<k-bubble>`, `<k-bubbles>` and `<k-bubbles-field-preview>`. Use `<k-tag>`, `<k-tags>` and `<k-tag-field-preview>` instead.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
