### PR TITLE
`Obj::toKeys()`

### DIFF
--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -75,14 +75,6 @@ class Obj extends stdClass
 	}
 
 	/**
-	 *  Returns the property names as keys
-	 */
-	public function keys(): array
-	{
-		return array_keys((array)$this);
-	}
-
-	/**
 	 * Converts the object to an array
 	 */
 	public function toArray(): array
@@ -109,5 +101,13 @@ class Obj extends stdClass
 	public function toJson(...$arguments): string
 	{
 		return json_encode($this->toArray(), ...$arguments);
+	}
+
+	/**
+	 *  Returns the property names as keys
+	 */
+	public function toKeys(): array
+	{
+		return array_keys((array)$this);
 	}
 }

--- a/src/Toolkit/Obj.php
+++ b/src/Toolkit/Obj.php
@@ -75,6 +75,14 @@ class Obj extends stdClass
 	}
 
 	/**
+	 *  Returns the property names as keys
+	 */
+	public function keys(): array
+	{
+		return array_keys((array)$this);
+	}
+
+	/**
 	 * Converts the object to an array
 	 */
 	public function toArray(): array

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -63,18 +63,6 @@ class ObjTest extends TestCase
 	}
 
 	/**
-	 * @covers ::keys
-	 */
-	public function testKeys()
-	{
-		$obj = new Obj(['foo' => 'bar']);
-		$this->assertSame(['foo'], $obj->keys());
-
-		$obj = new Obj(['foo' => 'bar', 'one' => 'first']);
-		$this->assertSame(['foo', 'one'], $obj->keys());
-	}
-
-	/**
 	 * @covers ::toArray
 	 */
 	public function testToArray()
@@ -108,6 +96,18 @@ class ObjTest extends TestCase
 	{
 		$obj = new Obj($expected = ['foo' => 'bar']);
 		$this->assertSame(json_encode($expected), $obj->toJson());
+	}
+
+	/**
+	 * @covers ::toKeys
+	 */
+	public function testToKeys()
+	{
+		$obj = new Obj(['foo' => 'bar']);
+		$this->assertSame(['foo'], $obj->toKeys());
+
+		$obj = new Obj(['foo' => 'bar', 'one' => 'first']);
+		$this->assertSame(['foo', 'one'], $obj->toKeys());
 	}
 
 	/**

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -63,6 +63,18 @@ class ObjTest extends TestCase
 	}
 
 	/**
+	 * @covers ::keys
+	 */
+	public function testKeys()
+	{
+		$obj = new Obj(['foo' => 'bar']);
+		$this->assertSame(['foo'], $obj->keys());
+
+		$obj = new Obj(['foo' => 'bar', 'one' => 'first']);
+		$this->assertSame(['foo', 'one'], $obj->keys());
+	}
+
+	/**
 	 * @covers ::toArray
 	 */
 	public function testToArray()


### PR DESCRIPTION
https://forum.getkirby.com/t/db-record-object-how-to-get-in-record-objekt-all-present-keys-field-names/31995

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- New `Toolkit\Obj::toKeys()` method



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
