### PR TITLE
Changes 20: Improve PlainTextContentStorageHandler ::read and ::exists methods

### DIFF
--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -177,7 +177,9 @@ abstract class ContentStorageHandler
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
 		foreach ($this->dynamicVersions() as $versionId) {
-			$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
+			if ($this->exists($versionId, $fromLanguage) === true) {
+				$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
+			}
 		}
 	}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -186,27 +186,22 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	{
 		$contentFile = $this->contentFile($versionId, $language);
 
-		/**
-		 * The version definitely exists, if there's a
-		 * matching content file
-		 */
+		// The version definitely exists, if there's a
+		// matching content file
 		if (file_exists($contentFile) === true) {
 			return true;
 		}
 
-		/**
-		 * A non-default version or non-default language version does not exist
-		 * if the content file was not found
-		 */
+		// A non-default version or non-default language version does not exist
+		// if the content file was not found
 		if (VersionId::default($this->model)->is($versionId) === false || $language->isDefault() === false) {
 			return false;
 		}
 
-		/**
-		 * Wether the default version exists, depends on different cases for each model.
-		 * Page, Site and User exist as soon as the folder is there. A File exists as
-		 * soon as the file is there.
-		 */
+		// Wether the default version exists,
+		// depends on different cases for each model.
+		// Page, Site and User exist as soon as the folder is there.
+		// A File exists as soon as the file is there.
 		return match (true) {
 			$this->model instanceof File => is_file($this->model->root()) === true,
 			$this->model instanceof Page,
@@ -267,11 +262,9 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	 */
 	public function read(VersionId $versionId, Language $language): array
 	{
-		/**
-		 * Verify that the version exists. The `::exists` method
-		 * makes sure to validate this correctly, based on the
-		 * requested version and language
-		 */
+		// Verify that the version exists. The `::exists` method
+		// makes sure to validate this correctly, based on the
+		// requested version and language
 		$this->ensure($versionId, $language);
 
 		$contentFile = $this->contentFile($versionId, $language);
@@ -280,12 +273,10 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 			return Data::read($contentFile);
 		}
 
-		/**
-		 * For existing versions that don't have a content file yet,
-		 * we can safely return an empty array that can be filled later.
-		 * This might be the case for pages that only have a directory
-		 * so far, or for files that don't have any metadata yet.
-		 */
+		// For existing versions that don't have a content file yet,
+		// we can safely return an empty array that can be filled later.
+		// This might be the case for pages that only have a directory
+		// so far, or for files that don't have any metadata yet.
 		return [];
 	}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -242,8 +242,19 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 		VersionId $toVersionId,
 		Language $toLanguage
 	): void {
+		// make sure the source version exists
+		$this->ensure($fromVersionId, $fromLanguage);
+
+		// check for an existing content file
+		$contentFile = $this->contentFile($fromVersionId, $fromLanguage);
+
+		// create the source file if it doesn't exist so far
+		if (file_exists($contentFile) === false) {
+			$this->touch($fromVersionId, $fromLanguage);
+		}
+
 		F::move(
-			$this->contentFile($fromVersionId, $fromLanguage),
+			$contentFile,
 			$this->contentFile($toVersionId, $toLanguage)
 		);
 	}

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -198,7 +198,7 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 			return false;
 		}
 
-		// Wether the default version exists,
+		// Whether the default version exists,
 		// depends on different cases for each model.
 		// Page, Site and User exist as soon as the folder is there.
 		// A File exists as soon as the file is there.

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -184,7 +184,38 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	 */
 	public function exists(VersionId $versionId, Language $language): bool
 	{
-		return is_file($this->contentFile($versionId, $language)) === true;
+		$contentFile = $this->contentFile($versionId, $language);
+
+		/**
+		 * The version definitely exists, if there's a
+		 * matching content file
+		 */
+		if (file_exists($contentFile) === true) {
+			return true;
+		}
+
+		/**
+		 * A non-default version or non-default language version does not exist
+		 * if the content file was not found
+		 */
+		if (VersionId::default($this->model)->is($versionId) === false || $language->isDefault() === false) {
+			return false;
+		}
+
+		/**
+		 * Wether the default version exists, depends on different cases for each model.
+		 * Page, Site and User exist as soon as the folder is there. A File exists as
+		 * soon as the file is there.
+		 */
+		return match (true) {
+			$this->model instanceof File => is_file($this->model->root()) === true,
+			$this->model instanceof Page,
+			$this->model instanceof Site,
+			$this->model instanceof User => is_dir($this->model->root()) === true,
+			// @codeCoverageIgnoreStart
+			default => throw new LogicException('Cannot determine existance for model type "' . $this->model::CLASS_ALIAS . '"')
+			// @codeCoverageIgnoreEnd
+		};
 	}
 
 	/**
@@ -221,12 +252,30 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
-	 * @throws \Kirby\Exception\NotFoundException If the content file is missing
+	 * @throws \Kirby\Exception\NotFoundException If the version is missing
 	 */
 	public function read(VersionId $versionId, Language $language): array
 	{
+		/**
+		 * Verify that the version exists. The `::exists` method
+		 * makes sure to validate this correctly, based on the
+		 * requested version and language
+		 */
 		$this->ensure($versionId, $language);
-		return Data::read($this->contentFile($versionId, $language));
+
+		$contentFile = $this->contentFile($versionId, $language);
+
+		if (file_exists($contentFile) === true) {
+			return Data::read($contentFile);
+		}
+
+		/**
+		 * For existing versions that don't have a content file yet,
+		 * we can safely return an empty array that can be filled later.
+		 * This might be the case for pages that only have a directory
+		 * so far, or for files that don't have any metadata yet.
+		 */
+		return [];
 	}
 
 	/**

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -258,6 +258,53 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::published(), Language::single()));
 	}
 
+	public function testMove()
+	{
+		$this->setUpSingleLanguage();
+
+		// create some content to move
+		$this->createContentSingleLanguage();
+
+		// the source file should exist now
+		$this->assertFileExists($this->model->root() . '/article.txt');
+
+		// but the destination file should not be there yet
+		$this->assertFileDoesNotExist($this->model->root() . '/_changes/article.txt');
+
+		$this->storage->move(
+			VersionId::published(),
+			Language::single(),
+			VersionId::changes(),
+			Language::single()
+		);
+
+		// the source file should no longer exist
+		$this->assertFileDoesNotExist($this->model->root() . '/article.txt');
+
+		// but the destination file should be there
+		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
+	}
+
+	public function testMoveNonExistingContentFile()
+	{
+		$this->setUpSingleLanguage();
+
+		$this->assertFileDoesNotExist($this->model->root() . '/article.txt');
+
+		$this->storage->move(
+			VersionId::published(),
+			Language::single(),
+			VersionId::changes(),
+			Language::single()
+		);
+
+		// the source file should still not exist
+		$this->assertFileDoesNotExist($this->model->root() . '/article.txt');
+
+		// but the destination file should now be there
+		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
+	}
+
 	/**
 	 * @covers ::read
 	 */

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -168,22 +168,27 @@ class TranslationTest extends TestCase
 		$translationEN = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
