### PR TITLE
Color field: warning for deprecated notation

### DIFF
--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cms\Helpers;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Field\FieldOptions;
 use Kirby\Toolkit\A;
@@ -73,30 +74,33 @@ return [
 				return [];
 			}
 
-			$options = match (true) {
-				// simple array of values
-				// or value=text (from Options class)
+			if (
 				is_numeric($options[0]['value']) ||
 				$options[0]['value'] === $options[0]['text']
-					=> A::map($options, fn ($option) => [
-						'value' => $option['text']
-					]),
+			) {
+				// simple array of values
+				// or value=text (from Options class)
+				$options = A::map($options, fn ($option) => [
+					'value' => $option['text']
+				]);
 
-				// deprecated: name => value, flipping
-				// TODO: start throwing in warning in v5
-				$this->isColor($options[0]['text'])
-					=> A::map($options, fn ($option) => [
-						'value' => $option['text'],
-						// ensure that any HTML in the new text is escaped
-						'text'  => Escape::html($option['value'])
-					]),
+			} elseif ($this->isColor($options[0]['text'])) {
+				// @deprecated 4.0.0
+				// TODO: Remove in Kirby 6
 
-				default
-				=> A::map($options, fn ($option) => [
+				Helpers::deprecated('Color field: the text => value notation for options has been deprecated and will be removed in Kirby 6. Please rewrite your options as value => text.');
+
+				$options = A::map($options, fn ($option) => [
+					'value' => $option['text'],
+					// ensure that any HTML in the new text is escaped
+					'text'  => Escape::html($option['value'])
+				]);
+			} else {
+				$options = A::map($options, fn ($option) => [
 					'value' => $option['value'],
 					'text'  => $option['text']
-				]),
-			};
+				]);
+			}
 
 			return $options;
 		}

--- a/tests/Form/Fields/ColorFieldTest.php
+++ b/tests/Form/Fields/ColorFieldTest.php
@@ -78,21 +78,6 @@ class ColorFieldTest extends TestCase
 			['value' => '#bbb', 'text' => 'Color b'],
 			['value' => '#ccc', 'text' => 'Color c']
 		], $field->options());
-
-		// Deprecated: name => value
-		$field = $this->field('color', [
-			'options' => [
-				'Color a' => '#aaa',
-				'Color b' => '#bbb',
-				'Color c' => '#ccc'
-			],
-		]);
-
-		$this->assertSame([
-			['value' => '#aaa', 'text' => 'Color a'],
-			['value' => '#bbb', 'text' => 'Color b'],
-			['value' => '#ccc', 'text' => 'Color c']
-		], $field->options());
 	}
 
 	public function testOptionsFromQuery()
@@ -122,27 +107,6 @@ class ColorFieldTest extends TestCase
 					'#bbb' => 'Color b',
 					'#ccc' => 'Color c'
 				]
-			]
-		]);
-
-		$field = $this->field('color', [
-			'options' => ['type' => 'query', 'query' => 'kirby.option("foo")'],
-		]);
-
-		$this->assertSame([
-			['value' => '#aaa', 'text' => 'Color a'],
-			['value' => '#bbb', 'text' => 'Color b'],
-			['value' => '#ccc', 'text' => 'Color c']
-		], $field->options());
-
-		// Deprecated: name => value
-		$this->app = new App([
-			'options' => [
-				'foo' => [
-					'Color a' => '#aaa',
-					'Color b' => '#bbb',
-					'Color c' => '#ccc'
-				],
 			]
 		]);
 


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Deprecated
- Color field: the `text => value` notation for options has been deprecated and will be removed in Kirby 6. Please rewrite your options as `value => text`.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
