### PR TITLE
Preview tokens 6: Version-based page caching

### DIFF
--- a/tests/Cms/Pages/PageRenderTest.php
+++ b/tests/Cms/Pages/PageRenderTest.php
@@ -147,6 +147,8 @@ class PageRenderTest extends TestCase
 		]);
 
 		$this->assertSame($expected, $app->page('default')->isCacheable());
+		$this->assertSame($expected, $app->page('default')->isCacheable(VersionId::latest()));
+		$this->assertFalse($app->page('default')->isCacheable(VersionId::changes()));
 	}
 
 	/**
@@ -195,7 +197,11 @@ class PageRenderTest extends TestCase
 		]);
 
 		$this->assertTrue($app->page('default')->isCacheable());
+		$this->assertTrue($app->page('default')->isCacheable(VersionId::latest()));
+		$this->assertFalse($app->page('default')->isCacheable(VersionId::changes()));
 		$this->assertFalse($app->page('data')->isCacheable());
+		$this->assertFalse($app->page('data')->isCacheable(VersionId::latest()));
+		$this->assertFalse($app->page('data')->isCacheable(VersionId::changes()));
 	}
 
 	/**
@@ -212,7 +218,11 @@ class PageRenderTest extends TestCase
 		]);
 
 		$this->assertFalse($app->page('default')->isCacheable());
+		$this->assertFalse($app->page('default')->isCacheable(VersionId::latest()));
+		$this->assertFalse($app->page('default')->isCacheable(VersionId::changes()));
 		$this->assertTrue($app->page('data')->isCacheable());
+		$this->assertTrue($app->page('data')->isCacheable(VersionId::latest()));
+		$this->assertFalse($app->page('data')->isCacheable(VersionId::changes()));
 	}
 
 	/**
@@ -250,12 +260,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('default');
 
-		$this->assertNull($cache->retrieve('default.html'));
+		$this->assertNull($cache->retrieve('default.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$value = $cache->retrieve('default.html');
+		$value = $cache->retrieve('default.latest.html');
 		$this->assertInstanceOf(Value::class, $value);
 		$this->assertSame($html1, $value->value()['html']);
 		$this->assertNull($value->expires());
@@ -273,11 +283,11 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('expiry');
 
-		$this->assertNull($cache->retrieve('expiry.html'));
+		$this->assertNull($cache->retrieve('expiry.latest.html'));
 
 		$time = $page->render();
 
-		$value = $cache->retrieve('expiry.html');
+		$value = $cache->retrieve('expiry.latest.html');
 		$this->assertInstanceOf(Value::class, $value);
 		$this->assertSame($time, $value->value()['html']);
 		$this->assertSame((int)$time, $value->expires());
@@ -292,7 +302,7 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('metadata');
 
-		$this->assertNull($cache->retrieve('metadata.html'));
+		$this->assertNull($cache->retrieve('metadata.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
@@ -323,12 +333,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('disabled');
 
-		$this->assertNull($cache->retrieve('disabled.html'));
+		$this->assertNull($cache->retrieve('disabled.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$this->assertNull($cache->retrieve('disabled.html'));
+		$this->assertNull($cache->retrieve('disabled.latest.html'));
 
 		$html2 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html2);
@@ -355,12 +365,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page($slug);
 
-		$this->assertNull($cache->retrieve($slug . '.html'));
+		$this->assertNull($cache->retrieve($slug . '.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$cacheValue = $cache->retrieve($slug . '.html');
+		$cacheValue = $cache->retrieve($slug . '.latest.html');
 		$this->assertNotNull($cacheValue);
 		$this->assertSame(in_array('auth', $dynamicElements), $cacheValue->value()['usesAuth']);
 		if (in_array('cookie', $dynamicElements)) {
@@ -394,12 +404,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page($slug);
 
-		$this->assertNull($cache->retrieve($slug . '.html'));
+		$this->assertNull($cache->retrieve($slug . '.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$cacheValue = $cache->retrieve($slug . '.html');
+		$cacheValue = $cache->retrieve($slug . '.latest.html');
 		$this->assertNull($cacheValue);
 
 		// reset the Kirby Responder object
@@ -419,12 +429,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page($slug);
 
-		$this->assertNull($cache->retrieve($slug . '.html'));
+		$this->assertNull($cache->retrieve($slug . '.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$cacheValue = $cache->retrieve($slug . '.html');
+		$cacheValue = $cache->retrieve($slug . '.latest.html');
 		$this->assertNotNull($cacheValue);
 		$this->assertSame(in_array('auth', $dynamicElements), $cacheValue->value()['usesAuth']);
 		if (in_array('cookie', $dynamicElements)) {
@@ -454,12 +464,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('data');
 
-		$this->assertNull($cache->retrieve('data.html'));
+		$this->assertNull($cache->retrieve('data.latest.html'));
 
 		$html = $page->render(['test' => 'custom test']);
 		$this->assertStringStartsWith('This is a custom test:', $html);
 
-		$this->assertNull($cache->retrieve('data.html'));
+		$this->assertNull($cache->retrieve('data.latest.html'));
 	}
 
 	/**
@@ -471,12 +481,12 @@ class PageRenderTest extends TestCase
 		$cache = $this->app->cache('pages');
 		$page  = $this->app->page('data');
 
-		$this->assertNull($cache->retrieve('data.html'));
+		$this->assertNull($cache->retrieve('data.latest.html'));
 
 		$html1 = $page->render();
 		$this->assertStringStartsWith('This is a test:', $html1);
 
-		$value = $cache->retrieve('data.html');
+		$value = $cache->retrieve('data.latest.html');
 		$this->assertInstanceOf(Value::class, $value);
 		$this->assertSame($html1, $value->value()['html']);
 		$this->assertNull($value->expires());
@@ -485,7 +495,7 @@ class PageRenderTest extends TestCase
 		$this->assertStringStartsWith('This is a custom test:', $html2);
 
 		// cache still stores the non-custom result
-		$value = $cache->retrieve('data.html');
+		$value = $cache->retrieve('data.latest.html');
 		$this->assertInstanceOf(Value::class, $value);
 		$this->assertSame($html1, $value->value()['html']);
 		$this->assertNull($value->expires());
@@ -595,13 +605,6 @@ class PageRenderTest extends TestCase
 	 */
 	public function testRenderVersionDetectedFromRequest()
 	{
-		// TODO: To be removed in the next PR when caching respects versions
-		$this->app = $this->app->clone([
-			'options' => [
-				'cache.pages' => false
-			]
-		]);
-
 		$page = $this->app->page('version');
 		$page->version('latest')->save(['title' => 'Latest Title']);
 		$page->version('changes')->save(['title' => 'Changes Title']);
@@ -623,13 +626,6 @@ class PageRenderTest extends TestCase
 	 */
 	public function testRenderVersionDetectedRecursive()
 	{
-		// TODO: To be removed in the next PR when caching respects versions
-		$this->app = $this->app->clone([
-			'options' => [
-				'cache.pages' => false
-			]
-		]);
-
 		$versionPage = $this->app->page('version');
 		$versionPage->version('latest')->save(['title' => 'Latest Title']);
 		$versionPage->version('changes')->save(['title' => 'Changes Title']);
@@ -658,13 +654,6 @@ class PageRenderTest extends TestCase
 	 */
 	public function testRenderVersionManual()
 	{
-		// TODO: To be removed in the next PR when caching respects versions
-		$this->app = $this->app->clone([
-			'options' => [
-				'cache.pages' => false
-			]
-		]);
-
 		$page = $this->app->page('version');
 		$page->version('latest')->save(['title' => 'Latest Title']);
 		$page->version('changes')->save(['title' => 'Changes Title']);
@@ -683,13 +672,6 @@ class PageRenderTest extends TestCase
 	 */
 	public function testRenderVersionException()
 	{
-		// TODO: To be removed in the next PR when caching respects versions
-		$this->app = $this->app->clone([
-			'options' => [
-				'cache.pages' => false
-			]
-		]);
-
 		$page = $this->app->page('version-exception');
 
 		try {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

This PR makes the pages cache behave well with the new `$versionId` param for `$page->render()`, even when e.g. generating a static site manually.

### Reasoning

Updating a changes version does not flush the pages cache (would be pretty wasteful), so rendered changes versions should also never be cached.

Extra logic is needed because one can now manually pass the changes version to render, even if no request param is set (which would also prevent caching with existing logic).

Cache ID is already changed because v5 is a good opportunity to do so. This prepares the code for future additions to our version types (e.g. revision support).

### Additional context

The breaking change also affects our Staticache plugin. We need to release a version for v5 that supports the version addition to the cache ID.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements (since alphas)

- The pages cache only caches the `latest` version, not the `changes` version. This is because updating the `changes` version does not flush the pages cache. So `changes` previews are always rendered live.

### Breaking changes

- The cache IDs in the pages cache now include a part for the version ID. Currently this is always `.latest`, e.g. `home.latest.html`.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
