### PR TITLE
Changes dialog: entry per language

### DIFF
--- a/src/Panel/ChangesDialog.php
+++ b/src/Panel/ChangesDialog.php
@@ -3,7 +3,10 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\Collection;
+use Kirby\Cms\Languages;
 use Kirby\Content\Changes;
+use Kirby\Content\VersionId;
+use Kirby\Toolkit\Str;
 
 /**
  * Manages the Panel dialog for content changes in
@@ -38,9 +41,25 @@ class ChangesDialog
 	 */
 	public function items(Collection $models): array
 	{
-		return $models->values(
-			fn ($model) => $model->panel()->dropdownOption()
-		);
+		$languages = Languages::ensure();
+		$items     = [];
+
+		foreach ($models as $model) {
+			foreach ($languages as $language) {
+				if ($model->version(VersionId::changes())->exists($language) === true) {
+					$item = $model->panel()->dropdownOption();
+
+					if ($languages->count() > 1) {
+						$item['info']  = Str::upper($language->code());
+						$item['link'] .= '?language=' . $language->code();
+					}
+
+					$items[] = $item;
+				}
+			}
+		}
+
+		return $items;
 	}
 
 	/**

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -107,6 +107,43 @@ class ChangesDialogTest extends AreaTestCase
 	}
 
 	/**
+	 * @covers ::items
+	 */
+	public function testItemsChangesForMultipleLanguages(): void
+	{
+		$this->setUpModels();
+		$this->app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			]
+		]);
+
+		$page = $this->app->page('page://test');
+		$page->version(VersionId::changes())->create([], 'en');
+		$page->version(VersionId::changes())->create([], 'de');
+
+		$dialog = new ChangesDialog();
+		$pages  = new Pages([$page]);
+		$items  = $dialog->items($pages);
+
+		$this->assertCount(2, $items);
+
+		$this->assertSame('test', $items[0]['text']);
+		$this->assertSame('EN', $items[0]['info']);
+		$this->assertSame('/pages/test?language=en', $items[0]['link']);
+
+		$this->assertSame('test', $items[1]['text']);
+		$this->assertSame('DE', $items[1]['info']);
+		$this->assertSame('/pages/test?language=de', $items[1]['link']);
+	}
+
+	/**
 	 * @covers ::load
 	 */
 	public function testLoad(): void

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Panel;
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Content\Changes;
+use Kirby\Content\VersionId;
 use Kirby\Panel\Areas\AreaTestCase;
 use Kirby\Uuid\Uuids;
 
@@ -68,9 +68,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->file('file://test')
-		);
+		$this->app->file('file://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$files  = $dialog->files();
@@ -94,21 +92,18 @@ class ChangesDialogTest extends AreaTestCase
 	 */
 	public function testItems(): void
 	{
+		$this->setUpModels();
+		$page = $this->app->page('page://test');
+		$page->version(VersionId::changes())->create([]);
+
 		$dialog = new ChangesDialog();
-		$pages  = new Pages([
-			new Page(['slug' => 'test-a']),
-			new Page(['slug' => 'test-b'])
-		]);
+		$pages  = new Pages([$page]);
+		$items  = $dialog->items($pages);
 
-		$items = $dialog->items($pages);
+		$this->assertCount(1, $items);
 
-		$this->assertCount(2, $items);
-
-		$this->assertSame('test-a', $items[0]['text']);
-		$this->assertSame('/pages/test-a', $items[0]['link']);
-
-		$this->assertSame('test-b', $items[1]['text']);
-		$this->assertSame('/pages/test-b', $items[1]['link']);
+		$this->assertSame('test', $items[0]['text']);
+		$this->assertSame('/pages/test', $items[0]['link']);
 	}
 
 	/**
@@ -137,9 +132,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->page('page://test')
-		);
+		$this->app->page('page://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$pages  = $dialog->pages();
@@ -165,9 +158,7 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->changes->track(
-			$this->app->user('user://test')
-		);
+		$this->app->user('user://test')->version(VersionId::changes())->create([]);
 
 		$dialog = new ChangesDialog();
 		$users  = $dialog->users();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### To be discussed

There is a certain overlap with https://github.com/getkirby/kirby/pull/6750 where we would now be checking twice if a version actually exists. Has me wondering if this logic should rather be part of `Content\Changes` but I don't have a good idea for syntax/method name or so.

### Summary of changes
- Shows a changes dialog entry per version language that has changes
- Shows language code as entry info in multilang

### Reasoning
- Users should be able to quickly get to the unsaved changes from the dialog. Before this PR it's difficult for them if the changes aren't in the default language.
- We only track the UUID for changes not the language. This is why it needs extra logic for the dialog, checking which language has the change. Alternatively, we would need to consider how to track and retrieve the language alongside uuid.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

