### PR TITLE
Changes: Locking

### DIFF
--- a/panel/lab/components/formcontrols/index.vue
+++ b/panel/lab/components/formcontrols/index.vue
@@ -59,7 +59,7 @@
 			<k-form-controls
 				:is-locked="true"
 				editor="editor@getkirby.com"
-				modified="5 minutes ago"
+				modified="2024-10-01T17:00:00"
 				preview="https://getkirby.com"
 				@discard="log('discard')"
 				@submit="log('submit')"

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -20,21 +20,25 @@
 			<p>
 				{{ $t("form.locked") }}
 			</p>
-			<hr />
-			<dl>
-				<div>
-					<dt><k-icon type="user" /></dt>
-					<dd>{{ editor }}</dd>
-				</div>
-				<div>
-					<dt><k-icon type="clock" /></dt>
-					<dd>{{ modified }}</dd>
-				</div>
-			</dl>
-			<hr />
-			<k-dropdown-item :link="preview" icon="preview" target="_blank">
-				{{ $t("form.preview") }}
-			</k-dropdown-item>
+			<template v-if="editor || modified">
+				<hr />
+				<dl>
+					<div v-if="editor">
+						<dt><k-icon type="user" /></dt>
+						<dd>{{ editor }}</dd>
+					</div>
+					<div v-if="modified">
+						<dt><k-icon type="clock" /></dt>
+						<dd>{{ $library.dayjs(modified).fromNow() }}</dd>
+					</div>
+				</dl>
+			</template>
+			<template v-if="preview">
+				<hr />
+				<k-dropdown-item :link="preview" icon="preview" target="_blank">
+					{{ $t("form.preview") }}
+				</k-dropdown-item>
+			</template>
 		</k-dropdown-content>
 	</k-button-group>
 </template>

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -29,7 +29,9 @@
 					</div>
 					<div v-if="modified">
 						<dt><k-icon type="clock" /></dt>
-						<dd>{{ $library.dayjs(modified).fromNow() }}</dd>
+						<dd>
+							{{ $library.dayjs(modified).format("YYYY-MM-DD HH:mm:ss") }}
+						</dd>
 					</div>
 				</dl>
 			</template>

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -20,8 +20,10 @@
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" @action="onAction" />
 				<k-form-controls
+					:editor="editor"
 					:is-locked="isLocked"
 					:is-unsaved="isUnsaved"
