### PR TITLE
Access permissions 6: Complete test cases

### DIFF
--- a/tests/Cms/Files/FilePermissionsTest.php
+++ b/tests/Cms/Files/FilePermissionsTest.php
@@ -25,10 +25,14 @@ class FilePermissionsTest extends TestCase
 	public static function actionProvider(): array
 	{
 		return [
+			['access'],
 			['changeName'],
+			// ['changeTemplate'], Tested separately because of the needed blueprints
 			['create'],
 			['delete'],
+			['list'],
 			['replace'],
+			['sort'],
 			['update']
 		];
 	}

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use ReflectionProperty;
 
 /**
  * @coversDefaultClass \Kirby\Cms\PagePermissions
@@ -22,16 +23,25 @@ class PagePermissionsTest extends TestCase
 		]);
 	}
 
+	public function tearDown(): void
+	{
+		$prop = new ReflectionProperty(PagePermissions::class, 'cache');
+		$prop->setValue(null, []);
+	}
+
 	public static function actionProvider(): array
 	{
 		return [
+			['access'],
 			['changeSlug'],
 			['changeStatus'],
-			// ['changeTemplate'], Returns false because of only one blueprint
+			// ['changeTemplate'], Tested separately because of the needed blueprints
 			['changeTitle'],
 			['create'],
 			['delete'],
 			['duplicate'],
+			['list'],
+			['move'],
 			['preview'],
 			['sort'],
 			['update'],


### PR DESCRIPTION
## 🚨 Merge first

- #6879
- #6880
- #6881

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Add missing provider cases for existing permissions

### Reasoning

We have added these permissions since creating these tests and seem to have forgotten to add them here as well.

### Additional context

Clearing the cache is needed for `PageBlueprint` tests because we reuse the same blueprint names with different options. Ideally we would clear the cache after every test in the `Cms` namespace, but for some reason many test classes inherit from `Kirby\TestCase` instead of `Kirby\Cms\TestCase`, thus making it hard to find a good place for this.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

*None* (too small of a change to be relevant)

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] ~Add lab and/or sandbox examples (wherever helpful)~
- [x] ~Add changes & docs to release notes draft in Notion~
