### PR TITLE
Add `avif` to resizable image types

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -28,6 +28,7 @@ class Image extends File
 	protected Dimensions|null $dimensions = null;
 
 	public static array $resizableTypes = [
+		'avif',
 		'jpg',
 		'jpeg',
 		'gif',


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `avif` images are allowed to be resized


### Reasoning
As far as I can tell, both SimpleImage and IM support resizing avifs by now.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement
- `avif` images are considered resizable now by default


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
