### PR TITLE
Models: translation-specific content lock

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -307,11 +307,20 @@ abstract class ModelWithContent implements Identifiable, Stringable
 
 	/**
 	 * Checks if the model is locked for the current user
-	 * @deprecated 5.0.0 Use `->lock()->isLocked()` instead
 	 */
-	public function isLocked(): bool
+	public function isLocked(Language|string $language = 'default'): bool
 	{
-		return $this->lock()->isLocked() === true;
+		if ($language === '*') {
+			foreach (Languages::ensure() as $language) {
+				if ($this->lock($language)->isLocked() === true) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return $this->lock($language)->isLocked() === true;
 	}
 
 	/**
@@ -333,13 +342,13 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	/**
 	 * Returns lock for the model
 	 */
-	public function lock(): Lock
+	public function lock(Language|string $language = 'current'): Lock
 	{
 		// get the changes for the current model
 		$version = $this->version(VersionId::changes());
 
 		// return lock object for the changes
-		return Lock::for($version);
+		return Lock::for($version, $language);
 	}
 
 	/**

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Cms\User;
 use Kirby\Toolkit\Str;
 
@@ -34,10 +35,11 @@ class Lock
 	 * lock user id from the version.
 	 */
 	public static function for(
-		Version $version
+		Version $version,
+		Language|string $language = 'current'
 	): static {
 		// if the version does not exist, it cannot be locked
-		if ($version->exists() === false) {
+		if ($version->exists($language) === false) {
 			// create an open lock for the current user
 			return new static(
 				user: App::instance()->user(),
@@ -45,13 +47,13 @@ class Lock
 		}
 
 		// Read the locked user id from the version
-		if ($userId = ($version->read('default')['lock'] ?? null)) {
+		if ($userId = ($version->read($language)['lock'] ?? null)) {
 			$user = App::instance()->user($userId);
 		}
 
 		return new static(
 			user: $user ?? null,
-			modified: $version->modified()
+			modified: $version->modified($language)
 		);
 	}
 

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -318,7 +318,7 @@ abstract class Model
 	{
 		$options = $this->model->permissions()->toArray();
 
-		if ($this->model->lock()->isLocked() === true) {
+		if ($this->model->isLocked('*') === true) {
 			foreach ($options as $key => $value) {
 				if (in_array($key, $unlock, true)) {
 					continue;
@@ -383,7 +383,7 @@ abstract class Model
 			'content'     => (object)$this->content(),
 			'id'          => $this->model->id(),
 			'link'        => $link,
-			'lock'        => $this->model->lock()->toArray(),
+			'lock'        => $this->model->lock('current')->toArray(),
 			'originals'   => (object)$this->originals(),
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\App;
 use Kirby\Cms\File as ModelFile;
+use Kirby\Cms\Language;
 use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
 use Kirby\Cms\User as ModelUser;
@@ -13,7 +14,7 @@ use Kirby\TestCase;
 
 class FileForceLocked extends ModelFile
 {
-	public function lock(): Lock
+	public function lock(Language|string $language = 'current'): Lock
 	{
 		return new Lock(
 			user: new ModelUser(['email' => 'test@getkirby.com']),

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Cms\Page as ModelPage;
 use Kirby\Cms\Site as ModelSite;
 use Kirby\Cms\User as ModelUser;
@@ -13,7 +14,7 @@ use Kirby\Toolkit\Str;
 
 class PageForceLocked extends ModelPage
 {
-	public function lock(): Lock
+	public function lock(Language|string $language = 'current'): Lock
 	{
 		return new Lock(
 			user: new ModelUser(['email' => 'test@getkirby.com']),

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Blueprint;
+use Kirby\Cms\Language;
 use Kirby\Cms\User as ModelUser;
 use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
@@ -12,7 +13,7 @@ use Kirby\Toolkit\Str;
 
 class UserForceLocked extends ModelUser
 {
-	public function lock(): Lock
+	public function lock(Language|string $language = 'current'): Lock
 	{
 		return new Lock(
 			user: new ModelUser(['email' => 'test@getkirby.com']),


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

An idea... if this feels too much for the moment, we can disregard it. Just tried it out and wanted to share it.

### Summary of changes
- Content lock gets handled for a specific content translation now
- `$model->isLocked(language: 'current')` for checking it the current translation is locked
- `$model->isLocked(language: '*')` for checking if any translation is locked
- Disables the fields if the current translation is locked
- Disabled dropdown options if any translation is locked

### Reasoning
- Reduces the likelihood of parallel editing by two users if translations are treated separately 


### Todo
- We would need a visual way to indicate if any other translation is locked currently
- How to avoid the following: User A loads view and edits translation A, user B a little later starts editing translation B. Because it's different translations, the save requests from user A also don't return any "locked by user B" error (since it's a different translation) but that's why the dropdown options stay enabled the whole time, even though they should be locked now as another user is editing any other translation.

