### PR TITLE
Block focus point in image file preview when the model is locked

### DIFF
--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -3,6 +3,7 @@
 		:is="preview"
 		v-bind="props"
 		:content="content"
+		:is-locked="isLocked"
 		class="k-file-preview"
 		@input="$emit('input', $event)"
 		@submit="$emit('submit', $event)"
@@ -18,6 +19,7 @@ export default {
 	props: {
 		component: String,
 		content: Object,
+		isLocked: Boolean,
 		props: Object
 	},
 	emits: ["input", "submit"],

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -33,6 +33,7 @@
 		<k-file-preview
 			v-bind="preview"
 			:content="content"
+			:is-locked="isLocked"
 			@input="onInput"
 			@submit="onSubmit"
 		/>

--- a/panel/src/components/Views/Files/ImageFilePreview.vue
+++ b/panel/src/components/Views/Files/ImageFilePreview.vue
@@ -5,7 +5,7 @@
 	>
 		<k-file-preview-frame :options="options">
 			<k-coords-input
-				:disabled="!focusable"
+				:disabled="!isFocusable"
 				:value="focus"
 				@input="setFocus($event)"
 			>
@@ -18,7 +18,7 @@
 				<dt>{{ $t("file.focus.title") }}</dt>
 				<dd>
 					<k-button
-						v-if="focusable"
+						v-if="isFocusable"
 						ref="focus"
 						:icon="focus ? 'cancel-small' : 'preview'"
 						:title="focus ? $t('file.focus.reset') : undefined"
@@ -56,6 +56,7 @@ export default {
 			default: () => ({}),
 			type: Object
 		},
+		isLocked: Boolean,
 		url: String
 	},
 	emits: ["focus", "input"],
@@ -74,6 +75,9 @@ export default {
 		hasFocus() {
 			return Boolean(this.focus);
 		},
+		isFocusable() {
+			return this.focusable === true && this.isLocked !== true;
+		},
 		options() {
 			return [
 				{
@@ -86,19 +90,23 @@ export default {
 					icon: "cancel",
 					text: this.$t("file.focus.reset"),
 					click: () => this.setFocus(undefined),
-					when: this.focusable && this.hasFocus
+					when: this.isFocusable && this.hasFocus
 				},
 				{
 					icon: "preview",
 					text: this.$t("file.focus.placeholder"),
 					click: () => this.setFocus({ x: 50, y: 50 }),
-					when: this.focusable && !this.hasFocus
+					when: this.isFocusable && !this.hasFocus
 				}
 			];
 		}
 	},
 	methods: {
 		setFocus(focus) {
+			if (this.isFocusable === false) {
+				return false;
+			}
+
 			if (!focus) {
 				focus = null;
 			} else if (this.$helper.object.isObject(focus) === true) {

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -79,12 +79,24 @@ export default {
 	},
 	methods: {
 		autosave() {
+			if (this.isLocked === true) {
+				return false;
+			}
+
 			this.$panel.content.save();
 		},
 		async onDiscard() {
+			if (this.isLocked === true) {
+				return false;
+			}
+
 			await this.$panel.content.discard();
 		},
 		onInput(values) {
+			if (this.isLocked === true) {
+				return false;
+			}
+
 			this.$panel.content.update(values);
 			this.autosave();
 		},
@@ -93,6 +105,10 @@ export default {
 			this.onSubmit();
 		},
 		onSubmit(values = {}) {
+			if (this.isLocked === true) {
+				return false;
+			}
+
 			this.$panel.content.update(values);
 			this.$panel.content.publish();
 		},


### PR DESCRIPTION
## Description

### Summary of changes

- The file preview components now also receive the is-locked property and can then decide for themselves how to disable their input methods (if they provide any)
- The image file preview component disables focus point setting correctly now. 
- All form methods (submit, discard, save) are now blocked if the model is locked. 