### PR TITLE
Changes 23: Simplify Draft Handling

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -189,7 +189,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$new = $this->clone(['template' => $blueprint]);
 
 		// temporary compatibility change (TODO: also convert changes)
-		$identifier = VersionId::default($this);
+		$identifier = VersionId::published();
 
 		// for multilang, we go through all translations and
 		// covnert the content for each of them, remove the content file
@@ -724,7 +724,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	{
 		return new Version(
 			model: $this,
-			id: VersionId::from($versionId ?? VersionId::default($this))
+			id: VersionId::from($versionId ?? VersionId::published())
 		);
 	}
 

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -38,7 +38,7 @@ abstract class ContentStorageHandler
 	public function all(): Generator
 	{
 		foreach (Languages::ensure() as $language) {
-			foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+			foreach (VersionId::list() as $versionId) {
 				if ($this->exists($versionId, $language) === true) {
 					yield $versionId => $language;
 				}
@@ -68,7 +68,7 @@ abstract class ContentStorageHandler
 	 */
 	public function deleteLanguage(Language $language): void
 	{
-		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+		foreach (VersionId::list() as $versionId) {
 			$this->delete($versionId, $language);
 		}
 	}
@@ -156,7 +156,7 @@ abstract class ContentStorageHandler
 	 */
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
-		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+		foreach (VersionId::list() as $versionId) {
 			if ($this->exists($versionId, $fromLanguage) === true) {
 				$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
 			}
@@ -208,7 +208,7 @@ abstract class ContentStorageHandler
 	 */
 	public function touchLanguage(Language $language): void
 	{
-		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+		foreach (VersionId::list() as $versionId) {
 			if ($this->exists($versionId, $language) === true) {
 				$this->touch($versionId, $language);
 			}

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -6,7 +6,6 @@ use Generator;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\A;
 
@@ -39,7 +38,7 @@ abstract class ContentStorageHandler
 	public function all(): Generator
 	{
 		foreach (Languages::ensure() as $language) {
-			foreach ($this->dynamicVersions() as $versionId) {
+			foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
 				if ($this->exists($versionId, $language) === true) {
 					yield $versionId => $language;
 				}
@@ -69,29 +68,9 @@ abstract class ContentStorageHandler
 	 */
 	public function deleteLanguage(Language $language): void
 	{
-		foreach ($this->dynamicVersions() as $version) {
-			$this->delete($version, $language);
+		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+			$this->delete($versionId, $language);
 		}
-	}
-
-	/**
-	 * Returns all versions available for the model that can be updated
-	 * @internal
-	 * @todo We might want to move this directly to the models later or work
-	 *       with a `Versions` class
-	 */
-	public function dynamicVersions(): array
-	{
-		$versions = [VersionId::changes()];
-
-		if (
-			$this->model instanceof Page === false ||
-			$this->model->isDraft() === false
-		) {
-			$versions[] = VersionId::published();
-		}
-
-		return $versions;
 	}
 
 	/**
@@ -177,7 +156,7 @@ abstract class ContentStorageHandler
 	 */
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
-		foreach ($this->dynamicVersions() as $versionId) {
+		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
 			if ($this->exists($versionId, $fromLanguage) === true) {
 				$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
 			}
@@ -229,9 +208,9 @@ abstract class ContentStorageHandler
 	 */
 	public function touchLanguage(Language $language): void
 	{
-		foreach ($this->dynamicVersions() as $version) {
-			if ($this->exists($version, $language) === true) {
-				$this->touch($version, $language);
+		foreach ([VersionId::published(), VersionId::changes()] as $versionId) {
+			if ($this->exists($versionId, $language) === true) {
+				$this->touch($versionId, $language);
 			}
 		}
 	}

--- a/src/Content/ContentStorageHandler.php
+++ b/src/Content/ContentStorageHandler.php
@@ -38,7 +38,7 @@ abstract class ContentStorageHandler
 	public function all(): Generator
 	{
 		foreach (Languages::ensure() as $language) {
-			foreach (VersionId::list() as $versionId) {
+			foreach (VersionId::all() as $versionId) {
 				if ($this->exists($versionId, $language) === true) {
 					yield $versionId => $language;
 				}
@@ -68,7 +68,7 @@ abstract class ContentStorageHandler
 	 */
 	public function deleteLanguage(Language $language): void
 	{
-		foreach (VersionId::list() as $versionId) {
+		foreach (VersionId::all() as $versionId) {
 			$this->delete($versionId, $language);
 		}
 	}
@@ -156,7 +156,7 @@ abstract class ContentStorageHandler
 	 */
 	public function moveLanguage(Language $fromLanguage, Language $toLanguage): void
 	{
-		foreach (VersionId::list() as $versionId) {
+		foreach (VersionId::all() as $versionId) {
 			if ($this->exists($versionId, $fromLanguage) === true) {
 				$this->move($versionId, $fromLanguage, $versionId, $toLanguage);
 			}
@@ -208,7 +208,7 @@ abstract class ContentStorageHandler
 	 */
 	public function touchLanguage(Language $language): void
 	{
-		foreach (VersionId::list() as $versionId) {
+		foreach (VersionId::all() as $versionId) {
 			if ($this->exists($versionId, $language) === true) {
 				$this->touch($versionId, $language);
 			}

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -180,9 +180,9 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 			return true;
 		}
 
-		// A non-default version or non-default language version does not exist
+		// A changed version or non-default language version does not exist
 		// if the content file was not found
-		if (VersionId::default($this->model)->is($versionId) === false || $language->isDefault() === false) {
+		if (VersionId::published()->is($versionId) === false || $language->isDefault() === false) {
 			return false;
 		}
 

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -77,19 +77,7 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	 */
 	protected function contentFileForPage(Page $model, VersionId $versionId, Language $language): string
 	{
-		$directory = $this->contentDirectory($versionId);
-
-		if ($model->isDraft() === true) {
-			if ($versionId->is(Versionid::PUBLISHED) === true) {
-				throw new LogicException('Drafts cannot have a published content file');
-			}
-
-			// drafts already have the `_drafts` prefix in their root.
-			// `_changes` must not be added to it in addition to that.
-			$directory = $this->model->root();
-		}
-
-		return $directory . '/' . $this->contentFilename($model->intendedTemplate()->name(), $language);
+		return $this->contentDirectory($versionId) . '/' . $this->contentFilename($model->intendedTemplate()->name(), $language);
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -245,8 +245,8 @@ class Version
 		// the version needs to exist
 		$this->ensure($language);
 
-		// update the default version
-		$this->model->version(VersionId::default($this->model))->save(
+		// update the published version
+		$this->model->version(VersionId::published())->save(
 			fields: $this->read($language),
 			language: $language
 		);

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -66,6 +66,17 @@ class VersionId implements Stringable
 	}
 
 	/**
+	 * List of available version ids
+	 */
+	public static function list(): array
+	{
+		return [
+			static::published(),
+			static::changes(),
+		];
+	}
+
+	/**
 	 * Creates a VersionId instance from a simple string value
 	 */
 	public static function from(VersionId|string $value): static

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -68,14 +68,6 @@ class VersionId implements Stringable
 	}
 
 	/**
-	 * Returns the default version id for the model
-	 */
-	public static function default(ModelWithContent $model): static
-	{
-		return VersionId::published();
-	}
-
-	/**
 	 * Creates a VersionId instance from a simple string value
 	 */
 	public static function from(VersionId|string $value): static

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\ModelWithContent;
-use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Stringable;
 

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -72,13 +72,6 @@ class VersionId implements Stringable
 	 */
 	public static function default(ModelWithContent $model): static
 	{
-		if (
-			$model instanceof Page === true &&
-			$model->isDraft() === true
-		) {
-			return VersionId::changes();
-		}
-
 		return VersionId::published();
 	}
 

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -58,22 +58,22 @@ class VersionId implements Stringable
 	}
 
 	/**
-	 * Creates a VersionId instance for the latest content changes
-	 */
-	public static function changes(): static
-	{
-		return new static(static::CHANGES);
-	}
-
-	/**
 	 * List of available version ids
 	 */
-	public static function list(): array
+	public static function all(): array
 	{
 		return [
 			static::published(),
 			static::changes(),
 		];
+	}
+
+	/**
+	 * Creates a VersionId instance for the latest content changes
+	 */
+	public static function changes(): static
+	{
+		return new static(static::CHANGES);
 	}
 
 	/**

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -525,9 +525,5 @@ class ModelWithContentTest extends TestCase
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(Version::class, $model->version());
 		$this->assertSame('published', $model->version()->id()->value());
-
-		$model = new Page(['slug' => 'foo', 'isDraft' => true]);
-		$this->assertInstanceOf(Version::class, $model->version());
-		$this->assertSame('changes', $model->version()->id()->value());
 	}
 }

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -953,15 +953,18 @@ class PageActionsTest extends TestCase
 			'parent' => $page,
 			'code'   => 'en',
 		]);
-		$this->assertFileExists($page->version(VersionId::changes())->contentFile('en'));
+
+		$versionId = VersionId::published();
+
+		$this->assertFileExists($page->version($versionId)->contentFile('en'));
 
 		$drafts = $app->site()->drafts();
 		$childrenAndDrafts = $app->site()->childrenAndDrafts();
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileExists($copy->version(VersionId::changes())->contentFile('en'));
-		$this->assertFileDoesNotExist($copy->version(VersionId::changes())->contentFile('de'));
+		$this->assertFileExists($copy->version($versionId)->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version($versionId)->contentFile('de'));
 
 		$this->assertIsPage($page, $drafts->find('test'));
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
@@ -993,8 +996,11 @@ class PageActionsTest extends TestCase
 			'slug'  => 'test-de'
 		], 'de');
 
-		$this->assertFileExists($page->version(VersionId::changes())->contentFile('en'));
-		$this->assertFileExists($page->version(VersionId::changes())->contentFile('de'));
+		$versionId = VersionId::published();
+
+		$this->assertFileExists($page->version($versionId)->contentFile('en'));
+		$this->assertFileExists($page->version($versionId)->contentFile('de'));
+
 		$this->assertSame('test', $page->slug());
 		$this->assertSame('test-de', $page->slug('de'));
 
@@ -1106,11 +1112,12 @@ class PageActionsTest extends TestCase
 			'code'   => 'en'
 		]);
 
+		$versionId = VersionId::published();
+
 		$copy = $page->duplicate('test-copy', ['children' => true]);
 
-		$this->assertFileExists($copy->version(VersionId::changes())->contentFile('en'));
-		$this->assertFileDoesNotExist($copy->version(VersionId::changes())->contentFile('de'));
-
+		$this->assertFileExists($copy->version($versionId)->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version($versionId)->contentFile('de'));
 
 		$this->assertNotSame($page->uuid()->id(), $copy->uuid()->id());
 		$this->assertNotSame($app->page('test/foo')->uuid()->id(), $app->page('test-copy/foo')->uuid()->id());

--- a/tests/Content/ContentStorageHandlerTest.php
+++ b/tests/Content/ContentStorageHandlerTest.php
@@ -5,8 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
-use Kirby\Cms\Site;
-use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
 
@@ -116,35 +114,6 @@ class ContentStorageHandlerTest extends TestCase
 	/**
 	 * @covers ::all
 	 */
-	public function testAllMultiLanguageForPageDraft()
-	{
-		$this->setUpMultiLanguage();
-
-		$handler = new TestContentStorageHandler(
-			new Page(['slug' => 'test', 'isDraft' => true])
-		);
-
-		$versions = iterator_to_array($handler->all(), false);
-
-		$this->assertCount(0, $versions);
-
-		$handler->create(VersionId::published(), $this->app->language('en'), []);
-		$handler->create(VersionId::published(), $this->app->language('de'), []);
-
-		$handler->create(VersionId::changes(), $this->app->language('en'), []);
-		$handler->create(VersionId::changes(), $this->app->language('de'), []);
-
-		// count again
-		$versions = iterator_to_array($handler->all(), false);
-
-		// A draft page has only changes and thus should only have
-		// a changes for every language, but no published versions
-		$this->assertCount(2, $versions);
-	}
-
-	/**
-	 * @covers ::all
-	 */
 	public function testAllSingleLanguageForPage()
 	{
 		$this->setUpSingleLanguage();
@@ -166,33 +135,6 @@ class ContentStorageHandlerTest extends TestCase
 
 		// A page that's not in draft mode can have published and changes versions
 		$this->assertCount(2, $versions);
-	}
-
-	/**
-	 * @covers ::all
-	 */
-	public function testAllSingleLanguageForPageDraft()
-	{
-		$this->setUpSingleLanguage();
-
-		$handler = new TestContentStorageHandler(
-			new Page(['slug' => 'test', 'isDraft' => true])
-		);
-
-		$versions = iterator_to_array($handler->all(), false);
-
-		$this->assertCount(0, $versions);
-
-		// create all possible versions
-		$handler->create(VersionId::published(), Language::single(), []);
-		$handler->create(VersionId::changes(), Language::single(), []);
-
-		// count again
-		$versions = iterator_to_array($handler->all(), false);
-
-		// A draft page has only changes and thus should only have
-		// a single version in a single language installation
-		$this->assertCount(1, $versions);
 	}
 
 	/**
@@ -245,88 +187,6 @@ class ContentStorageHandlerTest extends TestCase
 
 		$this->assertFalse($handler->exists(VersionId::published(), $language));
 		$this->assertFalse($handler->exists(VersionId::changes(), $language));
-	}
-
-	/**
-	 * @covers ::dynamicVersions
-	 */
-	public function testDynamicVersionsForFile()
-	{
-		$handler = new TestContentStorageHandler(
-			new File([
-				'filename' => 'test.jpg',
-				'parent'   => new Page(['slug' => 'test'])
-			])
-		);
-
-		$versions = $handler->dynamicVersions();
-
-		$this->assertCount(2, $versions);
-		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
-		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
-	}
-
-	/**
-	 * @covers ::dynamicVersions
-	 */
-	public function testDynamicVersionsForPage()
-	{
-		$handler = new TestContentStorageHandler(
-			new Page(['slug' => 'test', 'isDraft' => false])
-		);
-
-		$versions = $handler->dynamicVersions();
-
-		$this->assertCount(2, $versions);
-		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
-		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
-	}
-
-	/**
-	 * @covers ::dynamicVersions
-	 */
-	public function testDynamicVersionsForPageDraft()
-	{
-		$handler = new TestContentStorageHandler(
-			new Page(['slug' => 'test', 'isDraft' => true])
-		);
-
-		$versions = $handler->dynamicVersions();
-
-		$this->assertCount(1, $versions);
-		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
-	}
-
-	/**
-	 * @covers ::dynamicVersions
-	 */
-	public function testDynamicVersionsForSite()
-	{
-		$handler = new TestContentStorageHandler(
-			new Site()
-		);
-
-		$versions = $handler->dynamicVersions();
-
-		$this->assertCount(2, $versions);
-		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
-		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
-	}
-
-	/**
-	 * @covers ::dynamicVersions
-	 */
-	public function testDynamicVersionsForUser()
-	{
-		$handler = new TestContentStorageHandler(
-			new User(['email' => 'test@getkirby.com'])
-		);
-
-		$versions = $handler->dynamicVersions();
-
-		$this->assertCount(2, $versions);
-		$this->assertSame(VersionId::CHANGES, $versions[0]->value());
-		$this->assertSame(VersionId::PUBLISHED, $versions[1]->value());
 	}
 
 	/**

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -649,29 +649,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		]);
 
 		$storage = new PlainTextContentStorageHandler($model);
-		$this->assertSame(static::TMP . '/content/_drafts/a-page/article.txt', $storage->contentFile(VersionId::changes(), Language::single()));
-	}
-
-	/**
-	 * @covers ::contentFile
-	 */
-	public function testContentFileDraftPublished()
-	{
-		$this->setUpSingleLanguage();
-
-		$model = new Page([
-			'kirby' => $this->app,
-			'root' => static::TMP,
-			'isDraft' => true,
-			'slug' => 'a-page',
-			'template' => 'article'
-		]);
-
-		$storage = new PlainTextContentStorageHandler($model);
-
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Drafts cannot have a published content file');
-		$storage->contentFile(VersionId::published(), Language::single());
+		$this->assertSame(static::TMP . '/content/_drafts/a-page/_changes/article.txt', $storage->contentFile(VersionId::changes(), Language::single()));
 	}
 
 	/**

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -7,7 +7,6 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
-use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -11,6 +11,18 @@ use Kirby\TestCase;
 class VersionIdTest extends TestCase
 {
 	/**
+	 * @covers ::all
+	 */
+	public function testAll()
+	{
+		$list = VersionId::all();
+
+		$this->assertCount(2, $list);
+		$this->assertSame('published', $list[0]->value());
+		$this->assertSame('changes', $list[1]->value());
+	}
+
+	/**
 	 * @covers ::changes
 	 * @covers ::value
 	 */
@@ -63,18 +75,6 @@ class VersionIdTest extends TestCase
 		$this->assertTrue($version->is(VersionId::PUBLISHED));
 		$this->assertFalse($version->is('something-else'));
 		$this->assertFalse($version->is(VersionId::CHANGES));
-	}
-
-	/**
-	 * @covers ::list
-	 */
-	public function testList()
-	{
-		$list = VersionId::list();
-
-		$this->assertCount(2, $list);
-		$this->assertSame('published', $list[0]->value());
-		$this->assertSame('changes', $list[1]->value());
 	}
 
 	/**

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -35,27 +35,6 @@ class VersionIdTest extends TestCase
 	}
 
 	/**
-	 * @covers ::default
-	 */
-	public function testDefault()
-	{
-		$draft   = new Page(['slug' => 'test', 'isDraft' => true]);
-		$version = VersionId::default($draft);
-
-		$this->assertTrue($version->is(VersionId::CHANGES));
-
-		$unlisted = new Page(['slug' => 'test', 'isDraft' => false]);
-		$version  = VersionId::default($unlisted);
-
-		$this->assertTrue($version->is(VersionId::PUBLISHED));
-
-		$file    = new File(['filename' => 'foo.jpg', 'parent' => $unlisted]);
-		$version = VersionId::default($file);
-
-		$this->assertTrue($version->is(VersionId::PUBLISHED));
-	}
-
-	/**
 	 * @covers ::from
 	 * @covers ::value
 	 */

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -66,6 +66,18 @@ class VersionIdTest extends TestCase
 	}
 
 	/**
+	 * @covers ::list
+	 */
+	public function testList()
+	{
+		$list = VersionId::list();
+
+		$this->assertCount(2, $list);
+		$this->assertSame('published', $list[0]->value());
+		$this->assertSame('changes', $list[1]->value());
+	}
+
+	/**
 	 * @covers ::published
 	 * @covers ::value
 	 */

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\File;
-use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 


### PR DESCRIPTION
## Description

### Summary of changes

- Draft pages are no longer treated differently than other pages and can have their own _changes version
- `VersionId::published()` is now also used as default version for draft pages
- Removed `VersionId::default()`
- New `VersionId::all()` method to get an array with all available Version ids. 

### Reasoning

The reason to use `changes` as the default version for drafts seemed to make a lot of sense at first. But when implementing the panel integration, it turns out that this is adding a lot of unnecessary complexity. 

With our old approach of storing changes in local storage, we basically already had unsaved changes for drafts and it made a lot of sense in the interface and never felt weird. We can think the same way about how changes for drafts are handled. A draft is a page that has not been published yet. That unpublished page can still have two versions, or even multiple revisions later. 

By removing that distinction, we can avoid complexity in the backend and in the frontend. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass