### PR TITLE
Rename `VersionId::published()` to `::latest()`

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -330,7 +330,7 @@ class Version
 		// the version needs to exist
 		$this->ensure($language);
 
-		// update the published version
+		// update the latest version
 		$this->model->version(VersionId::latest())->save(
 			fields: $this->read($language),
 			language: $language

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -7,7 +7,7 @@ use Stringable;
 
 /**
  * The Version ID identifies a version of content.
- * This can be the currently published/latest version or changes
+ * This can be the currently latest version or changes
  * to the content. In the future, we also plan to use this
  * for older revisions of the content.
  *

--- a/src/Panel/Controller/Changes.php
+++ b/src/Panel/Controller/Changes.php
@@ -19,7 +19,7 @@ use Kirby\Form\Form;
 class Changes
 {
 	/**
-	 * Discards unpublished changes by deleting the version
+	 * Discards unsaved changes by deleting the changes version
 	 */
 	public static function discard(ModelWithContent $model): array
 	{

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -97,7 +97,7 @@ class LockTest extends TestCase
 		// create the version with the admin user
 		$this->app->impersonate('admin');
 
-		// the published version won't have a user id
+		// the latest version won't have a user id
 		$version = new Version(
 			model: $this->app->page('test'),
 			id: VersionId::latest()

--- a/tests/Content/MemoryStorageTest.php
+++ b/tests/Content/MemoryStorageTest.php
@@ -106,7 +106,7 @@ class MemoryStorageTest extends TestCase
 	 * @covers ::read
 	 * @covers ::write
 	 */
-	public function testCreateAndReadPublishedMultiLang()
+	public function testCreateAndReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -121,7 +121,7 @@ class MemoryStorageTest extends TestCase
 	 * @covers ::read
 	 * @covers ::write
 	 */
-	public function testCreateAndReadPublishedSingleLang()
+	public function testCreateAndReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -179,7 +179,7 @@ class MemoryStorageTest extends TestCase
 	/**
 	 * @covers ::delete
 	 */
-	public function testDeletePublishedMultiLang()
+	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -192,7 +192,7 @@ class MemoryStorageTest extends TestCase
 	/**
 	 * @covers ::delete
 	 */
-	public function testDeletePublishedSingleLang()
+	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -71,7 +71,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::create
 	 */
-	public function testCreatePublishedMultiLang()
+	public function testCreateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -87,7 +87,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::create
 	 */
-	public function testCreatePublishedSingleLang()
+	public function testCreateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -157,7 +157,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::delete
 	 */
-	public function testDeletePublishedMultiLang()
+	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -173,7 +173,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::delete
 	 */
-	public function testDeletePublishedSingleLang()
+	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -347,7 +347,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::read
 	 */
-	public function testReadPublishedMultiLang()
+	public function testReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -364,7 +364,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::read
 	 */
-	public function testReadPublishedSingleLang()
+	public function testReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -436,7 +436,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::touch
 	 */
-	public function testTouchPublishedMultiLang()
+	public function testTouchLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -456,7 +456,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::touch
 	 */
-	public function testTouchPublishedSingleLang()
+	public function testTouchLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -514,7 +514,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::update
 	 */
-	public function testUpdatePublishedMultiLang()
+	public function testUpdateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -532,7 +532,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::update
 	 */
-	public function testUpdatePublishedSingleLang()
+	public function testUpdateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 
@@ -683,7 +683,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::contentFiles
 	 */
-	public function testContentFilesPublishedMultiLang()
+	public function testContentFilesLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
 
@@ -696,7 +696,7 @@ class PlainTextStorageTest extends TestCase
 	/**
 	 * @covers ::contentFiles
 	 */
-	public function testContentFilesPublishedSingleLang()
+	public function testContentFilesLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -106,8 +106,8 @@ class StorageTest extends TestCase
 		// count again
 		$versions = iterator_to_array($handler->all(), false);
 
-		// A page that's not in draft mode can have latest and changes versions
-		// and thus should have changes and latest for every language
+		// A page that's not in draft mode can have Latest and changes versions
+		// and thus should have changes and Latest for every language
 		$this->assertCount(4, $versions);
 	}
 
@@ -133,7 +133,7 @@ class StorageTest extends TestCase
 		// count again
 		$versions = iterator_to_array($handler->all(), false);
 
-		// A page that's not in draft mode can have latest and changes versions
+		// A page that's not in draft mode can have Latest and changes versions
 		$this->assertCount(2, $versions);
 	}
 
@@ -296,19 +296,19 @@ class StorageTest extends TestCase
 
 		$handlerA = new PlainTextStorage(model: $this->model);
 
-		$versionPublished = VersionId::latest();
-		$versionChanges   = VersionId::changes();
+		$versionLatest  = VersionId::latest();
+		$versionChanges = VersionId::changes();
 
 		$en = $this->app->language('en');
 		$de = $this->app->language('de');
 
 		// create all possible versions
-		$handlerA->create($versionPublished, $en, $latestEN = [
-			'title' => 'Published EN'
+		$handlerA->create($versionLatest, $en, $LatestEN = [
+			'title' => 'Latest EN'
 		]);
 
-		$handlerA->create($versionPublished, $de, $latestDE = [
-			'title' => 'Published DE'
+		$handlerA->create($versionLatest, $de, $LatestDE = [
+			'title' => 'Latest DE'
 		]);
 
 		$handlerA->create($versionChanges, $en, $changesEN = [
@@ -324,8 +324,8 @@ class StorageTest extends TestCase
 
 		$this->assertNotSame($handlerA, $handlerB);
 
-		$this->assertSame($latestEN, $handlerB->read($versionPublished, $en));
-		$this->assertSame($latestDE, $handlerB->read($versionPublished, $de));
+		$this->assertSame($LatestEN, $handlerB->read($versionLatest, $en));
+		$this->assertSame($LatestDE, $handlerB->read($versionLatest, $de));
 
 		$this->assertSame($changesEN, $handlerB->read($versionChanges, $en));
 		$this->assertSame($changesDE, $handlerB->read($versionChanges, $de));
@@ -457,10 +457,10 @@ class StorageTest extends TestCase
 		// realistic, testable results for this test
 		$handler = new PlainTextStorage(model: $this->model);
 
-		Data::write($filePublished = $this->model->root() . '/article.txt', []);
+		Data::write($fileLatest = $this->model->root() . '/article.txt', []);
 		Data::write($fileChanges   = $this->model->root() . '/_changes/article.txt', []);
 
-		$this->assertFileExists($filePublished);
+		$this->assertFileExists($fileLatest);
 		$this->assertFileExists($fileChanges);
 
 		$handler->moveLanguage(
@@ -468,7 +468,7 @@ class StorageTest extends TestCase
 			$this->app->language('en')
 		);
 
-		$this->assertFileDoesNotExist($filePublished);
+		$this->assertFileDoesNotExist($fileLatest);
 		$this->assertFileDoesNotExist($fileChanges);
 
 		$this->assertFileExists($this->model->root() . '/article.en.txt');
@@ -487,10 +487,10 @@ class StorageTest extends TestCase
 		$handler = new PlainTextStorage(model: $this->model);
 
 
-		Data::write($filePublished = $this->model->root() . '/article.en.txt', []);
+		Data::write($fileLatest = $this->model->root() . '/article.en.txt', []);
 		Data::write($fileChanges   = $this->model->root() . '/_changes/article.en.txt', []);
 
-		$this->assertFileExists($filePublished);
+		$this->assertFileExists($fileLatest);
 		$this->assertFileExists($fileChanges);
 
 		$handler->moveLanguage(
@@ -498,7 +498,7 @@ class StorageTest extends TestCase
 			Language::single(),
 		);
 
-		$this->assertFileDoesNotExist($filePublished);
+		$this->assertFileDoesNotExist($fileLatest);
 		$this->assertFileDoesNotExist($fileChanges);
 
 		$this->assertFileExists($this->model->root() . '/article.txt');
@@ -549,10 +549,10 @@ class StorageTest extends TestCase
 		Dir::make($this->model->root());
 		Dir::make($this->model->root() . '/_changes');
 
-		touch($filePublished = $this->model->root() . '/article.de.txt', 123456);
+		touch($fileLatest = $this->model->root() . '/article.de.txt', 123456);
 		touch($fileChanges   = $this->model->root() . '/_changes/article.de.txt', 123456);
 
-		$this->assertSame(123456, filemtime($filePublished));
+		$this->assertSame(123456, filemtime($fileLatest));
 		$this->assertSame(123456, filemtime($fileChanges));
 
 		$minTime = time();
@@ -562,7 +562,7 @@ class StorageTest extends TestCase
 		clearstatcache();
 
 		$this->assertGreaterThanOrEqual($minTime, filemtime($fileChanges));
-		$this->assertGreaterThanOrEqual($minTime, filemtime($filePublished));
+		$this->assertGreaterThanOrEqual($minTime, filemtime($fileLatest));
 	}
 
 }

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -81,7 +81,7 @@ class VersionIdTest extends TestCase
 	 * @covers ::latest
 	 * @covers ::value
 	 */
-	public function testPublished()
+	public function testLatest()
 	{
 		$version = VersionId::latest();
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -549,7 +549,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::exists
 	 */
-	public function testExistsPublishedMultiLanguage(): void
+	public function testExistsLatestMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -608,7 +608,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::exists
 	 */
-	public function testExistsPublishedSingleLanguage(): void
+	public function testExistsLatestSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -771,9 +771,9 @@ class VersionTest extends TestCase
 	{
 		$this->setUpMultiLanguage();
 
-		$versionPublished = new Version(
+		$versionLatest = new Version(
 			model: $this->model,
-			id: $versionIdPublished = VersionId::latest()
+			id: $versionIdLatest = VersionId::latest()
 		);
 
 		$versionChanges = new Version(
@@ -781,34 +781,34 @@ class VersionTest extends TestCase
 			id: $versionIdChanges = VersionId::changes()
 		);
 
-		$this->assertContentFileDoesNotExist('en', $versionIdPublished);
+		$this->assertContentFileDoesNotExist('en', $versionIdLatest);
 		$this->assertContentFileDoesNotExist('en', $versionIdChanges);
 
-		$fileENPublished = $this->contentFile('en', $versionIdPublished);
+		$fileENLatest = $this->contentFile('en', $versionIdLatest);
 		$fileENChanges   = $this->contentFile('en', $versionIdChanges);
 
-		Data::write($fileENPublished, $content = [
+		Data::write($fileENLatest, $content = [
 			'title' => 'Test'
 		]);
 
-		$this->assertContentFileExists('en', $versionIdPublished);
+		$this->assertContentFileExists('en', $versionIdLatest);
 		$this->assertContentFileDoesNotExist('en', $versionIdChanges);
 
 		// move with string arguments
-		$versionPublished->move('en', $versionIdChanges);
+		$versionLatest->move('en', $versionIdChanges);
 
-		$this->assertContentFileDoesNotExist('en', $versionIdPublished);
+		$this->assertContentFileDoesNotExist('en', $versionIdLatest);
 		$this->assertContentFileExists('en', $versionIdChanges);
 
 		$this->assertSame($content, Data::read($fileENChanges));
 
 		// move the version back
-		$versionChanges->move('en', $versionIdPublished);
+		$versionChanges->move('en', $versionIdLatest);
 
 		$this->assertContentFileDoesNotExist('en', $versionIdChanges);
-		$this->assertContentFileExists('en', $versionIdPublished);
+		$this->assertContentFileExists('en', $versionIdLatest);
 
-		$this->assertSame($content, Data::read($fileENPublished));
+		$this->assertSame($content, Data::read($fileENLatest));
 	}
 
 	/**
@@ -823,28 +823,28 @@ class VersionTest extends TestCase
 			id: VersionId::changes()
 		);
 
-		Data::write($filePublished = $this->contentFile(null, VersionId::latest()), [
-			'title' => 'Title latest'
+		Data::write($fileLatest = $this->contentFile(null, VersionId::latest()), [
+			'title' => 'Title Latest'
 		]);
 
 		Data::write($fileChanges = $this->contentFile(null, VersionId::changes()), [
 			'title' => 'Title changes'
 		]);
 
-		$this->assertFileExists($filePublished);
+		$this->assertFileExists($fileLatest);
 		$this->assertFileExists($fileChanges);
 
 		$version->publish();
 
 		$this->assertFileDoesNotExist($fileChanges);
 
-		$this->assertSame('Title changes', Data::read($filePublished)['title']);
+		$this->assertSame('Title changes', Data::read($fileLatest)['title']);
 	}
 
 	/**
 	 * @covers ::publish
 	 */
-	public function testPublishAlreadyPublishedVersion()
+	public function testPublishAlreadyLatestVersion()
 	{
 		$this->setUpSingleLanguage();
 
@@ -905,7 +905,7 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::read
 	 */
-	public function testReadPublishedWithoutContentFile(): void
+	public function testReadLatestWithoutContentFile(): void
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -95,7 +95,7 @@ class ModelTest extends TestCase
 			new ModelPage(['slug' => 'test'])
 		);
 
-		$panel->model()->version('published')->save([
+		$panel->model()->version('latest')->save([
 			'foo'  => 'foo',
 			'uuid' => 'test'
 		]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] Merge https://github.com/getkirby/kirby/pull/6760 first
- [x] Merge `v5/develop` into `v5/changes/develop`
- [x] Rebase PR

### Summary of changes
- Rename `VersionId::published()` to `VersionId::latest()`


### Reasoning
It's confusing to talk about the `published` version of a page draft.

### Additional context
I think we can ignore the failing coverage test here.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

