### PR TITLE
Fix `PageRules::move()` one more time

### DIFF
--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -372,7 +372,7 @@ class PageRules
 			$parent->blueprint()->sections(),
 			fn ($section) =>
 				$section->type() === 'pages' &&
-				$section->parent() === $parent
+				$section->parent()->is($parent)
 		);
 
 		// check if the parent has at least one pages section
@@ -385,17 +385,20 @@ class PageRules
 			]);
 		}
 
-		// go through all allowed blueprints and
-		// add the name to the allow list
+		// go through all allowed templates and
+		// add the name to the allowlist
 		foreach ($sections as $section) {
-			foreach ($section->blueprints() as $blueprint) {
-				$allowed[] = $blueprint['name'];
+			foreach ($section->templates() as $template) {
+				$allowed[] = $template;
 			}
 		}
 
 		// check if the template of this page is allowed as subpage type
 		// for the potential new parent
-		if (in_array($page->intendedTemplate()->name(), $allowed) === false) {
+		if (
+			$allowed !== [] &&
+			in_array($page->intendedTemplate()->name(), $allowed) === false
+		) {
 			throw new PermissionException([
 				'key'  => 'page.move.template',
 				'data' => [

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -1008,7 +1008,7 @@ class PageRulesTest extends TestCase
 				'pages/photography' => [
 					'sections' => [
 						'albums' => [
-							'type' => 'pages',
+							'type' => 'pages'
 						]
 					]
 				]

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -908,6 +908,7 @@ class PageRulesTest extends TestCase
 						'related' => [
 							'type'      => 'pages',
 							'parent'    => 'site.find("parent-a")',
+							'create'    => 'album',
 							'templates' => ['article']
 						]
 					]
@@ -1000,6 +1001,7 @@ class PageRulesTest extends TestCase
 					[
 						'slug'     => 'parent-b',
 						'template' => 'photography',
+						'create'   => 'album'
 					]
 				]
 			],


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `PageRules::move()` now treats pages section with `create` option correctly


### Reasoning
`$section->blueprints()` doesn't return the template options if the `create` option is set 😑


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed move dialog for parents with pages sections where the `create` option is set


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
