### PR TITLE
Preview tokens 7: Main feature

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1277,7 +1277,7 @@ class App
 		if (!$page && $draft = $site->draft($path)) {
 			if (
 				$this->user() ||
-				$draft->isVerified($this->request()->get('_token'))
+				$draft->renderVersionFromRequest() !== null
 			) {
 				$page = $draft;
 			}

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -349,7 +349,7 @@ class Site extends ModelWithContent
 	}
 
 	/**
-	 * Returns the preview URL with authentication for drafts
+	 * Returns the preview URL with authentication for drafts and versions
 	 * @internal
 	 */
 	public function previewUrl(VersionId|string $versionId = 'latest'): string|null

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -552,7 +552,7 @@ class Version
 	}
 
 	/**
-	 * Returns the preview URL with authentication for drafts
+	 * Returns the preview URL with authentication for drafts and versions
 	 * @internal
 	 */
 	public function url(): string|null
@@ -576,7 +576,10 @@ class Version
 
 		$uri = new Uri($url);
 
-		if ($this->model instanceof Page && $this->model->isDraft() === true) {
+		if (
+			($this->model instanceof Page && $this->model->isDraft() === true) ||
+			$this->id->is('changes') === true
+		) {
 			$uri->query->_token = $this->previewToken();
 		}
 

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Panel\Page as Panel;
-use ReflectionMethod;
 use TypeError;
 
 class PageTestModel extends Page
@@ -692,83 +691,6 @@ class PageTest extends TestCase
 	{
 		$page = new Page(['slug' => 'test']);
 		$this->assertSame('test', $page->slug());
-	}
-
-	public function testToken()
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			]
-		]);
-
-		$page = new Page([
-			'slug'     => 'test',
-			'template' => 'default'
-		]);
-
-		$method = new ReflectionMethod(Page::class, 'token');
-		$method->setAccessible(true);
-
-		$expected = hash_hmac(
-			'sha1',
-			'testdefault',
-			'/dev/null/content/test'
-		);
-		$this->assertSame($expected, $method->invoke($page));
-	}
-
-	public function testTokenWithCustomSalt()
-	{
-		new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'options' => [
-				'content' => [
-					'salt' => 'testsalt'
-				]
-			]
-		]);
-
-		$page = new Page([
-			'slug'     => 'test',
-			'template' => 'default'
-		]);
-
-		$method = new ReflectionMethod(Page::class, 'token');
-		$method->setAccessible(true);
-
-		$expected = hash_hmac('sha1', 'test' . 'default', 'testsalt');
-		$this->assertSame($expected, $method->invoke($page));
-	}
-
-	public function testTokenWithSaltCallback()
-	{
-		new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'options' => [
-				'content' => [
-					'salt' => fn ($page) => $page->date()
-				]
-			]
-		]);
-
-		$page = new Page([
-			'slug'     => 'test',
-			'template' => 'default',
-			'content'  => [
-				'date' => '2012-12-12'
-			]
-		]);
-
-		$method = new ReflectionMethod(Page::class, 'token');
-		$method->setAccessible(true);
-
-		$expected = hash_hmac('sha1', 'test' . 'default', '2012-12-12');
-		$this->assertSame($expected, $method->invoke($page));
 	}
 
 	public function testToString()

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -125,7 +125,7 @@ class SiteTest extends AreaTestCase
 	{
 		$this->login();
 
-		$this->app->site()->createChild([
+		$page = $this->app->site()->createChild([
 			'slug'    => 'test',
 			'isDraft' => false,
 			'content' => [
@@ -136,9 +136,11 @@ class SiteTest extends AreaTestCase
 		$view  = $this->view('pages/test/preview/changes');
 		$props = $view['props'];
 
+		$token = $page->version('changes')->previewToken();
+
 		$this->assertSame('k-preview-view', $view['component']);
 		$this->assertSame('Test | Changes', $view['title']);
-		$this->assertSame('/test?_version=changes', $props['src']['changes']);
+		$this->assertSame('/test?_token=' . $token . '&_version=changes', $props['src']['changes']);
 		$this->assertSame('/test', $props['src']['latest']);
 	}
 
@@ -221,14 +223,21 @@ class SiteTest extends AreaTestCase
 	{
 		$this->login();
 
-		$this->app->site();
+		$site = $this->app->site();
+
+		$site->createChild([
+			'slug'    => 'home',
+			'isDraft' => false
+		]);
 
 		$view  = $this->view('site/preview/changes');
 		$props = $view['props'];
 
+		$token = $site->version('changes')->previewToken();
+
 		$this->assertSame('k-preview-view', $view['component']);
 		$this->assertSame('Site | Changes', $view['title']);
-		$this->assertSame('/?_version=changes', $props['src']['changes']);
+		$this->assertSame('/?_token=' . $token . '&_version=changes', $props['src']['changes']);
 		$this->assertSame('/', $props['src']['latest']);
 	}
 


### PR DESCRIPTION
## 🚨 Merge first

- #6827
- #6828

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

It's finally time for the real thing and main attraction for this PR series. 🎉

This actually:

- adds that the token is added to all changes preview URLs,
- validates the token when auto-detecting the changes version from the request and
- uses the same implementation in `$page->renderVersionFromRequest()` for the draft detection in `$app->resolve()`

### Reasoning

- General thought behind this feature: Prevent externals from accessing changes previews unless they received the full preview URL including token
- Avoid duplicated code by making the draft resolver hook into the same logic as well

### Additional context

This is the first PR where it really makes sense to test it by hand as well. All "default" previews should now work. Only custom blueprint `preview` options that point to other pages don't work yet, those will be added in the last (smaller) PRs 8 and 9.

So for this PR, we can already test the expected behavior for:

- Site preview URL includes token and renders the homepage correctly
- Changing or omitting that token makes Kirby render the latest version instead
- Same for any page previews
- Draft previews should still work as well (with token the draft gets resolved, without token the draft 404s completely)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements (since alphas)

- Preview URLs for changes versions now include a `_token` query param like draft previews. This protects those previews from access by external visitors.

### Breaking changes

- Removed internal `$page->isVerified()` method in favor of internal `$page->renderVersionFromRequest()`

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
