### PR TITLE
Page duplicate dialog: don't require toggles

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -410,19 +410,17 @@ return [
 
 			if ($hasFiles === true) {
 				$fields['files'] = [
-					'label'    => I18n::translate('page.duplicate.files'),
-					'type'     => 'toggle',
-					'required' => true,
-					'width'    => $toggleWidth
+					'label' => I18n::translate('page.duplicate.files'),
+					'type'  => 'toggle',
+					'width' => $toggleWidth
 				];
 			}
 
 			if ($hasChildren === true) {
 				$fields['children'] = [
-					'label'    => I18n::translate('page.duplicate.pages'),
-					'type'     => 'toggle',
-					'required' => true,
-					'width'    => $toggleWidth
+					'label' => I18n::translate('page.duplicate.pages'),
+					'type'  => 'toggle',
+					'width' => $toggleWidth
 				];
 			}
 


### PR DESCRIPTION
Fixes #6921

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Page duplicate dialog: don't require toggles


### Reasoning
- With `required` toggles, in v5 one cannot submit the form without activating the toggle, so false is no option.
- Apparently, in v4 toggles could be on or off even when required.
- I was wondering if we should change the general behavior for toggles (I assume also checkbox) to be the same as v4, but then `required: true` actually has no effect. So I do like that one can actually require a toggle/checkbox to be set. We just have to remove the required option from use cases like here where it's not right.


## Changelog

Not from this PR, but so far missed...

### Breaking changes
- `required: true` on checkbox and toggle fields now enforces that these fields need to be checked/toggles (active state)

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
