### PR TITLE
Changes dialog: rebuild cache if not exists

### DIFF
--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -38,6 +38,14 @@ class Changes
 	}
 
 	/**
+	 * Returns whether the cache has been populated
+	 */
+	public function cacheExists(): bool
+	{
+		return $this->cache()->get('__updated__') !== null;
+	}
+
+	/**
 	 * Returns the cache key for a given model
 	 */
 	public function cacheKey(ModelWithContent $model): string
@@ -157,6 +165,7 @@ class Changes
 		$changes = array_values($changes);
 
 		$this->cache()->set($key, $changes);
+		$this->cache()->set('__updated__', time());
 	}
 
 	/**

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -94,10 +94,20 @@ class Changes
 	 */
 	public function generateCache(): void
 	{
+		$models = [
+			'files' => [],
+			'pages' => [],
+			'users' => []
+		];
+
 		foreach ($this->kirby->models() as $model) {
 			if ($model->version(VersionId::changes())->exists('*') === true) {
-				$this->track($model);
+				$models[$this->cacheKey($model)][] = (string)($model->uuid() ?? $model->id());
 			}
+		}
+
+		foreach ($models as $key => $changes) {
+			$this->update($key, $changes);
 		}
 	}
 

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -19,8 +19,6 @@ use Kirby\Toolkit\A;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
- *
- * @todo Add support when UUIDs are disabled
  */
 class Changes
 {
@@ -127,8 +125,8 @@ class Changes
 	{
 		$key = $this->cacheKey($model);
 
-		$changes = $this->read($key);
-		$changes[] = (string)$model->uuid();
+		$changes   = $this->read($key);
+		$changes[] = (string)($model->uuid() ?? $model->id());
 
 		$this->update($key, $changes);
 	}
@@ -144,7 +142,7 @@ class Changes
 		// remove the model from the list of changes
 		$changes = A::filter(
 			$this->read($key),
-			fn ($uuid) => $uuid !== (string)$model->uuid()
+			fn ($id) => $id !== (string)($model->uuid() ?? $model->id())
 		);
 
 		$this->update($key, $changes);

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -19,6 +19,8 @@ use Kirby\Toolkit\A;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @todo Add support when UUIDs are disabled
  */
 class Changes
 {
@@ -79,6 +81,18 @@ class Changes
 		}
 
 		return $this->ensure($files);
+	}
+
+	/**
+	 * Rebuilds the cache by finding all models with changes version
+	 */
+	public function generateCache(): void
+	{
+		foreach ($this->kirby->models() as $model) {
+			if ($model->version(VersionId::changes())->exists('*') === true) {
+				$this->track($model);
+			}
+		}
 	}
 
 	/**

--- a/src/Panel/ChangesDialog.php
+++ b/src/Panel/ChangesDialog.php
@@ -18,11 +18,9 @@ use Kirby\Content\Changes;
  */
 class ChangesDialog
 {
-	protected Changes $changes;
-
-	public function __construct()
-	{
-		$this->changes = new Changes();
+	public function __construct(
+		protected Changes $changes = new Changes()
+	) {
 	}
 
 	/**
@@ -48,6 +46,10 @@ class ChangesDialog
 	 */
 	public function load(): array
 	{
+		if ($this->changes->cacheExists() === false) {
+			$this->changes->generateCache();
+		}
+
 		return [
 			'component' => 'k-changes-dialog',
 			'props'     => [

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -194,9 +194,9 @@ class ChangesTest extends TestCase
 	{
 		$changes = new Changes();
 
-		$this->assertCount(0, $changes->files());
-		$this->assertCount(0, $changes->pages());
-		$this->assertCount(0, $changes->users());
+		$this->assertCount(0, $changes->read('files'));
+		$this->assertCount(0, $changes->read('pages'));
+		$this->assertCount(0, $changes->read('users'));
 
 		$changes->track($this->app->page('test'));
 		$changes->track($this->app->file('test/test.jpg'));
@@ -226,21 +226,21 @@ class ChangesTest extends TestCase
 
 		$changes = new Changes();
 
-		$this->assertCount(0, $changes->files());
-		$this->assertCount(0, $changes->pages());
-		$this->assertCount(0, $changes->users());
+		$this->assertCount(0, $changes->read('files'));
+		$this->assertCount(0, $changes->read('pages'));
+		$this->assertCount(0, $changes->read('users'));
 
 		$changes->track($this->app->page('test'));
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $changes->files());
-		$this->assertCount(1, $changes->pages());
-		$this->assertCount(1, $changes->users());
+		$this->assertCount(1, $files = $changes->read('files'));
+		$this->assertCount(1, $pages = $changes->read('pages'));
+		$this->assertCount(1, $users = $changes->read('users'));
 
-		$this->assertSame('test', $changes->pages()->first()->id());
-		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
-		$this->assertSame('test', $changes->users()->first()->id());
+		$this->assertSame('test/test.jpg', $files[0]);
+		$this->assertSame('test', $pages[0]);
+		$this->assertSame('test', $users[0]);
 	}
 
 	/**
@@ -318,17 +318,17 @@ class ChangesTest extends TestCase
 		$changes->track($this->app->file('test/test.jpg'));
 		$changes->track($this->app->user('test'));
 
-		$this->assertCount(1, $changes->files());
-		$this->assertCount(1, $changes->pages());
-		$this->assertCount(1, $changes->users());
+		$this->assertCount(1, $changes->read('files'));
+		$this->assertCount(1, $changes->read('pages'));
+		$this->assertCount(1, $changes->read('users'));
 
 		$changes->untrack($this->app->page('test'));
 		$changes->untrack($this->app->file('test/test.jpg'));
 		$changes->untrack($this->app->user('test'));
 
-		$this->assertCount(0, $changes->files());
-		$this->assertCount(0, $changes->pages());
-		$this->assertCount(0, $changes->users());
+		$this->assertCount(0, $changes->read('files'));
+		$this->assertCount(0, $changes->read('pages'));
+		$this->assertCount(0, $changes->read('users'));
 	}
 
 	/**

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -209,6 +209,38 @@ class ChangesTest extends TestCase
 	}
 
 	/**
+	 * @covers ::track
+	 */
+	public function testTrackDisabledUuids()
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => false
+				]
+			]
+		]);
+
+		$changes = new Changes();
+
+		$this->assertCount(0, $changes->files());
+		$this->assertCount(0, $changes->pages());
+		$this->assertCount(0, $changes->users());
+
+		$changes->track($this->app->page('test'));
+		$changes->track($this->app->file('test/test.jpg'));
+		$changes->track($this->app->user('test'));
+
+		$this->assertCount(1, $changes->files());
+		$this->assertCount(1, $changes->pages());
+		$this->assertCount(1, $changes->users());
+
+		$this->assertSame('test', $changes->pages()->first()->id());
+		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
+		$this->assertSame('test', $changes->users()->first()->id());
+	}
+
+	/**
 	 * @covers ::update
 	 */
 	public function testUpdate()
@@ -262,6 +294,38 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('files'));
 		$this->assertCount(0, $changes->read('pages'));
 		$this->assertCount(0, $changes->read('users'));
+	}
+
+	/**
+	 * @covers ::untrack
+	 */
+	public function testUntrackDisabledUuids()
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => false
+				]
+			]
+		]);
+
+		$changes = new Changes();
+
+		$changes->track($this->app->page('test'));
+		$changes->track($this->app->file('test/test.jpg'));
+		$changes->track($this->app->user('test'));
+
+		$this->assertCount(1, $changes->files());
+		$this->assertCount(1, $changes->pages());
+		$this->assertCount(1, $changes->users());
+
+		$changes->untrack($this->app->page('test'));
+		$changes->untrack($this->app->file('test/test.jpg'));
+		$changes->untrack($this->app->user('test'));
+
+		$this->assertCount(0, $changes->files());
+		$this->assertCount(0, $changes->pages());
+		$this->assertCount(0, $changes->users());
 	}
 
 	/**

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -108,6 +108,7 @@ class ChangesTest extends TestCase
 	}
 
 	/**
+	 * @covers ::cacheExists
 	 * @covers ::generateCache
 	 */
 	public function testGenerateCache()
@@ -125,12 +126,14 @@ class ChangesTest extends TestCase
 
 		$this->app->cache('changes')->flush();
 
+		$this->assertFalse($changes->cacheExists());
 		$this->assertSame([], $changes->read('files'));
 		$this->assertSame([], $changes->read('pages'));
 		$this->assertSame([], $changes->read('users'));
 
 		$changes->generateCache();
 
+		$this->assertTrue($changes->cacheExists());
 		$this->assertSame(['file://test'], $changes->read('files'));
 		$this->assertSame(['page://test'], $changes->read('pages'));
 		$this->assertSame(['user://test'], $changes->read('users'));

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -108,6 +108,35 @@ class ChangesTest extends TestCase
 	}
 
 	/**
+	 * @covers ::generateCache
+	 */
+	public function testGenerateCache()
+	{
+		$changes = new Changes();
+
+		$file = $this->app->file('test/test.jpg');
+		$file->version(VersionId::changes())->create(['foo' => 'bar']);
+
+		$page = $this->app->page('test');
+		$page->version(VersionId::changes())->create(['foo' => 'bar']);
+
+		$user = $this->app->user('test');
+		$user->version(VersionId::changes())->create(['foo' => 'bar']);
+
+		$this->app->cache('changes')->flush();
+
+		$this->assertSame([], $changes->read('files'));
+		$this->assertSame([], $changes->read('pages'));
+		$this->assertSame([], $changes->read('users'));
+
+		$changes->generateCache();
+
+		$this->assertSame(['file://test'], $changes->read('files'));
+		$this->assertSame(['page://test'], $changes->read('pages'));
+		$this->assertSame(['user://test'], $changes->read('users'));
+	}
+
+	/**
 	 * @covers ::pages
 	 * @covers ::ensure
 	 */


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Content\Changes::cacheExists()` to check if the cache exists or was flushed
- `Content\Changes::generateCache()` to loop through models and update the cache
- Changes dialog: when opening and the changes cache doesn't exist, generate it from site index
  - _Any way we can make this performant for large indexes?_
- Adapted `Content\Changes` so it also works when UUIDs have been disabled

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
