### PR TITLE
Roles: fix extending blueprint

### DIFF
--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -82,7 +82,11 @@ class Role
 
 	public static function factory(array $props, array $inject = []): static
 	{
-		return new static($props + $inject);
+		// ensure to properly extend the blueprint
+		$props = $props + $inject;
+		$props = Blueprint::extend($props);
+
+		return new static($props);
 	}
 
 	public function id(): string

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -35,6 +35,7 @@ class RoleTest extends TestCase
 
 		$this->assertSame('editor', $role->name());
 		$this->assertSame('Editor', $role->title());
+		$this->assertSame('This should be inherited', $role->description());
 	}
 
 	public function testMissingRole()

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -32,8 +32,9 @@ class RolesTest extends TestCase
 
 		$this->assertInstanceOf(Roles::class, $roles);
 
-		// should contain the editor role from fixtures and the default admin role
-		$this->assertCount(2, $roles);
+		// should contain the base and editor role from fixtures
+		// and the default admin role
+		$this->assertCount(3, $roles);
 		$this->assertSame('admin', $roles->first()->name());
 		$this->assertSame('editor', $roles->last()->name());
 	}

--- a/tests/Cms/Roles/fixtures/blueprints/users/base.yml
+++ b/tests/Cms/Roles/fixtures/blueprints/users/base.yml
@@ -1,0 +1,1 @@
+description: This should be inherited

--- a/tests/Cms/Roles/fixtures/blueprints/users/editor.yml
+++ b/tests/Cms/Roles/fixtures/blueprints/users/editor.yml
@@ -1,1 +1,3 @@
 title: Editor
+
+extends: users/base


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
While user blueprints were properly extended, the `Role` class would not extend the loaded blueprint, but get permissions from it. For inheriting permissions (or description as in the new unit test), we need to also extend the blueprint when loading/factory-ing the `Role`.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Role blueprints get properly extended
#6167


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
