### PR TITLE
Align `User::create()` and `User::role()`

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -560,7 +560,7 @@ class User extends ModelWithContent
 			return $this->role;
 		}
 
-		$name = $this->role ?? $this->credentials()['role'] ?? 'visitor';
+		$name = $this->role ?? $this->credentials()['role'] ?? 'default';
 
 		return $this->role =
 			$this->kirby()->roles()->find($name) ??


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `User::role()` now also uses `default` as fallback role if none is in the credentials file. This is the same behavior as `UserActions::create()` when no role is passed.


### Reasoning
Currently it's weird that in one case we use `default` , in another `visitor`.


## Changelog

### Breaking changes
- Users without a role in their credentials file will now receive the `default` role (if exists), not the `visitor` role anymore

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
