### PR TITLE
Lazy load plugin license info

### DIFF
--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -174,12 +174,8 @@ class Plugin
 	 */
 	public function license(): License
 	{
-		if ($this->license instanceof License) {
-			return $this->license;
-		}
-
 		// resolve license info from Closure, array or string
-		return $this->license = License::from(
+		return License::from(
 			plugin: $this,
 			license: $this->license
 		);

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -29,7 +29,7 @@ use Throwable;
 class Plugin
 {
 	protected Assets $assets;
-	protected License $license;
+	protected License|Closure|array|string $license;
 	protected UpdateStatus|null $updateStatus = null;
 
 	/**
@@ -69,14 +69,9 @@ class Plugin
 		}
 
 		// read composer.json and use as info fallback
-		$info       = Data::read($this->manifest(), fail: false);
-		$this->info = [...$info, ...$this->info];
-
-		// set the license
-		$this->license = License::from(
-			plugin: $this,
-			license: $license ?? $this->info['license'] ?? '-'
-		);
+		$info          = Data::read($this->manifest(), fail: false);
+		$this->info    = [...$info, ...$this->info];
+		$this->license = $license ?? $this->info['license'] ?? '-';
 	}
 
 	/**
@@ -179,7 +174,15 @@ class Plugin
 	 */
 	public function license(): License
 	{
-		return $this->license;
+		if ($this->license instanceof License) {
+			return $this->license;
+		}
+
+		// resolve license info from Closure, array or string
+		return $this->license = License::from(
+			plugin: $this,
+			license: $this->license
+		);
 	}
 
 	/**

--- a/tests/Plugin/PluginTest.php
+++ b/tests/Plugin/PluginTest.php
@@ -254,8 +254,6 @@ class PluginTest extends TestCase
 	{
 		$plugin = new Plugin(name: 'getkirby/test-plugin');
 		$this->assertInstanceOf(License::class, $license = $plugin->license());
-		// check for cached instance
-		$this->assertSame($license, $plugin->license());
 	}
 
 	public function testLicenseFromString(): void

--- a/tests/Plugin/PluginTest.php
+++ b/tests/Plugin/PluginTest.php
@@ -253,7 +253,16 @@ class PluginTest extends TestCase
 	public function testLicense(): void
 	{
 		$plugin = new Plugin(name: 'getkirby/test-plugin');
+		$this->assertInstanceOf(License::class, $license = $plugin->license());
+		// check for cached instance
+		$this->assertSame($license, $plugin->license());
+	}
+
+	public function testLicenseFromString(): void
+	{
+		$plugin = new Plugin(name: 'getkirby/test-plugin', license: 'mit');
 		$this->assertInstanceOf(License::class, $plugin->license());
+		$this->assertSame('mit', $plugin->license()->name());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The Plugin class creates a new License instance in the constructor. The License class constructor uses Kirby\Cms\LicenseStatus to get label and info for the given status. But this already calls the I18n::translate method too early, before the I18n setup is completed. This creates a pretty nasty side-effect and breaks translations for plugins. By lazy-loading the license instance in the `Plugin::license()` method, we can work around this. 

## Changelog

### Fixes

- Fix broken plugin translations by lazy loading the license information https://github.com/getkirby/kirby/issues/6810

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
