### PR TITLE
Support for old locks

### DIFF
--- a/panel/src/components/Views/PreviewView.vue
+++ b/panel/src/components/Views/PreviewView.vue
@@ -91,10 +91,16 @@
 				</header>
 				<iframe v-if="hasChanges" ref="changes" :src="src.changes"></iframe>
 				<k-empty v-else>
-					{{ $t("lock.unsaved.empty") }}
-					<k-button icon="edit" variant="filled" :link="back">
-						{{ $t("edit") }}
-					</k-button>
+					<template v-if="lock.isLegacy">
+						This content is locked by our old lock system. <br />
+						Changes cannot be previewed.
+					</template>
+					<template v-else>
+						{{ $t("lock.unsaved.empty") }}
+						<k-button icon="edit" variant="filled" :link="back">
+							{{ $t("edit") }}
+						</k-button>
+					</template>
 				</k-empty>
 			</section>
 		</main>
@@ -223,6 +229,8 @@ export default {
 	flex-grow: 1;
 	justify-content: center;
 	flex-direction: column;
+	text-align: center;
+	padding-inline: var(--spacing-3);
 	gap: var(--spacing-6);
 	--button-color-text: var(--color-text);
 }

--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -21,7 +21,13 @@ use Kirby\Form\Form;
 class Changes
 {
 	/**
-	 * Cleans up legacy lock files
+	 * Cleans up legacy lock files. The `discard`, `publish` and `save` actions
+	 * are perfect for this cleanup job. They will be stopped early if
+	 * the lock is still active and otherwise, we can use them to clean
+	 * up outdated .lock files to keep the content folders clean. This
+	 * can be removed as soon as old .lock files should no longer be around.
+	 *
+	 * @todo Remove in 6.0.0
 	 */
 	protected static function cleanup(ModelWithContent $model): void
 	{
@@ -35,6 +41,8 @@ class Changes
 	{
 		$model->version(VersionId::changes())->delete('current');
 
+		// Removes the old .lock file when it is no longer needed
+		// @todo Remove in 6.0.0
 		static::cleanup($model);
 
 		return [
@@ -53,6 +61,8 @@ class Changes
 			input: $input
 		);
 
+		// Removes the old .lock file when it is no longer needed
+		// @todo Remove in 6.0.0
 		static::cleanup($model);
 
 		// get the changes version
@@ -91,6 +101,8 @@ class Changes
 		$changes = $model->version(VersionId::changes());
 		$latest  = $model->version(VersionId::latest());
 
+		// Removes the old .lock file when it is no longer needed
+		// @todo Remove in 6.0.0
 		static::cleanup($model);
 
 		// combine the new field changes with the

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Toolkit\Str;
@@ -42,7 +43,7 @@ class Lock
 		Language|string $language = 'default'
 	): static {
 
-		if ($legacy = static::legacy($version)) {
+		if ($legacy = static::legacy($version->model())) {
 			return $legacy;
 		}
 
@@ -143,12 +144,10 @@ class Lock
 	 * Looks for old .lock files and tries to create a
 	 * usable lock instance from them
 	 */
-	public static function legacy(Version $version): static|null
+	public static function legacy(ModelWithContent $model): static|null
 	{
-		$model = $version->model();
 		$kirby = $model->kirby();
-		$root  = $model::CLASS_ALIAS === 'file' ? dirname($model->root()) : $model->root();
-		$file  = $root . '/.lock';
+		$file  = static::legacyFile($model);
 		$id    = '/' . $model->id();
 
 		// no legacy lock file? no lock.
@@ -173,6 +172,15 @@ class Lock
 			modified: $data['lock']['time'],
 			legacy: true
 		);
+	}
+
+	/**
+	 * Returns the absolute path to a legacy lock file
+	 */
+	public static function legacyFile(ModelWithContent $model): string
+	{
+		$root = $model::CLASS_ALIAS === 'file' ? dirname($model->root()) : $model->root();
+		return $root . '/.lock';
 	}
 
 	/**

--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -179,7 +179,10 @@ class Lock
 	 */
 	public static function legacyFile(ModelWithContent $model): string
 	{
-		$root = $model::CLASS_ALIAS === 'file' ? dirname($model->root()) : $model->root();
+		$root = match ($model::CLASS_ALIAS) {
+			'file'  => dirname($model->root()),
+			default => $model->root()
+		};
 		return $root . '/.lock';
 	}
 

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -157,6 +157,28 @@ class LockTest extends TestCase
 	}
 
 	/**
+	 * @covers ::for
+	 */
+	public function testForWithLegacyLock()
+	{
+		$page = $this->app->page('test');
+		$file = $page->root() . '/.lock';
+
+		Data::write($file, [
+			'/' . $page->id() => [
+				'lock' => [
+					'user' => 'editor',
+					'time' => $time = time()
+				]
+			]
+		], 'yml');
+
+		$lock = Lock::for($page->version('changes'));
+		$this->assertInstanceOf(Lock::class, $lock);
+		$this->assertTrue($lock->isLocked());
+	}
+
+	/**
 	 * @covers ::isActive
 	 */
 	public function testIsActive()
@@ -329,6 +351,20 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLegacy());
 		$this->assertSame($this->app->user('editor'), $lock->user());
 		$this->assertSame($time, $lock->modified());
+	}
+
+	/**
+	 * @covers ::legacy
+	 */
+	public function testLegacyWithoutLockInfo()
+	{
+		$page = $this->app->page('test');
+		$file = $page->root() . '/.lock';
+
+		Data::write($file, [], 'yml');
+
+		$lock = Lock::legacy($page);
+		$this->assertNull($lock);
 	}
 
 	/**

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -319,6 +319,7 @@ class LockTest extends TestCase
 		);
 
 		$this->assertSame([
+			'isLegacy' => false,
 			'isLocked' => true,
 			'modified' => date('c', $modified),
 			'user'     => [

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -38,6 +38,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('default', $props['blueprint']);
 		$this->assertSame([
+			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,
 			'user'     => [
@@ -95,6 +96,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
+			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,
 			'user'     => [
@@ -190,6 +192,7 @@ class SiteTest extends AreaTestCase
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
+			'isLegacy' => false,
 			'isLocked' => false,
 			'modified' => null,
 			'user'     => [


### PR DESCRIPTION
### Summary of changes

- New `Lock::legacy()` method to return a lock instance based on an old .lock file
- New `Lock::legacyFile()` method to return an absolute path to an old lock file based on the model
- The PreviewView now shows a custom message for old lock states because it cannot display the current changes from other users. 
- New cleanup method in the Changes controller to remove old lock files as soon as new changes are stored or discarded