### PR TITLE
Improve `$field->isEmpty()`

### DIFF
--- a/src/Content/Field.php
+++ b/src/Content/Field.php
@@ -124,9 +124,17 @@ class Field
 	 */
 	public function isEmpty(): bool
 	{
+		$value = $this->value;
+
+		if (is_string($value) === true) {
+			$value = trim($value);
+		}
+
 		return
-			empty($this->value) === true &&
-			in_array($this->value, [0, '0', false], true) === false;
+			$value === null ||
+			$value === '' ||
+			$value === [] ||
+			$value === '[]';
 	}
 
 	/**

--- a/tests/Content/FieldTest.php
+++ b/tests/Content/FieldTest.php
@@ -168,6 +168,11 @@ class FieldTest extends TestCase
 			['false', false],
 			[null, true],
 			['', true],
+			['   ', true],
+			['[]', true],
+			[[], true],
+			['[1]', false],
+			['["a"]', false],
 		];
 	}
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Removed `empty()` check from `$field->isEmpty()` as it checks for too many false positives
- Instead checking all relevant cases explicitly
- Will also consider `'[]'` as empty (Symfony parser stores empty arrays like that)
- WIll also consider empty strings (just spaces) as empty



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed `$field->isEmpty()` for some empty arrays
#6637


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
