### PR TITLE
Fix sqlite driver using double quotes for string literals

### DIFF
--- a/src/Database/Sql/Sqlite.php
+++ b/src/Database/Sql/Sqlite.php
@@ -130,7 +130,7 @@ class Sqlite extends Sql
 	public function tables(): array
 	{
 		return [
-			'query'    => 'SELECT name FROM sqlite_master WHERE type = "table" OR type = "view"',
+			'query'    => 'SELECT name FROM sqlite_master WHERE type = \'table\' OR type = \'view\'',
 			'bindings' => []
 		];
 	}

--- a/tests/Database/Sql/SqliteTest.php
+++ b/tests/Database/Sql/SqliteTest.php
@@ -160,7 +160,7 @@ class SqliteTest extends TestCase
 	public function testTables()
 	{
 		$result = $this->sql->tables();
-		$this->assertSame('SELECT name FROM sqlite_master WHERE type = "table" OR type = "view"', $result['query']);
+		$this->assertSame('SELECT name FROM sqlite_master WHERE type = \'table\' OR type = \'view\'', $result['query']);
 		$this->assertSame([], $result['bindings']);
 	}
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->
Fix the table discovery query in the sqlite class using double quotes for string literals. 


### Summary of changes
 - Using single quotes in sqlite table discovery query fixes #6769


### Reasoning
Double quotes to enclose string literals are *sometimes* supported by sqlite configurations (mainly for backwards compatibility).
Single quotes are *always* supported. 

### Additional context
https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted

## Changelog
 - Using single quotes in sqlite table discovery query fixes #6769


### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
