### PR TITLE
Fix `ucfirst` behavior

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1405,7 +1405,7 @@ class Str
 	{
 		$first = static::substr($string, 0, 1);
 		$rest  = static::substr($string, 1);
-		return static::upper($first) . static::lower($rest);
+		return static::upper($first) . $rest;
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1492,7 +1492,10 @@ class StrTest extends TestCase
 	public function testUcfirst()
 	{
 		$this->assertSame('Hello world', Str::ucfirst('hello world'));
-		$this->assertSame('Hello world', Str::ucfirst('Hello World'));
+		$this->assertSame('Hello world', Str::ucfirst('Hello world'));
+		$this->assertSame('Hello World', Str::ucfirst('Hello World'));
+		$this->assertSame('HELLO WORLD', Str::ucfirst('HELLO WORLD'));
+		$this->assertSame('Hello WORLD', Str::ucfirst('hello WORLD'));
 	}
 
 	/**


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed `Str::ucfirst()` behavior, now behaves like PHP default #6834

### ⚠️ Breaking changes
- The `Str::ucfirst()` method no longer lowercases all but the first letter of the text, it only capitalizes the first letter.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
