### PR TITLE
Fix `$user->roles($purpose)`

### DIFF
--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -203,7 +203,9 @@ return [
 			'users/(:any)/roles',
 		],
 		'action'  => function (string $id) {
-			return $this->user($id)->roles();
+			$kirby   = $this->kirby();
+			$purpose = $kirby->request()->get('purpose');
+			return $this->user($id)->roles($purpose);
 		}
 	],
 	[

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -574,33 +574,36 @@ class User extends ModelWithContent
 	}
 
 	/**
-	 * Returns all available roles
-	 * for this user, that can be selected
-	 * by the authenticated user
+	 * Returns all available roles for this user,
+	 * that can be selected by the authenticated user
+	 *
+	 * @param string|null $purpose User action for which the roles are used (create, change)
 	 */
-	public function roles(): Roles
+	public function roles(string|null $purpose = null): Roles
 	{
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
-		// a collection with just the one role of the user
-		$myRole = $roles->filter('id', $this->role()->id());
-
-		// if there's an authenticated user …
-		// admin users can select pretty much any role
-		if ($kirby->user()?->isAdmin() === true) {
-			// except if the user is the last admin
-			if ($this->isLastAdmin() === true) {
-				// in which case they have to stay admin
-				return $myRole;
-			}
-
-			// return all roles for mighty admins
-			return $roles;
+		// for the last admin, only their current role (admin) is available
+		if ($this->isLastAdmin() === true) {
+			// a collection with just the one role of the user
+			return $roles->filter('id', $this->role()->id());
 		}
 
-		// any other user can only keep their role
-		return $myRole;
+		// filter roles based on the user action
+		// as user permissions and/or options can restrict these further
+		$roles = match ($purpose) {
+			'create' => $roles->canBeCreated(),
+			'change' => $roles->canBeChanged(),
+			default  => $roles
+		};
+
+		// exclude the admin role, if the user isn't an admin themselves
+		if ($kirby->user()?->isAdmin() !== true) {
+			$roles = $roles->filter(fn ($role) => $role->name() !== 'admin');
+		}
+
+		return $roles;
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
-  `User::roles()` has a new optional `$purpose` parameter to pass a user action (`create` or `change`). If one is passed, the roles collection is filtered via `$roles->canBeChanged()`/`$roles->canBeCreated()` which checks if the current user has the permissions to apply the action to each role.
- `::roles()` doesn't return only the current role for non-admin users but all available roles


### Reasoning
Available roles depend on the context as they depend on whether the current user has permissions to e.g. create a user with a certain role or change the role to a certain role.

### Additional context
We need to pass the `$purpose` parameters, e.g. in user dialogs, in a subsequent PR.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
