### PR TITLE
`k-table`: fix sortable rows

### DIFF
--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -64,11 +64,16 @@
 
 				<!-- Rows -->
 				<template v-else>
-					<tr v-for="(row, rowIndex) in values" :key="rowIndex">
+					<tr
+						v-for="(row, rowIndex) in values"
+						:key="rowIndex"
+						:class="{
+							'k-table-sortable-row': sortable && row.sortable !== false
+						}"
+					>
 						<!-- Index & drag handle -->
 						<td
 							v-if="hasIndexColumn"
-							:data-sortable="sortable && row.sortable !== false"
 							data-mobile="true"
 							class="k-table-index-column"
 						>
@@ -242,6 +247,7 @@ export default {
 		dragOptions() {
 			return {
 				disabled: !this.sortable,
+				draggable: ".k-table-sortable-row",
 				fallbackClass: "k-table-row-fallback",
 				ghostClass: "k-table-row-ghost"
 			};
@@ -491,10 +497,10 @@ export default {
 	--button-width: 100%;
 	display: none;
 }
-.k-table tr:hover .k-table-index-column[data-sortable="true"] .k-table-index {
+.k-table tr.k-table-sortable-row:hover .k-table-index-column .k-table-index {
 	display: none;
 }
-.k-table tr:hover .k-table-index-column[data-sortable="true"] .k-sort-handle {
+.k-table tr.k-table-sortable-row:hover .k-table-index-column .k-sort-handle {
 	display: flex;
 }
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Table sections: Only allow sorting rows that are sortable.
- Previously, the rows itself weren't sortable as the sort handle was hidden, but other sortable rows could be moved above/below/in-between unsortable rows.
- This PR aligns the behavior/code with how it's done for the other layouts (with `k-items`)


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Sections with table layout: fixed some issues with sorting rows that should be unsortable


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
