### PR TITLE
Fix picker fields when UUIDs disabled

### DIFF
--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -2,6 +2,7 @@
 
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
+use Kirby\Uuid\Uuids;
 
 return [
 	'props' => [
@@ -75,7 +76,11 @@ return [
 		 * @param string $store 'uuid'|'id'
 		 */
 		'store' => function (string $store = 'uuid') {
-			return Str::lower($store);
+			// fall back to ID, if UUIDs globally disabled
+			return match (Uuids::enabled()) {
+				false   => 'id',
+				default => Str::lower($store)
+			};
 		},
 
 		/**

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -352,12 +352,15 @@ class File extends Model
 		$id   = $this->model->id();
 
 		if (empty($params['model']) === false) {
-			$parent = $this->model->parent();
+			$parent   = $this->model->parent();
+			$absolute = $parent !== $params['model'];
 
 			// if the file belongs to the current parent model,
 			// store only name as ID to keep its path relative to the model
-			$id       = $parent === $params['model'] ? $name : $id;
-			$absolute = $parent !== $params['model'];
+			$id = match ($absolute) {
+				true  => $id,
+				false => $name
+			};
 		}
 
 		$params['text'] ??= '{{ file.filename }}';

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -335,7 +335,7 @@ abstract class Model
 			'link'     => $this->url(true),
 			'sortable' => true,
 			'text'     => $this->model->toSafeString($params['text'] ?? false),
-			'uuid'     => $this->model->uuid()?->toString() ?? $this->model->id(),
+			'uuid'     => $this->model->uuid()?->toString()
 		];
 	}
 

--- a/tests/Form/Fields/FilesFieldTest.php
+++ b/tests/Form/Fields/FilesFieldTest.php
@@ -75,6 +75,7 @@ class FilesFieldTest extends TestCase
 		$this->assertNull($field->max());
 		$this->assertTrue($field->multiple());
 		$this->assertTrue($field->save());
+		$this->assertSame('uuid', $field->store());
 	}
 
 	public function testValue()
@@ -291,5 +292,38 @@ class FilesFieldTest extends TestCase
 		]);
 
 		$this->assertSame($this->app->site(), $field->parentModel());
+	}
+
+	public function testStore()
+	{
+		// Default
+		$field = $this->field('files', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('uuid', $field->store());
+
+		// Custom
+		$field = $this->field('files', [
+			'model' => new Page(['slug' => 'test']),
+			'store' => 'id'
+		]);
+
+		$this->assertSame('id', $field->store());
+
+		// Disabled UUIDs
+		$this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => false
+				]
+			]
+		]);
+
+		$field = $this->field('files', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('id', $field->store());
 	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Enforce `id` as value for the `store` option on picker fields, when UUIDs disabled
- `Panel\Model::pickerData`: don't add the normal ID as fallback to `uuid` key, but rather keep it as `null` when UUIDs are disabled (we still have the ID as its own `id` entry)


### Reasoning
https://github.com/getkirby/kirby/pull/4892 was circumvented when UUIDs were disabled as the ID was still added as fallback to the `uuid` key. So when doing `$id['uuid'] ?? $id['id'] ?? null` it wouldn't fall back to `id` (the one that only contains the name instead of the ID when on the same parent, enhancement from https://github.com/getkirby/kirby/pull/4892), but just use the full ID added as fallback in the `uuid` entry.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Files field: store only filenames when UUIDs disabled and file belongs to the same page
#5084



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
