### PR TITLE
Changes 25: New Version::diff method

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -105,6 +105,23 @@ class Version
 	}
 
 	/**
+	 * Returns the changed fields, compared to the given version
+	 */
+	public function diff(VersionId|string $versionId, Language|string $language = 'default'): array
+	{
+		$versionId = VersionId::from($versionId);
+
+		if ($versionId->is($this->id) === true) {
+			return [];
+		}
+
+		$a = $this->read($language) ?? [];
+		$b = $this->model->version($versionId)->read($language) ?? [];
+
+		return array_diff($b, $a);
+	}
+
+	/**
 	 * Ensure that the version exists and otherwise
 	 * throw an exception
 	 *

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -267,6 +267,9 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist();
 	}
 
+	/**
+	 * @covers ::diff
+	 */
 	public function testDiffMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -308,6 +311,9 @@ class VersionTest extends TestCase
 		$this->assertSame($expectedDE, $diffDE);
 	}
 
+	/**
+	 * @covers ::diff
+	 */
 	public function testDiffSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -341,6 +347,9 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $diff);
 	}
 
+	/**
+	 * @covers ::diff
+	 */
 	public function testDiffWithoutChanges()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -267,6 +267,109 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist();
 	}
 
+	public function testDiffMultiLanguage()
+	{
+		$this->setUpMultiLanguage();
+
+		$a = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$b = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$a->create($content = [
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle',
+		], 'en');
+
+		$a->create($content, 'de');
+
+		$b->create($content, 'en');
+
+		$b->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle (changed)',
+		], 'de');
+
+		// no changes in English
+		$diffEN = $a->diff(VersionId::changes(), 'en');
+		$expectedEN = [];
+
+		$this->assertSame($expectedEN, $diffEN);
+
+		// changed subtitle in German
+		$diffDE = $a->diff(VersionId::changes(), 'de');
+		$expectedDE = ['subtitle' => 'Subtitle (changed)'];
+
+		$this->assertSame($expectedDE, $diffDE);
+	}
+
+	public function testDiffSingleLanguage()
+	{
+		$this->setUpSingleLanguage();
+
+		$a = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$b = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$a->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle',
+		]);
+
+		$b->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle (changed)',
+		]);
+
+		$diff = $a->diff(VersionId::changes());
+
+		// the result array should contain the changed fields
+		// the changed values
+		$expected = ['subtitle' => 'Subtitle (changed)'];
+
+		$this->assertSame($expected, $diff);
+	}
+
+	public function testDiffWithoutChanges()
+	{
+		$this->setUpSingleLanguage();
+
+		$a = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$b = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$a->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle',
+		]);
+
+		$b->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle',
+		]);
+
+		$diff = $a->diff(VersionId::changes());
+
+		$this->assertSame([], $diff);
+	}
+
 	/**
 	 * @covers ::ensure
 	 */

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -380,6 +380,28 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::diff
+	 */
+	public function testDiffWithSameVersion()
+	{
+		$this->setUpSingleLanguage();
+
+		$a = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$a->create([
+			'title'    => 'Title',
+			'subtitle' => 'Subtitle',
+		]);
+
+		$diff = $a->diff(VersionId::published());
+
+		$this->assertSame([], $diff);
+	}
+
+	/**
 	 * @covers ::ensure
 	 */
 	public function testEnsureMultiLanguage(): void


### PR DESCRIPTION
## Description

### Reasoning

- `Version::diff` will be used later to check if a changed version really has any differences. This will help to avoid tracking unnecessary changes. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Version::diff` method to compare two versions and get an array of changed fields

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
