### PR TITLE
Add the latest version of a translation automatically

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -95,6 +95,20 @@ class Version
 		Language|string $language = 'default'
 	): void {
 		$language = Language::ensure($language);
+		$latest   = $this->model->version(VersionId::latest());
+
+		// if the latest version of the translation does not exist yet,
+		// we have to copy over the content from the default language first.
+		if (
+			$this->isLatest() === false &&
+			$language->isDefault() === false &&
+			$latest->exists($language) === false
+		) {
+			$latest->create(
+				fields: $latest->read(Language::ensure('default')),
+				language: $language
+			);
+		}
 
 		// check if creating is allowed
 		VersionRules::create($this, $fields, $language);

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -191,6 +191,44 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::create
 	 */
+	public function testCreateMultiLanguageWhenLatestTranslationIsMissing(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$latest = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$changes = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$this->assertContentFileDoesNotExist('en', $latest->id());
+		$this->assertContentFileDoesNotExist('en', $changes->id());
+		$this->assertContentFileDoesNotExist('de', $latest->id());
+		$this->assertContentFileDoesNotExist('de', $changes->id());
+
+		// create the latest version for the default translation
+		$latest->save([
+			'title' => 'Test'
+		], $this->app->language('en'));
+
+		// create a changes version in the other language
+		$changes->save([
+			'title' => 'Translated Test',
+		], $this->app->language('de'));
+
+		$this->assertContentFileExists('en', $latest->id());
+		$this->assertContentFileDoesNotExist('en', $changes->id());
+		$this->assertContentFileExists('de', $latest->id());
+		$this->assertContentFileExists('de', $changes->id());
+	}
+
+	/**
+	 * @covers ::create
+	 */
 	public function testCreateSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();


### PR DESCRIPTION
## Description

If the latest version of a translation does not exist yet when creating changes, the latest version of the default language is automatically copied over. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
