### PR TITLE
`$model::detachStorage()`

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -88,7 +88,7 @@ trait FileActions
 			$oldFile->storage()->moveAll(to: $newFile->storage());
 
 			// detach storage handler of old object
-			$oldFile->detach();
+			$oldFile->detachStorage();
 
 			// update collections
 			$newFile->parent()->files()->remove($oldFile->id());
@@ -348,7 +348,7 @@ trait FileActions
 			$file->parent()->files()->remove($file);
 
 			// detach storage handler of old object
-			$file->detach();
+			$file->detachStorage();
 
 			return true;
 		});
@@ -430,7 +430,7 @@ trait FileActions
 			$newFile = $file->clone();
 
 			// detach storage handler of old object
-			$file->detach();
+			$file->detachStorage();
 
 			return $newFile;
 		});

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -87,6 +87,9 @@ trait FileActions
 			// move the content storage versions
 			$oldFile->storage()->moveAll(to: $newFile->storage());
 
+			// detach storage handler of old object
+			$oldFile->detach();
+
 			// update collections
 			$newFile->parent()->files()->remove($oldFile->id());
 			$newFile->parent()->files()->set($newFile->id(), $newFile);
@@ -344,6 +347,9 @@ trait FileActions
 			// remove the file from the sibling collection
 			$file->parent()->files()->remove($file);
 
+			// detach storage handler of old object
+			$file->detach();
+
 			return true;
 		});
 	}
@@ -421,7 +427,12 @@ trait FileActions
 			$file   = $file->manipulate($create);
 
 			// return a fresh clone
-			return $file->clone();
+			$newFile = $file->clone();
+
+			// detach storage handler of old object
+			$file->detach();
+
+			return $newFile;
 		});
 	}
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -254,8 +254,10 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 * Should be done in conjunction with cloning. The storage of the clone
 	 * can afterwards be mutated without affecting the content in the
 	 * original instance
+	 *
+	 * @internal
 	 */
-	public function detach(): void
+	public function detachStorage(): void
 	{
 		$this->storage = ImmutableMemoryContentStorageHandler::from($this->storage());
 	}
@@ -721,7 +723,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		);
 
 		// detach storage handler of old object
-		$this->detach();
+		$this->detachStorage();
 
 		return $newModel;
 	}

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -71,7 +71,7 @@ trait PageActions
 			}
 
 			// detach storage handler of old object
-			$oldPage->detach();
+			$oldPage->detachStorage();
 
 			// overwrite the child in the parent page
 			static::updateParentCollections($newPage, 'set');
@@ -135,7 +135,7 @@ trait PageActions
 			}
 
 			// detach storage handler of old object
-			$oldPage->detach();
+			$oldPage->detachStorage();
 
 			// overwrite the new page in the parent collection
 			static::updateParentCollections($newPage, 'set');
@@ -304,7 +304,7 @@ trait PageActions
 			$page = $oldPage->convertTo($template);
 
 			// detach storage handler of old object
-			$oldPage->detach();
+			$oldPage->detachStorage();
 
 			// update the parent collection
 			static::updateParentCollections($page, 'set');
@@ -337,7 +337,7 @@ trait PageActions
 			$newPage = $page->save(['title' => $title], $languageCode);
 
 			// detach storage handler of old object
-			$page->detach();
+			$page->detachStorage();
 
 			// flush the parent cache to get children and drafts right
 			static::updateParentCollections($newPage, 'set');
@@ -658,7 +658,7 @@ trait PageActions
 			}
 
 			// detach storage handler
-			$page->detach();
+			$page->detachStorage();
 
 			return true;
 		});
@@ -788,7 +788,7 @@ trait PageActions
 		}
 
 		// detach storage handler of old object
-		$this->detach();
+		$this->detachStorage();
 
 		return $page;
 	}
@@ -946,7 +946,7 @@ trait PageActions
 		$page->resortSiblingsAfterUnlisting();
 
 		// detach storage handler of old object
-		$this->detach();
+		$this->detachStorage();
 
 		return $page;
 	}

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -70,6 +70,9 @@ trait PageActions
 				}
 			}
 
+			// detach storage handler of old object
+			$oldPage->detach();
+
 			// overwrite the child in the parent page
 			static::updateParentCollections($newPage, 'set');
 
@@ -130,6 +133,9 @@ trait PageActions
 
 				Dir::remove($oldPage->mediaRoot());
 			}
+
+			// detach storage handler of old object
+			$oldPage->detach();
 
 			// overwrite the new page in the parent collection
 			static::updateParentCollections($newPage, 'set');
@@ -297,6 +303,9 @@ trait PageActions
 			// convert for new template/blueprint
 			$page = $oldPage->convertTo($template);
 
+			// detach storage handler of old object
+			$oldPage->detach();
+
 			// update the parent collection
 			static::updateParentCollections($page, 'set');
 