+					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -41,14 +41,20 @@ export default {
 		changes() {
 			return this.$panel.content.changes;
 		},
+		editor() {
+			return this.lock.user.email;
+		},
 		hasTabs() {
 			return this.tabs.length > 1;
 		},
 		isLocked() {
-			return false;
+			return this.lock.isLocked;
 		},
 		isUnsaved() {
 			return this.$panel.content.hasChanges;
+		},
+		modified() {
+			return this.lock.modified;
 		},
 		protectedFields() {
 			return [];

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -20,8 +20,10 @@
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
+					:editor="editor"
 					:is-locked="isLocked"
 					:is-unsaved="isUnsaved"
+					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -16,8 +16,10 @@
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
+					:editor="editor"
 					:is-locked="isLocked"
 					:is-unsaved="isUnsaved"
+					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -25,8 +25,10 @@
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
+					:editor="editor"
 					:is-locked="isLocked"
 					:is-unsaved="isUnsaved"
+					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>

--- a/panel/src/libraries/dayjs.js
+++ b/panel/src/libraries/dayjs.js
@@ -1,6 +1,5 @@
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import relativeTime from "dayjs/plugin/relativeTime";
 import interpret from "./dayjs-interpret.js";
 import iso from "./dayjs-iso.js";
 import merge from "./dayjs-merge.js";
@@ -13,7 +12,6 @@ dayjs.extend(interpret);
 dayjs.extend(iso);
 dayjs.extend(merge);
 dayjs.extend(pattern);
-dayjs.extend(relativeTime);
 dayjs.extend(round);
 dayjs.extend(validate);
 

--- a/panel/src/libraries/dayjs.js
+++ b/panel/src/libraries/dayjs.js
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
+import relativeTime from "dayjs/plugin/relativeTime";
 import interpret from "./dayjs-interpret.js";
 import iso from "./dayjs-iso.js";
 import merge from "./dayjs-merge.js";
@@ -12,6 +13,7 @@ dayjs.extend(interpret);
 dayjs.extend(iso);
 dayjs.extend(merge);
 dayjs.extend(pattern);
+dayjs.extend(relativeTime);
 dayjs.extend(round);
 dayjs.extend(validate);
 

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -3,9 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\App;
-use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\User;
-use Kirby\Exception\LogicException;
 use Kirby\Toolkit\Str;
 
 /**

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -44,15 +44,13 @@ class Lock
 			);
 		}
 
-		$user = null;
-
 		// Read the locked user id from the version
 		if ($userId = ($version->read('default')['lock'] ?? null)) {
 			$user = App::instance()->user($userId);
 		}
 
 		return new static(
-			user: $user,
+			user: $user ?? null,
 			modified: $version->modified()
 		);
 	}

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -66,6 +66,14 @@ class Lock
 	}
 
 	/**
+	 * Check if content locking is enabled at all
+	 */
+	public static function isEnabled(): bool
+	{
+		return App::instance()->option('content.locking', true) !== false;
+	}
+
+	/**
 	 * Checks if the lock is actually locked
 	 */
 	public function isLocked(): bool

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -46,7 +46,7 @@ class Lock
 		}
 
 		// Read the locked user id from the version
-		$userId = $version->read()['lock'] ?? null;
+		$userId = $version->read('default')['lock'] ?? null;
 
 		// No user? Create the lock for the currently authenticated user
 		$user = App::instance()->user($userId) ?? App::instance()->user();

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -41,7 +41,6 @@ class Lock
 			// create an open lock for the current user
 			return new static(
 				user: App::instance()->user(),
-				modified: null
 			);
 		}
 

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -72,6 +72,10 @@ class Lock
 	 */
 	public function isLocked(): bool
 	{
+		if ($this->user === null) {
+			return false;
+		}
+
 		// the version is not locked if the editing user
 		// is the currently logged in user
 		if ($this->user === App::instance()->user()) {
@@ -122,7 +126,7 @@ class Lock
 	/**
 	 * Returns the user to whom this lock belongs
 	 */
-	public function user(): User
+	public function user(): User|null
 	{
 		return $this->user;
 	}

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -45,11 +45,12 @@ class Lock
 			);
 		}
 
-		// Read the locked user id from the version
-		$userId = $version->read('default')['lock'] ?? null;
+		$user = null;
 
