### PR TITLE
Changes 18: New ImmutableMemoryContentStorageHandler class

### DIFF
--- a/src/Content/ImmutableMemoryContentStorageHandler.php
+++ b/src/Content/ImmutableMemoryContentStorageHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+use Kirby\Exception\LogicException;
+
+/**
+ * @package   Kirby Content
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class ImmutableMemoryContentStorageHandler extends MemoryContentStorageHandler
+{
+	public function delete(VersionId $versionId, Language $language): void
+	{
+		$this->preventMutation();
+	}
+
+	public function move(
+		VersionId $fromVersionId,
+		Language $fromLanguage,
+		VersionId $toVersionId,
+		Language $toLanguage
+	): void {
+		$this->preventMutation();
+	}
+
+	/**
+	 * Throws an exception to avoid the mutation of storage data
+	 *
+	 * @throws \Kirby\Exception\LogicException
+	 */
+	protected function preventMutation(): void
+	{
+		throw new LogicException('Storage for the ' . $this->model::CLASS_ALIAS . ' is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+	}
+
+	public function touch(VersionId $versionId, Language $language): void
+	{
+		$this->preventMutation();
+	}
+
+	public function update(VersionId $versionId, Language $language, array $fields): void
+	{
+		$this->preventMutation();
+	}
+}

--- a/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
+++ b/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+use Kirby\Exception\LogicException;
+
+/**
+ * @coversDefaultClass Kirby\Content\ImmutableMemoryContentStorageHandler
+ * @covers ::__construct
+ */
+class ImmutableMemoryContentStorageHandlerTest extends TestCase
+{
+	protected $storage;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		parent::setUpSingleLanguage();
+
+		$this->storage = new ImmutableMemoryContentStorageHandler($this->model);
+	}
+
+	/**
+	 * @covers ::delete
+	 * @covers ::preventMutation
+	 */
+	public function testDelete()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+
+		$this->storage->delete(VersionId::published(), Language::ensure());
+	}
+
+	/**
+	 * @covers ::move
+	 * @covers ::preventMutation
+	 */
+	public function testMove()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+
+		$this->storage->move(
+			fromVersionId: VersionId::published(),
+			fromLanguage: Language::ensure(),
+			toVersionId: VersionId::changes(),
+			toLanguage: Language::ensure()
+		);
+	}
+
+	/**
+	 * @covers ::touch
+	 * @covers ::preventMutation
+	 */
+	public function testTouch()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+
+		$this->storage->touch(VersionId::published(), Language::ensure());
+	}
+
+	/**
+	 * @covers ::update
+	 * @covers ::preventMutation
+	 */
+	public function testUpdate()
+	{
+		$this->storage->create(VersionId::published(), Language::ensure(), []);
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+
+		$this->storage->update(VersionId::published(), Language::ensure(), []);
+	}
+}

--- a/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
+++ b/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
@@ -6,7 +6,7 @@ use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
 
 /**
- * @coversDefaultClass Kirby\Content\ImmutableMemoryContentStorageHandler
+ * @coversDefaultClass \Kirby\Content\ImmutableMemoryContentStorageHandler
  * @covers ::__construct
  */
 class ImmutableMemoryContentStorageHandlerTest extends TestCase


### PR DESCRIPTION
### Summary of changes

- New `ImmutableMemoryContentStorageHandler` class to be used later for detached/outdated model versions that must no longer be mutated. 

### Additional context

The class is not yet used and will later become relevant in `ModelWithContent::clone` or a new `ModelWithContent::detach` method.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `ImmutableMemoryContentStorageHandler` to keep outdated model information in memory but avoid any mutations. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
