### PR TITLE
Retry failed save and publish requests

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -383,8 +383,12 @@
 	"form.discard.confirm": "Do you really want to <strong>discard all your changes</strong>?",
 	"form.locked": "This content is disabled for you as it is currently edited by another user",
 	"form.unsaved": "The current changes have not yet been saved",
+	"form.save.error": "Your changes could not be saved.",
+	"form.save.success": "Your changes have been saved",
 	"form.preview": "Preview changes",
 	"form.preview.draft": "Preview draft",
+	"form.publish.error": "Your changes could not be published.",
+	"form.publish.success": "Your changes have been published",
 
 	"hide": "Hide",
 	"hour": "Hour",

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -7,7 +7,7 @@
 				$vnode.data.staticClass,
 				$attrs.class
 			]"
-			:data-has-footer="cancelButton || submitButton"
+			:data-has-footer="Boolean(cancelButton || submitButton)"
 			:data-size="size"
 			method="dialog"
 			@click.stop

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -201,7 +201,7 @@ export default (panel) => {
 						// try again with the latest state in the props
 						await this.save(panel.view.props.content, api);
 
-						panel.dialog.isLoading = true;
+						panel.dialog.isLoading = false;
 
 						// give a more reassuring longer success notification
 						panel.notification.success(panel.t(`form.${method}.success`));

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -194,7 +194,7 @@ export default (panel) => {
 						this.dialog.isLoading = true;
 
 						// try again with the latest state in the props
-						await this.save(panel.view.props.content, api);
+						await this[method](panel.view.props.content, api);
 
 						// make sure the dialog is closed if the request was successful
 						this.dialog?.close();

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -35,6 +35,18 @@ export default (panel) => {
 		},
 
 		/**
+		 * Closes the retry dialog if it is still open
+		 */
+		closeRetryDialog() {
+			if (
+				panel.dialog.isOpen &&
+				panel.dialog.props.id === "content-retry-dialog"
+			) {
+				panel.dialog.close();
+			}
+		},
+
+		/**
 		 * Removes all unpublished changes
 		 */
 		async discard(api) {
@@ -145,15 +157,57 @@ export default (panel) => {
 			try {
 				await panel.api.post(api + "/changes/publish", values);
 
+				// close the retry dialog if it is still open
+				this.closeRetryDialog();
+
 				// update the props for the current view
 				if (this.isCurrent(api)) {
 					panel.view.props.originals = panel.view.props.content;
 				}
 
 				panel.events.emit("content.publish", { values, api });
+			} catch (error) {
+				this.retry("publish", error, panel.view.props.content, api);
 			} finally {
 				this.isProcessing = false;
 			}
+		},
+
+		/**
+		 * Opens a dialog with the error message
+		 * to retry the given method.
+		 */
+		retry(method, error, values, api) {
+			// log the error to the console to make it
+			// easier to debug the issue
+			console.error(error);
+
+			// show a dialog to the user to try again
+			panel.dialog.open({
+				component: "k-text-dialog",
+				props: {
+					id: "content-retry-dialog",
+					text: panel.t(`form.${method}.error`),
+					cancelButton: panel.t("close"),
+					submitButton: {
+						icon: "refresh",
+						text: panel.t("retry")
+					}
+				},
+				on: {
+					submit: async () => {
+						panel.dialog.isLoading = true;
+
+						// try again with the latest state in the props
+						await this.save(panel.view.props.content, api);
+
+						panel.dialog.isLoading = true;
+
+						// give a more reassuring longer success notification
+						panel.notification.success(panel.t(`form.${method}.success`));
+					}
+				}
+			});
 		},
 
 		/**
@@ -181,6 +235,9 @@ export default (panel) => {
 
 				this.isProcessing = false;
 
+				// close the retry dialog if it is still open
+				this.closeRetryDialog();
+
 				// update the lock timestamp
 				if (this.isCurrent(api) === true) {
 					panel.view.props.lock.modified = new Date();
@@ -191,7 +248,7 @@ export default (panel) => {
 				// silent aborted requests, but throw all other errors
 				if (error.name !== "AbortError") {
 					this.isProcessing = false;
-					throw error;
+					this.retry("save", error, panel.view.props.content, api);
 				}
 			}
 		},

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -179,7 +179,6 @@ export default (panel) => {
 			this.dialog.open({
 				component: "k-text-dialog",
 				props: {
-					id: "content-retry-dialog",
 					text: panel.t(`form.${method}.error`),
 					cancelButton: panel.t("close"),
 					submitButton: {


### PR DESCRIPTION
## Description

The model views will now show a "Retry" dialog when a save or publish request failed. 

![Screenshot 2024-12-05 at 10 21 32](https://github.com/user-attachments/assets/1fe551ba-4cef-47eb-8726-f1877ac9df9c)
![Screenshot 2024-12-05 at 10 21 48](https://github.com/user-attachments/assets/a850bbef-7caa-4f47-bcaf-6d332af2c922)

The methods will be executed again after clicking the "Try again" button. 

### Summary of changes

- New `panel.content.closeRetryDialog()` method
- New `panel.content.retry()` method

### Additional context

The easiest way to test this is with the following steps. 

1. Add this to the `Kirby\Api\Controller\Changes` class at the beginning of the `save` method:
```php
if ($input === ['error' => true]) {
	throw new \Exception('Something went wrong');
}
```
2. Open the browser console and check both dialog versions like this: 
```js
// to show the retry dialog for failed save requests
panel.content.save({error: true});
// to show the retry dialog for failed publish requests
panel.content.publish({error: true});
```

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fixed footer margin in dialogs if the `cancelButton` property is a string or object instead of a boolean.

### Enhancements

- New retry dialog if changes cannot be saved or published.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