-		// No user? Create the lock for the currently authenticated user
-		$user = App::instance()->user($userId) ?? App::instance()->user();
+		// Read the locked user id from the version
+		if ($userId = ($version->read('default')['lock'] ?? null)) {
+			$user = App::instance()->user($userId);
+		}
 
 		return new static(
 			user: $user,

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -78,6 +78,12 @@ class Lock
 	 */
 	public function isLocked(): bool
 	{
+		// if locking is disabled globally,
+		// the lock is always open
+		if (static::isEnabled() === false) {
+			return false;
+		}
+
 		if ($this->user === null) {
 			return false;
 		}

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\User;
+use Kirby\Exception\LogicException;
+use Kirby\Toolkit\Str;
+
+/**
+ * The Lock class provides information about the
+ * locking state of a content version, depending
+ * on the timestamp and locked user id
+ *
+ * @internal
+ * @since 5.0.0
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Lock
+{
+	public function __construct(
+		protected User $user,
+		protected int $modified,
+	) {
+	}
+
+	/**
+	 * Creates a lock for the given version by
+	 * reading the modification timestamp and
+	 * lock user id from the version.
+	 */
+	public static function for(
+		Version $version
+	): static {
+		// if the version does not exist, it cannot be locked
+		if ($version->exists() === false) {
+			// create an open lock for the current user
+			return new static(
+				user: App::instance()->user(),
+				modified: 0
+			);
+		}
+
+		// Read the locked user id from the version
+		$userId = $version->read()['lock'] ?? null;
+
+		// No user? Create the lock for the currently authenticated user
+		$user = App::instance()->user($userId) ?? App::instance()->user();
+
+		return new static(
+			user: $user,
+			modified: $version->modified()
+		);
+	}
+
+	/**
+	 * Checks if the lock is still active because
+	 * recent changes have been made to the content
+	 */
+	public function isActive(): bool
+	{
+		$minutes = 10;
+		return $this->modified > time() - (60 * $minutes);
+	}
+
+	/**
+	 * Checks if the lock is actually locked
+	 */
+	public function isLocked(): bool
+	{
+		// the version is not locked if the editing user
+		// is the currently logged in user
+		if ($this->user === App::instance()->user()) {
+			return false;
+		}
+
+		// check if the lock is still active due to the
+		// content currently being edited.
+		if ($this->isActive() === false) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the timestamp when the locked content has
+	 * been updated. You can pass a format to get a useful,
+	 * formatted date back.
+	 */
+	public function modified(
+		string|null $format = null,
+		string|null $handler = null
+	): int|string|false|null {
+		return Str::date($this->modified, $format, $handler);
+	}
+
+	/**
+	 * Converts the lock info to an array. This is directly
+	 * usable for Panel view props.
+	 */
+	public function toArray(): array
+	{
+		return [
+			'isLocked' => $this->isLocked(),
+			'modified' => $this->modified('c'),
+			'user'     => [
+				'id'    => $this->user->id(),
+				'email' => $this->user->email()
+			]
+		];
+	}
+
+	/**
+	 * Returns the user to whom this lock belongs
+	 */
+	public function user(): User
+	{
+		return $this->user;
+	}
+}

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -23,8 +23,8 @@ use Kirby\Toolkit\Str;
 class Lock
 {
 	public function __construct(
-		protected User $user,
-		protected int $modified,
+		protected User|null $user = null,
+		protected int|null $modified = null,
 	) {
 	}
 
@@ -41,7 +41,7 @@ class Lock
 			// create an open lock for the current user
 			return new static(
 				user: App::instance()->user(),
-				modified: 0
+				modified: null
 			);
 		}
 
@@ -96,6 +96,10 @@ class Lock
 		string|null $format = null,
 		string|null $handler = null
 	): int|string|false|null {
+		if ($this->modified === null) {
+			return null;
+		}
+
 		return Str::date($this->modified, $format, $handler);
 	}
 
@@ -109,8 +113,8 @@ class Lock
 			'isLocked' => $this->isLocked(),
 			'modified' => $this->modified('c'),
 			'user'     => [
-				'id'    => $this->user->id(),
-				'email' => $this->user->email()
+				'id'    => $this->user?->id(),
+				'email' => $this->user?->email()
 			]
 		];
 	}

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -214,13 +214,14 @@ class Version
 		// make sure to store the right fields for the model
 		$fields = $this->model->contentFileData($fields, $language);
 
