### PR TITLE
Fix link color in themed boxes

### DIFF
--- a/panel/lab/components/boxes/1_themes/index.vue
+++ b/panel/lab/components/boxes/1_themes/index.vue
@@ -24,13 +24,25 @@
 				/>
 			</k-grid>
 		</k-lab-example>
+		<k-lab-example label="Text, Icon & Link">
+			<k-grid style="--columns: 1; gap: 0.5rem">
+				<k-box
+					v-for="theme in themes"
+					:key="theme"
+					:html="true"
+					:theme="theme"
+					text='Text with <a href="/">URL</a>'
+					icon="box"
+				/>
+			</k-grid>
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 
 <script>
 export default {
 	props: {
-		themes: Array,
-	},
+		themes: Array
+	}
 };
 </script>

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -107,6 +107,8 @@ export default {
 	--box-color-back: var(--theme-color-back);
 	--box-color-text: var(--theme-color-text-highlight);
 	--box-color-icon: var(--theme-color-700);
+	--link-color: var(--box-color-text);
+	--link-color-hover: var(--box-color-text);
 	min-height: var(--box-height);
 	line-height: 1.25;
 	padding: 0.375rem var(--box-padding-inline);


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fixed link color in dark and light mode in all themed boxes https://github.com/getkirby/kirby/issues/6906

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
