### PR TITLE
Add a autoloader for plugins

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -802,19 +802,26 @@ trait AppPlugins
         return $this->core->components()[$component] ?? false;
     }
 
-    /**
-     * Kirby plugin factory and getter
-     *
-     * @param string $name
-     * @param array|null $extends If null is passed it will be used as getter. Otherwise as factory.
-     * @return \Kirby\Cms\Plugin|null
-     * @throws \Kirby\Exception\DuplicateException
-     */
-    public static function plugin(string $name, array $extends = null)
-    {
-        if ($extends === null) {
-            return static::$plugins[$name] ?? null;
-        }
+	/**
+	 * Kirby plugin factory
+	 *
+	 * @param array|null $extends If null is passed it will be take it from the folders. Otherwise as factory.
+	 * @throws \Kirby\Exception\DuplicateException
+	 */
+	public static function plugin(
+		string $name,
+		array $extends = null,
+		array $info = [],
+		string|null $root = null,
+		string|null $version = null
+	): Plugin|null {
+
+		if (
+			$extends === null &&
+			$plugin = static::$plugins[$name] ?? null
+		) {
+			return $plugin;
+		}
 
         // get the correct root for the plugin
         $extends['root'] = $extends['root'] ?? dirname(debug_backtrace()[0]['file']);


### PR DESCRIPTION
## Description

Managing the plugin definition can be very time-consuming.

If you want to create (for example) a snippet, you also have to declare it in the index.php file.

```php
Kirby::plugin('your/plugin', [
    'snippets' => [
        'header' => __DIR__ . '/snippets/header.php'
    ]
]);
```

This PR allows you, to leave the definition blank. It gets everything from the folders:

```Kirby::plugin('your/plugin')```


### Summary of changes

_Adding 3 new methods to Kirby\Cms\Plugin:_

`loadTranslations`: Generate definition of translation folder (I18n). Encoding json or/and adding prefix to keys
`loadFiles`: Generates the definition of a specific folder.
`autoload`: Generates the definition of a specific folder (or folder array).

### Reasoning

Many developers have already developed their own workaraound for this. It is time to implement something standardised.

### Additional context

NOTICE!
`Kirby::plugin('your/plugin');` gets the registered plugin and null if not registered before.
Now it's sets the extends. Please check for possible incompatibility.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes



### Breaking changes



## Docs

This example loads following items (based of the existing folders from the current plugin folder):

- File implementation for `snippets`, `templates`, `blueprint`
- Including the `config` folder and import the files (To outsource the plugin definition)
- Load the translations from the `I18n` folder. Converts JSON files (if needed) and adding prefix to the keys based by the plugin name

```php
Kirby::plugin("your/plugin", Plugin::autoload());
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
