### PR TITLE
Fix alt attribute for `FileVersion` instances

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Image;
 
+use Kirby\Cms\FileVersion;
 use Kirby\Content\Content;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\File;
@@ -115,15 +116,20 @@ class Image extends File
 	 */
 	public function html(array $attr = []): string
 	{
+		$model = match (true) {
+			$this->model instanceof FileVersion => $this->model->original(),
+			default                             => $this->model
+		};
+
 		// if no alt text explicitly provided,
 		// try to infer from model content file
 		if (
-			$this->model !== null &&
-			method_exists($this->model, 'content') === true &&
-			$this->model->content() instanceof Content &&
-			$this->model->content()->get('alt')->isNotEmpty() === true
+			$model !== null &&
+			method_exists($model, 'content') === true &&
+			$model->content() instanceof Content &&
+			$model->content()->get('alt')->isNotEmpty() === true
 		) {
-			$attr['alt'] ??= $this->model->content()->get('alt')->value();
+			$attr['alt'] ??= $model->content()->get('alt')->value();
 		}
 
 		if ($url = $this->url()) {

--- a/tests/Cms/Files/FileVersionTest.php
+++ b/tests/Cms/Files/FileVersionTest.php
@@ -107,7 +107,11 @@ class FileVersionTest extends TestCase
 			'slug' => 'test'
 		]);
 
-		$original = new File(['filename' => 'test.jpg', 'parent' => $page]);
+		$original = new File([
+			'filename' => 'test.jpg',
+			'parent' => $page,
+			'content' => ['alt' => 'Test text']
+		]);
 		$version  = new FileVersion([
 			'original' => $original,
 			'root'     => static::FIXTURES . '/test.txt',
@@ -122,6 +126,6 @@ class FileVersionTest extends TestCase
 			'url'      => $url = 'https://assets.getkirby.com/test-200x200.jpg',
 		]);
 
-		$this->assertSame('<img alt="" src="' . $url . '">', (string)$version);
+		$this->assertSame('<img alt="Test text" src="' . $url . '">', (string)$version);
 	}
 }


### PR DESCRIPTION
## Description

If a file is cropped/resized, the FileVersion instance is used. We can get the original model from `FileVersion::original()` method.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- #6852


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
