### PR TITLE
Fix updating new language variables for secondary languages

### DIFF
--- a/config/areas/languages/dialogs.php
+++ b/config/areas/languages/dialogs.php
@@ -256,7 +256,7 @@ return [
 		},
 		'submit' => function (string $languageCode, string $translationKey) {
 			Find::language($languageCode)->variable($translationKey, true)->update(
-				App::instance()->request()->get('value')
+				App::instance()->request()->get('value', '')
 			);
 
 			return true;

--- a/src/Cms/LanguageVariable.php
+++ b/src/Cms/LanguageVariable.php
@@ -56,7 +56,7 @@ class LanguageVariable
 			throw new DuplicateException('The variable is part of the core translation and cannot be overwritten');
 		}
 
-		$translations[$key] = trim($value ?? '');
+		$translations[$key] = $value ?? '';
 
 		$language->update(['translations' => $translations]);
 
@@ -102,10 +102,10 @@ class LanguageVariable
 	/**
 	 * Sets a new value for the language variable
 	 */
-	public function update(string $value): static
+	public function update(string|null $value = null): static
 	{
-		$translations = $this->language->translations();
-		$translations[$this->key] = $value;
+		$translations             = $this->language->translations();
+		$translations[$this->key] = $value ?? '';
 
 		$language = $this->language->update(['translations' => $translations]);
 


### PR DESCRIPTION
## Description

If you try to edit (without any update, open dialog and try to submit) new language variables from secondary language, you'll get following error in dialog.


> Kirby\Cms\LanguageVariable::update(): Argument # 1 ($value) must be of type string, null given, called in \kirby\config\areas\languages\dialogs.php on line 258

### Fixes

- Fixed updating new language variables for secondary languages

### Breaking changes
None 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
