### PR TITLE
Better content storage `::move()` + new `::copy()`

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -85,11 +85,7 @@ trait FileActions
 			F::move($oldFile->root(), $newFile->root());
 
 			// move the content storage versions
-			foreach ($oldFile->storage()->all() as $version => $lang) {
-				$content = $oldFile->storage()->read($version, $lang);
-				$oldFile->storage()->delete($version, $lang);
-				$newFile->storage()->create($version, $lang, $content);
-			}
+			$oldFile->storage()->moveAll(to: $newFile->storage());
 
 			// update collections
 			$newFile->parent()->files()->remove($oldFile->id());
@@ -218,10 +214,7 @@ trait FileActions
 		F::copy($this->root(), $page->root() . '/' . $this->filename());
 		$copy = $page->clone()->file($this->filename());
 
-		foreach ($this->storage()->all() as $version => $lang) {
-			$content = $this->storage()->read($version, $lang);
-			$copy->storage()->create($version, $lang, $content);
-		}
+		$this->storage()->copyAll(to: $copy->storage());
 
 		// ensure the content is re-read after copying it
 		// @todo find a more elegant way

--- a/src/Content/ImmutableMemoryContentStorageHandler.php
+++ b/src/Content/ImmutableMemoryContentStorageHandler.php
@@ -22,8 +22,9 @@ class ImmutableMemoryContentStorageHandler extends MemoryContentStorageHandler
 	public function move(
 		VersionId $fromVersionId,
 		Language $fromLanguage,
-		VersionId $toVersionId,
-		Language $toLanguage
+		VersionId|null $toVersionId = null,
+		Language|null $toLanguage = null,
+		ContentStorageHandler|null $toStorage = null
 	): void {
 		$this->preventMutation();
 	}

--- a/src/Content/PlainTextContentStorageHandler.php
+++ b/src/Content/PlainTextContentStorageHandler.php
@@ -223,32 +223,6 @@ class PlainTextContentStorageHandler extends ContentStorageHandler
 	}
 
 	/**
-	 * Moves content from one version-language combination to another
-	 */
-	public function move(
-		VersionId $fromVersionId,
-		Language $fromLanguage,
-		VersionId $toVersionId,
-		Language $toLanguage
-	): void {
-		// make sure the source version exists
-		$this->ensure($fromVersionId, $fromLanguage);
-
-		// check for an existing content file
-		$contentFile = $this->contentFile($fromVersionId, $fromLanguage);
-
-		// create the source file if it doesn't exist so far
-		if (file_exists($contentFile) === false) {
-			$this->touch($fromVersionId, $fromLanguage);
-		}
-
-		F::move(
-			$contentFile,
-			$this->contentFile($toVersionId, $toLanguage)
-		);
-	}
-
-	/**
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -178,15 +178,17 @@ class Version
 	 */
 	public function move(
 		Language|string $fromLanguage,
-		VersionId $toVersionId,
-		Language|string $toLanguage
+		VersionId|null $toVersionId = null,
+		Language|string|null $toLanguage = null,
+		ContentStorageHandler|null $toStorage = null
 	): void {
 		$this->ensure($fromLanguage);
 		$this->model->storage()->move(
 			fromVersionId: $this->id,
 			fromLanguage: Language::ensure($fromLanguage),
 			toVersionId: $toVersionId,
-			toLanguage: Language::ensure($toLanguage)
+			toLanguage: $toLanguage ? Language::ensure($toLanguage) : null,
+			toStorage: $toStorage
 		);
 	}
 

--- a/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
+++ b/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
@@ -45,8 +45,7 @@ class ImmutableMemoryContentStorageHandlerTest extends TestCase
 		$this->storage->move(
 			fromVersionId: VersionId::published(),
 			fromLanguage: Language::ensure(),
-			toVersionId: VersionId::changes(),
-			toLanguage: Language::ensure()
+			toVersionId: VersionId::changes()
 		);
 	}
 

--- a/tests/Content/PlainTextContentStorageHandlerTest.php
+++ b/tests/Content/PlainTextContentStorageHandlerTest.php
@@ -257,6 +257,9 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::published(), Language::single()));
 	}
 
+	/**
+	 * @coversNothing
+	 */
 	public function testMove()
 	{
 		$this->setUpSingleLanguage();
@@ -273,8 +276,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->storage->move(
 			VersionId::published(),
 			Language::single(),
-			VersionId::changes(),
-			Language::single()
+			VersionId::changes()
 		);
 
 		// the source file should no longer exist
@@ -284,6 +286,9 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
+	/**
+	 * @coversNothing
+	 */
 	public function testMoveNonExistingContentFile()
 	{
 		$this->setUpSingleLanguage();
@@ -293,8 +298,7 @@ class PlainTextContentStorageHandlerTest extends TestCase
 		$this->storage->move(
 			VersionId::published(),
 			Language::single(),
-			VersionId::changes(),
-			Language::single()
+			VersionId::changes()
 		);
 
 		// the source file should still not exist

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -666,7 +666,7 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist('de');
 
 		// move with string arguments
-		$version->move('en', $versionId, 'de');
+		$version->move('en', toLanguage: 'de');
 
 		$this->assertContentFileDoesNotExist('en');
 		$this->assertContentFileExists('de');
@@ -674,7 +674,7 @@ class VersionTest extends TestCase
 		$this->assertSame($content, Data::read($fileDE));
 
 		// move with Language arguments
-		$version->move($this->app->language('de'), $versionId, $this->app->language('en'));
+		$version->move($this->app->language('de'), toLanguage: $this->app->language('en'));
 
 		$this->assertContentFileExists('en');
 		$this->assertContentFileDoesNotExist('de');
@@ -713,7 +713,7 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist('en', $versionIdChanges);
 
 		// move with string arguments
-		$versionPublished->move('en', $versionIdChanges, 'en');
+		$versionPublished->move('en', $versionIdChanges);
 
 		$this->assertContentFileDoesNotExist('en', $versionIdPublished);
 		$this->assertContentFileExists('en', $versionIdChanges);
@@ -721,7 +721,7 @@ class VersionTest extends TestCase
 		$this->assertSame($content, Data::read($fileENChanges));
 
 		// move the version back
-		$versionChanges->move('en', $versionIdPublished, 'en');
+		$versionChanges->move('en', $versionIdPublished);
 
 		$this->assertContentFileDoesNotExist('en', $versionIdChanges);
 		$this->assertContentFileExists('en', $versionIdPublished);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `ContentStorageHandler::move()` treats `$toVersionId` and `$toLanguage` optionally and falls back to the same version Id/language as `$from` (avoids having to repeat arguments and allows for better usage with named arguments)
- `ContentStorageHandler::move()` allows specifying a `$toStorage` to move content to another storage 
- New `ContentStorageHandler::copy()` analogous to `::move()`
- New `ContentStorageHandler::moveAll(to: $storage)` and `ContentStorageHandler::copyAll(to: $storage)`
- Removed custom `PlainTextContentStorageHandler::move()`


### Reasoning
- Allows us to move storage logic out of the `FileActions` class into the storage handler classes
- Allows to keep those method class DRY (e.g. when moving between the same version ID, where only the language changes)
- While the `PlainTextContentStorageHandler ` implementation might have had a performance advantage, I think it's better to reuse the main implementation to keep the code complexity smaller.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
