### PR TITLE
System view: plugin license status separate column

### DIFF
--- a/config/areas/system/views.php
+++ b/config/areas/system/views.php
@@ -63,6 +63,7 @@ return [
 						'text' => $plugin->name() ?? '–',
 						'href' => $plugin->link(),
 					],
+					'status'  => $plugin->license()->status()->toArray(),
 					'version' => $version,
 				];
 			});

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -468,7 +468,7 @@
 	"license.status.missing.info": "No valid license",
 	"license.status.missing.label": "Please activate your license",
 	"license.status.unknown.info": "The license status is unknown",
-	"license.status.unknown.label": "Unknown license",
+	"license.status.unknown.label": "Unknown",
 	"license.manage": "Manage your licenses",
 	"license.purchased": "Purchased",
 	"license.success": "Thank you for supporting Kirby",

--- a/panel/src/components/Views/System/SystemPlugins.vue
+++ b/panel/src/components/Views/System/SystemPlugins.vue
@@ -19,6 +19,10 @@
 					label: $t('license'),
 					type: 'license'
 				},
+				status: {
+					label: $t('license.status'),
+					type: 'license-status'
+				},
 				version: {
 					label: $t('version'),
 					type: 'update-status',

--- a/panel/src/components/Views/System/TableLicenseCell.vue
+++ b/panel/src/components/Views/System/TableLicenseCell.vue
@@ -1,16 +1,9 @@
 <template>
-	<div class="k-table-license-cell">
-		<k-button
-			:element="value.link ? 'k-link' : 'span'"
-			:icon="value.status.icon"
-			:link="value.link"
-			:theme="value.status.theme"
-			:title="value.status.label"
-			size="xs"
-			target="_blank"
-		>
+	<div class="k-text-field-preview">
+		<k-link v-if="value.link" :href="value.link" target="_blank">
 			{{ value.name }}
-		</k-button>
+		</k-link>
+		<span v-else>{{ value.name }}</span>
 	</div>
 </template>
 
@@ -25,9 +18,3 @@ export default {
 	}
 };
 </script>
-
-<style>
-.k-table-license-cell {
-	padding: 0 var(--spacing-1);
-}
-</style>

--- a/panel/src/components/Views/System/TableLicenseCell.vue
+++ b/panel/src/components/Views/System/TableLicenseCell.vue
@@ -1,10 +1,9 @@
 <template>
-	<div class="k-text-field-preview">
-		<k-link v-if="value.link" :href="value.link" target="_blank">
-			{{ value.name }}
-		</k-link>
-		<span v-else>{{ value.name }}</span>
-	</div>
+	<k-url-field-preview
+		v-if="value.link"
+		:value="{ href: value.link, text: value.name }"
+	/>
+	<k-text-field-preview v-else :value="value.name" />
 </template>
 
 <script>

--- a/panel/src/components/Views/System/TableLicenseStatusCell.vue
+++ b/panel/src/components/Views/System/TableLicenseStatusCell.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="k-table-license-status-cell">
+		<k-button
+			:dialog="value.dialog"
+			:drawer="value.drawer"
+			:element="element"
+			:icon="value.icon"
+			:link="value.link"
+			:theme="value.theme"
+			size="xs"
+			target="_blank"
+		>
+			{{ value.label }}
+		</k-button>
+	</div>
+</template>
+
+<script>
+/**
+ * @internal
+ */
+export default {
+	inheritAttrs: false,
+	props: {
+		value: Object
+	},
+	computed: {
+		element() {
+			if (this.value.dialog || this.value.drawer || this.value.link) {
+				// allow using the computed component from `k-button`
+				return null;
+			}
+
+			// force a `<span>` element instead of a `<button>`
+			return "span";
+		}
+	}
+};
+</script>
+
+<style>
+.k-table-license-status-cell {
+	padding: 0 var(--spacing-1);
+}
+</style>

--- a/panel/src/components/Views/System/index.js
+++ b/panel/src/components/Views/System/index.js
@@ -1,11 +1,13 @@
 import SystemView from "./SystemView.vue";
 import TableLicenseCell from "./TableLicenseCell.vue";
+import TableLicenseStatusCell from "./TableLicenseStatusCell.vue";
 import TableUpdateStatusCell from "./TableUpdateStatusCell.vue";
 
 export default {
 	install(app) {
 		app.component("k-system-view", SystemView);
 		app.component("k-table-license-cell", TableLicenseCell);
+		app.component("k-table-license-status-cell", TableLicenseStatusCell);
 		app.component("k-table-update-status-cell", TableUpdateStatusCell);
 	}
 };

