### PR TITLE
Remove roles count check from `UserPermissions`

### DIFF
--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -39,7 +39,7 @@ class UserPermissions extends ModelPermissions
 			return false;
 		}
 
-		return $this->model->roles()->count() > 1;
+		return true;
 	}
 
 	protected function canCreate(): bool

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -70,7 +70,7 @@ class User extends Model
 			'dialog'   => $url . '/changeRole',
 			'icon'     => 'bolt',
 			'text'     => I18n::translate('user.changeRole'),
-			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions)
+			'disabled' => $this->isDisabledDropdownOption('changeRole', $options, $permissions) || $this->model->roles('change')->count() < 2
 		];
 
 		$result[] = [

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -151,7 +151,7 @@ class RolesTest extends TestCase
 
 		$app->impersonate('editor@getkirby.com');
 		$canBeChanged = $roles->canBeChanged();
-		$this->assertCount(0, $canBeChanged); // TODO: change once `User::roles()` and `UserPermissions::canChangeRole()` have been improved/fixed
+		$this->assertCount(1, $canBeChanged);
 
 		$app->impersonate('admin@getkirby.com');
 		$canBeChanged = $roles->canBeChanged();

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -275,7 +275,7 @@ class UserTest extends TestCase
 			'changeLanguage' => true,
 			'changeName'     => true,
 			'changePassword' => true,
-			'changeRole'     => false, // just one role
+			'changeRole'     => true,
 			'delete'         => true,
 			'update'         => true,
 		];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge https://github.com/getkirby/kirby/pull/6653 first
- [x] Merge https://github.com/getkirby/kirby/pull/6657 first

### Summary of changes
- Remove roles count check from `UserPermissions::canChangeRole()`


### Reasoning
It's not a permissions question but a UI thing to disable a button if only one role is available. Permission-wise, a user should be able to change a role even if only to the one available option.

This change is also needed to avoid a circular loop:
- `$user->roles('change')` filters the role collection by those that can be changed
- Check the permission to filter the roles collection
- The permission method itself would need to call `$user->roles('change')`

This is why this check should not be part of the permissions method.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
