### PR TITLE
Access permissions 2: New `LanguagePermissions` class

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -427,6 +427,14 @@ class Language implements Stringable
 	}
 
 	/**
+	 * Returns the permissions object for this language
+	 */
+	public function permissions(): LanguagePermissions
+	{
+		return new LanguagePermissions($this);
+	}
+
+	/**
 	 * Returns the absolute path to the language file
 	 */
 	public function root(): string

--- a/src/Cms/LanguagePermissions.php
+++ b/src/Cms/LanguagePermissions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Cms;
+
+/**
+ * LanguagePermissions
+ *
+ * @package   Kirby Cms
+ * @author    Ahmet Bora <ahmet@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class LanguagePermissions extends ModelPermissions
+{
+	protected string $category = 'languages';
+
+	protected function canDelete(): bool
+	{
+		return $this->model->isDeletable() === true;
+	}
+}

--- a/src/Cms/LanguageRules.php
+++ b/src/Cms/LanguageRules.php
@@ -37,9 +37,7 @@ class LanguageRules
 			);
 		}
 
-		$user = App::instance()->user();
-
-		if ($user?->role()->permissions()->for('languages', 'create') !== true) {
+		if ($language->permissions()->create() !== true) {
 			throw new PermissionException(
 				key: 'language.create.permission'
 			);
@@ -54,15 +52,7 @@ class LanguageRules
 	 */
 	public static function delete(Language $language): void
 	{
-		if ($language->isDeletable() === false) {
-			throw new LogicException(
-				message: 'The language cannot be deleted'
-			);
-		}
-
-		$user = App::instance()->user();
-
-		if ($user?->role()->permissions()->for('languages', 'delete') !== true) {
+		if ($language->permissions()->delete() !== true) {
 			throw new PermissionException(
 				key: 'language.delete.permission'
 			);
@@ -93,9 +83,7 @@ class LanguageRules
 			);
 		}
 
-		$user = $kirby->user();
-
-		if ($user?->role()->permissions()->for('languages', 'update') !== true) {
+		if ($newLanguage->permissions()->update() !== true) {
 			throw new PermissionException(
 				key: 'language.update.permission'
 			);

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -16,17 +16,21 @@ use Kirby\Toolkit\A;
 abstract class ModelPermissions
 {
 	protected string $category;
-	protected ModelWithContent $model;
+	protected ModelWithContent|Language $model;
 	protected array $options;
 	protected Permissions $permissions;
 	protected User $user;
 
-	public function __construct(ModelWithContent $model)
+	public function __construct(ModelWithContent|Language $model)
 	{
 		$this->model       = $model;
-		$this->options     = $model->blueprint()->options();
 		$this->user        = $model->kirby()->user() ?? User::nobody();
 		$this->permissions = $this->user->role()->permissions();
+
+		$this->options = match (true) {
+			$model instanceof ModelWithContent => $model->blueprint()->options(),
+			default                            => []
+		};
 	}
 
 	public function __call(string $method, array $arguments = []): bool

--- a/tests/Cms/Languages/LanguagePermissionsTest.php
+++ b/tests/Cms/Languages/LanguagePermissionsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Cms\LanguagePermissions
+ */
+class LanguagePermissionsTest extends TestCase
+{
+	public static function actionProvider(): array
+	{
+		return [
+			['create'],
+			['delete'],
+			['update'],
+		];
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::can
+	 * @dataProvider actionProvider
+	 */
+	public function testWithAdmin($action)
+	{
+		$kirby = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor']
+			]
+		]);
+
+		$kirby->impersonate('kirby');
+
+		$language = new Language(['code' => 'en']);
+		$perms    = $language->permissions();
+
+		$this->assertTrue($perms->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::can
+	 * @dataProvider actionProvider
+	 */
+	public function testWithNobody($action)
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor']
+			]
+		]);
+
+		$language = new Language(['code' => 'en']);
+		$perms    = $language->permissions();
+
+		$this->assertFalse($perms->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::can
+	 * @dataProvider actionProvider
+	 */
+	public function testWithNoAdmin($action)
+	{
+		$app = new App([
+			'languages' => [
+				[
+					'code' => 'en'
+				]
+			],
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin'],
+				[
+					'name' => 'editor',
+					'permissions' => [
+						'languages' => [
+							'create' => false,
+							'delete' => false,
+							'update' => false
+						],
+					]
+				]
+			],
+			'user'  => 'editor@getkirby.com',
+			'users' => [
+				[
+					'email' => 'admin@getkirby.com',
+					'role'  => 'admin'
+				],
+				[
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+		]);
+
+		$language = $app->language('en');
+		$perms    = $language->permissions();
+
+		$this->assertSame('editor', $app->role()->name());
+		$this->assertFalse($perms->can($action));
+	}
+
+	/**
+	 * @covers ::canDelete
+	 */
+	public function testCanDeleteWhenNotDeletable()
+	{
+		$app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'roles' => [
+				['name' => 'admin']
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$language = $app->language('en');
+		$perms    = $language->permissions();
+
+		$this->assertFalse($perms->can('delete'));
+	}
+}

--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -159,8 +159,8 @@ class LanguageRulesTest extends TestCase
 		$language = $this->createMock(Language::class);
 		$language->method('isDeletable')->willReturn(false);
 
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('The language cannot be deleted');
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to delete the language');
 
 		LanguageRules::delete($language);
 	}

--- a/tests/Cms/Users/UserPermissionsTest.php
+++ b/tests/Cms/Users/UserPermissionsTest.php
@@ -122,16 +122,24 @@ class UserPermissionsTest extends TestCase
 
 	public function testChangeSingleRole()
 	{
-		new App([
+		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
 			'roles' => [
 				['name' => 'admin']
+			],
+			'users' => [
+				[
+					'email' => 'test@getkirby.com',
+					'role'  => 'admin'
+				]
 			]
 		]);
 
-		$user  = new User(['email' => 'test@getkirby.com']);
+		$app->impersonate('kirby');
+
+		$user  = $app->user('test@getkirby.com');
 		$perms = $user->permissions();
 
 		$this->assertFalse($perms->can('changeRole'));


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Refactor out the permission handling for `Cms\Language` into `LanguagePermissions` to be consistent with other `ModelPermissions` classes

### Reasoning

Consistency when we add additional permissions for languages

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- `ModelPermissions` now also supports `Language` objects as quasi models
- New `LanguagePermissions` class that inherits the existing logic from `LanguageRules` for consistency with other models

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
