### PR TITLE
Page dropdown: fix disabling preview item

### DIFF
--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -107,13 +107,14 @@ class Page extends Model
 				'target'   => '_blank',
 				'icon'     => 'open',
 				'text'     => I18n::translate('open'),
-				'disabled' => $this->isDisabledDropdownOption('preview', $options, $permissions)
+				'disabled' => $isPreviewDisabled = $this->isDisabledDropdownOption('preview', $options, $permissions)
 			];
 
 			$result['preview'] = [
-				'icon' => 'window',
-				'link' => $page->panel()->url(true) . '/preview/compare',
-				'text' => I18n::translate('preview'),
+				'icon'     => 'window',
+				'link'     => $page->panel()->url(true) . '/preview/compare',
+				'text'     => I18n::translate('preview'),
+				'disabled' => $isPreviewDisabled
 			];
 
 			$result[] = '-';


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Page dropdown: when `preview` is disable, don't just disable the `Open` item but also the new `Preview` item
#6891

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
