### PR TITLE
User view: always show prev-next

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -666,7 +666,7 @@ class User extends ModelWithContent
 	 */
 	protected function siblingsCollection(): Users
 	{
-		return $this->kirby()->users();
+		return $this->kirby()->users()->sortBy('username', 'asc');
 	}
 
 	/**

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -223,7 +223,7 @@ class User extends Model
 
 		return array_merge(
 			parent::props(),
-			$account ? [] : $this->prevNext(),
+			$this->prevNext(),
 			[
 				'blueprint' => $this->model->role()->name(),
 				'model' => [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Prev/next arrows are shown on any user view, also the account view
- `$user->next()`, `$user->prev()` are based on a siblings collection that now is sorted by username (not id)


### Reasoning
- Current state has been too confusing. Maybe the new solution isn't the best one can imagine, but I'd argue better and a lot less confusing.
- Prev/next arrows should move through the same list as shown on users view. That's why the sorting needs to be added to `User::siblingsCollection()` too.


### Additional context
- I think we can improve this a lot more easily once we have view UI classes. That will allow us e.g. to have specific routes for the user view but when filtered by a specific role, where the prev-next arrows could then loop only through the users with that role.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- User view: show prev/next buttons also on account view

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
