### PR TITLE
Discard changes when no diff with published content

### DIFF
--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -163,7 +163,7 @@ class Translation extends ContentTranslation
 	 */
 	public function slug(): string|null
 	{
-		return $this->version->content($this->language)->data()['slug'] ?? null;
+		return $this->version->read($this->language)['slug'] ?? null;
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 
@@ -301,7 +303,16 @@ class Version
 		array $fields,
 		Language $language
 	): array {
-		unset($fields['lock'], $fields['slug']);
+		unset($fields['lock']);
+
+		if ($this->model instanceof Page) {
+			unset($fields['slug']);
+		}
+
+		if ($this->model instanceof File) {
+			unset($fields['template']);
+		}
+
 		return $fields;
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -50,6 +50,9 @@ class Version
 			];
 		}
 
+		// prepare raw content file fields as fields for Content object
+		$fields = $this->prepareFieldsForContent($fields, $language);
+
 		return new Content(
 			parent: $this->model,
 			data:   $fields,
@@ -281,6 +284,18 @@ class Version
 	protected function prepareFieldsAfterRead(array $fields, Language $language): array
 	{
 		return $this->convertFieldNamesToLowerCase($fields);
+	}
+
+	/**
+	 * Make sure that reading from storage will always
+	 * return a usable set of fields with clean field names
+	 */
+	protected function prepareFieldsForContent(
+		array $fields,
+		Language $language
+	): array {
+		unset($fields['lock'], $fields['slug']);
+		return $fields;
 	}
 
 	/**

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -125,17 +125,24 @@ class Version
 	 * Returns the changed fields, compared to the given version
 	 */
 	public function diff(
-		VersionId|string $versionId,
+		Version|VersionId|string $version,
 		Language|string $language = 'default'
 	): array {
-		$versionId = VersionId::from($versionId);
+		if (is_string($version) === true) {
+			$version = VersionId::from($version);
+		}
 
-		if ($versionId->is($this->id) === true) {
+		if ($version instanceof VersionId) {
+			$version = $this->model->version($version);
+		}
+
+
+		if ($version->id()->is($this->id) === true) {
 			return [];
 		}
 
-		$a = $this->read($language) ?? [];
-		$b = $this->model->version($versionId)->read($language) ?? [];
+		$a = $this->content($language)->toArray();
+		$b = $version->content($language)->toArray();
 
 		return array_diff($b, $a);
 	}

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -294,8 +294,8 @@ class Version
 	}
 
 	/**
-	 * Make sure that reading from storage will always
-	 * return a usable set of fields with clean field names
+	 * Make sure that the Content object receives the right set of fields
+	 * filtering fields used for lower logic (e.g. lock)
 	 */
 	protected function prepareFieldsForContent(
 		array $fields,

--- a/src/Panel/Controller/Changes.php
+++ b/src/Panel/Controller/Changes.php
@@ -80,7 +80,7 @@ class Changes
 			language: 'current'
 		);
 
-		if ($published->diff($changes, 'current') === []) {
+		if ($published->diff(version: $changes, language: 'current') === []) {
 			$changes->delete();
 		}
 

--- a/src/Panel/Controller/Changes.php
+++ b/src/Panel/Controller/Changes.php
@@ -67,15 +67,22 @@ class Changes
 			'input'          => $input,
 		]);
 
+		$changes   = $model->version(VersionId::changes());
+		$published = $model->version(VersionId::published());
+
 		// combine the new field changes with the
 		// last published state
