### PR TITLE
LanguagesDropdown: run via Fiber route

### DIFF
--- a/config/areas/account/dropdowns.php
+++ b/config/areas/account/dropdowns.php
@@ -7,8 +7,16 @@ return [
 		'pattern' => '(account)',
 		'options' => $dropdowns['user']['options']
 	],
+	'account.languages' => [
+		'pattern' => '(account)/languages',
+		'options' => $dropdowns['user.languages']['options']
+	],
 	'account.file' => [
 		'pattern' => '(account)/files/(:any)',
 		'options' => $dropdowns['user.file']['options']
 	],
+	'account.file.languages' => [
+		'pattern' => '(account)/files/(:any)/languages',
+		'options' => $files['language']
+	]
 ];

--- a/config/areas/files/dropdowns.php
+++ b/config/areas/files/dropdowns.php
@@ -6,7 +6,7 @@ use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 return [
 	'file' => function (string $parent, string $filename) {
 		return Find::file($parent, $filename)->panel()->dropdown();
-	}, 
+	},
 	'language' => function (string $parent, string $filename) {
 		$file = Find::file($parent, $filename);
 		return (new LanguagesDropdown($file))->options();

--- a/config/areas/files/dropdowns.php
+++ b/config/areas/files/dropdowns.php
@@ -1,9 +1,14 @@
 <?php
 
 use Kirby\Cms\Find;
+use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 
 return [
 	'file' => function (string $parent, string $filename) {
 		return Find::file($parent, $filename)->panel()->dropdown();
+	}, 
+	'language' => function (string $parent, string $filename) {
+		$file = Find::file($parent, $filename);
+		return (new LanguagesDropdown($file))->options();
 	}
 ];

--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -23,8 +23,10 @@ return [
 	'page.status' => function (Page $page) {
 		return new PageStatusButton($page);
 	},
-	// `languages` button needs to be in site area, as languages area itself
-	// is only loaded when in multilang setup
+	// `languages` button needs to be in site area,
+	// as the  languages might be not loaded even in
+	// multilang mode when the `languages` option is deactivated
+	// (but content languages to switch between still can exist)
 	'languages' => function (ModelWithContent $model) {
 		return new LanguagesDropdown($model);
 	},

--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -14,10 +14,10 @@ return [
 		}
 	],
 	'page.languages' => [
-		'pattern' => '(pages/.*?)/languages',
+		'pattern' => 'pages/(:any)/languages',
 		'options' => function (string $path) {
-			$model = Find::parent($path);
-			return (new LanguagesDropdown($model))->options();
+			$page = Find::page($path);
+			return (new LanguagesDropdown($page))->options();
 		}
 	],
 	'page.file' => [
@@ -26,10 +26,7 @@ return [
 	],
 	'page.file.languages' => [
 		'pattern' => '(pages/.*?)/files/(:any)/languages',
-		'options' => function (string $parent, string $filename) {
-			$file = Find::file($parent, $filename);
-			return (new LanguagesDropdown($file))->options();
-		}
+		'options' => $files['language']
 	],
 	'site.languages' => [
 		'pattern' => 'site/languages',
@@ -43,10 +40,7 @@ return [
 		'options' => $files['file']
 	],
 	'site.file.languages' => [
-		'pattern' => 'site/files/(:any)/languages',
-		'options' => function (string $filename) {
-			$file = App::instance()->site()->file($filename);
-			return (new LanguagesDropdown($file))->options();
-		}
+		'pattern' => '(site)/files/(:any)/languages',
+		'options' => $files['language']
 	]
 ];

--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Cms\Find;
+use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 
 $files = require __DIR__ . '/../files/dropdowns.php';
 
@@ -17,5 +19,12 @@ return [
 	'site.file' => [
 		'pattern' => '(site)/files/(:any)',
 		'options' => $files['file']
+	],
+	'languages' => [
+		'pattern' => '(site|pages/.*?)/languages',
+		'options' => function (string $path) {
+			$model = Find::parent($path);
+			return (new LanguagesDropdown($model))->options();
+		}
 	]
 ];

--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cms\App;
 use Kirby\Cms\Find;
 use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 
@@ -12,19 +13,40 @@ return [
 			return Find::page($path)->panel()->dropdown();
 		}
 	],
+	'page.languages' => [
+		'pattern' => '(pages/.*?)/languages',
+		'options' => function (string $path) {
+			$model = Find::parent($path);
+			return (new LanguagesDropdown($model))->options();
+		}
+	],
 	'page.file' => [
 		'pattern' => '(pages/.*?)/files/(:any)',
 		'options' => $files['file']
+	],
+	'page.file.languages' => [
+		'pattern' => '(pages/.*?)/files/(:any)/languages',
+		'options' => function (string $parent, string $filename) {
+			$file = Find::file($parent, $filename);
+			return (new LanguagesDropdown($file))->options();
+		}
+	],
+	'site.languages' => [
+		'pattern' => 'site/languages',
+		'options' => function () {
+			$site = App::instance()->site();
+			return (new LanguagesDropdown($site))->options();
+		}
 	],
 	'site.file' => [
 		'pattern' => '(site)/files/(:any)',
 		'options' => $files['file']
 	],
-	'languages' => [
-		'pattern' => '(site|pages/.*?)/languages',
-		'options' => function (string $path) {
-			$model = Find::parent($path);
-			return (new LanguagesDropdown($model))->options();
+	'site.file.languages' => [
+		'pattern' => 'site/files/(:any)/languages',
+		'options' => function (string $filename) {
+			$file = App::instance()->site()->file($filename);
+			return (new LanguagesDropdown($file))->options();
 		}
 	]
 ];

--- a/config/areas/users/dropdowns.php
+++ b/config/areas/users/dropdowns.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\Find;
+use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 
 $files = require __DIR__ . '/../files/dropdowns.php';
 
@@ -10,8 +11,22 @@ return [
 		'options' => fn (string $id) =>
 			Find::user($id)->panel()->dropdown()
 	],
+	'user.languages' => [
+		'pattern' => 'users/(:any)/languages',
+		'options' => function (string $id) {
+			$user = Find::user($id);
+			return (new LanguagesDropdown($user))->options();
+		}
+	],
 	'user.file' => [
 		'pattern' => '(users/.*?)/files/(:any)',
 		'options' => $files['file']
+	],
+	'user.file.languages' => [
+		'pattern' => '(users/.*?)/files/(:any)/languages',
+		'options' => function (string $parent, string $filename) {
+			$file = Find::file($parent, $filename);
+			return (new LanguagesDropdown($file))->options();
+		}
 	]
 ];

--- a/config/areas/users/dropdowns.php
+++ b/config/areas/users/dropdowns.php
@@ -24,9 +24,6 @@ return [
 	],
 	'user.file.languages' => [
 		'pattern' => '(users/.*?)/files/(:any)/languages',
-		'options' => function (string $parent, string $filename) {
-			$file = Find::file($parent, $filename);
-			return (new LanguagesDropdown($file))->options();
-		}
+		'options' => $files['language']
 	]
 ];

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-view-button v-bind="$props" :options="options" />
+	<k-view-button v-bind="$props" />
 </template>
 
 <script>

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-view-button v-bind="$props" :options="languages" />
+	<k-view-button v-bind="$props" :options="options" />
 </template>
 
 <script>