-		// add the editing user
-		if ($this->id->is(VersionId::changes()) === true) {
-			$fields['lock'] = $this->model->kirby()->user()?->id();
-		}
-
 		// the default language stores all fields
 		if ($language->isDefault() === true) {
+
+			// add the editing user
+			if ($this->id->is(VersionId::changes()) === true) {
+				$fields['lock'] = $this->model->kirby()->user()?->id();
+			}
+
 			return $fields;
 		}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -218,7 +218,7 @@ class Version
 		if ($language->isDefault() === true) {
 
 			// add the editing user
-			if ($this->id->is(VersionId::changes()) === true) {
+			if ($this->id->is(VersionId::changes()) === true && Lock::isEnabled() === true) {
 				$fields['lock'] = $this->model->kirby()->user()?->id();
 			}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -214,6 +214,11 @@ class Version
 		// make sure to store the right fields for the model
 		$fields = $this->model->contentFileData($fields, $language);
 
+		// add the editing user
+		if ($this->id->is(VersionId::changes()) === true) {
+			$fields['lock'] = $this->model->kirby()->user()?->id();
+		}
+
 		// the default language stores all fields
 		if ($language->isDefault() === true) {
 			return $fields;

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -3,10 +3,10 @@
 namespace Kirby\Panel;
 
 use Closure;
-use Kirby\Content\Lock;
-use Kirby\Content\VersionId;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Content\Lock;
+use Kirby\Content\VersionId;
 use Kirby\Filesystem\Asset;
 use Kirby\Form\Form;
 use Kirby\Http\Uri;

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -302,9 +302,6 @@ abstract class Model
 
 	/**
 	 * Returns lock info for the Panel
-	 *
-	 * @return array|false array with lock info,
-	 *                     false if locking is not supported
 	 */
 	public function lock(): array
 	{

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -3,6 +3,8 @@
 namespace Kirby\Panel;
 
 use Closure;
+use Kirby\Content\Lock;
+use Kirby\Content\VersionId;
 use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
@@ -304,9 +306,13 @@ abstract class Model
 	 * @return array|false array with lock info,
 	 *                     false if locking is not supported
 	 */
-	public function lock(): array|false
+	public function lock(): array
 	{
-		return $this->model->lock()?->toArray() ?? false;
+		// get the changes for the current model
+		$version = $this->model->version(VersionId::changes());
+
+		// return lock info for the changes
+		return Lock::for($version)->toArray();
 	}
 
 	/**

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -20,7 +20,7 @@ use Kirby\TestCase;
 class FieldMethodsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
-	public const TMP      = KIRBY_TMP_DIR . '/Filesystem.FieldMethods';
+	public const TMP      = KIRBY_TMP_DIR . '/Content.FieldMethods';
 
 	public function setUp(): void
 	{

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -149,6 +149,30 @@ class LockTest extends TestCase
 	}
 
 	/**
+	 * @covers ::isEnabled
+	 */
+	public function testIsEnabled()
+	{
+		$this->assertTrue(Lock::isEnabled());
+	}
+
+	/**
+	 * @covers ::isEnabled
+	 */
+	public function testIsEnabledWhenDisabled()
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'locking' => false,
+				]
+			]
+		]);
+
+		$this->assertFalse(Lock::isEnabled());
+	}
+
+	/**
 	 * @covers ::isLocked
 	 */
 	public function testIsLocked()

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -214,6 +214,29 @@ class LockTest extends TestCase
 	/**
 	 * @covers ::isLocked
 	 */
