### PR TITLE
Stucture field: fix preview input when paginated

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -64,7 +64,7 @@
 					:sortable="isSortable"
 					:data-invalid="isInvalid"
 					@cell="open($event.row, $event.columnIndex)"
-					@input="save"
+					@input="onTableInput"
 					@option="option"
 					@paginate="paginate"
 				/>
@@ -466,6 +466,23 @@ export default {
 					this.open(row);
 					break;
 			}
+		},
+
+		/**
+		 * Merges the updated values from the paginated table
+		 * into the original items array and saves them
+		 * @param {Array} values
+		 */
+		onTableInput(values) {
+			if (this.limit) {
+				values = this.items.toSpliced(
+					this.pagination.offset,
+					this.limit,
+					...values
+				);
+			}
+
+			this.save(values);
 		},
 
 		/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- When a structure field is paginated, `k-table` will only receive the slice of values for the current page.
- Consequently, it will only emit those rows again when a row is updated via a field preview.
- Thus, we cannot simply save what we receive from he table input event, but need to splice those rows into the full unpaginated array and save that one.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Structure field: fixed losing rows when changes were made through a field preview in a paginated table




## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
