### PR TITLE
Refactor Form Classes

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -303,6 +303,23 @@ class Field extends Component
 	}
 
 	/**
+	 * Sets a new value for the field
+	 */
+	public function fill(mixed $value): static
+	{
+		// overwrite the attribute value
+		$this->value = $this->attrs['value'] = $value;
+
+		// reevaluate the value prop
+		$this->applyProp('value', $this->options['props']['value'] ?? $value);
+
+		// reevaluate the computed props
+		$this->applyComputed($this->options['computed']);
+
+		return $this;
+	}
+
+	/**
 	 * Parent collection with all fields of the current form
 	 */
 	public function formFields(): Fields|null

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -340,6 +340,14 @@ class Field extends Component
 	}
 
 	/**
+	 * Checks if the field is disabled
+	 */
+	public function isDisabled(): bool
+	{
+		return $this->disabled === true;
+	}
+
+	/**
 	 * Checks if the field is empty
 	 */
 	public function isEmpty(mixed ...$args): bool

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -316,6 +316,9 @@ class Field extends Component
 		// reevaluate the computed props
 		$this->applyComputed($this->options['computed']);
 
+		// reset the errors cache
+		$this->errors = null;
+
 		return $this;
 	}
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -520,7 +520,6 @@ abstract class FieldClass
 	public function toArray(): array
 	{
 		$props = $this->props();
-		$props['signature'] = md5(json_encode($props));
 
 		ksort($props);
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Closure;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 
 /**
@@ -36,6 +37,14 @@ class Fields extends Collection
 		parent::__set($field->name(), $field);
 	}
 
+	/**
+	 * Returns an array with the default value of each field
+	 */
+	public function defaults(): array
+	{
+		return $this->toArray(fn($field) => $field->default());
+	}
+	
 	/**
 	 * Converts the fields collection to an
 	 * array and also does that for every

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -20,6 +20,13 @@ use Kirby\Toolkit\Collection;
 class Fields extends Collection
 {
 	/**
+	 * Cache for the errors array
+	 *
+	 * @var array<string, array<string, string>>|null
+	 */
+	protected array|null $errors = null;
+
+	/**
 	 * Internal setter for each object in the Collection.
 	 * This takes care of validation and of setting
 	 * the collection prop on each object correctly.
@@ -35,6 +42,9 @@ class Fields extends Collection
 		}
 
 		parent::__set($field->name(), $field);
+
+		// reset the errors cache if new fields are added
+		$this->errors = null;
 	}
 
 	/**
@@ -50,18 +60,22 @@ class Fields extends Collection
 	 */
 	public function errors(): array
 	{
-		$errors = [];
+		if ($this->errors !== null) {
+			return $this->errors;
+		}
+
+		$this->errors = [];
 
 		foreach ($this->data as $name => $field) {
 			if ($field->errors() !== []) {
-				$errors[$name] = [
+				$this->errors[$name] = [
 					'label'   => $field->label(),
 					'message' => $field->errors()
 				];
 			}
 		}
 
-		return $errors;
+		return $this->errors;
 	}
 
 	/**
@@ -72,6 +86,9 @@ class Fields extends Collection
 		foreach ($input as $name => $value) {
 			$this->get($name)?->fill($value);
 		}
+
+		// reset the errors cache
+		$this->errors = null;
 
 		return $this;
 	}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -42,9 +42,28 @@ class Fields extends Collection
 	 */
 	public function defaults(): array
 	{
-		return $this->toArray(fn($field) => $field->default());
+		return $this->toArray(fn ($field) => $field->default());
 	}
-	
+
+	/**
+	 * An array of all found in all fields errors
+	 */
+	public function errors(): array
+	{
+		$errors = [];
+
+		foreach ($this->data as $name => $field) {
+			if (empty($field->errors()) === false) {
+				$errors[$name] = [
+					'label'   => $field->label(),
+					'message' => $field->errors()
+				];
+			}
+		}
+
+		return $errors;
+	}
+
 	/**
 	 * Converts the fields collection to an
 	 * array and also does that for every
@@ -52,6 +71,6 @@ class Fields extends Collection
 	 */
 	public function toArray(Closure|null $map = null): array
 	{
-		return A::map($this->data, $map ?? fn($field) => $field->toArray());
+		return A::map($this->data, $map ?? fn ($field) => $field->toArray());
 	}
 }

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -67,10 +67,12 @@ class Fields extends Collection
 		$this->errors = [];
 
 		foreach ($this->data as $name => $field) {
-			if ($field->errors() !== []) {
+			$errors = $field->errors();
+
+			if ($errors !== []) {
 				$this->errors[$name] = [
 					'label'   => $field->label(),
-					'message' => $field->errors()
+					'message' => $errors
 				];
 			}
 		}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -53,7 +53,7 @@ class Fields extends Collection
 		$errors = [];
 
 		foreach ($this->data as $name => $field) {
-			if (empty($field->errors()) === false) {
+			if ($field->errors() !== []) {
 				$errors[$name] = [
 					'label'   => $field->label(),
 					'message' => $field->errors()

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -43,12 +43,6 @@ class Fields extends Collection
 	 */
 	public function toArray(Closure|null $map = null): array
 	{
-		$array = [];
-
-		foreach ($this as $field) {
-			$array[$field->name()] = $field->toArray();
-		}
-
-		return $array;
+		return A::map($this->data, $map ?? fn($field) => $field->toArray());
 	}
 }

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -65,6 +65,18 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Sets the value for each field with a matching key in the input array
+	 */
+	public function fill(array $input): static
+	{
+		foreach ($input as $name => $value) {
+			$this->get($name)?->fill($value);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Converts the fields collection to an
 	 * array and also does that for every
 	 * included field.

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -321,7 +321,7 @@ class Form
 	{
 		$array = [
 			'errors'  => $this->errors(),
-			'fields'  => $this->fields->toArray(fn ($item) => $item->toArray()),
+			'fields'  => $this->fields->toArray(),
 			'invalid' => $this->isInvalid()
 		];
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -27,11 +27,6 @@ use Throwable;
 class Form
 {
 	/**
-	 * An array of all found errors
-	 */
-	protected array|null $errors = null;
-
-	/**
 	 * Fields in the form
 	 */
 	protected Fields|null $fields;
@@ -143,22 +138,7 @@ class Form
 	 */
 	public function errors(): array
 	{
-		if ($this->errors !== null) {
-			return $this->errors;
-		}
-
-		$this->errors = [];
-
-		foreach ($this->fields as $field) {
-			if (empty($field->errors()) === false) {
-				$this->errors[$field->name()] = [
-					'label'   => $field->label(),
-					'message' => $field->errors()
-				];
-			}
-		}
-
-		return $this->errors;
+		return $this->fields->errors();
 	}
 
 	/**

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -145,34 +145,42 @@ class Component
 	}
 
 	/**
+	 * Register a single property
+	 */
+	protected function applyProp(string $name, mixed $value): void
+	{
+		if ($value instanceof Closure) {
+			if (isset($this->attrs[$name]) === true) {
+				try {
+					$this->$name = $this->props[$name] = $value->call(
+						$this,
+						$this->attrs[$name]
+					);
+					return;
+				} catch (TypeError) {
+					throw new TypeError('Invalid value for "' . $name . '"');
+				}
+			}
+
+			try {
+				$this->$name = $this->props[$name] = $value->call($this);
+				return;
+			} catch (ArgumentCountError) {
+				throw new ArgumentCountError('Please provide a value for "' . $name . '"');
+			}
+		}
+
+		$this->$name = $this->props[$name] = $value;
+	}
+
+	/**
 	 * Register all defined props and apply the
 	 * passed values.
 	 */
 	protected function applyProps(array $props): void
 	{
-		foreach ($props as $name => $function) {
-			if ($function instanceof Closure) {
-				if (isset($this->attrs[$name]) === true) {
-					try {
-						$this->$name = $this->props[$name] = $function->call(
-							$this,
-							$this->attrs[$name]
-						);
-						continue;
-					} catch (TypeError) {
-						throw new TypeError('Invalid value for "' . $name . '"');
-					}
-				}
-
-				try {
-					$this->$name = $this->props[$name] = $function->call($this);
-					continue;
-				} catch (ArgumentCountError) {
-					throw new ArgumentCountError('Please provide a value for "' . $name . '"');
-				}
-			}
-
-			$this->$name = $this->props[$name] = $function;
+		foreach ($props as $name => $value) {
+			$this->applyProp($name, $value);
 		}
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -503,7 +503,6 @@ class FieldClassTest extends TestCase
 		$array = $field->toArray();
 
 		$this->assertSame($props, $field->props());
-		$this->assertEquals($props + ['signature' => $array['signature']], $array); // cannot use strict assertion (array order)
 	}
 
 	/**

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -261,6 +261,7 @@ class FieldTest extends TestCase
 
 		$this->assertFalse($field->disabled());
 		$this->assertFalse($field->disabled);
+		$this->assertFalse($field->isDisabled());
 
 		// disabled
 		$field = new Field('test', [
@@ -270,6 +271,7 @@ class FieldTest extends TestCase
 
 		$this->assertTrue($field->disabled());
 		$this->assertTrue($field->disabled);
+		$this->assertTrue($field->isDisabled());
 	}
 
 	public function testErrors()

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -300,6 +300,34 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
+	public function testFill()
+	{
+		Field::$types = [
+			'test' => [
+				'computed' => [
+					'computedValue' => fn () => $this->value . ' computed'
+				]
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page,
+			'value' => 'test'
+		]);
+
+		$this->assertSame('test', $field->value());
+		$this->assertSame('test', $field->value);
+		$this->assertSame('test computed', $field->computedValue());
+
+		$field->fill('test2');
+
+		$this->assertSame('test2', $field->value());
+		$this->assertSame('test2', $field->value);
+		$this->assertSame('test2 computed', $field->computedValue());
+	}
+
 	public function testHelp()
 	{
 		Field::$types = [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -22,7 +22,7 @@ class FieldsTest extends TestCase
 
 	/**
 	 * @covers ::__construct
-	 */	
+	 */
 	public function testConstruct()
 	{
 		$fields = new Fields([
@@ -55,10 +55,66 @@ class FieldsTest extends TestCase
 				'default' => 'b',
 				'model'   => $this->model,
 				'type'    => 'text'
-			],	
+			],
 		]);
 
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->defaults());
+	}
+
+	/**
+	 * @covers ::errors
+	 */
+	public function testErrors()
+	{
+		$fields = new Fields([
+			'a' => [
+				'label'    => 'A',
+				'type'     => 'text',
+				'model'    => $this->model,
+				'required' => true
+			],
+			'b' => [
+				'label'    => 'B',
+				'type'      => 'text',
+				'model'     => $this->model,
+				'maxlength' => 3,
+				'value'     => 'Too long'
+			],
+		]);
+
+		$this->assertSame([
+			'a' => [
+				'label'   => 'A',
+				'message' => [
+					'required' => 'Please enter something'
+				]
+			],
+			'b' => [
+				'label'   => 'B',
+				'message' => [
+					'maxlength' => 'Please enter a shorter value. (max. 3 characters)'
+				]
+			]
+		], $fields->errors());
+	}
+
+	/**
+	 * @covers ::errors
+	 */
+	public function testErrorsWithoutErrors()
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'model' => $this->model
+			],
+			'b' => [
+				'type'  => 'text',
+				'model' => $this->model
+			],
+		]);
+
+		$this->assertSame([], $fields->errors());
 	}
 
 	/**
@@ -74,9 +130,9 @@ class FieldsTest extends TestCase
 			'b' => [
 				'type'  => 'text',
 				'model' => $this->model
-			],	
+			],
 		]);
 
-		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn($field) => $field->name()));
-	}	
+		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn ($field) => $field->name()));
+	}
 }

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -118,6 +118,37 @@ class FieldsTest extends TestCase
 	}
 
 	/**
+	 * @covers ::fill
+	 */
+	public function testFill()
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'model' => $this->model,
+				'value' => 'A'
+			],
+			'b' => [
+				'type'  => 'text',
+				'model' => $this->model,
+				'value' => 'B'
+			],
+		]);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B'
+		], $fields->toArray(fn ($field) => $field->value()));
+
+		$fields->fill($input = [
+			'a' => 'A updated',
+			'b' => 'B updated'
+		]);
+
+		$this->assertSame($input, $fields->toArray(fn ($field) => $field->value()));
+	}
+
+	/**
 	 * @covers ::toArray
 	 */
 	public function testToArray()

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -2,40 +2,81 @@
 
 namespace Kirby\Form;
 
