### PR TITLE
Add the plugin as required argument for the license object

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -870,7 +870,7 @@ trait AppPlugins
 		array $info = [],
 		string|null $root = null,
 		string|null $version = null,
-		License|string|array|null $license = null,
+		Closure|string|array|null $license = null,
 	): Plugin|null {
 		if ($extends === null) {
 			return static::$plugins[$name] ?? null;

--- a/src/Plugin/License.php
+++ b/src/Plugin/License.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Plugin;
 
+use Closure;
 use Stringable;
 
 /**
@@ -18,6 +19,7 @@ class License implements Stringable
 	protected LicenseStatus $status;
 
 	public function __construct(
+		protected Plugin $plugin,
 		protected string $name,
 		protected string|null $link = null,
 		LicenseStatus|null $status = null
@@ -36,14 +38,17 @@ class License implements Stringable
 	/**
 	 * Creates a license instance from a given value
 	 */
-	public static function from(License|array|string|null $license): static
-	{
-		if ($license instanceof License) {
-			return $license;
+	public static function from(
+		Plugin $plugin,
+		Closure|array|string|null $license
+	): static {
+		if ($license instanceof Closure) {
+			return $license($plugin);
 		}
 
 		if (is_array($license)) {
 			return new static(
+				plugin: $plugin,
 				name: $license['name'] ?? '',
 				link: $license['link'] ?? null,
 				status: LicenseStatus::from($license['status'] ?? 'active')
@@ -52,12 +57,14 @@ class License implements Stringable
 
 		if ($license === null || $license === '-') {
 			return new static(
+				plugin: $plugin,
 				name: '-',
 				status: LicenseStatus::from('unknown')
 			);
 		}
 
 		return new static(
+			plugin: $plugin,
 			name: $license,
 			status: LicenseStatus::from('active')
 		);

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Plugin;
 
+use Closure;
 use Composer\InstalledVersions;
 use Exception;
 use Kirby\Cms\App;
@@ -41,7 +42,7 @@ class Plugin
 		protected string $name,
 		protected array $extends = [],
 		protected array $info = [],
-		License|string|array|null $license = null,
+		Closure|string|array|null $license = null,
 		protected string|null $root = null,
 		protected string|null $version = null,
 	) {
@@ -78,7 +79,10 @@ class Plugin
 		$this->info = [...$info, ...$this->info];
 
 		// set the license
-		$this->license = License::from($license ?? $this->info['license'] ?? '-');
+		$this->license = License::from(
+			plugin: $this,
+			license: $license ?? $this->info['license'] ?? '-'
+		);
 	}
 
 	/**

--- a/tests/Plugin/LicenseTest.php
+++ b/tests/Plugin/LicenseTest.php
@@ -9,12 +9,20 @@ use Kirby\Cms\TestCase;
  */
 class LicenseTest extends TestCase
 {
+	protected function plugin(): Plugin
+	{
+		return new Plugin(
+			name: 'test/test'
+		);
+	}
+
 	/**
 	 * @covers ::__toString
 	 */
 	public function test__toString(): void
 	{
 		$license = new License(
+			plugin: $this->plugin(),
 			name: 'Custom license'
 		);
 
@@ -26,7 +34,7 @@ class LicenseTest extends TestCase
 	 */
 	public function testFromArray(): void
 	{
-		$license = License::from([
+		$license = License::from($this->plugin(), [
 			'name'   => 'Custom license',
 			'link'   => 'https://getkirby.com',
 			'status' => 'missing'
@@ -39,9 +47,16 @@ class LicenseTest extends TestCase
 	/**
 	 * @covers ::from
 	 */
-	public function testFromInstance(): void
+	public function testFromClosure(): void
 	{
-		$license = License::from(License::from('Custom license'));
+		$license = License::from($this->plugin(), function ($plugin) {
+			return new License(
+				plugin: $plugin,
+				name: 'Custom license',
+				status: LicenseStatus::from('active')
+			);
+		});
+
 		$this->assertSame('Custom license', $license->name());
 		$this->assertSame('active', $license->status()->value());
 	}
@@ -51,7 +66,7 @@ class LicenseTest extends TestCase
 	 */
 	public function testFromString(): void
 	{
-		$license = License::from('Custom license');
+		$license = License::from($this->plugin(), 'Custom license');
 		$this->assertSame('Custom license', $license->name());
 		$this->assertSame('active', $license->status()->value());
 	}
@@ -61,7 +76,7 @@ class LicenseTest extends TestCase
 	 */
 	public function testFromNull(): void
 	{
-		$license = License::from(null);
+		$license = License::from($this->plugin(), null);
 		$this->assertSame('-', $license->name());
 		$this->assertSame('unknown', $license->status()->value());
 	}
@@ -72,6 +87,7 @@ class LicenseTest extends TestCase
 	public function testLink(): void
 	{
 		$license = new License(
+			plugin: $this->plugin(),
 			name: 'Custom license',
 			link: 'https://getkirby.com'
 		);
@@ -85,6 +101,7 @@ class LicenseTest extends TestCase
 	public function testName(): void
 	{
 		$license = new License(
+			plugin: $this->plugin(),
 			name: 'Custom license'
 		);
 
@@ -97,6 +114,7 @@ class LicenseTest extends TestCase
 	public function testStatus(): void
 	{
 		$license = new License(
+			plugin: $this->plugin(),
 			name: 'Custom license',
 			status: LicenseStatus::from('missing')
 		);
@@ -111,6 +129,7 @@ class LicenseTest extends TestCase
 	public function testToArray(): void
 	{
 		$license = new License(
+			plugin: $this->plugin(),
 			name: 'Custom license',
 		);
 


### PR DESCRIPTION
## Description

@nilshoerrmann reported that the plugin instance might often be a very important dependency that's needed in a custom License class to return the proper directory for the license file for example. 

This PR adds the Plugin instance as required first argument to the License object and also changes the way that license instances can be added to a plugin. 

### Summary of changes

A custom license class has to have the plugin instance as first argument of the constructor. 

```php
use Kirby\Plugin\Plugin;
use Kirby\Plugin\License;

class MyLicense extends License
{
  public function __construct(
    protected Plugin $plugin
  ) {
  }  
}
```

A license can no longer be passed directly as instance, but has to be wrapped in a closure to inject the plugin instance. 

```php 
Kirby::plugin(
  name: 'my/plugin', 
  extends: [...]
  license: function ($plugin) {
    return new MyLicense(
      plugin: $plugin
    );
  }
)
```

Nothing changed about passing a license as string or array.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
