### PR TITLE
Preview tokens 2: Groundwork B (Core)

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -431,14 +431,14 @@ class App
 	 * Generates a non-guessable token based on model
 	 * data and a configured salt
 	 *
-	 * @param mixed $model Object to pass to the salt callback if configured
+	 * @param object|null $model Object to pass to the salt callback if configured
 	 * @param string $value Model data to include in the generated token
 	 */
-	public function contentToken(mixed $model, string $value): string
+	public function contentToken(object|null $model, string $value): string
 	{
 		$default = $this->root('content');
 
-		if (is_object($model) === true && method_exists($model, 'id') === true) {
+		if ($model !== null && method_exists($model, 'id') === true) {
 			$default .= '/' . $model->id();
 		}
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -438,7 +438,7 @@ class App
 	{
 		$default = $this->root('content');
 
-		if (method_exists($model, 'id') === true) {
+		if (is_object($model) === true && method_exists($model, 'id') === true) {
 			$default .= '/' . $model->id();
 		}
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -789,7 +789,7 @@ class Page extends ModelWithContent
 			return false;
 		}
 
-		return $this->token() === $token;
+		return hash_equals($this->token(), $token);
 	}
 
 	/**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -265,14 +265,28 @@ class AppTest extends TestCase
 	 */
 	public function testContentToken()
 	{
+		$model = new class () {
+			public function id(): string
+			{
+				return 'some-id';
+			}
+
+			public function type(): string
+			{
+				return 'sea';
+			}
+		};
+
 		// without configured salt
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			]
 		]);
+		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content/some-id'), $app->contentToken($model, 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken('model', 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken($app, 'test'));
+		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken(null, 'test'));
 
 		// with custom static salt
 		$app = new App([
@@ -280,15 +294,27 @@ class AppTest extends TestCase
 				'content.salt' => 'salt and pepper and chili'
 			]
 		]);
+		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken($model, 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken('model', 'test'));
+		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken($app, 'test'));
+		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken(null, 'test'));
 
-		// with callback
+		// with callback 1
 		$app = new App([
 			'options' => [
-				'content.salt' => fn ($model) => 'salt ' . $model
+				'content.salt' => fn (string $model) => 'salt ' . $model
 			]
 		]);
 		$this->assertSame(hash_hmac('sha1', 'test', 'salt lake city'), $app->contentToken('lake city', 'test'));
+
+		// with callback 2
+		$app = new App([
+			'options' => [
+				'content.salt' => fn (object|null $model) => $model?->type() . ' salt'
+			]
+		]);
+		$this->assertSame(hash_hmac('sha1', 'test', 'sea salt'), $app->contentToken($model, 'test'));
+		$this->assertSame(hash_hmac('sha1', 'test', ' salt'), $app->contentToken(null, 'test'));
 	}
 
 	/**

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -284,7 +284,6 @@ class AppTest extends TestCase
 			]
 		]);
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content/some-id'), $app->contentToken($model, 'test'));
-		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken('model', 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken($app, 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', '/dev/null/content'), $app->contentToken(null, 'test'));
 
@@ -295,19 +294,10 @@ class AppTest extends TestCase
 			]
 		]);
 		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken($model, 'test'));
-		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken('model', 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken($app, 'test'));
 		$this->assertSame(hash_hmac('sha1', 'test', 'salt and pepper and chili'), $app->contentToken(null, 'test'));
 
-		// with callback 1
-		$app = new App([
-			'options' => [
-				'content.salt' => fn (string $model) => 'salt ' . $model
-			]
-		]);
-		$this->assertSame(hash_hmac('sha1', 'test', 'salt lake city'), $app->contentToken('lake city', 'test'));
-
-		// with callback 2
+		// with callback
 		$app = new App([
 			'options' => [
 				'content.salt' => fn (object|null $model) => $model?->type() . ' salt'


### PR DESCRIPTION
## 🚨 Merge first

- #6821

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Two smaller changes that don't fit into the following PRs

### Additional context

The preview tokens will no longer depend on the model in PR 8 because we will need to be able to generate tokens for arbitrary URIs if a custom preview URL was set in the blueprint.

No unit test for `$page->isVerified()` as this method will be removed in PR 7.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Harden preview token verification to mitigate guessing the preview token with a timing attack

### Bug fixes

- Fix PHP error when `null` is passed as model to `$kirby->contentToken()`

### Breaking changes

- `$kirby->contentToken()` only accepts `object|null` for the `$model` parameter instead of `mixed`. In the Kirby core, we currently only ever pass `File` objects or `null`.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
