### PR TITLE
feat: AST-based query runner

### DIFF
--- a/src/Query/AST/ArgumentListNode.php
+++ b/src/Query/AST/ArgumentListNode.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents a list of (method) arguments
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class ArgumentListNode extends Node
+{
+	public function __construct(
+		public array $arguments = []
+	) {
+	}
+
+	public function resolve(Visitor $visitor): array|string
+	{
+		// Resolve each argument
+		$arguments = array_map(
+			fn ($argument) => $argument->resolve($visitor),
+			$this->arguments
+		);
+
+		// Keep as array or convert to string
+		// depending on the visitor type
+		return $visitor->arguments($arguments);
+	}
+}

--- a/src/Query/AST/ArgumentListNode.php
+++ b/src/Query/AST/ArgumentListNode.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents a list of (method) arguments
+ * Represents a list of (method) arguments in the AST
  *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
@@ -13,6 +13,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class ArgumentListNode extends Node
 {

--- a/src/Query/AST/ArithmeticNode.php
+++ b/src/Query/AST/ArithmeticNode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents an arithmetic operation between two values
+ *
+ * @package   Kirby Query
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class ArithmeticNode extends Node
+{
+	public function __construct(
+		public Node $left,
+		public string $operator,
+		public Node $right
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->arithmetic(
+			left: $this->left->resolve($visitor),
+			operator: $this->operator,
+			right: $this->right->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/ArithmeticNode.php
+++ b/src/Query/AST/ArithmeticNode.php
@@ -5,13 +5,14 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents an arithmetic operation between two values
+ * Represents an arithmetic operation between two values in the AST
  *
  * @package   Kirby Query
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class ArithmeticNode extends Node
 {

--- a/src/Query/AST/ArrayListNode.php
+++ b/src/Query/AST/ArrayListNode.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class ArrayListNode extends Node
+{
+	public function __construct(
+		public array $elements,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): array|string
+	{
+		// Resolve each array element
+		$elements = array_map(
+			fn ($element) => $element->resolve($visitor),
+			$this->elements
+		);
+
+		// Keep as array or convert to string
+		// depending on the visitor type
+		return $visitor->arrayList($elements);
+	}
+}

--- a/src/Query/AST/ArrayListNode.php
+++ b/src/Query/AST/ArrayListNode.php
@@ -5,12 +5,15 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
+ * Represents a (array) list of elements in the AST
+ *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
  *            Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class ArrayListNode extends Node
 {

--- a/src/Query/AST/ClosureNode.php
+++ b/src/Query/AST/ClosureNode.php
@@ -5,12 +5,15 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
+ * Represents a closure in the AST
+ *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
  *            Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class ClosureNode extends Node
 {

--- a/src/Query/AST/ClosureNode.php
+++ b/src/Query/AST/ClosureNode.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class ClosureNode extends Node
+{
+	/**
+	 * @param string[] $arguments The arguments names
+	 */
+	public function __construct(
+		public array $arguments,
+		public Node $body,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->closure($this);
+	}
+}

--- a/src/Query/AST/CoalesceNode.php
+++ b/src/Query/AST/CoalesceNode.php
@@ -5,12 +5,15 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
+ * Represents a coalesce operation in the AST
+ *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
  *            Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class CoalesceNode extends Node
 {

--- a/src/Query/AST/CoalesceNode.php
+++ b/src/Query/AST/CoalesceNode.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class CoalesceNode extends Node
+{
+	public function __construct(
+		public Node $left,
+		public Node $right,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->coalescence(
+			left:  $this->left->resolve($visitor),
+			right: $this->right->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/ComparisonNode.php
+++ b/src/Query/AST/ComparisonNode.php
@@ -5,13 +5,14 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents a comparison operation between two values
+ * Represents a comparison operation between two values in the AST
  *
  * @package   Kirby Query
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class ComparisonNode extends Node
 {

--- a/src/Query/AST/ComparisonNode.php
+++ b/src/Query/AST/ComparisonNode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents a comparison operation between two values
+ *
+ * @package   Kirby Query
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class ComparisonNode extends Node
+{
+	public function __construct(
+		public Node $left,
+		public string $operator,
+		public Node $right
+	) {
+	}
+
+	public function resolve(Visitor $visitor): bool|string
+	{
+		return $visitor->comparison(
+			left: $this->left->resolve($visitor),
+			operator: $this->operator,
+			right: $this->right->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/GlobalFunctionNode.php
+++ b/src/Query/AST/GlobalFunctionNode.php
@@ -5,12 +5,15 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
+ * Represents a global function call in the AST
+ *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
  *            Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class GlobalFunctionNode extends Node
 {

--- a/src/Query/AST/GlobalFunctionNode.php
+++ b/src/Query/AST/GlobalFunctionNode.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class GlobalFunctionNode extends Node
+{
+	public function __construct(
+		public string $name,
+		public ArgumentListNode $arguments,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->function(
+			name:      $this->name,
+			arguments: $this->arguments->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/LiteralNode.php
+++ b/src/Query/AST/LiteralNode.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents literal values (e.g. string, int, bool)
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class LiteralNode extends Node
+{
+	public function __construct(
+		public mixed $value,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->literal($this->value);
+	}
+}

--- a/src/Query/AST/LiteralNode.php
+++ b/src/Query/AST/LiteralNode.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents literal values (e.g. string, int, bool)
+ * Represents literal values (e.g. string, int, bool) in the AST
  *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
@@ -13,6 +13,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class LiteralNode extends Node
 {

--- a/src/Query/AST/LogicalNode.php
+++ b/src/Query/AST/LogicalNode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents a logical operation between two values
+ *
+ * @package   Kirby Query
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class LogicalNode extends Node
+{
+	public function __construct(
+		public Node $left,
+		public string $operator,
+		public Node $right
+	) {
+	}
+
+	public function resolve(Visitor $visitor): bool|string
+	{
+		return $visitor->logical(
+			left: $this->left->resolve($visitor),
+			operator: $this->operator,
+			right: $this->right->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/LogicalNode.php
+++ b/src/Query/AST/LogicalNode.php
@@ -5,13 +5,14 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents a logical operation between two values
+ * Represents a logical operation between two values in the AST
  *
  * @package   Kirby Query
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class LogicalNode extends Node
 {

--- a/src/Query/AST/MemberAccessNode.php
+++ b/src/Query/AST/MemberAccessNode.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents the access (e.g. method call) on a node
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class MemberAccessNode extends Node
+{
+	public function __construct(
+		public Node $object,
+		public Node $member,
+		public ArgumentListNode|null $arguments = null,
+		public bool $nullSafe = false,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->memberAccess(
+			object:    $this->object->resolve($visitor),
+			member:    $this->member->resolve($visitor),
+			arguments: $this->arguments?->resolve($visitor),
+			nullSafe:  $this->nullSafe
+		);
+	}
+}

--- a/src/Query/AST/MemberAccessNode.php
+++ b/src/Query/AST/MemberAccessNode.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents the access (e.g. method call) on a node
+ * Represents the access (e.g. method call) on a node in the AST
  *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
@@ -13,6 +13,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class MemberAccessNode extends Node
 {

--- a/src/Query/AST/Node.php
+++ b/src/Query/AST/Node.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Basic query node representation
+ * Basic node representation in the query AST
  *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
@@ -13,6 +13,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  *
  * @codeCoverageIgnore
  */

--- a/src/Query/AST/Node.php
+++ b/src/Query/AST/Node.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Basic query node representation
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ *
+ * @codeCoverageIgnore
+ */
+abstract class Node
+{
+	abstract public function resolve(Visitor $visitor);
+}

--- a/src/Query/AST/TernaryNode.php
+++ b/src/Query/AST/TernaryNode.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents a ternary condition
+ * with a value for when the condition is true
+ * and another value for when the condition is false
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class TernaryNode extends Node
+{
+	public function __construct(
+		public Node $condition,
+		public Node $false,
+		public Node|null $true = null
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->ternary(
+			condition: $this->condition->resolve($visitor),
+			true:      $this->true?->resolve($visitor),
+			false:     $this->false->resolve($visitor)
+		);
+	}
+}

--- a/src/Query/AST/TernaryNode.php
+++ b/src/Query/AST/TernaryNode.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents a ternary condition
+ * Represents a ternary condition in the AST,
  * with a value for when the condition is true
  * and another value for when the condition is false
  *
@@ -14,6 +14,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class TernaryNode extends Node
 {

--- a/src/Query/AST/VariableNode.php
+++ b/src/Query/AST/VariableNode.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\Visitor;
+
+/**
+ * Represents a variable (e.g. an object)
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class VariableNode extends Node
+{
+	public function __construct(
+		public string $name,
+	) {
+	}
+
+	public function resolve(Visitor $visitor): mixed
+	{
+		return $visitor->variable($this->name);
+	}
+}

--- a/src/Query/AST/VariableNode.php
+++ b/src/Query/AST/VariableNode.php
@@ -5,7 +5,7 @@ namespace Kirby\Query\AST;
 use Kirby\Query\Visitors\Visitor;
 
 /**
- * Represents a variable (e.g. an object)
+ * Represents a variable (e.g. an object) in the AST
  *
  * @package   Kirby Query
  * @author    Roman Steiner <roman@toastlab.ch>,
@@ -13,6 +13,7 @@ use Kirby\Query\Visitors\Visitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class VariableNode extends Node
 {

--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @todo Deprecate in v6
  */
 class Argument
 {

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -15,6 +15,8 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
+ * @todo Deprecate in v6
+ *
  * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
  */
 class Arguments extends Collection

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -14,6 +14,8 @@ use Kirby\Toolkit\A;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @todo Deprecate in v6
  */
 class Expression
 {

--- a/src/Query/Parser/Parser.php
+++ b/src/Query/Parser/Parser.php
@@ -1,0 +1,475 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+use Exception;
+use Iterator;
+use Kirby\Query\AST\ArgumentListNode;
+use Kirby\Query\AST\ArithmeticNode;
+use Kirby\Query\AST\ArrayListNode;
+use Kirby\Query\AST\ClosureNode;
+use Kirby\Query\AST\CoalesceNode;
+use Kirby\Query\AST\ComparisonNode;
+use Kirby\Query\AST\GlobalFunctionNode;
+use Kirby\Query\AST\LiteralNode;
+use Kirby\Query\AST\LogicalNode;
+use Kirby\Query\AST\MemberAccessNode;
+use Kirby\Query\AST\Node;
+use Kirby\Query\AST\TernaryNode;
+use Kirby\Query\AST\VariableNode;
+
+/**
+ * Parses query string by first splitting it into tokens
+ * and then matching and consuming tokens to create
+ * an abstract syntax tree (AST) of matching nodes
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class Parser
+{
+	protected Token $current;
+	protected Token|null $previous = null;
+
+	/**
+	 * @var Iterator<Token>
+	 */
+	protected Iterator $tokens;
+
+	public function __construct(string|Iterator $query)
+	{
+		if (is_string($query) === true) {
+			$tokenizer = new Tokenizer($query);
+			$query     = $tokenizer->tokens();
+		}
+
+		$this->tokens  = $query;
+		$this->current = $this->tokens->current();
+	}
+
+	/**
+	 * Move to the next token
+	 */
+	protected function advance(): Token|null
+	{
+		if ($this->isAtEnd() === false) {
+			$this->previous = $this->current;
+			$this->tokens->next();
+			$this->current  = $this->tokens->current();
+		}
+
+		return $this->previous;
+	}
+
+	/**
+	 * Parses an array
+	 */
+	private function array(): ArrayListNode|null
+	{
+		if ($this->consume(TokenType::T_OPEN_BRACKET)) {
+			return new ArrayListNode(
+				elements: $this->consumeList(TokenType::T_CLOSE_BRACKET)
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parses a list of arguments
+	 */
+	private function argumentList(): ArgumentListNode
+	{
+		return new ArgumentListNode(
+			arguments: $this->consumeList(TokenType::T_CLOSE_PAREN)
+		);
+	}
+
+	/**
+	 * Checks for and parses several atomic expressions
+	 */
+	private function atomic(): Node
+	{
+		$token   = $this->scalar();
+		$token ??= $this->array();
+		$token ??= $this->identifier();
+		$token ??= $this->grouping();
+
+		if ($token === null) {
+			throw new Exception('Expect expression'); // @codeCoverageIgnore
+		}
+
+		return $token;
+	}
+
+	/**
+	 * Checks for and parses a coalesce expression
+	 */
+	private function coalesce(): Node
+	{
+		$node = $this->logical();
+
+		while ($this->consume(TokenType::T_COALESCE)) {
+			$node = new CoalesceNode(
+				left: $node,
+				right: $this->logical()
+			);
+		}
+
+		return $node;
+	}
+
+	/**
+	 * Collect the next token of a type
+	 *
+	 * @throws \Exception when next token is not of specified type
+	 */
+	protected function consume(
+		TokenType $type,
+		string|false $error = false
+	): Token|false {
+		if ($this->is($type) === true) {
+			return $this->advance();
+		}
+
+		if (is_string($error) === true) {
+			throw new Exception($error);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Move to next token if of any specific type
+	 */
+	protected function consumeAny(array $types): Token|false
+	{
+		foreach ($types as $type) {
+			if ($this->is($type) === true) {
+				return $this->advance();
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Collect all list element until closing token
+	 */
+	private function consumeList(TokenType $until): array
+	{
+		$elements = [];
+
+		while (
+			$this->isAtEnd() === false &&
+			$this->is($until) === false
+		) {
+			$elements[] = $this->expression();
+
+			if ($this->consume(TokenType::T_COMMA) === false) {
+				break;
+			}
+		}
+
+		// consume the closing token
+		$this->consume($until, 'Expect closing bracket after list');
+
+		return $elements;
+	}
+
+	/**
+	 * Returns the current token
+	 */
+	public function current(): Token
+	{
+		return $this->current;
+	}
+
+	/**
+	 * Convert a full query expression into a node
+	 */
+	private function expression(): Node
+	{
+		// Top-level expression should be ternary
+		return $this->ternary();
+	}
+
+	/**
+	 * Parses comparison expressions with proper precedence
+	 */
+	private function comparison(): Node
+	{
+		$left = $this->arithmetic();
+
+		while ($token = $this->consumeAny([
+			TokenType::T_EQUAL,
+			TokenType::T_IDENTICAL,
+			TokenType::T_NOT_EQUAL,
+			TokenType::T_NOT_IDENTICAL,
+			TokenType::T_LESS_THAN,
+			TokenType::T_LESS_EQUAL,
+			TokenType::T_GREATER_THAN,
+			TokenType::T_GREATER_EQUAL
+		])) {
+			$left = new ComparisonNode(
+				left: $left,
+				operator: $token->lexeme,
+				right: $this->arithmetic()
+			);
+		}
+
+		return $left;
+	}
+
+	/**
+	 * Parses a grouping (e.g. closure)
+	 */
+	private function grouping(): ClosureNode|Node|null
+	{
+		if ($this->consume(TokenType::T_OPEN_PAREN)) {
+			$list = $this->consumeList(TokenType::T_CLOSE_PAREN);
+
+			if ($this->consume(TokenType::T_ARROW)) {
+				$expression = $this->expression();
+
+				/**
+				 * Assert that all elements are VariableNodes
+				 * @var VariableNode[] $list
+				 */
+				foreach ($list as $element) {
+					if ($element instanceof VariableNode === false) {
+						throw new Exception('Expecting only variables in closure argument list');
+					}
+				}
+
+				$arguments = array_map(fn ($element) => $element->name, $list);
+
+				return new ClosureNode(
+					arguments: $arguments,
+					body: $expression
+				);
+			}
+
+			if (count($list) > 1) {
+				throw new Exception('Expecting "=>" after closure argument list');
+			}
+
+			// this is just a grouping
+			return $list[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parses an identifier (global functions or variables)
+	 */
+	private function identifier(): GlobalFunctionNode|VariableNode|null
+	{
+		if ($token = $this->consume(TokenType::T_IDENTIFIER)) {
+			if ($this->consume(TokenType::T_OPEN_PAREN)) {
+				return new GlobalFunctionNode(
+					name: $token->lexeme,
+					arguments: $this->argumentList()
+				);
+			}
+
+			return new VariableNode(name: $token->lexeme);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the current token is of a specific type
+	 */
+	protected function is(TokenType $type): bool
+	{
+		if ($this->isAtEnd() === true) {
+			return false;
+		}
+
+		return $this->current->is($type);
+	}
+
+	/**
+	 * Whether the parser has reached the end of the query
+	 */
+	protected function isAtEnd(): bool
+	{
+		return $this->current->is(TokenType::T_EOF);
+	}
+
+	/**
+	 * Checks for and parses a member access expression
+	 */
+	private function memberAccess(): Node
+	{
+		$object = $this->atomic();
+
+		while ($token = $this->consumeAny([
+			TokenType::T_DOT,
+			TokenType::T_NULLSAFE,
+			TokenType::T_OPEN_BRACKET
+		])) {
+			if ($token->is(TokenType::T_OPEN_BRACKET) === true) {
+				// For subscript notation, parse the inside as expression…
+				$member = $this->expression();
+
+				// …and ensure consuming the closing bracket
+				$this->consume(
+					TokenType::T_CLOSE_BRACKET,
+					'Expect subscript closing bracket'
+				);
+			} elseif ($member = $this->consume(TokenType::T_IDENTIFIER)) {
+				$member = new LiteralNode($member->lexeme);
+			} elseif ($member = $this->consume(TokenType::T_INTEGER)) {
+				$member = new LiteralNode($member->literal);
+			} else {
+				throw new Exception('Expect property name after "."');
+			}
+
+			$object = new MemberAccessNode(
+				object: $object,
+				member: $member,
+				arguments: match ($this->consume(TokenType::T_OPEN_PAREN)) {
+					false   => null,
+					default => $this->argumentList(),
+				},
+				nullSafe: $token->is(TokenType::T_NULLSAFE)
+			);
+		}
+
+		return $object;
+	}
+
+	/**
+	 * Parses arithmetic expressions with proper precedence
+	 */
+	private function arithmetic(): Node
+	{
+		$left = $this->term();
+
+		while ($token = $this->consumeAny([
+			TokenType::T_PLUS,
+			TokenType::T_MINUS
+		])) {
+			$left = new ArithmeticNode(
+				left: $left,
+				operator: $token->lexeme,
+				right: $this->term()
+			);
+		}
+
+		return $left;
+	}
+
+	/**
+	 * Parses multiplication, division, and modulo expressions
+	 */
+	private function term(): Node
+	{
+		$left = $this->memberAccess();
+
+		while ($token = $this->consumeAny([
+			TokenType::T_MULTIPLY,
+			TokenType::T_DIVIDE,
+			TokenType::T_MODULO
+		])) {
+			$left = new ArithmeticNode(
+				left: $left,
+				operator: $token->lexeme,
+				right: $this->memberAccess()
+			);
+		}
+
+		return $left;
+	}
+
+	/**
+	 * Parses logical expressions with proper precedence
+	 */
+	private function logical(): Node
+	{
+		$left = $this->comparison();
+
+		while ($token = $this->consumeAny([
+			TokenType::T_AND,
+			TokenType::T_OR
+		])) {
+			$left = new LogicalNode(
+				left: $left,
+				operator: $token->lexeme,
+				right: $this->comparison()
+			);
+		}
+
+		return $left;
+	}
+
+	/**
+	 * Parses the tokenized query into AST node tree
+	 */
+	public function parse(): Node
+	{
+		// Start parsing chain
+		$expression = $this->expression();
+
+		// Ensure that we consumed all tokens
+		if ($this->isAtEnd() === false) {
+			$this->consume(TokenType::T_EOF, 'Expect end of expression'); // @codeCoverageIgnore
+		}
+
+		return $expression;
+	}
+
+	private function scalar(): LiteralNode|null
+	{
+		if ($token = $this->consumeAny([
+			TokenType::T_TRUE,
+			TokenType::T_FALSE,
+			TokenType::T_NULL,
+			TokenType::T_STRING,
+			TokenType::T_INTEGER,
+			TokenType::T_FLOAT,
+		])) {
+			return new LiteralNode(value: $token->literal);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Checks for and parses a ternary expression
+	 * (full `a ? b : c` or elvis shorthand `a ?: c`)
+	 */
+	private function ternary(): Node
+	{
+		$condition = $this->coalesce();
+
+		if ($token = $this->consumeAny([
+			TokenType::T_QUESTION_MARK,
+			TokenType::T_TERNARY_DEFAULT
+		])) {
+			if ($token->is(TokenType::T_TERNARY_DEFAULT) === false) {
+				$true = $this->expression();
+				$this->consume(
+					type:  TokenType::T_COLON,
+					error: 'Expect ":" after true branch'
+				);
+			}
+
+			return new TernaryNode(
+				condition: $condition,
+				true: $true ?? null,
+				false: $this->expression()
+			);
+		}
+
+		return $condition;
+	}
+}

--- a/src/Query/Parser/Parser.php
+++ b/src/Query/Parser/Parser.php
@@ -29,6 +29,7 @@ use Kirby\Query\AST\VariableNode;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class Parser
 {

--- a/src/Query/Parser/Token.php
+++ b/src/Query/Parser/Token.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+/**
+ * Represents a single token of a particular type
+ * within a query
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class Token
+{
+	public function __construct(
+		public TokenType $type,
+		public string $lexeme,
+		public mixed $literal = null,
+	) {
+	}
+
+	public function is(TokenType $type): bool
+	{
+		return $this->type === $type;
+	}
+}

--- a/src/Query/Parser/Token.php
+++ b/src/Query/Parser/Token.php
@@ -12,6 +12,7 @@ namespace Kirby\Query\Parser;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class Token
 {

--- a/src/Query/Parser/TokenType.php
+++ b/src/Query/Parser/TokenType.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+enum TokenType
+{
+	case T_DOT;
+	case T_COLON;
+	case T_QUESTION_MARK;
+	case T_OPEN_PAREN;
+	case T_CLOSE_PAREN;
+	case T_OPEN_BRACKET;
+	case T_CLOSE_BRACKET;
+	case T_TERNARY_DEFAULT; // ?:
+	case T_NULLSAFE; // ?.
+	case T_COALESCE; // ??
+	case T_COMMA;
+	case T_ARROW;
+	case T_WHITESPACE;
+	case T_EOF;
+
+	// Comparison operators
+	case T_EQUAL; // ==
+	case T_IDENTICAL; // ===
+	case T_NOT_EQUAL; // !=
+	case T_NOT_IDENTICAL; // !==
+	case T_LESS_THAN; // <
+	case T_LESS_EQUAL; // <=
+	case T_GREATER_THAN; // >
+	case T_GREATER_EQUAL; // >=
+
+	// Math operators
+	case T_PLUS; // +
+	case T_MINUS; // -
+	case T_MULTIPLY; // *
+	case T_DIVIDE; // /
+	case T_MODULO; // %
+
+	// Logical operators
+	case T_AND; // AND or &&
+	case T_OR;  // OR or ||
+
+	// Literals
+	case T_STRING;
+	case T_INTEGER;
+	case T_FLOAT;
+	case T_TRUE;
+	case T_FALSE;
+	case T_NULL;
+
+	case T_IDENTIFIER;
+}

--- a/src/Query/Parser/TokenType.php
+++ b/src/Query/Parser/TokenType.php
@@ -9,6 +9,7 @@ namespace Kirby\Query\Parser;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 enum TokenType
 {

--- a/src/Query/Parser/Tokenizer.php
+++ b/src/Query/Parser/Tokenizer.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+use Exception;
+use Generator;
+
+/**
+ * Parses a query string into its individual tokens
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class Tokenizer
+{
+	private int $length = 0;
+
+	/**
+	 * The more complex regexes are written here in nowdoc format
+	 * so we don't need to double or triple escape backslashes
+	 * (that becomes ridiculous rather fast).
+	 *
+	 * Identifiers can contain letters, numbers and underscores.
+	 * They can't start with a number.
+	 * For more complex identifier strings, subscript member access
+	 * should be used. With `this` to access the global context.
+	 */
+	private const IDENTIFIER_REGEX = <<<'REGEX'
+	(?:[\p{L}\p{N}_])*
+	REGEX;
+
+	private const SINGLEQUOTE_STRING_REGEX = <<<'REGEX'
+	'([^'\\]*(?:\\.[^'\\]*)*)'
+	REGEX;
+
+	private const DOUBLEQUOTE_STRING_REGEX = <<<'REGEX'
+	"([^"\\]*(?:\\.[^"\\]*)*)"
+	REGEX;
+
+	public function __construct(
+		private readonly string $query,
+	) {
+		$this->length = mb_strlen($query);
+	}
+
+	/**
+	 * Matches a regex pattern at the current position in the query string.
+	 * The matched lexeme will be stored in the $lexeme variable.
+	 *
+	 * @param int $offset Current position in the query string
+	 * @param string $regex Regex pattern without delimiters/flags
+	 */
+	public static function match(
+		string $query,
+		int $offset,
+		string $regex,
+		bool $caseInsensitive = false
+	): string|null {
+		// Add delimiters and flags to the regex
+		$regex = '/\G' . $regex . '/u';
+
+		if ($caseInsensitive === true) {
+			$regex .= 'i';
+		}
+
+		if (preg_match($regex, $query, $matches, 0, $offset) !== 1) {
+			return null;
+		}
+
+		return $matches[0];
+	}
+
+	/**
+	 * Scans the source string for a next token
+	 * starting from the given position
+	 *
+	 * @param int $current The current position in the source string
+	 *
+	 * @throws \Exception If an unexpected character is encountered
+	 */
+	public static function token(string $query, int $current): Token
+	{
+		$char = $query[$current];
+
+		// Multi character tokens (check these first):
+		// Whitespace
+		if ($lex = static::match($query, $current, '\s+')) {
+			return new Token(TokenType::T_WHITESPACE, $lex);
+		}
+
+		// true
+		if ($lex = static::match($query, $current, 'true', true)) {
+			return new Token(TokenType::T_TRUE, $lex, true);
+		}
+
+		// false
+		if ($lex = static::match($query, $current, 'false', true)) {
+			return new Token(TokenType::T_FALSE, $lex, false);
+		}
+
+		// null
+		if ($lex = static::match($query, $current, 'null', true)) {
+			return new Token(TokenType::T_NULL, $lex, null);
+		}
+
+		// "string"
+		if ($lex = static::match($query, $current, static::DOUBLEQUOTE_STRING_REGEX)) {
+			return new Token(
+				TokenType::T_STRING,
+				$lex,
+				stripcslashes(substr($lex, 1, -1))
+			);
+		}
+
+		// 'string'
+		if ($lex = static::match($query, $current, static::SINGLEQUOTE_STRING_REGEX)) {
+			return new Token(
+				TokenType::T_STRING,
+				$lex,
+				stripcslashes(substr($lex, 1, -1))
+			);
+		}
+
+		// float (check before single character tokens)
+		$lex = static::match($query, $current, '-?\d+\.\d+\b');
+		if ($lex !== null) {
+			return new Token(TokenType::T_FLOAT, $lex, (float)$lex);
+		}
+
+		// int (check before single character tokens)
+		$lex = static::match($query, $current, '-?\d+\b');
+		if ($lex !== null) {
+			return new Token(TokenType::T_INTEGER, $lex, (int)$lex);
+		}
+
+		// Two character tokens:
+		// ??
+		if ($lex = static::match($query, $current, '\?\?')) {
+			return new Token(TokenType::T_COALESCE, $lex);
+		}
+
+		// ?.
+		if ($lex = static::match($query, $current, '\?\s*\.')) {
+			return new Token(TokenType::T_NULLSAFE, $lex);
+		}
+
+		// ?:
+		if ($lex = static::match($query, $current, '\?\s*:')) {
+			return new Token(TokenType::T_TERNARY_DEFAULT, $lex);
+		}
+
+		// =>
+		if ($lex = static::match($query, $current, '=>')) {
+			return new Token(TokenType::T_ARROW, $lex);
+		}
+
+		// Logical operators (check before comparison operators)
+		if ($lex = static::match($query, $current, '&&|AND')) {
+			return new Token(TokenType::T_AND, $lex);
+		}
+
+		if ($lex = static::match($query, $current, '\|\||OR')) {
+			return new Token(TokenType::T_OR, $lex);
+		}
+
+		// Comparison operators (three characters first, then two, then one)
+		// === (must come before ==)
+		if ($lex = static::match($query, $current, '===')) {
+			return new Token(TokenType::T_IDENTICAL, $lex);
+		}
+
+		// !== (must come before !=)
+		if ($lex = static::match($query, $current, '!==')) {
+			return new Token(TokenType::T_NOT_IDENTICAL, $lex);
+		}
+
+		// <= (must come before <)
+		if ($lex = static::match($query, $current, '<=')) {
+			return new Token(TokenType::T_LESS_EQUAL, $lex);
+		}
+
+		// >= (must come before >)
+		if ($lex = static::match($query, $current, '>=')) {
+			return new Token(TokenType::T_GREATER_EQUAL, $lex);
+		}
+
+		// ==
+		if ($lex = static::match($query, $current, '==')) {
+			return new Token(TokenType::T_EQUAL, $lex);
+		}
+
+		// !=
+		if ($lex = static::match($query, $current, '!=')) {
+			return new Token(TokenType::T_NOT_EQUAL, $lex);
+		}
+
+		// Single character tokens (check these last):
+		$token = match ($char) {
+			'.'     => new Token(TokenType::T_DOT, '.'),
+			'('     => new Token(TokenType::T_OPEN_PAREN, '('),
+			')'     => new Token(TokenType::T_CLOSE_PAREN, ')'),
+			'['     => new Token(TokenType::T_OPEN_BRACKET, '['),
+			']'     => new Token(TokenType::T_CLOSE_BRACKET, ']'),
+			','     => new Token(TokenType::T_COMMA, ','),
+			':'     => new Token(TokenType::T_COLON, ':'),
+			'+'     => new Token(TokenType::T_PLUS, '+'),
+			'-'     => new Token(TokenType::T_MINUS, '-'),
+			'*'     => new Token(TokenType::T_MULTIPLY, '*'),
+			'/'     => new Token(TokenType::T_DIVIDE, '/'),
+			'%'     => new Token(TokenType::T_MODULO, '%'),
+			'?'     => new Token(TokenType::T_QUESTION_MARK, '?'),
+			'<'     => new Token(TokenType::T_LESS_THAN, '<'),
+			'>'     => new Token(TokenType::T_GREATER_THAN, '>'),
+			default => null
+		};
+
+		if ($token !== null) {
+			return $token;
+		}
+
+		// Identifier
+		if ($lex = static::match($query, $current, static::IDENTIFIER_REGEX)) {
+			return new Token(TokenType::T_IDENTIFIER, $lex);
+		}
+
+		// Unknown token
+		throw new Exception('Invalid character in query: ' . $query[$current]);
+	}
+
+	/**
+	 * Tokenizes the query string and returns a generator of tokens.
+	 * @return Generator<Token>
+	 */
+	public function tokens(): Generator
+	{
+		$current = 0;
+
+		while ($current < $this->length) {
+			$token = static::token($this->query, $current);
+
+			// Don't yield whitespace tokens (ignore them)
+			if ($token->type !== TokenType::T_WHITESPACE) {
+				yield $token;
+			}
+
+			$current += mb_strlen($token->lexeme);
+		}
+
+		yield new Token(TokenType::T_EOF, '', null);
+	}
+}

--- a/src/Query/Parser/Tokenizer.php
+++ b/src/Query/Parser/Tokenizer.php
@@ -14,6 +14,7 @@ use Generator;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class Tokenizer
 {

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -9,34 +9,28 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Image\QrCode;
+use Kirby\Query\Runners\Runner;
 use Kirby\Toolkit\I18n;
 
 /**
- * The Query class can be used to query arrays and objects,
- * including their methods with a very simple string-based syntax.
- *
- * Namespace structure - what handles what:
- * - Query			Main interface, direct entries
- * - Expression		Simple comparisons (`a ? b :c`)
- * - Segments		Chain of method calls (`site.find('notes').url`)
- * - Segment		Single method call (`find('notes')`)
- * - Arguments		Method call parameters (`'template', '!=', 'note'`)
- * - Argument		Single parameter, resolving into actual types
+ * The Query class can be used to run expressions on arrays and objects,
+ * including their methods with a very simple string-based syntax
  *
  * @package   Kirby Query
  * @author    Bastian Allgeier <bastian@getkirby.com>,
- * 			  Nico Hoffmann <nico@getkirby.com>
+ *            Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  */
 class Query
 {
-	/**
-	 * Default data entries
-	 */
+	public static array $cache = [];
 	public static array $entries = [];
+
+	public Runner|string $runner;
 
 	/**
 	 * Creates a new Query object
@@ -46,6 +40,17 @@ class Query
 	) {
 		if ($query !== null) {
 			$this->query = trim($query);
+		}
+
+		$this->runner = App::instance()->option('query.runner', 'legacy');
+
+		if ($this->runner !== 'legacy') {
+
+			if (is_subclass_of($this->runner, Runner::class) === false) {
+				throw new InvalidArgumentException("Query runner $this->runner must extend " . Runner::class);
+			}
+
+			$this->runner = $this->runner::for($this);
 		}
 	}
 
@@ -71,6 +76,7 @@ class Query
 	 * can be found, otherwise returns null
 	 *
 	 * @throws \Kirby\Exception\BadMethodCallException If an invalid method is accessed by the query
+	 * @throws \Kirby\Exception\InvalidArgumentException If an invalid query runner is set in the config option
 	 */
 	public function resolve(array|object $data = []): mixed
 	{
@@ -78,6 +84,24 @@ class Query
 			return $data;
 		}
 
+		// TODO: switch to 'interpreted' as default in v6
+		// TODO: remove in v7
+		// @codeCoverageIgnoreStart
+
+		if ($this->runner === 'legacy') {
+			return $this->resolveLegacy($data);
+		}
+		// @codeCoverageIgnoreEnd
+
+		return $this->runner->run($this->query, (array)$data);
+	}
+
+	/**
+	 * @deprecated 5.1.0
+	 * @codeCoverageIgnore
+	 */
+	private function resolveLegacy(array|object $data = []): mixed
+	{
 		// merge data with default entries
 		if (is_array($data) === true) {
 			$data = [...static::$entries, ...$data];

--- a/src/Query/Runners/DefaultRunner.php
+++ b/src/Query/Runners/DefaultRunner.php
@@ -15,6 +15,7 @@ use Kirby\Query\Visitors\DefaultVisitor;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class DefaultRunner extends Runner
 {

--- a/src/Query/Runners/DefaultRunner.php
+++ b/src/Query/Runners/DefaultRunner.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use Closure;
+use Kirby\Query\Parser\Parser;
+use Kirby\Query\Query;
+use Kirby\Query\Visitors\DefaultVisitor;
+
+/**
+ * Runner that caches the AST in memory
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class DefaultRunner extends Runner
+{
+	/**
+	 * Creates a runner for the Query
+	 */
+	public static function for(Query $query): static
+	{
+		return new static(
+			global:      $query::$entries,
+			interceptor: $query->intercept(...),
+			cache:       $query::$cache
+		);
+	}
+
+	protected function resolver(string $query): Closure
+	{
+		// Load closure from cache
+		if (isset($this->cache[$query]) === true) {
+			return $this->cache[$query];
+		}
+
+		// Parse query as AST
+		$parser = new Parser($query);
+		$ast    = $parser->parse();
+
+		// Cache closure to resolve same query
+		return $this->cache[$query] = fn (array $context) => $ast->resolve(
+			new DefaultVisitor($this->global, $context, $this->interceptor)
+		);
+	}
+
+	/**
+	 * Executes a query within a given data context
+	 *
+	 * @param array $context Optional variables to be passed to the query
+	 *
+	 * @throws \Exception when query is invalid or executor not callable
+	 */
+	public function run(string $query, array $context = []): mixed
+	{
+		// Try resolving query directly from data context or global functions
+		$entry = Scope::get($query, $context, $this->global, false);
+
+		if ($entry !== false) {
+			return $entry;
+		}
+
+		return $this->resolver($query)($context);
+	}
+}

--- a/src/Query/Runners/Runner.php
+++ b/src/Query/Runners/Runner.php
@@ -13,6 +13,7 @@ use Kirby\Query\Query;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 abstract class Runner
 {

--- a/src/Query/Runners/Runner.php
+++ b/src/Query/Runners/Runner.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use ArrayAccess;
+use Closure;
+use Kirby\Query\Query;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+abstract class Runner
+{
+	/**
+	 * @param array $global Allowed global function closures
+	 */
+	public function __construct(
+		public array $global = [],
+		protected Closure|null $interceptor = null,
+		protected ArrayAccess|array &$cache = [],
+	) {
+	}
+
+	/**
+	 * Creates a runner instance for the Query
+	 */
+	abstract public static function for(Query $query): static;
+
+	/**
+	 * Executes a query within a given data context
+	 *
+	 * @param array $context Optional variables to be passed to the query
+	 *
+	 * @throws \Exception when query is invalid or executor not callable
+	 */
+	abstract public function run(string $query, array $context = []): mixed;
+}

--- a/src/Query/Runners/Scope.php
+++ b/src/Query/Runners/Scope.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use Closure;
+use Exception;
+
+/**
+ * Helper class to execute logic during runtime
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class Scope
+{
+	/**
+	 * Access the key on the object/array during runtime
+	 */
+	public static function access(
+		array|object|null $object,
+		string|int $key,
+		bool $nullSafe = false,
+		...$arguments
+	): mixed {
+		if ($object === null && $nullSafe === true) {
+			return null;
+		}
+
+		if (is_array($object) === true) {
+			if ($item = $object[$key] ?? $object[(string)$key] ?? null) {
+				if ($arguments) {
+					return $item(...$arguments);
+				}
+
+				if ($item instanceof Closure) {
+					return $item();
+				}
+			}
+
+			return $item;
+		}
+
+		if (is_object($object) === true) {
+			$key = (string)$key;
+
+			if (
+				method_exists($object, $key) === true ||
+				method_exists($object, '__call') === true
+			) {
+				return $object->$key(...$arguments);
+			}
+
+			return $object->$key ?? null;
+		}
+
+		throw new Exception("Cannot access \"$key\" on " . gettype($object));
+	}
+
+	/**
+	 * Resolves a mapping from global context or functions during runtime
+	 */
+	public static function get(
+		string $name,
+		array $context = [],
+		array $global = [],
+		false|null $fallback = null
+	): mixed {
+		// What looks like a variable might actually be a global function
+		// but if there is a variable with the same name,
+		// the variable takes precedence
+		if (isset($context[$name]) === true) {
+			if ($context[$name] instanceof Closure) {
+				return $context[$name]();
+			}
+
+			return $context[$name];
+		}
+
+		if (isset($global[$name]) === true) {
+			return $global[$name]();
+		}
+
+		// Alias to access the global context
+		if ($name === 'this') {
+			return $context;
+		}
+
+		return $fallback;
+	}
+}

--- a/src/Query/Runners/Scope.php
+++ b/src/Query/Runners/Scope.php
@@ -13,6 +13,7 @@ use Exception;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class Scope
 {

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -16,6 +16,8 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @todo Deprecate in v6
  */
 class Segment
 {

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -15,6 +15,8 @@ use Kirby\Toolkit\Collection;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
+ * @todo Deprecate in v6
+ *
  * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
  */
 class Segments extends Collection

--- a/src/Query/Visitors/DefaultVisitor.php
+++ b/src/Query/Visitors/DefaultVisitor.php
@@ -16,6 +16,7 @@ use Kirby\Query\Runners\Scope;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  */
 class DefaultVisitor extends Visitor
 {

--- a/src/Query/Visitors/DefaultVisitor.php
+++ b/src/Query/Visitors/DefaultVisitor.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Kirby\Query\Visitors;
+
+use Closure;
+use Exception;
+use Kirby\Query\AST\ClosureNode;
+use Kirby\Query\Runners\Scope;
+
+/**
+ * Processes a query AST
+ *
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ */
+class DefaultVisitor extends Visitor
+{
+	/**
+	 * Processes list of arguments
+	 */
+	public function arguments(array $arguments): array
+	{
+		return $arguments;
+	}
+
+	/**
+	 * Processes arithmetic operation
+	 */
+	public function arithmetic(
+		int|float $left,
+		string $operator,
+		int|float $right
+	): mixed {
+		return match ($operator) {
+			'+'     => $left + $right,
+			'-'     => $left - $right,
+			'*'     => $left * $right,
+			'/'     => $left / $right,
+			'%'     => $left % $right,
+			default => throw new Exception("Unknown arithmetic operator: $operator")
+		};
+	}
+
+	/**
+	 * Processes array
+	 */
+	public function arrayList(array $elements): array
+	{
+		return $elements;
+	}
+
+	/**
+	 * Processes node into actual closure
+	 */
+	public function closure(ClosureNode $node): Closure
+	{
+		$self = $this;
+
+		return function (...$params) use ($self, $node) {
+			// [key1, key2] + [value1, value2] =>
+			// [key1 => value1, key2 => value2]
+			$arguments = array_combine(
+				$node->arguments,
+				$params
+			);
+
+			// Create new nested visitor with combined
+			// data context for resolving the closure body
+			$visitor = new static(
+				global:      $self->global,
+				context:     [...$self->context, ...$arguments],
+				interceptor: $self->interceptor
+			);
+
+			return $node->body->resolve($visitor);
+		};
+	}
+
+	/**
+	 * Processes coalescence operator
+	 */
+	public function coalescence(mixed $left, mixed $right): mixed
+	{
+		return $left ?? $right;
+	}
+
+	/**
+	 * Processes comparison operation
+	 */
+	public function comparison(
+		mixed $left,
+		string $operator,
+		mixed $right
+	): bool {
+		return match ($operator) {
+			'=='    => $left == $right,
+			'==='   => $left === $right,
+			'!='    => $left != $right,
+			'!=='   => $left !== $right,
+			'<'     => $left < $right,
+			'<='    => $left <= $right,
+			'>'     => $left > $right,
+			'>='    => $left >= $right,
+			default => throw new Exception("Unknown comparison operator: $operator")
+		};
+	}
+
+	/**
+	 * Processes global function
+	 */
+	public function function(string $name, array $arguments = []): mixed
+	{
+		$function = $this->global[$name] ?? null;
+
+		if ($function === null) {
+			throw new Exception("Invalid global function in query: $name");
+		}
+
+		return $function(...$arguments);
+	}
+
+	/**
+	 * Processes literals
+	 */
+	public function literal(mixed $value): mixed
+	{
+		return $value;
+	}
+
+	/**
+	 * Processes logical operation
+	 */
+	public function logical(
+		mixed $left,
+		string $operator,
+		mixed $right
+	): bool {
+		return match ($operator) {
+			'&&', 'AND' => $left && $right,
+			'||', 'OR'  => $left || $right,
+			default     => throw new Exception("Unknown logical operator: $operator")
+		};
+	}
+
+	/**
+	 * Processes member access
+	 */
+	public function memberAccess(
+		mixed $object,
+		string|int $member,
+		array|null $arguments = null,
+		bool $nullSafe = false
+	): mixed {
+		if ($this->interceptor !== null) {
+			$object = ($this->interceptor)($object);
+		}
+
+		return Scope::access($object, $member, $nullSafe, ...$arguments ?? []);
+	}
+
+	/**
+	 * Processes ternary operator
+	 */
+	public function ternary(
+		mixed $condition,
+		mixed $true,
+		mixed $false
+	): mixed {
+		if ($true === null) {
+			return $condition ?: $false;
+		}
+
+		return $condition ? $true : $false;
+	}
+
+	/**
+	 * Get variable from context or global function
+	 */
+	public function variable(string $name): mixed
+	{
+		return Scope::get($name, $this->context, $this->global);
+	}
+}

--- a/src/Query/Visitors/Visitor.php
+++ b/src/Query/Visitors/Visitor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kirby\Query\Visitors;
+
+use Closure;
+
+/**
+ * @package   Kirby Query
+ * @author    Roman Steiner <roman@toastlab.ch>,
+ *            Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.1.0
+ *
+ * Every visitor class must implement the following methods.
+ * As PHP won't allow increasing the typing specificity, we
+ * aren't actually adding them here in the abstract class, so that
+ * the actual visitor classes can work with much more specific type hints.
+ *
+ * @method mixed arguments(array $arguments)
+ * @method mixed arithmetic(mixed $left, string $operator, mixed $right)
+ * @method mixed arrayList(array $elements)
+ * @method mixed closure($ClosureNode $node))
+ * @method mixed coalescence($left, $right)
+ * @method mixed comparison(mixed $left, string $operator, mixed $right)
+ * @method mixed function($name, $arguments)
+ * @method mixed literal($value)
+ * @method mixed logical(mixed $left, string $operator, mixed $right)
+ * @method mixed memberAccess($object, string|int $member, $arguments, bool $nullSafe = false)
+ * @method mixed ternary($condition, $true, $false)
+ * @method mixed variable(string $name)
+ */
+abstract class Visitor
+{
+	/**
+	 * @param array<string,Closure> $global valid global function closures
+	 * @param array<string,mixed> $context data bindings for the query
+	 */
+	public function __construct(
+		public array $global = [],
+		public array $context = [],
+		protected Closure|null $interceptor = null
+	) {
+	}
+}

--- a/src/Query/Visitors/Visitor.php
+++ b/src/Query/Visitors/Visitor.php
@@ -11,6 +11,7 @@ use Closure;
  * @link      https://getkirby.com
  * @license   https://opensource.org/licenses/MIT
  * @since     5.1.0
+ * @unstable
  *
  * Every visitor class must implement the following methods.
  * As PHP won't allow increasing the typing specificity, we

--- a/tests/Query/AST/ArgumentListNodeTest.php
+++ b/tests/Query/AST/ArgumentListNodeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ArgumentListNode::class)]
+class ArgumentListNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new ArgumentListNode([
+			new LiteralNode('a'),
+			new LiteralNode(7)
+		]);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(['a', 7], $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/ArithmeticNodeTest.php
+++ b/tests/Query/AST/ArithmeticNodeTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use DivisionByZeroError;
+use Exception;
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ArithmeticNode::class)]
+class ArithmeticNodeTest extends TestCase
+{
+	public static function arithmeticProvider(): array
+	{
+		return [
+			['+', 5, 3, 8],
+			['-', 5, 3, 2],
+			['*', 5, 3, 15],
+			['/', 6, 2, 3],
+			['%', 7, 3, 1],
+		];
+	}
+
+	#[DataProvider('arithmeticProvider')]
+	public function testResolve(
+		string $operator,
+		int|float $left,
+		int|float $right,
+		int|float $expected
+	): void {
+		$node = new ArithmeticNode(
+			left: new LiteralNode($left),
+			operator: $operator,
+			right: new LiteralNode($right)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame($expected, $node->resolve($visitor));
+	}
+
+	public function testResolveWithVariables(): void
+	{
+		$node = new ArithmeticNode(
+			left: new VariableNode('a'),
+			operator: '+',
+			right: new VariableNode('b')
+		);
+
+		$context = ['a' => 5, 'b' => 3];
+
+		$visitor = new DefaultVisitor(context: $context);
+		$this->assertSame(8, $node->resolve($visitor));
+	}
+
+	public function testResolveWithComplexExpressions(): void
+	{
+		$node = new ArithmeticNode(
+			left: new ArithmeticNode(
+				left: new LiteralNode(2),
+				operator: '*',
+				right: new LiteralNode(3)
+			),
+			operator: '+',
+			right: new LiteralNode(4)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(10, $node->resolve($visitor));
+	}
+
+	public function testResolveWithFloats(): void
+	{
+		$node = new ArithmeticNode(
+			left: new LiteralNode(5.5),
+			operator: '*',
+			right: new LiteralNode(2.0)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(11.0, $node->resolve($visitor));
+	}
+
+	public function testResolveWithNegativeNumbers(): void
+	{
+		$node = new ArithmeticNode(
+			left: new LiteralNode(-5),
+			operator: '+',
+			right: new LiteralNode(3)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(-2, $node->resolve($visitor));
+	}
+
+	public function testResolveWithDivisionByZero(): void
+	{
+		$node = new ArithmeticNode(
+			left: new LiteralNode(5),
+			operator: '/',
+			right: new LiteralNode(0)
+		);
+
+		// Visitor should throw exception for division by zero
+		$visitor = new DefaultVisitor();
+		$this->expectException(DivisionByZeroError::class);
+		$node->resolve($visitor);
+	}
+
+	public function testResolveWithModuloByZero(): void
+	{
+		$node = new ArithmeticNode(
+			left: new LiteralNode(5),
+			operator: '%',
+			right: new LiteralNode(0)
+		);
+
+		// Visitor should throw exception for modulo by zero
+		$visitor = new DefaultVisitor();
+		$this->expectException(DivisionByZeroError::class);
+		$node->resolve($visitor);
+	}
+
+	public function testResolveWithInvalidOperator(): void
+	{
+		$node = new ArithmeticNode(
+			left: new LiteralNode(5),
+			operator: '^',
+			right: new LiteralNode(3)
+		);
+
+		// Visitor should throw exception for invalid operator
+		$visitor = new DefaultVisitor();
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Unknown arithmetic operator: ^');
+		$node->resolve($visitor);
+	}
+}

--- a/tests/Query/AST/ArrayListNodeTest.php
+++ b/tests/Query/AST/ArrayListNodeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ArrayListNode::class)]
+class ArrayListNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new ArrayListNode([
+			new LiteralNode('a'),
+			new LiteralNode(7)
+		]);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(['a', 7], $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/ClosureNodeTest.php
+++ b/tests/Query/AST/ClosureNodeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ClosureNode::class)]
+class ClosureNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new ClosureNode(
+			arguments: ['a', 'b'],
+			body: new CoalesceNode(
+				left: new VariableNode('a'),
+				right: new VariableNode('b')
+			)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertEquals(fn ($a, $b) => $a ?? $b, $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/CoalesceNodeTest.php
+++ b/tests/Query/AST/CoalesceNodeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(CoalesceNode::class)]
+class CoalesceNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new CoalesceNode(
+			left: new LiteralNode(null),
+			right: new LiteralNode('foo')
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame('foo', $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/ComparisonNodeTest.php
+++ b/tests/Query/AST/ComparisonNodeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+
+class ComparisonNodeTest extends TestCase
+{
+	public function testResolve()
+	{
+		$node = new ComparisonNode(
+			left: new LiteralNode(5),
+			operator: '==',
+			right: new LiteralNode(5)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertTrue($node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/GlobalFunctionNodeTest.php
+++ b/tests/Query/AST/GlobalFunctionNodeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(GlobalFunctionNode::class)]
+class GlobalFunctionNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new GlobalFunctionNode(
+			name: 'foo',
+			arguments: new ArgumentListNode([
+				new LiteralNode(3),
+				new LiteralNode(7)
+			])
+		);
+
+		$functions = ['foo' => fn ($a, $b) => $a + $b];
+
+		$visitor = new DefaultVisitor(global: $functions);
+		$this->assertSame(10, $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/LiteralNodeTest.php
+++ b/tests/Query/AST/LiteralNodeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LiteralNode::class)]
+class LiteralNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new LiteralNode('a');
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame('a', $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/LogicalNodeTest.php
+++ b/tests/Query/AST/LogicalNodeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+
+class LogicalNodeTest extends TestCase
+{
+	public function testResolveAnd()
+	{
+		$node = new LogicalNode(
+			left: new LiteralNode(true),
+			operator: '&&',
+			right: new LiteralNode(false)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertFalse($node->resolve($visitor));
+	}
+
+	public function testResolveOr()
+	{
+		$node = new LogicalNode(
+			left: new LiteralNode(false),
+			operator: '||',
+			right: new LiteralNode(true)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertTrue($node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/MemberAccessNodeTest.php
+++ b/tests/Query/AST/MemberAccessNodeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(MemberAccessNode::class)]
+class MemberAccessNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new MemberAccessNode(
+			new VariableNode('user'),
+			new LiteralNode('name')
+		);
+
+		$context = ['user' => new class () {
+			public function name(): string
+			{
+				return 'foo';
+			}
+		}];
+
+		$visitor = new DefaultVisitor(context: $context);
+		$this->assertSame('foo', $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/TernaryNodeTest.php
+++ b/tests/Query/AST/TernaryNodeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TernaryNode::class)]
+class TernaryNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new TernaryNode(
+			condition: new LiteralNode(false),
+			false: new LiteralNode(5.0)
+		);
+
+		$visitor = new DefaultVisitor();
+		$this->assertSame(5.0, $node->resolve($visitor));
+	}
+}

--- a/tests/Query/AST/VariableNodeTest.php
+++ b/tests/Query/AST/VariableNodeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirby\Query\AST;
+
+use Kirby\Query\Visitors\DefaultVisitor;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(VariableNode::class)]
+class VariableNodeTest extends TestCase
+{
+	public function testResolve(): void
+	{
+		$node = new VariableNode('a');
+
+		$visitor = new DefaultVisitor(context: ['a' => 'foo']);
+		$this->assertSame('foo', $node->resolve($visitor));
+	}
+}

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -4,17 +4,15 @@ namespace Kirby\Query;
 
 use Closure;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * @coversDefaultClass \Kirby\Query\Argument
+ * @todo Deprecate in v6
  */
+#[CoversClass(Argument::class)]
 class ArgumentTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		// strings
 		$argument = Argument::factory(" ' 23 '  ");
@@ -63,10 +61,7 @@ class ArgumentTest extends TestCase
 		$this->assertSame('foo', $argument->value);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolve()
+	public function testResolve(): void
 	{
 		// strings
 		$argument = Argument::factory(" ' 23 '  ")->resolve();
@@ -81,11 +76,7 @@ class ArgumentTest extends TestCase
 		$this->assertSame('bar', $argument);
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::resolve
-	 */
-	public function testWithClosure()
+	public function testWithClosure(): void
 	{
 		$argument = Argument::factory('() => site.children');
 		$this->assertInstanceOf(Closure::class, $argument->value);

--- a/tests/Query/ArgumentsTest.php
+++ b/tests/Query/ArgumentsTest.php
@@ -3,16 +3,15 @@
 namespace Kirby\Query;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * @coversDefaultClass \Kirby\Query\Arguments
+ * @todo Deprecate in v6
  */
+#[CoversClass(Arguments::class)]
 class ArgumentsTest extends TestCase
 {
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$arguments = Arguments::factory('1, 2, 3');
 		$this->assertCount(3, $arguments);
@@ -30,10 +29,7 @@ class ArgumentsTest extends TestCase
 		$this->assertCount(3, $arguments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolve()
+	public function testResolve(): void
 	{
 		$arguments = Arguments::factory('1, 2.3, 3');
 		$this->assertSame([1, 2.3, 3], $arguments->resolve());

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -4,17 +4,16 @@ namespace Kirby\Query;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @coversDefaultClass \Kirby\Query\Expression
+ * @todo Deprecate in v6
  */
+#[CoversClass(Expression::class)]
 class ExpressionTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$expression = Expression::factory('a ? b : c');
 		$this->assertCount(5, $expression->parts);
@@ -25,10 +24,7 @@ class ExpressionTest extends TestCase
 		$this->assertInstanceOf(Argument::class, $expression->parts[4]);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithoutComparison()
+	public function testFactoryWithoutComparison(): void
 	{
 		$expression = Expression::factory('foo.bar(true).url');
 		$this->assertInstanceOf(Segments::class, $expression);
@@ -72,11 +68,8 @@ class ExpressionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
-	public function testParse(string $expression, array $result)
+	#[DataProvider('parseProvider')]
+	public function testParse(string $expression, array $result): void
 	{
 		$parts = Expression::parse($expression);
 		$this->assertSame($result, $parts);
@@ -96,30 +89,21 @@ class ExpressionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider resolveProvider
-	 */
-	public function testResolve(string $input, mixed $result)
+	#[DataProvider('resolveProvider')]
+	public function testResolve(string $input, mixed $result): void
 	{
 		$expression = Expression::factory($input);
 		$this->assertSame($result, $expression->resolve());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObject()
+	public function testResolveWithObject(): void
 	{
 		$expression = Expression::factory('user.isYello(true) ? user.says("me") : "you"');
 		$data = ['user' => new TestUser()];
 		$this->assertSame('me', $expression->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveIncompleteTernary()
+	public function testResolveIncompleteTernary(): void
 	{
 		$expression = Expression::factory('"a" ? "b"');
 

--- a/tests/Query/Parser/ParserTest.php
+++ b/tests/Query/Parser/ParserTest.php
@@ -1,0 +1,633 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+use Exception;
+use Kirby\Query\AST\ArgumentListNode;
+use Kirby\Query\AST\ArithmeticNode;
+use Kirby\Query\AST\ArrayListNode;
+use Kirby\Query\AST\ClosureNode;
+use Kirby\Query\AST\CoalesceNode;
+use Kirby\Query\AST\ComparisonNode;
+use Kirby\Query\AST\GlobalFunctionNode;
+use Kirby\Query\AST\LiteralNode;
+use Kirby\Query\AST\MemberAccessNode;
+use Kirby\Query\AST\TernaryNode;
+use Kirby\Query\AST\VariableNode;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+
+#[CoversClass(Parser::class)]
+class ParserTest extends TestCase
+{
+	public function testConstructor(): void
+	{
+		$parser = new Parser('user.name');
+		$this->assertSame('user', $parser->current()->lexeme);
+	}
+
+	public function testAdvance(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$advance = $class->getMethod('advance');
+
+		$this->assertSame(TokenType::T_IDENTIFIER, $parser->current()->type);
+		$advance->invoke($parser);
+		$this->assertSame(TokenType::T_DOT, $parser->current()->type);
+		$advance->invoke($parser);
+		$this->assertSame(TokenType::T_IDENTIFIER, $parser->current()->type);
+		$advance->invoke($parser);
+		$this->assertSame(TokenType::T_EOF, $parser->current()->type);
+		$advance->invoke($parser);
+		$this->assertSame(TokenType::T_EOF, $parser->current()->type);
+	}
+
+	public function testArgumentList(): void
+	{
+		$parser = new Parser('site.method(a, b, c)');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				object: new VariableNode('site'),
+				member: new LiteralNode('method'),
+				arguments: new ArgumentListNode([
+					new VariableNode('a'),
+					new VariableNode('b'),
+					new VariableNode('c'),
+				])
+			),
+			$ast
+		);
+	}
+
+	public function testArithmetic(): void
+	{
+		$parser = new Parser('2 + 3 * 4');
+		$ast = $parser->parse();
+
+		// Should parse as: 2 + (3 * 4) due to operator precedence
+		$this->assertEquals(
+			new ArithmeticNode(
+				left: new LiteralNode(2),
+				operator: '+',
+				right: new ArithmeticNode(
+					left: new LiteralNode(3),
+					operator: '*',
+					right: new LiteralNode(4)
+				)
+			),
+			$ast
+		);
+	}
+
+	public function testArray(): void
+	{
+		$parser = new Parser('[1, 2, 3]');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ArrayListNode([
+				new LiteralNode(1),
+				new LiteralNode(2),
+				new LiteralNode(3)
+			]),
+			$ast
+		);
+
+		// no array to parse/consume
+		$parser = new Parser('foo');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new VariableNode('foo'),
+			$ast
+		);
+	}
+
+	public function testCoalesce(): void
+	{
+		$parser = new Parser('a ?? b');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new CoalesceNode(
+				new VariableNode('a'),
+				new VariableNode('b')
+			),
+			$ast
+		);
+	}
+
+	public static function operatorProvider(): array
+	{
+		return [
+			['==',  'T_EQUAL'],
+			['===', 'T_IDENTICAL'],
+			['!=',  'T_NOT_EQUAL'],
+			['!==', 'T_NOT_IDENTICAL'],
+			['<',   'T_LESS_THAN'],
+			['<=',  'T_LESS_EQUAL'],
+			['>',   'T_GREATER_THAN'],
+			['>=',  'T_GREATER_EQUAL']
+		];
+	}
+
+	#[DataProvider('operatorProvider')]
+	public function testComparison(string $operator): void
+	{
+		$parser = new Parser("a $operator b");
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new VariableNode('a'),
+				operator: $operator,
+				right: new VariableNode('b')
+			),
+			$ast,
+			"Failed for operator: $operator"
+		);
+	}
+
+	public function testComparisonWithLiterals(): void
+	{
+		$parser = new Parser('user.age > 18');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new MemberAccessNode(
+					object: new VariableNode('user'),
+					member: new LiteralNode('age')
+				),
+				operator: '>',
+				right: new LiteralNode(18)
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonWithStrings(): void
+	{
+		$parser = new Parser('user.name == "John"');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new MemberAccessNode(
+					object: new VariableNode('user'),
+					member: new LiteralNode('name')
+				),
+				operator: '==',
+				right: new LiteralNode('John')
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonChaining(): void
+	{
+		$parser = new Parser('a < b <= c');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new ComparisonNode(
+					left: new VariableNode('a'),
+					operator: '<',
+					right: new VariableNode('b')
+				),
+				operator: '<=',
+				right: new VariableNode('c')
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonWithTernary(): void
+	{
+		$parser = new Parser('user.age >= 18 ? "adult" : "minor"');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new TernaryNode(
+				condition: new ComparisonNode(
+					left: new MemberAccessNode(
+						object: new VariableNode('user'),
+						member: new LiteralNode('age')
+					),
+					operator: '>=',
+					right: new LiteralNode(18)
+				),
+				true: new LiteralNode('adult'),
+				false: new LiteralNode('minor')
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonWithCoalesce(): void
+	{
+		$parser = new Parser('(user.score ?? 0) > 100');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new CoalesceNode(
+					left: new MemberAccessNode(
+						object: new VariableNode('user'),
+						member: new LiteralNode('score')
+					),
+					right: new LiteralNode(0)
+				),
+				operator: '>',
+				right: new LiteralNode(100)
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonWithFunctionCalls(): void
+	{
+		$parser = new Parser('user.children.count() > 5');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new MemberAccessNode(
+					object: new MemberAccessNode(
+						object: new VariableNode('user'),
+						member: new LiteralNode('children')
+					),
+					member: new LiteralNode('count'),
+					arguments: new ArgumentListNode([])
+				),
+				operator: '>',
+				right: new LiteralNode(5)
+			),
+			$ast
+		);
+	}
+
+	public function testComparisonPrecedence(): void
+	{
+		$parser = new Parser('user.age > 18');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ComparisonNode(
+				left: new MemberAccessNode(
+					object: new VariableNode('user'),
+					member: new LiteralNode('age')
+				),
+				operator: '>',
+				right: new LiteralNode(18)
+			),
+			$ast
+		);
+	}
+
+	public function testConsume(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consume');
+		$token   = $consume->invokeArgs($parser, [TokenType::T_IDENTIFIER]);
+		$this->assertSame('user', $token->lexeme);
+	}
+
+	public function testConsumeInvalidType(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consume');
+		$this->assertFalse($consume->invokeArgs($parser, [TokenType::T_TRUE]));
+	}
+
+	public function testConsumeAny(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consumeAny');
+		$token   = $consume->invokeArgs($parser, [[TokenType::T_IDENTIFIER, TokenType::T_DOT]]);
+		$this->assertSame('user', $token->lexeme);
+	}
+
+	public function testConsumeInvalidTypeInvalidType(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consumeAny');
+		$this->assertFalse($consume->invokeArgs($parser, [[TokenType::T_TRUE, TokenType::T_FALSE]]));
+	}
+
+	public function testConsumeInvalidTypeCustomError(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consume');
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('foo');
+		$consume->invokeArgs($parser, [TokenType::T_TRUE, 'foo']);
+	}
+
+	public function testConsumeList(): void
+	{
+		$parser  = new Parser('1, 2)');
+		$class   = new ReflectionClass($parser);
+		$consume = $class->getMethod('consumeList');
+		$list    = $consume->invokeArgs($parser, [TokenType::T_CLOSE_PAREN]);
+		$this->assertEquals([new LiteralNode(1), new LiteralNode(2)], $list);
+	}
+
+	public function testGrouping(): void
+	{
+		// groupings
+		$parser = new Parser('(a ?: b)');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new TernaryNode(
+				new VariableNode('a'),
+				new VariableNode('b'),
+				null,
+				true
+			),
+			$ast
+		);
+
+		// closure
+		$parser = new Parser('(a, b) => a');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new ClosureNode(
+				['a', 'b'],
+				new VariableNode('a')
+			),
+			$ast
+		);
+	}
+
+	public function testGroupingClosureInvalidArgument(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Expecting only variables in closure argument list');
+
+		$parser = new Parser('(a, 2) => a');
+		$parser->parse();
+	}
+
+	public function testGroupingClosureInvalidNotation(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Expecting "=>" after closure argument list');
+
+		$parser = new Parser('(a, b) a');
+		$parser->parse();
+	}
+
+	public function testIdentifier(): void
+	{
+		// global functions
+		$parser = new Parser('user("editor")');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new GlobalFunctionNode(
+				'user',
+				new ArgumentListNode([
+					new LiteralNode('editor')
+				])
+			),
+			$ast
+		);
+
+		// variable
+		$parser = new Parser('user');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new VariableNode('user'),
+			$ast
+		);
+
+		// no identifier to parse/consume
+		$parser = new Parser('(1 ?? 2)');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new CoalesceNode(
+				left: new LiteralNode(1),
+				right: new LiteralNode(2)
+			),
+			$ast
+		);
+	}
+
+	public function testIs(): void
+	{
+		$parser = new Parser('user.name');
+		$class  = new ReflectionClass($parser);
+		$is     = $class->getMethod('is');
+
+		$this->assertTrue($is->invokeArgs($parser, [TokenType::T_IDENTIFIER]));
+
+		$advance = $class->getMethod('advance');
+		$advance->invoke($parser);
+		$advance->invoke($parser);
+		$advance->invoke($parser);
+
+		$this->assertFalse($is->invokeArgs($parser, [TokenType::T_IDENTIFIER]));
+	}
+
+	public function testIsAtEnd(): void
+	{
+		$parser  = new Parser('user.name');
+		$class   = new ReflectionClass($parser);
+		$isAtEnd = $class->getMethod('isAtEnd');
+
+		$this->assertFalse($isAtEnd->invoke($parser));
+
+		$advance = $class->getMethod('advance');
+		$advance->invoke($parser);
+		$this->assertFalse($isAtEnd->invoke($parser));
+
+		$advance->invoke($parser);
+		$this->assertFalse($isAtEnd->invoke($parser));
+
+		$advance->invoke($parser);
+		$this->assertTrue($isAtEnd->invoke($parser));
+	}
+
+	public function testMemberAccess(): void
+	{
+		$parser = new Parser('user.name');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				new VariableNode('user'),
+				new LiteralNode('name')
+			),
+			$ast
+		);
+	}
+
+	public function testMemberAccessIntegerIndex(): void
+	{
+		$parser = new Parser('user.1');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				new VariableNode('user'),
+				new LiteralNode(1)
+			),
+			$ast
+		);
+	}
+
+	public function testMemberAccessSubscriptString(): void
+	{
+		$parser = new Parser('user["This.is the key"](2)');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				new VariableNode('user'),
+				new LiteralNode('This.is the key'),
+				arguments: new ArgumentListNode([
+					new LiteralNode(2)
+				])
+			),
+			$ast
+		);
+	}
+
+	public function testMemberAccessSubscriptExpression(): void
+	{
+		$parser = new Parser('user[page.id]');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				new VariableNode('user'),
+				new MemberAccessNode(
+					new VariableNode('page'),
+					new LiteralNode('id')
+				)
+			),
+			$ast
+		);
+	}
+
+	public function testMemberAccessSequential(): void
+	{
+		$parser = new Parser('user.name("arg").age');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new MemberAccessNode(
+				new MemberAccessNode(
+					new VariableNode('user'),
+					new LiteralNode('name'),
+					new ArgumentListNode([new LiteralNode('arg')])
+				),
+				new LiteralNode('age')
+			),
+			$ast
+		);
+	}
+
+	public function testMemberAccessInvalid(): void
+	{
+		$parser = new Parser('user.true');
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Expect property name after "."');
+		$parser->parse();
+	}
+
+	public function testParse(): void
+	{
+		$parser = new Parser('site.method(5) ?: ("fox" ?? false)');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new TernaryNode(
+				condition: new MemberAccessNode(
+					object: new VariableNode('site'),
+					member: new LiteralNode('method'),
+					arguments: new ArgumentListNode([
+						new LiteralNode(5)
+					])
+				),
+				false: new CoalesceNode(
+					left: new LiteralNode('fox'),
+					right: new LiteralNode(false),
+				)
+			),
+			$ast
+		);
+	}
+
+	public function testScalar(): void
+	{
+		$parser = new Parser('true');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new LiteralNode(true),
+			$ast
+		);
+
+		$parser = new Parser('-5.74');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new LiteralNode(-5.74),
+			$ast
+		);
+
+		// no scalar to parse
+		$parser = new Parser('user');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new VariableNode('user'),
+			$ast
+		);
+	}
+
+	public function testTernary(): void
+	{
+		$parser = new Parser('true ? 2 : 5.0');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new TernaryNode(
+				condition: new LiteralNode(true),
+				true: new LiteralNode(2),
+				false: new LiteralNode(5.0),
+			),
+			$ast
+		);
+
+		$parser = new Parser('"foo" ?: \'bar\'');
+		$ast    = $parser->parse();
+
+		$this->assertEquals(
+			new TernaryNode(
+				condition: new LiteralNode('foo'),
+				false: new LiteralNode('bar')
+			),
+			$ast
+		);
+	}
+}

--- a/tests/Query/Parser/TokenTest.php
+++ b/tests/Query/Parser/TokenTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Token::class)]
+class TokenTest extends TestCase
+{
+	public function testToken(): void
+	{
+		$token = new Token(
+			type: $type = TokenType::T_FLOAT,
+			lexeme: $lexeme = '4.3',
+			literal: $literal = 4.3
+		);
+
+		$this->assertSame($type, $token->type);
+		$this->assertSame($lexeme, $token->lexeme);
+		$this->assertSame($literal, $token->literal);
+
+		$token = new Token(
+			type: $type = TokenType::T_IDENTIFIER,
+			lexeme: $lexeme = 'page'
+		);
+
+		$this->assertSame($type, $token->type);
+		$this->assertSame($lexeme, $token->lexeme);
+		$this->assertNull($token->literal);
+	}
+
+	public function testIs(): void
+	{
+		$token = new Token(
+			type: TokenType::T_FLOAT,
+			lexeme: '4.3',
+		);
+
+		$this->assertTrue($token->is(TokenType::T_FLOAT));
+		$this->assertFalse($token->is(TokenType::T_INTEGER));
+	}
+}

--- a/tests/Query/Parser/TokenizerTest.php
+++ b/tests/Query/Parser/TokenizerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Kirby\Query\Parser;
+
+use Exception;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(Tokenizer::class)]
+class TokenizerTest extends TestCase
+{
+	public function testMatch(): void
+	{
+		$string = 'Find ?? a TRUE';
+
+		$this->assertNull(Tokenizer::match($string, 0, '\?\?'));
+		$this->assertSame('??', Tokenizer::match($string, 5, '\?\?'));
+
+		$this->assertNull(Tokenizer::match($string, 10, 'true'));
+		$this->assertSame('TRUE', Tokenizer::match($string, 10, 'true', true));
+	}
+
+	public static function stringProvider(): string
+	{
+		return 'site.method?.([\'number\' => 3], null) ? (true ?: 4.1) : ("fox" ?? false)';
+	}
+
+	public static function tokenProvider(): array
+	{
+		return [
+			[0, TokenType::T_IDENTIFIER, 'site'],
+			[4, TokenType::T_DOT, '.'],
+			[5, TokenType::T_IDENTIFIER, 'method'],
+			[11, TokenType::T_NULLSAFE, '?.'],
+			[13, TokenType::T_OPEN_PAREN, '('],
+			[14, TokenType::T_OPEN_BRACKET, '['],
+			[15, TokenType::T_STRING, '\'number\'', 'number'],
+			[23, TokenType::T_WHITESPACE, ' '],
+			[24, TokenType::T_ARROW, '=>'],
+			[27, TokenType::T_INTEGER, '3', 3],
+			[28, TokenType::T_CLOSE_BRACKET, ']'],
+			[29, TokenType::T_COMMA, ','],
+			[31, TokenType::T_NULL, 'null', null],
+			[35, TokenType::T_CLOSE_PAREN, ')'],
+			[37, TokenType::T_QUESTION_MARK, '?'],
+			[39, TokenType::T_OPEN_PAREN, '('],
+			[40, TokenType::T_TRUE, 'true', true],
+			[45, TokenType::T_TERNARY_DEFAULT, '?:'],
+			[48, TokenType::T_FLOAT, '4.1', 4.1],
+			[51, TokenType::T_CLOSE_PAREN, ')'],
+			[53, TokenType::T_COLON, ':'],
+			[55, TokenType::T_OPEN_PAREN, '('],
+			[56, TokenType::T_STRING, '"fox"', 'fox'],
+			[62, TokenType::T_COALESCE, '??'],
+			[65, TokenType::T_FALSE, 'false', false],
+			[70, TokenType::T_CLOSE_PAREN, ')']
+		];
+	}
+
+	#[DataProvider('tokenProvider')]
+	public function testToken(
+		int $offset,
+		TokenType $type,
+		string $lexeme,
+		mixed $literal = null
+	): void {
+		$string = static::stringProvider();
+		$token  = Tokenizer::token($string, $offset);
+		$this->assertSame($type, $token->type);
+		$this->assertSame($lexeme, $token->lexeme);
+		$this->assertSame($literal, $token->literal);
+	}
+
+	public function testTokenInvalidCharacter(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Invalid character in query: @');
+		Tokenizer::token('a ?? @', 5);
+	}
+
+	public function testTokens(): void
+	{
+		$string    = static::stringProvider();
+		$tokenizer = new Tokenizer($string);
+		$tokens    = $tokenizer->tokens();
+
+		foreach (static::tokenProvider() as $expected) {
+			if ($expected[1] === TokenType::T_WHITESPACE) {
+				continue;
+			}
+
+			$token = $tokens->current();
+			$this->assertSame($expected[1], $token->type);
+			$this->assertSame($expected[2], $token->lexeme);
+			$this->assertSame($expected[3] ?? null, $token->literal);
+			$tokens->next();
+		}
+
+		$token = $tokens->current();
+		$this->assertSame(TokenType::T_EOF, $token->type);
+	}
+
+	public function testTokensWithCoalesceWithZero(): void
+	{
+		$query = '(user.score ?? 0) > 100';
+		$tokenizer = new Tokenizer($query);
+		$tokens = iterator_to_array($tokenizer->tokens());
+
+		$expected = [
+			TokenType::T_OPEN_PAREN,
+			TokenType::T_IDENTIFIER,    // user
+			TokenType::T_DOT,
+			TokenType::T_IDENTIFIER,    // score
+			TokenType::T_COALESCE,      // ??
+			TokenType::T_INTEGER,       // 0
+			TokenType::T_CLOSE_PAREN,
+			TokenType::T_GREATER_THAN,  // >
+			TokenType::T_INTEGER,        // 100
+			TokenType::T_EOF
+		];
+
+		$this->assertSame($expected, array_map(fn ($t) => $t->type, $tokens));
+
+		$this->assertSame('user', $tokens[1]->lexeme);
+		$this->assertSame('score', $tokens[3]->lexeme);
+		$this->assertSame('??', $tokens[4]->lexeme);
+		$this->assertSame('0', $tokens[5]->lexeme);
+		$this->assertSame(0, $tokens[5]->literal);
+		$this->assertSame('>', $tokens[7]->lexeme);
+		$this->assertSame('100', $tokens[8]->lexeme);
+		$this->assertSame(100, $tokens[8]->literal);
+	}
+
+	public static function comparisonTokenProvider(): array
+	{
+		return [
+			['a == b',  2, TokenType::T_EQUAL, '=='],
+			['a === b', 2, TokenType::T_IDENTICAL, '==='],
+			['a != b',  2, TokenType::T_NOT_EQUAL, '!='],
+			['a !== b', 2, TokenType::T_NOT_IDENTICAL, '!=='],
+			['a < b',   2, TokenType::T_LESS_THAN, '<'],
+			['a <= b',  2, TokenType::T_LESS_EQUAL, '<='],
+			['a > b',   2, TokenType::T_GREATER_THAN, '>'],
+			['a >= b',  2, TokenType::T_GREATER_EQUAL, '>='],
+		];
+	}
+
+	#[DataProvider('comparisonTokenProvider')]
+	public function testTokensWithComparisonOperators(
+		string $query,
+		int $offset,
+		TokenType $expectedType,
+		string $expectedLexeme
+	): void {
+		$token = Tokenizer::token($query, $offset);
+		$this->assertSame($expectedType, $token->type);
+		$this->assertSame($expectedLexeme, $token->lexeme);
+	}
+
+	public function testTokensWithLogicalOperatorsAndMemberAccess(): void
+	{
+		$query 	   = 'user.isAdmin && user.hasPermission';
+		$tokenizer = new Tokenizer($query);
+		$tokens    = iterator_to_array($tokenizer->tokens());
+
+		$expected = [
+			TokenType::T_IDENTIFIER,
+			TokenType::T_DOT,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_AND,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_DOT,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_EOF,
+		];
+
+		$this->assertSame($expected, array_map(fn ($t) => $t->type, $tokens));
+	}
+
+	public function testTokensWithComparisonOperatorsPrecedence(): void
+	{
+		// Test that longer operators are matched before shorter ones
+		$query = 'a === b';
+		$token = Tokenizer::token($query, 2);
+		$this->assertSame(TokenType::T_IDENTICAL, $token->type);
+		$this->assertSame('===', $token->lexeme);
+
+		$query = 'a !== b';
+		$token = Tokenizer::token($query, 2);
+		$this->assertSame(TokenType::T_NOT_IDENTICAL, $token->type);
+		$this->assertSame('!==', $token->lexeme);
+
+		$query = 'a <= b';
+		$token = Tokenizer::token($query, 2);
+		$this->assertSame(TokenType::T_LESS_EQUAL, $token->type);
+		$this->assertSame('<=', $token->lexeme);
+
+		$query = 'a >= b';
+		$token = Tokenizer::token($query, 2);
+		$this->assertSame(TokenType::T_GREATER_EQUAL, $token->type);
+		$this->assertSame('>=', $token->lexeme);
+	}
+
+	public function testTokensWithComparisonOperatorsSequence(): void
+	{
+		$query = 'a == b != c < d <= e > f >= g';
+		$tokenizer = new Tokenizer($query);
+		$tokens = iterator_to_array($tokenizer->tokens());
+
+		$expected = [
+			TokenType::T_IDENTIFIER,
+			TokenType::T_EQUAL,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_NOT_EQUAL,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_LESS_THAN,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_LESS_EQUAL,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_GREATER_THAN,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_GREATER_EQUAL,
+			TokenType::T_IDENTIFIER,
+			TokenType::T_EOF,
+		];
+
+		$this->assertSame($expected, array_map(fn ($t) => $t->type, $tokens));
+	}
+
+	public static function mathTokenProvider(): array
+	{
+		return [
+			['a + b',  2, TokenType::T_PLUS, '+'],
+			['a - b',  2, TokenType::T_MINUS, '-'],
+			['a * b',  2, TokenType::T_MULTIPLY, '*'],
+			['a / b',  2, TokenType::T_DIVIDE, '/'],
+			['a % b',  2, TokenType::T_MODULO, '%'],
+		];
+	}
+
+	#[DataProvider('mathTokenProvider')]
+	public function testTokenWithMathOperators(
+		string $query,
+		int $offset,
+		TokenType $expectedType,
+		string $expectedLexeme
+	): void {
+		$token = Tokenizer::token($query, $offset);
+		$this->assertSame($expectedType, $token->type);
+		$this->assertSame($expectedLexeme, $token->lexeme);
+
+	}
+}

--- a/tests/Query/QueryLegacyDefaultFunctionsTest.php
+++ b/tests/Query/QueryLegacyDefaultFunctionsTest.php
@@ -6,28 +6,15 @@ use Kirby\Cms\App;
 use Kirby\Cms\Pages;
 use Kirby\Filesystem\Dir;
 use Kirby\Image\QrCode;
-use Kirby\Query\Runners\DefaultRunner;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 
-class QueryDefaultFunctionsTest extends TestCase
+class QueryLegacyDefaultFunctionsTest extends TestCase
 {
-	public const TMP = KIRBY_TMP_DIR . '/Query.QueryDefaultFunctions';
+	public const TMP = KIRBY_TMP_DIR . '/Query.QueryLegacyDefaultFunctions';
 
-	protected function setUp(): void
+	public function tearDown(): void
 	{
-		new App([
-			'options' => [
-				'query' => [
-					'runner' => DefaultRunner::class
-				]
-			]
-		]);
-	}
-
-	protected function tearDown(): void
-	{
-		App::destroy();
 		Dir::remove(static::TMP);
 	}
 

--- a/tests/Query/QueryLegacyTest.php
+++ b/tests/Query/QueryLegacyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kirby\Query;
+
+use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Query::class)]
+class QueryLegacyTest extends TestCase
+{
+	public function testFactory(): void
+	{
+		$query = Query::factory(' user.me ');
+		$this->assertSame('user.me', $query->query);
+	}
+
+	public function testIntercept(): void
+	{
+		$query = new Query('kirby');
+		$this->assertSame('foo', $query->intercept('foo'));
+	}
+
+	public function testResolve(): void
+	{
+		$query = new Query("user.self.likes(['(', ')']).self.drink");
+		$data  = ['user' => new TestUser()];
+		$this->assertSame(['gin', 'tonic', 'cucumber'], $query->resolve($data));
+	}
+
+	public function testResolveWithEmptyQuery(): void
+	{
+		$query = new Query('');
+		$data = ['foo' => 'bar'];
+		$this->assertSame($data, $query->resolve($data));
+	}
+
+	public function testResolveWithComparisonExpresion(): void
+	{
+		$query = new Query('user.nothing ?? (user.nothing ?? user.isYello(false)) ? user.says("error") : (user.nothing ?? user.says("success"))');
+		$data  = ['user' => new TestUser()];
+		$this->assertSame('success', $query->resolve($data));
+	}
+
+	public function testResolveWithExactArrayMatch(): void
+	{
+		$query = new Query('user');
+		$this->assertSame('homer', $query->resolve(['user' => 'homer']));
+
+		$query = new Query('user.username');
+		$this->assertSame('homer', $query->resolve(['user.username' => 'homer']));
+
+		$query = new Query('user.callback');
+		$this->assertSame('homer', $query->resolve(['user.callback' => fn () => 'homer']));
+	}
+
+	public function testResolveWithClosureArgument(): void
+	{
+		$query = new Query('foo.bar(() => foo.homer)');
+		$data  = [
+			'foo' => [
+				'bar'   => fn ($callback) => $callback,
+				'homer' => 'simpson'
+			]
+		];
+
+		$bar = $query->resolve($data);
+		$this->assertInstanceOf(Closure::class, $bar);
+		$bar = $bar();
+		$this->assertSame('simpson', $bar);
+	}
+}

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -3,81 +3,163 @@
 namespace Kirby\Query;
 
 use Closure;
+use Exception;
+use Kirby\Cms\App;
+use Kirby\Query\Runners\DefaultRunner;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Query\Query
- */
+#[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	protected function setUp(): void
+	{
+		new App([
+			'options' => [
+				'query' => [
+					'runner' => DefaultRunner::class
+				]
+			]
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		App::destroy();
+	}
+
+	public function test__Construct(): void
+	{
+		$query = new Query('');
+		$this->assertInstanceOf(DefaultRunner::class, $query->runner);
+	}
+
+	public function test__ConstructWithoutConfig(): void
+	{
+		new App([
+			'options' => [
+				'query' => [
+					'runner' => null
+				]
+			]
+		]);
+
+		$query = new Query('');
+		$this->assertSame('legacy', $query->runner);
+	}
+
+	public function test__ConstructWithInvalidConfig(): void
+	{
+		new App([
+			'options' => [
+				'query' => [
+					'runner' => 'foo'
+				]
+			]
+		]);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Query runner foo must extend Kirby\Query\Runners\Runner');
+
+		new Query('');
+	}
+
+	public function testFactory(): void
 	{
 		$query = Query::factory(' user.me ');
 		$this->assertSame('user.me', $query->query);
 	}
 
-	/**
-	 * @covers ::intercept
-	 */
-	public function testIntercept()
+	public function testIntercept(): void
 	{
 		$query = new Query('kirby');
 		$this->assertSame('foo', $query->intercept('foo'));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolve()
+	public static function resolveProvider(): array
 	{
-		$query = new Query("user.self.likes(['(', ')']).self.drink");
-		$data  = ['user' => new TestUser()];
-		$this->assertSame(['gin', 'tonic', 'cucumber'], $query->resolve($data));
+		return [
+			[
+				'user.self.likes([\'(\', \')\']).self.drink',
+				['user' => new TestUser()],
+				['gin', 'tonic', 'cucumber']
+			],
+			// empty query
+			[
+				'',
+				['foo' => 'bar'],
+				['foo' => 'bar']
+			],
+			// coalescing
+			[
+				'user.nothing ?? (user.nothing ?? user.isYello(false)) ? user.says("error") : (user.nothing ?? user.says("success"))',
+				['user' => new TestUser()],
+				'success'
+			],
+			// exact array match
+			[
+				'user',
+				['user' => 'homer'],
+				'homer'
+			],
+			[
+				'user.username',
+				['user.username' => 'homer'],
+				'homer'
+			],
+			[
+				'user callback',
+				['user callback' => fn () => 'homer'],
+				'homer'
+			],
+			// global this keyword
+			[
+				'this["user.username"]',
+				['user.username' => 'homer'],
+				'homer'
+			],
+			[
+				'this["user callback"]',
+				['user callback' => fn () => 'homer'],
+				'homer'
+			],
+			// comparison
+			[
+				'age > 18',
+				['age' => 20],
+				true
+			],
+			[
+				'age >= minAge',
+				['age' => 15, 'minAge' => 18],
+				false
+			],
+			// arithmetic
+			[
+				'age + 1',
+				['age' => 20],
+				21
+			],
+			[
+				'2 + 15 * 2 % 10',
+				[],
+				2
+			]
+		];
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithEmptyQuery()
-	{
-		$query = new Query('');
-		$data = ['foo' => 'bar'];
-		$this->assertSame($data, $query->resolve($data));
+	#[DataProvider('resolveProvider')]
+	public function testResolve(
+		string $query,
+		array $data,
+		mixed $expected
+	): void {
+		$query = new Query($query);
+		$this->assertSame($expected, $query->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithComparisonExpresion()
-	{
-		$query = new Query('user.nothing ?? (user.nothing ?? user.isYello(false)) ? user.says("error") : (user.nothing ?? user.says("success"))');
-		$data  = ['user' => new TestUser()];
-		$this->assertSame('success', $query->resolve($data));
-	}
-
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithExactArrayMatch()
-	{
-		$query = new Query('user');
-		$this->assertSame('homer', $query->resolve(['user' => 'homer']));
-
-		$query = new Query('user.username');
-		$this->assertSame('homer', $query->resolve(['user.username' => 'homer']));
-
-		$query = new Query('user.callback');
-		$this->assertSame('homer', $query->resolve(['user.callback' => fn () => 'homer']));
-	}
-
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithClosureArgument()
+	public function testResolveWithClosureArgument(): void
 	{
 		$query = new Query('foo.bar(() => foo.homer)');
 		$data  = [
@@ -89,7 +171,44 @@ class QueryTest extends TestCase
 
 		$bar = $query->resolve($data);
 		$this->assertInstanceOf(Closure::class, $bar);
+
 		$bar = $bar();
 		$this->assertSame('simpson', $bar);
+	}
+
+	public function testResolveWithClosureWithArgument(): void
+	{
+		$query = new Query('(foo) => foo.homer');
+		$data  = [];
+
+		$bar = $query->resolve($data);
+		$this->assertInstanceOf(Closure::class, $bar);
+
+		$bar = $bar(['homer' => 'simpson']);
+		$this->assertSame('simpson', $bar);
+	}
+
+	public function testResolveWithInterceptor(): void
+	{
+		$query = new class ('foo.getObj.name') extends Query {
+			public function intercept($result): mixed
+			{
+				if (is_object($result) === true) {
+					$result = clone $result;
+					$result->name .= ' simpson';
+				}
+
+				return $result;
+			}
+		};
+
+		$data  = [
+			'foo' => [
+				'getObj' => fn () => (object)['name' => 'homer']
+			]
+		];
+
+		$bar = $query->resolve($data);
+		$this->assertSame('homer simpson', $bar);
 	}
 }

--- a/tests/Query/Runners/DefaultRunnerTest.php
+++ b/tests/Query/Runners/DefaultRunnerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use ArrayAccess;
+use Kirby\Query\Query;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(DefaultRunner::class)]
+class DefaultRunnerTest extends TestCase
+{
+	public function testFor(): void
+	{
+		$query  = new Query('');
+		$runner = DefaultRunner::for($query);
+
+		$this->assertInstanceOf(DefaultRunner::class, $runner);
+	}
+
+	#[DataProvider('interceptProvider')]
+	#[CoversNothing]
+	public function testIntercept(
+		string $query,
+		array $context,
+		array $intercept,
+		array $global = []
+	): void {
+		$intercepted = [];
+		$interceptor = function ($value) use (&$intercepted) {
+			$intercepted[] = $value;
+			return $value;
+		};
+
+		$runner = new DefaultRunner($global, $interceptor);
+		$runner->run($query, $context);
+
+		$this->assertSame($intercept, $intercepted);
+	}
+
+	/**
+	 * Runners should keep a cache of parsed queries
+	 * to avoid parsing the same query multiple times
+	 */
+	public function testResolverMemoryCache(): void
+	{
+		$cache = [];
+
+		$cacheSpy = $this->createMock(ArrayAccess::class);
+
+		$cacheSpy
+			->expects($this->exactly(3))
+			->method('offsetExists')
+			->willReturnCallback(function ($key) use (&$cache) {
+				return isset($cache[$key]);
+			});
+
+		$cacheSpy
+			->expects($this->exactly(2))
+			->method('offsetGet')
+			->willReturnCallback(function ($key) use (&$cache) {
+				return $cache[$key] ?? null;
+			});
+
+		$cacheSpy
+			->expects($this->exactly(1))
+			->method('offsetSet')
+			->willReturnCallback(function ($key, $val) use (&$cache) {
+				$cache[$key] = $val;
+			});
+
+		$runner1 = new DefaultRunner(cache: $cacheSpy);
+		$runner2 = new DefaultRunner(cache: $cacheSpy);
+
+		// it should still give different results for different contexts
+		$result = $runner1->run('foo.bar', ['foo' => ['bar' => 42]]);
+		$this->assertSame(42, $result);
+
+		$result = $runner2->run('foo.bar', ['foo' => ['bar' => 84]]);
+		$this->assertSame(84, $result);
+
+		$runner3 = new DefaultRunner(cache: $cacheSpy);
+		$result = $runner3->run('foo.bar', ['foo' => ['bar' => 97]]);
+		$this->assertSame(97, $result);
+	}
+
+	#[DataProvider('resultProvider')]
+	public function testRun(
+		string $query,
+		array $context,
+		mixed $expected,
+		array $global = []
+	): void {
+		$runner = new DefaultRunner(global: $global);
+		$result = $runner->run($query, $context);
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function testRunDirectContextEntry(): void
+	{
+		$runner = new DefaultRunner();
+		$result = $runner->run('null', ['null' => 'foo']);
+		$this->assertSame('foo', $result);
+
+		$runner = new DefaultRunner();
+		$result = $runner->run('null', ['null' => fn () => 'foo']);
+		$this->assertSame('foo', $result);
+
+		$runner = new DefaultRunner();
+		$result = $runner->run('null', ['null' => null]);
+		$this->assertNull($result);
+
+		$runner = new DefaultRunner(global: ['null' => fn () => 'foo']);
+		$result = $runner->run('null');
+		$this->assertSame('foo', $result);
+
+		$runner = new DefaultRunner(global: ['null' => fn () => null]);
+		$result = $runner->run('null');
+		$this->assertNull($result);
+	}
+}

--- a/tests/Query/Runners/ScopeTest.php
+++ b/tests/Query/Runners/ScopeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Scope::class)]
+class ScopeTest extends TestCase
+{
+	public function testAccessWithArray(): void
+	{
+		$array  = [
+			'bar' => 'bar',
+			'bax' => fn (string $string = 'bax') => $string
+		];
+
+		$result = Scope::access($array, 'bar');
+		$this->assertSame('bar', $result);
+
+		$result = Scope::access($array, 'bax');
+		$this->assertSame('bax', $result);
+
+		$result = Scope::access($array, 'bax', false, 'custom');
+		$this->assertSame('custom', $result);
+
+		$result = Scope::access($array, 'fox');
+		$this->assertNull($result);
+	}
+
+	public function testAccessWithObject(): void
+	{
+		$obj = new class () {
+			public string $bax = 'qox';
+
+			public function print(string $string = 'bar'): string
+			{
+				return $string;
+			}
+		};
+
+		$result = Scope::access($obj, 'print');
+		$this->assertSame('bar', $result);
+
+		$result = Scope::access($obj, 'print', false, 'custom');
+		$this->assertSame('custom', $result);
+
+		$result = Scope::access($obj, 'bax');
+		$this->assertSame('qox', $result);
+
+		$result = Scope::access($obj, 'fox');
+		$this->assertNull($result);
+	}
+
+	public function testAccessWithNullSafe(): void
+	{
+		$result = Scope::access(null, 'bar', true);
+		$this->assertNull($result);
+	}
+
+	public function testAccessWithoutNullSafe(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Cannot access "bar" on NULL');
+		Scope::access(null, 'bar', false);
+	}
+
+	public function testGet(): void
+	{
+		$context   = ['foo' => 'bar', 'qox' => fn () => 'bax'];
+		$functions = ['fox' => fn () => 'fax'];
+
+		$result = Scope::get('foo', $context);
+		$this->assertSame('bar', $result);
+
+		$result = Scope::get('qox', $context);
+		$this->assertSame('bax', $result);
+
+		$result = Scope::get('fox', $context);
+		$this->assertNull($result);
+
+		$result = Scope::get('fox', $context, $functions);
+		$this->assertSame('fax', $result);
+	}
+}

--- a/tests/Query/Runners/TestCase.php
+++ b/tests/Query/Runners/TestCase.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Kirby\Query\Runners;
+
+use Kirby\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+	public static function resultProvider(): array
+	{
+		return [
+			'field' => [
+				'user.name', // query
+				['user' => ['name' => 'Homer']], // context
+				'Homer', // result
+			],
+
+			'nested field' => [
+				'user.name.first', // query
+				['user' => ['name' => ['first' => 'Homer']]], // context
+				'Homer' // result
+			],
+
+			'subscript notation with string as key' => [
+				'this["my.key"]["another key"]', // query
+				['my.key' => ['another key' => 'yes']], // context
+				'yes' // result
+			],
+
+			'subscript notation with expression as key' => [
+				'this["my.key"][page.id]', // query
+				[
+					'my.key' => ['another key' => 'yes'],
+					'page'   => ['id' => 'another key']
+				], // context
+				'yes' // result
+			],
+
+			'method result' => [
+				'user.get("arg").thing', // query
+				['user' => ['get' => fn ($a) => ['thing' => $a]]], // context
+				'arg' // result
+			],
+
+			'closure access to parent context' => [
+				'thing.call(() => result).field', // query
+				[
+					'result' => ['field' => 42],
+					'thing'  => ['call' => fn ($callback) => $callback()]
+				], // context
+				42 // result
+			],
+
+			'function result for explicit global function' => [
+				'foo(42).bar', // query
+				[], // context
+				84, // result
+				['foo' => fn ($a) => ['bar' => $a * 2]] // functions
+			],
+
+			'global function result when function looks like variable - i' => [
+				'foo.bar', // query
+				[], // context
+				42, // result
+				['foo' => fn () => ['bar' => 42]] // functions
+			],
+
+			'equal comparison' => [
+				'5 == 5', // query
+				[], // context
+				true, // result
+			],
+
+			'strict equal comparison' => [
+				'5 === 5', // query
+				[], // context
+				true, // result
+			],
+
+			'not equal comparison' => [
+				'5 != 3', // query
+				[], // context
+				true, // result
+			],
+
+			'strict not equal comparison' => [
+				'5 !== "5"', // query
+				[], // context
+				true, // result
+			],
+
+			'greater than comparison' => [
+				'5 > 3', // query
+				[], // context
+				true, // result
+			],
+
+			'less than comparison' => [
+				'3 < 5', // query
+				[], // context
+				true, // result
+			],
+
+			'greater than or equal comparison' => [
+				'5 >= 5', // query
+				[], // context
+				true, // result
+			],
+
+			'less than or equal comparison' => [
+				'5 <= 5', // query
+				[], // context
+				true, // result
+			],
+
+			'comparison with variables' => [
+				'a > b', // query
+				['a' => 10, 'b' => 3], // context
+				true, // result
+			],
+
+			'comparison with member access' => [
+				'user.age > user.minAge', // query
+				['user' => ['age' => 25, 'minAge' => 18]], // context
+				true, // result
+			],
+
+			// Logical operations
+			'logical AND' => [
+				'true && true', // query
+				[], // context
+				true, // result
+			],
+
+			'logical OR' => [
+				'false || true', // query
+				[], // context
+				true, // result
+			],
+
+			'complex logical expression' => [
+				'(a > b) && (c || d)', // query
+				[
+					'a' => 10,
+					'b' => 3,
+					'c' => false,
+					'd' => true
+				], // context
+				true, // result
+			],
+
+			'logical operations with member access' => [
+				'user.isAdmin && user.hasPermission', // query
+				['user' => ['isAdmin' => true, 'hasPermission' => true]], // context
+				true, // result
+			],
+			// Arithmetic operations
+			'basic addition' => [
+				'2 + 3', // query
+				[], // context
+				5, // result
+			],
+
+			'basic subtraction' => [
+				'5 - 3', // query
+				[], // context
+				2, // result
+			],
+
+			'basic multiplication' => [
+				'4 * 3', // query
+				[], // context
+				12, // result
+			],
+
+			'basic division' => [
+				'10 / 2', // query
+				[], // context
+				5, // result
+			],
+
+			'basic modulo' => [
+				'7 % 3', // query
+				[], // context
+				1, // result
+			],
+
+			'arithmetic with variables' => [
+				'a + b', // query
+				['a' => 10, 'b' => 3], // context
+				13, // result
+			],
+
+			'arithmetic precedence' => [
+				'2 + 3 * 4', // query
+				[], // context
+				14, // result (2 + (3 * 4) = 2 + 12 = 14)
+			],
+
+			'arithmetic with member access' => [
+				'user.age + user.bonus', // query
+				['user' => ['age' => 25, 'bonus' => 5]], // context
+				30, // result
+			],
+
+			'complex arithmetic expression' => [
+				'(x + y) * z', // query
+				['x' => 10, 'y' => 3, 'z' => 2], // context
+				26, // result
+			],
+		];
+	}
+
+
+	public static function interceptProvider(): array
+	{
+		return [
+			'field' => [
+				'user.name', // query
+				['user' => $user = ['name' => 'Homer']], // context
+				[$user], // intercept
+			],
+
+			'nested field' => [
+				'user.name.first', // query
+				[
+					'user' => $user = [
+						'name' => $name = ['first' => 'Homer']
+					]
+				], // context
+				[$user, $name] // intercept
+			],
+
+			'method result' => (function () {
+				$closureResult = ['age' => 42];
+				$user = ['get' => fn () => $closureResult];
+
+				return [
+					'user.get("arg").age', // query
+					['user' => $user], // context
+					[$user, $closureResult] // intercept
+				];
+			})(),
+
+			'closure result' => (function () {
+				$result = ['field' => 'value'];
+				$thing = ['call' => fn ($callback) => $callback()];
+
+				return [
+					'thing.call(() => result).field', // query
+					['thing' => $thing, 'result' => $result], // context
+					[$thing, $result] // intercept
+				];
+			})(),
+
+			'function result for explicit global function' => (function () {
+				$result = ['bar' => 'baz'];
+				$functions = ['foo' => fn () => $result];
+
+				return [
+					'foo("arg").bar', // query
+					[], // context
+					[$result], // intercept
+					$functions // functions
+				];
+			})(),
+
+			'global function result when function looks like variable - a' => (function () {
+				$result    = ['bar' => 'baz'];
+				$functions = ['foo' => fn () => $result];
+
+				return [
+					'foo.bar', // query
+					[], // context
+					[$result], // intercept
+					$functions // functions
+				];
+			})()
+		];
+	}
+}

--- a/tests/Query/SegmentTest.php
+++ b/tests/Query/SegmentTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class MyObj
@@ -35,8 +37,9 @@ class MyGetObj
 }
 
 /**
- * @coversDefaultClass \Kirby\Query\Segment
+ * @todo Deprecate in v6
  */
+#[CoversClass(Segment::class)]
 class SegmentTest extends TestCase
 {
 	public static function scalarProvider(): array
@@ -51,11 +54,8 @@ class SegmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::error
-	 * @dataProvider scalarProvider
-	 */
-	public function testErrorWithScalars($scalar, $label)
+	#[DataProvider('scalarProvider')]
+	public function testErrorWithScalars($scalar, $label): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method "foo" on ' . $label);
@@ -63,10 +63,7 @@ class SegmentTest extends TestCase
 		Segment::error($scalar, 'foo', 'method');
 	}
 
-	/**
-	 * @covers ::error
-	 */
-	public function testErrorWithObject()
+	public function testErrorWithObject(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method "foo" on object');
@@ -74,11 +71,7 @@ class SegmentTest extends TestCase
 		Segment::error(new stdClass(), 'foo', 'method');
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$segment = Segment::factory('foo');
 		$this->assertSame('foo', $segment->method);
@@ -93,10 +86,7 @@ class SegmentTest extends TestCase
 		$this->assertCount(2, $segment->arguments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveFirst()
+	public function testResolveFirst(): void
 	{
 		// without parameters
 		$segment = Segment::factory('foo');
@@ -107,11 +97,7 @@ class SegmentTest extends TestCase
 		$this->assertSame('2bar', $segment->resolve(null, ['foo' => fn (int $a, string $b) => $a . $b]));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
-	public function testResolveFirstWithDataObject()
+	public function testResolveFirstWithDataObject(): void
 	{
 		$obj      = new stdClass();
 		$obj->foo = 'bar';
@@ -120,33 +106,21 @@ class SegmentTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
-	public function testResolveArray()
+	public function testResolveArray(): void
 	{
 		$segment = Segment::factory('foo', 1);
 		$data    = ['foo' => $expected = [1, 2]];
 		$this->assertSame($expected, $segment->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
-	public function testResolveArrayClosure()
+	public function testResolveArrayClosure(): void
 	{
 		$segment = Segment::factory('foo', 0);
 		$data    = ['foo' => fn () => 'bar'];
 		$this->assertSame('bar', $segment->resolve(null, $data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
-	public function testResolveArrayInvalidKey()
+	public function testResolveArrayInvalidKey(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing property "foo" on array');
@@ -155,11 +129,7 @@ class SegmentTest extends TestCase
 		$segment->resolve(['bar' => 2]);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
-	public function testResolveArrayArgOnNonClosure()
+	public function testResolveArrayArgOnNonClosure(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Cannot access array element "foo" with arguments');
@@ -168,21 +138,13 @@ class SegmentTest extends TestCase
 		$segment->resolve(['foo' => 'bar']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
-	public function testResolveArrayFromGlobalEntry()
+	public function testResolveArrayFromGlobalEntry(): void
 	{
 		$segment = Segment::factory('kirby');
 		$this->assertSame(App::instance(), $segment->resolve(null, []));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
-	public function testResolveObject()
+	public function testResolveObject(): void
 	{
 		$obj     = new MyObj();
 		$segment = Segment::factory('foo(2)', 1);
@@ -201,11 +163,7 @@ class SegmentTest extends TestCase
 		$this->assertSame('simpson', $segment->resolve($obj));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
-	public function testResolveObjectInvalid()
+	public function testResolveObjectInvalid(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method/property "foo" on string');
@@ -214,11 +172,7 @@ class SegmentTest extends TestCase
 		$segment->resolve('bar');
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
-	public function testResolveObjectInvalidMethod()
+	public function testResolveObjectInvalidMethod(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method/property "notfound" on object');
@@ -228,11 +182,7 @@ class SegmentTest extends TestCase
 		$segment->resolve($obj);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
-	public function testResolveObjectMethodWithoutArgs()
+	public function testResolveObjectMethodWithoutArgs(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method "notfound" on object');
@@ -242,10 +192,7 @@ class SegmentTest extends TestCase
 		$segment->resolve($obj);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayNullValueError()
+	public function testResolveWithArrayNullValueError(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method/property "method" on null');

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -5,18 +5,17 @@ namespace Kirby\Query;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 /**
- * @coversDefaultClass \Kirby\Query\Segments
+ * @todo Deprecate in v6
  */
+#[CoversClass(Segments::class)]
 class SegmentsTest extends TestCase
 {
-	/**
-	 * @covers ::factory
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$segments = Segments::factory('a.b.c');
 		$this->assertCount(5, $segments);
@@ -54,20 +53,14 @@ class SegmentsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
-	public function testParse(string $string, array $result)
+	#[DataProvider('parseProvider')]
+	public function testParse(string $string, array $result): void
 	{
 		$segments = Segments::parse($string);
 		$this->assertSame($result, $segments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveNestedArray1Level()
+	public function testResolveNestedArray1Level(): void
 	{
 		$segments = Segments::factory('user.username');
 		$data  = [
@@ -79,10 +72,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveNestedNumericKeys()
+	public function testResolveNestedNumericKeys(): void
 	{
 		$segments = Segments::factory('user.0');
 		$data  = [
@@ -98,10 +88,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('marge', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveNestedArrayWithNumericMethods()
+	public function testResolveNestedArrayWithNumericMethods(): void
 	{
 		$segments = Segments::factory('user0.profiles1.mastodon');
 		$data  = [
@@ -115,10 +102,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('@homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveNestedArray2Levels()
+	public function testResolveNestedArray2Levels(): void
 	{
 		$segments = Segments::factory('user.profiles.mastodon');
 		$data  = [
@@ -143,22 +127,16 @@ class SegmentsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValue($scalar)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValue($scalar): void
 	{
 		$segments = Segments::factory('value');
 		$data     = ['value' => $scalar];
 		$this->assertSame($scalar, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValue2Level($scalar)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValue2Level($scalar): void
 	{
 		$segments = Segments::factory('parent.value');
 		$data     =  [
@@ -169,11 +147,8 @@ class SegmentsTest extends TestCase
 		$this->assertSame($scalar, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValueError($scalar, $type)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValueError($scalar, $type): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method/property "method" on ' . $type);
@@ -183,20 +158,14 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayNullValue()
+	public function testResolveWithArrayNullValue(): void
 	{
 		$segments = Segments::factory('value');
 		$data     = ['value' => null];
 		$this->assertNull($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayNullValueError()
+	public function testResolveWithArrayNullValueError(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method/property "method" on null');
@@ -206,20 +175,14 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayCallClosure()
+	public function testResolveWithArrayCallClosure(): void
 	{
 		$segments = Segments::factory('closure("test")');
 		$data     = ['closure' => fn ($arg) => strtoupper($arg)];
 		$this->assertSame('TEST', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayCallError()
+	public function testResolveWithArrayCallError(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Cannot access array element "editor" with arguments');
@@ -229,10 +192,7 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayMissingKey1()
+	public function testResolveWithArrayMissingKey1(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing property "editor" on array');
@@ -241,10 +201,7 @@ class SegmentsTest extends TestCase
 		$segments->resolve();
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithArrayMissingKey2()
+	public function testResolveWithArrayMissingKey2(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing property "editor" on array');
@@ -253,30 +210,21 @@ class SegmentsTest extends TestCase
 		$segments->resolve();
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObject1Level()
+	public function testResolveWithObject1Level(): void
 	{
 		$segments = Segments::factory('user.username');
 		$data     = ['user' => new TestUser()];
 		$this->assertSame('homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function tesResolvetWithObject2Level()
+	public function tesResolvetWithObject2Level(): void
 	{
 		$segments = Segments::factory('user.profiles.mastodon');
 		$data     = ['user' => new TestUser()];
 		$this->assertSame('@homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectProperty()
+	public function testResolveWithObjectProperty(): void
 	{
 		$obj = new stdClass();
 		$obj->test = 'testtest';
@@ -284,10 +232,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('testtest', $segments->resolve(compact('obj')));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectPropertyCallError()
+	public function testResolveWithObjectPropertyCallError(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method "test" on object');
@@ -298,20 +243,14 @@ class SegmentsTest extends TestCase
 		$segments->resolve(compact('obj'));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithInteger()
+	public function testResolveWithObjectMethodWithInteger(): void
 	{
 		$segments = Segments::factory('user.age(12)');
 		$data     = ['user' => new TestUser()];
 		$this->assertSame(12, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithBoolean()
+	public function testResolveWithObjectMethodWithBoolean(): void
 	{
 		// true
 		$segments = Segments::factory('user.isYello(true)');
@@ -324,20 +263,14 @@ class SegmentsTest extends TestCase
 		$this->assertFalse($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithNull()
+	public function testResolveWithObjectMethodWithNull(): void
 	{
 		$segments = Segments::factory('user.brainDump(null)');
 		$data     = ['user' => new TestUser()];
 		$this->assertNull($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithString()
+	public function testResolveWithObjectMethodWithString(): void
 	{
 		// double quotes
 		$segments = Segments::factory('user.says("hello world")');
@@ -350,10 +283,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello world', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithEmptyString()
+	public function testResolveWithObjectMethodWithEmptyString(): void
 	{
 		// double quotes
 		$segments = Segments::factory('user.says("")');
@@ -366,10 +296,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithStringEscape()
+	public function testResolveWithObjectMethodWithStringEscape(): void
 	{
 		// double quotes
 		$segments = Segments::factory('user.says("hello \" world")');
@@ -382,10 +309,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame("hello ' world", $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithMultipleArguments()
+	public function testResolveWithObjectMethodWithMultipleArguments(): void
 	{
 		$segments = Segments::factory('user.says("hello", "world")');
 		$data     = ['user' => new TestUser()];
@@ -402,10 +326,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello\' : world"', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithMultipleArgumentsAndComma()
+	public function testResolveWithObjectMethodWithMultipleArgumentsAndComma(): void
 	{
 		$segments = Segments::factory('user.says("hello,", "world")');
 		$data     = ['user' => new TestUser()];
@@ -417,10 +338,7 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello," : world', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithMultipleArgumentsAndDot()
+	public function testResolveWithObjectMethodWithMultipleArgumentsAndDot(): void
 	{
 		$segments = Segments::factory('user.says("I like", "love.jpg")');
 		$data     = ['user' => new TestUser()];
@@ -432,60 +350,42 @@ class SegmentsTest extends TestCase
 		$this->assertSame('I " like : love."jpg', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithTrickyCharacters()
+	public function testResolveWithObjectMethodWithTrickyCharacters(): void
 	{
 		$segments = Segments::factory("user.likes(['(', ',', ']', '[', ')']).self.brainDump('hello')");
 		$data     = ['user' => new TestUser()];
 		$this->assertSame('hello', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithArray()
+	public function testResolveWithObjectMethodWithArray(): void
 	{
 		$segments = Segments::factory('user.self.check("gin", "tonic", ["gin", "tonic", "cucumber"])');
 		$data     = ['user' => new TestUser()];
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithObjectMethodAsParameter()
+	public function testResolveWithObjectMethodWithObjectMethodAsParameter(): void
 	{
 		$segments = Segments::factory('user.self.check("gin", "tonic", user.drink)');
 		$data     = ['user' => new TestUser()];
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithNestedMethodCall()
+	public function testResolveWithNestedMethodCall(): void
 	{
 		$segments = Segments::factory('user.check("gin", "tonic", user.array("gin", "tonic").args)');
 		$data     = ['user' => new TestUser()];
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMethodWithObjectMethodAsParameterAndMoreLevels()
+	public function testResolveWithObjectMethodWithObjectMethodAsParameterAndMoreLevels(): void
 	{
 		$segments = Segments::factory("user.likes([',']).likes(user.brainDump(['(', ',', ']', ')', '['])).self");
 		$data     = ['user' => $user = new TestUser()];
 		$this->assertSame($user, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMissingMethod1()
+	public function testResolveWithObjectMissingMethod1(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method/property "username" on object');
@@ -495,10 +395,7 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithObjectMissingMethod2()
+	public function testResolveWithObjectMissingMethod2(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to non-existing method "username" on object');
@@ -508,10 +405,7 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveWithOptionalChaining()
+	public function testResolveWithOptionalChaining(): void
 	{
 		$segments = Segments::factory('user?.says("hi")');
 		$data     = ['user' => new TestUser()];

--- a/tests/Query/TestUser.php
+++ b/tests/Query/TestUser.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Query;
 
+use Exception;
+
 class TestUser
 {
 	public function username()
@@ -60,7 +62,7 @@ class TestUser
 	{
 		foreach ($arguments as $arg) {
 			if (in_array($arg, ['(', ')', ',', ']', '[']) === false) {
-				throw new \Exception();
+				throw new Exception();
 			}
 		}
 

--- a/tests/Query/Visitors/DefaultVisitorTest.php
+++ b/tests/Query/Visitors/DefaultVisitorTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Kirby\Query\Visitors;
+
+use Exception;
+use Kirby\Query\AST\ClosureNode;
+use Kirby\Query\AST\CoalesceNode;
+use Kirby\Query\AST\VariableNode;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DefaultVisitor::class)]
+class DefaultVisitorTest extends TestCase
+{
+	public function testArgumentList(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->assertSame([1, 2, 3], $visitor->arguments([1, 2, 3]));
+	}
+
+	public function testArrayList(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->assertSame([1, 2, 3], $visitor->arrayList([1, 2, 3]));
+	}
+
+	public function testClosure(): void
+	{
+		$visitor = new DefaultVisitor();
+		$node    = new ClosureNode(
+			arguments: ['a', 'b'],
+			body: new CoalesceNode(
+				left: new VariableNode('a'),
+				right: new VariableNode('b')
+			)
+		);
+
+		$this->assertEquals(
+			fn ($a, $b) => $a ?? $b,
+			$closure = $visitor->closure($node)
+		);
+		$this->assertSame(3, $closure(3, 4));
+	}
+
+	public function testCoalescence(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->assertSame(3, $visitor->coalescence(3, 4));
+		$this->assertSame(4, $visitor->coalescence(null, 4));
+	}
+
+	public function testComparison(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		// Equal comparisons
+		$this->assertTrue($visitor->comparison(5, '==', 5));
+		$this->assertTrue($visitor->comparison('5', '==', 5));
+		$this->assertFalse($visitor->comparison(5, '==', 6));
+
+		// Identical comparisons
+		$this->assertTrue($visitor->comparison(5, '===', 5));
+		$this->assertFalse($visitor->comparison('5', '===', 5));
+		$this->assertFalse($visitor->comparison(5, '===', 6));
+
+		// Not equal comparisons
+		$this->assertFalse($visitor->comparison(5, '!=', 5));
+		$this->assertFalse($visitor->comparison('5', '!=', 5));
+		$this->assertTrue($visitor->comparison(5, '!=', 6));
+
+		// Not identical comparisons
+		$this->assertFalse($visitor->comparison(5, '!==', 5));
+		$this->assertTrue($visitor->comparison('5', '!==', 5));
+		$this->assertTrue($visitor->comparison(5, '!==', 6));
+
+		// Less than comparisons
+		$this->assertTrue($visitor->comparison(3, '<', 5));
+		$this->assertFalse($visitor->comparison(5, '<', 5));
+		$this->assertFalse($visitor->comparison(7, '<', 5));
+
+		// Less than or equal comparisons
+		$this->assertTrue($visitor->comparison(3, '<=', 5));
+		$this->assertTrue($visitor->comparison(5, '<=', 5));
+		$this->assertFalse($visitor->comparison(7, '<=', 5));
+
+		// Greater than comparisons
+		$this->assertTrue($visitor->comparison(7, '>', 5));
+		$this->assertFalse($visitor->comparison(5, '>', 5));
+		$this->assertFalse($visitor->comparison(3, '>', 5));
+
+		// Greater than or equal comparisons
+		$this->assertTrue($visitor->comparison(7, '>=', 5));
+		$this->assertTrue($visitor->comparison(5, '>=', 5));
+		$this->assertFalse($visitor->comparison(3, '>=', 5));
+	}
+
+	public function testComparisonWithStrings(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		$this->assertTrue($visitor->comparison('abc', '==', 'abc'));
+		$this->assertTrue($visitor->comparison('abc', '===', 'abc'));
+		$this->assertFalse($visitor->comparison('abc', '==', 'def'));
+		$this->assertTrue($visitor->comparison('abc', '<', 'def'));
+		$this->assertTrue($visitor->comparison('abc', '<=', 'abc'));
+		$this->assertTrue($visitor->comparison('def', '>', 'abc'));
+		$this->assertTrue($visitor->comparison('abc', '>=', 'abc'));
+	}
+
+	public function testComparisonWithNull(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		$this->assertTrue($visitor->comparison(null, '==', null));
+		$this->assertTrue($visitor->comparison(null, '===', null));
+		$this->assertTrue($visitor->comparison(null, '==', 0)); // null == 0 is true in PHP
+		$this->assertFalse($visitor->comparison(null, '!=', 0)); // null != 0 is false in PHP
+		$this->assertTrue($visitor->comparison(null, '!==', 0)); // null !== 0 is true in PHP
+	}
+
+	public function testComparisonWithBooleans(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		$this->assertTrue($visitor->comparison(true, '==', true));
+		$this->assertTrue($visitor->comparison(true, '===', true));
+		$this->assertFalse($visitor->comparison(true, '==', false));
+		$this->assertTrue($visitor->comparison(true, '!=', false));
+		$this->assertTrue($visitor->comparison(true, '!==', false));
+	}
+
+	public function testComparisonWithArrays(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		$arr1 = [1, 2, 3];
+		$arr2 = [1, 2, 3];
+		$arr3 = [1, 2, 4];
+
+		$this->assertTrue($visitor->comparison($arr1, '==', $arr2));
+		$this->assertTrue($visitor->comparison($arr1, '===', $arr2));
+		$this->assertFalse($visitor->comparison($arr1, '==', $arr3));
+		$this->assertTrue($visitor->comparison($arr1, '!=', $arr3));
+	}
+
+	public function testComparisonInvalidOperator(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Unknown comparison operator: <=>');
+		$visitor->comparison(5, '<=>', 6);
+	}
+
+	public function testGlobalFunction(): void
+	{
+		$visitor = new DefaultVisitor(
+			global: ['foo' => fn () => 'bar']
+		);
+		$this->assertSame('bar', $visitor->function('foo'));
+	}
+
+	public function testGlobalFunctionInvalid(): void
+	{
+		$visitor = new DefaultVisitor();
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Invalid global function in query: fox');
+
+		$visitor->function('fox', []);
+	}
+
+	public function testLiteral(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->assertSame(3, $visitor->literal(3));
+		$this->assertSame(null, $visitor->literal(null));
+	}
+
+	public function testMemberAccess(): void
+	{
+		$visitor = new DefaultVisitor();
+		$obj     = new class () {
+			public function foo(): string
+			{
+				return 'bar';
+			}
+		};
+
+		$this->assertSame('bar', $visitor->memberAccess($obj, 'foo'));
+	}
+
+	public function testMemberAccessWithInterceptor(): void
+	{
+		$visitor = new DefaultVisitor(interceptor: fn ($obj) => new class () {
+			public function foo(): string
+			{
+				return 'baz';
+			}
+		});
+
+		$obj = new class () {
+			public function foo(): string
+			{
+				return 'bar';
+			}
+		};
+
+		$this->assertSame('baz', $visitor->memberAccess($obj, 'foo'));
+	}
+
+	public function testTernary(): void
+	{
+		$visitor = new DefaultVisitor();
+		$this->assertSame(2, $visitor->ternary(true, 2, 3));
+		$this->assertSame(3, $visitor->ternary(false, 2, 3));
+
+		$this->assertSame('truthy', $visitor->ternary('truthy', null, 3));
+		$this->assertSame(3, $visitor->ternary(null, null, 3));
+	}
+
+	public function testVariable(): void
+	{
+		$visitor = new DefaultVisitor(
+			context: [
+				'foo' => 'bar',
+				'fox' => fn () => 'bax'
+			],
+			global: [
+				'foz' => fn () => 'baz'
+			]
+		);
+
+		$this->assertSame('bar', $visitor->variable('foo'));
+		$this->assertSame('bax', $visitor->variable('fox'));
+		$this->assertSame('baz', $visitor->variable('foz'));
+		$this->assertNull($visitor->variable('nil'));
+	}
+}


### PR DESCRIPTION
## Description
This PR Introduces a new query classes based on parsing queries as Abstract Syntax Tree. Based on initial tests, this new runner seems to be about 38% faster. 

### Summary of changes
- Many new classes in `Kirby\Query`:
  - `Kirby\Query\Parser`: take care of splitting a string query first into tokens of specific types and then parsing these into an AST nodes tree
  - `Kirby\Query\AST`: all kind of nodes a query can consist of and the logic how they can be resolved
  - `Kirby\Query\Visitor`: classes that help resolving (visit) an AST and turn nodes either directly into processed results (`DefaultVisitor`), but plugins could build also different visitor e.g. producing PHP code representations (transpired)
  - `Kirby\Query\Runner`: classes that take a query and with the help of the above either directly process the result (`DefaultRunner`, with in-memory cache)

- The general process is:
  1. Query string is split into a flat sequence of tokens (`Kirby\Query\Parser\Tokenizer`).
  2. Tokens are parsed into a recursive abstract syntax tree (AST) (`Kirby\Query\Parser\Parser`).
  3. AST is then [visited](https://en.wikipedia.org/wiki/Visitor_pattern) by an `Interpreter` that directly evaluates the query, or a `Transpiler` that transpiles it into PHP code.
  4. The whole process and the caching is handled by the "runner" class: `DefaultRunner`
- The original `Kirby\Query\Query` class remains in place and chooses which runner to use based on the `query.runner` option.
- All previous Query classes have been deprecated and will be removed in v7. Until then setting `query.runner` to `legacy` can still make use of them.

### Reasoning
Separating the parsing and execution steps allows for more flexibility and better performance, since it allows us to cache the AST, either in memory during a request or (via a plugin) as transpired and stored PHP code.

By adding the new runners as optional and leaving the old parser as default legacy in place, this minimizes the risk of issues and hopefully allows us to add this still to v5, only changing the default in v6.

### Additional context
The parser is a predictive recursive descent parser, making the parsing step `O(n)`. As such it can't support ambigous code, which leads to the following breaking change.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
#### Query language
Kirby 5.1 adds a number of improvements to the Kirby Query language. These are based on a new AST-based parser and runner that has been added in addition to the previous (legacy) parser. The legacy parser which will remain the default parser for now but we aim to replace it with the new runner in Kirby 6. Consider the new runner in beta state during Kirby 5.x releases.

The new AST-based runner (thx to @rasteiner for starting off the work on this) runs not only more reliably and performant, but also allow us to add more functionalities. Those are not supported by the legacy runner.

- Support for more operators:
  - Logic (`AND`/`&&`/`OR`/`||`)
  - Compare (`==`, `!=`, `>`, `<, `<=`, `>=`)
  - Math (`+`, `-`, `*`, `/`, `%`)
- Closures in queries can now accept arguments
- Queries support subscript access notation, e.g. `page[site.pageMethodName]`
- `query.runner` option to switch to `Kirby\Query\Runners\DefaultRunner::class` to activate the new AST-based runner

### Breaking changes (only when manually switching to new runner)
The new query runner is stricter in parsing queries. Ambiguous terms aren't supported anymore. In some edge cases, this will require you to access an array/object via subscript notation - in rare cases on the top level via the new `this` keyword, e.g. `this["indentifier.with dots and spaces"]`. 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

#### `query.runner` config option

Kirby offers a new runner for its query syntax based on parsing the query as abstract syntax tree. This runner is more reliable and efficient than the rudimentary legacy runner (which in Kirby 5 remains the default).  The new runner is currently in its beta phase. You can activate it by setting the `query.runner` config option:

  ```php
  <?php 

use Kirby\Query\Runners\DefaultRunner;
  
  return [
    'query.runner' => DefaultRunner::class
  ];
  ```
  
  #### Query syntax
  
  When using the new query runner, you can also use logical, comparison and math operators in your queries as well as receive arguments in closures:
  ```php
  // new operators
  $query = new Query('age > 25 && name != "John"');
  $query = new Query('price + vat');
  
  // arguments in query closures
  $query = new Query('(foo) => foo.homer');
  $data  = [];
  
  $bar = $query->resolve($data);
  $bar = $bar(['homer' => 'simpson']);
  $this->assertSame('simpson', $bar);
  ```

Queries will still be tried to resolve first directly from the data context, e.g. when your query is `null` and your data `['null' => 'foo']` the result will directly be `'foo'`. Same for `user.username` and `['user.username' => 'foo']`.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
--> 

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
