### PR TITLE
Changes 19: Improve PlainTextContentStorageHandler::delete

### DIFF
--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -108,9 +108,18 @@ class PlainTextContentStorageHandlerTest extends TestCase
 	{
 		$this->setUpSingleLanguage();
 
+		$versionId = VersionId::published();
+		$language  = Language::single();
+
+		$this->assertContentFileDoesNotExist($language, $versionId);
+
 		// test idempotency
-		$this->storage->delete(VersionId::published(), Language::single());
-		$this->assertDirectoryDoesNotExist($this->model->root());
+		$this->storage->delete($versionId, $language);
+
+		$this->assertContentFileDoesNotExist($language, $versionId);
+
+		// The page directory should not be deleted
+		$this->assertDirectoryExists($this->model->root());
 	}
 
 	/**


### PR DESCRIPTION
## Description

### Summary of changes

- `PlainTextContentStorageHandler::delete` does no longer delete a page directory if it is empty. 

### Reasoning

The `delete` method tried to clean up after deleting content files. This makes a lot of sense for empty _changes directories, but it's actually quite risky for page directories. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
