### PR TITLE
Changes 19: New default read and exists behavior for PlainTextContentStorageHandler 

### DIFF
--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -37,14 +37,14 @@ class TestCase extends BaseTestCase
 			'.txt';
 	}
 
-	public function createContentMultiLanguage(): array
+	public function createContentMultiLanguage(VersionId|null $versionId = null): array
 	{
-		Data::write($fileEN = $this->contentFile('en'), $contentEN = [
+		Data::write($fileEN = $this->contentFile('en', $versionId), $contentEN = [
 			'title'    => 'Title English',
 			'subtitle' => 'Subtitle English'
 		]);
 
-		Data::write($fileDE = $this->contentFile('de'), $contentDE = [
+		Data::write($fileDE = $this->contentFile('de', $versionId), $contentDE = [
 			'title'    => 'Title Deutsch',
 			'subtitle' => 'Subtitle Deutsch'
 		]);
@@ -61,9 +61,9 @@ class TestCase extends BaseTestCase
 		];
 	}
 
-	public function createContentSingleLanguage(): array
+	public function createContentSingleLanguage(VersionId|null $versionId = null): array
 	{
-		Data::write($file = $this->contentFile(), $content = [
+		Data::write($file = $this->contentFile(null, $versionId), $content = [
 			'title'    => 'Title',
 			'subtitle' => 'Subtitle'
 		]);
@@ -112,7 +112,7 @@ class TestCase extends BaseTestCase
 			]
 		);
 
-		$this->model = $this->app->page('a-page');
+		$this->model = $this->app->site()->children()->first();
 
 		Dir::make($this->model->root());
 	}

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -165,25 +165,27 @@ class TranslationTest extends TestCase
 	{
 		$this->setUpMultiLanguage();
 
+		$versionId = VersionId::changes();
+
 		$translationEN = new Translation(
 			model: $this->model,
-			version: $this->model->version(),
+			version: $this->model->version($versionId),
 			language: Language::ensure('en')
 		);
 
 		$translationDE = new Translation(
 			model: $this->model,
-			version: $this->model->version(),
+			version: $this->model->version($versionId),
 			language: Language::ensure('de')
 		);
 
-		$this->assertFalse($translationEN->version()->exists());
-		$this->assertFalse($translationDE->version()->exists());
+		$this->assertFalse($translationEN->version($versionId)->exists());
+		$this->assertFalse($translationDE->version($versionId)->exists());
 
-		$this->createContentMultiLanguage();
+		$this->createContentMultiLanguage($versionId);
 
-		$this->assertTrue($translationEN->version()->exists());
-		$this->assertTrue($translationDE->version()->exists());
+		$this->assertTrue($translationEN->version($versionId)->exists());
+		$this->assertTrue($translationDE->version($versionId)->exists());
 	}
 
 	/**
@@ -193,17 +195,19 @@ class TranslationTest extends TestCase
 	{
 		$this->setUpSingleLanguage();
 
+		$versionId = VersionId::changes();
+
 		$translation = new Translation(
 			model: $this->model,
-			version: $this->model->version(),
+			version: $this->model->version($versionId),
 			language: Language::single()
 		);
 
-		$this->assertFalse($translation->version()->exists());
+		$this->assertFalse($translation->version($versionId)->exists());
 
-		$this->createContentSingleLanguage();
+		$this->createContentSingleLanguage($versionId);
 
-		$this->assertTrue($translation->version()->exists());
+		$this->assertTrue($translation->version($versionId)->exists());
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -314,11 +314,11 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: VersionId::changes()
 		);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published (de)" does not already exist');
+		$this->expectExceptionMessage('Version "changes (de)" does not already exist');
 
 		$version->ensure('de');
 	}
@@ -332,11 +332,11 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: VersionId::changes()
 		);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published" does not already exist');
+		$this->expectExceptionMessage('Version "changes" does not already exist');
 
 		$version->ensure();
 	}
@@ -368,7 +368,7 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: $versionId = VersionId::changes()
 		);
 
 		$this->assertFalse($version->exists('en'));
@@ -377,7 +377,7 @@ class VersionTest extends TestCase
 		$this->assertFalse($version->exists('de'));
 		$this->assertFalse($version->exists($this->app->language('de')));
 
-		$this->createContentMultiLanguage();
+		$this->createContentMultiLanguage($versionId);
 
 		$this->assertTrue($version->exists('en'));
 		$this->assertTrue($version->exists($this->app->language('en')));
@@ -395,12 +395,12 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: $versionId = VersionId::changes()
 		);
 
 		$this->assertFalse($version->exists());
 
-		$this->createContentSingleLanguage();
+		$this->createContentSingleLanguage($versionId);
 
 		$this->assertTrue($version->exists());
 	}
@@ -692,7 +692,7 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: VersionId::changes()
 		);
 
 		$this->assertFileDoesNotExist($this->contentFile());


### PR DESCRIPTION
## Description

### Summary of changes

- `PlainTextContentStorageHandler::exists` now checks for existing folders and files for default versions and languages to improve the logic when a model exists.
- `PlainTextContentStorageHandler::read` provides default content arrays for the default version. The page returns the slug as title in this array if there's no text file yet, to emulate the default behavior we always had. All other models return an empty array. 

### Reasoning

The `PlainTextContentStorageHandler` needs to make sure to return proper content if the model exists but does not have a default content storage file. This was not working so far. It always assumed that a text file needs to exist. But so far, a page, file, site or user could exist without having a text file yet.

### Additional context

This is needed to move on with the optional return value for the `ModelWithContent::version` method

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
