### PR TITLE
Preview tokens 6a: Fix preview token of the site model

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -398,15 +398,24 @@ class Version
 	 */
 	public function previewToken(): string
 	{
-		$id = match (true) {
-			$this->model instanceof Site => '',
-			$this->model instanceof Page => $this->model->id() . $this->model->template(),
-			default                      => throw new LogicException('Invalid model type')
-		};
+		if ($this->model instanceof Site) {
+			// the site itself does not render; its preview is the home page
+			$homePage = $this->model->homePage();
+
+			if ($homePage === null) {
+				throw new NotFoundException('The home page does not exist');
+			}
+
+			return $homePage->version($this->id)->previewToken();
+		}
+
+		if (($this->model instanceof Page) === false) {
+			throw new LogicException('Invalid model type');
+		}
 
 		return $this->model->kirby()->contentToken(
 			$this->model,
-			$id
+			$this->model->id() . $this->model->template()
 		);
 	}
 

--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -86,6 +86,10 @@ class TestCase extends BaseTestCase
 			site: $site ?? [
 				'children' => [
 					[
+						'slug'     => 'home',
+						'template' => 'default'
+					],
+					[
 						'slug'     => 'a-page',
 						'template' => 'article',
 						'files'    => [
@@ -109,6 +113,10 @@ class TestCase extends BaseTestCase
 		parent::setUpSingleLanguage(
 			site: $site ?? [
 				'children' => [
+					[
+						'slug'     => 'home',
+						'template' => 'default'
+					],
 					[
 						'slug'     => 'a-page',
 						'template' => 'article',

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
@@ -785,7 +786,7 @@ class VersionTest extends TestCase
 			model: $this->app->site(),
 			id: VersionId::latest()
 		);
-		$this->assertSame(hash_hmac('sha1', '', static::TMP . '/content/'), $version->previewToken());
+		$this->assertSame(hash_hmac('sha1', 'home' . 'default', static::TMP . '/content/home'), $version->previewToken());
 
 		// page
 		$version = new Version(
@@ -807,6 +808,28 @@ class VersionTest extends TestCase
 
 		$version = new Version(
 			model: $this->model->file(),
+			id: VersionId::latest()
+		);
+
+		$version->previewToken();
+	}
+
+	/**
+	 * @covers ::previewToken
+	 */
+	public function testPreviewTokenMissingHomePage()
+	{
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The home page does not exist');
+
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			]
+		]);
+
+		$version = new Version(
+			model: $app->site(),
 			id: VersionId::latest()
 		);
 


### PR DESCRIPTION
## 🚨 Merge first

- #6827

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

In PR 3 I introduced the new `$version->previewToken()` method. While writing tests for PR 7 I realized that giving the site model its own preview token was wrong. The site preview renders the home page by default, so it also needs to use the home page's preview token by default.

### Additional context

This is an "intermediary" PR that gets its name 6a so that we can continue with PR 7 with its original intended contents I already announced.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

*None* (internal change before any release)

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
