### PR TITLE
New `redis` cache driver

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         php: ["8.2", "8.3"]
     env:
-      extensions: mbstring, ctype, curl, gd, apcu, memcached
+      extensions: mbstring, ctype, curl, gd, apcu, memcached, redis
       ini: apc.enabled=1, apc.enable_cli=1, pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
 
     steps:
@@ -73,6 +73,11 @@ jobs:
 
       - name: Install memcached
         uses: niden/actions-memcached@3b3ecd9d0d035ea92db716dc1540a7dbe9e56349 # pin@v7
+
+      - name: Install redis
+        uses: supercharge/redis-github-action@ea9b21c6ecece47bd99595c532e481390ea0f044 # pin@v1
+        with:
+          redis-version: 7
 
       - name: Install system locales
         run: sudo apt-get update && sudo apt-get install -y locales-all
@@ -168,7 +173,7 @@ jobs:
     timeout-minutes: 5
     env:
       php: "8.2"
-      extensions: mbstring, ctype, curl, gd, apcu, memcached
+      extensions: mbstring, ctype, curl, gd, apcu, memcached, redis
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
 		"ext-fileinfo": "Improved mime type detection for files",
 		"ext-intl": "Improved i18n number formatting",
 		"ext-memcached": "Support for the Memcached cache driver",
+		"ext-redis": "Support for the Redis cache driver",
 		"ext-sodium": "Support for the crypto class and more robust session handling",
 		"ext-zip": "Support for ZIP archive file functions",
 		"ext-zlib": "Sanitization and validation for svgz files"

--- a/composer.lock
+++ b/composer.lock
@@ -1023,7 +1023,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -1040,7 +1040,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.0"
     },

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -70,7 +70,6 @@ abstract class Cache
 		return $this->expired($key) === false;
 	}
 
-
 	/**
 	 * Calculates the expiration timestamp
 	 */

--- a/src/Cache/RedisCache.php
+++ b/src/Cache/RedisCache.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Kirby\Cache;
+
+use Kirby\Cms\Helpers;
+use Redis;
+use Throwable;
+
+/**
+ * Redis Cache Driver
+ *
+ * @package   Kirby Cache
+ * @author    Ahmet Bora <ahmet@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class RedisCache extends Cache
+{
+	/**
+	 * Store for the redis connection
+	 */
+	protected Redis $connection;
+
+	/**
+	 * Sets all parameters which are needed to connect to Redis
+	 *
+	 * @param array $options 'host'   (default: 127.0.0.1)
+	 *                       'port'   (default: 6379)
+	 */
+	public function __construct(array $options = [])
+	{
+		$options = [
+			'host' => '127.0.0.1',
+			'port' => 6379,
+			...$options
+		];
+
+		parent::__construct($options);
+
+		// available options for the redis driver
+		$allowed = [
+			'host',
+			'port',
+			'readTimeout',
+			'connectTimeout',
+			'persistent',
+			'auth',
+			'ssl',
+			'retryInterval',
+			'backoff'
+		];
+
+		// filters only redis supported keys
+		$redisOptions = array_intersect_key($options, array_flip($allowed));
+
+		// creates redis connection
+		$this->connection = new Redis($redisOptions);
+
+		// sets the prefix if defined
+		if ($prefix = $options['prefix'] ?? null) {
+			$this->connection->setOption(Redis::OPT_PREFIX, rtrim($prefix, '/') . '/');
+		}
+
+		// selects the database if defined
+		$database = $options['database'] ?? null;
+		if ($database !== null) {
+			$this->connection->select($database);
+		}
+	}
+
+	/**
+	 * Returns the database number
+	 */
+	public function databaseNum(): int
+	{
+		return $this->connection->getDbNum();
+	}
+
+	/**
+	 * Returns whether the cache is ready to store values
+	 */
+	public function enabled(): bool
+	{
+		try {
+			return Helpers::handleErrors(
+				fn () => $this->connection->ping(),
+				fn (int $errno, string $errstr) => true,
+				fn () => false
+			);
+		} catch (Throwable) {
+			return false;
+		}
+	}
+
+	/**
+	 * Determines if an item exists in the cache
+	 */
+	public function exists(string $key): bool
+	{
+		return $this->connection->exists($this->key($key)) !== 0;
+	}
+
+	/**
+	 * Removes keys from the database
+	 * and returns whether the operation was successful
+	 */
+	public function flush(): bool
+	{
+		return $this->connection->flushDB();
+	}
+
+	/**
+	 * The key is not modified, because the prefix is added by the redis driver itself
+	 */
+	protected function key(string $key): string
+	{
+		return $key;
+	}
+
+	/**
+	 * Removes an item from the cache
+	 * and returns whether the operation was successful
+	 */
+	public function remove(string $key): bool
+	{
+		return $this->connection->del($this->key($key));
+	}
+
+	/**
+	 * Internal method to retrieve the raw cache value;
+	 * needs to return a Value object or null if not found
+	 */
+	public function retrieve(string $key): Value|null
+	{
+		$value = $this->connection->get($this->key($key));
+		return Value::fromJson($value);
+	}
+
+	/**
+	 * Writes an item to the cache for a given number of minutes
+	 * and returns whether the operation was successful
+	 *
+	 * <code>
+	 *   // put an item in the cache for 15 minutes
+	 *   $cache->set('value', 'my value', 15);
+	 * </code>
+	 */
+	public function set(string $key, $value, int $minutes = 0): bool
+	{
+		$key   = $this->key($key);
+		$value = (new Value($value, $minutes))->toJson();
+
+		if ($minutes > 0) {
+			return $this->connection->setex($key, $minutes * 60, $value);
+		}
+
+		return $this->connection->set($key, $value);
+	}
+}

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -6,6 +6,7 @@ use Kirby\Cache\ApcuCache;
 use Kirby\Cache\FileCache;
 use Kirby\Cache\MemCached;
 use Kirby\Cache\MemoryCache;
