### PR TITLE
Preview tokens 5: Version-based rendering

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -4,7 +4,6 @@ namespace Kirby\Cms;
 
 use Closure;
 use Generator;
-use Kirby\Content\VersionId;
 use Kirby\Data\Data;
 use Kirby\Email\Email as BaseEmail;
 use Kirby\Exception\ErrorPageException;
@@ -1216,17 +1215,6 @@ class App
 	): Response|null {
 		if (($_ENV['KIRBY_RENDER'] ?? true) === false) {
 			return null;
-		}
-
-		/**
-		 * TODO: very rough preview mode for changes.
-		 *
-		 * We need page token verification for this before v5
-		 * hits beta. This rough implementation will only help
-		 * to get the panel integration up and running during the alpha
-		 */
-		if ($this->request()->get('_version') === 'changes') {
-			VersionId::$render = VersionId::changes();
 		}
 
 		return $this->io($this->call($path, $method));

--- a/tests/Cms/Pages/fixtures/PageRenderTest/templates/version-exception.php
+++ b/tests/Cms/Pages/fixtures/PageRenderTest/templates/version-exception.php
@@ -1,0 +1,13 @@
+<?php
+
+use Kirby\Content\VersionId;
+use Kirby\Exception\Exception;
+use PHPUnit\Framework\AssertionFailedError;
+
+// validate the correct test scenario
+if (VersionId::$render?->value() !== 'changes') {
+	throw new AssertionFailedError('Version ID is not changes');
+}
+
+// this one is expected and used in the test
+throw new Exception('Something went wrong');

--- a/tests/Cms/Pages/fixtures/PageRenderTest/templates/version-recursive.php
+++ b/tests/Cms/Pages/fixtures/PageRenderTest/templates/version-recursive.php
@@ -1,0 +1,3 @@
+<recursive>
+<?= page('version')->render() . "\n" ?>
+</recursive>

--- a/tests/Cms/Pages/fixtures/PageRenderTest/templates/version.php
+++ b/tests/Cms/Pages/fixtures/PageRenderTest/templates/version.php
@@ -1,0 +1,2 @@
+Version: <?= (\Kirby\Content\VersionId::$render?->value() ?? 'none') . "\n"?>
+Content: <?= $page->title() ?>


### PR DESCRIPTION
## 🚨 Merge first

- #6821
- #6822
- #6823
- #6824

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

`$page->render()` is now responsible to choose the correct version to render.

Users can at any time pass a custom version ID that will always be used if passed. Otherwise the version ID is auto-detected.

If a render version is already set globally, this is the first detection priority. This can be relevant if a template calls `$somePage->render()` of another page. By using the global render version ID, that rendered version will match the one of the "outer" page.

Otherwise the version ID will be taken from the request. In this PR this only re-implements the draft tokens.

### Reasoning

- Usage flexibility
- DRY code

### Additional context

- Logic is moved over 1:1 for now. Following PRs 7-9 will implement the actual version tokens.
- Tests need to disable caching in this PR because the current caching logic would make those tests fail otherwise. PR 6 will fix this and delete the temporary `TODO` additions to the tests.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- It is now possible to override the version ID in `$page->render()` with the new `$versionId` parameter.

### Refactoring (since alphas)

- Move request-based version detection from the `App` class closer to the action in `$page->render()`

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*We could document the new `$versionId` argument to `$page->render()`. But I don't think we already have a place in the guide or cookbook that uses `$page->render()`, at least I couldn't find one.*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