@@ -14,33 +14,7 @@ import { props as ButtonProps } from "@/components/Navigation/Button.vue";
 export default {
 	mixins: [ButtonProps],
 	props: {
-		options: {
-			type: Array,
-			default: () => []
-		}
-	},
-	computed: {
-		languages() {
-			return this.options.map((option) => {
-				if (option === "-") {
-					return option;
-				}
-
-				return {
-					...option,
-					click: () => this.change(option)
-				};
-			});
-		}
-	},
-	methods: {
-		change(language) {
-			this.$reload({
-				query: {
-					language: language.code
-				}
-			});
-		}
+		options: String
 	}
 };
 </script>

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -31,7 +31,9 @@ class LanguagesDropdown extends ViewButton
 			component: 'k-languages-dropdown',
 			class: 'k-languages-dropdown',
 			icon: 'translate',
-			options: $this->options(),
+			// Fiber dropdown endpoint to load options
+			// only when dropdown is opened
+			options: $this->model->panel()->url(true) . '/languages',
 			responsive: 'text',
 			text: Str::upper($this->kirby->language()?->code())
 		);
@@ -43,9 +45,14 @@ class LanguagesDropdown extends ViewButton
 			'text'    => $language->name(),
 			'code'    => $language->code(),
 			'current' => $language->code() === $this->kirby->language()?->code(),