@@ -325,12 +334,15 @@ trait PageActions
 		$arguments = ['page' => $this, 'title' => $title, 'languageCode' => $languageCode];
 
 		return $this->commit('changeTitle', $arguments, function ($page, $title, $languageCode) {
-			$page = $page->save(['title' => $title], $languageCode);
+			$newPage = $page->save(['title' => $title], $languageCode);
+
+			// detach storage handler of old object
+			$page->detach();
 
 			// flush the parent cache to get children and drafts right
-			static::updateParentCollections($page, 'set');
+			static::updateParentCollections($newPage, 'set');
 
-			return $page;
+			return $newPage;
 		});
 	}
 
@@ -645,6 +657,9 @@ trait PageActions
 				$page->resortSiblingsAfterUnlisting();
 			}
 
+			// detach storage handler
+			$page->detach();
+
 			return true;
 		});
 	}
@@ -771,6 +786,9 @@ trait PageActions
 		if ($parentModel->childrenAndDrafts !== null) {
 			$parentModel->childrenAndDrafts()->set($page->id(), $page);
 		}
+
+		// detach storage handler of old object
+		$this->detach();
 
 		return $page;
 	}
@@ -926,6 +944,9 @@ trait PageActions
 		}
 
 		$page->resortSiblingsAfterUnlisting();
+
+		// detach storage handler of old object
+		$this->detach();
 
 		return $page;
 	}

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -42,7 +42,7 @@ trait UserActions
 			$user->kirby()->users()->set($newUser->id(), $newUser);
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return $newUser;
 		});
@@ -61,7 +61,7 @@ trait UserActions
 			$user->kirby()->users()->set($newUser->id(), $newUser);
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return $newUser;
 		});
@@ -82,7 +82,7 @@ trait UserActions
 			$user->kirby()->users()->set($newUser->id(), $newUser);
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return $newUser;
 		});
@@ -113,7 +113,7 @@ trait UserActions
 			}
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return $newUser;
 		});
@@ -132,7 +132,7 @@ trait UserActions
 			$user->kirby()->users()->set($newUser->id(), $newUser);
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return $newUser;
 		});
@@ -328,7 +328,7 @@ trait UserActions
 			$user->kirby()->users()->remove($user);
 
 			// detach storage handler of old object
-			$user->detach();
+			$user->detachStorage();
 
 			return true;
 		});

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -35,13 +35,16 @@ trait UserActions
 		$email = trim($email);
 
 		return $this->commit('changeEmail', ['user' => $this, 'email' => Idn::decodeEmail($email)], function ($user, $email) {
-			$user = $user->clone(['email' => $email]);
-			$user->updateCredentials(['email' => $email]);
+			$newUser = $user->clone(['email' => $email]);
+			$newUser->updateCredentials(['email' => $email]);
 
 			// update the users collection
-			$user->kirby()->users()->set($user->id(), $user);
+			$user->kirby()->users()->set($newUser->id(), $newUser);
 
-			return $user;
+			// detach storage handler of old object
+			$user->detach();
+
+			return $newUser;
 		});
 	}
 
@@ -51,13 +54,16 @@ trait UserActions
 	public function changeLanguage(string $language): static
 	{
 		return $this->commit('changeLanguage', ['user' => $this, 'language' => $language], function ($user, $language) {
-			$user = $user->clone(['language' => $language]);
-			$user->updateCredentials(['language' => $language]);
+			$newUser = $user->clone(['language' => $language]);
+			$newUser->updateCredentials(['language' => $language]);
 
 			// update the users collection
-			$user->kirby()->users()->set($user->id(), $user);
+			$user->kirby()->users()->set($newUser->id(), $newUser);
 
-			return $user;
+			// detach storage handler of old object
+			$user->detach();
+
+			return $newUser;
 		});
 	}
 
@@ -69,13 +75,16 @@ trait UserActions
 		$name = trim($name);
 
 		return $this->commit('changeName', ['user' => $this, 'name' => $name], function ($user, $name) {
-			$user = $user->clone(['name' => $name]);
-			$user->updateCredentials(['name' => $name]);
+			$newUser = $user->clone(['name' => $name]);
+			$newUser->updateCredentials(['name' => $name]);
 
 			// update the users collection
-			$user->kirby()->users()->set($user->id(), $user);
+			$user->kirby()->users()->set($newUser->id(), $newUser);
 
-			return $user;
+			// detach storage handler of old object
+			$user->detach();
+
+			return $newUser;
 		});
 	}
 