+use Kirby\Cache\RedisCache;
 use Kirby\Cms\Auth\EmailChallenge;
 use Kirby\Cms\Auth\TotpChallenge;
 use Kirby\Form\Field\BlocksField;
@@ -165,6 +166,7 @@ class Core
 			'file'      => FileCache::class,
 			'memcached' => MemCached::class,
 			'memory'    => MemoryCache::class,
+			'redis'     => RedisCache::class
 		];
 	}
 

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Kirby\Cache;
+
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Cache\RedisCache
+ */
+class RedisCacheTest extends TestCase
+{
+	public function setUp(): void
+	{
+		if (class_exists('Redis') === false) {
+			$this->markTestSkipped('The Redis extension is not available.');
+			return;
+		}
+
+		try {
+			$connection = new \Redis();
+			$connection->ping();
+		} catch (\Throwable) {
+			$this->markTestSkipped('The Redis server is not running.');
+		}
+	}
+
+	public function tearDown(): void
+	{
+		$connection = new RedisCache();
+		$connection->flush();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::enabled
+	 */
+	public function testConstructServer()
+	{
+		// invalid port
+		$cache = new RedisCache([
+			'port' => 1234
+		]);
+		$this->assertFalse($cache->enabled());
+
+		// invalid host
+		$cache = new RedisCache([
+			'host' => 'invalid.host'
+		]);
+		$this->assertFalse($cache->enabled());
+	}
+
+	/**
+	 * @covers ::databaseNum
+	 */
+	public function testDatabase()
+	{
+		$cache = new RedisCache([
+			'database' => 1
+		]);
+
+		$cache->set('a', 'A basic value');
+
+		$this->assertSame(1, $cache->databaseNum());
+		$this->assertTrue($cache->exists('a'));
+		$this->assertSame('A basic value', $cache->retrieve('a')->value());
+	}
+
+	/**
+	 * @covers ::enabled
+	 */
+	public function testEnabled()
+	{
+		$cache = new RedisCache();
+		$this->assertTrue($cache->enabled());
+	}
+
+	/**
+	 * @covers ::exists
+	 * @covers ::flush
+	 */
+	public function testFlush()
+	{
+		$cache = new RedisCache();
+
+		$cache->set('a', 'A basic value');
+		$cache->set('b', 'A basic value');
+		$cache->set('c', 'A basic value');
+
+		$this->assertTrue($cache->exists('a'));
+		$this->assertTrue($cache->exists('b'));
+		$this->assertTrue($cache->exists('c'));
+
+		$this->assertTrue($cache->flush());
+		$this->assertFalse($cache->exists('a'));
+		$this->assertFalse($cache->exists('b'));
+		$this->assertFalse($cache->exists('c'));
+	}
+
+	/**
+	 * @covers ::exists
+	 * @covers ::key
+	 * @covers ::set
+	 * @covers ::retrieve
+	 * @covers ::remove
+	 */
+	public function testOperations()
+	{
+		$cache = new RedisCache();
+
+		$time = time();
+		$this->assertTrue($cache->set('foo', 'A basic value', 10));
+
+		$this->assertTrue($cache->exists('foo'));
+		$this->assertSame('A basic value', $cache->retrieve('foo')->value());
+		$this->assertSame($time, $cache->created('foo'));
+		$this->assertSame($time + 600, $cache->expires('foo'));
+
+		$this->assertTrue($cache->remove('foo'));
+		$this->assertFalse($cache->exists('foo'));
+		$this->assertNull($cache->retrieve('foo'));
+
+		$this->assertFalse($cache->remove('doesnotexist'));
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::exists
+	 * @covers ::key
+	 * @covers ::set
+	 * @covers ::retrieve
+	 * @covers ::remove
+	 */
+	public function testOperationsWithPrefix()
+	{
+		$cache1 = new RedisCache([
+			'prefix' => 'test1:'
+		]);
+		$cache2 = new RedisCache([
+			'prefix' => 'test2:'
+		]);
+
+		$time = time();
+		$this->assertTrue($cache1->set('foo', 'A basic value', 10));
+
+		$this->assertTrue($cache1->exists('foo'));
+		$this->assertFalse($cache2->exists('foo'));
+		$this->assertSame('A basic value', $cache1->retrieve('foo')->value());
+		$this->assertSame($time, $cache1->created('foo'));
+		$this->assertSame($time + 600, $cache1->expires('foo'));
+
+		$this->assertTrue($cache2->set('foo', 'Another basic value'));
+		$this->assertTrue($cache2->exists('foo'));
+
+		$this->assertSame('A basic value', $cache1->retrieve('foo')->value());
+		$this->assertTrue($cache1->remove('foo'));
+		$this->assertFalse($cache1->exists('foo'));
+		$this->assertNull($cache1->retrieve('foo'));
+		$this->assertTrue($cache2->exists('foo'));
+		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -41,6 +41,7 @@ return array(
     'Kirby\\Cache\\MemCached' => $baseDir . '/src/Cache/MemCached.php',
     'Kirby\\Cache\\MemoryCache' => $baseDir . '/src/Cache/MemoryCache.php',
     'Kirby\\Cache\\NullCache' => $baseDir . '/src/Cache/NullCache.php',
+    'Kirby\\Cache\\RedisCache' => $baseDir . '/src/Cache/RedisCache.php',
     'Kirby\\Cache\\Value' => $baseDir . '/src/Cache/Value.php',
     'Kirby\\Cms\\Api' => $baseDir . '/src/Cms/Api.php',
     'Kirby\\Cms\\App' => $baseDir . '/src/Cms/App.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -161,6 +161,7 @@ class ComposerStaticInit0bf5c8a9cfa251a218fc581ac888fe35
         'Kirby\\Cache\\MemCached' => __DIR__ . '/../..' . '/src/Cache/MemCached.php',
         'Kirby\\Cache\\MemoryCache' => __DIR__ . '/../..' . '/src/Cache/MemoryCache.php',
         'Kirby\\Cache\\NullCache' => __DIR__ . '/../..' . '/src/Cache/NullCache.php',
+        'Kirby\\Cache\\RedisCache' => __DIR__ . '/../..' . '/src/Cache/RedisCache.php',
         'Kirby\\Cache\\Value' => __DIR__ . '/../..' . '/src/Cache/Value.php',
         'Kirby\\Cms\\Api' => __DIR__ . '/../..' . '/src/Cms/Api.php',
         'Kirby\\Cms\\App' => __DIR__ . '/../..' . '/src/Cms/App.php',


### PR DESCRIPTION
## Description
Redis is one of the most used cache types and I thought it should be in the core. Since I don't use Redis cache much, PR may have some shortcomings. Redis has many features but I wanted to add its basic features.

````php
<?php

return [
    'cache' => [
        'pages' => [
            'active'    => true,
            'type'      => 'redis',
            'host'      => '127.0.0.1', // default host address
            'port'      => 6379, // default port number
            'auth'      => ['user', 'password'], // optional
        ]
    ]
];

````

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Featues
- New `redis` cache driver


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
