### PR TITLE
Models fields: default empty string for single

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -331,6 +331,7 @@
 	"field.blocks.video.url.placeholder": "https://youtube.com/?v=",
 
 	"field.files.empty": "No files selected yet",
+	"field.files.empty.single": "No file selected yet",
 
 	"field.layout.change": "Change layout",
 	"field.layout.delete": "Delete layout",
@@ -342,6 +343,7 @@
 	"field.object.empty": "No information yet",
 
 	"field.pages.empty": "No pages selected yet",
+	"field.pages.empty.single": "No page selected yet",
 
 	"field.structure.delete.confirm": "Do you really want to delete this row?",
 	"field.structure.delete.confirm.all": "Do you really want to delete all entries?",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -350,6 +350,7 @@
 	"field.structure.empty": "No entries yet",
 
 	"field.users.empty": "No users selected yet",
+	"field.users.empty.single": "No user selected yet",
 
 	"fields.empty": "No fields yet",
 

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -26,7 +26,11 @@ export default {
 		emptyProps() {
 			return {
 				icon: "image",
-				text: this.empty ?? this.$t("field.files.empty")
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.files.empty")
+						: this.$t("field.files.empty.single"))
 			};
 		},
 		hasDropzone() {

--- a/panel/src/components/Forms/Field/PagesField.vue
+++ b/panel/src/components/Forms/Field/PagesField.vue
@@ -8,7 +8,11 @@ export default {
 		emptyProps() {
 			return {
 				icon: "page",
-				text: this.empty ?? this.$t("field.pages.empty")
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.pages.empty")
+						: this.$t("field.pages.empty.single"))
 			};
 		}
 	}

--- a/panel/src/components/Forms/Field/UsersField.vue
+++ b/panel/src/components/Forms/Field/UsersField.vue
@@ -8,7 +8,11 @@ export default {
 		emptyProps() {
 			return {
 				icon: "users",
-				text: this.empty ?? this.$t("field.users.empty")
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.users.empty")
+						: this.$t("field.users.empty.single"))
 			};
 		}
 	}


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Pages, files and users field: default empty string is now correct when only allowed to select one page/file/user
 #6565



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
