### PR TITLE
Improvements for the content.js module

### DIFF
--- a/panel/lab/components/formcontrols/index.vue
+++ b/panel/lab/components/formcontrols/index.vue
@@ -15,7 +15,7 @@
 					/>
 
 					<k-form-controls
-						:is-unsaved="isUnsaved"
+						:has-changes="hasChanges"
 						:is-locked="isLocked"
 						editor="editor@getkirby.com"
 						modified="2024-10-01T17:00:00"
@@ -35,9 +35,9 @@
 			>
 				<k-input
 					type="toggle"
-					:value="isUnsaved"
-					text="is-unsaved"
-					@input="isUnsaved = $event"
+					:value="hasChanges"
+					text="has-changes"
+					@input="hasChanges = $event"
 				/>
 				<k-input
 					type="toggle"
@@ -48,9 +48,9 @@
 			</k-grid>
 		</k-lab-example>
 
-		<k-lab-example label="Unsaved">
+		<k-lab-example label="Changes">
 			<k-form-controls
-				:is-unsaved="true"
+				:has-changes="true"
 				editor="editor@getkirby.com"
 				modified="2024-10-01T17:00:00"
 				preview="https://getkirby.com"
@@ -75,8 +75,8 @@
 export default {
 	data() {
 		return {
-			isLocked: false,
-			isUnsaved: false
+			hasChanges: false,
+			isLocked: false
 		};
 	},
 	methods: {

--- a/panel/src/api/index.js
+++ b/panel/src/api/index.js
@@ -44,7 +44,7 @@ export default (panel) => {
 		api.requests.push(id);
 
 		// start the loader if it's not a silent request
-		if (silent === false) {
+		if (silent === false && options.silent !== true) {
 			panel.isLoading = true;
 		}
 

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -58,8 +58,8 @@
 export default {
 	props: {
 		editor: String,
+		hasChanges: Boolean,
 		isLocked: Boolean,
-		isUnsaved: Boolean,
 		modified: [String, Date],
 		/**
 		 * Preview URL for changes
@@ -81,7 +81,7 @@ export default {
 				];
 			}
 
-			if (this.isUnsaved === true) {
+			if (this.hasChanges === true) {
 				return [
 					{
 						theme: "notice",

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -8,6 +8,7 @@
  */
 export default {
 	props: {
+		changes: Object,
 		tab: String,
 		tabs: {
 			type: Array,
@@ -16,7 +17,7 @@ export default {
 	},
 	computed: {
 		withBadges() {
-			const changes = Object.keys(this.$panel.content.changes);
+			const changes = Object.keys(this.changes);
 
 			return this.tabs.map((tab) => {
 				// collect all fields per tab

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -67,7 +67,7 @@ export default {
 			// any other backend request that would update `hasChanges`
 			if (this.hasChanges || this.$panel.content.hasChanges) {
 				return {
-					theme: this.$panel.view.props.lock.isLocked ? "red" : "orange"
+					theme: this.$panel.content.isLocked() ? "red" : "orange"
 				};
 			}
 

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -67,7 +67,7 @@ export default {
 			// any other backend request that would update `hasChanges`
 			if (this.hasChanges || this.$panel.content.hasChanges) {
 				return {
-					theme: this.$panel.content.lock.isLocked ? "red" : "orange"
+					theme: this.$panel.view.props.lock.isLocked ? "red" : "orange"
 				};
 			}
 

--- a/panel/src/components/View/Buttons/SettingsButton.vue
+++ b/panel/src/components/View/Buttons/SettingsButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-view-button
 		v-bind="$props"
-		:disabled="$panel.content.isLocked"
+		:disabled="$panel.view.props.lock.isLocked"
 		@action="$emit('action', $event)"
 	/>
 </template>

--- a/panel/src/components/View/Buttons/SettingsButton.vue
+++ b/panel/src/components/View/Buttons/SettingsButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-view-button
 		v-bind="$props"
-		:disabled="$panel.view.props.lock.isLocked"
+		:disabled="$panel.content.isLocked()"
 		@action="$emit('action', $event)"
 	/>
 </template>

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-view-button
 		v-bind="$props"
-		:disabled="disabled || $panel.content.isLocked"
+		:disabled="disabled || $panel.view.props.lock.isLocked"
 	/>
 </template>
 

--- a/panel/src/components/View/Buttons/StatusButton.vue
+++ b/panel/src/components/View/Buttons/StatusButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-view-button
 		v-bind="$props"
-		:disabled="disabled || $panel.view.props.lock.isLocked"
+		:disabled="disabled || $panel.content.isLocked()"
 	/>
 </template>
 

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -22,7 +22,7 @@
 				<k-form-controls
 					:editor="editor"
 					:is-locked="isLocked"
-					:is-unsaved="isUnsaved"
+					:is-unsaved="hasChanges"
 					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -21,8 +21,8 @@
 				<k-view-buttons :buttons="buttons" @action="onAction" />
 				<k-form-controls
 					:editor="editor"
+					:has-changes="hasChanges"
 					:is-locked="isLocked"
-					:is-unsaved="hasChanges"
 					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -38,7 +38,7 @@
 			@submit="onSubmit"
 		/>
 
-		<k-model-tabs :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -98,8 +98,6 @@ export default {
 			// update the content for the current view
 			// this will also refresh the content prop
 			this.$panel.content.update(values, this.api);
-			// trigger a throttled save call with the updated content
-			this.$panel.content.saveLazy(this.content, this.api);
 		},
 		async onSubmit() {
 			await this.$panel.content.publish(this.content, this.api);

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -1,4 +1,5 @@
 <script>
+import { length } from "@/helpers/object";
 import throttle from "@/helpers/throttle.js";
 
 /**
@@ -37,9 +38,25 @@ export default {
 		},
 		uuid: String
 	},
+	data() {
+		return {
+			isSaved: true
+		};
+	},
 	computed: {
 		changes() {
-			return this.$panel.content.changes;
+			const changes = {};
+
+			for (const field in this.content) {
+				const changed = JSON.stringify(this.content[field]);
+				const original = JSON.stringify(this.originals[field]);
+
+				if (changed !== original) {
+					changes[field] = this.content[field];
+				}
+			}
+
+			return changes;
 		},
 		editor() {
 			return this.lock.user.email;
@@ -51,7 +68,7 @@ export default {
 			return this.lock.isLocked;
 		},
 		isUnsaved() {
-			return this.$panel.content.hasChanges;
+			return length(this.changes) > 0;
 		},
 		modified() {
 			return this.lock.modified;
@@ -60,37 +77,62 @@ export default {
 			return [];
 		}
 	},
+	watch: {
+		// watch for view changes and
+		// trigger saving for changes that where
+		// not sent to the server yet
+		api() {
+			if (this.isSaved === false) {
+				this.save();
+			}
+		}
+	},
 	mounted() {
-		this.autosave = throttle(this.autosave, 1000, {
+		// create a delayed version of save
+		// that we can use in the input event
+		this.autosave = throttle(this.save, 1000, {
 			leading: true,
 			trailing: true
 		});
 
+		this.$events.on("beforeunload", this.onBeforeUnload);
 		this.$events.on("model.reload", this.$reload);
 		this.$events.on("keydown.left", this.toPrev);
 		this.$events.on("keydown.right", this.toNext);
 		this.$events.on("view.save", this.onSave);
 	},
 	destroyed() {
+		this.$events.off("beforeunload", this.onBeforeUnload);
 		this.$events.off("model.reload", this.$reload);
 		this.$events.off("keydown.left", this.toPrev);
 		this.$events.off("keydown.right", this.toNext);
 		this.$events.off("view.save", this.onSave);
 	},
 	methods: {
-		autosave() {
+		async save() {
 			if (this.isLocked === true) {
 				return false;
 			}
 
-			this.$panel.content.save();
+			await this.$panel.content.save(this.api, this.content);
+
+			// update the last modification timestamp
+			this.$panel.view.props.lock.modified = new Date();
+			this.isSaved = true;
+		},
+		onBeforeUnload(e) {
+			if (this.isSaved === false) {
+				e.preventDefault();
+				e.returnValue = "";
+			}
 		},
 		async onDiscard() {
 			if (this.isLocked === true) {
 				return false;
 			}
 
-			await this.$panel.content.discard();
+			await this.$panel.content.discard(this.api);
+			this.$panel.view.props.content = this.$panel.view.props.originals;
 			this.$panel.view.reload();
 		},
 		onInput(values) {
@@ -98,7 +140,7 @@ export default {
 				return false;
 			}
 
-			this.$panel.content.update(values);
+			this.update(values);
 			this.autosave();
 		},
 		onSave(e) {
@@ -110,8 +152,15 @@ export default {
 				return false;
 			}
 
-			this.$panel.content.update(values);
-			await this.$panel.content.publish();
+			this.update(values);
+
+			await this.$panel.content.publish(this.api, this.content);
+
+			this.$panel.view.props.originals = this.content;
+			this.$panel.notification.success();
+
+			this.$events.emit("model.update");
+
 			await this.$panel.view.refresh();
 		},
 		toPrev(e) {
@@ -123,6 +172,18 @@ export default {
 			if (this.next && e.target.localName === "body") {
 				this.$go(this.next.link);
 			}
+		},
+		update(values) {
+			if (length(values) === 0) {
+				return;
+			}
+
+			this.$panel.view.props.content = {
+				...this.originals,
+				...values
+			};
+
+			this.isSaved = false;
 		}
 	}
 };

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -22,7 +22,7 @@
 				<k-form-controls
 					:editor="editor"
 					:is-locked="isLocked"
-					:is-unsaved="isUnsaved"
+					:is-unsaved="hasChanges"
 					:modified="modified"
 					:preview="permissions.preview ? api + '/preview/compare' : false"
 					@discard="onDiscard"
@@ -53,11 +53,6 @@ export default {
 	extends: ModelView,
 	props: {
 		title: String
-	},
-	computed: {
-		protectedFields() {
-			return ["title"];
-		}
 	}
 };
 </script>

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -21,8 +21,8 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
+					:has-changes="hasChanges"
 					:is-locked="isLocked"
-					:is-unsaved="hasChanges"
 					:modified="modified"
 					:preview="permissions.preview ? api + '/preview/compare' : false"
 					@discard="onDiscard"

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -31,7 +31,7 @@
 			</template>
 		</k-header>
 
-		<k-model-tabs :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -18,7 +18,7 @@
 				<k-form-controls
 					:editor="editor"
 					:is-locked="isLocked"
-					:is-unsaved="isUnsaved"
+					:is-unsaved="hasChanges"
 					:modified="modified"
 					:preview="api + '/preview/compare'"
 					@discard="onDiscard"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -27,7 +27,7 @@
 			</template>
 		</k-header>
 
-		<k-model-tabs :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -17,8 +17,8 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
+					:has-changes="hasChanges"
 					:is-locked="isLocked"
-					:is-unsaved="hasChanges"
 					:modified="modified"
 					:preview="api + '/preview/compare'"
 					@discard="onDiscard"

--- a/panel/src/components/Views/PreviewView.vue
+++ b/panel/src/components/Views/PreviewView.vue
@@ -80,8 +80,8 @@
 						/>
 						<k-form-controls
 							:editor="editor"
+							:has-changes="hasChanges"
 							:is-locked="isLocked"
-							:is-unsaved="hasChanges"
 							:modified="modified"
 							size="sm"
 							@discard="onDiscard"

--- a/panel/src/components/Views/PreviewView.vue
+++ b/panel/src/components/Views/PreviewView.vue
@@ -81,7 +81,7 @@
 						<k-form-controls
 							:editor="editor"
 							:is-locked="isLocked"
-							:is-unsaved="isUnsaved"
+							:is-unsaved="hasChanges"
 							:modified="modified"
 							size="sm"
 							@discard="onDiscard"
@@ -89,7 +89,7 @@
 						/>
 					</k-button-group>
 				</header>
-				<iframe v-if="isUnsaved" :src="src.changes"></iframe>
+				<iframe v-if="hasChanges" :src="src.changes"></iframe>
 				<k-empty v-else>
 					{{ $t("lock.unsaved.empty") }}
 					<k-button icon="edit" variant="filled" :link="back">

--- a/panel/src/components/Views/PreviewView.vue
+++ b/panel/src/components/Views/PreviewView.vue
@@ -153,28 +153,12 @@ export default {
 
 			this.$panel.view.open(this.link + "/preview/" + mode);
 		},
-		async onDiscard() {
-			if (this.isLocked === true) {
-				return false;
-			}
-
-			await this.$panel.content.discard();
-			await this.$panel.view.reload();
-		},
 		onExit() {
 			if (this.$panel.overlays().length > 0) {
 				return;
 			}
 
 			this.$panel.view.open(this.link);
-		},
-		async onSubmit() {
-			if (this.isLocked === true) {
-				return false;
-			}
-
-			await this.$panel.content.publish();
-			await this.$panel.view.reload();
 		}
 	}
 };

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -26,8 +26,8 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
+					:has-changes="hasChanges"
 					:is-locked="isLocked"
-					:is-unsaved="hasChanges"
 					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -27,7 +27,7 @@
 				<k-form-controls
 					:editor="editor"
 					:is-locked="isLocked"
-					:is-unsaved="isUnsaved"
+					:is-unsaved="hasChanges"
 					:modified="modified"
 					@discard="onDiscard"
 					@submit="onSubmit"

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -49,7 +49,7 @@
 			:role="role"
 		/>
 
-		<k-model-tabs :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -13,6 +13,7 @@ export default (panel) => {
 		 * @returns {Object}
 		 */
 		changes(api = panel.view.props.api) {
+			// changes can only be computed for the current view
 			if (this.isCurrent(api) === false) {
 				throw new Error("Cannot get changes from another view");
 			}
@@ -39,6 +40,8 @@ export default (panel) => {
 				return;
 			}
 
+			// In the current view, we can use the existing
+			// lock state to determine if we can discard
 			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
 				throw new Error("Cannot discard locked changes");
 			}
@@ -48,6 +51,7 @@ export default (panel) => {
 			try {
 				await panel.api.post(api + "/changes/discard");
 
+				// update the props for the current view
 				if (this.isCurrent(api)) {
 					panel.view.props.content = panel.view.props.originals;
 				}
@@ -87,7 +91,7 @@ export default (panel) => {
 		lock(api = panel.view.props.api) {
 			if (this.isCurrent(api) === false) {
 				throw new Error(
-					"The lock state cannot be detected for content from in another view"
+					"The lock state cannot be detected for content from another view"
 				);
 			}
 
@@ -102,6 +106,8 @@ export default (panel) => {
 				return;
 			}
 
+			// In the current view, we can use the existing
+			// lock state to determine if changes can be published
 			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
 				throw new Error("Cannot publish locked changes");
 			}
@@ -112,11 +118,12 @@ export default (panel) => {
 			try {
 				await panel.api.post(api + "/changes/publish", values);
 
+				// update the props for the current view
 				if (this.isCurrent(api)) {
 					panel.view.props.originals = panel.view.props.content;
 				}
 
-				panel.events.emit("content.publish", { api, values });
+				panel.events.emit("content.publish", { values, api });
 			} finally {
 				this.isProcessing = false;
 			}

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -197,6 +197,8 @@ export default (panel) => {
 				...panel.view.props.originals,
 				...values
 			};
+
+			this.saveLazy(panel.view.props.content, api);
 		}
 	});
 

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -15,7 +15,7 @@ export default (panel) => {
 		changes(api = panel.view.props.api) {
 			// changes can only be computed for the current view
 			if (this.isCurrent(api) === false) {
-				throw new Error("Cannot get changes from another view");
+				throw new Error("Cannot get changes for another view");
 			}
 
 			const changes = {};

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -59,7 +59,8 @@ export default (panel) => {
 
 			try {
 				await panel.api.post(api + "/changes/save", values, {
-					signal: this.saveAbortController.signal
+					signal: this.saveAbortController.signal,
+					silent: true
 				});
 
 				this.isProcessing = false;

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,4 +1,5 @@
-import { reactive } from "vue";
+import { length } from "@/helpers/object";
+import { reactive, set } from "vue";
 
 /**
  * @since 5.0.0
@@ -8,18 +9,48 @@ export default (panel) => {
 		/**
 		 * Removes all unpublished changes
 		 */
-		async discard(api) {
+		async discard(api = panel.view.props.api) {
 			if (this.isProcessing === true) {
 				return;
+			}
+
+			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
+				throw new Error("Cannot discard locked changes");
 			}
 
 			this.isProcessing = true;
 
 			try {
 				await panel.api.post(api + "/changes/discard");
+
+				if (this.isCurrent(api)) {
+					panel.view.props.content = panel.view.props.originals;
+				}
 			} finally {
 				this.isProcessing = false;
 			}
+		},
+
+		/**
+		 * Whether the api endpoint belongs to the current view
+		 * @var {Boolean}
+		 */
+		isCurrent(api) {
+			return panel.view.props.api === api;
+		},
+
+		/**
+		 * Whether the current view is locked
+		 * @var {Boolean}
+		 */
+		isLocked(api = panel.view.props.api) {
+			if (this.isCurrent(api) === false) {
+				throw new Error(
+					"The lock state cannot be detected for content from in another view"
+				);
+			}
+
+			return panel.view.props.lock.isLocked;
 		},
 
 		/**
@@ -31,16 +62,25 @@ export default (panel) => {
 		/**
 		 * Publishes any changes
 		 */
-		async publish(api, values) {
+		async publish(values, api = panel.view.props.api) {
 			if (this.isProcessing === true) {
 				return;
 			}
 
+			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
+				throw new Error("Cannot publish locked changes");
+			}
+
 			this.isProcessing = true;
+			this.update(api, values);
 
 			// Send updated values to API
 			try {
 				await panel.api.post(api + "/changes/publish", values);
+
+				if (this.isCurrent(api)) {
+					panel.view.props.originals = panel.view.props.content;
+				}
 			} finally {
 				this.isProcessing = false;
 			}
@@ -49,7 +89,11 @@ export default (panel) => {
 		/**
 		 * Saves any changes
 		 */
-		async save(api, values) {
+		async save(values, api = panel.view.props.api) {
+			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
+				throw new Error("Cannot save locked changes");
+			}
+
 			this.isProcessing = true;
 
 			// ensure to abort unfinished previous save request
@@ -64,6 +108,11 @@ export default (panel) => {
 				});
 
 				this.isProcessing = false;
+
+				// update the lock info
+				if (this.isCurrent(api) === true) {
+					panel.view.props.lock.modified = new Date();
+				}
 			} catch (error) {
 				// silent aborted requests, but throw all other errors
 				if (error.name !== "AbortError") {
@@ -77,6 +126,24 @@ export default (panel) => {
 		 * @internal
 		 * @var {AbortController}
 		 */
-		saveAbortController: null
+		saveAbortController: null,
+
+		/**
+		 * Updates the form values of the current view
+		 */
+		update(values, api = panel.view.props.api) {
+			if (length(values) === 0) {
+				return;
+			}
+
+			if (this.isCurrent(api) === false) {
+				throw new Error("The content in another view cannot be updated");
+			}
+
+			panel.view.props.content = {
+				...panel.view.props.originals,
+				...values
+			};
+		}
 	});
 };

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -12,7 +12,9 @@ export default (panel) => {
 		 * @param {String} api
 		 * @returns {Object}
 		 */
-		changes(api = panel.view.props.api) {
+		changes(api) {
+			api ??= panel.view.props.api;
+
 			// changes can only be computed for the current view
 			if (this.isCurrent(api) === false) {
 				throw new Error("Cannot get changes for another view");
@@ -35,7 +37,9 @@ export default (panel) => {
 		/**
 		 * Removes all unpublished changes
 		 */
-		async discard(api = panel.view.props.api) {
+		async discard(api) {
+			api ??= panel.view.props.api;
+
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -74,8 +78,8 @@ export default (panel) => {
 		 * Whether the current view is locked
 		 * @param {String} api
 		 */
-		isLocked(api = panel.view.props.api) {
-			return this.lock(api).isLocked;
+		isLocked(api) {
+			return this.lock(api ?? panel.view.props.api).isLocked;
 		},
 
 		/**
@@ -88,8 +92,8 @@ export default (panel) => {
 		 * Get the lock state for the current view
 		 * @param {String} api
 		 */
-		lock(api = panel.view.props.api) {
-			if (this.isCurrent(api) === false) {
+		lock(api) {
+			if (this.isCurrent(api ?? panel.view.props.api) === false) {
 				throw new Error(
 					"The lock state cannot be detected for content from another view"
 				);
@@ -101,7 +105,9 @@ export default (panel) => {
 		/**
 		 * Publishes any changes
 		 */
-		async publish(values, api = panel.view.props.api) {
+		async publish(values, api) {
+			api ??= panel.view.props.api;
+
 			if (this.isProcessing === true) {
 				return;
 			}
@@ -132,7 +138,9 @@ export default (panel) => {
 		/**
 		 * Saves any changes
 		 */
-		async save(values, api = panel.view.props.api) {
+		async save(values, api) {
+			api ??= panel.view.props.api;
+
 			if (this.isCurrent(api) === true && this.isLocked(api) === true) {
 				throw new Error("Cannot save locked changes");
 			}
@@ -176,12 +184,12 @@ export default (panel) => {
 		/**
 		 * Updates the form values of the current view
 		 */
-		update(values, api = panel.view.props.api) {
+		update(values, api) {
 			if (length(values) === 0) {
 				return;
 			}
 
-			if (this.isCurrent(api) === false) {
+			if (this.isCurrent(api ?? panel.view.props.api) === false) {
 				throw new Error("The content in another view cannot be updated");
 			}
 


### PR DESCRIPTION
## Description

### Summary of changes

- New option to pass the silent argument to api requests in the options object. This will simplify the API calls quite a bit. Before: `this.$panel.api.post('/path', data, options, 'POST', silent = true)` after: `this.$panel.api.post('/path', data, { silent: true})` This is now used in `this.$panel.content.save()` to keep safe calls silent.
- New `changes` property for the `k-model-tabs` component to pass an object of changes directly. This will make the model tabs more independent from the content module and we can reuse the computed changes object that we already define in the model views.
- All content module methods with a dependency on the api endpoint now have a second optional api endpoint argument. This argument will use the view's api prop by default. 
  - `this.$panel.content.discard(api)`
  - `this.$panel.content.isLocked(api)`
  - `this.$panel.content.lock(api)`
  - `this.$panel.content.publish(values, api)`
  - `this.$panel.content.save(values, api)`
  - `this.$panel.content.saveLazy(values, api)`
  - `this.$panel.content.update(values, api)`  
- All content module methods will throw an Error if they cannot be used on a different view for a different API endpoint
- New content module methods: 
  - `this.$panel.content.isLocked()`
  - `this.$panel.content.lock()`
  - `this.$panel.content.changes()`
  - `this.$panel.content.isCurrent()`
  - `this.$panel.content.saveLazy()` 
- Removed content module props/getters
  - `this.$panel.content.isSaved`
  - `this.$panel.content.originals`
- `this.$panel.content.saveLazy` is now used in the model view `onInput` event instead of throttling it directly in the view. This means that devs can now choose between calling `this.$panel.content.save` or `this.$panel.content.saveLazy` if the action should be delayed.
- The ModelView `onSave` method has been renamed to `onViewSave` This matches the custom event in the events.js, which will trigger this and causes less confusion. This event is only fired on `keydown.cmd.s` and will in fact submit the form and not simply save the content. That's why I believe we should rename this right away.
- The ModelView `isUnsaved` computed property has been renamed to `hasChanges`. This is also supposed to clean up possible confusions, because it's computing the number of items in the `this.$panel.content.changes()` object. 
- All actions in the content module now fire custom events after the requests went through: 
  - `content.save`
  - `content.discard`
  - `content.publish`
- The new `content.save` event is used to update the new ModelView `isSaved` data property. By moving it to the ModelView and using the custom event to keep it updated, we can make sure that it is always correct and bound to the right api endpoint. Otherwise, we would need to keep track of multiple `isSaved` states in the content module. 
- Redundant `on` methods have been removed from the PreviewView.
- The outdated `protectedFields` property has been removed from ModelView

## Outlook

Methods that depend on data from the current view could later be refactored to make API calls instead whenever they are used with different endpoints. 

I.e. right now `this.$panel.content.lock()` wiil only work for the current view and throw an error if you try to pass a different endpoint. But it's totally possible to simply check for the endpoint and then make an async call to that view instead and get the lock info from there. The same would work for `this.$panel.content.changes()` for example. But I didn't want to blow this up even more. I just think that this is a nice way forward that could be really useful. 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
