### PR TITLE
Move lock wildcard into the Lock::for method

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -335,7 +335,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function lock(): Lock
 	{
-		return $this->version(VersionId::changes())->lock();
+		return $this->version(VersionId::changes())->lock('*');
 	}
 
 	/**

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -72,7 +72,7 @@ class Lock
 
 		return new static(
 			user: $user ?? null,
-			modified: $version->modified()
+			modified: $version->modified($language)
 		);
 	}
 

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -4,6 +4,7 @@ namespace Kirby\Content;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
+use Kirby\Cms\Languages;
 use Kirby\Cms\User;
 use Kirby\Toolkit\Str;
 
@@ -38,6 +39,22 @@ class Lock
 		Version $version,
 		Language|string $language = 'default'
 	): static {
+		// wildcard to search for a lock in any language
+		// the first locked one will be preferred
+		if ($language === '*') {
+			foreach (Languages::ensure() as $language) {
+				$lock = static::for($version, $language);
+
+				// return the first locked lock if any exists
+				if ($lock->isLocked() === true) {
+					return $lock;
+				}
+			}
+
+			// return the last lock if no lock was found
+			return $lock;
+		}
+
 		$language = Language::ensure($language);
 
 		// if the version does not exist, it cannot be locked

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -233,17 +233,6 @@ class Version
 	 */
 	public function isLocked(Language|string $language = 'default'): bool
 	{
-		// check if the version is locked in any language
-		if ($language === '*') {
-			foreach (Languages::ensure() as $language) {
-				if ($this->isLocked($language) === true) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
 		return $this->lock($language)->isLocked();
 	}
 


### PR DESCRIPTION
## Description

`Lock::for` now accepts the Language wildcard to search for a lock in any translation. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
