### PR TITLE
Clean up `UserRules`

### DIFF
--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -26,6 +26,19 @@ class UserPermissions extends ModelPermissions
 
 	protected function canChangeRole(): bool
 	{
+		// protect admin from role changes by non-admin
+		if (
+			$this->model->isAdmin() === true &&
+			$this->user->isAdmin() !== true
+		) {
+			return false;
+		}
+
+		// prevent demoting the last admin
+		if ($this->model->isLastAdmin() === true) {
+			return false;
+		}
+
 		return $this->model->roles()->count() > 1;
 	}
 

--- a/tests/Cms/Users/UserRulesTest.php
+++ b/tests/Cms/Users/UserRulesTest.php
@@ -174,7 +174,8 @@ class UserRulesTest extends TestCase
 			'user' => 'user@domain.com',
 			'users' => [
 				['email' => 'user@domain.com', 'role' => 'editor'],
-				['email' => 'admin@domain.com', 'role' => 'admin']
+				['email' => 'admin@domain.com', 'role' => 'admin'],
+				['email' => 'another@domain.com', 'role' => 'admin']
 			]
 		]);
 		$kirby->impersonate('user@domain.com');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge https://github.com/getkirby/kirby/pull/6653 first

### Summary of changes
- Added guards for non-admin changing admins as well as changing last admin to `UserPermissions::canChangeRole()` instead of `UserRules::changeRole()`
- Deprecated `UserRules::validRole()` as checks need to be more specific with a specific roles collection that this helper method cannot provide
- Added instead a role validation check to  `UserRules::changeRole()`
- Removed permissions check from `UserRules::create()` that Is already covered by the general permissions check running `UserPermissions::canCreate()` 

## Changelog

### Deprecated
- `UserRules::validRole()`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
