### PR TITLE
Properly add the current language to every content module call

### DIFF
--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -9,13 +9,16 @@ export default (api) => {
 			cache: "no-store",
 			credentials: "same-origin",
 			mode: "same-origin",
-			headers: {
-				"content-type": "application/json",
-				"x-csrf": api.csrf,
-				"x-language": api.language,
-				...toLowerKeys(options.headers ?? {})
-			},
 			...options
+		};
+
+		// make sure to keep essential headers
+		// unless they are explicitely overwritten
+		options.headers = {
+			"content-type": "application/json",
+			"x-csrf": api.csrf,
+			"x-language": api.language,
+			...toLowerKeys(options.headers ?? {})
 		};
 
 		// adapt headers for all non-GET and non-POST methods

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -44,7 +44,10 @@ export default {
 	},
 	computed: {
 		changes() {
-			return this.$panel.content.changes(this.api);
+			return this.$panel.content.changes({
+				api: this.api,
+				language: this.$panel.language.code
+			});
 		},
 		editor() {
 			return this.lock.user.email;

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -104,15 +104,13 @@ export default {
 		onInput(values) {
 			// update the content for the current view
 			// this will also refresh the content prop
-			this.$panel.content.updateLazy({
-				values: values,
+			this.$panel.content.updateLazy(values, {
 				api: this.api,
 				language: this.$panel.language.code
 			});
 		},
 		async onSubmit() {
-			await this.$panel.content.publish({
-				values: this.content,
+			await this.$panel.content.publish(this.content, {
 				api: this.api,
 				language: this.$panel.language.code
 			});

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -85,22 +85,34 @@ export default {
 				e.returnValue = "";
 			}
 		},
-		onContentSave({ api }) {
-			if (api === this.api) {
+		onContentSave({ api, language }) {
+			if (api === this.api && language === this.$panel.language.code) {
 				this.isSaved = true;
 			}
 		},
 		async onDiscard() {
-			await this.$panel.content.discard(this.api);
+			await this.$panel.content.discard({
+				api: this.api,
+				language: this.$panel.language.code
+			});
+
 			this.$panel.view.refresh();
 		},
 		onInput(values) {
 			// update the content for the current view
 			// this will also refresh the content prop
-			this.$panel.content.updateLazy(values, this.api);
+			this.$panel.content.updateLazy({
+				values: values,
+				api: this.api,
+				language: this.$panel.language.code
+			});
 		},
 		async onSubmit() {
-			await this.$panel.content.publish(this.content, this.api);
+			await this.$panel.content.publish({
+				values: this.content,
+				api: this.api,
+				language: this.$panel.language.code
+			});
 
 			this.$panel.notification.success();
 			this.$events.emit("model.update");

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -9,12 +9,12 @@ export default (panel) => {
 	const content = reactive({
 		/**
 		 * Returns an object with all changed fields
-		 * @param {Object} options
+		 * @param {Object} env
 		 * @returns {Object}
 		 */
-		changes(options = {}) {
+		changes(env = {}) {
 			// changes can only be computed for the current view
-			if (this.isCurrent(options) === false) {
+			if (this.isCurrent(env) === false) {
 				throw new Error("Cannot get changes for another view");
 			}
 


### PR DESCRIPTION
## Description

To ensure maximum stability in multi lang setups, all content module calls now accept an additional language option together with the existing API prop. This way, we can make sure that the API requests are always sent for the right language. 

This needed a bit of refactoring in the content module and some methods have changed arguments now. 

### Summary of changes

- New `content.env({ api, language })` method to always build a proper environment object with existing api and language properties. It will fall back to the current view api and the active language if nothing else is specified
- New `content.emit(event, options, env)` method to simplify emitting content-specific events.
- All content methods now take an env object instead of a separate api and language property. I.e. `content.isLocked({ api, language })`
- New `content.request()` method to handle save, discard and publish requests and ensure that the x-language header is always set correctly. 
- Fixed header handling in the api.request method. If you wanted to set a customer header before, all other essential headers would have be overwritten. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
