### PR TITLE
Fix `page` on models sections + use sessionStorage

### DIFF
--- a/config/sections/mixins/pagination.php
+++ b/config/sections/mixins/pagination.php
@@ -12,7 +12,7 @@ return [
 			return $limit;
 		},
 		/**
-		 * Sets the default page for the pagination. This will overwrite default pagination.
+		 * Sets the default page for the pagination.
 		 */
 		'page' => function (int|null $page = null) {
 			return App::instance()->request()->get('page', $page);

--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -143,7 +143,7 @@ export default {
 				...this.emptyProps,
 				text: this.searching
 					? this.$t("search.results.none")
-					: this.options.empty ?? this.emptyProps.text
+					: (this.options.empty ?? this.emptyProps.text)
 			};
 		},
 		items() {
@@ -197,7 +197,9 @@ export default {
 			}
 
 			const page =
-				this.pagination.page ?? localStorage.getItem(this.paginationId) ?? 1;
+				this.pagination.page ??
+				sessionStorage.getItem(this.paginationId) ??
+				null;
 
 			try {
 				const response = await this.$api.get(
@@ -222,7 +224,7 @@ export default {
 		onDrop() {},
 		onSort() {},
 		onPaginate(pagination) {
-			localStorage.setItem(this.paginationId, pagination.page);
+			sessionStorage.setItem(this.paginationId, pagination.page);
 			this.pagination = pagination;
 			this.reload();
 		},


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Remove `1` as fallback for `page` from `ModelsSection.vue`, otherwise the `page` blueprint option cannot come into use in the `config/sections/mixin/pagination.php`
- Use `sessionStorage` instead of `localStorage` to store pagination position less long-term
- Remove docs sentence that doesn't make sense

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Pages and files sections: fixed `page` option
#6735

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] https://github.com/getkirby/sandbox/pull/15
- [x] Add changes & docs to release notes draft in Notion
