### PR TITLE
Changes 24: New Content Flow

### DIFF
--- a/panel/src/components/Forms/FormButtons.vue
+++ b/panel/src/components/Forms/FormButtons.vue
@@ -72,7 +72,7 @@ export default {
 					{
 						icon: "check",
 						text: this.$t("save"),
-						click: () => this.save()
+						click: () => this.$emit("submit")
 					}
 				];
 			}
@@ -169,13 +169,11 @@ export default {
 		if (this.supportsLocking) {
 			this.isLoading = setInterval(this.check, 10000);
 		}
-		this.$events.on("view.save", this.save);
 	},
 	destroyed() {
 		// make sure to clear all intervals
 		clearInterval(this.isLoading);
 		clearInterval(this.isLocking);
-		this.$events.off("view.save", this.save);
 	},
 	methods: {
 		async check() {
@@ -231,7 +229,7 @@ export default {
 					// If setting lock failed, a competing lock has been set between
 					// API calls. In that case, discard changes, stop setting lock
 					clearInterval(this.isLocking);
-					this.$panel.content.discard();
+					this.$emit("discard");
 				}
 			}
 
@@ -244,7 +242,7 @@ export default {
 		async resolve() {
 			// remove content unlock and throw away unsaved changes
 			await this.unlock(false);
-			this.$panel.content.discard();
+			this.$emit("discard");
 		},
 		revert() {
 			this.$panel.dialog.open({
@@ -258,14 +256,11 @@ export default {
 				},
 				on: {
 					submit: () => {
-						this.$panel.content.discard();
 						this.$panel.dialog.close();
+						this.$emit("discard");
 					}
 				}
 			});
-		},
-		save(e) {
-			this.$panel.content.publish(e);
 		},
 		async unlock(unlock = true) {
 			const api = [this.$panel.view.path + "/unlock", null, null, true];

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -15,32 +15,29 @@
 		<k-form
 			:fields="fields"
 			:validate="true"
-			:value="values"
+			:value="content"
 			:disabled="lock && lock.state === 'lock'"
-			@input="onInput"
-			@submit="onSubmit"
+			@input="$emit('input', $event)"
+			@submit="$emit('submit', $event)"
 		/>
 	</k-section>
 </template>
 
 <script>
 import SectionMixin from "@/mixins/section.js";
-import debounce from "@/helpers/debounce.js";
 
 export default {
 	mixins: [SectionMixin],
 	inheritAttrs: false,
+	props: {
+		content: Object
+	},
 	data() {
 		return {
 			fields: {},
 			isLoading: true,
 			issue: null
 		};
-	},
-	computed: {
-		values() {
-			return this.$panel.content.values;
-		}
 	},
 	watch: {
 		// Reload values and field definitions
@@ -50,7 +47,6 @@ export default {
 		}
 	},
 	mounted() {
-		this.onInput = debounce(this.onInput, 50);
 		this.fetch();
 	},
 	methods: {
@@ -72,14 +68,6 @@ export default {
 			} finally {
 				this.isLoading = false;
 			}
-		},
-		onInput(values) {
-			this.$panel.content.set(values);
-		},
-		onSubmit(values) {
-			// ensure that all values are actually committed to content store
-			this.onInput(values);
-			this.$events.emit("keydown.cmd.s", values);
 		}
 	}
 };

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -28,11 +28,13 @@
 						"
 						v-bind="section"
 						:column="column.width"
+						:content="content"
 						:lock="lock"
 						:name="section.name"
 						:parent="parent"
 						:timestamp="$panel.view.timestamp"
 						:class="'k-section-name-' + section.name"
+						@input="$emit('input', $event)"
 						@submit="$emit('submit', $event)"
 					/>
 					<template v-else>
@@ -54,18 +56,14 @@
 <script>
 export default {
 	props: {
-		empty: String,
 		blueprint: String,
+		content: Object,
+		empty: String,
 		lock: [Boolean, Object],
 		parent: String,
 		tab: Object
 	},
 	emits: ["submit"],
-	computed: {
-		content() {
-			return this.$panel.content.values;
-		}
-	},
 	methods: {
 		exists(type) {
 			return this.$helper.isComponent(`k-${type}-section`);

--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -1,5 +1,12 @@
 <template>
-	<component :is="preview" v-bind="props" class="k-file-preview" />
+	<component
+		:is="preview"
+		v-bind="props"
+		:content="content"
+		class="k-file-preview"
+		@input="$emit('input', $event)"
+		@submit="$emit('submit', $event)"
+	/>
 </template>
 
 <script>
@@ -10,6 +17,7 @@
 export default {
 	props: {
 		component: String,
+		content: Object,
 		props: Object
 	},
 	computed: {

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -19,7 +19,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" @action="onAction" />
-				<k-form-buttons />
+				<k-form-buttons @discard="onDiscard" @submit="onSubmit" />
 			</template>
 		</k-header>
 
@@ -29,10 +29,13 @@
 
 		<k-sections
 			:blueprint="blueprint"
+			:content="content"
 			:empty="$t('file.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
 			:parent="id"
 			:tab="tab"
+			@input="onInput"
+			@submit="onSubmit"
 		/>
 	</k-panel-inside>
 </template>

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -23,7 +23,12 @@
 			</template>
 		</k-header>
 
-		<k-file-preview v-bind="preview" />
+		<k-file-preview
+			v-bind="preview"
+			:content="content"
+			@input="onInput"
+			@submit="onSubmit"
+		/>
 
 		<k-model-tabs :tab="tab.name" :tabs="tabs" />
 

--- a/panel/src/components/Views/Files/ImageFilePreview.vue
+++ b/panel/src/components/Views/Files/ImageFilePreview.vue
@@ -46,6 +46,7 @@
  */
 export default {
 	props: {
+		content: Object,
 		details: Array,
 		focusable: Boolean,
 		image: {
@@ -57,7 +58,7 @@ export default {
 	emits: ["focus"],
 	computed: {
 		focus() {
-			const focus = this.$panel.content.values["focus"];
+			const focus = this.content.focus;
 
 			if (!focus) {
 				return;
@@ -101,7 +102,7 @@ export default {
 				focus = `${focus.x.toFixed(1)}% ${focus.y.toFixed(1)}%`;
 			}
 
-			this.$panel.content.set({ focus });
+			this.$emit("input", { focus });
 		}
 	}
 };

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -1,4 +1,6 @@
 <script>
+import debounce from "@/helpers/debounce.js";
+
 /**
  * @internal
  */
@@ -33,6 +35,9 @@ export default {
 		}
 	},
 	computed: {
+		content() {
+			return this.$panel.content.values;
+		},
 		id() {
 			return this.model.link;
 		},
@@ -57,16 +62,34 @@ export default {
 		}
 	},
 	mounted() {
+		this.onInput = debounce(this.onInput, 50);
+
 		this.$events.on("model.reload", this.$reload);
 		this.$events.on("keydown.left", this.toPrev);
 		this.$events.on("keydown.right", this.toNext);
+		this.$events.on("view.save", this.onSave);
 	},
 	destroyed() {
 		this.$events.off("model.reload", this.$reload);
 		this.$events.off("keydown.left", this.toPrev);
 		this.$events.off("keydown.right", this.toNext);
+		this.$events.off("view.save", this.onSave);
 	},
 	methods: {
+		onDiscard() {
+			this.$panel.content.discard();
+		},
+		onInput(values) {
+			this.$panel.content.set(values);
+		},
+		onSave(e) {
+			e?.preventDefault?.();
+			this.onSubmit();
+		},
+		onSubmit(values = {}) {
+			this.$panel.content.set(values);
+			this.$panel.content.publish();
+		},
 		toPrev(e) {
 			if (this.prev && e.target.localName === "body") {
 				this.$go(this.prev.link);

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -19,7 +19,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons />
+				<k-form-buttons @discard="onDiscard" @submit="onSubmit" />
 			</template>
 		</k-header>
 
@@ -27,10 +27,13 @@
 
 		<k-sections
 			:blueprint="blueprint"
+			:content="content"
 			:empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
 			:parent="id"
 			:tab="tab"
+			@input="onInput"
+			@submit="onSubmit"
 		/>
 	</k-panel-inside>
 </template>

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -15,7 +15,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons />
+				<k-form-buttons @discard="onDiscard" @submit="onSubmit" />
 			</template>
 		</k-header>
 
@@ -23,11 +23,13 @@
 
 		<k-sections
 			:blueprint="blueprint"
+			:content="content"
 			:empty="$t('site.blueprint')"
 			:lock="lock"
 			:tab="tab"
 			parent="site"
-			@submit="$emit('submit', $event)"
+			@input="onInput"
+			@submit="onSubmit"
 		/>
 	</k-panel-inside>
 </template>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -27,7 +27,7 @@
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
-				<k-form-buttons />
+				<k-form-buttons @discard="onDiscard" @submit="onSubmit" />
 			</template>
 		</k-header>
 
@@ -41,10 +41,13 @@
 
 		<k-sections
 			:blueprint="blueprint"
+			:content="content"
 			:empty="$t('user.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
 			:parent="id"
 			:tab="tab"
+			@input="onInput"
+			@submit="onSubmit"
 		/>
 	</k-panel-inside>
 </template>

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -78,9 +78,7 @@ export default (panel) => {
 		/**
 		 * Publishes any changes
 		 */
-		async publish(e) {
-			e?.preventDefault?.();
-
+		async publish() {
 			this.isPublishing = true;
 			await panel.app.$store.dispatch("content/save");
 			panel.events.emit("model.update");


### PR DESCRIPTION
## Description

**I messed up the previous PR. This is replicating https://github.com/getkirby/kirby/pull/6678. See https://github.com/getkirby/kirby/pull/6678#issuecomment-2354688899 for a more detailed explanation why I think this is a good and important step**

<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- `content` is passed as prop to the `k-sections` component, which will then pass it on to all child section components. 
- `input` and `submit` events are bubbling up from the fields section -> to the sections component -> to the model view components. 
- The `k-form-button` component is simplified and no longer handles `submit` and `discard` events itself. It sends the events up to the model view components to be handled there.
- The file preview components now also receive the content as property and can send input and submit events up to the model view. 
- The `ModelView` component class takes over handling submit, input and discard events. It also listens to the `view.save` event and handles that. With this change, each view component is the single place of truth to pass content down to child components and handle input, submit and discard events. This drastically reduces the mental load to parse which component is responsible for what and the child components can be a lot more simple. 

### Reasoning

Simplifying the content flow will help a lot with the next steps when changes are coming from the backend. We can pass them as view property and the view can then pass it further down. This will avoid having to run some weird content module init code like we currently do in the Vuex module. It will also no longer tightly couple module logic with the components. 

### Next steps

- The `k-form-buttons` component is about to be removed and replaced by the new `k-form-controls` component. I wanted to refactor it in this PR anyway, to already get prepared for this step. The form controls component will also send the events up to the model view so it makes sense to already do that and reduce the dependency on the old form buttons component. 
- The content module will likely need a few more changes. I've prepared a couple things on the next-steps branch, but didn't want to blow this PR up even more. 
