### PR TITLE
Fix tabs margins after :has refactoring

### DIFF
--- a/panel/src/components/Lab/IndexView.vue
+++ b/panel/src/components/Lab/IndexView.vue
@@ -39,9 +39,6 @@ export default {
 </script>
 
 <style>
-.k-lab-index-view .k-header {
-	margin-bottom: 0;
-}
 .k-lab-index-view .k-panel-main > .k-box {
 	margin-bottom: var(--spacing-8);
 }

--- a/panel/src/components/Lab/PlaygroundView.vue
+++ b/panel/src/components/Lab/PlaygroundView.vue
@@ -103,10 +103,6 @@ export default {
 </script>
 
 <style>
-.k-lab-playground-view:has(> .k-tabs) .k-lab-playground-header {
-	margin-bottom: 0;
-}
-
 .k-lab-examples h2 {
 	margin-bottom: var(--spacing-6);
 }

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -78,6 +78,11 @@ export default {
 		-2px 0 0 0 var(--header-color-back);
 }
 
+/** Remove the bottom margin from the header if it is followed by tabs */
+.k-header:has(+ .k-tabs) {
+	margin-bottom: 0;
+}
+
 .k-header-title {
 	font-size: var(--text-h1);
 	font-weight: var(--font-h1);

--- a/panel/src/components/Views/Files/FilePreview.vue
+++ b/panel/src/components/Views/Files/FilePreview.vue
@@ -51,4 +51,9 @@ export default {
 	margin-bottom: var(--spacing-12);
 	overflow: hidden;
 }
+
+/** Remove the bottom margin from the preview box if it is followed by tabs */
+.k-file-preview:has(+ .k-tabs) {
+	margin-bottom: 0;
+}
 </style>

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="hasTabs"
 		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"
@@ -88,9 +87,5 @@ export default {
 .k-file-view-header {
 	margin-bottom: 0;
 	border-bottom: 0;
-}
-
-.k-file-view[data-has-tabs="true"] .k-file-preview {
-	margin-bottom: 0;
 }
 </style>

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="hasTabs"
 		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="hasTabs"
 		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"

--- a/panel/src/components/Views/SearchView.vue
+++ b/panel/src/components/Views/SearchView.vue
@@ -147,10 +147,6 @@ export default {
 </script>
 
 <style>
-.k-search-view .k-header {
-	margin-bottom: 0;
-}
-
 /* if not tabs are displayed, add space */
 .k-header + .k-search-view-results {
 	margin-top: var(--spacing-12);

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-panel-inside
-		:data-has-tabs="hasTabs"
 		:data-id="id"
 		:data-locked="isLocked"
 		:data-template="blueprint"


### PR DESCRIPTION
## Description

After the :has refactoring, there were a few places where the views still somehow had a margin between header and tabs. I fixed this and cleaned up a few other things afterwards. 