### PR TITLE
Move page: allow parent without any pages sections

### DIFF
--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -385,7 +385,10 @@ class PageRules
 		}
 
 		// check if the template of this page is allowed as subpage type
-		if (in_array($page->intendedTemplate()->name(), $allowed) === false) {
+		if (
+			$allowed !== [] &&
+			in_array($page->intendedTemplate()->name(), $allowed) === false
+		) {
 			throw new PermissionException([
 				'key'  => 'page.move.template',
 				'data' => [

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -764,6 +764,9 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
+	/**
+	 * @covers ::move
+	 */
 	public function testMove()
 	{
 		$app = new App([
@@ -808,6 +811,9 @@ class PageRulesTest extends TestCase
 		$this->assertTrue(PageRules::move($child, $parentB));
 	}
 
+	/**
+	 * @covers ::move
+	 */
 	public function testMoveWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -823,6 +829,9 @@ class PageRulesTest extends TestCase
 		PageRules::move($page, new Page(['slug' => 'test']));
 	}
 
+	/**
+	 * @covers ::move
+	 */
 	public function testMoveWithDuplicate()
 	{
 		$app = new App([
@@ -862,6 +871,9 @@ class PageRulesTest extends TestCase
 		PageRules::move($child, $parentB);
 	}
 
+	/**
+	 * @covers ::move
+	 */
 	public function testMoveWithInvalidTemplate()
 	{
 		$app = new App([
@@ -910,6 +922,54 @@ class PageRulesTest extends TestCase
 
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('The "article" template is not accepted as a subpage of "parent-b"');
+
+		PageRules::move($child, $parentB);
+	}
+
+	/**
+	 * @covers ::move
+	 */
+	public function testMoveWithNoTemplateRestrictions()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP,
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'parent-a',
+						'template' => 'blog',
+						'children' => [
+							[
+								'slug'     => 'child',
+								'template' => 'article'
+							]
+						]
+					],
+					[
+						'slug'     => 'parent-b',
+						'template' => 'photography',
+					]
+				]
+			],
+			'blueprints' => [
+				'pages/photography' => [
+					'sections' => [
+						'albums' => [
+							'type'      => 'info',
+						]
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$parentB = $app->page('parent-b');
+		$child   = $app->page('parent-a/child');
+
+		$this->expectNotToPerformAssertions();
 
 		PageRules::move($child, $parentB);
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Unit test

### Summary of changes
- Allow any templates as children for a page that does not define any pages sections or only sections with no template restrictions


### Reasoning
It's confusing why currently no template is accepted when moving, while no template restrictions exists for the page.


### Additional context
Could be seen a breaking change but I think the current behavior is more a unexpected bug.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- https://github.com/getkirby/kirby/issues/6716


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
