### PR TITLE
Filename sanitization: consider user language

### DIFF
--- a/src/Filesystem/Filename.php
+++ b/src/Filesystem/Filename.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Filesystem;
 
+use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Toolkit\Str;
 
 /**
@@ -29,19 +31,9 @@ use Kirby\Toolkit\Str;
 class Filename
 {
 	/**
-	 * List of all applicable attributes
-	 */
-	protected array $attributes;
-
-	/**
 	 * The sanitized file extension
 	 */
 	protected string $extension;
-
-	/**
-	 * The source original filename
-	 */
-	protected string $filename;
 
 	/**
 	 * The sanitized file name
@@ -49,23 +41,21 @@ class Filename
 	protected string $name;
 
 	/**
-	 * The template for the final name
-	 */
-	protected string $template;
-
-	/**
 	 * Creates a new Filename object
+	 *
+	 * @param string $template for the final name
+	 * @param array $attributes List of all applicable attributes
 	 */
-	public function __construct(string $filename, string $template, array $attributes = [])
-	{
-		$this->filename   = $filename;
-		$this->template   = $template;
-		$this->attributes = $attributes;
-		$this->extension  = $this->sanitizeExtension(
+	public function __construct(
+		protected string $filename,
+		protected string $template,
+		protected array $attributes = []
+	) {
+		$this->name      = $this->sanitizeName($filename);
+		$this->extension = $this->sanitizeExtension(
 			$attributes['format'] ??
 			pathinfo($filename, PATHINFO_EXTENSION)
 		);
-		$this->name       = $this->sanitizeName($filename);
 	}
 
 	/**
@@ -242,7 +232,24 @@ class Filename
 	 */
 	protected function sanitizeName(string $name): string
 	{
-		return F::safeBasename($name);
+		// temporarily store language rules
+		$rules = Str::$language;
+		$kirby = App::instance(null, true);
+
+		// if current user, add rules for their language to `Str` class
+		if ($user = $kirby?->user()) {
+			Str::$language = [
+				...Str::$language,
+				...Language::loadRules($user->language())];
+		}
+
+		// sanitize name
+		$name = F::safeBasename($this->filename);
+
+		// restore language rules
+		Str::$language = $rules;
+
+		return $name;
 	}
 
 	/**

--- a/tests/Filesystem/FilenameTest.php
+++ b/tests/Filesystem/FilenameTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Filesystem;
 
+use Kirby\Cms\App;
 use Kirby\TestCase as TestCase;
 
 /**
@@ -304,6 +305,23 @@ class FilenameTest extends TestCase
 	{
 		$name = new Filename('/var/www/söme file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file', $name->name());
+	}
+
+	/**
+	 * @covers ::name
+	 */
+	public function testNameSanitizationUserLanguageRules()
+	{
+		$app = new App([
+			'users' => [
+				['email' => 'test@getkirby.com', 'language' => 'ko']
+			]
+		]);
+
+		$app->impersonate('test@getkirby.com');
+
+		$name = new Filename('/var/www/안녕하세요.pdf', '{{ name }}.{{ extension }}');
+		$this->assertSame('annyeonghaseyo', $name->name());
 	}
 
 	public static function qualityOptionProvider(): array


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Filesystem\Filename::sanitizeName()` considers the current user language for filename sanitization


### Reasoning
The assumption is that a file name might be in the same language as the user is using the Panel with. Avoids more cases where just the ASCII rules would leave an empty string (e.g. with filenames such as `안녕하세요.pdf`).


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement
- Filename sanitization considers user language for better results
#4972

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
