### PR TITLE
Mark all `*Rules` class methods void

### DIFF
--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -27,7 +27,7 @@ class FileRules
 	 * @throws \Kirby\Exception\DuplicateException If a file with this name exists
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to rename the file
 	 */
-	public static function changeName(File $file, string $name): bool
+	public static function changeName(File $file, string $name): void
 	{
 		if ($file->permissions()->changeName() !== true) {
 			throw new PermissionException([
@@ -51,14 +51,12 @@ class FileRules
 				'data' => ['filename' => $duplicate->filename()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
 	 * Validates if the file can be sorted
 	 */
-	public static function changeSort(File $file, int $sort): bool
+	public static function changeSort(File $file, int $sort): void
 	{
 		if ($file->permissions()->sort() !== true) {
 			throw new PermissionException([
@@ -66,8 +64,6 @@ class FileRules
 				'data' => ['filename' => $file->filename()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -76,7 +72,7 @@ class FileRules
 	 * @throws \Kirby\Exception\LogicException If the template of the page cannot be changed at all
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the template
 	 */
-	public static function changeTemplate(File $file, string $template): bool
+	public static function changeTemplate(File $file, string $template): void
 	{
 		if ($file->permissions()->changeTemplate() !== true) {
 			throw new PermissionException([
@@ -102,8 +98,6 @@ class FileRules
 				]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -112,7 +106,7 @@ class FileRules
 	 * @throws \Kirby\Exception\DuplicateException If a file with the same name exists
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create the file
 	 */
-	public static function create(File $file, BaseFile $upload): bool
+	public static function create(File $file, BaseFile $upload): void
 	{
 		// We want to ensure that we are not creating duplicate files.
 		// If a file with the same name already exists
@@ -128,7 +122,7 @@ class FileRules
 				$file->sha1() === $upload->sha1() &&
 				$file->template() === $existing->template()
 			) {
-				return true;
+				return;
 			}
 
 			// otherwise throw an error for duplicate file
@@ -148,8 +142,6 @@ class FileRules
 
 		$upload->match($file->blueprint()->accept());
 		$upload->validateContents(true);
-
-		return true;
 	}
 
 	/**
@@ -157,13 +149,11 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete the file
 	 */
-	public static function delete(File $file): bool
+	public static function delete(File $file): void
 	{
 		if ($file->permissions()->delete() !== true) {
 			throw new PermissionException('The file cannot be deleted');
 		}
-
-		return true;
 	}
 
 	/**
@@ -172,7 +162,7 @@ class FileRules
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to replace the file
 	 * @throws \Kirby\Exception\InvalidArgumentException If the file type of the new file is different
 	 */
-	public static function replace(File $file, BaseFile $upload): bool
+	public static function replace(File $file, BaseFile $upload): void
 	{
 		if ($file->permissions()->replace() !== true) {
 			throw new PermissionException('The file cannot be replaced');
@@ -192,8 +182,6 @@ class FileRules
 
 		$upload->match($file->blueprint()->accept());
 		$upload->validateContents(true);
-
-		return true;
 	}
 
 	/**
@@ -201,13 +189,11 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the file
 	 */
-	public static function update(File $file, array $content = []): bool
+	public static function update(File $file, array $content = []): void
 	{
 		if ($file->permissions()->update() !== true) {
 			throw new PermissionException('The file cannot be updated');
 		}
-
-		return true;
 	}
 
 	/**
@@ -215,7 +201,7 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the extension is missing or forbidden
 	 */
-	public static function validExtension(File $file, string $extension): bool
+	public static function validExtension(File $file, string $extension): void
 	{
 		// make it easier to compare the extension
 		$extension = strtolower($extension);
@@ -251,8 +237,6 @@ class FileRules
 				'data' => ['extension' => $extension]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -265,17 +249,14 @@ class FileRules
 	public static function validFile(
 		File $file,
 		string|false|null $mime = null
-	): bool {
-		$validMime = match ($mime) {
-			// request to skip the MIME check for performance reasons
-			false   => true,
-			default => static::validMime($file, $mime ?? $file->mime())
-		};
+	): void {
+		// request to skip the MIME check for performance reasons
+		if ($mime !== false) {
+			static::validMime($file, $mime ?? $file->mime());
+		}
 
-		return
-			$validMime &&
-			static::validExtension($file, $file->extension()) &&
-			static::validFilename($file, $file->filename());
+		static::validExtension($file, $file->extension());
+		static::validFilename($file, $file->filename());
 	}
 
 	/**
@@ -283,7 +264,7 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the filename is missing or forbidden
 	 */
-	public static function validFilename(File $file, string $filename): bool
+	public static function validFilename(File $file, string $filename): void
 	{
 		// make it easier to compare the filename
 		$filename = strtolower($filename);
@@ -310,8 +291,6 @@ class FileRules
 				'data' => ['type' => 'invisible']
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -319,7 +298,7 @@ class FileRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the MIME type is missing or forbidden
 	 */
-	public static function validMime(File $file, string|null $mime = null): bool
+	public static function validMime(File $file, string|null $mime = null): void
 	{
 		// make it easier to compare the mime
 		$mime = strtolower($mime ?? '');
@@ -344,7 +323,5 @@ class FileRules
 				'data' => ['mime' => $mime]
 			]);
 		}
-
-		return true;
 	}
 }

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -25,13 +25,11 @@ class PageRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the given number is invalid
 	 */
-	public static function changeNum(Page $page, int|null $num = null): bool
+	public static function changeNum(Page $page, int|null $num = null): void
 	{
 		if ($num !== null && $num < 0) {
 			throw new InvalidArgumentException(['key' => 'page.num.invalid']);
 		}
-
-		return true;
 	}
 
 	/**
@@ -40,7 +38,7 @@ class PageRules
 	 * @throws \Kirby\Exception\DuplicateException If a page with this slug already exists
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the slug
 	 */
-	public static function changeSlug(Page $page, string $slug): bool
+	public static function changeSlug(Page $page, string $slug): void
 	{
 		if ($page->permissions()->changeSlug() !== true) {
 			throw new PermissionException([
@@ -74,8 +72,6 @@ class PageRules
 				]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -87,12 +83,12 @@ class PageRules
 		Page $page,
 		string $status,
 		int|null $position = null
-	): bool {
+	): void {
 		if (isset($page->blueprint()->status()[$status]) === false) {
 			throw new InvalidArgumentException(['key' => 'page.status.invalid']);
 		}
 
-		return match ($status) {
+		match ($status) {
 			'draft'     => static::changeStatusToDraft($page),
 			'listed'    => static::changeStatusToListed($page, $position),
 			'unlisted'  => static::changeStatusToUnlisted($page),
@@ -105,7 +101,7 @@ class PageRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the status or the page cannot be converted to a draft
 	 */
-	public static function changeStatusToDraft(Page $page): bool
+	public static function changeStatusToDraft(Page $page): void
 	{
 		if ($page->permissions()->changeStatus() !== true) {
 			throw new PermissionException([
@@ -124,8 +120,6 @@ class PageRules
 				]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -134,7 +128,7 @@ class PageRules
 	 * @throws \Kirby\Exception\InvalidArgumentException If the given position is invalid
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the status or the status for the page cannot be changed by any user
 	 */
-	public static function changeStatusToListed(Page $page, int $position): bool
+	public static function changeStatusToListed(Page $page, int $position): void
 	{
 		// no need to check for status changing permissions,
 		// instead we need to check for sorting permissions
@@ -148,7 +142,7 @@ class PageRules
 				]);
 			}
 
-			return true;
+			return;
 		}
 
 		static::publish($page);
@@ -156,8 +150,6 @@ class PageRules
 		if ($position !== null && $position < 0) {
 			throw new InvalidArgumentException(['key' => 'page.num.invalid']);
 		}
-
-		return true;
 	}
 
 	/**
@@ -168,8 +160,6 @@ class PageRules
 	public static function changeStatusToUnlisted(Page $page)
 	{
 		static::publish($page);
-
-		return true;
 	}
 
 	/**
@@ -178,7 +168,7 @@ class PageRules
 	 * @throws \Kirby\Exception\LogicException If the template of the page cannot be changed at all
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the template
 	 */
-	public static function changeTemplate(Page $page, string $template): bool
+	public static function changeTemplate(Page $page, string $template): void
 	{
 		if ($page->permissions()->changeTemplate() !== true) {
 			throw new PermissionException([
@@ -200,8 +190,6 @@ class PageRules
 				'data' => ['slug' => $page->slug()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -210,7 +198,7 @@ class PageRules
 	 * @throws \Kirby\Exception\InvalidArgumentException If the new title is empty
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the title
 	 */
-	public static function changeTitle(Page $page, string $title): bool
+	public static function changeTitle(Page $page, string $title): void
 	{
 		if ($page->permissions()->changeTitle() !== true) {
 			throw new PermissionException([
@@ -222,8 +210,6 @@ class PageRules
 		}
 
 		static::validateTitleLength($title);
-
-		return true;
 	}
 
 	/**
@@ -233,7 +219,7 @@ class PageRules
 	 * @throws \Kirby\Exception\InvalidArgumentException If the slug is invalid
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create this page
 	 */
-	public static function create(Page $page): bool
+	public static function create(Page $page): void
 	{
 		if ($page->permissions()->create() !== true) {
 			throw new PermissionException([
@@ -273,8 +259,6 @@ class PageRules
 				'data' => ['slug' => $slug]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -283,7 +267,7 @@ class PageRules
 	 * @throws \Kirby\Exception\LogicException If the page has children and should not be force-deleted
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete the page
 	 */
-	public static function delete(Page $page, bool $force = false): bool
+	public static function delete(Page $page, bool $force = false): void
 	{
 		if ($page->permissions()->delete() !== true) {
 			throw new PermissionException([
@@ -297,8 +281,6 @@ class PageRules
 		if (($page->hasChildren() === true || $page->hasDrafts() === true) && $force === false) {
 			throw new LogicException(['key' => 'page.delete.hasChildren']);
 		}
-
-		return true;
 	}
 
 	/**
@@ -310,7 +292,7 @@ class PageRules
 		Page $page,
 		string $slug,
 		array $options = []
-	): bool {
+	): void {
 		if ($page->permissions()->duplicate() !== true) {
 			throw new PermissionException([
 				'key' => 'page.duplicate.permission',
@@ -321,19 +303,17 @@ class PageRules
 		}
 
 		self::validateSlugLength($slug);
-
-		return true;
 	}
 
 	/**
 	 * Check if the page can be moved
 	 * to the given parent
 	 */
-	public static function move(Page $page, Site|Page $parent): bool
+	public static function move(Page $page, Site|Page $parent): void
 	{
 		// if nothing changes, there's no need for checks
 		if ($parent->is($page->parent()) === true) {
-			return true;
+			return;
 		}
 
 		if ($page->permissions()->move() !== true) {
@@ -394,15 +374,13 @@ class PageRules
 				]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
 	 * Check if the page can be published
 	 * (status change from draft to listed or unlisted)
 	 */
-	public static function publish(Page $page): bool
+	public static function publish(Page $page): void
 	{
 		if ($page->permissions()->changeStatus() !== true) {
 			throw new PermissionException([
@@ -419,8 +397,6 @@ class PageRules
 				'details' => $page->errors()
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -428,7 +404,7 @@ class PageRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the page
 	 */
-	public static function update(Page $page, array $content = []): bool
+	public static function update(Page $page, array $content = []): void
 	{
 		if ($page->permissions()->update() !== true) {
 			throw new PermissionException([
@@ -438,8 +414,6 @@ class PageRules
 				]
 			]);
 		}
-
-		return true;
 	}
 
 	/**

--- a/src/Cms/SiteRules.php
+++ b/src/Cms/SiteRules.php
@@ -23,7 +23,7 @@ class SiteRules
 	 * @throws \Kirby\Exception\InvalidArgumentException If the title is empty
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the title
 	 */
-	public static function changeTitle(Site $site, string $title): bool
+	public static function changeTitle(Site $site, string $title): void
 	{
 		if ($site->permissions()->changeTitle() !== true) {
 			throw new PermissionException(['key' => 'site.changeTitle.permission']);
@@ -32,8 +32,6 @@ class SiteRules
 		if (Str::length($title) === 0) {
 			throw new InvalidArgumentException(['key' => 'site.changeTitle.empty']);
 		}
-
-		return true;
 	}
 
 	/**
@@ -41,12 +39,10 @@ class SiteRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the site
 	 */
-	public static function update(Site $site, array $content = []): bool
+	public static function update(Site $site, array $content = []): void
 	{
 		if ($site->permissions()->update() !== true) {
 			throw new PermissionException(['key' => 'site.update.permission']);
 		}
-
-		return true;
 	}
 }

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -273,9 +273,8 @@ trait UserActions
 		do {
 			try {
 				$id = Str::random($length);
-				if (UserRules::validId($this, $id) === true) {
-					return $id;
-				}
+				UserRules::validId($this, $id);
+				return $id;
 
 				// we can't really test for a random match
 				// @codeCoverageIgnoreStart

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -27,7 +27,7 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the address
 	 */
-	public static function changeEmail(User $user, string $email): bool
+	public static function changeEmail(User $user, string $email): void
 	{
 		if ($user->permissions()->changeEmail() !== true) {
 			throw new PermissionException([
@@ -36,7 +36,7 @@ class UserRules
 			]);
 		}
 
-		return static::validEmail($user, $email);
+		static::validEmail($user, $email);
 	}
 
 	/**
@@ -44,7 +44,7 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the language
 	 */
-	public static function changeLanguage(User $user, string $language): bool
+	public static function changeLanguage(User $user, string $language): void
 	{
 		if ($user->permissions()->changeLanguage() !== true) {
 			throw new PermissionException([
@@ -53,7 +53,7 @@ class UserRules
 			]);
 		}
 
-		return static::validLanguage($user, $language);
+		static::validLanguage($user, $language);
 	}
 
 	/**
@@ -61,7 +61,7 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the name
 	 */
-	public static function changeName(User $user, string $name): bool
+	public static function changeName(User $user, string $name): void
 	{
 		if ($user->permissions()->changeName() !== true) {
 			throw new PermissionException([
@@ -69,8 +69,6 @@ class UserRules
 				'data' => ['name' => $user->username()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -82,7 +80,7 @@ class UserRules
 		User $user,
 		#[SensitiveParameter]
 		string $password
-	): bool {
+	): void {
 		if ($user->permissions()->changePassword() !== true) {
 			throw new PermissionException([
 				'key'  => 'user.changePassword.permission',
@@ -90,7 +88,7 @@ class UserRules
 			]);
 		}
 
-		return static::validPassword($user, $password);
+		static::validPassword($user, $password);
 	}
 
 	/**
@@ -99,7 +97,7 @@ class UserRules
 	 * @throws \Kirby\Exception\LogicException If the user is the last admin
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the role
 	 */
-	public static function changeRole(User $user, string $role): bool
+	public static function changeRole(User $user, string $role): void
 	{
 		// protect admin from role changes by non-admin
 		if (
@@ -137,8 +135,6 @@ class UserRules
 				'data' => ['name' => $user->username()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -151,7 +147,7 @@ class UserRules
 		User $user,
 		#[SensitiveParameter]
 		string|null $secret
-	): bool {
+	): void {
 		$currentUser = $user->kirby()->user();
 
 		if (
@@ -166,8 +162,6 @@ class UserRules
 		if ($secret !== null) {
 			new Totp($secret);
 		}
-
-		return true;
 	}
 
 	/**
@@ -175,7 +169,7 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create a new user
 	 */
-	public static function create(User $user, array $props = []): bool
+	public static function create(User $user, array $props = []): void
 	{
 		static::validId($user, $user->id());
 		static::validEmail($user, $user->email(), true);
@@ -196,7 +190,7 @@ class UserRules
 
 		// admins are allowed everything
 		if ($currentUser?->isAdmin() === true) {
-			return true;
+			return;
 		}
 
 		// only admins are allowed to add admins
@@ -217,8 +211,6 @@ class UserRules
 				'key' => 'user.create.permission'
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -227,7 +219,7 @@ class UserRules
 	 * @throws \Kirby\Exception\LogicException If this is the last user or last admin, which cannot be deleted
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete this user
 	 */
-	public static function delete(User $user): bool
+	public static function delete(User $user): void
 	{
 		if ($user->isLastAdmin() === true) {
 			throw new LogicException(['key' => 'user.delete.lastAdmin']);
@@ -245,8 +237,6 @@ class UserRules
 				'data' => ['name' => $user->username()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -258,15 +248,13 @@ class UserRules
 		User $user,
 		array $values = [],
 		array $strings = []
-	): bool {
+	): void {
 		if ($user->permissions()->update() !== true) {
 			throw new PermissionException([
 				'key'  => 'user.update.permission',
 				'data' => ['name' => $user->username()]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -279,7 +267,7 @@ class UserRules
 		User $user,
 		string $email,
 		bool $strict = false
-	): bool {
+	): void {
 		if (V::email($email ?? null) === false) {
 			throw new InvalidArgumentException([
 				'key' => 'user.email.invalid',
@@ -297,8 +285,6 @@ class UserRules
 				'data' => ['email' => $email]
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -306,7 +292,7 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\DuplicateException If the user already exists
 	 */
-	public static function validId(User $user, string $id): bool
+	public static function validId(User $user, string $id): void
 	{
 		if (in_array($id, ['account', 'kirby', 'nobody']) === true) {
 			throw new InvalidArgumentException('"' . $id . '" is a reserved word and cannot be used as user id');
@@ -315,8 +301,6 @@ class UserRules
 		if ($user->kirby()->users()->find($id)) {
 			throw new DuplicateException('A user with this id exists');
 		}
-
-		return true;
 	}
 
 	/**
@@ -324,15 +308,13 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the language does not exist
 	 */
-	public static function validLanguage(User $user, string $language): bool
+	public static function validLanguage(User $user, string $language): void
 	{
 		if (in_array($language, $user->kirby()->translations()->keys(), true) === false) {
 			throw new InvalidArgumentException([
 				'key' => 'user.language.invalid',
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -344,7 +326,7 @@ class UserRules
 		User $user,
 		#[SensitiveParameter]
 		string $password
-	): bool {
+	): void {
 		// too short passwords are ineffective
 		if (Str::length($password ?? null) < 8) {
 			throw new InvalidArgumentException([
@@ -361,8 +343,6 @@ class UserRules
 				'key' => 'user.password.excessive',
 			]);
 		}
-
-		return true;
 	}
 
 	/**
@@ -370,14 +350,12 @@ class UserRules
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the user role does not exist
 	 */
-	public static function validRole(User $user, string $role): bool
+	public static function validRole(User $user, string $role): void
 	{
-		if ($user->kirby()->roles()->find($role) instanceof Role) {
-			return true;
+		if ($user->kirby()->roles()->find($role) instanceof Role === false) {
+			throw new InvalidArgumentException([
+				'key' => 'user.role.invalid',
+			]);
 		}
-
-		throw new InvalidArgumentException([
-			'key' => 'user.role.invalid',
-		]);
 	}
 }

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -42,9 +42,10 @@ class FileRulesTest extends TestCase
 			]
 		]);
 
-		$file = $page->file('a.jpg');
+		$this->expectNotToPerformAssertions();
 
-		$this->assertTrue(FileRules::changeName($file, 'c'));
+		$file = $page->file('a.jpg');
+		FileRules::changeName($file, 'c');
 	}
 
 	public function testChangeNameWithEmptyInput()
@@ -83,9 +84,10 @@ class FileRulesTest extends TestCase
 			]
 		]);
 
-		$file = $page->file('a.jpg');
+		$this->expectNotToPerformAssertions();
 
-		$this->assertTrue(FileRules::changeSort($file, 1));
+		$file = $page->file('a.jpg');
+		FileRules::changeSort($file, 1);
 	}
 
 	public function testChangeSortWithoutPermissions()
@@ -113,9 +115,10 @@ class FileRulesTest extends TestCase
 			]
 		]);
 
-		$file = $page->file('a.jpg');
+		$this->expectNotToPerformAssertions();
 
-		$this->assertTrue(FileRules::changeName($file, 'b'));
+		$file = $page->file('a.jpg');
+		FileRules::changeName($file, 'b');
 	}
 
 	public function testChangeNameToExistingFile()
@@ -168,8 +171,10 @@ class FileRulesTest extends TestCase
 
 		$app->impersonate('kirby');
 
+		$this->expectNotToPerformAssertions();
+
 		$file = $app->page('test')->file('test.jpg');
-		$this->assertTrue(FileRules::changeTemplate($file, 'b'));
+		FileRules::changeTemplate($file, 'b');
 	}
 
 	public function testChangeTemplateWithoutPermissions()
@@ -272,10 +277,10 @@ class FileRulesTest extends TestCase
 			]
 		]);
 
-		$upload = new BaseFile($testImage);
-		$create = FileRules::create($newFile, $upload);
+		$this->expectNotToPerformAssertions();
 
-		$this->assertTrue($create);
+		$upload = new BaseFile($testImage);
+		FileRules::create($newFile, $upload);
 	}
 
 	public function testCreateSameFileWithDifferentTemplate()
@@ -529,11 +534,11 @@ class FileRulesTest extends TestCase
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
 			$this->expectExceptionMessage($message);
+		} else {
+			$this->expectNotToPerformAssertions();
 		}
 
-		$result = FileRules::validExtension($file, $extension);
-
-		$this->assertTrue($result);
+		FileRules::validExtension($file, $extension);
 	}
 
 	public static function fileProvider(): array
@@ -594,11 +599,11 @@ class FileRulesTest extends TestCase
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
 			$this->expectExceptionMessage($message);
+		} else {
+			$this->expectNotToPerformAssertions();
 		}
 
-		$result = FileRules::validFile($file);
-
-		$this->assertTrue($result);
+		FileRules::validFile($file);
 	}
 
 	public function testValidFileSkipMime()
@@ -612,11 +617,11 @@ class FileRulesTest extends TestCase
 		$file->method('extension')->willReturn('jpg');
 		$file->method('mime')->willReturn('text/html');
 
-		$this->assertTrue(FileRules::validFile($file, false));
+		FileRules::validFile($file, false);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The media type "text/html" is not allowed');
-		$this->assertTrue(FileRules::validFile($file));
+		FileRules::validFile($file);
 	}
 
 	public static function filenameProvider(): array
@@ -642,11 +647,11 @@ class FileRulesTest extends TestCase
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
 			$this->expectExceptionMessage($message);
+		} else {
+			$this->expectNotToPerformAssertions();
 		}
 
-		$result = FileRules::validFilename($file, $filename);
-
-		$this->assertTrue($result);
+		FileRules::validFilename($file, $filename);
 	}
 
 	public static function mimeProvider(): array
@@ -672,10 +677,10 @@ class FileRulesTest extends TestCase
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
 			$this->expectExceptionMessage($message);
+		} else {
+			$this->expectNotToPerformAssertions();
 		}
 
-		$result = FileRules::validMime($file, $mime);
-
-		$this->assertTrue($result);
+		FileRules::validMime($file, $mime);
 	}
 }

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -40,8 +40,10 @@ class PageRulesTest extends TestCase
 			'kirby' => $this->appWithAdmin(),
 		]);
 
-		$this->assertTrue(PageRules::changeNum($page, 2));
-		$this->assertTrue(PageRules::changeNum($page));
+		$this->expectNotToPerformAssertions();
+
+		PageRules::changeNum($page, 2);
+		PageRules::changeNum($page);
 	}
 
 	/**
@@ -78,7 +80,7 @@ class PageRulesTest extends TestCase
 			'kirby' => $app,
 		]);
 
-		$this->assertTrue(PageRules::changeSlug($page, 'test-a'));
+		PageRules::changeSlug($page, 'test-a');
 
 		$this->expectException(DuplicateException::class);
 		$this->expectExceptionMessage('A page with the URL appendix "test-b" already exists');
@@ -266,12 +268,14 @@ class PageRulesTest extends TestCase
 			]
 		]);
 
+		$this->expectNotToPerformAssertions();
+
 		$page = new Page([
 			'slug'  => 'test-' . $status,
 			'kirby' => $app,
 		]);
 
-		$this->assertTrue(PageRules::changeStatus($page, $status, ...$args));
+		PageRules::changeStatus($page, $status, ...$args);
 	}
 
 	/**
@@ -310,7 +314,9 @@ class PageRulesTest extends TestCase
 			]
 		]);
 
-		$this->assertTrue(PageRules::changeTemplate($page, 'b'));
+		$this->expectNotToPerformAssertions();
+
+		PageRules::changeTemplate($page, 'b');
 	}
 
 	/**
@@ -501,7 +507,9 @@ class PageRulesTest extends TestCase
 			'slug'  => 'test',
 		]);
 
-		$this->assertTrue(PageRules::delete($page));
+		$this->expectNotToPerformAssertions();
+
+		PageRules::delete($page);
 	}
 
 	/**
@@ -532,7 +540,9 @@ class PageRulesTest extends TestCase
 			'slug'  => 'test',
 		]);
 
-		$this->assertTrue(PageRules::delete($page));
+		$this->expectNotToPerformAssertions();
+
+		PageRules::delete($page);
 	}
 
 	/**
@@ -617,8 +627,9 @@ class PageRulesTest extends TestCase
 			],
 		]);
 
+		$this->expectNotToPerformAssertions();
 
-		$this->assertTrue(PageRules::delete($page, true));
+		PageRules::delete($page, true);
 	}
 
 	/**
@@ -631,7 +642,9 @@ class PageRulesTest extends TestCase
 			'kirby' => $this->appWithAdmin(),
 		]);
 
-		$this->assertTrue(PageRules::duplicate($page, 'test-copy'));
+		$this->expectNotToPerformAssertions();
+
+		PageRules::duplicate($page, 'test-copy');
 	}
 
 	/**
@@ -678,9 +691,11 @@ class PageRulesTest extends TestCase
 			'slug'  => 'test',
 		]);
 
-		$this->assertTrue(PageRules::update($page, [
+		$this->expectNotToPerformAssertions();
+
+		PageRules::update($page, [
 			'color' => 'red'
-		]));
+		]);
 	}
 
 	/**
@@ -802,10 +817,11 @@ class PageRulesTest extends TestCase
 
 		$app->impersonate('kirby');
 
+		$this->expectNotToPerformAssertions();
+
 		$parentB = $app->page('parent-b');
 		$child   = $app->page('parent-a/child');
-
-		$this->assertTrue(PageRules::move($child, $parentB));
+		PageRules::move($child, $parentB);
 	}
 
 	public function testMoveWithoutPermissions()

--- a/tests/Cms/Site/SiteRulesTest.php
+++ b/tests/Cms/Site/SiteRulesTest.php
@@ -25,10 +25,10 @@ class SiteRulesTest extends TestCase
 		$app = new App();
 		$app->impersonate('kirby');
 
+		$this->expectNotToPerformAssertions();
+
 		$site = new Site([]);
-		$this->assertTrue(SiteRules::update($site, [
-			'copyright' => '2018'
-		]));
+		SiteRules::update($site, ['copyright' => '2018']);
 	}
 
 	public function testUpdateWithoutPermissions()

--- a/tests/Cms/Users/UserRulesTest.php
+++ b/tests/Cms/Users/UserRulesTest.php
@@ -50,7 +50,9 @@ class UserRulesTest extends TestCase
 		$kirby = $this->appWithAdmin();
 		$user  = $kirby->user('user@domain.com');
 
-		$this->assertTrue(UserRules::{'change' . $key}($user, $value));
+		$this->expectNotToPerformAssertions();
+
+		UserRules::{'change' . $key}($user, $value);
 	}
 
 	public static function invalidDataProvider(): array
@@ -159,7 +161,9 @@ class UserRulesTest extends TestCase
 		]);
 		$kirby->impersonate('admin@domain.com');
 
-		$this->assertTrue(UserRules::changeRole($kirby->user('user@domain.com'), 'editor'));
+		$this->expectNotToPerformAssertions();
+
+		UserRules::changeRole($kirby->user('user@domain.com'), 'editor');
 	}
 
 	public function testChangeRoleFromAdminByNonAdmin()
@@ -196,7 +200,9 @@ class UserRulesTest extends TestCase
 		]);
 		$kirby->impersonate('user1@domain.com');
 
-		$this->assertTrue(UserRules::changeRole($kirby->user('user2@domain.com'), 'admin'));
+		$this->expectNotToPerformAssertions();
+
+		UserRules::changeRole($kirby->user('user2@domain.com'), 'admin');
 	}
 
 	public function testChangeRoleToAdminByNonAdmin()
@@ -239,15 +245,17 @@ class UserRulesTest extends TestCase
 			]
 		]);
 
+		$this->expectNotToPerformAssertions();
+
 		// as user for themselves
 		$kirby->impersonate('user@domain.com');
-		$this->assertTrue(UserRules::changeTotp($kirby->user('user@domain.com'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'));
-		$this->assertTrue(UserRules::changeTotp($kirby->user('user@domain.com'), null));
+		UserRules::changeTotp($kirby->user('user@domain.com'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+		UserRules::changeTotp($kirby->user('user@domain.com'), null);
 
 		// as admin for other users
 		$kirby->impersonate('admin@domain.com');
-		$this->assertTrue(UserRules::changeTotp($kirby->user('user@domain.com'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'));
-		$this->assertTrue(UserRules::changeTotp($kirby->user('user@domain.com'), null));
+		UserRules::changeTotp($kirby->user('user@domain.com'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+		UserRules::changeTotp($kirby->user('user@domain.com'), null);
 	}
 
 	public function testChangeTotpAsAnotherUser()
@@ -287,7 +295,9 @@ class UserRulesTest extends TestCase
 			'kirby'    => $this->appWithAdmin()
 		]);
 
-		$this->assertTrue(UserRules::create($user, $props));
+		$this->expectNotToPerformAssertions();
+
+		UserRules::create($user, $props);
 	}
 
 	public function testCreateFirstUserWithoutPassword()
@@ -362,18 +372,22 @@ class UserRulesTest extends TestCase
 
 	public function testUpdate()
 	{
-		$app  = $this->appWithAdmin();
+		$this->expectNotToPerformAssertions();
+
+		$this->appWithAdmin();
 		$user = new User(['email' => 'user@domain.com']);
-		$this->assertTrue(UserRules::update($user, $input = [
+		UserRules::update($user, $input = [
 			'zodiac' => 'lion'
-		], $input));
+		], $input);
 	}
 
 	public function testDelete()
 	{
-		$app  = $this->appWithAdmin();
+		$this->expectNotToPerformAssertions();
+
+		$this->appWithAdmin();
 		$user = new User(['email' => 'user@domain.com']);
-		$this->assertTrue(UserRules::delete($user));
+		UserRules::delete($user);
 	}
 
 	public function testDeleteLastAdmin()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Switching all rules class methods to void


### Reasoning
- Consistency
- As we work with throwing exceptions, I think the main factor to check for is whether an exception is thrown to not. And not checking for a `true` returned.

### Additional context
Language rules are covered in https://github.com/getkirby/kirby/pull/6659


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass