### PR TITLE
File upload: use preview options

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -23,7 +23,11 @@ return [
 				$uploads = [];
 			}
 
-			$uploads['accept'] = '*';
+			$uploads['accept']  = '*';
+
+			if ($preview = $this->image) {
+				$uploads['preview'] = $preview;
+			}
 
 			if ($template = $uploads['template'] ?? null) {
 				// get parent object for upload target

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -194,6 +194,7 @@ return [
 				'multiple'   => $multiple,
 				'max'        => $max,
 				'api'        => $this->parent->apiUrl(true) . '/files',
+				'preview'    => $this->image,
 				'attributes' => [
 					// TODO: an edge issue that needs to be solved:
 					//		 if multiple users load the same section

--- a/panel/lab/components/dialogs/5_upload/index.vue
+++ b/panel/lab/components/dialogs/5_upload/index.vue
@@ -5,6 +5,11 @@
 				Open
 			</k-button>
 		</k-lab-example>
+		<k-lab-example :flex="true" label="Custom Preview">
+			<k-button icon="open" variant="filled" @click="openCustomPreview">
+				Open
+			</k-button>
+		</k-lab-example>
 		<k-lab-example :flex="true" label="Upload error">
 			<k-button icon="open" variant="filled" @click="openUploadError">
 				Open
@@ -16,6 +21,38 @@
 <script>
 export default {
 	methods: {
+		openCustomPreview() {
+			this.$panel.upload.open();
+			this.$panel.upload.files = [
+				{
+					back: "red",
+					cover: false,
+					name: "test-0",
+					extension: "jpg",
+					url: "https://picsum.photos/600/850",
+					type: "image/jpeg",
+					niceSize: "80kb"
+				},
+				{
+					back: "orange",
+					cover: false,
+					name: "test-1",
+					extension: "jpg",
+					niceSize: "80kb",
+					url: "https://picsum.photos/850/600",
+					type: "image/jpeg"
+				},
+				{
+					back: "green",
+					cover: false,
+					name: "test-2",
+					extension: "jpg",
+					niceSize: "80kb",
+					url: "https://picsum.photos/400/850",
+					type: "image/jpeg"
+				}
+			];
+		},
 		openEmpty() {
 			this.$panel.upload.reset();
 			this.$panel.upload.open();
@@ -28,7 +65,7 @@ export default {
 					extension: "jpg",
 					url: "https://picsum.photos/600/850",
 					type: "image/jpeg",
-					niceSize: "80kb",
+					niceSize: "80kb"
 				},
 				{
 					name: "test-1",
@@ -37,7 +74,7 @@ export default {
 					url: "https://picsum.photos/600/850",
 					type: "image/jpeg",
 					error:
-						"Thisisaverylongerrormessagethatcouldbreakthelayoutoftheuploaderandmaybeevenshouldbecauseotherwisewedon'tseeit.",
+						"Thisisaverylongerrormessagethatcouldbreakthelayoutoftheuploaderandmaybeevenshouldbecauseotherwisewedon'tseeit."
 				},
 				{
 					name: "test-2",
@@ -46,10 +83,10 @@ export default {
 					url: "https://picsum.photos/600/850",
 					type: "image/jpeg",
 					error:
-						"This one should wrap proplery because it has some spaces and isn't completely bonkers",
-				},
+						"This one should wrap proplery because it has some spaces and isn't completely bonkers"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/lab/components/uploads/2_upload-item/index.vue
+++ b/panel/lab/components/uploads/2_upload-item/index.vue
@@ -11,6 +11,19 @@
 				@rename="rename"
 			/>
 		</k-lab-example>
+		<k-lab-example label="Upload Item with custom preview settings">
+			<k-upload-item
+				:cover="false"
+				back="gray-400"
+				extension="jpeg"
+				type="image/jpeg"
+				name="test"
+				niceSize="128 kB"
+				url="https://picsum.photos/100/300"
+				@remove="remove"
+				@rename="rename"
+			/>
+		</k-lab-example>
 		<k-lab-example label="Progress">
 			<k-upload-item
 				:progress="80"

--- a/panel/lab/components/uploads/3_upload-item-preview/index.vue
+++ b/panel/lab/components/uploads/3_upload-item-preview/index.vue
@@ -1,9 +1,24 @@
 <template>
 	<k-lab-examples>
-		<k-lab-example label="Image with preview">
+		<k-lab-example label="Image">
 			<k-upload-item-preview
 				type="image/jpeg"
-				url="https://picsum.photos/200/200"
+				url="https://picsum.photos/100/200"
+			/>
+		</k-lab-example>
+		<k-lab-example label="Image & cover: false">
+			<k-upload-item-preview
+				:cover="false"
+				type="image/jpeg"
+				url="https://picsum.photos/100/200"
+			/>
+		</k-lab-example>
+		<k-lab-example label="Image & cover: false & back: white">
+			<k-upload-item-preview
+				back="white"
+				:cover="false"
+				type="image/jpeg"
+				url="https://picsum.photos/100/200"
 			/>
 		</k-lab-example>
 		<k-lab-example label="Image without preview">

--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -41,6 +41,7 @@ export default {
 				accept: this.uploads.accept,
 				max: this.max,
 				multiple: this.multiple,
+				preview: this.uploads.preview,
 				url: this.$panel.urls.api + "/" + this.endpoints.field + "/upload",
 				on: {
 					done: (files) => {

--- a/panel/src/components/Uploads/UploadItem.vue
+++ b/panel/src/components/Uploads/UploadItem.vue
@@ -1,6 +1,7 @@
 <template>
 	<li :data-completed="completed" class="k-upload-item">
 		<k-upload-item-preview
+			v-bind="$panel.upload.preview"
 			:color="color"
 			:icon="icon"
 			:type="type"

--- a/panel/src/components/Uploads/UploadItem.vue
+++ b/panel/src/components/Uploads/UploadItem.vue
@@ -1,8 +1,9 @@
 <template>
 	<li :data-completed="completed" class="k-upload-item">
 		<k-upload-item-preview
-			v-bind="$panel.upload.preview"
+			:back="back"
 			:color="color"
+			:cover="cover"
 			:icon="icon"
 			:type="type"
 			:url="url"

--- a/panel/src/components/Uploads/UploadItemPreview.vue
+++ b/panel/src/components/Uploads/UploadItemPreview.vue
@@ -1,11 +1,16 @@
 <template>
 	<a :href="url" class="k-upload-item-preview" target="_blank">
-		<k-image v-if="isPreviewable" :cover="true" :src="url" back="pattern" />
+		<k-image
+			v-if="isPreviewable"
+			:cover="cover"
+			:src="url"
+			:back="back ?? 'pattern'"
+		/>
 		<k-icon-frame
 			v-else
 			:color="color ?? fallbackColor"
 			:icon="icon ?? fallbackIcon"
-			back="black"
+			:back="back ?? 'black'"
 			ratio="1/1"
 		/>
 	</a>
@@ -15,9 +20,17 @@
 export const props = {
 	props: {
 		/**
+		 * Preview back color
+		 */
+		back: String,
+		/**
 		 * Preview icon color
 		 */
 		color: String,
+		cover: {
+			type: Boolean,
+			default: true
+		},
 		/**
 		 * Preview icon type
 		 */

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -106,6 +106,7 @@ export default (panel) => {
 			const url = URL.createObjectURL(file);
 
 			return {
+				...this.preview,
 				completed: false,
 				error: null,
 				extension: extension(file.name),

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -12,6 +12,7 @@ export const defaults = () => {
 		files: [],
 		max: null,
 		multiple: true,
+		preview: {},
 		replacing: null,
 		url: null
 	};
@@ -137,6 +138,9 @@ export default (panel) => {
 
 			const dialog = {
 				component: "k-upload-dialog",
+				props: {
+					preview: this.preview
+				},
 				on: {
 					cancel: () => this.cancel(),
 					submit: async () => {
@@ -147,10 +151,10 @@ export default (panel) => {
 				}
 			};
 
-			// when replacing a file, use decdicated dialog component
+			// when replacing a file, use dedicated dialog component
 			if (this.replacing) {
 				dialog.component = "k-upload-replace-dialog";
-				dialog.props = { original: this.replacing };
+				dialog.props.original = this.replacing;
 			}
 
 			panel.dialog.open(dialog);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Upload item preview supports `back` and `cover` props
- New `$panel.upload.preview` object that can hold defaults for the upload item preview component
- Files field and files section pass their `image` options to `$panel.upload.preview`


### Reasoning
- Likely, the options that one uses to make the preview in the field/section better also make the preview in the upload dialog better, as they consider what kind of files are likely uploaded (e.g. black SVG might want to use a colored background)


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements:
- File uploads: preview uses `image` options from field/section
#5729


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
