### PR TITLE
User create dialog: Fix `role` default

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -54,7 +54,7 @@ return [
 						'email'       => '',
 						'password'    => '',
 						'translation' => $kirby->panelLanguage(),
-						'role'        => $role ?? $roles['options'][0]['value'] ?? null
+						'role'        => $role ?: $roles['options'][0]['value'] ?? null
 					]
 				]
 			];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Fixes #6801
  - `$role` can also be an empty string in which case `??` doesn't work 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass
