### PR TITLE
Revert "Redirect language URLs with non-translated slugs"

### DIFF
--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
-use Kirby\Toolkit\Str;
 
 class LanguageRoutes
 {
@@ -30,25 +29,8 @@ class LanguageRoutes
 				'pattern' => $language->pattern(),
 				'method'  => 'ALL',
 				'env'     => 'site',
-				'action'  => function ($path = null) use ($kirby, $language) {
+				'action'  => function ($path = null) use ($language) {
 					$result = $language->router()->call($path);
-
-					// redirect secondary-language pages that have
-					// been accessed with non-translated slugs in their path
-					// to their fully translated URL
-					if ($path !== null && $result instanceof Page) {
-						if (Str::endsWith($result->url(), $path) === false) {
-							$url   = $result->url();
-							$query = $kirby->request()->query()->toString();
-
-							// preserve query across redirect
-							if (empty($query) === false) {
-								$url .= '?' . $query;
-							}
-
-							return $kirby->response()->redirect($url);
-						}
-					}
 
 					// explicitly test for null as $result can
 					// contain falsy values that should still be returned

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -122,42 +122,4 @@ class LanguageRoutesTest extends TestCase
 		$this->assertSame(1, $d);
 		$this->assertSame(2, $e);
 	}
-
-	public function testRedirectWhenNonTranslatedSlugs()
-	{
-		$app = $this->app->clone([
-			'site' => [
-				'children' => [
-					[
-						'slug'         => 'page1',
-						'translations' => [
-							[
-								'code' => 'en',
-							],
-							[
-								'code' => 'de',
-								'slug' => 'seite1',
-							]
-						]
-					]
-				]
-			],
-			'request' => [
-				'query' => [
-					'foo' => 'bar',
-				]
-			]
-		]);
-
-		$result = $app->call('page1');
-		$this->assertSame($app->page('page1'), $result);
-
-		$result = $app->call('de/page1');
-		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertSame(302, $result->code());
-		$this->assertSame('/de/seite1?foo=bar', $result->header('Location'));
-
-		$result = $app->call('de/seite1');
-		$this->assertSame($app->page('page1'), $result);
-	}
 }


### PR DESCRIPTION
## Description

This PR reverts commit 8e8f9e521537df0c904b54d78539c1de1b94c1b4.

It means that we have to reopen https://github.com/getkirby/kirby/issues/3550

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- https://github.com/getkirby/kirby/issues/6676

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
