### PR TITLE
PageCreateDialog: prevent tmp using actual page

### DIFF
--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -249,7 +249,7 @@ class PageCreateDialog
 	public function model(): Page
 	{
 		return $this->model ??= Page::factory([
-			'slug'     => 'new',
+			'slug'     => '__new__',
 			'template' => $this->template,
 			'model'    => $this->template,
 			'parent'   => $this->parent instanceof Page ? $this->parent : null
@@ -267,12 +267,7 @@ class PageCreateDialog
 
 		// create temporary page object
 		// to resolve the template strings
-		$page = new Page([
-			'slug'     => 'tmp',
-			'template' => $this->template,
-			'parent'   => $this->model(),
-			'content'  => $input
-		]);
+		$page = $this->model()->clone(['content' => $input]);
 
 		if (is_string($title)) {
 			$input['title'] = $page->toSafeString($title);

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -248,6 +248,7 @@ class PageCreateDialog
 	 */
 	public function model(): Page
 	{
+		// TODO: use actual in-memory page in v5
 		return $this->model ??= Page::factory([
 			'slug'     => '__new__',
 			'template' => $this->template,


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

@afbora Would appreciate your testing skills for this.

### Summary of changes
- Page create dialog's temporary page object would use actual page if called `new`
- Not a perfect solution (ideal will be real in-memory virtual pages), but a lot less likely for a real-world page `__new__`

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed issue where the page create dialog would use an existing page `new` instead just creating a temporary object
 #6640 



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
