### PR TITLE
Views 2 - `Panel\View::reponse()`: auto-render UI views

### DIFF
--- a/src/Panel/Ui/View.php
+++ b/src/Panel/Ui/View.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\App;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.0.0
+ * @internal
+ */
+class View extends Component
+{
+	protected App $kirby;
+
+	public function __construct(
+		public string $id,
+		string|null $component = null,
+		public string|null $class = null,
+		public string|null $search = null,
+		public string|null $style = null,
+		public string|null $title = null,
+	) {
+		$this->kirby = App::instance();
+
+		parent::__construct(
+			component: $component ?? 'k-' . $id . '-view',
+			class: $class,
+			style: $style
+		);
+	}
+
+	/**
+	 * Returns breadcrumb trail to  display
+	 */
+	public function breadcrumb(): array
+	{
+		return [];
+	}
+
+	/**
+	 * Returns header button names which should be displayed
+	 */
+	public function buttons(): ViewButtons
+	{
+		return ViewButtons::view($this->id);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			// add buttons lazily as closure
+			'buttons' => fn () => $this->buttons()->render()
+		];
+	}
+
+	public function render(): array|null
+	{
+		return [
+			...parent::render(),
+			// add breadcrumb lazily as closure
+			'breadcrumb' => fn () => $this->breadcrumb(),
+			'search'     => $this->search,
+			'title'      => $this->title
+		];
+	}
+}

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -6,6 +6,7 @@ use Kirby\Api\Upload;
 use Kirby\Cms\App;
 use Kirby\Exception\Exception;
 use Kirby\Http\Response;
+use Kirby\Panel\Ui\View as UiView;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 use Throwable;
@@ -314,8 +315,12 @@ class View
 			return Response::redirect($data->location(), $data->code());
 		}
 
+		// handle UI view objects
+		if ($data instanceof UiView) {
+			$data = $data->render();
+
 		// handle Kirby exceptions
-		if ($data instanceof Exception) {
+		} elseif ($data instanceof Exception) {
 			$data = static::error($data->getMessage(), $data->getHttpCode());
 
 		// handle regular exceptions

--- a/tests/Panel/Ui/ViewTest.php
+++ b/tests/Panel/Ui/ViewTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Closure;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Panel\Ui\View
+ * @covers ::__construct
+ */
+class ViewTest extends TestCase
+{
+	/**
+	 * @covers ::breadcrumb
+	 */
+	public function testBreadcrumb()
+	{
+		$view      = new View(id: 'test');
+		$breadcrumb = $view->breadcrumb();
+		$this->assertSame([], $breadcrumb);
+	}
+
+	/**
+	 * @covers ::buttons
+	 */
+	public function testButtons()
+	{
+		$view    = new View(id: 'test');
+		$buttons = $view->buttons();
+		$this->assertInstanceOf(ViewButtons::class, $buttons);
+		$this->assertSame([], $buttons->render());
+	}
+
+	/**
+	 * @covers ::props
+	 */
+	public function testProps()
+	{
+		$view  = new View(id: 'test');
+		$props = $view->props();
+		$this->assertInstanceOf(Closure::class, $props['buttons']);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRender()
+	{
+		$view   = new View(id: 'test', title: 'Test', search: 'users');
+		$result = $view->render();
+
+		$this->assertSame('k-test-view', $result['component']);
+		$this->assertSame('Test', $result['title']);
+		$this->assertSame('users', $result['search']);
+		$this->assertInstanceOf(Closure::class, $result['breadcrumb']);
+		$this->assertSame([], $result['breadcrumb']());
+		$this->assertInstanceOf(Closure::class, $result['props']['buttons']);
+		$this->assertSame([], $result['props']['buttons']());
+
+	}
+}

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
+use Kirby\Panel\Ui\View as UiView;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
@@ -570,6 +571,25 @@ class ViewTest extends TestCase
 
 		$this->assertSame('application/json', $response->type());
 		$this->assertSame('true', $response->header('X-Fiber'));
+	}
+
+	/**
+	 * @covers ::response
+	 */
+	public function testResponseForUiView()
+	{
+		$this->app = $this->app->clone([
+			'request' => [
+				'query' => [
+					'_json' => true
+				]
+			]
+		]);
+
+		$view = new UiView(id: 'test');
+		$response = View::response($view);
+
+		$this->assertSame('k-test-view', json_decode($response->body(), true)['$view']['component']);
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [ ] Merge https://github.com/getkirby/kirby/pulls

### Summary of changes
- `Panel\View::reponse()` can handle `Panel\Ui\View` objects and automatically calls `::render()` on them


### Reasoning
- Allows us to directly return the object from the closures in `config/areas/` instead of having to call `->render()` in every definition.
- At the same time, returning an array continues to work.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass
