### PR TITLE
Avoid discarding content changes on upload

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -59,6 +59,7 @@ export default {
 							[this.name]: this.selected
 						});
 
+						this.onInput();
 						this.$events.emit("file.upload");
 						this.$events.emit("model.update");
 					}

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -167,6 +167,7 @@ export default (panel) => {
 
 			panel.view.props.content = {
 				...panel.view.props.originals,
+				...panel.view.props.content,
 				...values
 			};
 


### PR DESCRIPTION
## Description

A file upload caused a loss of content changes. This is now avoided by merging the latest changes in the content.js module. With this fix, we can also fix another issue with file uploads in blocks and layouts by bringing back the onInput emitter in the files field from v4. This has been removed in one of the last releases to fix a collision with unsaved changes. 

Related sandbox setup https://github.com/getkirby/sandbox/pull/13

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fixed field value resets after file uploads #6889
- Fixed file field upload in blocks and layouts #6873

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
