### PR TITLE
Changes: New Changes Dialog

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -641,13 +641,7 @@ return [
 	'changes' => [
 		'pattern' => 'changes',
 		'load'    => function () {
-			$dialog = new ChangesDialog();
-			return $dialog->load();
+			return (new ChangesDialog())->load();
 		},
-		'submit' => function () {
-			$dialog = new ChangesDialog();
-			$ids    = App::instance()->request()->get('ids');
-			return $dialog->submit($ids);
-		}
 	],
 ];

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -468,7 +468,10 @@
 	"loading": "Loading",
 
 	"lock.unsaved": "Unsaved changes",
-	"lock.unsaved.empty": "There are no more unsaved changes",
+	"lock.unsaved.empty": "There are no unsaved changes",
+	"lock.unsaved.files": "Unsaved files",
+	"lock.unsaved.pages": "Unsaved pages",
+	"lock.unsaved.users": "Unsaved accounts",
 	"lock.isLocked": "Unsaved changes by {email}",
 	"lock.unlock": "Unlock",
 	"lock.unlock.submit": "Unlock and overwrite unsaved changes by <strong>{email}</strong>",

--- a/panel/src/components/Dialogs/ChangesDialog.vue
+++ b/panel/src/components/Dialogs/ChangesDialog.vue
@@ -1,13 +1,24 @@
 <template>
 	<k-dialog v-bind="$props" class="k-changes-dialog">
-		<template v-if="loading === false">
+		<section v-if="pages.length">
+			<k-headline>{{ $t("lock.unsaved.pages") }}</k-headline>
+			<k-items :items="pages" layout="list" />
+		</section>
+
+		<section v-if="files.length">
+			<k-headline>{{ $t("lock.unsaved.files") }}</k-headline>
+			<k-items :items="files" layout="list" />
+		</section>
+
+		<section v-if="users.length">
+			<k-headline>{{ $t("lock.unsaved.users") }}</k-headline>
+			<k-items :items="users" layout="list" />
+		</section>
+
+		<section v-if="!pages.length && !files.length && !users.length">
 			<k-headline>{{ $t("lock.unsaved") }}</k-headline>
-			<k-items v-if="changes.length" :items="changes" layout="list" />
-			<k-empty v-else icon="edit-line">{{ $t("lock.unsaved.empty") }}</k-empty>
-		</template>
-		<template v-else>
-			<k-icon type="loader" />
-		</template>
+			<k-empty icon="edit-line">{{ $t("lock.unsaved.empty") }}</k-empty>
+		</section>
 	</k-dialog>
 </template>
 
