### PR TITLE
Email 3 - modernize `Body` class

### DIFF
--- a/src/Email/Address.php
+++ b/src/Email/Address.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Kirby\Email;
+
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\A;
+use Kirby\Toolkit\V;
+
+/**
+ * An email address with optional name
+ *
+ * @package   Kirby Email
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.0.0
+ */
+class Address
+{
+	public function __construct(
+		protected string $email,
+		public string|null $name = null
+	) {
+		if (V::email($email) === false) {
+			throw new InvalidArgumentException(sprintf('"%s" is not a valid email address', $email));
+		}
+	}
+
+	/**
+	 * Creates one or multiple address objects from a
+	 * User object, simple string or email-name key-value pairs
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException email address is invalid
+	 */
+	public static function factory(
+		Users|array|User|string $emails,
+		bool $multiple = false
+	): static|array {
+		// ensure we can iterate over $emails
+		if (is_iterable($emails) === false) {
+			$emails = A::wrap($emails);
+		}
+
+		$addresses = [];
+
+		foreach ($emails as $address => $name) {
+			$addresses[] = match (true) {
+				$name instanceof User => new static(
+					email: $name->email(),
+					name: $name->name()
+				),
+
+				is_string($address) => new static(
+					email: $address,
+					name: $name
+				),
+
+				default => new static(email: $name)
+			};
+		}
+
+		if ($multiple === false) {
+			return $addresses[0];
+		}
+
+		return $addresses;
+	}
+
+	/**
+	 * Returns the email address
+	 */
+	public function email(): string
+	{
+		return $this->email;
+	}
+
+	/**
+	 * Returns the name, if available
+	 */
+	public function name(): string|null
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Returns one or multiple addresses as array
+	 * where the emails are the keys and the names the values
+	 */
+	public static function resolve(array|Address $address): array
+	{
+		if (is_array($address) === true) {
+			return array_reduce(
+				$address,
+				fn ($result, $address) => [
+					...$result,
+					...static::resolve($address)
+				],
+				[]
+			);
+		}
+
+		return $address->toArray();
+	}
+
+	/**
+	 * Returns the address as array where the
+	 * email is the key and the name the value
+	 */
+	public function toArray(): array
+	{
+		return [$this->email() => $this->name()];
+	}
+}

--- a/src/Email/Attachment.php
+++ b/src/Email/Attachment.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kirby\Email;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Files;
+
+/**
+ * An email attachment
+ *
+ * @package   Kirby Email
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.0.0
+ */
+class Attachment
+{
+	public function __construct(
+		protected string $root
+	) {
+	}
+
+	/**
+	 * Creates an array fof attachment objects
+	 */
+	public static function factory(
+		Files|array|File|string $files
+	): static|array {
+		if (is_iterable($files) === false) {
+			return match (true) {
+				$files instanceof File => new static(root: $files->root()),
+				default                => new static(root: $files)
+			};
+		}
+
+		$attachments = [];
+
+		foreach ($files as $file) {
+			$attachments[] = static::factory($file);
+		}
+
+		return $attachments;
+	}
+
+	/**
+	 * Returns the absolute path to the attachment
+	 */
+	public function root(): string
+	{
+		return $this->root;
+	}
+}

--- a/src/Email/Body.php
+++ b/src/Email/Body.php
@@ -2,7 +2,9 @@
 
 namespace Kirby\Email;
 
