### PR TITLE
View buttons: i18n + query support, component name from key

### DIFF
--- a/config/areas/languages/views.php
+++ b/config/areas/languages/views.php
@@ -75,9 +75,8 @@ return [
 				],
 				'props'      => [
 					'buttons' => fn () =>
-						ViewButtons::view('language')
+						ViewButtons::view('language', model: $language)
 							->defaults('preview', 'settings', 'delete')
-							->bind(['language' => $language])
 							->render(),
 					'deletable'    => $language->isDeletable(),
 					'code'         => Escape::html($language->code()),

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -35,6 +35,11 @@ class Language implements Stringable
 	use HasSiblings;
 
 	/**
+	 * Short human-readable version used in template queries
+	 */
+	public const CLASS_ALIAS = 'language';
+
+	/**
 	 * The parent Kirby instance
 	 */
 	public static App|null $kirby;

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -76,10 +76,7 @@ class File extends Model
 			'preview',
 			'settings',
 			'languages'
-		)->bind([
-			'file'  => $this->model(),
-			'model' => $this->model()
-		])->render();
+		)->render();
 	}
 
 	/**

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -51,10 +51,7 @@ class Page extends Model
 			'settings',
 			'languages',
 			'status'
-		)->bind([
-			'page'  => $this->model(),
-			'model' => $this->model()
-		])->render();
+		)->render();
 	}
 
 	/**

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -33,10 +33,7 @@ class Site extends Model
 		return ViewButtons::view($this)->defaults(
 			'preview',
 			'languages'
-		)->bind([
-			'model' => $this->model(),
-			'site'  => $this->model()
-		])->render();
+		)->render();
 	}
 
 	/**

--- a/src/Panel/Ui/Button.php
+++ b/src/Panel/Ui/Button.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Panel\Ui;
 
+use Kirby\Toolkit\I18n;
+
 /**
  * @package   Kirby Panel
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -28,9 +30,9 @@ class Button extends Component
 		public string|null $size = null,
 		public string|null $style = null,
 		public string|null $target = null,
-		public string|null $text = null,
+		public string|array|null $text = null,
 		public string|null $theme = null,
-		public string|null $title = null,
+		public string|array|null $title = null,
 		public string $type = 'button',
 		public string|null $variant = null,
 	) {
@@ -51,9 +53,9 @@ class Button extends Component
 			'responsive' => $this->responsive,
 			'size'       => $this->size,
 			'target'     => $this->target,
-			'text'       => $this->text,
+			'text'       => I18n::translate($this->text, $this->text),
 			'theme'      => $this->theme,
-			'title'      => $this->title,
+			'title'      => I18n::translate($this->title, $this->title),
 			'type'       => $this->type,
 			'variant'    => $this->variant,
 		];

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -25,17 +25,18 @@ class LanguagesDropdown extends ViewButton
 	protected App $kirby;
 
 	public function __construct(
-		protected ModelWithContent $model
+		ModelWithContent $model
 	) {
 		$this->kirby = $model->kirby();
 
 		parent::__construct(
 			component: 'k-languages-dropdown',
+			model: $model,
 			class: 'k-languages-dropdown',
 			icon: 'translate',
 			// Fiber dropdown endpoint to load options
 			// only when dropdown is opened
-			options: $this->model->panel()->url(true) . '/languages',
+			options: $model->panel()->url(true) . '/languages',
 			responsive: 'text',
 			text: Str::upper($this->kirby->language()?->code())
 		);

--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -55,6 +55,7 @@ class ViewButton extends Button
 	 */
 	public static function factory(
 		string|array|Closure $button,
+		string|int|null $name = null,
 		string|null $view = null,
 		ModelWithContent|null $model = null,
 		array $data = []
@@ -64,6 +65,7 @@ class ViewButton extends Button
 			$button = static::find($button, $view);
 		}
 
+		// turn closure into actual button (object or array)
 		$button = static::resolve($button, $model, $data);
 
 		if (
@@ -73,7 +75,17 @@ class ViewButton extends Button
 			return $button;
 		}
 