+			'link'    => $this->model->panel()->url(true) . '?language=' . $language->code()
 		];
 	}
 
+	/**
+	 * Options are used for the Fiber dropdown at endpoint
+	 * `(site|pages/.*?)/languages`
+	 */
 	public function options(): array
 	{
 		$languages = $this->kirby->languages();

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -50,8 +50,7 @@ class LanguagesDropdown extends ViewButton
 	}
 
 	/**
-	 * Options are used for the Fiber dropdown at endpoint
-	 * `(site|pages/.*?)/languages`
+	 * Options are used in the Fiber dropdown routes
 	 */
 	public function options(): array
 	{

--- a/tests/Panel/Areas/AccountDropdownsTest.php
+++ b/tests/Panel/Areas/AccountDropdownsTest.php
@@ -52,4 +52,23 @@ class AccountDropdownsTest extends AreaTestCase
 		$this->assertSame('/account/delete', $delete['dialog']);
 		$this->assertSame('Delete your account', $delete['text']);
 	}
+
+	public function testAccountLanguageDropdown()
+	{
+		$this->app([
+			'languages' => [
+				'en' => [
+					'code' => 'en',
+					'name' => 'English',
+				],
+				'de' => [
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$this->login();
+		$this->assertLanguageDropdown('account/languages');
+	}
 }

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -68,6 +68,15 @@ abstract class AreaTestCase extends TestCase
 		$this->assertSame('k-form-dialog', $dialog['component']);
 	}
 
+	protected function assertLanguageDropdown(string $path): void
+	{
+		$options = $this->dropdown($path)['options'];
+
+		$this->assertSame('English', $options[0]['text']);
+		$this->assertSame('-', $options[1]);
+		$this->assertSame('Deutsch', $options[2]['text']);
+	}
+
 	protected function assertRedirect(
 		string $source,
 		string $dest = '/',

--- a/tests/Panel/Areas/FileDropdownsTest.php
+++ b/tests/Panel/Areas/FileDropdownsTest.php
@@ -13,6 +13,20 @@ class FileDropdownsTest extends AreaTestCase
 		$this->login();
 	}
 
+	protected function createLanguages(): array
+	{
+		return [
+			'en' => [
+				'code' => 'en',
+				'name' => 'English',
+			],
+			'de' => [
+				'code' => 'de',
+				'name' => 'Deutsch',
+			]
+		];
+	}
+
 	protected function createPageFile(): void
 	{
 		$this->app([
@@ -24,8 +38,9 @@ class FileDropdownsTest extends AreaTestCase
 							['filename' => 'test.jpg']
 						]
 					]
-				]
-			]
+				],
+			],
+			'languages' => $this->createLanguages(),
 		]);
 
 		// pretend the file exists
@@ -41,7 +56,8 @@ class FileDropdownsTest extends AreaTestCase
 				'files' => [
 					['filename' => 'test.jpg']
 				]
-			]
+			],
+			'languages' => $this->createLanguages(),
 		]);
 
 		// pretend the file exists
@@ -67,7 +83,8 @@ class FileDropdownsTest extends AreaTestCase
 					'email' => 'admin@getkirby.com',
 					'role'  => 'admin',
 				]
-			]
+			],
+			'languages' => $this->createLanguages(),
 		]);
 
 		// pretend the file exists
@@ -163,5 +180,33 @@ class FileDropdownsTest extends AreaTestCase
 
 		$this->assertSame('/users/test/files/test.jpg/delete', $options[5]['dialog']);
 		$this->assertSame('Delete', $options[5]['text']);
+	}
+
+	public function testFileLanguageDropdownForAccountFile()
+	{
+		$this->createUserFile();
+		$this->login();
+		$this->assertLanguageDropdown('account/files/test.jpg/languages');
+	}
+
+	public function testFileLanguageDropdownForPageFile()
+	{
+		$this->createPageFile();
+		$this->login();
+		$this->assertLanguageDropdown('pages/test/files/test.jpg/languages');
+	}
+
+	public function testFileLanguageDropdownForSiteFile()
+	{
+		$this->createSiteFile();
+		$this->login();
+		$this->assertLanguageDropdown('site/files/test.jpg/languages');
+	}
+
+	public function testFileLanguageDropdownForUserFile()
+	{
+		$this->createUserFile();
+		$this->login();
+		$this->assertLanguageDropdown('users/test/files/test.jpg/languages');
 	}
 }