-			language: Language::ensure('en')
+			language: $languageEN = Language::ensure('en')
 		);
 
 		$translationDE = new Translation(
 			model: $this->model,
 			version: $this->model->version(),
-			language: Language::ensure('de')
+			language: $languageDE = Language::ensure('de')
 		);
 
-		$this->assertFalse($translationEN->version()->exists());
-		$this->assertFalse($translationDE->version()->exists());
+		// the default version + default language exists as soon as the
+		// model directory exists
+		$this->assertTrue($translationEN->version()->exists($languageEN));
+
+		// the secondary language only exists as soon as
+		// the content file exists
+		$this->assertFalse($translationDE->version()->exists($languageDE));
 
 		$this->createContentMultiLanguage();
 
-		$this->assertTrue($translationEN->version()->exists());
-		$this->assertTrue($translationDE->version()->exists());
+		$this->assertTrue($translationEN->version()->exists($languageEN));
+		$this->assertTrue($translationDE->version()->exists($languageDE));
 	}
 
 	/**
@@ -199,10 +204,7 @@ class TranslationTest extends TestCase
 			language: Language::single()
 		);
 
-		$this->assertFalse($translation->version()->exists());
-
-		$this->createContentSingleLanguage();
-
+		// the version exists as soon as the directory exists
 		$this->assertTrue($translation->version()->exists());
 	}
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -314,11 +314,11 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: VersionId::changes()
 		);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published (de)" does not already exist');
+		$this->expectExceptionMessage('Version "changes (de)" does not already exist');
 
 		$version->ensure('de');
 	}
@@ -332,11 +332,11 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model,
-			id: VersionId::published()
+			id: VersionId::changes()
 		);
 
 		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('Version "published" does not already exist');
+		$this->expectExceptionMessage('Version "changes" does not already exist');
 
 		$version->ensure();
 	}
@@ -362,7 +362,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::exists
 	 */
-	public function testExistsMultiLanguage(): void
+	public function testExistsPublishedMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -371,16 +371,19 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$this->assertFalse($version->exists('en'));
-		$this->assertFalse($version->exists($this->app->language('en')));
+		$this->assertDirectoryExists($this->model->root());
 
+		// the default version + default language exists without
+		// content file as long as the page directory exists
+		$this->assertTrue($version->exists('en'));
+		$this->assertTrue($version->exists($this->app->language('en')));
+
+		// the secondary language only exists as soon as the content
+		// file also exists
 		$this->assertFalse($version->exists('de'));
 		$this->assertFalse($version->exists($this->app->language('de')));
 
 		$this->createContentMultiLanguage();
-
-		$this->assertTrue($version->exists('en'));
-		$this->assertTrue($version->exists($this->app->language('en')));
 
 		$this->assertTrue($version->exists('de'));
 		$this->assertTrue($version->exists($this->app->language('de')));
@@ -389,7 +392,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::exists
 	 */
-	public function testExistsSingleLanguage(): void
+	public function testExistsPublishedSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -398,10 +401,10 @@ class VersionTest extends TestCase
 			id: VersionId::published()
 		);
 
-		$this->assertFalse($version->exists());
+		$this->assertDirectoryExists($this->model->root());
 
-		$this->createContentSingleLanguage();
-
+		// the default version exists without content file as long as
+		// the page directory exists
 		$this->assertTrue($version->exists());
 	}
 
@@ -686,7 +689,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::read
 	 */
-	public function testReadWhenMissing(): void
+	public function testReadPublishedWithoutContentFile(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -696,7 +699,9 @@ class VersionTest extends TestCase
 		);
 
 		$this->assertFileDoesNotExist($this->contentFile());
-		$this->assertNull($version->read());
+
+		// the page has empty content if there's no default content file
+		$this->assertSame([], $version->read());
 	}
 
 	/**


### PR DESCRIPTION
## Description

### Summary of changes

`PlainTextContentStorageHandler` methods `::read` and `::exists` now allow models without an existing text file to support our existing state of pages or files without content.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

~~- [ ] Add changes & docs to release notes draft in Notion~~
