### PR TITLE
`files.sort` permission

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -110,7 +110,8 @@ return [
 			$dragTextAbsolute = $this->model->is($this->parent) === false;
 
 			foreach ($this->models as $file) {
-				$panel = $file->panel();
+				$panel       = $file->panel();
+				$permissions = $file->permissions();
 
 				$item = [
 					'dragText'  => $panel->dragText('auto', $dragTextAbsolute),
@@ -125,6 +126,9 @@ return [
 					'link'      => $panel->url(true),
 					'mime'      => $file->mime(),
 					'parent'    => $file->parent()->panel()->path(),
+					'permissions' => [
+						'sort' => $permissions->can('sort'),
+					],
 					'template'  => $file->template(),
 					'text'      => $file->toSafeString($this->text),
 					'url'       => $file->url(),

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -118,6 +118,7 @@
 	"error.file.name.missing": "The filename must not be empty",
 	"error.file.notFound": "The file \"{filename}\" cannot be found",
 	"error.file.orientation": "The orientation of the image must be \"{orientation}\"",
+	"error.file.sort.permission": "You are not allowed to change the sorting of \"{filename}\"",
 	"error.file.type.forbidden": "You are not allowed to upload {type} files",
 	"error.file.type.invalid": "Invalid file type: {type}",
 	"error.file.undefined": "The file cannot be found",

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -22,26 +22,21 @@ export default {
 			};
 		},
 		items() {
-			return this.data.map((file) => {
-				const sortable = this.options.sortable;
-
-				return {
-					...file,
-					column: this.column,
-					data: {
-						"data-id": file.id,
-						"data-template": file.template
-					},
-					options: this.$dropdown(file.link, {
-						query: {
-							view: "list",
-							update: sortable,
-							delete: this.data.length > this.options.min
-						}
-					}),
-					sortable
-				};
-			});
+			return this.data.map((file) => ({
+				...file,
+				column: this.column,
+				data: {
+					"data-id": file.id,
+					"data-template": file.template
+				},
+				options: this.$dropdown(file.link, {
+					query: {
+						view: "list",
+						delete: this.data.length > this.options.min
+					}
+				}),
+				sortable: file.permissions.sort && this.options.sortable
+			}));
 		},
 		type() {
 			return "files";

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -41,6 +41,7 @@ class FileBlueprint extends Blueprint
 				'list'     	     => null,
 				'read'       	 => null,
 				'replace'    	 => null,
+				'sort'           => null,
 				'update'     	 => null,
 			]
 		);

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -60,6 +60,13 @@ class FileRules
 	 */
 	public static function changeSort(File $file, int $sort): bool
 	{
+		if ($file->permissions()->sort() !== true) {
+			throw new PermissionException([
+				'key'  => 'file.sort.permission',
+				'data' => ['filename' => $file->filename()]
+			]);
+		}
+
 		return true;
 	}
 

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -37,6 +37,7 @@ class Permissions
 			'list'           => true,
 			'read'           => true,
 			'replace'        => true,
+			'sort'           => true,
 			'update'         => true
 		],
 		'languages' => [

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -134,7 +134,7 @@ class File extends Model
 	{
 		$file     = $this->model;
 		$request  = $file->kirby()->request();
-		$defaults = $request->get(['view', 'update', 'delete']);
+		$defaults = $request->get(['view', 'delete']);
 		$options  = [...$defaults, ...$options];
 
 		$permissions = $this->options(['preview']);
@@ -164,7 +164,7 @@ class File extends Model
 				'dialog'   => $url . '/changeSort',
 				'icon'     => 'sort',
 				'text'     => I18n::translate('file.sort'),
-				'disabled' => $this->isDisabledDropdownOption('update', $options, $permissions)
+				'disabled' => $this->isDisabledDropdownOption('sort', $options, $permissions)
 			];
 		}
 

--- a/tests/Cms/Files/FileBlueprintTest.php
+++ b/tests/Cms/Files/FileBlueprintTest.php
@@ -28,6 +28,7 @@ class FileBlueprintTest extends TestCase
 			'list'     	 	 => null,
 			'read'       	 => null,
 			'replace'    	 => null,
+			'sort'           => null,
 			'update'     	 => null,
 		];
 

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -75,8 +75,32 @@ class FileRulesTest extends TestCase
 
 	public function testChangeSort()
 	{
-		$file = $this->createMock(File::class);
+		$page = new Page([
+			'slug' => 'test',
+			'files' => [
+				['filename' => 'a.jpg'],
+				['filename' => 'b.jpg']
+			]
+		]);
+
+		$file = $page->file('a.jpg');
+
 		$this->assertTrue(FileRules::changeSort($file, 1));
+	}
+
+	public function testChangeSortWithoutPermissions()
+	{
+		$permissions = $this->createMock(FilePermissions::class);
+		$permissions->method('__call')->with('sort')->willReturn(false);
+
+		$file = $this->createMock(File::class);
+		$file->method('permissions')->willReturn($permissions);
+		$file->method('filename')->willReturn('test.jpg');
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to change the sorting of "test.jpg"');
+
+		FileRules::changeSort($file, 1);
 	}
 
 	public function testChangeToSameNameWithDifferentException()

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -533,6 +533,7 @@ class FileTest extends TestCase
 			'list'         	 => true,
 			'read'           => true,
 			'replace'        => true,
+			'sort'           => true,
 			'update'         => true,
 		];
 
@@ -566,6 +567,7 @@ class FileTest extends TestCase
 			'list'           => false,
 			'read'           => false,
 			'replace'        => false,
+			'sort'           => false,
 			'update'         => false,
 		];
 
@@ -582,6 +584,7 @@ class FileTest extends TestCase
 			'list'           => false,
 			'read'           => false,
 			'replace'        => false,
+			'sort'           => false,
 			'update'         => false,
 		];
 
@@ -613,6 +616,7 @@ class FileTest extends TestCase
 			'list'           => true,
 			'read'           => true,
 			'replace'        => false,
+			'sort'           => true,
 			'update'         => true,
 		];
 
@@ -655,6 +659,7 @@ class FileTest extends TestCase
 			'list'           => true,
 			'read'           => true,
 			'replace'        => true,
+			'sort'           => true,
 			'update'         => true,
 		];
 
@@ -699,6 +704,7 @@ class FileTest extends TestCase
 			'list'           => true,
 			'read'           => true,
 			'replace'        => false,
+			'sort'           => true,
 			'update'         => true,
 		];
 


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement
- New `files.sort` permission
#1969


### Breaking changes
- If file sorting was previously disabled via the `files.update` permission, the new `file.sort` permission has to be configured accordingly.


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

- Add new `files.sort` permission

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
