### PR TITLE
Prevent partial matches for `pattern` validation

### DIFF
--- a/src/Form/Validations.php
+++ b/src/Form/Validations.php
@@ -162,11 +162,18 @@ class Validations
 	 */
 	public static function pattern(Field|FieldClass $field, mixed $value): bool
 	{
-		if ($field->isEmpty($value) === false && $field->pattern() !== null) {
-			if (V::match($value, '/' . $field->pattern() . '/i') === false) {
-				throw new InvalidArgumentException(
-					V::message('match')
-				);
+		if ($field->isEmpty($value) === false) {
+			if ($pattern = $field->pattern()) {
+				// ensure that that pattern needs to match the whole
+				// input value from start to end, not just a partial match
+				// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview
+				$pattern = '^(?:' . trim($pattern, '/') . ')$';
+
+				if (V::match($value, '/' . $pattern . '/i') === false) {
+					throw new InvalidArgumentException(
+						V::message('match')
+					);
+				}
 			}
 		}
 

--- a/tests/Form/ValidationsTest.php
+++ b/tests/Form/ValidationsTest.php
@@ -212,6 +212,23 @@ class ValidationsTest extends TestCase
 		Validations::pattern($field, '#MMM');
 	}
 
+	public function testPatternInvalidMatchButMore()
+	{
+		$page  = new Page(['slug' => 'test']);
+		$field = new Field('test', [
+			'pattern' => '\d{3,4}',
+			'model'   => $page
+		]);
+
+		$this->assertTrue(Validations::pattern($field, '123'));
+		$this->assertTrue(Validations::pattern($field, '1234'));
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The value does not match the expected pattern');
+
+		Validations::pattern($field, '12345');
+	}
+
 	public function testRequiredValid()
 	{
 		$page  = new Page(['slug' => 'test']);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Validations::match()` now acts like the native HTML validation: "The pattern's regular expression must match the entire input's value, rather than matching a substring"

### Additional context
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `pattern` attribute for Panel fields: fixed inconsistencies between frontend and backend validation
#6585


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
