### PR TITLE
Support for old local storage entries

### DIFF
--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -66,7 +66,7 @@ export default {
 		api: {
 			handler(newValue, oldValue) {
 				if (newValue !== oldValue) {
-					this.supportLegacyChanges();
+					this.$panel.content.legacy.import(newValue);
 				}
 			},
 			immediate: true
@@ -122,24 +122,6 @@ export default {
 		onViewSave(e) {
 			e?.preventDefault?.();
 			this.onSubmit();
-		},
-		async supportLegacyChanges() {
-			const changes = this.$panel.content.legacyChanges(this.api);
-
-			if (!changes) {
-				return;
-			}
-
-			this.$panel.view.props.content = {
-				...this.$panel.view.props.originals,
-				...changes
-			};
-
-			// store the changes from local storage
-			await this.$panel.content.save(this.$panel.view.props.content, this.api);
-
-			// remove the local storage key
-			window.localStorage.removeItem(this.$panel.content.legacyId(this.api));
 		},
 		toNext(e) {
 			if (this.next && e.target.localName === "body") {

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -91,6 +91,31 @@ export default (panel) => {
 		isProcessing: false,
 
 		/**
+		 * Returns legacy content changes, stored in
+		 * localStorage if they exist.
+		 */
+		legacyChanges(api) {
+			if (this.isCurrent(api ?? panel.view.props.api) === false) {
+				throw new Error("The legacy state cannot be detected for another view");
+			}
+
+			const data = window.localStorage.getItem(this.legacyId(api));
+
+			if (!data) {
+				return null;
+			}
+
+			return JSON.parse(data).changes;
+		},
+
+		/**
+		 * Returns the localstorage id for legacy changes
+		 */
+		legacyId(api) {
+			return `kirby$content$${api}?language=${panel.language.code}`;
+		},
+
+		/**
 		 * Get the lock state for the current view
 		 * @param {String} api
 		 */

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,4 +1,5 @@
 import { isObject } from "@/helpers/object";
+import legacy from "./content.legacy.js";
 import { reactive } from "vue";
 import throttle from "@/helpers/throttle.js";
 
@@ -91,29 +92,9 @@ export default (panel) => {
 		isProcessing: false,
 
 		/**
-		 * Returns legacy content changes, stored in
-		 * localStorage if they exist.
+		 * Legacy content changes support
 		 */
-		legacyChanges(api) {
-			if (this.isCurrent(api ?? panel.view.props.api) === false) {
-				throw new Error("The legacy state cannot be detected for another view");
-			}
-
-			const data = window.localStorage.getItem(this.legacyId(api));
-
-			if (!data) {
-				return null;
-			}
-
-			return JSON.parse(data).changes;
-		},
-
-		/**
-		 * Returns the localstorage id for legacy changes
-		 */
-		legacyId(api) {
-			return `kirby$content$${api}?language=${panel.language.code}`;
-		},
+		legacy: legacy(panel),
 
 		/**
 		 * Get the lock state for the current view

--- a/panel/src/panel/content.legacy.js
+++ b/panel/src/panel/content.legacy.js
@@ -1,0 +1,80 @@
+/**
+ * @since 5.0.0
+ * @deprecated 5.0.0 Remove in 6.0.0
+ */
+export default (panel) => {
+	return {
+		/**
+		 * Returns legacy content changes, stored in
+		 * localStorage if they exist.
+		 */
+		changes(api) {
+			const data = window.localStorage.getItem(this.id(api));
+
+			if (!data) {
+				return null;
+			}
+
+			return JSON.parse(data).changes;
+		},
+		cleanup(api) {
+			const id = this.id(api);
+
+			if (window.localStorage.getItem(id)) {
+				this.log("Cleaning up legacy changes for", api);
+				window.localStorage.removeItem(id);
+			}
+		},
+		/**
+		 * Returns the localstorage id for legacy changes
+		 */
+		id(api) {
+			return `kirby$content$${api}?language=${panel.language.code}`;
+		},
+		async import(api) {
+			const lock = panel.content.lock(api);
+
+			if (lock.isLocked === true) {
+				this.log("The content is locked by someone else", api);
+				this.cleanup(api);
+				return;
+			}
+
+			if (lock.isLegacy === false) {
+				this.log("No legacy lock detected", api);
+				this.cleanup(api);
+				return;
+			}
+
+			if (lock.isActive === false) {
+				this.log("The lock is no longer active", api);
+				this.cleanup(api);
+				return;
+			}
+
+			const changes = this.changes(api);
+
+			if (!changes) {
+				this.log("No valid legacy changes found", api);
+				this.cleanup(api);
+				return;
+			}
+
+			this.log("Importing legacy changes", api);
+			await panel.content.update(changes, api);
+		},
+		log(message, api) {
+			if (panel.debug) {
+				console.info(`[Legacy changes] ${message}:`, api);
+			}
+		},
+		simulate(values, api) {
+			window.localStorage.setItem(
+				this.id(api),
+				JSON.stringify({
+					changes: values
+				})
+			);
+		}
+	};
+};

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -209,6 +209,7 @@ class Lock
 	public function toArray(): array
 	{
 		return [
+			'isActive' => $this->isActive(),
 			'isLegacy' => $this->isLegacy(),
 			'isLocked' => $this->isLocked(),
 			'modified' => $this->modified('c'),

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -450,6 +450,7 @@ class LockTest extends TestCase
 		);
 
 		$this->assertSame([
+			'isActive' => true,
 			'isLegacy' => false,
 			'isLocked' => true,
 			'modified' => date('c', $modified),

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -38,6 +38,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('default', $props['blueprint']);
 		$this->assertSame([
+			'isActive' => false,
 			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,
@@ -96,6 +97,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
+			'isActive' => false,
 			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,
@@ -194,6 +196,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
+			'isActive' => false,
 			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,


### PR DESCRIPTION
## Description

The ModelView checks for old content changes in local storage and sends those to the changes API when the view is being loaded. 


### Summary of changes

- New `panel.content.legacy` module with methods to check for legacy changes, to import them and clean up local storage afterwards.
- New watch method for the api prop in the model view component to import legacy changes whenever the api endpoint changes
- The `isActive` is now being added to the `lock` object. This makes it possible to check if the lock already expired, which we need in order to decide if the changes in local storage should still be imported. 

### How to test?

This is pretty tricky, because a couple things have to be true for this to work. Here's the best way that I found so far: 

1. Switch to the demo lab
2. Go to https://sandbox.test/panel/pages/blog+exploring-the-universe
3. Open the browser console and add some legacy changes to localStorage with this: 
```js
panel.content.legacy.simulate({ subheading: "Test"}, "/pages/blog+exploring-the-universe")
```
4. Create an old .lock file in /public/content/blog/exploring-the-universe/.lock with the following content: 
```
/blog/exploring-the-universe:
  lock:
    user: test
    time: 1732545399
```
5. Adjust the timestamp to be not older than 10 minutes ago.
6. Reload the view

You should now see the Test subheading and active changes. The following should be true: 

1. The localStorage entry is gone
2. The "Test" subheading is visible in the form and changes have been correctly stored in the _changes folder of the article
3. You should be able to see a log of what happened in the browser console.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
