### PR TITLE
Changes 22: Provide access to pages rendered with changes via URL

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Generator;
+use Kirby\Content\VersionId;
 use Kirby\Data\Data;
 use Kirby\Email\Email as BaseEmail;
 use Kirby\Exception\ErrorPageException;
@@ -1222,6 +1223,17 @@ class App
 	): Response|null {
 		if (($_ENV['KIRBY_RENDER'] ?? true) === false) {
 			return null;
+		}
+
+		/**
+		 * TODO: very rough preview mode for changes.
+		 *
+		 * We need page token verification for this before v5
+		 * hits beta. This rough implementation will only help
+		 * to get the panel integration up and running during the alpha
+		 */
+		if ($this->request()->get('_version') === 'changes') {
+			VersionId::$render = VersionId::changes();
 		}
 
 		return $this->io($this->call($path, $method));


### PR DESCRIPTION
## Description

> [!CAUTION]
> This PR leads to a big TODO to get the final token verification for preview URLs right later.

### Summary of changes

This is a very rough and insecure first implementation to get preview URLs for changes. After a huge App class rabbit hole, I decided to go for a very simple first "better done than perfect" approach to finally be able to move on with the panel integration. 

Add `?_version=changes` to the URL of any page to see changes if any are available
