### PR TITLE
Changes 24: Show dropdown for the page preview button if there are changes

### DIFF
--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -13,7 +13,28 @@ return [
 	},
 	'page.preview' => function (Page $page) {
 		if ($page->permissions()->can('preview') === true) {
-			return new PreviewButton(link: $page->previewUrl());
+			$button = new PreviewButton(link: $page->previewUrl());
+
+			if ($page->version('changes')->exists() === true) {
+				$button->link = null;
+				$button->options = [
+					[
+						'icon'   => 'preview',
+						'text'   => I18n::translate('form.preview'),
+						'link'   => $page->url() . '?_version=changes',
+						'target' => '_blank'
+					],
+					'-',
+					[
+						'icon'   => 'open',
+						'text'   => 'Open current public version',
+						'link'   => $page->url(),
+						'target' => '_blank'
+					],
+				];
+			}
+
+			return $button;
 		}
 	},
 	'page.settings' => function (Page $page) {


### PR DESCRIPTION
## Description

### Merge first

- [ ] https://github.com/getkirby/kirby/pull/6596
- [ ] https://github.com/getkirby/kirby/pull/6661

### Summary of changes

The page preview button will now show a dropdown if there are changes

### Additional context

![Screenshot 2024-09-11 at 12 48 24](https://github.com/user-attachments/assets/b01ee6b7-de7b-42c5-9f2b-feddd132bb7f)

### Todos

- [ ] Translate "Open current public version"
- [ ] The button is not yet reactive and does not show the dropdown when changes happen. 
