### PR TITLE
Remove field signature

### DIFF
--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -4,7 +4,7 @@
 			<template v-for="(field, fieldName) in fields">
 				<k-column
 					v-if="$helper.field.isVisible(field, value)"
-					:key="field.signature"
+					:key="field.name"
 					:width="field.width"
 				>
 					<!-- @event input Triggered whenever any field value changes -->

--- a/panel/src/components/Forms/Fieldset.vue
+++ b/panel/src/components/Forms/Fieldset.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="k-fieldset">
 		<k-grid variant="fields">
-			<template v-for="(field, fieldName) in fields">
+			<template v-for="field in fields">
 				<k-column
 					v-if="$helper.field.isVisible(field, value)"
 					:key="field.name"
@@ -14,21 +14,21 @@
 					<component
 						:is="'k-' + field.type + '-field'"
 						v-if="hasFieldType(field.type)"
-						:ref="fieldName"
+						:ref="field.name"
 						v-bind="field"
 						:disabled="disabled || field.disabled"
 						:form-data="value"
-						:name="fieldName"
-						:value="value[fieldName]"
-						@input="onInput($event, field, fieldName)"
-						@focus="$emit('focus', $event, field, fieldName)"
-						@submit="$emit('submit', $event, field, fieldName)"
+						:name="field.name"
+						:value="value[field.name]"
+						@input="onInput($event, field, field.name)"
+						@focus="$emit('focus', $event, field, field.name)"
+						@submit="$emit('submit', $event, field, field.name)"
 					/>
 					<k-box v-else theme="negative">
 						<k-text size="small">
 							{{
 								$t("error.field.type.missing", {
-									name: fieldName,
+									name: field.name,
 									type: field.type
 								})
 							}}

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -446,9 +446,8 @@ class Field extends Component
 
 		unset($array['model']);
 
-		$array['hidden']    = $this->isHidden();
-		$array['saveable']  = $this->save();
-		$array['signature'] = md5(json_encode($array));
+		$array['hidden']   = $this->isHidden();
+		$array['saveable'] = $this->save();
 
 		ksort($array);
 

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -707,7 +707,6 @@ class FieldTest extends TestCase
 		$this->assertSame('bar', $array['foo']);
 		$this->assertSame('1/1', $array['width']);
 
-		$this->assertArrayHasKey('signature', $array);
 		$this->assertArrayNotHasKey('model', $array);
 	}
 


### PR DESCRIPTION
## Description

The Field class added an md5 signature for very field by json_encoding all its props. We added this ages ago to provide unique field keys for Vue components. This is no longer needed as far as I can see and it's a potential performance bottleneck. 

### Summary of changes

- Remove signature key in `\Kirby\Form\Field::toArray()`
- Use field name as key for Vue field components in the `k-fieldset` component
- Remove the unit test for the signature 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Remove unnecessary generic signature key for each form field.  

### Breaking changes

- The signature is longer available as field property when loading fields from the panel backend. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