+use Kirby\Cms\App;
 use Kirby\Cms\Page;
-use Kirby\TestCase;
+use Kirby\Cms\TestCase;
 
+/**
+ * @coversDefaultClass \Kirby\Form\Fields
+ */
 class FieldsTest extends TestCase
 {
+	protected App $app;
+	protected Page $model;
+
 	public function setUp(): void
 	{
-		Field::$types = [];
+		$this->app   = App::instance();
+		$this->model = new Page(['slug' => 'test']);
 	}
 
-	public function tearDown(): void
-	{
-		Field::$types = [];
-	}
-
+	/**
+	 * @covers ::__construct
+	 */	
 	public function testConstruct()
 	{
-		Field::$types = [
-			'test' => []
-		];
-
-		$page   = new Page(['slug' => 'test']);
 		$fields = new Fields([
 			'a' => [
-				'type' => 'test',
-				'model' => $page
+				'type'  => 'text',
+				'model' => $this->model
 			],
 			'b' => [
-				'type' => 'test',
-				'model' => $page
+				'type'  => 'text',
+				'model' => $this->model
 			],
 		]);
 
 		$this->assertSame('a', $fields->first()->name());
 		$this->assertSame('b', $fields->last()->name());
 	}
+
+	/**
+	 * @covers ::defaults
+	 */
+	public function testDefaults()
+	{
+		$fields = new Fields([
+			'a' => [
+				'default' => 'a',
+				'model'   => $this->model,
+				'type'    => 'text'
+			],
+			'b' => [
+				'default' => 'b',
+				'model'   => $this->model,
+				'type'    => 'text'
+			],	
+		]);
+
+		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->defaults());
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray()
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'model' => $this->model
+			],
+			'b' => [
+				'type'  => 'text',
+				'model' => $this->model
+			],	
+		]);
+
+		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn($field) => $field->name()));
+	}	
 }

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -96,6 +96,19 @@ class FieldsTest extends TestCase
 				]
 			]
 		], $fields->errors());
