### PR TITLE
Structure field: fix label of remove dropdown item

### DIFF
--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -177,21 +177,6 @@ export default {
 
 			return (this.page - 1) * this.limit + 1;
 		},
-		/**
-		 * Returns if new entries can be added
-		 * @returns {bool}
-		 */
-		more() {
-			if (this.disabled === true) {
-				return false;
-			}
-
-			if (this.max && this.items.length >= this.max) {
-				return false;
-			}
-
-			return true;
-		},
 		hasFields() {
 			return this.$helper.object.length(this.fields) > 0;
 		},
@@ -242,6 +227,21 @@ export default {
 			return true;
 		},
 		/**
+		 * Returns if new entries can be added
+		 * @returns {bool}
+		 */
+		more() {
+			if (this.disabled === true) {
+				return false;
+			}
+
+			if (this.max && this.items.length >= this.max) {
+				return false;
+			}
+
+			return true;
+		},
+		/**
 		 * Returns config for `k-pagination`
 		 * @returns {Obect}
 		 */
@@ -270,31 +270,25 @@ export default {
 				return [];
 			}
 
-			let options = [];
-			let more = this.duplicate && this.more;
-
-			options.push({
-				icon: "edit",
-				text: this.$t("edit"),
-				click: "edit"
-			});
-
-			options.push({
-				disabled: !more,
-				icon: "copy",
-				text: this.$t("duplicate"),
-				click: "duplicate"
-			});
-
-			options.push("-");
-
-			options.push({
-				icon: "trash",
-				text: more ? this.$t("delete") : null,
-				click: "remove"
-			});
-
-			return options;
+			return [
+				{
+					icon: "edit",
+					text: this.$t("edit"),
+					click: "edit"
+				},
+				{
+					disabled: !this.duplicate || !this.more,
+					icon: "copy",
+					text: this.$t("duplicate"),
+					click: "duplicate"
+				},
+				"-",
+				{
+					icon: "trash",
+					text: this.$t("delete"),
+					click: "remove"
+				}
+			];
 		},
 		/**
 		 * Returns paginated slice of items/rows


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Since by now we always show a dropdown, this https://github.com/getkirby/kirby/blob/94cc37ee7c3004ebb4950a53f14e1329ed4d28d3/panel/src/components/Forms/Field/StructureField.vue#L293 doesn't make sense anymore
- Remove dropdown item should always have a text label


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Structure field: fix missing label of remove dropdown entry 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