--- a/src/Plugin/LicenseStatus.php
+++ b/src/Plugin/LicenseStatus.php
@@ -20,6 +20,9 @@ class LicenseStatus implements Stringable
 		protected string $value,
 		protected string $icon,
 		protected string $label,
+		protected string|null $link = null,
+		protected string|null $dialog = null,
+		protected string|null $drawer = null,
 		protected string|null $theme = null
 	) {
 	}
@@ -30,6 +33,22 @@ class LicenseStatus implements Stringable
 	public function __toString(): string
 	{
 		return $this->label();
+	}
+
+	/**
+	 * Returns the status dialog
+	 */
+	public function dialog(): string|null
+	{
+		return $this->dialog;
+	}
+
+	/**
+	 * Returns the status drawer
+	 */
+	public function drawer(): string|null
+	{
+		return $this->drawer;
 	}
 
 	/**
@@ -73,6 +92,14 @@ class LicenseStatus implements Stringable
 	}
 
 	/**
+	 * Returns the status link
+	 */
+	public function link(): string|null
+	{
+		return $this->link;
+	}
+
+	/**
 	 * Returns the theme
 	 */
 	public function theme(): string|null
@@ -86,10 +113,13 @@ class LicenseStatus implements Stringable
 	public function toArray(): array
 	{
 		return [
-			'icon'  => $this->icon(),
-			'label' => $this->label(),
-			'theme' => $this->theme(),
-			'value' => $this->value(),
+			'dialog' => $this->dialog(),
+			'drawer' => $this->drawer(),
+			'icon'   => $this->icon(),
+			'label'  => $this->label(),
+			'link'   => $this->link(),
+			'theme'  => $this->theme(),
+			'value'  => $this->value(),
 		];
 	}
 

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -4,7 +4,6 @@ namespace Kirby\Plugin;
 
 use Closure;
 use Composer\InstalledVersions;
-use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
 use Kirby\Cms\System\UpdateStatus;

--- a/tests/Panel/Areas/SystemTest.php
+++ b/tests/Panel/Areas/SystemTest.php
@@ -37,14 +37,22 @@ class SystemTest extends AreaTestCase
 	public function unknownLicense(): array
 	{
 		return [
-			'link' => null,
-			'name' => '-',
-			'status' => [
-				'icon'  => 'question',
-				'label' => 'Unknown license',
-				'theme' => 'passive',
-				'value' => 'unknown',
-			]
+			'link'   => null,
+			'name'   => '-',
+			'status' => $this->unknownLicenseStatus()
+		];
+	}
+
+	public function unknownLicenseStatus(): array
+	{
+		return [
+			'dialog' => null,
+			'drawer' => null,
+			'icon'   => 'question',
+			'label'  => 'Unknown license',
+			'link'	 => null,
+			'theme'  => 'passive',
+			'value'  => 'unknown',
 		];
 	}
 
@@ -199,6 +207,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/private',
 					'href' => null
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '?',
 					'icon' => 'question',
@@ -216,6 +225,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/public',
 					'href' => 'https://getkirby.com'
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '1.0.0',
 					'icon' => 'info',
@@ -233,6 +243,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/unknown',
 					'href' => null
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '1.0.0',
 					'icon' => 'question',
@@ -293,6 +304,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/private',
 					'href' => null
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '?',
 					'icon' => 'question',
@@ -310,6 +322,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/public',
 					'href' => 'https://getkirby.com'
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '1.0.0',
 					'icon' => 'info',
@@ -327,6 +340,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/unknown',
 					'href' => null
 				],
+				'status' => $this->unknownLicenseStatus(),
 				'version' => [
 					'currentVersion' => '1.0.0',
 					'icon' => 'question',
@@ -411,6 +425,7 @@ class SystemTest extends AreaTestCase
 					'text' => 'getkirby/public',
 					'href' => 'https://getkirby.com'
 				],
+				'status'  => $this->unknownLicenseStatus(),
 				'version' => '1.0.0'
 			]
 		], $props['plugins']);

--- a/tests/Panel/Areas/SystemTest.php
+++ b/tests/Panel/Areas/SystemTest.php
@@ -49,7 +49,7 @@ class SystemTest extends AreaTestCase
 			'dialog' => null,
 			'drawer' => null,
 			'icon'   => 'question',
-			'label'  => 'Unknown license',
+			'label'  => 'Unknown',
 			'link'	 => null,
 			'theme'  => 'passive',
 			'value'  => 'unknown',

