### PR TITLE
Preview tokens 8: New structure for preview tokens

### DIFF
--- a/tests/Cms/Pages/PageRenderTest.php
+++ b/tests/Cms/Pages/PageRenderTest.php
@@ -788,6 +788,36 @@ class PageRenderTest extends TestCase
 	/**
 	 * @covers ::renderVersionFromRequest
 	 */
+	public function testRenderVersionFromRequestMismatch()
+	{
+		$page = $this->app->page('default');
+
+		$this->app->clone([
+			'request' => [
+				'query' => [
+					'_token'   => $page->version('changes')->previewToken(),
+					'_version' => 'latest'
+				]
+			]
+		]);
+
+		$this->assertSame('latest', $page->renderVersionFromRequest()->value());
+
+		$this->app->clone([
+			'request' => [
+				'query' => [
+					'_token'   => $page->version('latest')->previewToken(),
+					'_version' => 'changes'
+				]
+			]
+		]);
+
+		$this->assertSame('latest', $page->renderVersionFromRequest()->value());
+	}
+
+	/**
+	 * @covers ::renderVersionFromRequest
+	 */
 	public function testRenderVersionFromRequestInvalidId()
 	{
 		$page       = $this->app->page('default');

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -677,9 +677,10 @@ class PageTest extends TestCase
 		]);
 
 		if ($draft === true && $expected !== null) {
+			$expectedToken = substr(hash_hmac('sha1', '{"uri":"' . $page->uri() . '","versionId":"latest"}', $page->kirby()->root('content')), 0, 10);
 			$expected = str_replace(
 				'{token}',
-				'_token=' . hash_hmac('sha1', $page->id() . $page->template(), $page->kirby()->root('content') . '/' . $page->id()),
+				'_token=' . $expectedToken,
 				$expected
 			);
 		}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes & Reasoning

- Use URI instead of ID + template to be able to generate tokens for arbitrary custom blueprint preview URIs
- Include version ID (in a secure way wrapped in JSON) to differentiate preview access by version
- Shorten the token to 10 characters to make the preview URLs more manageable

### Additional context

PR 9 will build on the URI-based tokens to implement preview tokens for custom blueprint `preview` options.

Coverage: One line in the `previewTokenFromUrl` method is not tested by this PR. This is because this case is prepared for PR 9 and will be tested there.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Preview authentication tokens of drafts and (new in Kirby 5) versions have been shortened to 10 characters to make the preview URLs more manageable.

### Breaking changes

- Closures defined for the `content.salt` option will no longer receive a model when generating a salt for preview authentication tokens of drafts and versions as those tokens are now only based on the URI. Thus the salt callback instead receives `null` and is expected to return a fixed model-independent salt in this case. When generating a salt for a file media token, the file object is still passed as model.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*Replacing https://getkirby.com/docs/reference/system/options/content#salt-for-drafts-and-media-files:*

### Salt for page previews and media files

URLs of page previews and media files contain a hashed token that should be hard to guess. The tokens are based on the page URI or file ID and are authenticated with a salt value. In the way Kirby uses this salt value, it should ideally be a secret. By default, Kirby uses the filesystem path of the content folder. You can define your own salt that will be used instead:

```php
return [
  'content' => [
    'salt' => '...'
  ]
];
```

You can also dynamically generate a salt based on the model that needs a token:

```php
return [
  'content' => [
    'salt' => function ($model) {
      return '...';
    }
  ]
];
```

\<since v="5.0.0">
The `$model` value is set to the `File` object when generating a media token for a file. For page preview tokens, `$model` is always passed as `null`. Your callback should return a fixed model-independent salt in this case.
\</since>

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
