### PR TITLE
Remove deprecated JS shortcuts

### DIFF
--- a/panel/src/components/Dialogs/Elements/Fields.vue
+++ b/panel/src/components/Dialogs/Elements/Fields.vue
@@ -17,7 +17,7 @@ export const props = {
 		 * Empty state message if no fields are defined
 		 */
 		empty: {
-			default: () => window.panel.$t("dialog.fields.empty"),
+			default: () => window.panel.t("dialog.fields.empty"),
 			type: String
 		},
 		/**

--- a/panel/src/components/Dialogs/Elements/Text.vue
+++ b/panel/src/components/Dialogs/Elements/Text.vue
@@ -15,7 +15,7 @@ export const props = {
 		 */
 		empty: {
 			type: String,
-			default: () => window.panel.$t("dialog.text.empty")
+			default: () => window.panel.t("dialog.text.empty")
 		},
 		text: {
 			type: String

--- a/panel/src/components/Dialogs/EmailDialog.vue
+++ b/panel/src/components/Dialogs/EmailDialog.vue
@@ -19,12 +19,12 @@ export default {
 		fields: {
 			default: () => ({
 				href: {
-					label: window.panel.$t("email"),
+					label: window.panel.t("email"),
 					type: "email",
 					icon: "email"
 				},
 				title: {
-					label: window.panel.$t("title"),
+					label: window.panel.t("title"),
 					type: "text",
 					icon: "title"
 				}
@@ -36,7 +36,7 @@ export default {
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
-			default: () => window.panel.$t("insert")
+			default: () => window.panel.t("insert")
 		}
 	},
 	data() {

--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -17,7 +17,7 @@ export default {
 			type: Object,
 			default: () => ({
 				icon: "image",
-				text: window.panel.$t("dialog.files.empty")
+				text: window.panel.t("dialog.files.empty")
 			})
 		}
 	}

--- a/panel/src/components/Dialogs/FormDialog.vue
+++ b/panel/src/components/Dialogs/FormDialog.vue
@@ -30,7 +30,7 @@ export default {
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
-			default: () => window.panel.$t("save")
+			default: () => window.panel.t("save")
 		},
 		text: {
 			type: String

--- a/panel/src/components/Dialogs/LinkDialog.vue
+++ b/panel/src/components/Dialogs/LinkDialog.vue
@@ -19,20 +19,20 @@ export default {
 		fields: {
 			default: () => ({
 				href: {
-					label: window.panel.$t("link"),
+					label: window.panel.t("link"),
 					type: "link",
-					placeholder: window.panel.$t("url.placeholder"),
+					placeholder: window.panel.t("url.placeholder"),
 					icon: "url"
 				},
 				title: {
-					label: window.panel.$t("title"),
+					label: window.panel.t("title"),
 					type: "text",
 					icon: "title"
 				},
 				target: {
-					label: window.panel.$t("open.newWindow"),
+					label: window.panel.t("open.newWindow"),
 					type: "toggle",
-					text: [window.panel.$t("no"), window.panel.$t("yes")]
+					text: [window.panel.t("no"), window.panel.t("yes")]
 				}
 			})
 		},
@@ -42,7 +42,7 @@ export default {
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
-			default: () => window.panel.$t("insert")
+			default: () => window.panel.t("insert")
 		}
 	},
 	data() {

--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -40,7 +40,7 @@ export default {
 		},
 		submitButton: {
 			type: [String, Boolean],
-			default: () => window.panel.$t("save")
+			default: () => window.panel.t("save")
 		},
 		template: {
 			type: String

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -41,7 +41,7 @@ export default {
 			type: Object,
 			default: () => ({
 				icon: "page",
-				text: window.panel.$t("dialog.pages.empty")
+				text: window.panel.t("dialog.pages.empty")
 			})
 		}
 	},

--- a/panel/src/components/Dialogs/RemoveDialog.vue
+++ b/panel/src/components/Dialogs/RemoveDialog.vue
@@ -21,7 +21,7 @@ export default {
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
-			default: () => window.panel.$t("delete")
+			default: () => window.panel.t("delete")
 		},
 		// eslint-disable-next-line vue/require-prop-types
 		theme: {

--- a/panel/src/components/Dialogs/TotpDialog.vue
+++ b/panel/src/components/Dialogs/TotpDialog.vue
@@ -84,7 +84,7 @@ export default {
 		// eslint-disable-next-line vue/require-prop-types
 		submitButton: {
 			default: () => ({
-				text: window.panel.$t("activate"),
+				text: window.panel.t("activate"),
 				icon: "lock",
 				theme: "notice"
 			})

--- a/panel/src/components/Dialogs/UploadDialog.vue
+++ b/panel/src/components/Dialogs/UploadDialog.vue
@@ -51,7 +51,7 @@ export default {
 			default: () => {
 				return {
 					icon: "upload",
-					text: window.panel.$t("upload")
+					text: window.panel.t("upload")
 				};
 			}
 		}

--- a/panel/src/components/Dialogs/UploadReplaceDialog.vue
+++ b/panel/src/components/Dialogs/UploadReplaceDialog.vue
@@ -45,7 +45,7 @@ export default {
 			default: () => {
 				return {
 					icon: "upload",
-					text: window.panel.$t("replace")
+					text: window.panel.t("replace")
 				};
 			}
 		}

--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -17,7 +17,7 @@ export default {
 			type: Object,
 			default: () => ({
 				icon: "users",
-				text: window.panel.$t("dialog.users.empty")
+				text: window.panel.t("dialog.users.empty")
 			})
 		},
 		item: {

--- a/panel/src/components/Drawers/Elements/Fields.vue
+++ b/panel/src/components/Drawers/Elements/Fields.vue
@@ -15,7 +15,7 @@ export const props = {
 	props: {
 		empty: {
 			type: String,
-			default: () => window.panel.$t("drawer.fields.empty")
+			default: () => window.panel.t("drawer.fields.empty")
 		},
 		fields: Object,
 		value: Object

--- a/panel/src/components/Drawers/Elements/Text.vue
+++ b/panel/src/components/Drawers/Elements/Text.vue
@@ -16,7 +16,7 @@ export const props = {
 		 */
 		empty: {
 			type: String,
-			default: () => window.panel.$t("drawer.text.empty")
+			default: () => window.panel.t("drawer.text.empty")
 		},
 		text: {
 			type: String

--- a/panel/src/components/Forms/Input/EmailInput.vue
+++ b/panel/src/components/Forms/Input/EmailInput.vue
@@ -19,7 +19,7 @@ export const props = {
 		},
 		placeholder: {
 			type: String,
-			default: () => window.panel.$t("email.placeholder")
+			default: () => window.panel.t("email.placeholder")
 		}
 	}
 };

--- a/panel/src/components/Forms/Input/SearchInput.vue
+++ b/panel/src/components/Forms/Input/SearchInput.vue
@@ -21,7 +21,7 @@ export const props = {
 		spellcheck: null,
 
 		placeholder: {
-			default: () => window.panel.$t("search") + " …",
+			default: () => window.panel.t("search") + " …",
 			type: String
 		}
 	}

--- a/panel/src/components/Forms/Input/TelInput.vue
+++ b/panel/src/components/Forms/Input/TelInput.vue
@@ -17,7 +17,7 @@ export const props = {
 			default: "tel"
 		},
 		placeholder: {
-			default: () => window.panel.$t("tel.placeholder")
+			default: () => window.panel.t("tel.placeholder")
 		}
 	}
 };

--- a/panel/src/components/Forms/Input/UrlInput.vue
+++ b/panel/src/components/Forms/Input/UrlInput.vue
@@ -19,7 +19,7 @@ export const props = {
 		},
 		placeholder: {
 			type: String,
-			default: () => window.panel.$t("url.placeholder")
+			default: () => window.panel.t("url.placeholder")
 		}
 	}
 };

--- a/panel/src/components/Forms/Toolbar/EmailDialog.vue
+++ b/panel/src/components/Forms/Toolbar/EmailDialog.vue
@@ -10,7 +10,7 @@ export default {
 				const fields = EmailDialog.props.fields.default();
 
 				// change the label to "Link Text"
-				fields.title.label = window.panel.$t("link.text");
+				fields.title.label = window.panel.t("link.text");
 
 				return fields;
 			}

--- a/panel/src/components/Forms/Toolbar/LinkDialog.vue
+++ b/panel/src/components/Forms/Toolbar/LinkDialog.vue
@@ -8,13 +8,13 @@ export default {
 		fields: {
 			default: () => ({
 				href: {
-					label: window.panel.$t("link"),
+					label: window.panel.t("link"),
 					type: "link",
-					placeholder: window.panel.$t("url.placeholder"),
+					placeholder: window.panel.t("url.placeholder"),
 					icon: "url"
 				},
 				title: {
-					label: window.panel.$t("link.text"),
+					label: window.panel.t("link.text"),
 					type: "text",
 					icon: "title"
 				}

--- a/panel/src/panel/legacy.js
+++ b/panel/src/panel/legacy.js
@@ -1,6 +1,3 @@
-/* eslint-disable-next-line no-unused-vars */
-import Vue from "vue";
-
 /**
  * This is the graveyard for all deprecated
  * aliases. We can remove them step by step
@@ -11,68 +8,18 @@ import Vue from "vue";
  */
 export default {
 	install(app) {
-		/**
-		 * Method object binding for the polyfills below
-		 */
-		window.panel.redirect = window.panel.redirect.bind(window.panel);
-		window.panel.reload = window.panel.reload.bind(window.panel);
-		window.panel.request = window.panel.request.bind(window.panel);
-		window.panel.search = window.panel.search.bind(window.panel);
-
-		/**
-		 * @deprecated 4.0.0 Dollar Sign Shortcuts for panel data
-		 *
-		 * @example
-		 * // Old:
-		 * `window.panel.$config`
-		 * // New:
-		 * window.panel.config
-		 *
-		 * @example
-		 * // Old:
-		 * this.$config
-		 * // New
-		 * this.$panel.config
-		 */
-		const polyfills = [
-			"api",
-			"config",
-			"direction",
-			"events",
-			"language",
-			"languages",
-			"license",
-			"menu",
-			"multilang",
-			"permissions",
-			"search",
-			"searches",
-			"system",
-			"t",
-			"translation",
-			"url",
-			"urls",
-			"user",
-			"view"
-		];
-
-		for (const polyfill of polyfills) {
-			const key = `$${polyfill}`;
-			app.prototype[key] = window.panel[key] = window.panel[polyfill];
-		}
-
+		const panel = window.panel;
 		/**
 		 * Some more shortcuts to the Panel's features
 		 */
-		app.prototype.$dialog = window.panel.dialog.open.bind(window.panel.dialog);
-		app.prototype.$drawer = window.panel.drawer.open.bind(window.panel.drawer);
-		app.prototype.$dropdown = window.panel.dropdown.openAsync.bind(
-			window.panel.dropdown
-		);
-		app.prototype.$go = window.panel.view.open.bind(window.panel.view);
-		app.prototype.$reload = window.panel.reload.bind(window.panel);
-
-		// Kirbyup relies on this
-		window.panel.$vue = window.panel.app;
+		app.prototype.$api = panel.api;
+		app.prototype.$dialog = panel.dialog.open.bind(panel.dialog);
+		app.prototype.$drawer = panel.drawer.open.bind(panel.drawer);
+		app.prototype.$dropdown = panel.dropdown.openAsync.bind(panel.dropdown);
+		app.prototype.$events = panel.events;
+		app.prototype.$go = panel.view.open.bind(panel.view);
+		app.prototype.$reload = panel.reload;
+		app.prototype.$t = panel.$t = panel.t;
+		app.prototype.$url = panel.url;
 	}
 };


### PR DESCRIPTION
## Description

This PR removes already deprecated JS shortcuts for more clarity. https://github.com/getkirby/kirby/issues/6808#issuecomment-2507551380

### Breaking changes

- Removed global JS shortcuts. Use versions without `$` 
  - `window.panel.$api`
  - `window.panel.$config`
  - `window.panel.$direction`
  - `window.panel.$events`
  - `window.panel.$language`
  - `window.panel.$languages`
  - `window.panel.$license`
  - `window.panel.$menu`
  - `window.panel.$multilang`
  - `window.panel.$search`
  - `window.panel.$searches`
  - `window.panel.$system`
  - `window.panel.$t`
  - `window.panel.$translation`
  - `window.panel.$url`
  - `window.panel.$urls`
  - `window.panel.$user`
  - `window.panel.$view`
- Removed Vue app prototype shortcuts. Access via `this.$panel` instead.
  - `this.$config`
  - `this.$direction`
  - `this.$language`
  - `this.$languages`
  - `this.$license`
  - `this.$menu`
  - `this.$multilang`
  - `this.$search`
  - `this.$searches`
  - `this.$system`
  - `this.$translation`
  - `this.$urls`
  - `this.$user`
  - `this.$view`
- Removed `window.panel.$vue` Use `window.panel.app` instead

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
