### PR TITLE
Changes: Content Flow

### DIFF
--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="tabs.length > 1"
-		:data-id="model.id"
+		:data-has-tabs="hasTabs"
+		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"
 		class="k-file-view"
@@ -13,9 +13,9 @@
 		<k-header
 			:editable="permissions.changeName && !isLocked"
 			class="k-file-view-header"
-			@edit="$dialog(id + '/changeName')"
+			@edit="$dialog(api + '/changeName')"
 		>
-			{{ model.filename }}
+			{{ filename }}
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" @action="onAction" />
@@ -42,7 +42,7 @@
 			:content="content"
 			:empty="$t('file.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
-			:parent="id"
+			:parent="api"
 			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
@@ -56,15 +56,24 @@ import ModelView from "../ModelView.vue";
 export default {
 	extends: ModelView,
 	props: {
-		preview: Object
+		extension: String,
+		filename: String,
+		mime: String,
+		preview: Object,
+		type: String,
+		url: String
 	},
 	methods: {
 		onAction(action) {
 			switch (action) {
 				case "replace":
 					return this.$panel.upload.replace({
-						...this.preview,
-						...this.model
+						extension: this.extension,
+						filename: this.filename,
+						image: this.preview.image,
+						link: this.link,
+						mime: this.mime,
+						url: this.url
 					});
 			}
 		}

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -6,18 +6,19 @@ import debounce from "@/helpers/debounce.js";
  */
 export default {
 	props: {
+		api: String,
 		blueprint: String,
 		buttons: Array,
-		next: Object,
-		prev: Object,
-		permissions: {
-			type: Object,
-			default: () => ({})
-		},
+		content: Object,
+		id: String,
+		link: String,
 		lock: {
 			type: [Boolean, Object]
 		},
-		model: {
+		next: Object,
+		originals: Object,
+		prev: Object,
+		permissions: {
 			type: Object,
 			default: () => ({})
 		},
@@ -32,38 +33,24 @@ export default {
 		tabs: {
 			type: Array,
 			default: () => []
-		}
+		},
+		uuid: String
 	},
 	computed: {
 		changes() {
 			return this.$panel.content.changes;
 		},
-		content() {
-			return this.$panel.content.values;
-		},
-		id() {
-			return this.model.link;
+		hasTabs() {
+			return this.tabs.length > 1;
 		},
 		isLocked() {
 			return false;
 		},
 		isUnsaved() {
-			return this.$helper.object.length(this.changes) > 0;
+			return this.$panel.content.hasChanges;
 		},
 		protectedFields() {
 			return [];
-		}
-	},
-	watch: {
-		"$panel.view.timestamp": {
-			handler() {
-				// this is a temporary emulation of what should be coming
-				// directly from the backend.
-				this.$panel.view.props.originals = this.model.content;
-				this.$panel.view.props.content = this.model.content;
-				this.$panel.view.props.api = this.id;
-			},
-			immediate: true
 		}
 	},
 	mounted() {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -15,6 +15,7 @@ export default {
 		lock: {
 			type: [Boolean, Object]
 		},
+		model: Object,
 		next: Object,
 		originals: Object,
 		prev: Object,

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -1,5 +1,5 @@
 <script>
-import debounce from "@/helpers/debounce.js";
+import throttle from "@/helpers/throttle.js";
 
 /**
  * @internal
@@ -55,7 +55,7 @@ export default {
 		}
 	},
 	mounted() {
-		this.autosave = debounce(this.autosave, 200);
+		this.autosave = throttle(this.autosave, 1000);
 
 		this.$events.on("model.reload", this.$reload);
 		this.$events.on("keydown.left", this.toPrev);

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -1,21 +1,21 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="tabs.length > 1"
-		:data-id="model.id"
+		:data-has-tabs="hasTabs"
+		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"
 		class="k-page-view"
 	>
 		<template #topbar>
-			<k-prev-next v-if="model.id" :prev="prev" :next="next" />
+			<k-prev-next :prev="prev" :next="next" />
 		</template>
 
 		<k-header
 			:editable="permissions.changeTitle && !isLocked"
 			class="k-page-view-header"
-			@edit="$dialog(id + '/changeTitle')"
+			@edit="$dialog(api + '/changeTitle')"
 		>
-			{{ model.title }}
+			{{ title }}
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
@@ -35,7 +35,7 @@
 			:content="content"
 			:empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
-			:parent="id"
+			:parent="api"
 			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
@@ -48,6 +48,9 @@ import ModelView from "../ModelView.vue";
 
 export default {
 	extends: ModelView,
+	props: {
+		title: String
+	},
 	computed: {
 		protectedFields() {
 			return ["title"];

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -1,17 +1,17 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="tabs.length > 1"
+		:data-has-tabs="hasTabs"
+		:data-id="id"
 		:data-locked="isLocked"
-		data-id="/"
-		data-template="site"
+		:data-template="blueprint"
 		class="k-site-view"
 	>
 		<k-header
 			:editable="permissions.changeTitle && !isLocked"
 			class="k-site-view-header"
-			@edit="$dialog('site/changeTitle')"
+			@edit="$dialog(api + '/changeTitle')"
 		>
-			{{ model.title }}
+			{{ title }}
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
@@ -44,11 +44,8 @@ import ModelView from "../ModelView.vue";
 
 export default {
 	extends: ModelView,
-	emits: ["submit"],
-	computed: {
-		protectedFields() {
-			return ["title"];
-		}
+	props: {
+		title: String
 	}
 };
 </script>

--- a/panel/src/components/Views/Users/UserAvatar.vue
+++ b/panel/src/components/Views/Users/UserAvatar.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-button :title="$t('avatar')" class="k-user-view-image" @click="open">
-		<template v-if="model.avatar">
-			<k-image-frame :cover="true" :src="model.avatar" />
+		<template v-if="avatar">
+			<k-image-frame :cover="true" :src="avatar" />
 			<k-dropdown-content
 				ref="dropdown"
 				:options="[
@@ -30,24 +30,26 @@
  */
 export default {
 	props: {
-		model: Object
+		api: String,
+		avatar: String,
+		id: String
 	},
 	methods: {
 		open() {
-			if (this.model.avatar) {
+			if (this.avatar) {
 				this.$refs.dropdown.toggle();
 			} else {
 				this.upload();
 			}
 		},
 		async remove() {
-			await this.$api.users.deleteAvatar(this.model.id);
+			await this.$api.users.deleteAvatar(this.id);
 			this.$panel.notification.success();
 			this.$reload();
 		},
 		upload() {
 			this.$panel.upload.pick({
-				url: this.$panel.urls.api + "/" + this.model.link + "/avatar",
+				url: this.$panel.urls.api + "/" + this.api + "/avatar",
 				accept: "image/*",
 				immediate: true,
 				multiple: false

--- a/panel/src/components/Views/Users/UserProfile.vue
+++ b/panel/src/components/Views/Users/UserProfile.vue
@@ -1,29 +1,29 @@
 <template>
 	<div class="k-user-profile">
-		<k-user-avatar :disabled="isLocked" :model="model" />
+		<k-user-avatar :id="id" :api="api" :avatar="avatar" :disabled="isLocked" />
 
 		<k-button-group
 			:buttons="[
 				{
 					icon: 'email',
-					text: `${model.email}`,
-					title: `${$t('email')}: ${model.email}`,
+					text: `${email}`,
+					title: `${$t('email')}: ${email}`,
 					disabled: !permissions.changeEmail || isLocked,
-					click: () => $dialog(model.link + '/changeEmail')
+					click: () => $dialog(api + '/changeEmail')
 				},
 				{
 					icon: 'bolt',
-					text: `${model.role}`,
-					title: `${$t('role')}: ${model.role}`,
+					text: `${role}`,
+					title: `${$t('role')}: ${role}`,
 					disabled: !permissions.changeRole || isLocked,
-					click: () => $dialog(model.link + '/changeRole')
+					click: () => $dialog(api + '/changeRole')
 				},
 				{
 					icon: 'translate',
-					text: `${model.language}`,
-					title: `${$t('language')}: ${model.language}`,
+					text: `${language}`,
+					title: `${$t('language')}: ${language}`,
 					disabled: !permissions.changeLanguage || isLocked,
-					click: () => $dialog(model.link + '/changeLanguage')
+					click: () => $dialog(api + '/changeLanguage')
 				}
 			]"
 		/>
@@ -37,9 +37,14 @@
  */
 export default {
 	props: {
+		api: String,
+		avatar: String,
+		email: String,
+		id: String,
 		isLocked: Boolean,
-		model: Object,
-		permissions: Object
+		language: String,
+		permissions: Object,
+		role: String
 	}
 };
 </script>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="tabs.length > 1"
-		:data-id="model.id"
+		:data-has-tabs="hasTabs"
+		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"
 		class="k-user-view"
@@ -13,16 +13,13 @@
 		<k-header
 			:editable="permissions.changeName && !isLocked"
 			class="k-user-view-header"
-			@edit="$dialog(id + '/changeName')"
+			@edit="$dialog(api + '/changeName')"
 		>
-			<span
-				v-if="!model.name || model.name.length === 0"
-				class="k-user-name-placeholder"
-			>
+			<span v-if="!name || name.length === 0" class="k-user-name-placeholder">
 				{{ $t("name") }} …
 			</span>
 			<template v-else>
-				{{ model.name }}
+				{{ name }}
 			</template>
 
 			<template #buttons>
@@ -37,9 +34,14 @@
 		</k-header>
 
 		<k-user-profile
+			:id="id"
+			:api="api"
+			:avatar="avatar"
+			:email="email"
 			:is-locked="isLocked"
-			:model="model"
+			:language="language"
 			:permissions="permissions"
+			:role="role"
 		/>
 
 		<k-model-tabs :tab="tab.name" :tabs="tabs" />
@@ -49,7 +51,7 @@
 			:content="content"
 			:empty="$t('user.blueprint', { blueprint: $esc(blueprint) })"
 			:lock="lock"
-			:parent="id"
+			:parent="api"
 			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
@@ -61,7 +63,14 @@
 import ModelView from "../ModelView.vue";
 
 export default {
-	extends: ModelView
+	extends: ModelView,
+	props: {
+		avatar: String,
+		email: String,
+		language: String,
+		name: String,
+		role: String
+	}
 };
 </script>
 

--- a/panel/src/helpers/throttle.js
+++ b/panel/src/helpers/throttle.js
@@ -1,0 +1,37 @@
+export default (func, delay, options = { leading: true, trailing: false }) => {
+	let timer = null,
+		lastRan = null,
+		trailingArgs = null;
+
+	return function (...args) {
+		if (timer) {
+			//called within cooldown period
+			lastRan = this; //update context
+			trailingArgs = args; //save for later
+			return;
+		}
+
+		if (options.leading) {
+			// if leading
+			func.call(this, ...args); //call the 1st instance
+		} else {
+			// else it's trailing
+			lastRan = this; //update context
+			trailingArgs = args; //save for later
+		}
+
+		const coolDownPeriodComplete = () => {
+			if (options.trailing && trailingArgs) {
+				// if trailing and the trailing args exist
+				func.call(lastRan, ...trailingArgs); //invoke the instance with stored context "lastRan"
+				lastRan = null; //reset the status of lastRan
+				trailingArgs = null; //reset trailing arguments
+				timer = setTimeout(coolDownPeriodComplete, delay); //clear the timout
+			} else {
+				timer = null; // reset timer
+			}
+		};
+
+		timer = setTimeout(coolDownPeriodComplete, delay);
+	};
+};

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,3 +1,4 @@
+import { length } from "@/helpers/object";
 import { reactive } from "vue";
 
 /**
@@ -50,6 +51,15 @@ export default (panel) => {
 			} finally {
 				this.isProcessing = false;
 			}
+		},
+
+		/**
+		 * Whether there are any changes
+		 *
+		 * @returns {Boolean}
+		 */
+		get hasChanges() {
+			return length(this.changes) > 0;
 		},
 
 		/**
@@ -119,6 +129,10 @@ export default (panel) => {
 		 * @param {Object} values
 		 */
 		update(values) {
+			if (length(values) === 0) {
+				return;
+			}
+
 			panel.view.props.content = {
 				...panel.view.props.originals,
 				...values

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -399,16 +399,38 @@ class File extends Model
 	 */
 	public function props(): array
 	{
+		$props = parent::props();
+		$file  = $this->model;
+
+		// Additional model information
+		// @deprecated Use the top-level props instead
+		$model = [
+			'content'    => $props['content'],
+			'dimensions' => $file->dimensions()->toArray(),
+			'extension'  => $file->extension(),
+			'filename'   => $file->filename(),
+			'link'       => $props['link'],
+			'mime'       => $file->mime(),
+			'niceSize'   => $file->niceSize(),
+			'id'         => $props['id'],
+			'parent'     => $file->parent()->panel()->path(),
+			'template'   => $file->template(),
+			'type'       => $file->type(),
+			'url'        => $file->url(),
+			'uuid'       => $props['uuid'],
+		];
+
 		return [
-			...parent::props(),
+			...$props,
 			...$this->prevNext(),
 			'blueprint' => $this->model->template() ?? 'default',
-			'extension' => $this->model->extension(),
-			'filename'  => $this->model->filename(),
-			'mime'      => $this->model->mime(),
+			'extension' => $model['extension'],
+			'filename'  => $model['filename'],
+			'mime'      => $model['mime'],
+			'model'     => $model,
 			'preview'   => FilePreview::factory($this->model)->render(),
-			'type'      => $this->model->type(),
-			'url'       => $this->model->url(),
+			'type'      => $model['type'],
+			'url'       => $model['url'],
 		];
 	}
 

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -399,29 +399,16 @@ class File extends Model
 	 */
 	public function props(): array
 	{
-		$file       = $this->model;
-		$dimensions = $file->dimensions();
-
 		return [
 			...parent::props(),
 			...$this->prevNext(),
 			'blueprint' => $this->model->template() ?? 'default',
-			'model' => [
-				'content'    => $this->content(),
-				'dimensions' => $dimensions->toArray(),
-				'extension'  => $file->extension(),
-				'filename'   => $file->filename(),
-				'link'       => $this->url(true),
-				'mime'       => $file->mime(),
-				'niceSize'   => $file->niceSize(),
-				'id'         => $id = $file->id(),
-				'parent'     => $file->parent()->panel()->path(),
-				'template'   => $file->template(),
-				'type'       => $file->type(),
-				'url'        => $file->url(),
-				'uuid'       => fn () => $file->uuid()?->toString(),
-			],
-			'preview' => FilePreview::factory($this->model)->render()
+			'extension' => $this->model->extension(),
+			'filename'  => $this->model->filename(),
+			'mime'      => $this->model->mime(),
+			'preview'   => FilePreview::factory($this->model)->render(),
+			'type'      => $this->model->type(),
+			'url'       => $this->model->url(),
 		];
 	}
 

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -343,6 +343,14 @@ abstract class Model
 	}
 
 	/**
+	 * Get the original content values for the model
+	 */
+	public function originals(): array
+	{
+		return Form::for(model: $this->model)->values();
+	}
+
+	/**
 	 * Returns the full path without leading slash
 	 */
 	abstract public function path(): string;
@@ -375,15 +383,22 @@ abstract class Model
 	public function props(): array
 	{
 		$blueprint = $this->model->blueprint();
+		$link      = $this->url(true);
 		$request   = $this->model->kirby()->request();
 		$tabs      = $blueprint->tabs();
 		$tab       = $blueprint->tab($request->get('tab')) ?? $tabs[0] ?? null;
 
 		$props = [
+			'api'         => $link,
 			'buttons'     => fn () => $this->buttons(),
+			'content'     => $this->content(),
+			'id'          => $this->model->id(),
+			'link'        => $link,
 			'lock'        => $this->lock(),
+			'originals'   => $this->originals(),
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,
+			'uuid'        => fn () => $this->model->uuid()?->toString()
 		];
 
 		// only send the tab if it exists

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -391,11 +391,11 @@ abstract class Model
 		$props = [
 			'api'         => $link,
 			'buttons'     => fn () => $this->buttons(),
-			'content'     => $this->content(),
+			'content'     => (object)$this->content(),
 			'id'          => $this->model->id(),
 			'link'        => $link,
 			'lock'        => $this->lock(),
-			'originals'   => $this->originals(),
+			'originals'   => (object)$this->originals(),
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,
 			'uuid'        => fn () => $this->model->uuid()?->toString()

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -344,22 +344,11 @@ class Page extends Model
 	 */
 	public function props(): array
 	{
-		$page = $this->model;
-
 		return [
 			...parent::props(),
 			...$this->prevNext(),
-			'blueprint' => $page->intendedTemplate()->name(),
-			'model' => [
-				'content'    => $this->content(),
-				'id'         => $page->id(),
-				'link'       => $this->url(true),
-				'parent'     => $page->parentModel()->panel()->url(true),
-				'previewUrl' => $page->previewUrl(),
-				'status'     => $page->status(),
-				'title'      => $page->title()->toString(),
-				'uuid'       => fn () => $page->uuid()?->toString(),
-			]
+			'blueprint' => $this->model->intendedTemplate()->name(),
+			'title'     => $this->model->title()->toString(),
 		];
 	}
 

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -344,11 +344,27 @@ class Page extends Model
 	 */
 	public function props(): array
 	{
+		$props = parent::props();
+
+		// Additional model information
+		// @deprecated Use the top-level props instead
+		$model = [
+			'content'    => $props['content'],
+			'id'         => $props['id'],
+			'link'       => $props['link'],
+			'parent'     => $this->model->parentModel()->panel()->url(true),
+			'previewUrl' => $this->model->previewUrl(),
+			'status'     => $this->model->status(),
+			'title'      => $this->model->title()->toString(),
+			'uuid'       => $props['uuid'],
+		];
+
 		return [
-			...parent::props(),
+			...$props,
 			...$this->prevNext(),
 			'blueprint' => $this->model->intendedTemplate()->name(),
-			'title'     => $this->model->title()->toString(),
+			'model'     => $model,
+			'title'     => $model['title'],
 		];
 	}
 

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -81,13 +81,8 @@ class Site extends Model
 		return [
 			...parent::props(),
 			'blueprint' => 'site',
-			'model' => [
-				'content'    => $this->content(),
-				'link'       => $this->url(true),
-				'previewUrl' => $this->model->previewUrl(),
-				'title'      => $this->model->title()->toString(),
-				'uuid'       => fn () => $this->model->uuid()?->toString(),
-			]
+			'id'        => '/',
+			'title'     => $this->model->title()->toString(),
 		];
 	}
 

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -78,11 +78,24 @@ class Site extends Model
 	 */
 	public function props(): array
 	{
+		$props = parent::props();
+
+		// Additional model information
+		// @deprecated Use the top-level props instead
+		$model = [
+			'content'    => $props['content'],
+			'link'       => $props['link'],
+			'previewUrl' => $this->model->previewUrl(),
+			'title'      => $this->model->title()->toString(),
+			'uuid'       => $props['uuid'],
+		];
+
 		return [
-			...parent::props(),
+			...$props,
 			'blueprint' => 'site',
 			'id'        => '/',
-			'title'     => $this->model->title()->toString(),
+			'model'     => $model,
+			'title'     => $model['title'],
 		];
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -235,20 +235,37 @@ class User extends Model
 	 */
 	public function props(): array
 	{
-		$user    = $this->model;
+		$props = parent::props();
+		$user  = $this->model;
 		$account = $user->isLoggedIn();
+
+		// Additional model information
+		// @deprecated Use the top-level props instead
+		$model = [
+			'account'  => $user->isLoggedIn(),
+			'avatar'   => $user->avatar()?->url(),
+			'content'  => $props['content'],
+			'email'    => $user->email(),
+			'id'       => $props['id'],
+			'language' => $this->translation()->name(),
+			'link'     => $props['link'],
+			'name'     => $user->name()->toString(),
+			'role'     => $user->role()->title(),
+			'username' => $user->username(),
+			'uuid'     => $props['uuid'],
+		];
 
 		return [
 			...parent::props(),
 			...$this->prevNext(),
-			'account'   => $account,
-			'avatar'    => $user->avatar()?->url(),
+			'avatar'    => $model['avatar'],
 			'blueprint' => $this->model->role()->name(),
-			'email'     => $user->email(),
-			'language'  => $this->translation()->name(),
-			'name'      => $user->name()->toString(),
-			'role'      => $user->role()->title(),
-			'username'  => $user->username(),
+			'email'     => $model['email'],
+			'language'  => $model['language'],
+			'model'     => $model,
+			'name'      => $model['name'],
+			'role'      => $model['role'],
+			'username'  => $model['username'],
 		];
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -241,20 +241,14 @@ class User extends Model
 		return [
 			...parent::props(),
 			...$this->prevNext(),
+			'account'   => $account,
+			'avatar'    => $user->avatar()?->url(),
 			'blueprint' => $this->model->role()->name(),
-			'model' => [
-				'account'  => $account,
-				'avatar'   => $user->avatar()?->url(),
-				'content'  => $this->content(),
-				'email'    => $user->email(),
-				'id'       => $user->id(),
-				'language' => $this->translation()->name(),
-				'link'     => $this->url(true),
-				'name'     => $user->name()->toString(),
-				'role'     => $user->role()->title(),
-				'username' => $user->username(),
-				'uuid'     => fn () => $user->uuid()?->toString()
-			]
+			'email'     => $user->email(),
+			'language'  => $this->translation()->name(),
+			'name'      => $user->name()->toString(),
+			'role'      => $user->role()->title(),
+			'username'  => $user->username(),
 		];
 	}
 


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/6702

## Known problems

- [x] `Invalid prop: type check failed for prop "content". Expected Object, got Array ` on AccountView (probably when `content` etc. are empty as then PHP empty array !== empty object in JS anymore)

## Summary of changes

### Refactored `panel.content` module
- removed `content.hasUnsavedChanges`
- removed `content.hasUnublishedChanges`
- removed `content.isDraft`
- removed `content.isPublishing`
- removed `content.isSaving`
- simplified `content.isLocked` and temporarliy removed `content.lock` and `content.unlock` for now to start the lock concept from scratch as soon as it exists in the backend.
- Changed `content.set` to `content.update`

### Refactored Panel Model classes
- New `Model::originals()` method 
- Refactored `::props` methods

### Refactored all Model Views 
- The model child object is gone and required props are directly registered for each model view
- `k-user-profile` and `k-user-avatar` have been refactored to register props directly instead of working with a model object property

## Questions 

Is the View refactoring too much? We could do it without it, but I think it's a great chance to clean up the model views and make them less smart. 