### PR TITLE
FormControls: fix error for preview prop type

### DIFF
--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -64,7 +64,7 @@ export default {
 		/**
 		 * Preview URL for changes
 		 */
-		preview: String
+		preview: [String, Boolean]
 	},
 	emits: ["discard", "submit"],
 	computed: {

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -20,7 +20,7 @@
 					:is-locked="isLocked"
 					:is-unsaved="isUnsaved"
 					:modified="modified"
-					:preview="permissions.preview ? api + '/preview/compare' : false"
+					:preview="api + '/preview/compare'"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>


### PR DESCRIPTION
### Todo

- [x] https://github.com/getkirby/kirby/blob/v5/changes/develop/panel/src/components/Views/Pages/SiteView.vue#L23 references a site `preview` permission which is also mentioned in the docs. However, this neither does exist in `SiteBlueprint` nor has it been used in the past to control the display of the preview button on the site view https://github.com/getkirby/kirby/blob/main/panel/src/components/Views/Pages/SiteView.vue#L17-L25
   - Are we introducing this new permission and need to properly implement it in all the places (blueprint, area buttons)?
   - Or do we need to remove this here in site view and from the docs? 

### Summary of changes
- `k-form-controls` accepts a boolean (false) for `preview` prop