--- a/tests/Plugin/LicenseStatusTest.php
+++ b/tests/Plugin/LicenseStatusTest.php
@@ -34,6 +34,36 @@ class LicenseStatusTest extends TestCase
 	}
 
 	/**
+	 * @covers ::dialog
+	 */
+	public function testDialog(): void
+	{
+		$status = new LicenseStatus(
+			value: 'missing',
+			icon: 'alert',
+			label: 'Enter license',
+			dialog: $dialog = 'my/dialog'
+		);
+
+		$this->assertSame($dialog, $status->dialog());
+	}
+
+	/**
+	 * @covers ::drawer
+	 */
+	public function testDrawer(): void
+	{
+		$status = new LicenseStatus(
+			value: 'missing',
+			icon: 'alert',
+			label: 'Enter license',
+			drawer: $drawer = 'my/drawer'
+		);
+
+		$this->assertSame($drawer, $status->drawer());
+	}
+
+	/**
 	 * @covers ::from
 	 */
 	public function testFromInstance(): void
@@ -113,6 +143,21 @@ class LicenseStatusTest extends TestCase
 	}
 
 	/**
+	 * @covers ::link
+	 */
+	public function testLink(): void
+	{
+		$status = new LicenseStatus(
+			value: 'missing',
+			icon: 'alert',
+			label: 'Buy license',
+			link: $url = 'https://getkirby.com/buy'
+		);
+
+		$this->assertSame($url, $status->link());
+	}
+
+	/**
 	 * @covers ::theme
 	 */
 	public function testTheme(): void
@@ -139,10 +184,13 @@ class LicenseStatusTest extends TestCase
 		);
 
 		$this->assertSame([
-			'icon'  => 'check',
-			'label' => 'Valid license',
-			'theme' => null,
-			'value' => 'active'
+			'dialog' => null,
+			'drawer' => null,
+			'icon'   => 'check',
+			'label'  => 'Valid license',
+			'link'   => null,
+			'theme'  => null,
+			'value'  => 'active'
 		], $status->toArray());
 	}
 

--- a/tests/Plugin/LicenseTest.php
+++ b/tests/Plugin/LicenseTest.php
@@ -137,10 +137,13 @@ class LicenseTest extends TestCase
 			'link'   => null,
 			'name'   => 'Custom license',
 			'status' => [
-				'icon'  => 'question',
-				'label' => 'Unknown license',
-				'theme' => 'passive',
-				'value' => 'unknown',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => 'question',
+				'label'  => 'Unknown',
+				'link'   => null,
+				'theme'  => 'passive',
+				'value'  => 'unknown',
 			]
 		], $license->toArray());
 	}

--- a/tests/Plugin/PluginTest.php
+++ b/tests/Plugin/PluginTest.php
@@ -211,11 +211,22 @@ class PluginTest extends TestCase
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
 			info: [
-				'license' => 'MIT'
+				'license' => 'MIT',
+				'authors' => [
+					[
+						'name'  => 'A',
+						'email' => 'a@getkirby.com'
+					],
+					[
+						'name'  => 'B',
+						'email' => 'b@getkirby.com'
+					]
+				]
 			]
 		);
 
 		$this->assertSame('MIT', $plugin->info()['license']);
+		$this->assertSame('A, B', $plugin->authorsNames());
 	}
 
 	/**
@@ -473,10 +484,13 @@ class PluginTest extends TestCase
 				'link'   => null,
 				'name'   => 'MIT',
 				'status' => [
-					'icon'  => 'check',
-					'label' => 'Valid license',
-					'theme' => 'positive',
-					'value' => 'active',
+					'dialog' => null,
+					'drawer' => null,
+					'icon'   => 'check',
+					'label'  => 'Valid license',
+					'link'   => null,
+					'theme'  => 'positive',
+					'value'  => 'active',
 				]
 			],
 			'link'        => 'https://getkirby.com',


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Plugin license status now has its own column in the System view to actually display the `LicenseStatus::$label` string
  <img width="1304" alt="Screenshot 2025-01-18 at 11 11 35" src="https://github.com/user-attachments/assets/e4bc3408-1911-49b8-85fe-b90841a4a5be" />
  

- `LicenseStatus` supports new `link`, `dialog`, `drawer` props


## Docs

```php
App::plugin(
  name: 'my/plugin',
  extends: [...],
  license: [
    'name' => 'Custom license',
    'link' => 'https://mylicenseshop.com',
    'status' => [
      'value' => 'missing',
      'theme' => 'purple',
      'label' => 'Get a license',
      'icon' => 'smile',
      'dialog' => 'my/dialog',
    ]
  ]
);
```


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] https://github.com/getkirby/sandbox/pull/14
- [x] Add changes & docs to release notes draft in Notion
