### PR TITLE
Range/Number field: fix `isEmpty()` usage

### DIFF
--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -34,7 +34,7 @@ return [
 	],
 	'methods' => [
 		'toNumber' => function ($value) {
-			if ($this->isEmpty($value) === true) {
+			if ($this->isEmptyValue($value) === true) {
 				return null;
 			}
 

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -67,7 +67,7 @@ return [
 		'required' => function ($value) {
 			if (
 				$this->isRequired() &&
-				($value === false || $this->isEmpty($value))
+				($value === false || $this->isEmptyValue($value))
 			) {
 				throw new InvalidArgumentException(
 					message: I18n::translate('field.required')

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -30,7 +30,9 @@ class Field extends Component
 	use Mixin\Translatable;
 	use Mixin\Validation;
 	use Mixin\When;
-	use Mixin\Value;
+	use Mixin\Value {
+		isEmptyValue as protected isEmptyValueFromMixin;
+	}
 
 	/**
 	 * Parent collection with all fields of the current form
@@ -297,6 +299,21 @@ class Field extends Component
 	public function isDisabled(): bool
 	{
 		return $this->disabled === true;
+	}
+
+	/**
+	 * Checks if the given value is considered empty
+	 */
+	public function isEmptyValue(mixed $value = null): bool
+	{
+		if (
+			isset($this->options['isEmpty']) === true &&
+			$this->options['isEmpty'] instanceof Closure
+		) {
+			return $this->options['isEmpty']->call($this, $value);
+		}
+
+		return $this->isEmptyValueFromMixin($value);
 	}
 
 	/**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -5,7 +5,6 @@ namespace Kirby\Form;
 use Closure;
 use Kirby\Cms\HasSiblings;
 use Kirby\Exception\InvalidArgumentException;
-use Kirby\Toolkit\A;
 use Kirby\Toolkit\Component;
 use Kirby\Toolkit\I18n;
 

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -531,6 +531,29 @@ class FieldTest extends TestCase
 	}
 
 	/**
+	 * @covers ::isEmptyValue
+	 */
+	public function testIsEmptyValueFromOption()
+	{
+		Field::$types = [
+			'test' => [
+				'isEmpty' => function ($value) {
+					return $value === 'empty';
+				}
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page,
+		]);
+
+		$this->assertFalse($field->isEmptyValue('test'));
+		$this->assertTrue($field->isEmptyValue('empty'));
+	}
+
+	/**
 	 * @covers ::isHidden
 	 */
 	public function testIsHidden()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- After restructuring the form classes, `Form\Value::isEmpty()` (and by that `$field->isEmpty()` cannot be called anymore with a value passed
- Number, range and toggle field therefore must use `Value::isEmptyValue($value)` instead

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
