### PR TITLE
Fix `image` with query string in blueprint

### DIFF
--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -115,12 +115,19 @@ abstract class Model
 			$blueprint = null;
 		}
 
+		// convert string blueprint settings to proper array
+		if (is_string($blueprint) === true) {
+			$blueprint = ['query' => $blueprint];
+		}
+
 		// skip image thumbnail if option
 		// is explicitly set to show the icon
 		if ($settings === 'icon') {
 			$settings = ['query' => false];
-		} elseif (is_string($settings) === true) {
-			// convert string settings to proper array
+		}
+
+		// convert string settings to proper array
+		if (is_string($settings) === true) {
 			$settings = ['query' => $settings];
 		}
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -419,6 +419,35 @@ class ModelTest extends TestCase
 	/**
 	 * @covers ::image
 	 */
+	public function testImageWithBlueprintString()
+	{
+		$app  = $this->app->clone([
+			'blueprints' => [
+				'pages/fox' => [
+					'image' => 'site.page("test").image'
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'template' => 'fox',
+						'files' => [
+							['filename' => 'test.jpg']
+						]
+					]
+				]
+			]
+		]);
+
+		$panel = $app->page('test')->panel();
+		$image = $panel->image([]);
+		$this->assertStringEndsWith('test.jpg', $image['url']);
+	}
+
+	/**
+	 * @covers ::image
+	 */
 	public function testImageWithQuery()
 	{
 		$site  = new ModelSiteWithImageMethod();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
Now supports 
```yaml
image: page.image
```
instead of only
```yaml
image:
  query: page.image
```


### Reasoning
We already have it like that in the docs: https://getkirby.com/docs/reference/panel/blueprints/page#image-options

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Blueprint `image` option: fixed support for query string
#6797



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
  - I do have a unit test, not sure why the code coverage doesn't agree
- [x] Tests and CI checks all pass
### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
