### PR TITLE
Fix user `create` & `changeRole` permissions/options handling in Panel UI

### DIFF
--- a/config/api/routes/roles.php
+++ b/config/api/routes/roles.php
@@ -8,13 +8,9 @@ return [
 		'pattern' => 'roles',
 		'method'  => 'GET',
 		'action'  => function () {
-			$kirby = $this->kirby();
-
-			return match ($kirby->request()->get('canBe')) {
-				'changed' => $kirby->roles()->canBeChanged(),
-				'created' => $kirby->roles()->canBeCreated(),
-				default   => $kirby->roles()
-			};
+			$kirby   = $this->kirby();
+			$context = $kirby->request()->get('canBe');
+			return $kirby->roles($context);
 		}
 	],
 	[

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -21,9 +21,14 @@ return [
 		'load' => function () {
 			$kirby = App::instance();
 
+			// get role field definition, incl available role options
+			$roles = Field::role(context: 'create', props: [
+				'required' => true
+			]);
+
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
-				$role = $kirby->roles()->find($role)?->id();
+				$role = $kirby->roles()->canBeCreated()->find($role)?->id();
 			}
 
 			return [
@@ -39,9 +44,7 @@ return [
 						'translation'  => Field::translation([
 							'required' => true
 						]),
-						'role' => Field::role(props: [
-							'required' => true
-						])
+						'role' => $roles
 					],
 					'submitButton' => I18n::translate('create'),
 					'value' => [
@@ -49,7 +52,7 @@ return [
 						'email'       => '',
 						'password'    => '',
 						'translation' => $kirby->panelLanguage(),
-						'role'        => $role ?? $kirby->user()->role()->name()
+						'role'        => $role ?? $roles['options'][0]['value'] ?? null
 					]
 				]
 			];
@@ -228,7 +231,7 @@ return [
 				'component' => 'k-form-dialog',
 				'props' => [
 					'fields' => [
-						'role' => Field::role($user, [
+						'role' => Field::role($user, 'change', [
 							'label'    => I18n::translate('user.changeRole.select'),
 							'required' => true,
 						])

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -20,16 +20,15 @@ return [
 		'pattern' => 'users/create',
 		'load' => function () {
 			$kirby = App::instance();
-
-			// get role field definition, incl available role options
-			$roles = Field::role(context: 'create', props: [
-				'required' => true
-			]);
+			$roles = $kirby->roles('create');
 
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
-				$role = $kirby->roles('create')->find($role)?->id();
+				$role = $roles->find($role)?->id();
 			}
+
+			// get role field definition, incl available role options
+			$roles = Field::role(['required' => true], $roles);
 
 			return [
 				'component' => 'k-form-dialog',
@@ -231,10 +230,10 @@ return [
 				'component' => 'k-form-dialog',
 				'props' => [
 					'fields' => [
-						'role' => Field::role($user, 'change', [
+						'role' => Field::role([
 							'label'    => I18n::translate('user.changeRole.select'),
 							'required' => true,
-						])
+						], $user->roles('change'))
 					],
 					'submitButton' => I18n::translate('user.changeRole'),
 					'value' => [

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -28,7 +28,7 @@ return [
 
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
-				$role = $kirby->roles()->canBeCreated()->find($role)?->id();
+				$role = $kirby->roles('create')->find($role)?->id();
 			}
 
 			return [

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -39,7 +39,7 @@ return [
 						'translation'  => Field::translation([
 							'required' => true
 						]),
-						'role' => Field::role([
+						'role' => Field::role(props: [
 							'required' => true
 						])
 					],
@@ -228,7 +228,7 @@ return [
 				'component' => 'k-form-dialog',
 				'props' => [
 					'fields' => [
-						'role' => Field::role([
+						'role' => Field::role($user, [
 							'label'    => I18n::translate('user.changeRole.select'),
 							'required' => true,
 						])

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1302,9 +1302,19 @@ class App
 	/**
 	 * Returns all user roles
 	 */
-	public function roles(): Roles
+	public function roles(string|null $context = null): Roles
 	{
-		return $this->roles ??= Roles::load($this->root('roles'));
+		$roles = $this->roles ??= Roles::load($this->root('roles'));
+
+		// filter roles based on the context
+		// as user options can restrict these further
+		$roles = match ($context) {
+			'create' => $roles->canBeCreated(),
+			'change' => $roles->canBeChanged(),
+			default  => $roles
+		};
+
+		return $roles;
 	}
 
 	/**

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -33,7 +33,7 @@ class Roles extends Collection
 	 */
 	public function canBeChanged(): static
 	{
-		if (App::instance()->user()) {
+		if (App::instance()->user()?->isAdmin() !== true) {
 			return $this->filter(function ($role) {
 				$newUser = new User([
 					'email' => 'test@getkirby.com',
@@ -57,7 +57,7 @@ class Roles extends Collection
 	 */
 	public function canBeCreated(): static
 	{
-		if (App::instance()->user()) {
+		if (App::instance()->user()?->isAdmin() !== true) {
 			return $this->filter(function ($role) {
 				$newUser = new User([
 					'email' => 'test@getkirby.com',

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -574,33 +574,27 @@ class User extends ModelWithContent
 	}
 
 	/**
-	 * Returns all available roles
-	 * for this user, that can be selected
-	 * by the authenticated user
+	 * Returns all available roles for this user,
+	 * that can be selected by the authenticated user
 	 */
 	public function roles(): Roles
 	{
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
-		// a collection with just the one role of the user
-		$myRole = $roles->filter('id', $this->role()->id());
-
-		// if there's an authenticated user …
-		// admin users can select pretty much any role
-		if ($kirby->user()?->isAdmin() === true) {
-			// except if the user is the last admin
-			if ($this->isLastAdmin() === true) {
-				// in which case they have to stay admin
-				return $myRole;
-			}
-
-			// return all roles for mighty admins
-			return $roles;
+		// for the last admin, only their current role (admin) is available
+		if ($this->isLastAdmin() === true) {
+			// a collection with just the one role of the user
+			return $roles->filter('id', $this->role()->id());
 		}
 
-		// any other user can only keep their role
-		return $myRole;
+		// exclude the admin role, if the user
+		// is not allowed to change role to admin
+		if ($kirby->user()?->isAdmin() !== true) {
+			$roles = $roles->filter(fn ($role) => $role->name() !== 'admin');
+		}
+
+		return $roles;
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -577,10 +577,10 @@ class User extends ModelWithContent
 	 * Returns all available roles for this user,
 	 * that can be selected by the authenticated user
 	 */
-	public function roles(): Roles
+	public function roles(string|null $context = null): Roles
 	{
 		$kirby = $this->kirby();
-		$roles = $kirby->roles();
+		$roles = $kirby->roles($context);
 
 		// for the last admin, only their current role (admin) is available
 		if ($this->isLastAdmin() === true) {

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -26,6 +26,19 @@ class UserPermissions extends ModelPermissions
 
 	protected function canChangeRole(): bool
 	{
+		// protect admin from role changes by non-admin
+		if (
+			$this->model->isAdmin() === true &&
+			$this->user?->isAdmin() !== true
+		) {
+			return false;
+		}
+
+		// prevent demoting the last admin
+		if ($this->model->isLastAdmin() === true) {
+			return false;
+		}
+
 		return $this->model->roles()->count() > 1;
 	}
 

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -39,7 +39,7 @@ class UserPermissions extends ModelPermissions
 			return false;
 		}
 
-		return $this->model->roles()->count() > 1;
+		return true;
 	}
 
 	protected function canCreate(): bool

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -128,7 +128,7 @@ class UserRules
 		}
 
 		// prevent changing to role that is not available for user
-		if ($user->roles()->canBeChanged()->find($role) instanceof Role === false) {
+		if ($user->roles('change')->find($role) instanceof Role === false) {
 			throw new InvalidArgumentException([
 				'key' => 'user.role.invalid',
 			]);
@@ -210,7 +210,7 @@ class UserRules
 		// prevent creating a role that is not available for user
 		if (
 			in_array($role, [null, 'default', 'nobody'], true) === false &&
-			$user->kirby()->roles()->canBeCreated()->find($role) instanceof Role === false
+			$user->kirby()->roles('create')->find($role) instanceof Role === false
 		) {
 			throw new InvalidArgumentException([
 				'key' => 'user.role.invalid',

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
+use Kirby\Cms\Roles;
 use Kirby\Cms\User;
 use Kirby\Form\Form;
 use Kirby\Http\Router;
@@ -193,17 +194,15 @@ class Field
 	 * User role radio buttons
 	 */
 	public static function role(
-		User|null $user = null,
-		string|null $context = null,
-		array $props = []
+		array $props = [],
+		Roles|null $roles = null
 	): array {
 		$kirby = App::instance();
-		$roles = $user?->roles($context);
 
 		// if this role field is not for any specific user (but e.g. a new one),
 		// get all roles but filter out the admin role
 		// if the current user is no admin
-		$roles ??= $kirby->roles($context)->filter(
+		$roles ??= $kirby->roles()->filter(
 			fn ($role) =>
 				$role->name() !== 'admin' ||
 				$kirby->user()?->isAdmin() === true

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -198,24 +198,16 @@ class Field
 		array $props = []
 	): array {
 		$kirby = App::instance();
-		$roles = $user?->roles();
+		$roles = $user?->roles($context);
 
 		// if this role field is not for any specific user (but e.g. a new one),
 		// get all roles but filter out the admin role
 		// if the current user is no admin
-		$roles ??= $kirby->roles()->filter(
+		$roles ??= $kirby->roles($context)->filter(
 			fn ($role) =>
 				$role->name() !== 'admin' ||
 				$kirby->user()?->isAdmin() === true
 		);
-
-		// filter roles based on the context
-		// as user options can restrict these further
-		$roles = match ($context) {
-			'create' => $roles->canBeCreated(),
-			'change' => $roles->canBeChanged(),
-			null     => $roles
-		};
 
 		$roles = $roles->values(fn ($role) => [
 			'text'  => $role->title(),

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
+use Kirby\Cms\User;
 use Kirby\Form\Form;
 use Kirby\Http\Router;
 use Kirby\Toolkit\I18n;
@@ -191,30 +192,30 @@ class Field
 	/**
 	 * User role radio buttons
 	 */
-	public static function role(array $props = []): array
-	{
-		$kirby   = App::instance();
-		$isAdmin = $kirby->user()?->isAdmin() ?? false;
-		$roles   = [];
+	public static function role(
+		User|null $user = null,
+		array $props = []
+	): array {
+		$kirby = App::instance();
+		$roles = $user?->roles();
 
-		foreach ($kirby->roles() as $role) {
-			// exclude the admin role, if the user
-			// is not allowed to change role to admin
-			if ($role->name() === 'admin' && $isAdmin === false) {
-				continue;
-			}
+		// if this role field is not for any specific user (but e.g. a new one),
+		// get all roles but filter out the admin role
+		// if the current user is no admin
+		$roles ??= $kirby->roles()->filter(
+			fn ($role) => $role->name() !== 'admin' || $kirby->user()?->isAdmin() === true
+		);
 
-			$roles[] = [
-				'text'  => $role->title(),
-				'info'  => $role->description() ?? I18n::translate('role.description.placeholder'),
-				'value' => $role->name()
-			];
-		}
+		$roles = $roles->values(fn ($role) => [
+			'text'  => $role->title(),
+			'info'  => $role->description() ?? I18n::translate('role.description.placeholder'),
+			'value' => $role->name()
+		]);
 
 		return array_merge([
-			'label'    => I18n::translate('role'),
-			'type'     => count($roles) <= 1 ? 'hidden' : 'radio',
-			'options'  => $roles
+			'label'   => I18n::translate('role'),
+			'type'    => count($roles) <= 1 ? 'hidden' : 'radio',
+			'options' => $roles
 		], $props);
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -70,7 +70,7 @@ class User extends Model
 			'dialog'   => $url . '/changeRole',
 			'icon'     => 'bolt',
 			'text'     => I18n::translate('user.changeRole'),
-			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions)
+			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles('change')->count() < 2
 		];
 
 		$result[] = [

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -767,6 +767,72 @@ class AppTest extends TestCase
 		$this->assertInstanceOf(Roles::class, $app->roles());
 	}
 
+	/**
+	 * @covers ::roles
+	 */
+	public function testRolesInContext()
+	{
+		$app = new App([
+			'user'  => 'editor@getkirby.com',
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'blueprints' => [
+				'users/admin' => [
+					'name' => 'admin'
+				],
+				'users/editor' => [
+					'name' => 'editor'
+				],
+				'users/client' => [
+					'name' => 'client'
+				]
+			]
+		]);
+
+		$this->assertCount(3, $app->roles());
+		$this->assertCount(2, $app->roles('create'));
+		$this->assertCount(2, $app->roles('change'));
+
+		Blueprint::$loaded = [];
+
+		$app = new App([
+			'user'  => 'editor@getkirby.com',
+			'users' => [
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'blueprints' => [
+				'users/admin' => [
+					'name' => 'admin'
+				],
+				'users/editor' => [
+					'name' => 'editor'
+				],
+				'users/client' => [
+					'name'    => 'client',
+					'options' => [
+						'create' => [
+							'editor' => false
+						],
+						'changeRole' => [
+							'editor' => false
+						]
+					]
+				],
+			]
+		]);
+
+		$this->assertCount(3, $app->roles());
+		$this->assertCount(1, $app->roles('create'));
+		$this->assertCount(1, $app->roles('change'));
+	}
+
 	// TODO: debug is not working properly
 	// public function testEmail()
 	// {

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -123,7 +123,7 @@ class RolesTest extends TestCase
 	public function testCanBeChanged()
 	{
 		new App([
-			'user'  => 'admin@getkirby.com',
+			'user'  => 'editor@getkirby.com',
 			'users' => [
 				[
 					'email' => 'admin@getkirby.com',
@@ -143,6 +143,10 @@ class RolesTest extends TestCase
 					'name'  => 'editor',
 					'title' => 'Editor'
 				],
+				'users/client' => [
+					'name'  => 'client',
+					'title' => 'Client'
+				]
 			]
 		]);
 
@@ -150,14 +154,14 @@ class RolesTest extends TestCase
 		$canBeChanged = $roles->canBeChanged();
 
 		$this->assertInstanceOf(Roles::class, $roles);
-		$this->assertCount(2, $roles);
-		$this->assertCount(1, $canBeChanged);
+		$this->assertCount(3, $roles);
+		$this->assertCount(2, $canBeChanged);
 	}
 
 	public function testCanBeCreated()
 	{
 		new App([
-			'user'  => 'admin@getkirby.com',
+			'user'  => 'editor@getkirby.com',
 			'users' => [
 				[
 					'email' => 'admin@getkirby.com',
@@ -185,6 +189,6 @@ class RolesTest extends TestCase
 
 		$this->assertInstanceOf(Roles::class, $roles);
 		$this->assertCount(2, $roles);
-		$this->assertCount(2, $canBeCreated);
+		$this->assertCount(1, $canBeCreated);
 	}
 }

--- a/tests/Cms/Users/UserActionsTest.php
+++ b/tests/Cms/Users/UserActionsTest.php
@@ -26,19 +26,15 @@ class UserActionsTest extends TestCase
 
 		$this->app = new App([
 			'roles' => [
-				[
-					'name' => 'admin'
-				],
-				[
-					'name' => 'editor'
-				]
+				['name' => 'admin'],
+				['name' => 'editor']
 			],
 			'roots' => [
 				'index'    => '/dev/null',
 				'accounts' => static::TMP . '/accounts',
 				'sessions' => static::TMP . '/sessions'
 			],
-			'user'  => 'admin@domain.com'
+			'user' => 'admin@domain.com'
 		]);
 	}
 

--- a/tests/Cms/Users/UserPermissionsTest.php
+++ b/tests/Cms/Users/UserPermissionsTest.php
@@ -222,7 +222,7 @@ class UserPermissionsTest extends TestCase
 		]);
 
 		$user = $app->user('editor@getkirby.com');
-		$this->assertFalse($user->permissions()->can('changeRole'));
+		$this->assertTrue($user->permissions()->can('changeRole'));
 
 		// change role if multiple roles are available
 		$app = new App([

--- a/tests/Cms/Users/UserRulesTest.php
+++ b/tests/Cms/Users/UserRulesTest.php
@@ -376,6 +376,53 @@ class UserRulesTest extends TestCase
 		]);
 	}
 
+	public function testCreateInvalidRole()
+	{
+		$app = $this->app()->clone([
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$app->impersonate('editor@getkirby.com');
+
+		$permissions = $this->createMock(UserPermissions::class);
+		$permissions->method('__call')->with('create')->willReturn(true);
+
+		$user = $this->createMock(User::class);
+		$user->method('kirby')->willReturn($app);
+		$user->method('permissions')->willReturn($permissions);
+		$user->method('id')->willReturn('test');
+		$user->method('email')->willReturn('test@getkirby.com');
+		$user->method('language')->willReturn('en');
+
+		// no role
+		$this->assertTrue(UserRules::create($user, [
+			'password' => 12345678
+		]));
+
+		// role: nobody
+		$this->assertTrue(UserRules::create($user, [
+			'password' => 12345678,
+			'role'     => 'nobody'
+		]));
+
+		// role: default
+		$this->assertTrue(UserRules::create($user, [
+			'password' => 12345678,
+			'role'     => 'default'
+		]));
+
+		// invalid role
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Please enter a valid role');
+
+		UserRules::create($user, [
+			'password' => 12345678,
+			'role'     => 'foo'
+		]);
+	}
+
 	public function testUpdate()
 	{
 		$app  = $this->appWithAdmin();

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -341,6 +341,49 @@ class UserTest extends TestCase
 		];
 	}
 
+	/**
+	 * @covers ::roles
+	 */
+	public function testRoles(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor'],
+				['name' => 'guest']
+			],
+			'users' => [
+				[
+					'email' => 'admin@getkirby.com',
+					'role'  => 'admin'
+				],
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+		]);
+
+		// last admin has only admin role as option
+		$user  = $app->user('admin@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['admin'], $roles);
+
+		// normal user should not have admin as option
+		$user  = $app->user('editor@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['editor', 'guest'], $roles);
+
+		// only if current user is admin, normal user can also have admin option
+		$app->impersonate('admin@getkirby.com');
+		$user  = $app->user('editor@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['admin', 'editor', 'guest'], $roles);
+	}
+
 	public function testSecret()
 	{
 		$app = new App([

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -245,6 +245,7 @@ class FieldTest extends TestCase
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',
+			'value'   => null,
 			'options' => [
 				[
 					'text'  => 'Admin',
@@ -271,6 +272,7 @@ class FieldTest extends TestCase
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',
+			'value'   => null,
 			'options' => [
 				[
 					'text'  => 'Admin',
@@ -298,6 +300,7 @@ class FieldTest extends TestCase
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',
+			'value'   => null,
 			'options' => [
 				[
 					'text'  => 'Editor',
@@ -319,7 +322,8 @@ class FieldTest extends TestCase
 		$field = Field::role($user);
 		$expected = [
 			'label'   => 'Role',
-			'type'    => 'hidden',
+			'type'    => 'radio',
+			'value'   => 'admin',
 			'options' => [
 				[
 					'text'  => 'Admin',

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -238,10 +238,10 @@ class FieldTest extends TestCase
 		]);
 
 
-		// pass user
+		// pass roles
 		$this->app->impersonate('admin@getkirby.com');
 		$user  = $this->app->user('editor@getkirby.com');
-		$field = Field::role($user);
+		$field = Field::role(roles: $user->roles());
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',
@@ -267,7 +267,7 @@ class FieldTest extends TestCase
 
 		$this->assertSame($expected, $field);
 
-		// pass no user
+		// pass no roles
 		$field = Field::role();
 		$expected = [
 			'label'   => 'Role',
@@ -294,7 +294,7 @@ class FieldTest extends TestCase
 
 		$this->assertSame($expected, $field);
 
-		// pass no user, but current user is not an admin
+		// pass no roles, but current user is not an admin
 		$this->app->impersonate('editor@getkirby.com');
 		$field = Field::role();
 		$expected = [
@@ -319,7 +319,7 @@ class FieldTest extends TestCase
 
 		// last admin
 		$user  = $this->app->user('admin@getkirby.com');
-		$field = Field::role($user);
+		$field = Field::role(roles: $user->roles());
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -219,78 +219,113 @@ class FieldTest extends TestCase
 	 */
 	public function testRole(): void
 	{
-		$field = Field::role();
-		$expected = [
-			'label'   => 'Role',
-			'type'    => 'hidden',
-			'options' => []
-		];
-
-		$this->assertSame($expected, $field);
-
-		// without authenticated user
 		$this->app = $this->app->clone([
-			'blueprints' => [
-				'users/admin'  => [
-					'name'        => 'admin',
-					'title'       => 'Admin',
-					'description' => 'Admin description'
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor'],
+				['name' => 'guest']
+			],
+			'users' => [
+				[
+					'email' => 'admin@getkirby.com',
+					'role'  => 'admin'
 				],
-				'users/editor' => [
-					'name'        => 'editor',
-					'title'       => 'Editor',
-					'description' => 'Editor description'
-				],
-				'users/client' => [
-					'name'  => 'client',
-					'title' => 'Client'
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
 				]
-			]
+			],
 		]);
 
-		$field = Field::role();
+
+		// pass user
+		$this->app->impersonate('admin@getkirby.com');
+		$user  = $this->app->user('editor@getkirby.com');
+		$field = Field::role($user);
 		$expected = [
 			'label'   => 'Role',
 			'type'    => 'radio',
 			'options' => [
 				[
-					'text' => 'Client',
-					'info' => 'No description',
-					'value' => 'client'
-				],
-				[
-					'text' => 'Editor',
-					'info' => 'Editor description',
-					'value' => 'editor'
-				],
-			]
-		];
-
-		$this->assertSame($expected, $field);
-
-		// with authenticated admin
-		$this->app->impersonate('kirby');
-
-		$field = Field::role();
-		$expected = [
-			'label'   => 'Role',
-			'type'    => 'radio',
-			'options' => [
-				[
-					'text' => 'Admin',
-					'info' => 'Admin description',
+					'text'  => 'Admin',
+					'info'  => 'No description',
 					'value' => 'admin'
 				],
 				[
-					'text' => 'Client',
-					'info' => 'No description',
-					'value' => 'client'
-				],
-				[
-					'text' => 'Editor',
-					'info' => 'Editor description',
+					'text'  => 'Editor',
+					'info'  => 'No description',
 					'value' => 'editor'
 				],
+				[
+					'text'  => 'Guest',
+					'info'  => 'No description',
+					'value' => 'guest'
+				]
+			]
+		];
+
+		$this->assertSame($expected, $field);
+
+		// pass no user
+		$field = Field::role();
+		$expected = [
+			'label'   => 'Role',
+			'type'    => 'radio',
+			'options' => [
+				[
+					'text'  => 'Admin',
+					'info'  => 'No description',
+					'value' => 'admin'
+				],
+				[
+					'text'  => 'Editor',
+					'info'  => 'No description',
+					'value' => 'editor'
+				],
+				[
+					'text'  => 'Guest',
+					'info'  => 'No description',
+					'value' => 'guest'
+				]
+			]
+		];
+
+		$this->assertSame($expected, $field);
+
+		// pass no user, but current user is not an admin
+		$this->app->impersonate('editor@getkirby.com');
+		$field = Field::role();
+		$expected = [
+			'label'   => 'Role',
+			'type'    => 'radio',
+			'options' => [
+				[
+					'text'  => 'Editor',
+					'info'  => 'No description',
+					'value' => 'editor'
+				],
+				[
+					'text'  => 'Guest',
+					'info'  => 'No description',
+					'value' => 'guest'
+				]
+			]
+		];
+
+		$this->assertSame($expected, $field);
+
+		// last admin
+		$user  = $this->app->user('admin@getkirby.com');
+		$field = Field::role($user);
+		$expected = [
+			'label'   => 'Role',
+			'type'    => 'hidden',
+			'options' => [
+				[
+					'text'  => 'Admin',
+					'info'  => 'No description',
+					'value' => 'admin'
+				]
 			]
 		];
 

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -275,7 +275,7 @@ class UserTest extends TestCase
 			'changeLanguage' => true,
 			'changeName'     => true,
 			'changePassword' => true,
-			'changeRole'     => false, // just one role
+			'changeRole'     => true,
 			'delete'         => true,
 			'update'         => true,
 		];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

⚠️ Trying to split this into smaller, more modular PRs.
- [x] https://github.com/getkirby/kirby/pull/6653
- [ ] https://github.com/getkirby/kirby/pull/6654
- [x] https://github.com/getkirby/kirby/pull/6655
- [x] https://github.com/getkirby/kirby/pull/6657
- [ ] https://github.com/getkirby/kirby/pull/6658
- [ ] https://github.com/getkirby/kirby/pull/6694

### Summary of changes
- `Cms\User::roles()`:
  - So far, this only handled admin vs. anybody else: admins would get all roles, everyone else just their own role. This is not what the method promises to return.
  - Changed it to return the actual list of available roles for any users.
  - Also checks permissions and user options: `User::roles($context)` and `App::roles($context)` which apply `->canBeChanged()` or `->canBeCreated()` accordingly to the context.
- Panel dialogs: `user.create` and `user.changeRole`
  - Pass `$roles` to `Panel\Field::role()` using the right `$context` to retrieve the roles depending on their action
  - Show a radio input, even if only one option is available (though to make it transparent what gets created)
- Resorted UserPermissions and UserRules
  - `UserPermssions::canChangeRole()` can be true even if only one role is available - as this isn't a permissions restriction. Instead this check is performed separately  where the UI needs it.


### Reasoning
The main issue of #5146 why the permission wasn't reflected in the UI, was `UserPermissions::canChangeRole` only checking if `User::roles()` returns more than one role. However, `User::roles()` would always only return the current role for non-admins. That's why the permission itself never was acknowledged. Fixing these now really relies on the permission.

Moreover, in the refactoring to Panel backend dialogs etc. it got lost to filter available roles further by applying `->canBeChanged()` or `->canBeCreated()`.


### Additional context
As `UserRules::changeRole()` was fully restrictive in place, this is no security fix - the permission was always fully enforced. Even more, the Panel UI was falsely more restrictive than it should've been based on the permissions.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Panel UI fixed for `create` and `changeRole` permission and user options
#5146

### Enhancements
- Role always shown when creating a new user, even if only one role available

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

- [ ] Consistent listing of `user.changeRole` AND `users.changeRole`


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
