### PR TITLE
Support role permissions for  `preview` option

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -624,7 +624,7 @@ class File extends ModelWithContent
 	 * Page URL and the filename as a more stable
 	 * alternative for the media URLs.
 	 */
-	public function previewUrl(): string
+	public function previewUrl(): string|null
 	{
 		$parent = $this->parent();
 		$url    = Url::to($this->id());
@@ -632,6 +632,12 @@ class File extends ModelWithContent
 		switch ($parent::CLASS_ALIAS) {
 			case 'page':
 				$preview = $parent->blueprint()->preview();
+
+				// user has no permission to preview page,
+				// also return null for file preview
+				if ($preview === false) {
+					return null;
+				}
 
 				// the page has a custom preview setting,
 				// thus the file is only accessible through

--- a/src/Cms/PageBlueprint.php
+++ b/src/Cms/PageBlueprint.php
@@ -180,7 +180,7 @@ class PageBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $preview;
+		return $this->model->permissions()->can('preview', true);
 	}
 
 	/**

--- a/src/Cms/SiteBlueprint.php
+++ b/src/Cms/SiteBlueprint.php
@@ -51,6 +51,6 @@ class SiteBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $preview;
+		return $this->model->permissions()->can('preview', true);
 	}
 }

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -725,6 +725,25 @@ class FileTest extends TestCase
 
 	public function testPreviewUrl()
 	{
+		$app = $this->app->clone([
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
+			]
+		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
+
 		$page = new Page([
 			'slug'  => 'test',
 			'files' => [
@@ -738,8 +757,42 @@ class FileTest extends TestCase
 		$this->assertSame('/test/test.pdf', $file->previewUrl());
 	}
 
+	public function testPreviewUrlUnauthenticated()
+	{
+		$page = new Page([
+			'slug'  => 'test',
+			'files' => [
+				[
+					'filename' => 'test.pdf'
+				]
+			]
+		]);
+
+		$file = $page->file('test.pdf');
+		$this->assertSame('/media/pages/test/' . $file->mediaHash() . '/test.pdf', $file->previewUrl());
+	}
+
 	public function testPreviewUrlForDraft()
 	{
+		$app = $this->app->clone([
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
+			]
+		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
+
 		$page = new Page([
 			'slug'    => 'test',
 			'isDraft' => true,
@@ -779,8 +832,24 @@ class FileTest extends TestCase
 						]
 					]
 				]
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
 			]
 		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
 
 		$file = $app->file('test/test.pdf');
 		$this->assertSame($file->url(), $file->previewUrl());
@@ -788,6 +857,25 @@ class FileTest extends TestCase
 
 	public function testPreviewUrlForUserFile()
 	{
+		$app = $this->app->clone([
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
+			]
+		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
+
 		$user = new User([
 			'email' => 'test@getkirby.com',
 			'files' => [
@@ -820,8 +908,24 @@ class FileTest extends TestCase
 						]
 					]
 				]
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
 			]
 		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
 
 		$file = $app->file('test/test.pdf');
 		$this->assertSame('https://getkirby.com/test.pdf', $file->previewUrl());

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -769,7 +769,7 @@ class FileTest extends TestCase
 		]);
 
 		$file = $page->file('test.pdf');
-		$this->assertSame('/media/pages/test/' . $file->mediaHash() . '/test.pdf', $file->previewUrl());
+		$this->assertNull($file->previewUrl());
 	}
 
 	public function testPreviewUrlForDraft()
@@ -807,13 +807,61 @@ class FileTest extends TestCase
 		$this->assertSame($file->url(), $file->previewUrl());
 	}
 
-	public function testPreviewUrlForPageWithCustomPreviewSetting()
+	public function testPreviewUrlForPageWithDeniedPreviewSetting()
 	{
 		$app = new App([
 			'blueprints' => [
 				'pages/test' => [
 					'options' => [
 						'preview' => false
+					]
+				]
+			],
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test',
+						'files'    => [
+							[
+								'filename' => 'test.pdf'
+							]
+						]
+					]
+				]
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
+			]
+		]);
+
+		// authenticate
+		$app->impersonate('test@getkirby.com');
+
+		$file = $app->file('test/test.pdf');
+		$this->assertNull($file->previewUrl());
+	}
+
+	public function testPreviewUrlForPageWithCustomPreviewSetting()
+	{
+		$app = new App([
+			'blueprints' => [
+				'pages/test' => [
+					'options' => [
+						'preview' => '/foo/bar'
 					]
 				]
 			],

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -583,7 +583,28 @@ class PageTest extends TestCase
 			'slug' => 'test'
 		]);
 
+		// authenticate
+		$app->impersonate('kirby');
+
 		$this->assertSame('/test', $page->previewUrl());
+	}
+
+	public function testPreviewUrlUnauthenticated()
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'urls' => [
+				'index' => '/'
+			]
+		]);
+
+		$page = new Page([
+			'slug' => 'test'
+		]);
+
+		$this->assertNull($page->previewUrl());
 	}
 
 	public static function previewUrlProvider(): array
@@ -600,22 +621,45 @@ class PageTest extends TestCase
 			['{{ page.url }}?preview=true', '/test?preview=true&{token}', true],
 			[false, null, false],
 			[false, null, true],
+			[null, null, false, false],
 		];
 	}
 
 	/**
 	 * @dataProvider previewUrlProvider
 	 */
-	public function testCustomPreviewUrl($input, $expected, $draft)
-	{
+	public function testCustomPreviewUrl(
+		$input,
+		$expected,
+		bool $draft,
+		bool $authenticated = true
+	): void {
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
 			'urls' => [
 				'index' => '/'
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
 			]
 		]);
+
+		// authenticate
+		if ($authenticated) {
+			$app->impersonate('test@getkirby.com');
+		}
 
 		$options = [];
 

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -194,22 +194,44 @@ class SiteTest extends TestCase
 			['https://test.com', 'https://test.com'],
 			['{{ site.url }}#test', '/#test'],
 			[false, null],
+			[null, null, false],
 		];
 	}
 
 	/**
 	 * @dataProvider previewUrlProvider
 	 */
-	public function testCustomPreviewUrl($input, $expected)
-	{
+	public function testCustomPreviewUrl(
+		$input,
+		$expected,
+		bool $authenticated = true
+	): void {
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
 			'urls' => [
 				'index' => '/'
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'    => 'editor',
+					'name'  => 'editor',
+				]
 			]
 		]);
+
+		// authenticate
+		if ($authenticated) {
+			$app->impersonate('test@getkirby.com');
+		}
 
 		$options = [];
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Blueprint classes for `::preview()` are now using the permissions to actually resolve what to return
- This allows not just to set true/false or the string, but an array with role-based permissions



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `preview` blueprint option now supports setting role-based permissions
#6400

### Breaking changes
- `$file->previewUrl()` returns `null` if the user has no permission for the file's parent (page/site) preview

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