-		$model->version(VersionId::changes())->save(
+		$changes->save(
 			fields: [
-				...$model->version(VersionId::published())->read(),
+				...$published->read(),
 				...$form->strings(),
 			],
 			language: 'current'
 		);
+
+		if ($published->diff($changes, 'current') === []) {
+			$changes->delete();
+		}
 
 		return [
 			'status' => 'ok'

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -154,7 +154,7 @@ class TranslationTest extends TestCase
 			slug: 'foo'
 		);
 
-		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->version()->content()->toArray());
+		$this->assertSame(['title' => 'Test', 'slug' => 'foo'], $translation->version()->read());
 		$this->assertSame('foo', $translation->slug());
 	}
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -78,6 +78,28 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::content
+	 * @covers ::prepareFieldsForContent
+	 */
+	public function testContentPrepareFields(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::published()
+		);
+
+		$version->update([
+			'lock' => 'test',
+			'slug' => 'foo',
+			'text' => 'Lorem ipsum'
+		]);
+
+		$this->assertSame(['text' => 'Lorem ipsum'], $version->content()->toArray());
+	}
+
+	/**
 	 * @covers ::contentFile
 	 */
 	public function testContentFileMultiLanguage(): void
@@ -343,7 +365,7 @@ class VersionTest extends TestCase
 			'subtitle' => 'Subtitle (changed)',
 		]);
 
-		$diff = $a->diff(VersionId::changes());
+		$diff = $a->diff('changes');
 
 		// the result array should contain the changed fields
 		// the changed values
@@ -401,7 +423,7 @@ class VersionTest extends TestCase
 			'subtitle' => 'Subtitle',
 		]);
 
-		$diff = $a->diff(VersionId::published());
+		$diff = $a->diff($a);
 
 		$this->assertSame([], $diff);
 	}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\File;
 use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
@@ -85,6 +86,7 @@ class VersionTest extends TestCase
 	{
 		$this->setUpSingleLanguage();
 
+		// for pages
 		$version = new Version(
 			model: $this->model,
 			id: VersionId::published()
@@ -94,6 +96,25 @@ class VersionTest extends TestCase
 			'lock' => 'test',
 			'slug' => 'foo',
 			'text' => 'Lorem ipsum'
+		]);
+
+		$this->assertSame(['text' => 'Lorem ipsum'], $version->content()->toArray());
+
+		// for files
+		$model = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->model
+		]);
+
+		$version = new Version(
+			model: $model,
+			id: VersionId::published()
+		);
+
+		$version->create([
+			'lock'     => 'test',
+			'template' => 'foo',
+			'text'     => 'Lorem ipsum'
 		]);
 
 		$this->assertSame(['text' => 'Lorem ipsum'], $version->content()->toArray());

--- a/tests/Panel/Controller/ChangesTest.php
+++ b/tests/Panel/Controller/ChangesTest.php
@@ -83,4 +83,28 @@ class ChangesTest extends TestCase
 
 		$this->assertSame(['title' => 'Test'], $changes);
 	}
+
+	public function testSaveWithNoDiff()
+	{
+		Data::write($this->page->root() . '/article.txt', [
+			'title' => 'Test'
+		]);
+		Data::write($this->page->root() . '/_changes/article.txt', [
+			'title' => 'Test'
+		]);
+
+		$response = Changes::save($this->page, [
+			'title' => 'Foo'
+		]);
+
+		$this->assertSame(['status' => 'ok'], $response);
+		$this->assertFileExists($this->page->root() . '/_changes/article.txt');
+
+		$response = Changes::save($this->page, [
+			'title' => 'Test'
+		]);
+
+		$this->assertSame(['status' => 'ok'], $response);
+		$this->assertFileDoesNotExist($this->page->root() . '/_changes/article.txt');
+	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- New `Version::prepareFieldsForContent()` where we e.g. unset fields (currently, `lock` and `slug`) that will be returned from `::read()` (and cannot be filtered by `::prepareFieldsAfterRead()`, otherwise we cannot read them for legitimate use cases) but should not be part of the `Content` object
- Use `::content()` instead of `::read()` for `Version::diff()`
- Allow passing a `Version` object directly to `Version::diff()`
- Delete changes version when `Panel\Controller\Changes::save()` produces a result with no diff between published and changes (basically when the user manually modifies the content back to the state of published)


### Reasoning
Prevent the from controls from becoming a ghost (appearing even though there are no real changes).


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
