### PR TITLE
Page status button: use custom label for title

### DIFF
--- a/src/Panel/Ui/Buttons/PageStatusButton.php
+++ b/src/Panel/Ui/Buttons/PageStatusButton.php
@@ -24,7 +24,8 @@ class PageStatusButton extends ViewButton
 		$status    = $page->status();
 		$blueprint = $page->blueprint()->status()[$status] ?? null;
 		$disabled  = $page->permissions()->cannot('changeStatus');
-		$title     = I18n::translate('page.status') . ': ' . I18n::translate('page.status.' . $status);
+		$text      = $blueprint['label'] ?? I18n::translate('page.status.' . $status);
+		$title     = I18n::translate('page.status') . ': ' . $text;
 
 		if ($disabled === true) {
 			$title .= ' (' . I18n::translate('disabled') . ')';
@@ -37,7 +38,7 @@ class PageStatusButton extends ViewButton
 			disabled: $disabled,
 			icon: 'status-' . $status,
 			style: '--icon-size: 15px',
-			text: $blueprint['label'] ?? $status,
+			text: $text,
 			title: $title,
 			theme: match($status) {
 				'draft'    => 'negative-icon',


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Page status button uses custom status labels for `title`


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
