### PR TITLE
Access permissions 5: DRY permission caching

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -318,12 +318,7 @@ class File extends ModelWithContent
 			return false;
 		}
 
-		static $accessible   = [];
-		$role                = $this->kirby()->role()?->id() ?? '__none__';
-		$template            = $this->template() ?? '__none__';
-		$accessible[$role] ??= [];
-
-		return $accessible[$role][$template] ??= $this->permissions()->can('access');
+		return FilePermissions::canFromCache($this, 'access');
 	}
 
 	/**
@@ -342,12 +337,7 @@ class File extends ModelWithContent
 			return false;
 		}
 
-		static $listable   = [];
-		$role              = $this->kirby()->role()?->id() ?? '__none__';
-		$template          = $this->template() ?? '__none__';
-		$listable[$role] ??= [];
-
-		return $listable[$role][$template] ??= $this->permissions()->can('list');
+		return FilePermissions::canFromCache($this, 'list');
 	}
 
 	/**

--- a/src/Cms/FilePermissions.php
+++ b/src/Cms/FilePermissions.php
@@ -15,6 +15,14 @@ class FilePermissions extends ModelPermissions
 {
 	protected const CATEGORY = 'files';
 
+	/**
+	 * Used to cache once determined permissions in memory
+	 */
+	protected static function cacheKey(ModelWithContent|Language $model): string
+	{
+		return $model->template() ?? '__none__';
+	}
+
 	protected function canChangeTemplate(): bool
 	{
 		if (count($this->model->blueprints()) <= 1) {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -522,12 +522,7 @@ class Page extends ModelWithContent
 			return false;
 		}
 
-		static $accessible   = [];
-		$role                = $this->kirby()->role()?->id() ?? '__none__';
-		$template            = $this->intendedTemplate()->name();
-		$accessible[$role] ??= [];
-
-		return $accessible[$role][$template] ??= $this->permissions()->can('access');
+		return PagePermissions::canFromCache($this, 'access');
 	}
 
 	/**
@@ -694,12 +689,7 @@ class Page extends ModelWithContent
 			return false;
 		}
 
-		static $listable   = [];
-		$role              = $this->kirby()->role()?->id() ?? '__none__';
-		$template          = $this->intendedTemplate()->name();
-		$listable[$role] ??= [];
-
-		return $listable[$role][$template] ??= $this->permissions()->can('list');
+		return PagePermissions::canFromCache($this, 'list');
 	}
 
 	/**

--- a/src/Cms/PagePermissions.php
+++ b/src/Cms/PagePermissions.php
@@ -15,6 +15,14 @@ class PagePermissions extends ModelPermissions
 {
 	protected const CATEGORY = 'pages';
 
+	/**
+	 * Used to cache once determined permissions in memory
+	 */
+	protected static function cacheKey(ModelWithContent|Language $model): string
+	{
+		return $model->intendedTemplate()->name();
+	}
+
 	protected function canChangeSlug(): bool
 	{
 		return $this->model->isHomeOrErrorPage() !== true;

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -13,6 +13,14 @@ namespace Kirby\Cms;
  */
 class UserPermissions extends ModelPermissions
 {
+	/**
+	 * Used to cache once determined permissions in memory
+	 */
+	protected static function cacheKey(ModelWithContent|Language $model): string
+	{
+		return $model->role()->id();
+	}
+
 	protected function canChangeRole(): bool
 	{
 		// protect admin from role changes by non-admin

--- a/tests/Cms/Files/FilePermissionsTest.php
+++ b/tests/Cms/Files/FilePermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\LogicException;
 use Kirby\TestCase;
 
 /**
@@ -14,6 +15,9 @@ class FilePermissionsTest extends TestCase
 		$this->app = new App([
 			'roots' => [
 				'index' => '/dev/null'
+			],
+			'users' => [
+				['id' => 'bastian', 'role' => 'admin']
 			]
 		]);
 	}
@@ -58,6 +62,51 @@ class FilePermissionsTest extends TestCase
 		$perms = $file->permissions();
 
 		$this->assertFalse($perms->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
+	 */
+	public function testCanFromCache()
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page(['slug' => 'test']);
+		$file = new File([
+			'filename'  => 'test.jpg',
+			'parent'    => $page,
+			'template'  => 'some-template',
+			'blueprint' => [
+				'name' => 'files/some-template',
+				'options' => [
+					'access' => false,
+					'list'   => false
+				]
+			]
+		]);
+
+		$this->assertFalse(FilePermissions::canFromCache($file, 'access'));
+		$this->assertFalse(FilePermissions::canFromCache($file, 'access'));
+		$this->assertFalse(FilePermissions::canFromCache($file, 'list'));
+		$this->assertFalse(FilePermissions::canFromCache($file, 'list'));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
+	 */
+	public function testCanFromCacheDynamic()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Cannot use permission cache for dynamically-determined permission');
+
+		$page = new Page(['slug' => 'test']);
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $page,
+			'template' => 'some-template',
+		]);
+
+		FilePermissions::canFromCache($file, 'changeTemplate');
 	}
 
 	/**

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\LogicException;
 use Kirby\TestCase;
 
 /**
@@ -268,6 +269,49 @@ class PagePermissionsTest extends TestCase
 		$perms = $page->permissions();
 
 		$this->assertFalse($perms->can($action));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
+	 */
+	public function testCanFromCache()
+	{
+		$this->app->impersonate('bastian');
+
+		$page = new Page([
+			'slug'      => 'test',
+			'num'       => 1,
+			'template'  => 'some-template',
+			'blueprint' => [
+				'name' => 'some-template',
+				'options' => [
+					'access' => false,
+					'list'   => false
+				]
+			]
+		]);
+
+		$this->assertFalse(PagePermissions::canFromCache($page, 'access'));
+		$this->assertFalse(PagePermissions::canFromCache($page, 'access'));
+		$this->assertFalse(PagePermissions::canFromCache($page, 'list'));
+		$this->assertFalse(PagePermissions::canFromCache($page, 'list'));
+	}
+
+	/**
+	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
+	 */
+	public function testCanFromCacheDynamic()
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('Cannot use permission cache for dynamically-determined permission');
+
+		$page = new Page([
+			'slug'     => 'test',
+			'num'      => 1,
+			'template' => 'some-template',
+		]);
+
+		PagePermissions::canFromCache($page, 'changeTemplate');
 	}
 
 	/**


### PR DESCRIPTION
## 🚨 Merge first

- #6879
- #6880 

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Move caching of `access` and `list` permissions to `ModelPermissions`

### Reasoning

DRY code, especially now that we would add five more of these methods to the `User`, `Site` and `Language` classes

### Additional context

We could cache all other permissions as well, but I've wrestled with unit tests for too long before Christmas. The write permissions would also benefit less from the caching as there is usually only one write operation per request (in contrast to potentially hundreds of list/access permission checks).

Another advantage of the separate `canFromCache()` method is that it makes explicit which checks come from cache and which are dynamic. If we ever use `canFromCache()` in a place that needs dynamic checking, we will immediately be able to tell because of the `LogicException` that is thrown then.

The new `UserPermissions::cacheKey()` is currently uncovered as the `User` class does not have `access`/`list` permissions at the moment. This will be fixed in the PR 7.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Globally cache `access` and `list` permissions per permission category, model type and user role to reduce code duplication

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] Add changes & docs to release notes draft in Notion