@@ -24,11 +35,13 @@ export default {
 		cancelButton: {
 			default: false
 		},
-		changes: {
-			type: Array
+		files: {
+			type: Array,
+			default: () => []
 		},
-		loading: {
-			type: Boolean
+		pages: {
+			type: Array,
+			default: () => []
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		size: {
@@ -37,35 +50,19 @@ export default {
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
 			default: false
-		}
-	},
-	computed: {
-		ids() {
-			return Object.keys(this.store).filter(
-				(id) => this.$helper.object.length(this.store[id]?.changes) > 0
-			);
 		},
-		store() {
-			return this.$store.state.content.models;
-		}
-	},
-	watch: {
-		ids: {
-			handler(ids) {
-				this.$panel.dialog.refresh({
-					method: "POST",
-					body: {
-						ids: ids
-					}
-				});
-			},
-			immediate: true
+		users: {
+			type: Array,
+			default: () => []
 		}
 	}
 };
 </script>
 
 <style>
+.k-changes-dialog section + section {
+	margin-top: var(--spacing-6);
+}
 .k-changes-dialog .k-headline {
 	margin-top: -0.5rem;
 	margin-bottom: var(--spacing-3);

--- a/src/Panel/ChangesDialog.php
+++ b/src/Panel/ChangesDialog.php
@@ -21,13 +21,9 @@ class ChangesDialog
 
 	public function items(Collection $models): array
 	{
-		$items = [];
-
-		foreach ($models as $model) {
-			$items[] = $model->panel()->dropdownOption();
-		}
-
-		return $items;
+		return $models->values(
+			fn ($model) => $model->panel()->dropdownOption()
+		);
 	}
 
 	public function load(): array

--- a/src/Panel/ChangesDialog.php
+++ b/src/Panel/ChangesDialog.php
@@ -5,6 +5,17 @@ namespace Kirby\Panel;
 use Kirby\Cms\Collection;
 use Kirby\Content\Changes;
 
+/**
+ * Manages the Panel dialog for content changes in
+ * pages, users and files
+ * @since 5.0.0
+ *
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
 class ChangesDialog
 {
 	protected Changes $changes;
@@ -14,11 +25,17 @@ class ChangesDialog
 		$this->changes = new Changes();
 	}
 
+	/**
+	 * Returns the item props for all changed files
+	 */
 	public function files(): array
 	{
 		return $this->items($this->changes->files());
 	}
 
+	/**
+	 * Helper method to return item props for the given models
+	 */
 	public function items(Collection $models): array
 	{
 		return $models->values(
@@ -26,6 +43,9 @@ class ChangesDialog
 		);
 	}
 
+	/**
+	 * Returns the backend full definition for dialog
+	 */
 	public function load(): array
 	{
 		return [
@@ -38,11 +58,17 @@ class ChangesDialog
 		];
 	}
 
+	/**
+	 * Returns the item props for all changed pages
+	 */
 	public function pages(): array
 	{
 		return $this->items($this->changes->pages());
 	}
 
+	/**
+	 * Returns the item props for all changed users
+	 */
 	public function users(): array
 	{
 		return $this->items($this->changes->users());

--- a/tests/Panel/Areas/SiteDialogsTest.php
+++ b/tests/Panel/Areas/SiteDialogsTest.php
@@ -36,4 +36,15 @@ class SiteDialogsTest extends AreaTestCase
 
 		$this->assertSame('Test', $this->app->site()->title()->value());
 	}
+
+	public function testChanges(): void
+	{
+		$dialog = $this->dialog('changes');
+		$props  = $dialog['props'];
+
+		$this->assertSame('k-changes-dialog', $dialog['component']);
+		$this->assertSame([], $props['files']);
+		$this->assertSame([], $props['pages']);
+		$this->assertSame([], $props['users']);
+	}
 }

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Kirby\Panel;
+
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Content\Changes;
+use Kirby\Panel\Areas\AreaTestCase;
+use Kirby\Uuid\Uuids;
+
+/**
+ * @coversDefaultClass \Kirby\Panel\ChangesDialog
+ */
+class ChangesDialogTest extends AreaTestCase
+{
+	protected Changes $changes;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->install();
+		$this->login();
+
+		$this->changes = new Changes();
+	}
+
+	public function setUpModels(): void
+	{
+		$this->app = $this->app->clone([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'content' => [
+							'uuid' => 'test'
+						],
+						'files' => [
+							[
+								'filename' => 'test.jpg',
+								'content'  => [
+									'uuid' => 'test'
+								],
+							]
+						]
+					]
+				]
+			],
+			'users' => [
+				[
+					'id' => 'test',
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		Uuids::populate();
+	}
+
+	/**
+	 * @covers ::files
+	 */
+	public function testFiles(): void
+	{
+		$this->setUpModels();
+
+		$this->changes->track(
+			$this->app->file('file://test')
+		);
+
+		$dialog = new ChangesDialog();
+		$files  = $dialog->files();
+
+		$this->assertCount(1, $files);
+		$this->assertSame('test.jpg', $files[0]['text']);
+		$this->assertSame('/pages/test/files/test.jpg', $files[0]['link']);
+	}
+
+	/**
+	 * @covers ::files
+	 */
+	public function testFilesWithoutChanges(): void
+	{
+		$dialog = new ChangesDialog();
+		$this->assertSame([], $dialog->files());
+	}
+
+	/**
+	 * @covers ::items
+	 */
+	public function testItems(): void
+	{
+		$dialog = new ChangesDialog();
+		$pages  = new Pages([
+			new Page(['slug' => 'test-a']),
+			new Page(['slug' => 'test-b'])
+		]);
+
+		$items = $dialog->items($pages);
+
+		$this->assertCount(2, $items);
+
+		$this->assertSame('test-a', $items[0]['text']);
+		$this->assertSame('/pages/test-a', $items[0]['link']);
+
+		$this->assertSame('test-b', $items[1]['text']);
+		$this->assertSame('/pages/test-b', $items[1]['link']);
+	}
+
+	/**
+	 * @covers ::load
+	 */
+	public function testLoad(): void
+	{
+		$dialog = new ChangesDialog();
+
+		$expected = [
+			'component' => 'k-changes-dialog',
+			'props' => [
+				'files' => [],
+				'pages' => [],
+				'users' => [],
+			]
+		];
+
+		$this->assertSame($expected, $dialog->load());
+	}
+
+	/**
+	 * @covers ::pages
+	 */
+	public function testPages(): void
+	{
+		$this->setUpModels();
+
+		$this->changes->track(
+			$this->app->page('page://test')
+		);
+
+		$dialog = new ChangesDialog();
+		$pages  = $dialog->pages();
+
+		$this->assertCount(1, $pages);
+		$this->assertSame('test', $pages[0]['text']);
+		$this->assertSame('/pages/test', $pages[0]['link']);
+	}
+
+	/**
+	 * @covers ::pages
+	 */
+	public function testPagesWithoutChanges(): void
+	{
+		$dialog = new ChangesDialog();
+		$this->assertSame([], $dialog->pages());
+	}
+
+	/**
+	 * @covers ::users
+	 */
+	public function testUsers(): void
+	{
+		$this->setUpModels();
+
+		$this->changes->track(
+			$this->app->user('user://test')
+		);
+
+		$dialog = new ChangesDialog();
+		$users  = $dialog->users();
+
+		$this->assertCount(1, $users);
+		$this->assertSame('test@getkirby.com', $users[0]['text']);
+		$this->assertSame('/users/test', $users[0]['link']);
+	}
+
+	/**
+	 * @covers ::users
+	 */
+	public function testUsersWithoutChanges(): void
+	{
+		$dialog = new ChangesDialog();
+		$this->assertSame([], $dialog->users());
+	}
+}

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -10,6 +10,7 @@ use Kirby\Uuid\Uuids;
 
 /**
  * @coversDefaultClass \Kirby\Panel\ChangesDialog
+ * @covers ::__construct
  */
 class ChangesDialogTest extends AreaTestCase
 {


### PR DESCRIPTION
## Description

### Summary of changes

![Screenshot 2024-09-25 at 12 53 27](https://github.com/user-attachments/assets/f5ee757c-0a40-4b7b-a526-5428a9a7688c)

- The `k-changes-dialog` component is now refactored to receive a list of changed pages, files and accounts directly from the backend. This simplifies the component drastically. 
- The `/panel/dialogs/changes` route now only has a load handler. The submit handler is no longer needed
- The `Kirby\Panel\ChangesDialog` class can be a lot simpler as well and now pulls changes directly via the new `Kirby\Content\Changes` class. 
- The en.json has new strings for the dialog. 

### Temporarily broken

- The changes in local storage are completely ignored and no longer shown in the dialog. 

### How to test the new dialog

As long as changes are not yet stored and tracked in the panel, you have to emulate changed pages, files and accounts by adding a list of UUIDs to the `Changes` field in the site.txt

### Additional ideas

- We could extend the dialog to save or discard all current changes
- Each item in the dialog could contain the last edited time and editor. 