### PR TITLE
`Xml::attr()`: remove deprecated code

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -43,13 +43,7 @@ class Helpers
 		// Some of them can be replaced by using `Version` class methods instead
 		// (see method comments). `Content\Translation::contentFile` should be avoided
 		//  entirely and has no recommended replacement.
-		'translation-methods' => true,
-
-		// Passing a single space as value to `Xml::attr()` has been
-		// deprecated. In a future version, passing a single space won't
-		// render an empty value anymore but a single space.
-		// To render an empty value, please pass an empty string.
-		'xml-attr-single-space' => true,
+		'translation-methods' => true
 	];
 
 	/**

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Toolkit;
 
-use Kirby\Cms\Helpers;
 use SimpleXMLElement;
 
 /**
@@ -96,15 +95,6 @@ class Xml
 		if ($value === null || $value === false || $value === []) {
 			return null;
 		}
-
-		// TODO: In 5.0, remove this block to render space as space
-		// @codeCoverageIgnoreStart
-		if ($value === ' ') {
-			Helpers::deprecated('Passing a single space as value to `Xml::attr()` has been deprecated. In a future version, passing a single space won\'t render an empty value anymore but a single space. To render an empty value, please pass an empty string.', 'xml-attr-single-space');
-
-			return $name . '=""';
-		}
-		// @codeCoverageIgnoreEnd
 
 		if ($value === true) {
 			return $name . '="' . $name . '"';


### PR DESCRIPTION

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->


### Breaking changes
- Passing a single space as value to `Xml::attr()` won't render an empty value anymore but a single space. To render an empty value, please pass an empty string.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
