### PR TITLE
Better contrast for current item in light dropdown

### DIFF
--- a/panel/lab/components/dropdowns/1_themes/index.vue
+++ b/panel/lab/components/dropdowns/1_themes/index.vue
@@ -30,19 +30,25 @@ export default {
 			return [
 				{
 					text: "Edit",
-					icon: "edit",
+					icon: "edit"
 				},
 				{
 					text: "Duplicate",
-					icon: "copy",
+					icon: "copy"
+				},
+				"-",
+				{
+					text: "Active item",
+					icon: "heart",
+					current: true
 				},
 				"-",
 				{
 					text: "Delete",
-					icon: "trash",
-				},
+					icon: "trash"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/src/components/Dropdowns/DropdownContent.vue
+++ b/panel/src/components/Dropdowns/DropdownContent.vue
@@ -384,7 +384,7 @@ export default {
 .k-dropdown-content[data-theme="light"] {
 	--dropdown-color-bg: var(--color-white);
 	--dropdown-color-text: var(--color-black);
-	--dropdown-color-current: var(--color-blue-700);
+	--dropdown-color-current: var(--color-blue-800);
 	--dropdown-color-hr: rgba(0, 0, 0, 0.1);
 }
 </style>

--- a/panel/src/components/Dropdowns/DropdownContent.vue
+++ b/panel/src/components/Dropdowns/DropdownContent.vue
@@ -338,6 +338,7 @@ export default {
 :root {
 	--dropdown-color-bg: var(--color-black);
 	--dropdown-color-text: var(--color-white);
+	--dropdown-color-current: var(--color-blue-500);
 	--dropdown-color-hr: rgba(255, 255, 255, 0.25);
 	--dropdown-padding: var(--spacing-2);
 	--dropdown-rounded: var(--rounded);
@@ -383,6 +384,7 @@ export default {
 .k-dropdown-content[data-theme="light"] {
 	--dropdown-color-bg: var(--color-white);
 	--dropdown-color-text: var(--color-black);
+	--dropdown-color-current: var(--color-blue-700);
 	--dropdown-color-hr: rgba(0, 0, 0, 0.1);
 }
 </style>

--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -54,7 +54,7 @@ export default {
 	outline: var(--outline);
 }
 .k-dropdown-item.k-button[aria-current] {
-	--button-color-text: var(--color-blue-500);
+	--button-color-text: var(--dropdown-color-current);
 }
 .k-dropdown-item.k-button:not([aria-disabled]):hover {
 	--button-color-back: var(--dropdown-color-hr);

--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -48,13 +48,18 @@ export default {
 	--button-rounded: var(--rounded-sm);
 	--button-width: 100%;
 	display: flex;
-	gap: 0.75rem;
 }
 .k-dropdown-item.k-button:focus {
 	outline: var(--outline);
 }
 .k-dropdown-item.k-button[aria-current] {
 	--button-color-text: var(--dropdown-color-current);
+}
+.k-dropdown-item.k-button[aria-current]::after {
+	margin-inline-start: auto;
+	text-align: center;
+	content: "✓";
+	padding-inline-start: var(--spacing-1);
 }
 .k-dropdown-item.k-button:not([aria-disabled]):hover {
 	--button-color-back: var(--dropdown-color-hr);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Improve color contrast for current item in light theme dropdown
<img width="167" alt="Screenshot 2024-09-14 at 11 23 03 AM" src="https://github.com/user-attachments/assets/9cece2f3-1c3e-4576-acc5-cc701ce50b66">


### Reasoning
Using `color-blue-700` is actually not fully compliant with WCAG AA, only achieving 4.43:1 contrast ratio.
However the next available color step `color-blue-800` is way too dark to be a noticeable difference:
<img width="158" alt="Screenshot 2024-09-14 at 11 23 22 AM" src="https://github.com/user-attachments/assets/8f3f6bf4-b97f-4ae1-aa35-0dadabf937b5">

How do we want to deal with such situations. Break out of our color system? `#2A78C6` would be conforming and close to `color-blue-700`.