### PR TITLE
Ensure changes exists after reading from cache

### DIFF
--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -68,7 +68,7 @@ class Changes
 	/**
 	 * Return all files with unsaved changes
 	 */
-	public function files(bool $ensure = true): Files
+	public function files(): Files
 	{
 		$files = new Files([]);
 
@@ -78,17 +78,13 @@ class Changes
 			}
 		}
 
-		if ($ensure === true) {
-			$files = $this->ensure($files);
-		}
-
-		return $files;
+		return $this->ensure($files);
 	}
 
 	/**
 	 * Return all pages with unsaved changes
 	 */
-	public function pages(bool $ensure = true): Pages
+	public function pages(): Pages
 	{
 		/**
 		 * @var \Kirby\Cms\Pages $pages
@@ -99,11 +95,7 @@ class Changes
 			...$this->read('pages')
 		);
 
-		if ($ensure === true) {
-			$pages = $this->ensure($pages);
-		}
-
-		return $pages;
+		return $this->ensure($pages);
 	}
 
 	/**
@@ -158,7 +150,7 @@ class Changes
 	/**
 	 * Return all users with unsaved changes
 	 */
-	public function users(bool $ensure = true): Users
+	public function users(): Users
 	{
 		/**
 		 * @var \Kirby\Cms\Users $users
@@ -169,10 +161,6 @@ class Changes
 			...$this->read('users')
 		);
 
-		if ($ensure === true) {
-			$users = $this->ensure($users);
-		}
-
-		return $users;
+		return $this->ensure($users);
 	}
 }

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -170,13 +170,13 @@ class ChangesTest extends TestCase
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $files = $changes->files(ensure: false));
-		$this->assertCount(1, $pages = $changes->pages(ensure: false));
-		$this->assertCount(1, $users = $changes->users(ensure: false));
+		$this->assertCount(1, $files = $changes->read('files'));
+		$this->assertCount(1, $pages = $changes->read('pages'));
+		$this->assertCount(1, $users = $changes->read('users'));
 
-		$this->assertSame('test/test.jpg', $files->first()->id());
-		$this->assertSame('test', $pages->first()->id());
-		$this->assertSame('test', $users->first()->id());
+		$this->assertSame('file://test', $files[0]);
+		$this->assertSame('page://test', $pages[0]);
+		$this->assertSame('user://test', $users[0]);
 	}
 
 	/**
@@ -198,17 +198,17 @@ class ChangesTest extends TestCase
 			$this->app->user('test')->uuid()->toString()
 		]);
 
-		$this->assertCount(1, $changes->files(ensure: false));
-		$this->assertCount(1, $changes->pages(ensure: false));
-		$this->assertCount(1, $changes->users(ensure: false));
+		$this->assertCount(1, $changes->read('files'));
+		$this->assertCount(1, $changes->read('pages'));
+		$this->assertCount(1, $changes->read('users'));
 
 		$changes->update('files', []);
 		$changes->update('pages', []);
 		$changes->update('users', []);
 
-		$this->assertCount(0, $changes->files(ensure: false));
-		$this->assertCount(0, $changes->pages(ensure: false));
-		$this->assertCount(0, $changes->users(ensure: false));
+		$this->assertCount(0, $changes->read('files'));
+		$this->assertCount(0, $changes->read('pages'));
+		$this->assertCount(0, $changes->read('users'));
 	}
 
 	/**
@@ -222,17 +222,17 @@ class ChangesTest extends TestCase
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $changes->files(ensure: false));
-		$this->assertCount(1, $changes->pages(ensure: false));
-		$this->assertCount(1, $changes->users(ensure: false));
+		$this->assertCount(1, $changes->read('files'));
+		$this->assertCount(1, $changes->read('pages'));
+		$this->assertCount(1, $changes->read('users'));
 
 		$changes->untrack($this->app->page('test'));
 		$changes->untrack($this->app->file('test/test.jpg'));
 		$changes->untrack($this->app->user('test'));
 
-		$this->assertCount(0, $changes->files(ensure: false));
-		$this->assertCount(0, $changes->pages(ensure: false));
-		$this->assertCount(0, $changes->users(ensure: false));
+		$this->assertCount(0, $changes->read('files'));
+		$this->assertCount(0, $changes->read('pages'));
+		$this->assertCount(0, $changes->read('users'));
 	}
 
 	/**

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -62,22 +62,31 @@ class ChangesTest extends TestCase
 	 */
 	public function testCache()
 	{
-		$cache = App::instance()->cache('changes');
+		$cache = $this->app->cache('changes');
 
 		$this->assertInstanceOf(Cache::class, $cache);
 	}
 
 	/**
 	 * @covers ::files
+	 * @covers ::ensure
 	 */
 	public function testFiles()
 	{
-		App::instance()->cache('changes')->set('files', [
+		$this->app->cache('changes')->set('files', $cache = [
 			'file://test'
 		]);
 
 		$changes = new Changes();
 
+		// in cache, but changes don't exist in reality
+		$this->assertCount(0, $changes->files());
+		$this->assertSame([], $this->app->cache('changes')->get('files'));
+
+		// in cache and changes exist in reality
+		$this->app->file('test/test.jpg')->version(VersionId::changes())->create([]);
+
+		$this->assertSame($cache, $this->app->cache('changes')->get('files'));
 		$this->assertCount(1, $changes->files());
 		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
 	}
@@ -100,15 +109,24 @@ class ChangesTest extends TestCase
 
 	/**
 	 * @covers ::pages
+	 * @covers ::ensure
 	 */
 	public function testPages()
 	{
-		App::instance()->cache('changes')->set('pages', [
+		$this->app->cache('changes')->set('pages', $cache = [
 			'page://test'
 		]);
 
 		$changes = new Changes();
 
+		// in cache, but changes don't exist in reality
+		$this->assertCount(0, $changes->pages());
+		$this->assertSame([], $this->app->cache('changes')->get('pages'));
+
+		// in cache and changes exist in reality
+		$this->app->page('test')->version(VersionId::changes())->create([]);
+
+		$this->assertSame($cache, $this->app->cache('changes')->get('pages'));
 		$this->assertCount(1, $changes->pages());
 		$this->assertSame('test', $changes->pages()->first()->id());
 	}
@@ -118,15 +136,15 @@ class ChangesTest extends TestCase
 	 */
 	public function testRead()
 	{
-		App::instance()->cache('changes')->set('files', [
+		$this->app->cache('changes')->set('files', [
 			'file://test'
 		]);
 
-		App::instance()->cache('changes')->set('pages', [
+		$this->app->cache('changes')->set('pages', [
 			'page://test'
 		]);
 
-		App::instance()->cache('changes')->set('users', [
+		$this->app->cache('changes')->set('users', [
 			'user://test'
 		]);
 
@@ -152,13 +170,13 @@ class ChangesTest extends TestCase
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $changes->files());
-		$this->assertCount(1, $changes->pages());
-		$this->assertCount(1, $changes->users());
+		$this->assertCount(1, $files = $changes->files(ensure: false));
+		$this->assertCount(1, $pages = $changes->pages(ensure: false));
+		$this->assertCount(1, $users = $changes->users(ensure: false));
 
-		$this->assertSame('test', $changes->pages()->first()->id());
-		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
-		$this->assertSame('test', $changes->users()->first()->id());
+		$this->assertSame('test/test.jpg', $files->first()->id());
+		$this->assertSame('test', $pages->first()->id());
+		$this->assertSame('test', $users->first()->id());
 	}
 
 	/**
@@ -180,17 +198,17 @@ class ChangesTest extends TestCase
 			$this->app->user('test')->uuid()->toString()
 		]);
 
-		$this->assertCount(1, $changes->files());
-		$this->assertCount(1, $changes->pages());
-		$this->assertCount(1, $changes->users());
+		$this->assertCount(1, $changes->files(ensure: false));
+		$this->assertCount(1, $changes->pages(ensure: false));
+		$this->assertCount(1, $changes->users(ensure: false));
 
 		$changes->update('files', []);
 		$changes->update('pages', []);
 		$changes->update('users', []);
 
-		$this->assertCount(0, $changes->files());
-		$this->assertCount(0, $changes->pages());
-		$this->assertCount(0, $changes->users());
+		$this->assertCount(0, $changes->files(ensure: false));
+		$this->assertCount(0, $changes->pages(ensure: false));
+		$this->assertCount(0, $changes->users(ensure: false));
 	}
 
 	/**
@@ -204,30 +222,39 @@ class ChangesTest extends TestCase
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $changes->files());
-		$this->assertCount(1, $changes->pages());
-		$this->assertCount(1, $changes->users());
+		$this->assertCount(1, $changes->files(ensure: false));
+		$this->assertCount(1, $changes->pages(ensure: false));
+		$this->assertCount(1, $changes->users(ensure: false));
 
 		$changes->untrack($this->app->page('test'));
 		$changes->untrack($this->app->file('test/test.jpg'));
 		$changes->untrack($this->app->user('test'));
 
-		$this->assertCount(0, $changes->files());
-		$this->assertCount(0, $changes->pages());
-		$this->assertCount(0, $changes->users());
+		$this->assertCount(0, $changes->files(ensure: false));
+		$this->assertCount(0, $changes->pages(ensure: false));
+		$this->assertCount(0, $changes->users(ensure: false));
 	}
 
 	/**
 	 * @covers ::users
+	 * @covers ::ensure
 	 */
 	public function testUsers()
 	{
-		App::instance()->cache('changes')->set('users', [
+		$this->app->cache('changes')->set('users', $cache = [
 			'user://test'
 		]);
 
 		$changes = new Changes();
 
+		// in cache, but changes don't exist in reality
+		$this->assertCount(0, $changes->users());
+		$this->assertSame([], $this->app->cache('changes')->get('users'));
+
+		// in cache and changes exist in reality
+		$this->app->user('test')->version(VersionId::changes())->create([]);
+
+		$this->assertSame($cache, $this->app->cache('changes')->get('users'));
 		$this->assertCount(1, $changes->users());
 		$this->assertSame('test', $changes->users()->first()->id());
 	}

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Panel;
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Content\Changes;
+use Kirby\Content\VersionId;
 use Kirby\Panel\Areas\AreaTestCase;
 use Kirby\Uuid\Uuids;
 
@@ -68,9 +68,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->file('file://test')
-		);
+		$this->app->file('file://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$files  = $dialog->files();
@@ -94,21 +92,18 @@ class ChangesDialogTest extends AreaTestCase
 	 */
 	public function testItems(): void
 	{
+		$this->setUpModels();
+		$page = $this->app->page('page://test');
+		$page->version(VersionId::changes())->create([]);
+
 		$dialog = new ChangesDialog();
-		$pages  = new Pages([
-			new Page(['slug' => 'test-a']),
-			new Page(['slug' => 'test-b'])
-		]);
+		$pages  = new Pages([$page]);
+		$items  = $dialog->items($pages);
 
-		$items = $dialog->items($pages);
+		$this->assertCount(1, $items);
 
-		$this->assertCount(2, $items);
-
-		$this->assertSame('test-a', $items[0]['text']);
-		$this->assertSame('/pages/test-a', $items[0]['link']);
-
-		$this->assertSame('test-b', $items[1]['text']);
-		$this->assertSame('/pages/test-b', $items[1]['link']);
+		$this->assertSame('test', $items[0]['text']);
+		$this->assertSame('/pages/test', $items[0]['link']);
 	}
 
 	/**
@@ -137,9 +132,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->page('page://test')
-		);
+		$this->app->page('page://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$pages  = $dialog->pages();
@@ -165,9 +158,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->user('user://test')
-		);
+		$this->app->user('user://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$users  = $dialog->users();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

See discussion of https://github.com/getkirby/kirby/pull/6751 that might interplay with this PR.
 
### Summary of changes
- New `Content\Changes::ensure()` method that double-checks for existing changes and untracks model if none exist anymore
- `Changes::files()`, `Changes::pages()` and `Changes::users()` have new `$ensure = true` parameter that controls whether the collection retrieved from the cache should be double-checked

### Reasoning
This really enforces that those changes for the model really exists. However, it makes the `Changes` class a little less flexible (and probably performant due to the extra checks), especially when testing just the cache.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
