### PR TITLE
Allow creating license status from array

### DIFF
--- a/src/Plugin/LicenseStatus.php
+++ b/src/Plugin/LicenseStatus.php
@@ -35,10 +35,14 @@ class LicenseStatus implements Stringable
 	/**
 	 * Returns a status by its name
 	 */
-	public static function from(LicenseStatus|string|null $status): static
+	public static function from(LicenseStatus|string|array|null $status): static
 	{
 		if ($status instanceof LicenseStatus) {
 			return $status;
+		}
+
+		if (is_array($status) === true) {
+			return new static(...$status);
 		}
 
 		$status   = SystemLicenseStatus::from($status ?? 'unknown');

--- a/tests/Plugin/LicenseStatusTest.php
+++ b/tests/Plugin/LicenseStatusTest.php
@@ -20,6 +20,19 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('Valid license', (string)$status);
 	}
 
+	public function testFromArray(): void
+	{
+		$status = LicenseStatus::from([
+			'icon'  => 'check',
+			'label' => 'Valid license',
+			'theme' => 'success',
+			'value' => 'active',
+		]);
+
+		$this->assertInstanceOf(LicenseStatus::class, $status);
+		$this->assertSame('active', $status->value());
+	}
+
 	/**
 	 * @covers ::from
 	 */


### PR DESCRIPTION
## Description

### Summary of changes

A license status can now also be set via an array: 

```php
App::plugin(
  name: 'my/plugin', 
  extends: [...],
  license: [
    'name' => 'Custom license', 
    'link' => 'https://mylicenseshop.com', 
    'status' => [
      'value' => 'missing', 
      'theme' => 'negative', 
      'label' => 'Get a license please',
      'icon' => 'alert'
    ]
  ]
);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
