### PR TITLE
Version::isIdentical now uses form values to check for identical versions

### DIFF
--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -38,11 +38,6 @@ export default (panel) => {
 		 * Removes all unpublished changes
 		 */
 		async discard() {
-			// avoid requests if there is no API defined
-			if (!this.api) {
-				return;
-			}
-
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -91,11 +86,6 @@ export default (panel) => {
 		 * Publishes any changes
 		 */
 		async publish() {
-			// avoid requests if there is no API defined
-			if (!this.api) {
-				return;
-			}
-
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -122,11 +112,6 @@ export default (panel) => {
 		 * Saves any changes
 		 */
 		async save() {
-			// avoid requests if there is no API defined
-			if (!this.api) {
-				return;
-			}
-
 			this.isProcessing = true;
 
 			// ensure to abort unfinished previous save request

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -38,6 +38,11 @@ export default (panel) => {
 		 * Removes all unpublished changes
 		 */
 		async discard() {
+			// avoid requests if there is no API defined
+			if (!this.api) {
+				return;
+			}
+
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -86,6 +91,11 @@ export default (panel) => {
 		 * Publishes any changes
 		 */
 		async publish() {
+			// avoid requests if there is no API defined
+			if (!this.api) {
+				return;
+			}
+
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -112,6 +122,11 @@ export default (panel) => {
 		 * Saves any changes
 		 */
 		async save() {
+			// avoid requests if there is no API defined
+			if (!this.api) {
+				return;
+			}
+
 			this.isProcessing = true;
 
 			// ensure to abort unfinished previous save request

--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -88,7 +88,9 @@ class Changes
 		);
 
 		if ($changes->isIdentical(version: $latest, language: 'current')) {
-			$changes->delete();
+			$changes->delete(
+				language: 'current'
+			);
 		}
 
 		return [

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
+use Kirby\Form\Form;
 
 /**
  * The Version class handles all actions for a single
@@ -214,6 +215,27 @@ class Version
 		);
 
 		// ensure both arrays of fields are sorted the same
+		ksort($a);
+		ksort($b);
+
+		if ($a === $b) {
+			return true;
+		}
+
+		$a = Form::for(
+			model: $this->model,
+			props: [
+				'values' => $a
+			]
+		)->values();
+
+		$b = Form::for(
+			model: $this->model,
+			props: [
+				'values' => $b
+			]
+		)->values();
+
 		ksort($a);
 		ksort($b);
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -192,7 +192,6 @@ class Version
 			$version = $this->model->version($version);
 		}
 
-
 		if ($version->id()->is($this->id) === true) {
 			return true;
 		}
@@ -214,25 +213,19 @@ class Version
 			$b['uuid']
 		);
 
-		// ensure both arrays of fields are sorted the same
-		ksort($a);
-		ksort($b);
-
-		if ($a === $b) {
-			return true;
-		}
-
 		$a = Form::for(
 			model: $this->model,
 			props: [
-				'values' => $a
+				'language' => $language->code(),
+				'values'   => $a,
 			]
 		)->values();
 
 		$b = Form::for(
 			model: $this->model,
 			props: [
-				'values' => $b
+				'language' => $language->code(),
+				'values'   => $b
 			]
 		)->values();
 


### PR DESCRIPTION
## Description

Using the Form class to create form values is unfortunately the only reliable method at the moment to compare two versions with each other. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
