### PR TITLE
Changes 21: Render Mode

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -136,7 +136,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		// @todo this entire block can be radically simplified as soon
 		// as the models use the versions exclusively.
 		if (VersionId::$render ?? null) {
-			$version = $this->version(VersionId::render($this));
+			$version = $this->version(VersionId::$render);
 
 			if ($version->exists($language) === true) {
 				return $version->content($language);

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -129,13 +129,24 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function content(string|null $languageCode = null): Content
 	{
-		// single language support
-		if ($this->kirby()->multilang() === false) {
-			return $this->content ??= $this->version()->content('default');
-		}
-
 		// get the targeted language
 		$language = Language::ensure($languageCode);
+
+		// fetch a specific version in preview render mode
+		// @todo this entire block can be radically simplified as soon
+		// as the models use the versions exclusively.
+		if (VersionId::$render ?? null) {
+			$version = $this->version(VersionId::render($this));
+
+			if ($version->exists($language) === true) {
+				return $version->content($language);
+			}
+		}
+
+		// single language support
+		if ($this->kirby()->multilang() === false) {
+			return $this->content ??= $this->version()->content($language);
+		}
 
 		// only fetch from cache for the current language
 		if ($languageCode === null && $this->content instanceof Content) {

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -32,7 +32,13 @@ class VersionId implements Stringable
 	/**
 	 * Latest changes to the content (optional)
 	 */
-	public const CHANGES   = 'changes';
+	public const CHANGES = 'changes';
+
+	/**
+	 * A global store for a version id that should be
+	 * rendered for each model in a live preview scenario.
+	 */
+	public static self|null $render = null;
 
 	/**
 	 * @throws \Kirby\Exception\InvalidArgumentException If the version ID is not valid
@@ -102,6 +108,16 @@ class VersionId implements Stringable
 	public static function published(): static
 	{
 		return new static(static::PUBLISHED);
+	}
+
+	/**
+	 * Returns the VersionId which should be rendered for the given
+	 * Model. This can be changed by overwriting the static `::$render` property
+	 * and thus can be used to render different versions for all models (e.g. in a preview)
+	 */
+	public static function render(ModelWithContent $model): static
+	{
+		return static::$render ?? static::default($model);
 	}
 
 	/**

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -111,16 +111,6 @@ class VersionId implements Stringable
 	}
 
 	/**
-	 * Returns the VersionId which should be rendered for the given
-	 * Model. This can be changed by overwriting the static `::$render` property
-	 * and thus can be used to render different versions for all models (e.g. in a preview)
-	 */
-	public static function render(ModelWithContent $model): static
-	{
-		return static::$render ?? static::default($model);
-	}
-
-	/**
 	 * Returns the ID value
 	 */
 	public function value(): string

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -43,8 +43,9 @@ abstract class Model
 		if ($version->exists() === true) {
 			$changes = $version->content()->toArray();
 		}
-// create a form which will collect the published values for the model,
-// but also pass along unpublished changes as overwrites
+
+		// create a form which will collect the published values for the model,
+		// but also pass along unpublished changes as overwrites
 		return Form::for(
 			model: $this->model,
 			props: [

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -37,7 +37,19 @@ abstract class Model
 	 */
 	public function content(): array
 	{
-		return Form::for($this->model)->values();
+		$version = $this->model->version('changes');
+		$changes = [];
+
+		if ($version->exists() === true) {
+			$changes = $version->content()->toArray();
+		}
+
+		return Form::for(
+			model: $this->model,
+			props: [
+				'values' => $changes
+			]
+		)->values();
 	}
 
 	/**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -43,7 +43,8 @@ abstract class Model
 		if ($version->exists() === true) {
 			$changes = $version->content()->toArray();
 		}
-
+// create a form which will collect the published values for the model,
+// but also pass along unpublished changes as overwrites
 		return Form::for(
 			model: $this->model,
 			props: [

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Content\VersionId;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
@@ -372,25 +371,11 @@ class Page extends Model
 	 */
 	public function view(): array
 	{
-		$page = $this->model;
-
-		// This is placed here as a proof of concept
-		// @todo we need to find a better place for it
-		// to switch into changes mode in the panel
-		VersionId::$render = VersionId::changes();
-
-		$view = [
-			'breadcrumb' => $page->panel()->breadcrumb(),
+		return [
+			'breadcrumb' => $this->model->panel()->breadcrumb(),
 			'component'  => 'k-page-view',
 			'props'      => $this->props(),
-			'title'      => $page->title()->toString(),
+			'title'      => $this->model->title()->toString(),
 		];
-
-		// The render mode needs to be undone here to keep unit tests working
-		// That's the downside of such static properties. They are likely to
-		// cause side-effects
-		VersionId::$render = null;
-
-		return $view;
 	}
 }

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Content\VersionId;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
@@ -373,11 +374,23 @@ class Page extends Model
 	{
 		$page = $this->model;
 
-		return [
+		// This is placed here as a proof of concept
+		// @todo we need to find a better place for it
+		// to switch into changes mode in the panel
+		VersionId::$render = VersionId::changes();
+
+		$view = [
 			'breadcrumb' => $page->panel()->breadcrumb(),
 			'component'  => 'k-page-view',
 			'props'      => $this->props(),
 			'title'      => $page->title()->toString(),
 		];
+
+		// The render mode needs to be undone here to keep unit tests working
+		// That's the downside of such static properties. They are likely to
+		// cause side-effects
+		VersionId::$render = null;
+
+		return $view;
 	}
 }

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -230,6 +230,39 @@ class ModelWithContentTest extends TestCase
 		$this->assertNull($model->lock());
 	}
 
+	public function testContentWithChanges()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'foo',
+					]
+				],
+			]
+		]);
+
+		$page = $app->page('foo');
+
+		$this->assertSame(null, $page->content()->title()->value());
+
+		// create some changes
+		$page->version('changes')->save([
+			'title' => 'Test'
+		]);
+
+		VersionId::$render = VersionId::changes();
+
+		$this->assertSame('Test', $page->content()->title()->value());
+
+		VersionId::$render = null;
+
+		$this->assertSame(null, $page->content()->title()->value());
+	}
+
 	/**
 	 * @dataProvider modelsProvider
 	 */


### PR DESCRIPTION
## Description

### Summary of changes

- New `VersionId::$render` property
- Use new render mode in `ModelWithContent::content` method
- Use `changes` Version in `Panel\Model::content()` if it exists, to show changes in the panel.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team

- [x] Add changes & docs to release notes draft in Notion
