### PR TITLE
Page section w/ table layout: fix flag column

### DIFF
--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -12,24 +12,26 @@ export default {
 				const sortable = page.permissions.sort && this.options.sortable;
 				const deletable = this.data.length > this.options.min;
 
+				const flag = {
+					...this.$helper.page.status(
+						page.status,
+						page.permissions.changeStatus === false
+					),
+					click: () => this.$dialog(page.link + "/changeStatus")
+				};
+
 				return {
 					...page,
-					buttons: [
-						{
-							...this.$helper.page.status(
-								page.status,
-								page.permissions.changeStatus === false
-							),
-							click: () => this.$dialog(page.link + "/changeStatus")
-						},
-						...(page.buttons ?? [])
-					],
+					buttons: [flag, ...(page.buttons ?? [])],
 					column: this.column,
 					data: {
 						"data-id": page.id,
 						"data-status": page.status,
 						"data-template": page.template
 					},
+					// TODO: remove `flag` once table layout has been refactored
+					// into a separate component and `buttons` support has been added
+					flag,
 					deletable,
 					options: this.$dropdown(page.link, {
 						query: {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Adds page status data both as button (for cards, card lets and let) and as separate `flag` entry (for table layout)
- Fixes https://github.com/getkirby/kirby/issues/6866


### Reasoning
It's not the prettiest solution, but the most pragmatic to fix the regression right now.

Mid term, it would be good to encapsulate `k-table` into a `k-table-items` wrapper component which adds support for `buttons` entry as individual columns. 


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
