### PR TITLE
Preview tokens 4: `VersionId::render()`

### DIFF
--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use Stringable;
 
@@ -102,6 +103,24 @@ class VersionId implements Stringable
 	public static function latest(): static
 	{
 		return new static(static::LATEST);
+	}
+
+	/**
+	 * Temporarily sets the version ID for preview rendering
+	 * only for the logic in the callback
+	 */
+	public static function render(VersionId|string $versionId, Closure $callback): mixed
+	{
+		$original       = static::$render;
+		static::$render = static::from($versionId);
+
+		try {
+			return $callback();
+		} finally {
+			// ensure that the render version ID is *always* reset
+			// to the original value, even if an error occurred
+			static::$render = $original;
+		}
 	}
 
 	/**

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 
@@ -10,6 +11,13 @@ use Kirby\TestCase;
  */
 class VersionIdTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		parent::tearDown();
+
+		VersionId::$render = null;
+	}
+
 	/**
 	 * @covers ::all
 	 */
@@ -86,6 +94,114 @@ class VersionIdTest extends TestCase
 		$version = VersionId::latest();
 
 		$this->assertSame('latest', $version->value());
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderString()
+	{
+		$executed = 0;
+
+		$this->assertNull(VersionId::$render);
+
+		$return = VersionId::render('latest', function () use (&$executed) {
+			$executed++;
+			$this->assertSame('latest', VersionId::$render->value());
+
+			return 'some string';
+		});
+		$this->assertSame('some string', $return);
+
+		$this->assertNull(VersionId::$render);
+
+		$return = VersionId::render('changes', function () use (&$executed) {
+			$executed += 2;
+			$this->assertSame('changes', VersionId::$render->value());
+
+			return 12345;
+		});
+		$this->assertSame(12345, $return);
+
+		$this->assertNull(VersionId::$render);
+		$this->assertSame(3, $executed);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderInstance()
+	{
+		$executed = 0;
+
+		$this->assertNull(VersionId::$render);
+
+		$return = VersionId::render(VersionId::latest(), function () use (&$executed) {
+			$executed++;
+			$this->assertSame('latest', VersionId::$render->value());
+
+			return 'some string';
+		});
+		$this->assertSame('some string', $return);
+
+		$this->assertNull(VersionId::$render);
+
+		$return = VersionId::render(VersionId::changes(), function () use (&$executed) {
+			$executed += 2;
+			$this->assertSame('changes', VersionId::$render->value());
+
+			return 12345;
+		});
+		$this->assertSame(12345, $return);
+
+		$this->assertNull(VersionId::$render);
+		$this->assertSame(3, $executed);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderPreviousValue()
+	{
+		$executed = 0;
+
+		VersionId::$render = VersionId::latest();
+
+		$return = VersionId::render('changes', function () use (&$executed) {
+			$executed++;
+			$this->assertSame('changes', VersionId::$render->value());
+
+			return 'some string';
+		});
+		$this->assertSame('some string', $return);
+
+		$this->assertSame('latest', VersionId::$render->value());
+		$this->assertSame(1, $executed);
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function testRenderException()
+	{
+		$executed = 0;
+
+		$this->assertNull(VersionId::$render);
+
+		try {
+			VersionId::render(VersionId::latest(), function () use (&$executed) {
+				$executed++;
+				$this->assertSame('latest', VersionId::$render->value());
+
+				throw new Exception('Something went wrong');
+			});
+		} catch (Exception $e) {
+			$executed += 2;
+			$this->assertSame('Something went wrong', $e->getMessage());
+		}
+
+		$this->assertNull(VersionId::$render);
+		$this->assertSame(3, $executed);
 	}
 
 	/**


### PR DESCRIPTION
## 🚨 Merge first

- #6821
- #6822
- #6823

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Helper method `VersionId::render()` to set `VersionId::$render` only during rendering

### Reasoning

- Atomically set the value (always ensure to restore it afterwards using `try finally`)
- Avoids having to mess with the static `$render` property from other classes (clean code); we could set the visibility of that prop asymmetrically once we drop support for PHP 8.3

### Additional context

Will be used in PR 5

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Features

- New `Kirby\Content\VersionId::render()` method to atomically set the render version during a render operation

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
