### PR TITLE
Multi-language fixes

### DIFF
--- a/src/Panel/Controller/Changes.php
+++ b/src/Panel/Controller/Changes.php
@@ -24,10 +24,7 @@ class Changes
 	 */
 	public static function discard(ModelWithContent $model): array
 	{
-		$model->version(VersionId::changes())->delete();
-
-		// remove the model from the user's list of unsaved changes
-		App::instance()->site()->changes()->untrack($model);
+		$model->version(VersionId::changes())->delete('current');
 
 		return [
 			'status' => 'ok'
@@ -83,9 +80,6 @@ class Changes
 			],
 			language: 'current'
 		);
-
-		// add the model to the user's list of unsaved changes
-		App::instance()->site()->changes()->track($model);
 
 		return [
 			'status' => 'ok'

--- a/src/Panel/Controller/Changes.php
+++ b/src/Panel/Controller/Changes.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel\Controller;
 
-use Kirby\Cms\App;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Content\VersionId;
 use Kirby\Form\Form;
@@ -49,9 +48,6 @@ class Changes
 		$changes->publish(
 			language: 'current'
 		);
-
-		// remove the model from the user's list of unsaved changes
-		App::instance()->site()->changes()->untrack($model);
 
 		return [
 			'status' => 'ok'

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -40,8 +40,8 @@ abstract class Model
 		$version = $this->model->version('changes');
 		$changes = [];
 
-		if ($version->exists() === true) {
-			$changes = $version->content()->toArray();
+		if ($version->exists('current') === true) {
+			$changes = $version->content('current')->toArray();
 		}
 
 		// create a form which will collect the published values for the model,

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -238,7 +238,12 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists('en');
 		$this->assertContentFileExists('de');
 
-		$version->delete();
+		$version->delete('en');
+
+		$this->assertContentFileDoesNotExist('en');
+		$this->assertContentFileExists('de');
+
+		$version->delete('de');
 
 		$this->assertContentFileDoesNotExist('en');
 		$this->assertContentFileDoesNotExist('de');
@@ -521,6 +526,35 @@ class VersionTest extends TestCase
 
 		$this->assertTrue($version->exists('de'));
 		$this->assertTrue($version->exists($this->app->language('de')));
+	}
+
+	/**
+	 * @covers ::exists
+	 */
+	public function testExistsWithLanguageWildcard(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$this->createContentMultiLanguage();
+
+		$this->assertTrue($version->exists('en'));
+		$this->assertTrue($version->exists('de'));
+		$this->assertTrue($version->exists('*'));
+
+		// delete the German translation
+		$version->delete('de');
+
+		$this->assertTrue($version->exists('en'));
+		$this->assertFalse($version->exists('de'));
+
+		// The wildcard should now still return true
+		// because the English translation still exists
+		$this->assertTrue($version->exists('*'));
 	}
 
 	/**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\App;
 use Kirby\Cms\File as ModelFile;
+use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
@@ -80,7 +81,33 @@ class ModelTest extends TestCase
 				'foo' => 'bar'
 			]
 		]);
+
 		$this->assertSame($content, $panel->content());
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::content
+	 */
+	public function testContentWithChanges()
+	{
+		$panel = new CustomPanelModel(
+			new ModelPage(['slug' => 'test'])
+		);
+
+		$panel->model()->version('published')->save([
+			'foo'  => 'foo',
+			'uuid' => 'test'
+		]);
+
+		$panel->model()->version('changes')->save([
+			'foo' => 'foobar'
+		]);
+
+		$this->assertSame([
+			'foo'  => 'foobar',
+			'uuid' => 'test'
+		], $panel->content());
 	}
 
 	/**


### PR DESCRIPTION
## Description

### Summary of changes

- `Version::exists` has a new wildcard option to check if a version exists in any language. E.g. `$page->version('changes')->exists('*')` We had this in an earlier draft where you could pass null to achieve this. But needing this again, I thought that the wildcard is helping to avoid confusion. It could be indeed an option for more places like this later. 
- I made sure to always get the `current` language in more places to fix bugs when changing the language. 
- Tracking changes has been improved and the wildcard above is used to untrack model changes properly if there are no more changes in any other language. 
- The lock field is now stored in every language file. This will already help to simplify the logic and it already enables the option to work on translations side by side. This has been possible before as well, when we stored stuff in local storage. 
- The lock field is now properly removed from the published version. 