+	public function testIsLockedWhenDisabled()
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'locking' => false
+				]
+			]
+		]);
+
+		$this->app->impersonate('admin');
+
+		$lock = new Lock(
+			modified: time(),
+			user: $this->app->user('editor')
+		);
+
+		$this->assertFalse($lock->isLocked());
+	}
+
+	/**
+	 * @covers ::isLocked
+	 */
 	public function testIsLockedWithDifferentUserAndOldTimestamp()
 	{
 		$this->app->impersonate('admin');

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\App;
+use Kirby\Cms\User;
+
+/**
+ * @coversDefaultClass \Kirby\Content\Lock
+ * @covers ::__construct
+ */
+class LockTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Content.LockTest';
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test'
+					]
+				]
+			],
+			'users' => [
+				[
+					'email' => 'admin@getkirby.com',
+					'id'    => 'admin',
+				],
+				[
+					'email' => 'editor@getkirby.com',
+					'id'    => 'editor',
+				]
+			]
+		]);
+	}
+
+	/**
+	 * @covers ::for
+	 */
+	public function testForWithAuthenticatedUser()
+	{
+		$this->app->impersonate('admin');
+
+		$version = new Version(
+			model: $this->app->page('test'),
+			id: VersionId::changes()
+		);
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$lock = Lock::for($version);
+
+		$this->assertTrue($lock->isActive());
+		$this->assertFalse($lock->isLocked());
+		$this->assertSame($this->app->user('admin'), $lock->user());
+	}
+
+	/**
+	 * @covers ::for
+	 */
+	public function testForWithDifferentUser()
+	{
+		// create the version with the admin user
+		$this->app->impersonate('admin');
+
+		$version = new Version(
+			model: $this->app->page('test'),
+			id: VersionId::changes()
+		);
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		// switch to a different user to simulate locked content
+		$this->app->impersonate('editor');
+
+		$lock = Lock::for($version);
+
+		$this->assertTrue($lock->isActive());
+		$this->assertTrue($lock->isLocked());
+		$this->assertSame($this->app->user('admin'), $lock->user());
+	}
+
+	/**
+	 * @covers ::isActive
+	 */
+	public function testIsActive()
+	{
+		// just modified
+		$lock = new Lock(
+			modified: time()
+		);
+
+		$this->assertTrue($lock->isActive());
+	}
+
+	/**
+	 * @covers ::isActive
+	 */
+	public function testIsActiveWithOldModificationTimestamp()
+	{
+		// create a lock that has not been modified for 20 minutes
+		$lock = new Lock(
+			modified: time() - 60 * 20
+		);
+
+		$this->assertFalse($lock->isActive());
+	}
+
+	/**
+	 * @covers ::isActive
+	 */
+	public function testIsActiveWithoutModificationTimestamp()
+	{
+		// a lock without modification time should also be inactive
+		$lock = new Lock();
+		$this->assertFalse($lock->isActive());
+	}
+
+	/**
+	 * @covers ::isLocked
+	 */
+	public function testIsLocked()
+	{
+		$lock = new Lock();
+		$this->assertFalse($lock->isLocked());
+	}
+
+	/**
+	 * @covers ::isLocked
+	 */
+	public function testIsLockedWithCurrentUser()
+	{
+		$this->app->impersonate('admin');
+
+		$lock = new Lock(
+			modified: time(),
+			user: $this->app->user('admin')
+		);
+
+		$this->assertFalse($lock->isLocked());
+	}
+
+	/**
+	 * @covers ::isLocked
+	 */
+	public function testIsLockedWithDifferentUser()
+	{
+		$this->app->impersonate('admin');
+
+		$lock = new Lock(
+			modified: time(),
+			user: $this->app->user('editor')
+		);
+
+		$this->assertTrue($lock->isLocked());
+	}
+
+	/**
+	 * @covers ::isLocked
+	 */
+	public function testIsLockedWithDifferentUserAndOldTimestamp()
+	{
+		$this->app->impersonate('admin');
+
+		$lock = new Lock(
+			modified: time() - 60 * 20,
+			user: $this->app->user('editor')
+		);
+
+		$this->assertFalse($lock->isLocked());
+	}
+
+	/**
+	 * @covers ::modified
+	 */
+	public function testModified()
+	{
+		$lock = new Lock(
+			modified: $modified = time()
+		);
+
+		$this->assertSame($modified, $lock->modified());
+		$this->assertSame(date('c', $modified), $lock->modified('c'));
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray()
+	{
+		$lock = new Lock(
+			user: $user = new User([
+				'email' => 'test@getkirby.com',
+				'id'    => 'test'
+			]),
+			modified: $modified = time()
+		);
+
+		$this->assertSame([
+			'isLocked' => true,
+			'modified' => date('c', $modified),
+			'user'     => [
+				'id'    => 'test',
+				'email' => 'test@getkirby.com'
+			]
+		], $lock->toArray());
+	}
+
+	/**
+	 * @covers ::user
+	 */
+	public function testUser()
+	{
+		$lock = new Lock(
+			user: $user = $this->app->user('admin')
+		);
+
+		$this->assertSame($user, $lock->user());
+	}
+
+	/**
+	 * @covers ::user
+	 */
+	public function testUserWithoutUser()
+	{
+		$lock = new Lock();
+		$this->assertNull($lock->user());
+	}
+}

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -90,6 +90,29 @@ class LockTest extends TestCase
 	}
 
 	/**
+	 * @covers ::for
+	 */
+	public function testForWithoutUser()
+	{
+		// create the version with the admin user
+		$this->app->impersonate('admin');
+
+		// the published version won't have a user id
+		$version = new Version(
+			model: $this->app->page('test'),
+			id: VersionId::published()
+		);
+
+		$version->create([
+			'title' => 'Test'
+		]);
+
+		$lock = Lock::for($version);
+
+		$this->assertNull($lock->user());
+	}
+
+	/**
 	 * @covers ::isActive
 	 */
 	public function testIsActive()

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -37,8 +37,14 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('default', $props['blueprint']);
-		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
-
+		$this->assertSame([
+			'isLocked' => false,
+			'modified' => null,
+			'user'     => [
+				'id'    => 'test',
+				'email' => 'test@getkirby.com'
+			]
+		], $props['lock']);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
 
