### PR TITLE
Redirect language URLs with non-translated slugs

### DIFF
--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\Str;
 
 class LanguageRoutes
 {
@@ -29,8 +30,25 @@ class LanguageRoutes
 				'pattern' => $language->pattern(),
 				'method'  => 'ALL',
 				'env'     => 'site',
-				'action'  => function ($path = null) use ($language) {
+				'action'  => function ($path = null) use ($kirby, $language) {
 					$result = $language->router()->call($path);
+
+					// redirect secondary-language pages that have
+					// been accessed with non-translated slugs in their path
+					// to their fully translated URL
+					if ($path !== null && $result instanceof Page) {
+						if (Str::endsWith($result->url(), $path) === false) {
+							$url   = $result->url();
+							$query = $kirby->request()->query()->toString();
+
+							// preserve query across redirect
+							if (empty($query) === false) {
+								$url .= '?' . $query;
+							}
+
+							return Response::redirect($url);
+						}
+					}
 
 					// explicitly test for null as $result can
 					// contain falsy values that should still be returned

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -46,7 +46,7 @@ class LanguageRoutes
 								$url .= '?' . $query;
 							}
 
-							return Response::redirect($url);
+							return $kirby->response()->redirect($url);
 						}
 					}
 

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -153,7 +153,7 @@ class LanguageRoutesTest extends TestCase
 		$this->assertSame($app->page('page1'), $result);
 
 		$result = $app->call('de/page1');
-		$this->assertInstanceOf(Response::class, $result);
+		$this->assertInstanceOf(Responder::class, $result);
 		$this->assertSame(302, $result->code());
 		$this->assertSame('/de/seite1?foo=bar', $result->header('Location'));
 

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -122,4 +122,42 @@ class LanguageRoutesTest extends TestCase
 		$this->assertSame(1, $d);
 		$this->assertSame(2, $e);
 	}
+
+	public function testRedirectWhenNonTranslatedSlugs()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'         => 'page1',
+						'translations' => [
+							[
+								'code' => 'en',
+							],
+							[
+								'code' => 'de',
+								'slug' => 'seite1',
+							]
+						]
+					]
+				]
+			],
+			'request' => [
+				'query' => [
+					'foo' => 'bar',
+				]
+			]
+		]);
+
+		$result = $app->call('page1');
+		$this->assertSame($app->page('page1'), $result);
+
+		$result = $app->call('de/page1');
+		$this->assertInstanceOf(Response::class, $result);
+		$this->assertSame(302, $result->code());
+		$this->assertSame('/de/seite1?foo=bar', $result->header('Location'));
+
+		$result = $app->call('de/seite1');
+		$this->assertSame($app->page('page1'), $result);
+	}
 }

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -156,7 +156,6 @@ class PageUuidTest extends TestCase
 							],
 							[
 								'code' => 'de',
-								'slug' => 'bar',
 								'content' => [
 									'title' => 'Bar',
 								]


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- If a secondary-language page gets accessed with a URL that contains untranslated slugs (for which a translation exists), the request is redirected to the fully translated URL (302 redirect)


### Reasoning
To make those pages only available under the main (full- translated) URL and not several ones (with untranslated slug parts).


### Additional context
In https://github.com/getkirby/kirby/issues/3550#issue-947976809 under "Complex example", @lukasbestle asks for an additional unit test where the translated slug of a page is the same as the untranslated slug of another page. This unit test is not included here as it would fail. However, this behavior is also different before this PR: if a translated slug is the same as the untranslated slug of a different page, our router will return the different page. Moreover,  our page rules also prevent creating a translated slug that matches an existing untranslated slug. This is why I didn't include this aspect in this PR. To me this seems as a much larger change to be discussed, while this PR implements the solution for #3550 based on the existing rules.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- #3550


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
