### PR TITLE
Fix `User::roles()` for last admin

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -584,8 +584,9 @@ class User extends ModelWithContent
 		$kirby = $this->kirby();
 		$roles = $kirby->roles();
 
-		// for the last admin, only their current role (admin) is available
-		if ($this->isLastAdmin() === true) {
+		// for the last admin,
+		// only their current role (admin) is available for changing
+		if ($purpose === 'change' && $this->isLastAdmin() === true) {
 			// a collection with just the one role of the user
 			return $roles->filter('id', $this->role()->id());
 		}

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -367,11 +367,6 @@ class UserTest extends TestCase
 			],
 		]);
 
-		// last admin has only admin role as option
-		$user  = $app->user('admin@getkirby.com');
-		$roles = $user->roles()->values(fn ($role) => $role->id());
-		$this->assertSame(['admin'], $roles);
-
 		// normal user should not have admin as option
 		$user  = $app->user('editor@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
@@ -382,6 +377,11 @@ class UserTest extends TestCase
 		$user  = $app->user('editor@getkirby.com');
 		$roles = $user->roles()->values(fn ($role) => $role->id());
 		$this->assertSame(['admin', 'editor', 'guest'], $roles);
+
+		// last admin has only admin role as option
+		$user  = $app->user('admin@getkirby.com');
+		$roles = $user->roles('change')->values(fn ($role) => $role->id());
+		$this->assertSame(['admin'], $roles);
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
Clean up from previous PRs: For the last admin
- We want to limit roles to just their current role when changing roles.
- But we don't want limit roles when that last admin is creating users.