@@ -88,8 +94,14 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
-		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
-
+		$this->assertSame([
+			'isLocked' => false,
+			'modified' => null,
+			'user'     => [
+				'id'    => 'test',
+				'email' => 'test@getkirby.com'
+			]
+		], $props['lock']);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
 
@@ -156,8 +168,14 @@ class SiteTest extends AreaTestCase
 		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
-		$this->assertSame(['state' => null, 'data' => false], $props['lock']);
-
+		$this->assertSame([
+			'isLocked' => false,
+			'modified' => null,
+			'user'     => [
+				'id'    => 'test',
+				'email' => 'test@getkirby.com'
+			]
+		], $props['lock']);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -3,68 +3,11 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
-use Kirby\Cms\ContentLock;
 use Kirby\Cms\File as ModelFile;
-use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
-
-class CustomContentLockIsLocked extends ContentLock
-{
-	public function __construct()
-	{
-		$this->model = new ModelPage(['slug' => 'test']);
-	}
-
-	public function get(): array
-	{
-		return ['email' => 'foo@bar.com'];
-	}
-
-	public function isLocked(): bool
-	{
-		return true;
-	}
-
-	public function isUnlocked(): bool
-	{
-		return false;
-	}
-}
-
-class CustomContentLockIsUnlocked extends CustomContentLockIslocked
-{
-	public function isUnlocked(): bool
-	{
-		return true;
-	}
-}
-
-class ModelSiteNoLocking extends ModelSite
-{
-	public function lock(): ContentLock|null
-	{
-		return null;
-	}
-}
-
-class ModelSiteTestForceLocked extends ModelSite
-{
-	public function lock(): ContentLock|null
-	{
-		return new CustomContentLockIsLocked();
-	}
-}
-
-class ModelSiteTestForceUnlocked extends ModelSite
-{
-	public function lock(): ContentLock|null
-	{
-		return new CustomContentLockIsUnlocked();
-	}
-}
 
 class CustomPanelModel extends Model
 {
@@ -445,27 +388,15 @@ class ModelTest extends TestCase
 	 */
 	public function testLock()
 	{
-		// content locking not supported
-		$site = new ModelSiteNoLocking();
-		$this->assertFalse($site->panel()->lock());
-
-		Dir::make(static::TMP . '/content');
-		$app = $this->app->clone();
-		$app->impersonate('kirby');
-
-		// no lock or unlock
 		$site = new ModelSite();
-		$this->assertSame(['state' => null, 'data' => false], $site->panel()->lock());
-
-		// lock
-		$site = new ModelSiteTestForceLocked();
-		$lock = $site->panel()->lock();
-		$this->assertSame('lock', $lock['state']);
-		$this->assertSame('foo@bar.com', $lock['data']['email']);
-
-		// unlock
-		$site = new ModelSiteTestForceUnlocked();
-		$this->assertSame('unlock', $site->panel()->lock()['state']);
+		$this->assertSame([
+			'isLocked' => false,
+			'modified' => null,
+			'user'     => [
+				'id'    => null,
+				'email' => null
+			]
+		], $site->panel()->lock());
 	}
 
 	/**


### PR DESCRIPTION
## Description

### Merge first 

- [x] https://github.com/getkirby/kirby/pull/6705

### Summary of changes

- Keep track of the editing user in the `Version` class.
- New `Content\Lock` class to eventually replace `Cms\ContentLock`
- Use the new Lock class to return an updated lock prop for all panel model views.
- Pass new lock info to form controls.

### Additional context

The best way to test the locking state manually … 

1. create a second user
2. make some changes to a page without saving
3. go to the _changes folder and the content text file and change the lock id to second user's id
4. Reload the panel view to see the lock state. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
