### PR TITLE
Fix file field upload issue with a new async input event

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -44,7 +44,7 @@ export default {
 				preview: this.uploads.preview,
 				url: this.$panel.urls.api + "/" + this.endpoints.field + "/upload",
 				on: {
-					done: (files) => {
+					done: async (files) => {
 						if (this.multiple === false) {
 							this.selected = [];
 						}
@@ -55,7 +55,10 @@ export default {
 							}
 						}
 
-						this.onInput();
+						await this.$panel.content.update({
+							[this.name]: this.selected
+						});
+
 						this.$events.emit("file.upload");
 						this.$events.emit("model.update");
 					}

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -97,7 +97,7 @@ export default {
 		onInput(values) {
 			// update the content for the current view
 			// this will also refresh the content prop
-			this.$panel.content.update(values, this.api);
+			this.$panel.content.updateLazy(values, this.api);
 		},
 		async onSubmit() {
 			await this.$panel.content.publish(this.content, this.api);

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,4 +1,4 @@
-import { length } from "@/helpers/object";
+import { isObject } from "@/helpers/object";
 import { reactive } from "vue";
 import throttle from "@/helpers/throttle.js";
 
@@ -103,6 +103,27 @@ export default (panel) => {
 		},
 
 		/**
+		 * Merge new content changes with the
+		 * original values and update the view props
+		 */
+		merge(values, api) {
+			if (this.isCurrent(api ?? panel.view.props.api) === false) {
+				throw new Error("The content in another view cannot be merged");
+			}
+
+			if (isObject(values) === false) {
+				values = {};
+			}
+
+			panel.view.props.content = {
+				...panel.view.props.originals,
+				...values
+			};
+
+			return panel.view.props.content;
+		},
+
+		/**
 		 * Publishes any changes
 		 */
 		async publish(values, api) {
@@ -184,21 +205,15 @@ export default (panel) => {
 		/**
 		 * Updates the form values of the current view
 		 */
-		update(values, api) {
-			if (length(values) === 0) {
-				return;
-			}
+		async update(values, api) {
+			return await this.save(this.merge(values, api), api);
+		},
 
-			if (this.isCurrent(api ?? panel.view.props.api) === false) {
-				throw new Error("The content in another view cannot be updated");
-			}
-
-			panel.view.props.content = {
-				...panel.view.props.originals,
-				...values
-			};
-
-			this.saveLazy(panel.view.props.content, api);
+		/**
+		 * Updates the form values of the current view with a delay
+		 */
+		async updateLazy(values, api) {
+			return await this.saveLazy(this.merge(values, api), api);
 		}
 	});
 

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -212,8 +212,8 @@ export default (panel) => {
 		/**
 		 * Updates the form values of the current view with a delay
 		 */
-		async updateLazy(values, api) {
-			return await this.saveLazy(this.merge(values, api), api);
+		updateLazy(values, api) {
+			this.saveLazy(this.merge(values, api), api);
 		}
 	});
 

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -41,8 +41,8 @@ export default (panel) => {
 		/**
 		 * Called when dialog's cancel button was clicked
 		 */
-		cancel() {
-			this.emit("cancel");
+		async cancel() {
+			await this.emit("cancel");
 
 			// abort any ongoing requests
 			this.abort?.abort();
@@ -52,7 +52,7 @@ export default (panel) => {
 			// now cancel was clicked, but already some files have
 			// been completely uploaded
 			if (this.completed.length > 0) {
-				this.emit("complete", this.completed);
+				await this.emit("complete", this.completed);
 				panel.view.reload();
 			}
 
@@ -70,11 +70,11 @@ export default (panel) => {
 		 * Gets called when the dialog's submit button was clicked
 		 * and all remaining files have been uploaded
 		 */
-		done() {
+		async done() {
 			panel.dialog.close();
 
 			if (this.completed.length > 0) {
-				this.emit("done", this.completed);
+				await this.emit("done", this.completed);
 
 				if (panel.drawer.isOpen === false) {
 					panel.notification.success({ context: "view" });


### PR DESCRIPTION
## Description

## Changelog

### Fixes

- A file can be uploaded correctly in the files field again: https://github.com/getkirby/kirby/issues/6812 

### Enhancements since (last alpha)

- New `$panel.content.merge` method to merge new changes with the original content and update the view props accordingly. This method will not save the merged changes yet and is used internally in the `update` and `updateLazy` methods. But it could become helpful in other cases as well. 
- New `$panel.content.updateLazy()` method. The `$panel.content.update()` method is now asynchronous and will fire the save call immediately. The new `updateLazy` method is used in the `k-model-view` components `onInput` event to trigger throttled save calls with a short delay. 
- Await is added to every emit call in the upload.js module. This will make it possible to fire asynchronous custom events, which can be quite important. Especially, if the module reloads the panel view after an event.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