@@ -87,23 +96,26 @@ trait UserActions
 		string $password
 	): static {
 		return $this->commit('changePassword', ['user' => $this, 'password' => $password], function ($user, $password) {
-			$user = $user->clone([
+			$newUser = $user->clone([
 				'password' => $password = User::hashPassword($password)
 			]);
 
-			$user->writePassword($password);
+			$newUser->writePassword($password);
 
 			// update the users collection
-			$user->kirby()->users()->set($user->id(), $user);
+			$user->kirby()->users()->set($newUser->id(), $newUser);
 
 			// keep the user logged in to the current browser
 			// if they changed their own password
 			// (regenerate the session token, update the login timestamp)
 			if ($user->isLoggedIn() === true) {
-				$user->loginPasswordless();
+				$newUser->loginPasswordless();
 			}
 
-			return $user;
+			// detach storage handler of old object
+			$user->detach();
+
+			return $newUser;
 		});
 	}
 
@@ -113,13 +125,16 @@ trait UserActions
 	public function changeRole(string $role): static
 	{
 		return $this->commit('changeRole', ['user' => $this, 'role' => $role], function ($user, $role) {
-			$user = $user->clone(['role' => $role]);
-			$user->updateCredentials(['role' => $role]);
+			$newUser = $user->clone(['role' => $role]);
+			$newUser->updateCredentials(['role' => $role]);
 
 			// update the users collection
-			$user->kirby()->users()->set($user->id(), $user);
+			$user->kirby()->users()->set($newUser->id(), $newUser);
 
-			return $user;
+			// detach storage handler of old object
+			$user->detach();
+
+			return $newUser;
 		});
 	}
 
@@ -311,6 +326,9 @@ trait UserActions
 
 			// remove the user from users collection
 			$user->kirby()->users()->remove($user);
+
+			// detach storage handler of old object
+			$user->detach();
 
 			return true;
 		});

--- a/src/Content/ImmutableMemoryContentStorageHandler.php
+++ b/src/Content/ImmutableMemoryContentStorageHandler.php
@@ -37,7 +37,7 @@ class ImmutableMemoryContentStorageHandler extends MemoryContentStorageHandler
 	protected function preventMutation(): void
 	{
 		throw new LogicException(
-			message: 'Storage for the ' . $this->model::CLASS_ALIAS . ' is immutable and cannot be deleted. Make sure to use the last alteration of the object.'
+			message: 'Storage for the ' . $this->model::CLASS_ALIAS . ' is immutable and cannot be altered. Make sure to use the last alteration of the object.'
 		);
 	}
 

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -105,10 +105,11 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->version(VersionId::published())->contentFile('default'), '');
+		F::write($oldContentFile = $file->version(VersionId::published())->contentFile('default'), '');
+
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->version(VersionId::published())->contentFile('default'));
+		$this->assertFileExists($oldContentFile);
 
 		$result = $file->changeName('test');
 
@@ -117,7 +118,7 @@ class FileActionsTest extends TestCase
 		$this->assertFileExists($result->root());
 		$this->assertFileExists($result->version(VersionId::published())->contentFile('default'));
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->version(VersionId::published())->contentFile('default'));
+		$this->assertFileDoesNotExist($oldContentFile);
 	}
 
 	public static function fileProviderMultiLang(): array
@@ -982,17 +983,17 @@ class FileActionsTest extends TestCase
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->version(VersionId::published())->contentFile('default'), '');
+		F::write($contentFile = $file->version(VersionId::published())->contentFile('default'), '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->version(VersionId::published())->contentFile('default'));
+		$this->assertFileExists($contentFile);
 
 		$result = $file->delete();
 
 		$this->assertTrue($result);
 
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->version(VersionId::published())->contentFile('default'));
+		$this->assertFileDoesNotExist($contentFile);
 	}
 
 	/**

--- a/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
+++ b/tests/Content/ImmutableMemoryContentStorageHandlerTest.php
@@ -28,7 +28,7 @@ class ImmutableMemoryContentStorageHandlerTest extends TestCase
 	public function testDelete()
 	{
 		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be altered. Make sure to use the last alteration of the object.');
 
 		$this->storage->delete(VersionId::published(), Language::ensure());
 	}
@@ -40,7 +40,7 @@ class ImmutableMemoryContentStorageHandlerTest extends TestCase
 	public function testMove()
 	{
 		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be altered. Make sure to use the last alteration of the object.');
 
 		$this->storage->move(
 			fromVersionId: VersionId::published(),
@@ -56,7 +56,7 @@ class ImmutableMemoryContentStorageHandlerTest extends TestCase
 	public function testTouch()
 	{
 		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be altered. Make sure to use the last alteration of the object.');
 
 		$this->storage->touch(VersionId::published(), Language::ensure());
 	}
@@ -70,7 +70,7 @@ class ImmutableMemoryContentStorageHandlerTest extends TestCase
 		$this->storage->create(VersionId::published(), Language::ensure(), []);
 
 		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
+		$this->expectExceptionMessage('Storage for the page is immutable and cannot be altered. Make sure to use the last alteration of the object.');
 
 		$this->storage->update(VersionId::published(), Language::ensure(), []);
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [ ] Cloning in e.g. `saveContent` resets immutable memory storage to plain text storage
- [ ] Unit tests
- [x] Consider more descriptive method name, e.g. `::detachStorage()`

### Summary of changes
- Content storage handler gets switched to `ImmutableMemoryContentStorageHandler`, which does not allow any alteration of content, after model actions that return a new, altered model object.
- New `$model->detachStorage()` method


### Reasoning
This prevents working with the outdated object and ensures working with the latest object within our immutable model objects.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes
When altering an object, only the newly greeted model object can be used to further modify content. The old object will throw an exception when one tries to further alter its content.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
