### PR TITLE
Abort `save` requests to prevent race conditions

### DIFF
--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -64,8 +64,7 @@ export default (panel) => {
 
 		/**
 		 * Whether content is currently being discarded, saved or published
-		 *
-		 * @returns {Boolean}
+		 * @var {Boolean}
 		 */
 		isProcessing: false,
 
@@ -122,18 +121,23 @@ export default (panel) => {
 					signal: this.saveAbortController.signal
 				});
 
-				this.isProcessing = false;
-
 				// update the last modification timestamp
 				panel.view.props.lock.modified = new Date();
+
+				this.isProcessing = false;
 			} catch (error) {
 				// silent aborted requests, but throw all other errors
 				if (error.name !== "AbortError") {
+					this.isProcessing = false;
 					throw error;
 				}
 			}
 		},
 
+		/**
+		 * @internal
+		 * @var {AbortController}
+		 */
 		saveAbortController: null,
 
 		/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Abort previous requests in `$panel.content.save()` to avoid that a long-running previous request with old data is processed after the new request with the newer data
- Ensure that the last request really is being sent