-		return new static(...static::normalize($button), model: $model);
+		// flatten definition array into list of arguments for this class
+		$button = static::normalize($button);
+
+		// if button definition has a name, use it for the component name
+		if (is_string($name) === true) {
+			// If this specific component does not exist,
+			// `k-view-buttons` will fall back to `k-view-button` again
+			$button['component'] ??= 'k-' . $name . '-view-button';
+		}
+
+		return new static(...$button, model: $model);
 	}
 
 	/**
@@ -128,6 +140,7 @@ class ViewButton extends Button
 
 	public function props(): array
 	{
+		// helper for props that support Kirby queries
 		$resolve = fn ($value) =>
 			$value ?
 			$this->model?->toSafeString($value) ?? $value :

--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Closure;
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Panel\Panel;
 use Kirby\Panel\Ui\Button;
@@ -25,7 +26,7 @@ class ViewButton extends Button
 {
 	public function __construct(
 		public string $component = 'k-view-button',
-		public readonly ModelWithContent|null $model = null,
+		public readonly ModelWithContent|Language|null $model = null,
 		public array|null $badge = null,
 		public string|null $class = null,
 		public string|bool|null $current = null,
@@ -57,7 +58,7 @@ class ViewButton extends Button
 		string|array|Closure $button,
 		string|int|null $name = null,
 		string|null $view = null,
-		ModelWithContent|null $model = null,
+		ModelWithContent|Language|null $model = null,
 		array $data = []
 	): static|null {
 		// referenced by name
@@ -162,14 +163,17 @@ class ViewButton extends Button
 	 */
 	public static function resolve(
 		Closure|array $button,
-		ModelWithContent|null $model = null,
+		ModelWithContent|Language|null $model = null,
 		array $data = []
 	): static|array|null {
 		if ($button instanceof Closure) {
 			$kirby      = App::instance();
 			$controller = new Controller($button);
 
-			if ($model instanceof ModelWithContent) {
+			if (
+				$model instanceof ModelWithContent ||
+				$model instanceof Language
+			) {
 				$data = [
 					'model'             => $model,
 					$model::CLASS_ALIAS => $model,

--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -148,10 +148,13 @@ class ViewButton extends Button
 			null;
 
 		return [
-			...parent::props(),
-			'dialog'  => $resolve($this->dialog),
-			'drawer'  => $resolve($this->drawer),
-			'link'    => $resolve($this->link),
+			...$props = parent::props(),
+			'dialog'  => $resolve($props['dialog']),
+			'drawer'  => $resolve($props['drawer']),
+			'icon'    => $resolve($props['icon']),
+			'link'    => $resolve($props['link']),
+			'text'    => $resolve($props['text']),
+			'theme'   => $resolve($props['theme']),
 			'options' => $this->options
 		];
 	}

--- a/src/Panel/Ui/Buttons/ViewButtons.php
+++ b/src/Panel/Ui/Buttons/ViewButtons.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Panel\Model;
 
@@ -21,7 +22,7 @@ class ViewButtons
 {
 	public function __construct(
 		public readonly string $view,
-		public readonly ModelWithContent|null $model = null,
+		public readonly ModelWithContent|Language|null $model = null,
 		public array|false|null $buttons = null,
 		public array $data = []
 	) {
@@ -86,7 +87,7 @@ class ViewButtons
 	 */
 	public static function view(
 		string|Model $view,
-		ModelWithContent|null $model = null
+		ModelWithContent|Language|null $model = null
 	): static {
 		if ($view instanceof Model) {
 			$model     = $view->model();

--- a/src/Panel/Ui/Buttons/ViewButtons.php
+++ b/src/Panel/Ui/Buttons/ViewButtons.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Panel\Model;
-use Kirby\Toolkit\A;
 
 /**
  * Collects view buttons for a specific view
@@ -26,6 +25,8 @@ class ViewButtons
 		public array|false|null $buttons = null,
 		public array $data = []
 	) {
+		// if no specific buttons are passed,
+		// use default buttons for this view from config
 		$this->buttons ??= App::instance()->option(
 			'panel.viewButtons.' . $view
 		);
@@ -64,18 +65,19 @@ class ViewButtons
 			return [];
 		}
 
-		$buttons = A::map(
-			$this->buttons ?? [],
-			fn ($button) =>
-				ViewButton::factory(
-					button: $button,
-					view: $this->view,
-					model: $this->model,
-					data: $this->data
-				)?->render()
-		);
+		$buttons = [];
 
-		return array_values(array_filter($buttons));
+		foreach ($this->buttons ?? [] as $name => $button) {
+			$buttons[] = ViewButton::factory(
+				button: $button,
+				name: $name,
+				view: $this->view,
+				model: $this->model,
+				data: $this->data
+			)?->render();
+		}
+
+		return array_filter($buttons);
 	}
 
 	/**

--- a/src/Panel/Ui/Buttons/ViewButtons.php
+++ b/src/Panel/Ui/Buttons/ViewButtons.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Panel\Model;
 use Kirby\Toolkit\A;
 
@@ -21,6 +22,7 @@ class ViewButtons
 {
 	public function __construct(
 		public readonly string $view,
+		public readonly ModelWithContent|null $model = null,
 		public array|false|null $buttons = null,
 		public array $data = []
 	) {
@@ -66,9 +68,10 @@ class ViewButtons
 			$this->buttons ?? [],
 			fn ($button) =>
 				ViewButton::factory(
-					$button,
-					$this->view,
-					$this->data
+					button: $button,
+					view: $this->view,
+					model: $this->model,
+					data: $this->data
 				)?->render()
 		);
 
@@ -79,15 +82,19 @@ class ViewButtons
 	 * Creates new instance for a view
 	 * with special support for model views
 	 */
-	public static function view(string|Model $view): static
-	{
+	public static function view(
+		string|Model $view,
+		ModelWithContent|null $model = null
+	): static {
 		if ($view instanceof Model) {
-			$blueprint = $view->model()->blueprint()->buttons();
-			$view      = $view->model()::CLASS_ALIAS;
+			$model     = $view->model();
+			$blueprint = $model->blueprint()->buttons();
+			$view      = $model::CLASS_ALIAS;
 		}
 
 		return new static(
 			view: $view,
+			model: $model ?? null,
 			buttons: $blueprint ?? null
 		);
 	}

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -50,10 +50,7 @@ class User extends Model
 			'theme',
 			'settings',
 			'languages'
-		)->bind([
-			'model' => $this->model(),
-			'user'  => $this->model()
-		])->render();
+		)->render();
 	}
 
 	/**

--- a/tests/Panel/Ui/ButtonTest.php
+++ b/tests/Panel/Ui/ButtonTest.php
@@ -44,4 +44,20 @@ class ButtonTest extends TestCase
 			'variant'    => 'filled',
 		], $component->props());
 	}
+
+	/**
+	 * @covers ::props
+	 */
+	public function testPropsWithI18n()
+	{
+		$component = new Button(
+			text: [
+				'en' => 'Congrats',
+				'de' => 'Glückwunsch'
+			],
+		);
+
+		$props = $component->props();
+		$this->assertSame('Congrats', $props['text']);
+	}
 }

--- a/tests/Panel/Ui/Buttons/ViewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonTest.php
@@ -24,9 +24,11 @@ class ViewButtonTest extends AreaTestCase
 	public function testFactoryFromClosure()
 	{
 		$button = ViewButton::factory(
-			fn (string $name) => ['component' => 'k-' . $name . '-view-button'],
-			'test',
-			['name' => 'foo']
+			button: fn (string $name) => [
+				'component' => 'k-' . $name . '-view-button'
+			],
+			view: 'test',
+			data: ['name' => 'foo']
 		);
 
 		$this->assertInstanceOf(ViewButton::class, $button);
@@ -175,15 +177,18 @@ class ViewButtonTest extends AreaTestCase
 	public function testResolve(): void
 	{
 		$test   = $this;
-		$result = ViewButton::resolve(function (string $b, bool $a, App $kirby) use ($test) {
-			$test->assertFalse($a);
-			$test->assertSame('foo', $b);
-			$test->assertInstanceOf(App::class, $kirby);
-			return ['component' => 'k-test-view-button'];
-		}, [
-			'a' => false,
-			'b' => 'foo'
-		]);
+		$result = ViewButton::resolve(
+			button: function (string $b, bool $a, App $kirby) use ($test) {
+				$test->assertFalse($a);
+				$test->assertSame('foo', $b);
+				$test->assertInstanceOf(App::class, $kirby);
+				return ['component' => 'k-test-view-button'];
+			},
+			data: [
+				'a' => false,
+				'b' => 'foo'
+			]
+		);
 
 		$this->assertSame('k-test-view-button', $result['component']);
 

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -37,11 +37,11 @@ class ViewButtonsTest extends AreaTestCase
 	public function testConstruct()
 	{
 		// no buttons
-		$buttons = new ViewButtons('test', []);
+		$buttons = new ViewButtons('test', buttons: []);
 		$this->assertCount(0, $buttons->buttons);
 
 		// passed directly
-		$buttons = new ViewButtons('test', ['a', 'b']);
+		$buttons = new ViewButtons('test', buttons: ['a', 'b']);
 		$this->assertCount(2, $buttons->buttons);
 
 		// from options
@@ -82,7 +82,7 @@ class ViewButtonsTest extends AreaTestCase
 	 */
 	public function testRender()
 	{
-		$buttons = new ViewButtons('test', ['a', 'b']);
+		$buttons = new ViewButtons('test', buttons: ['a', 'b']);
 		$result  = $buttons->render();
 
 		$this->assertCount(2, $result);

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -121,6 +121,7 @@ class ViewButtonsTest extends AreaTestCase
 		// view name
 		$buttons = ViewButtons::view('page');
 		$this->assertCount(0, $buttons->buttons ?? []);
+		$this->assertNull($buttons->model);
 
 		// view model
 		$page = new Page([
@@ -132,5 +133,6 @@ class ViewButtonsTest extends AreaTestCase
 
 		$buttons = ViewButtons::view($page->panel());
 		$this->assertCount(2, $buttons->buttons);
+		$this->assertSame($page, $buttons->model);
 	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Panel\Ui\Button`: i18n support for `text` and `title` props
- `Panel\Ui\Buttons\ViewButtons` and `Panel\Ui\Buttons\ViewButton` have new optional `$model` property
- Kirby query support in `Panel\Ui\Buttons\ViewButton` for `link`, `dialog`, `drawer`, `icon`, `text`, `theme` props
- Deriving the Vue component name from key:
```yaml
buttons:
  - preview
  retour:
    text: Retour
```
This first looks up `k-retour-view-button` and falls back to `k-view-button`.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
  - I think code coverage is given

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] https://github.com/getkirby/sandbox/pull/11
- [x] Add changes & docs to release notes draft in Notion
