### PR TITLE
New storage core component

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -4,8 +4,11 @@ use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
 use Kirby\Cms\FileVersion;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\User;
+use Kirby\Content\PlainTextStorage;
+use Kirby\Content\Storage;
 use Kirby\Data\Data;
 use Kirby\Email\PHPMailer as Emailer;
 use Kirby\Exception\NotFoundException;
@@ -299,6 +302,16 @@ return [
 		bool $slots = false
 	): Snippet|string {
 		return Snippet::factory($name, $data, $slots);
+	},
+
+	/**
+	 * Create a new storage object for the given model
+	 */
+	'storage' => function (
+		App $kirby,
+		ModelWithContent $model
+	): Storage {
+		return new PlainTextStorage(model: $model);
 	},
 
 	/**

--- a/config/components.php
+++ b/config/components.php
@@ -233,7 +233,7 @@ return [
 					$scoring['score'] += 16 * $score;
 					$scoring['hits']  += 1;
 
-					// check for exact beginning matches
+				// check for exact beginning matches
 				} elseif (
 					$options['words'] === false &&
 					Str::startsWith($lowerValue, $query) === true
@@ -241,7 +241,7 @@ return [
 					$scoring['score'] += 8 * $score;
 					$scoring['hits']  += 1;
 
-					// check for exact query matches
+				// check for exact query matches
 				} elseif ($matches = preg_match_all('!' . $exact . '!ui', $value, $r)) {
 					$scoring['score'] += 2 * $score;
 					$scoring['hits']  += $matches;

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Generator;
+use Kirby\Content\Storage;
 use Kirby\Data\Data;
 use Kirby\Email\Email as BaseEmail;
 use Kirby\Exception\ErrorPageException;
@@ -1614,6 +1615,14 @@ class App
 
 		echo $snippet;
 		return null;
+	}
+
+	/**
+	 * Returns the default storage instance for a given Model
+	 */
+	public function storage(ModelWithContent $model): Storage
+	{
+		return $this->component('storage')($this, $model);
 	}
 
 	/**

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -51,19 +51,19 @@ class Files extends Collection
 		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
-			// add a file by id
+		// add a file by id
 		} elseif (
 			is_string($object) === true &&
 			$file = App::instance()->file($object)
 		) {
 			$this->__set($file->id(), $file);
 
-			// add a file object
+		// add a file object
 		} elseif ($object instanceof File) {
 			$this->__set($object->id(), $object);
 
-			// give a useful error message on invalid input;
-			// silently ignore "empty" values for compatibility with existing setups
+		// give a useful error message on invalid input;
+		// silently ignore "empty" values for compatibility with existing setups
 		} elseif (in_array($object, [null, false, true], true) !== true) {
 			throw new InvalidArgumentException(
 				message: 'You must pass a Files or File object or an ID of an existing file to the Files collection'

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -6,7 +6,6 @@ use Closure;
 use Kirby\Content\Content;
 use Kirby\Content\ContentTranslation;
 use Kirby\Content\Lock;
-use Kirby\Content\PlainTextStorage;
 use Kirby\Content\Storage;
 use Kirby\Content\Version;
 use Kirby\Content\VersionId;
@@ -547,7 +546,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function storage(): Storage
 	{
-		return $this->storage ??= new PlainTextStorage(model: $this);
+		return $this->storage ??= $this->kirby()->storage($this);
 	}
 
 	/**

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -127,13 +127,13 @@ class PagePicker extends Picker
 		if (empty($this->options['query']) === true) {
 			$items = $this->itemsForParent();
 
-			// when subpage navigation is enabled, a parent
-			// might be passed in addition to the query.
-			// The parent then takes priority.
+		// when subpage navigation is enabled, a parent
+		// might be passed in addition to the query.
+		// The parent then takes priority.
 		} elseif ($this->options['subpages'] === true && empty($this->options['parent']) === false) {
 			$items = $this->itemsForParent();
 
-			// search by query
+		// search by query
 		} else {
 			$items = $this->itemsForQuery();
 		}

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -64,19 +64,19 @@ class Pages extends Collection
 		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
-			// add a page by id
+		// add a page by id
 		} elseif (
 			is_string($object) === true &&
 			$page = $site->find($object)
 		) {
 			$this->__set($page->id(), $page);
 
-			// add a page object
+		// add a page object
 		} elseif ($object instanceof Page) {
 			$this->__set($object->id(), $object);
 
-			// give a useful error message on invalid input;
-			// silently ignore "empty" values for compatibility with existing setups
+		// give a useful error message on invalid input;
+		// silently ignore "empty" values for compatibility with existing setups
 		} elseif (in_array($object, [null, false, true], true) !== true) {
 			throw new InvalidArgumentException(
 				message: 'You must pass a Pages or Page object or an ID of an existing page to the Pages collection'

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -51,19 +51,19 @@ class Users extends Collection
 		if ($object instanceof self) {
 			$this->data = [...$this->data, ...$object->data];
 
-			// add a user by id
+		// add a user by id
 		} elseif (
 			is_string($object) === true &&
 			$user = App::instance()->user($object)
 		) {
 			$this->__set($user->id(), $user);
 
-			// add a user object
+		// add a user object
 		} elseif ($object instanceof User) {
 			$this->__set($object->id(), $object);
 
-			// give a useful error message on invalid input;
-			// silently ignore "empty" values for compatibility with existing setups
+		// give a useful error message on invalid input;
+		// silently ignore "empty" values for compatibility with existing setups
 		} elseif (in_array($object, [null, false, true], true) !== true) {
 			throw new InvalidArgumentException(
 				message: 'You must pass a Users or User object or an ID of an existing user to the Users collection'

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -178,11 +178,11 @@ class Environment
 		if ($options['allowed'] === '*' || $options['allowed'] === ['*']) {
 			$this->detectAuto(true);
 
-			// fixed environments
+		// fixed environments
 		} elseif (empty($options['allowed']) === false) {
 			$this->detectAllowed($options['allowed']);
 
-			// secure auto-detection
+		// secure auto-detection
 		} else {
 			$this->detectAuto();
 		}

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -274,7 +274,7 @@ class Panel
 				message: 'The data could not be found'
 			);
 
-			// interpret strings as errors
+		// interpret strings as errors
 		} elseif (is_string($result) === true) {
 			$result = new Exception($result);
 		}

--- a/src/Parsley/Parsley.php
+++ b/src/Parsley/Parsley.php
@@ -214,7 +214,7 @@ class Parsley
 		) {
 			$this->blocks[$lastIndex]['content']['text'] .= ' ' . $block['content']['text'];
 
-			// append
+		// append
 		} else {
 			$this->blocks[] = $block;
 		}

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -510,7 +510,7 @@ class A
 				) {
 					$merged[] = $value;
 
-					// recursively merge the two array values
+				// recursively merge the two array values
 				} elseif (
 					is_array($value) === true &&
 					isset($merged[$key]) === true &&
@@ -518,7 +518,7 @@ class A
 				) {
 					$merged[$key] = static::merge($merged[$key], $value, $mode);
 
-					// simply overwrite with the value from the second array
+				// simply overwrite with the value from the second array
 				} else {
 					$merged[$key] = $value;
 				}

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -3,6 +3,8 @@
 namespace Kirby\Cms;
 
 use Kirby\Content\Field;
+use Kirby\Content\MemoryStorage;
+use Kirby\Content\PlainTextStorage;
 use Kirby\Email\Email;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
@@ -344,6 +346,37 @@ class AppComponentsTest extends TestCase
 		// with direct output
 		$this->expectOutputString('test');
 		$app->snippet('variable', ['message' => 'test'], false);
+	}
+
+	public function testStorage()
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$this->assertInstanceOf(PlainTextStorage::class, $this->app->storage($this->app->page('test')));
+	}
+
+	public function testStorageWithModifiedComponent()
+	{
+		$this->app = $this->app->clone([
+			'components' => [
+				'storage' => function (App $app, ModelWithContent $model) {
+					return new MemoryStorage($model);
+				}
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$this->assertInstanceOf(MemoryStorage::class, $this->app->storage($this->app->page('test')));
 	}
 
 	public function testTemplate()


### PR DESCRIPTION
## Description

The new storage component can define the default storage instance for any model (site, page, user, file)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `App::storage(ModelWithContent $model)` method
- New `storage` component, which can be overwritten in plugins or the app instance setup.
- The storage component is now used in all Models to create the default storage instance

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

A new default storage component can be defined like this: 

```php
use Kirby\Cms\App;
use Kirby\Cms\ModelWithContent;
use Kirby\Content\PlainTextStorage;

class MyCustomStorageClass extends PlainTextStorage
{

}

// on app initialisation
$kirby = new App([
  'components' => [
    'storage' => function (App $kirby, ModelWithContent $model) {
        return MyCustomStorageClass($model);
    ]
  ]  
]);

// in a plugin
App::plugin('my/storage', [
  'components' => [
    'storage' => function (App $kirby, ModelWithContent $model) {
        return MyCustomStorageClass($model);
    ]
  ]  
]);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
