### PR TITLE
Changes 23: Move status button to the topbar

### DIFF
--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -7,7 +7,10 @@
 		class="k-page-view"
 	>
 		<template #topbar>
-			<k-prev-next v-if="model.id" :prev="prev" :next="next" />
+			<k-button-group>
+				<k-button v-bind="statusbutton" variant="default" />
+				<k-prev-next v-if="model.id" :prev="prev" :next="next" />
+			</k-button-group>
 		</template>
 
 		<k-header
@@ -40,6 +43,11 @@ import ModelView from "../ModelView.vue";
 
 export default {
 	extends: ModelView,
+	props: {
+		statusbutton: {
+			type: Object
+		}
+	},
 	computed: {
 		protectedFields() {
 			return ["title"];
@@ -52,5 +60,9 @@ export default {
 /** TODO: .k-page-view:has(.k-tabs) .k-page-view-header */
 .k-page-view[data-has-tabs="true"] .k-page-view-header {
 	margin-bottom: 0;
+}
+
+.k-page-status-button .k-button-text {
+	padding-bottom: 1px;
 }
 </style>

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -5,8 +5,8 @@ namespace Kirby\Panel;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
-use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Panel\Ui\Buttons\PageStatusButton;
+use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\I18n;
 
 /**

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -6,6 +6,7 @@ use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
+use Kirby\Panel\Ui\Buttons\PageStatusButton;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -50,7 +51,6 @@ class Page extends Model
 			'preview',
 			'settings',
 			'languages',
-			'status'
 		)->bind(['page' => $this->model()])
 			->render();
 	}
@@ -350,6 +350,7 @@ class Page extends Model
 			...parent::props(),
 			...$this->prevNext(),
 			'blueprint' => $page->intendedTemplate()->name(),
+			'statusbutton' => (new PageStatusButton($page))->props(),
 			'model' => [
 				'content'    => $this->content(),
 				'id'         => $page->id(),

--- a/src/Panel/Ui/Buttons/PageStatusButton.php
+++ b/src/Panel/Ui/Buttons/PageStatusButton.php
@@ -35,7 +35,8 @@ class PageStatusButton extends ViewButton
 			dialog: $page->panel()->url(true) . '/changeStatus',
 			disabled: $disabled,
 			icon: 'status-' . $status,
-			style: '--icon-size: 15px',
+			size: 'xs',
+			style: '--icon-size: 16px',
 			text: $blueprint['label'] ?? $status,
 			title: $title,
 			theme: match($status) {

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -101,7 +101,6 @@ class PageTest extends TestCase
 			'k-preview-view-button',
 			'k-settings-view-button',
 			'k-languages-view-button',
-			'k-status-view-button',
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 


### PR DESCRIPTION
## Description

### Merge first 

- [ ] https://github.com/getkirby/kirby/pull/6596

### Summary of changes

In this PR, the page status button is moved to the topbar.

### Reasoning

The moved status button is making room for the form buttons and other custom view buttons, but more importantly, it's avoiding colliding UI conflicts with our new form control concept …

![Screenshot 2024-09-12 at 11 41 47](https://github.com/user-attachments/assets/09c257a8-0fe6-455c-a328-3c49c5288981)

"Public vs. Publish" really is a big problem here. Moving it up will not entirely remove the mixed messaging, but it separates it far enough to understand that one is the current state of the page and the other is the action to perform.

### Additional context

![Screenshot 2024-09-11 at 11 51 20](https://github.com/user-attachments/assets/2bf9e380-07df-43c1-87f6-8c0f7b37ee8d)