-use Kirby\Toolkit\Properties;
+use Kirby\Cms\App;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 
 /**
  * Representation of a an Email body
@@ -17,29 +19,51 @@ use Kirby\Toolkit\Properties;
  */
 class Body
 {
-	protected string|null $html;
-	protected string|null $text;
-
-	/**
-	 * Email body constructor
-	 */
-	public function __construct(array $props = [])
-	{
-		$this->html = $props['html'] ?? null;
-		$this->text = $props['text'] ?? null;
+	public function __construct(
+		protected string|null $html = null,
+		protected string|null $text = null
+	) {
 	}
 
-	/**
-	 * Creates a new instance while
-	 * merging initial and new properties
-	 * @deprecated 4.0.0
-	 */
-	public function clone(array $props = []): static
-	{
-		return new static(array_merge_recursive([
-			'html' => $this->html,
-			'text' => $this->text
-		], $props));
+	public static function factory(
+		string|array|null $body = null,
+		string|null $template = null,
+		array $data = []
+	): static {
+		if ($body !== null) {
+			return match (true) {
+				is_string($body) => new static(text: $body),
+				is_array($body)  => new static(...$body),
+				default          => $body
+			};
+		}
+
+		if ($template !== null) {
+			$kirby = App::instance();
+
+			// check if html/text templates exist
+			$html = $kirby->template('emails/' . $template, 'html', 'text');
+			$text = $kirby->template('emails/' . $template, 'text', 'text');
+
+			if ($html->exists() === false && $text->exists() === false) {
+				throw new NotFoundException('The email template "' . $template . '" cannot be found');
+			}
+
+			if ($html->exists() === true) {
+				if ($text->exists() === true) {
+					return new static(
+						html: $html->render($data),
+						text: $text->render($data)
+					);
+				}
+
+				return new static(html: $html->render($data));
+			}
+
+			return new static(text: $text->render($data));
+		}
+
+		throw new InvalidArgumentException('Email requires either body or template');
 	}
 
 	/**
@@ -48,6 +72,15 @@ class Body
 	public function html(): string
 	{
 		return $this->html ?? '';
+	}
+
+	/**
+	 * Checks if body is HTML
+	 * @since 5.0.0
+	 */
+	public function isHtml(): bool
+	{
+		return empty($this->html()) === false;
 	}
 
 	/**

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -123,29 +123,6 @@ class Email
 	}
 
 	/**
-	 * Creates a new instance while
-	 * merging initial and new properties
-	 * @deprecated 4.0.0
-	 */
-	public function clone(array $props = []): static
-	{
-		return new static(array_merge_recursive([
-			'attachments'   => $this->attachments,
-			'bcc'			=> $this->bcc,
-			'beforeSend'    => $this->beforeSend,
-			'body'			=> $this->body->toArray(),
-			'cc'   			=> $this->cc,
-			'from'			=> $this->from,
-			'fromName'   	=> $this->fromName,
-			'replyTo' 		=> $this->replyTo,
-			'replyToName'	=> $this->replyToName,
-			'subject'   	=> $this->subject,
-			'to'   			=> $this->to,
-			'transport' 	=> $this->transport
-		], $props));
-	}
-
-	/**
 	 * Returns default transport settings
 	 */
 	protected function defaultTransport(): array

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -4,6 +4,7 @@ namespace Kirby\Email;
 
 use Closure;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\A;
 
 /**
  * Wrapper for email libraries
@@ -58,7 +59,7 @@ class Email
 		}
 
 
-		$this->attachments = $props['attachments'] ?? [];
+		$this->attachments = Attachment::factory($props['attachments'] ?? []);
 		$this->bcc         = Address::factory($props['bcc'] ?? [], multiple: true);
 		$this->beforeSend  = $props['beforeSend'] ?? null;
 		$this->body        = new Body($props['body']);
@@ -86,7 +87,10 @@ class Email
 	 */
 	public function attachments(): array
 	{
-		return $this->attachments;
+		return A::map(
+			$this->attachments,
+			fn ($attachment) => $attachment->root()
+		);
 	}
 
 	/**

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -62,7 +62,7 @@ class Email
 		$this->attachments = Attachment::factory($props['attachments'] ?? []);
 		$this->bcc         = Address::factory($props['bcc'] ?? [], multiple: true);
 		$this->beforeSend  = $props['beforeSend'] ?? null;
-		$this->body        = new Body($props['body']);
+		$this->body        = Body::factory($props['body']);
 		$this->cc          = Address::factory($props['cc'] ?? [], multiple: true);
 		$this->from        = Address::factory([$props['from'] => $props['fromName'] ?? null]);
 		$this->subject     = $props['subject'];

--- a/tests/Email/AddressTest.php
+++ b/tests/Email/AddressTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kirby\Email;
+
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Email\Address
+ * @covers ::__construct
+ */
+class AddressTest extends TestCase
+{
+	/**
+	 * @covers ::email
+	 */
+	public function testEmail(): void
+	{
+		$address = new Address(email: $email = 'homer@simpson.com');
+		$this->assertSame($email, $address->email());
+	}
+
+	/**
+	 * @covers ::email
+	 */
+	public function testEmailInvalid(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('"homer@" is not a valid email address');
+		new Address(email: 'homer@');
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactory(): void
+	{
+		$address = Address::factory($email = 'homer@simpson.com');
+		$this->assertSame($email, $address->email());
+
+		$address = Address::factory([$email => $name = 'Homer Simpson']);
+		$this->assertSame($email, $address->email());
+		$this->assertSame($name, $address->name());
+
+		$user    = new User(['email' => $email, 'name' => $name]);
+		$address = Address::factory($user);
+		$this->assertSame($email, $address->email());
+		$this->assertSame($name, $address->name());
+
+
+		$address = Address::factory([$email => $name = 'Homer Simpson'], true);
+		$this->assertSame($email, $address[0]->email());
+		$this->assertSame($name, $address[0]->name());
+
+		$address = Address::factory([$a = 'a@getkirby.com', $b = 'b@getkirby.com'], true);
+		$this->assertSame($a, $address[0]->email());
+		$this->assertSame($b, $address[1]->email());
+
+		$users = new Users([
+			new User(['email' => $a = 'ceo@company.com']),
+			new User(['email' => $b = 'marketing@company.com'])
+		]);
+		$address = Address::factory($users, true);
+		$this->assertSame($a, $address[0]->email());
+		$this->assertSame($b, $address[1]->email());
+	}
+
+	/**
+	 * @covers ::name
+	 */
+	public function testName(): void
+	{
+		$address = new Address(email: 'homer@simpson.com');
+		$this->assertNull($address->name());
+
+		$address = new Address(
+			email: 'homer@simpson.com',
+			name: $name = 'Homer Simpson'
+		);
+		$this->assertSame($name, $address->name());
+	}
+
+	/**
+	 * @covers ::resolve
+	 */
+	public function testResolve(): void
+	{
+		$address1 = new Address(email: 'homer@simpson.com');
+		$address2 = new Address(
+			email: 'lisa@simpson.com',
+			name: 'Lisa Simpson'
+		);
+
+
+		$this->assertSame(
+			['homer@simpson.com' => null],
+			Address::resolve($address1)
+		);
+		$this->assertSame(
+			[
+				'homer@simpson.com' => null,
+				'lisa@simpson.com'  => 'Lisa Simpson'
+			],
+			Address::resolve([$address1, $address2])
+		);
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray(): void
+	{
+		$address = new Address(email: 'homer@simpson.com');
+		$this->assertSame(
+			['homer@simpson.com' => null],
+			$address->toArray()
+		);
+
+		$address = new Address(
+			email: 'homer@simpson.com',
+			name: 'Homer Simpson'
+		);
+		$this->assertSame(
+			['homer@simpson.com' => 'Homer Simpson'],
+			$address->toArray()
+		);
+	}
+}

--- a/tests/Email/AttachmentTest.php
+++ b/tests/Email/AttachmentTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Kirby\Email;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Email\Attachment
+ * @covers ::__construct
+ */
+class AttachmentTest extends TestCase
+{
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactory(): void
+	{
+		$root = __DIR__ . '/fixtures/files/test.jpg';
+
+		$attachment = Attachment::factory($root);
+		$this->assertSame($root, $attachment->root());
+
+		$attachments = Attachment::factory([$root]);
+		$this->assertSame($root, $attachments[0]->root());
+
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'  => new Page(['slug' => 'test'])
+		]);
+		$attachment = Attachment::factory($file);
+		$this->assertSame('/dev/null/content/test/test.jpg', $attachment->root());
+
+		$files = new Files([
+			new File([
+				'filename' => 'test.jpg',
+				'parent'   => new Page(['slug' => 'test'])
+			]),
+			new File([
+				'filename' => 'foo.mp4',
+				'parent'   => new Page(['slug' => 'test'])
+			]),
+		]);
+
+		$attachments = Attachment::factory($files);
+		$this->assertSame('/dev/null/content/test/test.jpg', $attachments[0]->root());
+		$this->assertSame('/dev/null/content/test/foo.mp4', $attachments[1]->root());
+	}
+
+	/**
+	 * @covers ::root
+	 */
+	public function testRoot(): void
+	{
+		$attachment = new Attachment(
+			root: $root = __DIR__ . '/fixtures/files/test.jpg'
+		);
+		$this->assertSame($root, $attachment->root());
+	}
+}

--- a/tests/Email/BodyTest.php
+++ b/tests/Email/BodyTest.php
@@ -2,40 +2,177 @@
 
 namespace Kirby\Email;
 
+use Kirby\Cms\App;
+use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
+use Kirby\TestCase;
+
 /**
  * @coversDefaultClass \Kirby\Email\Body
+ * @covers ::__construct
  */
 class BodyTest extends TestCase
 {
-	public function testConstruct()
-	{
-		$body = new Body();
+	public const FIXTURES = __DIR__ . '/fixtures';
 
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactory(): void
+	{
+		$body = Body::factory($text = 'test');
+		$this->assertSame($text, $body->text());
 		$this->assertSame('', $body->html());
-		$this->assertSame('', $body->text());
+
+		$body = Body::factory([
+			'text' => $text,
+			'html' => $html = '<b>test</b>'
+		]);
+		$this->assertSame($text, $body->text());
+		$this->assertSame($html, $body->html());
 	}
 
-	public function testConstructParams()
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryTemplate(): void
 	{
-		$data = [
-			'html' => '<strong>We will never reply</strong>',
-			'text' => 'We will never reply'
-		];
-
-		$body = new Body($data);
-
-		$this->assertSame($data['html'], $body->html());
-		$this->assertSame($data['text'], $body->text());
-	}
-
-	public function testConstructNullParams()
-	{
-		$body = new Body([
-			'html' => null,
-			'text' => null
+		new App([
+			'templates' => [
+				'emails/contact' => static::FIXTURES . '/contact.php'
+			]
 		]);
 
-		$this->assertSame('', $body->html());
+		$body = Body::factory(null, 'contact', ['name' => 'Alex']);
+		$this->assertSame('Cheers, Alex!', $body->text());
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryTemplateHtml(): void
+	{
+		new App([
+			'templates' => [
+				'emails/media.html' => static::FIXTURES . '/media.html.php'
+			]
+		]);
+
+		$body = Body::factory(null, 'media');
+		$this->assertSame('<b>Image:</b> <img src=""/>', $body->html());
 		$this->assertSame('', $body->text());
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryTemplateHtmlText(): void
+	{
+		new App([
+			'templates' => [
+				'emails/media.html' => static::FIXTURES . '/media.html.php',
+				'emails/media.text' => static::FIXTURES . '/media.text.php',
+			]
+		]);
+
+		$body = Body::factory(null, 'media');
+		$this->assertSame('<b>Image:</b> <img src=""/>', $body->html());
+		$this->assertSame('Image: Description', $body->text());
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryTemplateData(): void
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'templates' => [
+				'emails/user-info' => static::FIXTURES . '/user-info.php'
+			]
+		]);
+
+		$user = new User([
+			'email' => 'ceo@company.com',
+			'name'  => 'Mario'
+		]);
+
+		$body = Body::factory(null, 'user-info', ['user' => $user]);
+		$this->assertSame('Welcome, Mario!', trim($body->text()));
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryTemplateInvalid(): void
+	{
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The email template "subscription" cannot be found');
+		Body::factory(null, 'subscription');
+	}
+
+	/**
+	 * @covers ::factory
+	 */
+	public function testFactoryInvalid(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Email requires either body or template');
+		Body::factory();
+	}
+
+	/**
+	 * @covers ::html
+	 */
+	public function testHtml(): void
+	{
+		$body = new Body();
+		$this->assertSame('', $body->html());
+
+		$body = new Body(html: $html = '<strong>Foo</strong>');
+		$this->assertSame($html, $body->html());
+	}
+
+	/**
+	 * @covers ::isHtml
+	 */
+	public function testIsHtml(): void
+	{
+		$body = new Body();
+		$this->assertFalse($body->isHtml());
+
+		$body = new Body(html: '<strong>Foo</strong>');
+		$this->assertTrue($body->isHtml());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testText(): void
+	{
+		$body = new Body();
+		$this->assertSame('', $body->text());
+
+		$body = new Body(text: $text = 'Foo');
+		$this->assertSame($text, $body->text());
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray(): void
+	{
+		$body = new Body(
+			text: 'test',
+			html: '<b>test</b>'
+		);
+
+		$this->assertSame([
+			'html' => '<b>test</b>',
+			'text' => 'test'
+		], $body->toArray());
 	}
 }

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -52,6 +52,37 @@ class EmailTest extends TestCase
 		$this->assertSame(['type' => 'mail'], $email->transport());
 	}
 
+	public function testToArray()
+	{
+		$email = $this->_email([
+			'from'    => $from = 'no-reply@supercompany.com',
+			'to'      => $to = 'someone@gmail.com',
+			'subject' => $subject = 'Thank you for your contact request',
+			'body'    => $body = 'We will never reply',
+		]);
+
+		$expected = [
+			'attachments' => [],
+			'bcc'         => [],
+			'body'        => [
+				'html' => '',
+				'text' => $body
+			],
+			'cc'          => [],
+			'from'        => $from,
+			'fromName'    => null,
+			'replyTo'     => '',
+			'replyToName' => null,
+			'subject'     => $subject,
+			'to'          => [$to => null],
+			'transport'   => [
+				'type' => 'mail'
+			]
+		];
+
+		$this->assertSame($expected, $email->toArray());
+	}
+
 	public function testRequiredProperty()
 	{
 		$this->expectException(Exception::class);

--- a/tests/Email/fixtures/contact.php
+++ b/tests/Email/fixtures/contact.php
@@ -1,0 +1,1 @@
+Cheers, <?= $name ?>!

--- a/tests/Email/fixtures/media.html.php
+++ b/tests/Email/fixtures/media.html.php
@@ -1,0 +1,1 @@
+<b>Image:</b> <img src=""/>

--- a/tests/Email/fixtures/media.text.php
+++ b/tests/Email/fixtures/media.text.php
@@ -1,0 +1,1 @@
+Image: Description

--- a/tests/Email/fixtures/user-info.php
+++ b/tests/Email/fixtures/user-info.php
@@ -1,0 +1,1 @@
+Welcome, <?= $user->name() ?>!


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [ ] https://github.com/getkirby/kirby/pull/6629
- [ ] https://github.com/getkirby/kirby/pull/6630

### Summary of changes
- Refactored `Email\Body` to use named arguments
- `Body::factory()` to support array props, but also loading templates


### Reasoning
- Loading templates should move from `Cms\Email` etc. into the body class



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes
- `Body\Email` now accepts named arguments instead of `$props` array. Removed `::toArray()` method.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
