### PR TITLE
Extending section: prevent duplicate mixin

### DIFF
--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -48,15 +48,13 @@
 
 <script>
 import debounce from "@/helpers/debounce";
+import section from "@/mixins/section";
 
 export default {
+	mixins: [section],
 	inheritAttrs: false,
 	props: {
-		blueprint: String,
-		column: String,
-		parent: String,
-		name: String,
-		timestamp: Number
+		column: String
 	},
 	data() {
 		return {

--- a/panel/src/mixins/section.js
+++ b/panel/src/mixins/section.js
@@ -1,7 +1,6 @@
 export default {
 	props: {
 		blueprint: String,
-		lock: [Boolean, Object],
 		help: String,
 		name: String,
 		parent: String,

--- a/panel/src/panel/plugins.js
+++ b/panel/src/panel/plugins.js
@@ -127,9 +127,27 @@ export const installComponentMixins = (options) => {
 		section
 	};
 
-	options.mixins = options.mixins.map((mixin) =>
-		typeof mixin === "string" ? mixins[mixin] : mixin
-	);
+	options.mixins = options.mixins
+		.map((mixin) => {
+			// mixin got referenced by name
+			if (typeof mixin === "string" && mixins[mixin] !== undefined) {
+				// component inherits from a parent component:
+				// make sure to only include the mixin if the parent component
+				// hasn't already included it (to avoid duplicate mixins)
+				if (options.extends) {
+					const inherited = new options.extends().$options.mixins ?? [];
+
+					if (inherited.includes(mixins[mixin]) === true) {
+						return;
+					}
+				}
+
+				return mixins[mixin];
+			}
+
+			return mixin;
+		})
+		.filter((mixin) => mixin !== undefined);
 
 	return options;
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Our model sections now also use the `section` mixin.
- For plugin components, when resolving mixin names to actual mixins, we check now if the component is extending a parent component. And if so, if that parent already included the mixin.

### Reasoning
- All plugin sections get the `section` mixin automatically injected. Our core sections should deal with the same.
- When a section like pages section got extended so far, the `section` mixin was force injected and overwrote the `load` method from the parent (pages section). 


### Additional context
Marked for 4.7.0 to have sufficient time for testing and not needing to rush merging for 4.6.0 - if it can be tested before, no objections against including it already in 4.6.0.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Custom sections: fixed issue where Vue mixin would overwrite `load` method
#6809



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
