### PR TITLE
`Panel\Field::role()` allow passing `$roles`

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -20,7 +20,7 @@ return [
 		'pattern' => 'users/create',
 		'load' => function () {
 			$kirby = App::instance();
-			$roles = $kirby->user()->roles('create');
+			$roles = $kirby->roles()->canBeCreated();
 
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
@@ -234,7 +234,7 @@ return [
 				'props' => [
 					'fields' => [
 						'role' => Field::role(
-							roles: $user->roles('changeRole'),
+							roles: $user->roles(),
 							props: [
 								'label'    => I18n::translate('user.changeRole.select'),
 								'required' => true,

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -20,11 +20,18 @@ return [
 		'pattern' => 'users/create',
 		'load' => function () {
 			$kirby = App::instance();
+			$roles = $kirby->roles();
 
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
-				$role = $kirby->roles()->find($role)?->id();
+				$role = $roles->find($role)?->id();
 			}
+
+			// get role field definition, incl. available role options
+			$roles = Field::role(
+				roles: $roles,
+				props: ['required' => true]
+			);
 
 			return [
 				'component' => 'k-form-dialog',
@@ -39,9 +46,7 @@ return [
 						'translation'  => Field::translation([
 							'required' => true
 						]),
-						'role' => Field::role([
-							'required' => true
-						])
+						'role' => $roles
 					],
 					'submitButton' => I18n::translate('create'),
 					'value' => [
@@ -49,7 +54,7 @@ return [
 						'email'       => '',
 						'password'    => '',
 						'translation' => $kirby->panelLanguage(),
-						'role'        => $role ?? $kirby->user()->role()->name()
+						'role'        => $role ?? $roles['options'][0]['value'] ?? null
 					]
 				]
 			];
@@ -228,10 +233,13 @@ return [
 				'component' => 'k-form-dialog',
 				'props' => [
 					'fields' => [
-						'role' => Field::role([
-							'label'    => I18n::translate('user.changeRole.select'),
-							'required' => true,
-						])
+						'role' => Field::role(
+							roles: App::instance()->roles(),
+							props: [
+								'label'    => I18n::translate('user.changeRole.select'),
+								'required' => true,
+							]
+						)
 					],
 					'submitButton' => I18n::translate('user.changeRole'),
 					'value' => [

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -20,7 +20,7 @@ return [
 		'pattern' => 'users/create',
 		'load' => function () {
 			$kirby = App::instance();
-			$roles = $kirby->roles();
+			$roles = $kirby->user()->roles('create');
 
 			// get default value for role
 			if ($role = $kirby->request()->get('role')) {
@@ -234,7 +234,7 @@ return [
 				'props' => [
 					'fields' => [
 						'role' => Field::role(
-							roles: App::instance()->roles(),
+							roles: $user->roles('change'),
 							props: [
 								'label'    => I18n::translate('user.changeRole.select'),
 								'required' => true,

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -234,7 +234,7 @@ return [
 				'props' => [
 					'fields' => [
 						'role' => Field::role(
-							roles: $user->roles('change'),
+							roles: $user->roles('changeRole'),
 							props: [
 								'label'    => I18n::translate('user.changeRole.select'),
 								'required' => true,

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -18,7 +18,8 @@ return [
 			return [
 				'component' => 'k-users-view',
 				'props'     => [
-					'role' => function () use ($kirby, $roles, $role) {
+					'canCreate' => $kirby->roles()->canBeCreated()->count() > 0,
+					'role' => function () use ($roles, $role) {
 						if ($role) {
 							return $roles[$role] ?? null;
 						}

--- a/panel/src/components/Views/Users/UserAvatar.vue
+++ b/panel/src/components/Views/Users/UserAvatar.vue
@@ -1,5 +1,10 @@
 <template>
-	<k-button :title="$t('avatar')" class="k-user-view-image" @click="open">
+	<k-button
+		:disabled="isLocked"
+		:title="$t('avatar')"
+		class="k-user-view-image"
+		@click="open"
+	>
 		<template v-if="model.avatar">
 			<k-image-frame :cover="true" :src="model.avatar" />
 			<k-dropdown-content
@@ -30,6 +35,7 @@
  */
 export default {
 	props: {
+		isLocked: Boolean,
 		model: Object
 	},
 	methods: {

--- a/panel/src/components/Views/Users/UserProfile.vue
+++ b/panel/src/components/Views/Users/UserProfile.vue
@@ -8,21 +8,21 @@
 					icon: 'email',
 					text: `${model.email}`,
 					title: `${$t('email')}: ${model.email}`,
-					disabled: !permissions.changeEmail || isLocked,
+					disabled: !canChangeEmail,
 					click: () => $dialog(model.link + '/changeEmail')
 				},
 				{
 					icon: 'bolt',
 					text: `${model.role}`,
 					title: `${$t('role')}: ${model.role}`,
-					disabled: !permissions.changeRole || isLocked,
+					disabled: !canChangeRole,
 					click: () => $dialog(model.link + '/changeRole')
 				},
 				{
 					icon: 'translate',
 					text: `${model.language}`,
 					title: `${$t('language')}: ${model.language}`,
-					disabled: !permissions.changeLanguage || isLocked,
+					disabled: !canChangeLanguage,
 					click: () => $dialog(model.link + '/changeLanguage')
 				}
 			]"
@@ -37,8 +37,14 @@
  */
 export default {
 	props: {
+		canChangeEmail: Boolean,
+		canChangeLanguage: Boolean,
+		canChangeRole: Boolean,
 		isLocked: Boolean,
 		model: Object,
+		/**
+		 * @deprecated Will be remove in v5
+		 */
 		permissions: Object
 	}
 };

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -11,7 +11,7 @@
 		</template>
 
 		<k-header
-			:editable="permissions.changeName && !isLocked"
+			:editable="canChangeName"
 			class="k-user-view-header"
 			@edit="$dialog(id + '/changeName')"
 		>
@@ -50,6 +50,10 @@
 		</k-header>
 
 		<k-user-profile
+			:can-change-email="canChangeEmail"
+			:can-change-language="canChangeLanguage"
+			:can-change-name="canChangeName"
+			:can-change-role="canChangeRole"
 			:is-locked="isLocked"
 			:model="model"
 			:permissions="permissions"
@@ -71,7 +75,13 @@
 import ModelView from "../ModelView.vue";
 
 export default {
-	extends: ModelView
+	extends: ModelView,
+	props: {
+		canChangeEmail: Boolean,
+		canChangeLanguage: Boolean,
+		canChangeName: Boolean,
+		canChangeRole: Boolean
+	}
 };
 </script>
 

--- a/panel/src/components/Views/Users/UsersView.vue
+++ b/panel/src/components/Views/Users/UsersView.vue
@@ -5,7 +5,7 @@
 
 			<template #buttons>
 				<k-button
-					:disabled="!$panel.permissions.users.create"
+					:disabled="!canCreate"
 					:text="$t('user.create')"
 					icon="add"
 					size="sm"
@@ -30,6 +30,7 @@
  */
 export default {
 	props: {
+		canCreate: Boolean,
 		role: Object,
 		roles: Array,
 		search: String,

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -25,8 +25,12 @@ class Roles extends Collection
 
 	/**
 	 * Returns a filtered list of all
-	 * roles that can be created by the
+	 * roles that can be changed by the
 	 * current user
+	 *
+	 * Use with `$kirby->roles()`. For retrieving
+	 * which roles are available for a specific user,
+	 * use `$user->roles()` without additional filters.
 	 *
 	 * @return $this|static
 	 * @throws \Exception
@@ -50,7 +54,9 @@ class Roles extends Collection
 	/**
 	 * Returns a filtered list of all
 	 * roles that can be created by the
-	 * current user
+	 * current user.
+	 *
+	 * Use with `$kirby->roles()`.
 	 *
 	 * @return $this|static
 	 * @throws \Exception

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -577,26 +577,26 @@ class User extends ModelWithContent
 	 * Returns all available roles for this user,
 	 * that can be selected by the authenticated user
 	 *
-	 * @param string|null $purpose User action for which the roles are used (create, change)
+	 * @param string|null $action User action for which the roles are used (create, change)
 	 */
-	public function roles(string|null $purpose = null): Roles
+	public function roles(string|null $action = null): Roles
 	{
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
 		// for the last admin,
 		// only their current role (admin) is available for changing
-		if ($purpose === 'change' && $this->isLastAdmin() === true) {
+		if ($action === 'changeRole' && $this->isLastAdmin() === true) {
 			// a collection with just the one role of the user
 			return $roles->filter('id', $this->role()->id());
 		}
 
 		// filter roles based on the user action
 		// as user permissions and/or options can restrict these further
-		$roles = match ($purpose) {
-			'create' => $roles->canBeCreated(),
-			'change' => $roles->canBeChanged(),
-			default  => $roles
+		$roles = match ($action) {
+			'create'     => $roles->canBeCreated(),
+			'changeRole' => $roles->canBeChanged(),
+			default      => $roles
 		};
 
 		// exclude the admin role, if the user isn't an admin themselves

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -575,29 +575,26 @@ class User extends ModelWithContent
 
 	/**
 	 * Returns all available roles for this user,
-	 * that can be selected by the authenticated user
+	 * that the authenticated user can change to.
 	 *
-	 * @param string|null $action User action for which the roles are used (create, change)
+	 * For all roles the current user can create
+	 * use `$kirby->roles()->canBeCreated()`.
 	 */
-	public function roles(string|null $action = null): Roles
+	public function roles(): Roles
 	{
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
-		// for the last admin,
-		// only their current role (admin) is available for changing
-		if ($action === 'changeRole' && $this->isLastAdmin() === true) {
-			// a collection with just the one role of the user
+		// for the last admin, only their current role (admin) is available
+		if ($this->isLastAdmin() === true) {
 			return $roles->filter('id', $this->role()->id());
 		}
 
-		// filter roles based on the user action
-		// as user permissions and/or options can restrict these further
-		$roles = match ($action) {
-			'create'     => $roles->canBeCreated(),
-			'changeRole' => $roles->canBeChanged(),
-			default      => $roles
-		};
+		// if the current user doesn't have the permission to change the role,
+		// only the current role is available
+		if ($this->permissions()->can('changeRole') === false) {
+			return $roles->filter('id', $this->role()->id());
+		}
 
 		// exclude the admin role, if the user isn't an admin themselves
 		if ($kirby->user()?->isAdmin() !== true) {

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -585,13 +585,8 @@ class User extends ModelWithContent
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
-		// for the last admin, only their current role (admin) is available
-		if ($this->isLastAdmin() === true) {
-			return $roles->filter('id', $this->role()->id());
-		}
-
-		// if the current user doesn't have the permission to change the role,
-		// only the current role is available
+		// if the authenticated user doesn't have the permission to change
+		// the role of this user, only the current role is available
 		if ($this->permissions()->can('changeRole') === false) {
 			return $roles->filter('id', $this->role()->id());
 		}

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -591,12 +591,7 @@ class User extends ModelWithContent
 			return $roles->filter('id', $this->role()->id());
 		}
 
-		// exclude the admin role, if the user isn't an admin themselves
-		if ($kirby->user()?->isAdmin() !== true) {
-			$roles = $roles->filter(fn ($role) => $role->name() !== 'admin');
-		}
-
-		return $roles;
+		return $roles->canBeCreated();
 	}
 
 	/**

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -128,7 +128,7 @@ class UserRules
 		}
 
 		// prevent changing to role that is not available for user
-		if ($user->roles('changeRole')->find($role) instanceof Role === false) {
+		if ($user->roles()->find($role) instanceof Role === false) {
 			throw new InvalidArgumentException([
 				'key' => 'user.role.invalid',
 			]);
@@ -210,7 +210,7 @@ class UserRules
 		// prevent creating a role that is not available for user
 		if (
 			in_array($role, [null, 'default', 'nobody'], true) === false &&
-			$user->kirby()->roles('create')->find($role) instanceof Role === false
+			$user->kirby()->roles()->canBeCreated()->find($role) instanceof Role === false
 		) {
 			throw new InvalidArgumentException([
 				'key' => 'user.role.invalid',

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -128,7 +128,7 @@ class UserRules
 		}
 
 		// prevent changing to role that is not available for user
-		if ($user->roles('change')->find($role) instanceof Role === false) {
+		if ($user->roles('changeRole')->find($role) instanceof Role === false) {
 			throw new InvalidArgumentException([
 				'key' => 'user.role.invalid',
 			]);

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -218,7 +218,7 @@ class Field
 
 		return array_merge([
 			'label'    => I18n::translate('role'),
-			'type'     => count($roles) === 0 ? 'hidden' : 'radio',
+			'type'     => count($roles) < 1 ? 'hidden' : 'radio',
 			'options'  => $roles
 		], $props);
 	}

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
+use Kirby\Cms\Roles;
 use Kirby\Form\Form;
 use Kirby\Http\Router;
 use Kirby\Toolkit\I18n;
@@ -191,30 +192,32 @@ class Field
 	/**
 	 * User role radio buttons
 	 */
-	public static function role(array $props = []): array
-	{
-		$kirby   = App::instance();
-		$isAdmin = $kirby->user()?->isAdmin() ?? false;
-		$roles   = [];
+	public static function role(
+		array $props = [],
+		Roles|null $roles = null
+	): array {
+		$kirby = App::instance();
 
-		foreach ($kirby->roles() as $role) {
-			// exclude the admin role, if the user
-			// is not allowed to change role to admin
-			if ($role->name() === 'admin' && $isAdmin === false) {
-				continue;
-			}
+		// if no $roles where provided, fall back to all roles
+		// but exclude the admin role, if the user
+		// is not allowed to change role to admin
+		$roles ??= $kirby->roles()->filter(
+			fn ($role) =>
+				$role->name() !== 'admin' ||
+				$kirby->user()?->isAdmin() === true
+		);
 
-			$roles[] = [
-				'text'  => $role->title(),
-				'info'  => $role->description() ?? I18n::translate('role.description.placeholder'),
-				'value' => $role->name()
-			];
-		}
+		// turn roles into radio field options
+		$roles = $roles->values(fn ($role) => [
+			'text'  => $role->title(),
+			'info'  => $role->description() ?? I18n::translate('role.description.placeholder'),
+			'value' => $role->name()
+		]);
 
 		return array_merge([
-			'label'    => I18n::translate('role'),
-			'type'     => count($roles) <= 1 ? 'hidden' : 'radio',
-			'options'  => $roles
+			'label'   => I18n::translate('role'),
+			'type'    => count($roles) <= 1 ? 'hidden' : 'radio',
+			'options' => $roles
 		], $props);
 	}
 

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -215,9 +215,9 @@ class Field
 		]);
 
 		return array_merge([
-			'label'   => I18n::translate('role'),
-			'type'    => count($roles) <= 1 ? 'hidden' : 'radio',
-			'options' => $roles
+			'label'    => I18n::translate('role'),
+			'type'     => count($roles) === 0 ? 'hidden' : 'radio',
+			'options'  => $roles
 		], $props);
 	}
 

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -199,9 +199,11 @@ class Field
 		$kirby = App::instance();
 
 		// if no $roles where provided, fall back to all roles
-		// but exclude the admin role, if the user
+		$roles ??= $kirby->roles();
+
+		// exclude the admin role, if the user
 		// is not allowed to change role to admin
-		$roles ??= $kirby->roles()->filter(
+		$roles = $roles->filter(
 			fn ($role) =>
 				$role->name() !== 'admin' ||
 				$kirby->user()?->isAdmin() === true

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -218,14 +218,19 @@ class User extends Model
 	 */
 	public function props(): array
 	{
-		$user    = $this->model;
-		$account = $user->isLoggedIn();
+		$user        = $this->model;
+		$account     = $user->isLoggedIn();
+		$permissions = $this->options();
 
 		return array_merge(
 			parent::props(),
 			$this->prevNext(),
 			[
-				'blueprint' => $this->model->role()->name(),
+				'blueprint'         => $this->model->role()->name(),
+				'canChangeEmail'    => $permissions['changeEmail'],
+				'canChangeLanguage' => $permissions['changeLanguage'],
+				'canChangeName'     => $permissions['changeName'],
+				'canChangeRole'     => $permissions['changeRole'] && $this->model->roles('changeRole')->count() > 1,
 				'model' => [
 					'account'  => $account,
 					'avatar'   => $user->avatar()?->url(),

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -70,7 +70,7 @@ class User extends Model
 			'dialog'   => $url . '/changeRole',
 			'icon'     => 'bolt',
 			'text'     => I18n::translate('user.changeRole'),
-			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles('changeRole')->count() < 2
+			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles()->count() < 2
 		];
 
 		$result[] = [
@@ -230,7 +230,7 @@ class User extends Model
 				'canChangeEmail'    => $permissions['changeEmail'],
 				'canChangeLanguage' => $permissions['changeLanguage'],
 				'canChangeName'     => $permissions['changeName'],
-				'canChangeRole'     => $permissions['changeRole'] && $this->model->roles('changeRole')->count() > 1,
+				'canChangeRole'     => $this->model->roles()->count() > 1,
 				'model' => [
 					'account'  => $account,
 					'avatar'   => $user->avatar()?->url(),

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -70,7 +70,7 @@ class User extends Model
 			'dialog'   => $url . '/changeRole',
 			'icon'     => 'bolt',
 			'text'     => I18n::translate('user.changeRole'),
-			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles('change')->count() < 2
+			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles('changeRole')->count() < 2
 		];
 
 		$result[] = [

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -464,6 +464,7 @@ class UserTest extends TestCase
 			],
 			'roles' => [
 				['name' => 'admin'],
+				['name' => 'manager'],
 				['name' => 'editor'],
 				['name' => 'guest']
 			],
@@ -482,6 +483,13 @@ class UserTest extends TestCase
 				]
 			],
 			'blueprints' => [
+				'users/manager' => [
+					'options' => [
+						'create' => [
+							'editor' => false
+						]
+					]
+				],
 				'users/editor' => [
 					'permissions' => [
 						'user' => [
@@ -508,6 +516,11 @@ class UserTest extends TestCase
 		$user  = $app->user('guest@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
 		$this->assertSame(['guest'], $roles);
+
+		// blueprint `create` option limits available roles
+		$user  = $app->user('editor@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['editor', 'guest'], $roles);
 	}
 
 	public function testSecret()

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -363,16 +363,32 @@ class UserTest extends TestCase
 				[
 					'email' => 'editor@getkirby.com',
 					'role'  => 'editor'
+				],
+				[
+					'email' => 'guest@getkirby.com',
+					'role'  => 'guest'
 				]
 			],
 		]);
 
-		// normal user should not have admin as option
+		// unauthenticated, should only have the current role
+		$user  = $app->user('editor@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['editor'], $roles);
+
+		// user on another normal user should not have admin as option
+		$app->impersonate('editor@getkirby.com');
+		$user  = $app->user('guest@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['editor', 'guest'], $roles);
+
+		// user on themselves should not have admin as option
+		$app->impersonate('editor@getkirby.com');
 		$user  = $app->user('editor@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
 		$this->assertSame(['editor', 'guest'], $roles);
 
-		// only if current user is admin, normal user can also have admin option
+		// current user is admin, user can also have admin option
 		$app->impersonate('admin@getkirby.com');
 		$user  = $app->user('editor@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
@@ -387,35 +403,26 @@ class UserTest extends TestCase
 	/**
 	 * @covers ::roles
 	 */
-	public function testRolesFilteredForPurpose(): void
+	public function testRolesWithPermissions(): void
 	{
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
-			'blueprints' => [
-				'users/admin' => [
-					'name' => 'admin',
-				],
-				'users/editor' => [
-					'name' => 'editor',
-				],
-				'users/client' => [
-					'name'    => 'client',
-					'options' => [
-						'create' => [
-							'editor' => false
+			'roles' => [
+				['name' => 'admin'],
+				[
+					'name'        => 'editor',
+					'permissions' => [
+						'user' => [
+							'changeRole' => true
+						],
+						'users' => [
+							'changeRole' => false
 						]
 					]
 				],
-				'users/guest' => [
-					'name' => 'guest',
-					'options' => [
-						'changeRole' => [
-							'editor' => false
-						]
-					]
-				]
+				['name' => 'guest']
 			],
 			'users' => [
 				[
@@ -425,21 +432,82 @@ class UserTest extends TestCase
 				[
 					'email' => 'editor@getkirby.com',
 					'role'  => 'editor'
+				],
+				[
+					'email' => 'guest@getkirby.com',
+					'role'  => 'guest'
 				]
-			],
+			]
 		]);
 
 		$app->impersonate('editor@getkirby.com');
-		$user = $app->user('editor@getkirby.com');
 
+		// user has permission to change their own role
+		$user  = $app->user('editor@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
-		$this->assertSame(['client', 'editor', 'guest'], $roles);
-
-		$roles = $user->roles('create')->values(fn ($role) => $role->id());
 		$this->assertSame(['editor', 'guest'], $roles);
 
-		$roles = $user->roles('changeRole')->values(fn ($role) => $role->id());
-		$this->assertSame(['client', 'editor'], $roles);
+		// user has no permission to change someone else's role
+		$user  = $app->user('guest@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['guest'], $roles);
+	}
+
+	/**
+	 * @covers ::roles
+	 */
+	public function testRolesWithOptions(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor'],
+				['name' => 'guest']
+			],
+			'users' => [
+				[
+					'email' => 'admin@getkirby.com',
+					'role'  => 'admin'
+				],
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				],
+				[
+					'email' => 'guest@getkirby.com',
+					'role'  => 'guest'
+				]
+			],
+			'blueprints' => [
+				'users/editor' => [
+					'permissions' => [
+						'user' => [
+							'changeRole' => true
+						],
+						'users' => [
+							'changeRole' => true
+						]
+					]
+				],
+				'users/guest' => [
+					'options' => [
+						'changeRole' => [
+							'editor' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('editor@getkirby.com');
+
+		// blueprint option disallows changing role for guest role
+		$user  = $app->user('guest@getkirby.com');
+		$roles = $user->roles()->values(fn ($role) => $role->id());
+		$this->assertSame(['guest'], $roles);
 	}
 
 	public function testSecret()

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -396,7 +396,7 @@ class UserTest extends TestCase
 
 		// last admin has only admin role as option
 		$user  = $app->user('admin@getkirby.com');
-		$roles = $user->roles('changeRole')->values(fn ($role) => $role->id());
+		$roles = $user->roles()->values(fn ($role) => $role->id());
 		$this->assertSame(['admin'], $roles);
 	}
 

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -380,7 +380,7 @@ class UserTest extends TestCase
 
 		// last admin has only admin role as option
 		$user  = $app->user('admin@getkirby.com');
-		$roles = $user->roles('change')->values(fn ($role) => $role->id());
+		$roles = $user->roles('changeRole')->values(fn ($role) => $role->id());
 		$this->assertSame(['admin'], $roles);
 	}
 
@@ -430,7 +430,7 @@ class UserTest extends TestCase
 		]);
 
 		$app->impersonate('editor@getkirby.com');
-		$user  = $app->user('editor@getkirby.com');
+		$user = $app->user('editor@getkirby.com');
 
 		$roles = $user->roles()->values(fn ($role) => $role->id());
 		$this->assertSame(['client', 'editor', 'guest'], $roles);
@@ -438,7 +438,7 @@ class UserTest extends TestCase
 		$roles = $user->roles('create')->values(fn ($role) => $role->id());
 		$this->assertSame(['editor', 'guest'], $roles);
 
-		$roles = $user->roles('change')->values(fn ($role) => $role->id());
+		$roles = $user->roles('changeRole')->values(fn ($role) => $role->id());
 		$this->assertSame(['client', 'editor'], $roles);
 	}
 

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -35,6 +35,26 @@ class UsersDialogsTest extends AreaTestCase
 		$this->assertSame('admin', $props['value']['role']);
 	}
 
+	public function testCreateWithRoleQuery(): void
+	{
+		$this->app = $this->app->clone([
+			'request' => [
+				'query' => [
+					'role' => 'editor',
+				]
+			]
+		]);
+
+		$this->installEditor();
+		$this->login();
+
+		$dialog = $this->dialog('users/create');
+		$props  = $dialog['props'];
+
+		$this->assertFormDialog($dialog);
+		$this->assertSame('editor', $props['value']['role']);
+	}
+
 	public function testCreateOnSubmit(): void
 	{
 		$this->submit([


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Revert `User::roles()` action parameter, that was a turn in the wrong direction
- Consistently use `$kirby->roles()->canBeCreated()` for when creating a user, `$user->roles()` when changing the role of a user
- Fix `User::roles()` with simplified logic for `changeRole` permission checking
  - If no permission to change role of this user, return only current role
  - Otherwise return all roles that can create (implied that if a user can create role A and B, they also should be able to change someone to role A and B)
- `Panel\Field::role()`:
  - Allow passing roles collection to 
  - Use roles collection methods for logic instead foreach
  - Only hide field if no option available. Otherwise show as radio button for transparency which role is chosen.
- User create dialog preselects first role option instead of the role of the current user (or is the assumption users create mostly other users with the same role as theirs?)
- `UsersView`: use new `canCreate` prop that also takes available roles count into consideration, not just permission
- `UserView` and `UserProfile`: new `canChangeEmail`, `canChangeRole`, `canChangeName ` and `canChangeLanguage ` props instead of working with permissions array
  - Allows to take available roles count into consideration for `canChangeRole`

### Reasoning
Different action contexts will have a different set of roles available to display. Instead of putting that logic into the `Panel\Field::roles()` UI method, it should rather allow to pass the appropriate roles collection to this helper method.

Previous PRs introduced `User::roles($action)` - that was a turn in the wrong direction as the create and change role actions have very different relations to the user object. For creating, `$kirby->roles()` is actually the right base, not `$user->roles()`. For these cases, one should use `$kirby->roles()->canBeCrreated()` then. This allows to simplify `$user->roles()` to always only return the available roles for a user to be changed to.

Furthermore, our Panel UI had some problems where it only focused on the general permission, but not the actual available role count. While a user can have the general permission, blueprint options for specific roles can still lead to situations where no roles are available. The UI needs to consider that.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Panel UI fixed for `create` and `changeRole` permissions and user options
https://github.com/getkirby/kirby/issues/5147
https://github.com/getkirby/kirby/issues/5146

### Enhancements
- Role always shown when creating a new user, even if only one role available


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass
