### PR TITLE
`panel.upload`: emit `open` event

### DIFF
--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -143,6 +143,7 @@ export default (panel) => {
 					preview: this.preview
 				},
 				on: {
+					open: (dialog) => this.emit("open", dialog),
 					cancel: () => this.cancel(),
 					submit: async () => {
 						panel.dialog.isLoading = true;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Expose the dialog's `open` event to `panel.upload`


### Reasoning
E.g. to allow automatically submitting the dialog/upload once the files have been picked up(and subsequently the dialog has opened).