--- a/tests/Panel/Areas/SiteDropdownsTest.php
+++ b/tests/Panel/Areas/SiteDropdownsTest.php
@@ -97,4 +97,47 @@ class SiteDropdownsTest extends AreaTestCase
 		$this->assertSame('_blank', $preview['target']);
 		$this->assertSame('Open', $preview['text']);
 	}
+
+	public function testPageLanguageDropdown()
+	{
+		$this->app([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			],
+			'languages' => [
+				'en' => [
+					'code' => 'en',
+					'name' => 'English',
+				],
+				'de' => [
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$this->login();
+		$this->assertLanguageDropdown('pages/test/languages');
+	}
+
+	public function testSiteLanguageDropdown()
+	{
+		$this->app([
+			'languages' => [
+				'en' => [
+					'code' => 'en',
+					'name' => 'English',
+				],
+				'de' => [
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$this->login();
+		$this->assertLanguageDropdown('site/languages');
+	}
 }

--- a/tests/Panel/Areas/UserDropdownsTest.php
+++ b/tests/Panel/Areas/UserDropdownsTest.php
@@ -52,4 +52,23 @@ class UserDropdownsTest extends AreaTestCase
 		$this->assertSame('/users/editor/delete', $delete['dialog']);
 		$this->assertSame('Delete this user', $delete['text']);
 	}
+
+	public function testUserLanguageDropdown()
+	{
+		$this->app([
+			'languages' => [
+				'en' => [
+					'code' => 'en',
+					'name' => 'English',
+				],
+				'de' => [
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$this->login();
+		$this->assertLanguageDropdown('users/editor/languages');
+	}
 }

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -30,6 +30,7 @@ class LanguagesDropdownTest extends AreaTestCase
 
 	/**
 	 * @covers ::options
+	 * @
 	 */
 	public function testOptionsSingleLang()
 	{
@@ -40,6 +41,7 @@ class LanguagesDropdownTest extends AreaTestCase
 
 	/**
 	 * @covers ::options
+	 * 
 	 */
 	public function testOptionsMultiLang()
 	{

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -41,7 +41,6 @@ class LanguagesDropdownTest extends AreaTestCase
 
 	/**
 	 * @covers ::options
-	 * 
 	 */
 	public function testOptionsMultiLang()
 	{

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -23,7 +23,8 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertSame([
 			'text'    => 'Deutsch',
 			'code'    => 'de',
-			'current' => false
+			'current' => false,
+			'link'    => '/pages/test?language=de'
 		], $button->option($language));
 	}
 
@@ -51,13 +52,15 @@ class LanguagesDropdownTest extends AreaTestCase
 			[
 				'text'    => 'English',
 				'code'    => 'en',
-				'current' => true
+				'current' => true,
+				'link'    => '/pages/test?language=en'
 			],
 			'-',
 			[
 				'text'    => 'Deutsch',
 				'code'    => 'de',
-				'current' => false
+				'current' => false,
+				'link'    => '/pages/test?language=de'
 			]
 		], $button->options());
 	}
@@ -86,7 +89,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertSame('k-languages-dropdown', $button->component);
 		$this->assertSame('k-languages-dropdown', $button->class);
 		$this->assertSame('translate', $button->icon);
-		$this->assertCount(3, $button->options);
+		$this->assertSame('/pages/test/languages', $button->options);
 		$this->assertSame('text', $button->responsive);
 		$this->assertSame('EN', $button->text);
 
@@ -94,6 +97,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertIsArray($render);
 		$this->assertSame('k-languages-dropdown', $render['component']);
 		$this->assertIsArray($render['props']);
-		$this->assertIsArray($render['props']['options']);
+		$this->assertSame('/pages/test/languages', $render['props']['options']);
 	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `link` instead of `$reload` when changing a language
- New Fiber dropdown endpoint that loads the dropdown options


### Reasoning
Allows us that the dropdown options are always the most up-to-date version when opening the dropdown (e.g. when we add later info on existing changes or locks).



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactored
- `<k-languages-dropdown>` now receives Fiber dropdown endpoint instead of array of options


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass
  - `LanguagesDropdown::option()` actually has a unit test
  - I think it's ok to leave the dropdown routes without their own unit test
### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
