### PR TITLE
Refactor `LanguageRules`

### DIFF
--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -4,19 +4,58 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\PermissionException;
 use Kirby\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\LanguageRules
+ */
 class LanguageRulesTest extends TestCase
 {
 	public function setUp(): void
 	{
-		new App([
+		$this->app = new App([
 			'roots' => [
 				'index' => '/dev/null'
+			],
+			'roles' => [
+				'editor' => [
+					'name' => 'editor',
+					'permissions' => [
+						'languages' => [
+							'*' => false
+						]
+					]
+				],
+			],
+			'users' => [
+				['email' => 'admin@getkirby.com', 'role' => 'admin'],
+				['email' => 'test@getkirby.com', 'role' => 'editor']
 			]
 		]);
 	}
 
+	/**
+	 * @covers ::create
+	 */
+	public function testCreate()
+	{
+		$this->app->impersonate('admin@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectNotToPerformAssertions();
+
+		LanguageRules::create($language);
+	}
+
+	/**
+	 * @covers ::create
+	 */
 	public function testCreateWithInvalidCode()
 	{
 		$language = new Language([
@@ -29,6 +68,9 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
+	/**
+	 * @covers ::create
+	 */
 	public function testCreateWithInvalidName()
 	{
 		$language = new Language([
@@ -42,6 +84,9 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
+	/**
+	 * @covers ::create
+	 */
 	public function testCreateWhenExists()
 	{
 		$language = $this->createMock(Language::class);
@@ -55,6 +100,125 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateWithoutCurrentUser()
+	{
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to create a language');
+
+		LanguageRules::create($language);
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreateWithoutPermissions()
+	{
+		$this->app->impersonate('test@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to create a language');
+
+		LanguageRules::create($language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDelete()
+	{
+		$this->app->impersonate('admin@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectNotToPerformAssertions();
+
+		LanguageRules::delete($language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteWhenNotDeletable()
+	{
+		$language = $this->createMock(Language::class);
+		$language->method('isDeletable')->willReturn(false);
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('The language cannot be deleted');
+
+		LanguageRules::delete($language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteWithoutCurrentUser()
+	{
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to delete the language');
+
+		LanguageRules::delete($language);
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteWithoutPermissions()
+	{
+		$this->app->impersonate('test@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to delete the language');
+
+		LanguageRules::delete($language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdate()
+	{
+		$this->app->impersonate('admin@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectNotToPerformAssertions();
+
+		LanguageRules::update($language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
 	public function testUpdateWithoutCode()
 	{
 		$language = $this->createMock(Language::class);
@@ -67,6 +231,9 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
+	/**
+	 * @covers ::update
+	 */
 	public function testUpdateWithoutName()
 	{
 		$language = $this->createMock(Language::class);
@@ -77,5 +244,72 @@ class LanguageRulesTest extends TestCase
 		$this->expectExceptionMessage('Please enter a valid name for the language');
 
 		LanguageRules::update($language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateWithoutCurrentUser()
+	{
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to update the language');
+
+		LanguageRules::update($language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateWithoutPermissions()
+	{
+		$this->app->impersonate('test@getkirby.com');
+
+		$language = new Language([
+			'code' => 'de',
+			'name' => 'Deutsch'
+		]);
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to update the language');
+
+		LanguageRules::update($language);
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function testUpdateDemoteDefault()
+	{
+		$this->app = $this->app->clone([
+			'languages' => [
+				'de' => [
+					'code' => 'de',
+					'name'    => 'Deutsch',
+					'default' => true
+				],
+				'en' => [
+					'code' => 'en'
+				]
+			]
+		]);
+
+		$this->app->impersonate('admin@getkirby.com');
+
+		$oldLanguage = $this->app->language('de');
+		$newLanguage = new Language([
+			'code'    => 'de',
+			'name'    => 'Deutsch',
+			'default' => false
+		]);
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Please select another language to be the primary language');
+
+		LanguageRules::update($newLanguage, $oldLanguage);
 	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Moved logic from language methods to `LanguageRules` methods
- Marked all language rules methods void
- Added tests for all cases for `LanguageRules` class
- Switched language hooks to apply
- Apply language rules before and after applying before hook

### Reasoning
Trying to create consistency for all `*Rules` classes

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
