### PR TITLE
ChangeUrl dialog: include language URL in path

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -194,11 +194,22 @@ return [
 	'page.changeTitle' => [
 		'pattern' => 'pages/(:any)/changeTitle',
 		'load' => function (string $id) {
-			$request = App::instance()->request();
+			$kirby   = App::instance();
+			$request = $kirby->request();
 
 			$page        = Find::page($id);
 			$permissions = $page->permissions();
 			$select      = $request->get('select', 'title');
+
+			// build the path prefix
+			$path = match ($kirby->multilang()) {
+				true  => Str::after($kirby->site()->url(), $kirby->url()) . '/',
+				false => '/'
+			};
+
+			if ($parent = $page->parent()) {
+				$path .= $parent->uri() . '/';
+			}
 
 			return [
 				'component' => 'k-form-dialog',
@@ -212,7 +223,7 @@ return [
 						'slug' => Field::slug([
 							'required'  => true,
 							'preselect' => $select === 'slug',
-							'path'      => $page->parent() ? '/' . $page->parent()->uri() . '/' : '/',
+							'path'      => $path,
 							'disabled'  => $permissions->can('changeSlug') === false,
 							'wizard'    => [
 								'text'  => I18n::translate('page.changeSlug.fromTitle'),


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Change URL dialog: in multilang, show the language URL segment as part of the path preview


### Reasoning
Makes it easier to understand what slug you're currently editing (pre-PR the dialog looks the same whether you're editing the main language/actual slug or just a translation)

### Additional context
- I'd suggest to ignore the code coverage warning as this doesn't really change anything in this regard. And I'd love to wait for moving dialogs to UI classes before adding unit tests.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Change URL dialog: in multilang, show the language segment as part of the path preview
#6600


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