+
+		$fields->fill([
+			'a' => 'A',
+		]);
+
+		$this->assertSame([
+			'b' => [
+				'label'   => 'B',
+				'message' => [
+					'maxlength' => 'Please enter a shorter value. (max. 3 characters)'
+				]
+			]
+		], $fields->errors());
 	}
 
 	/**

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -21,6 +21,7 @@ class ComponentTest extends TestCase
 	/**
 	 * @covers ::__construct
 	 * @covers ::__call
+	 * @covers ::applyProp
 	 * @covers ::applyProps
 	 */
 	public function testProp()
@@ -40,6 +41,7 @@ class ComponentTest extends TestCase
 	}
 
 	/**
+	 * @covers ::applyProp
 	 * @covers ::applyProps
 	 */
 	public function testPropWithDefaultValue()
@@ -59,6 +61,7 @@ class ComponentTest extends TestCase
 	}
 
 	/**
+	 * @covers ::applyProp
 	 * @covers ::applyProps
 	 */
 	public function testPropWithFixedValue()
@@ -78,6 +81,7 @@ class ComponentTest extends TestCase
 	}
 
 	/**
+	 * @covers ::applyProp
 	 * @covers ::applyProps
 	 */
 	public function testPropWithInvalidValue()
@@ -97,6 +101,7 @@ class ComponentTest extends TestCase
 	}
 
 	/**
+	 * @covers ::applyProp
 	 * @covers ::applyProps
 	 */
 	public function testPropWithMissingValue()


### PR DESCRIPTION
## Description

This is a first step to clean up the form and field classes. We need this for our changes to make sure that we only run through field property evaluation when really necessary. 

### Summary of changes

- New `Kirby\Toolkit\Component::applyProp` method to refactor prop application and make it more accessible for individual props
- Refactored `Kirby\Form\Field` class
  - New `Kirby\Form\Field::fill` method which overwrites the value and reevaluates the computed properties. 
  - New `Kirby\Form\Field::isDisabled` method to get the old class closer to the new `FieldClass`
- Refactored `Kirby\Form\Fields` class
  - Improved `Kirby\Form\Fields::toArray` to accept a map function 
  - New `Kirby\Form\Fields::defaults` method to return default values for all fields in the collection
  - New `Kirby\Form\Fields::errors` method to return all validation errors for all fields in the collection
  - New `Kirby\Form\Fields::fill` method to add new values to matching fields
- Remove the outdated md5 signature from the `FieldClass`. I missed this the last time when I removed the signature from the old Field class. 
- Refactored `Kirby\Form\Form` class
  - Simplified `Kirby\Form\Form::toArray` method
  - Use the new `Kirby\Form\Fields::errors` method for `Kirby\Form\Form::errors`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
