### PR TITLE
Set require: true on image block location field 

### DIFF
--- a/config/blocks/image/image.yml
+++ b/config/blocks/image/image.yml
@@ -7,6 +7,7 @@ fields:
     type: radio
     columns: 2
     default: "kirby"
+    required: true
     options:
       kirby: "{{ t('field.blocks.image.location.internal') }}"
       web: "{{ t('field.blocks.image.location.external') }}"


### PR DESCRIPTION
This is a cleaned-up version of https://github.com/getkirby/kirby/pull/6818

## Description

The location field in the image block wasn't required and editors could deselect the radio button options so no option was selected.

This pull request makes the location field required, thus requiring the field to always have an option selected

## Fixes

- The image location is now required in an image block

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
