### PR TITLE
Plugin update status: passive theme for unkown

### DIFF
--- a/src/Cms/System/UpdateStatus.php
+++ b/src/Cms/System/UpdateStatus.php
@@ -102,15 +102,15 @@ class UpdateStatus
 	/**
 	 * Returns the Panel icon for the status value
 	 *
-	 * @return string 'check'|'alert'|'info'
+	 * @return string 'check'|'alert'|'info'|'question'
 	 */
 	public function icon(): string
 	{
 		return match ($this->status()) {
-			'up-to-date', 'not-vulnerable' => 'check',
+			'up-to-date', 'not-vulnerable'        => 'check',
 			'security-update', 'security-upgrade' => 'alert',
-			'update', 'upgrade' => 'info',
-			default => 'question'
+			'update', 'upgrade'                   => 'info',
+			default                               => 'question'
 		};
 	}
 
@@ -252,10 +252,10 @@ class UpdateStatus
 	public function theme(): string
 	{
 		return match ($this->status()) {
-			'up-to-date', 'not-vulnerable' => 'positive',
+			'up-to-date', 'not-vulnerable'        => 'positive',
 			'security-update', 'security-upgrade' => 'negative',
-			'update', 'upgrade' => 'info',
-			default => 'notice'
+			'update', 'upgrade'                   => 'info',
+			default                               => 'passive'
 		};
 	}
 

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -412,7 +412,7 @@ class UpdateStatusTest extends TestCase
 					'messages' => [],
 					'status' => 'unreleased',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null,
 					'vulnerabilities' => [],
 					'exceptionMessages' => []
@@ -675,7 +675,7 @@ class UpdateStatusTest extends TestCase
 						'label' => 'Unreleased version',
 						'latestVersion' => '88888.8.8',
 						'pluginName' => 'getkirby/test',
-						'theme' => 'notice',
+						'theme' => 'passive',
 						'url' => null
 					],
 					'vulnerabilities' => [],
@@ -841,7 +841,7 @@ class UpdateStatusTest extends TestCase
 						'label' => 'Could not check for updates',
 						'latestVersion' => '88888.8.8',
 						'pluginName' => 'getkirby/test',
-						'theme' => 'notice',
+						'theme' => 'passive',
 						'url' => 'https://getkirby.com/releases/88888.8.8',
 					],
 					'vulnerabilities' => null,
@@ -863,7 +863,7 @@ class UpdateStatusTest extends TestCase
 						'label' => 'Could not check for updates',
 						'latestVersion' => '88888.8.8',
 						'pluginName' => 'getkirby/test',
-						'theme' => 'notice',
+						'theme' => 'passive',
 						'url' => 'https://getkirby.com/releases/88888.8.8',
 					],
 					'vulnerabilities' => null,
@@ -1235,7 +1235,7 @@ class UpdateStatusTest extends TestCase
 					'messages' => null,
 					'status' => 'error',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null,
 					'vulnerabilities' => null,
 					'exceptionMessages' => [
@@ -1257,7 +1257,7 @@ class UpdateStatusTest extends TestCase
 					'messages' => [],
 					'status' => 'error',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null,
 					'vulnerabilities' => [],
 					'exceptionMessages' => [
@@ -1317,7 +1317,7 @@ class UpdateStatusTest extends TestCase
 					'messages' => [],
 					'status' => 'error',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => 'https://getkirby.com/releases/77777.7.7',
 					'vulnerabilities' => [],
 					'exceptionMessages' => [
@@ -1458,7 +1458,7 @@ class UpdateStatusTest extends TestCase
 					'messages' => [],
 					'status' => 'error',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => 'https://getkirby.com/releases/77777.7.7',
 					'vulnerabilities' => [],
 					'exceptionMessages' => [
@@ -1485,7 +1485,7 @@ class UpdateStatusTest extends TestCase
 					],
 					'status' => 'error',
 					'targetVersion' => null,
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => 'https://getkirby.com/releases/77777.4.3',
 					'vulnerabilities' => [
 						[

--- a/tests/Panel/Areas/SystemTest.php
+++ b/tests/Panel/Areas/SystemTest.php
@@ -205,7 +205,7 @@ class SystemTest extends AreaTestCase
 					'label' => 'Could not check for updates',
 					'latestVersion' => '?',
 					'pluginName' => 'getkirby/private',
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null
 				]
 			],
@@ -239,7 +239,7 @@ class SystemTest extends AreaTestCase
 					'label' => 'Could not check for updates',
 					'latestVersion' => '?',
 					'pluginName' => 'getkirby/unknown',
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null
 				]
 			]
@@ -299,7 +299,7 @@ class SystemTest extends AreaTestCase
 					'label' => 'Could not check for updates',
 					'latestVersion' => '?',
 					'pluginName' => 'getkirby/private',
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null
 				]
 			],
@@ -333,7 +333,7 @@ class SystemTest extends AreaTestCase
 					'label' => 'Could not check for updates',
 					'latestVersion' => '?',
 					'pluginName' => 'getkirby/unknown',
-					'theme' => 'notice',
+					'theme' => 'passive',
 					'url' => null
 				]
 			]


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- System view: update status dropdown uses passive theme when update status is unknown 
<img width="1311" alt="Screenshot 2025-01-18 at 11 17 49" src="https://github.com/user-attachments/assets/60a72750-6808-4628-8bcf-39c68c696bca" />

### Reasoning
The `notice` seem always has implied some urgency to act for the user. However, the user/developer cannot do much about this actually. Only the plugin developer can. I feel like the passive theme is more fitting for this unknown status

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass