### PR TITLE
UI component class: support non-pre-defined props

### DIFF
--- a/src/Panel/Ui/Button.php
+++ b/src/Panel/Ui/Button.php
@@ -35,7 +35,9 @@ class Button extends Component
 		public string|array|null $title = null,
 		public string $type = 'button',
 		public string|null $variant = null,
+		...$attrs
 	) {
+		$this->attrs = $attrs;
 	}
 
 	public function props(): array

--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -46,7 +46,9 @@ class ViewButton extends Button
 		public string|array|null $title = null,
 		public string $type = 'button',
 		public string|null $variant = 'filled',
+		...$attrs
 	) {
+		$this->attrs = $attrs;
 	}
 
 	/**

--- a/src/Panel/Ui/Component.php
+++ b/src/Panel/Ui/Component.php
@@ -20,12 +20,15 @@ use Kirby\Toolkit\Str;
 abstract class Component
 {
 	protected string $key;
+	public array $attrs = [];
 
 	public function __construct(
 		public string $component,
 		public string|null $class = null,
-		public string|null $style = null
+		public string|null $style = null,
+		...$attrs
 	) {
+		$this->attrs = $attrs;
 	}
 
 	/**
@@ -70,6 +73,7 @@ abstract class Component
 		return [
 			'class' => $this->class,
 			'style' => $this->style,
+			...$this->attrs
 		];
 	}
 

--- a/tests/Panel/Ui/ButtonTest.php
+++ b/tests/Panel/Ui/ButtonTest.php
@@ -11,6 +11,24 @@ use Kirby\TestCase;
 class ButtonTest extends TestCase
 {
 	/**
+	 * @covers ::__construct
+	 */
+	public function testAttrs()
+	{
+		$button = new Button(
+			text: 'Attrs',
+			foo: 'bar'
+		);
+
+		$this->assertSame([
+			'foo'        => 'bar',
+			'responsive' => true,
+			'text'       => 'Attrs',
+			'type'       => 'button',
+		], array_filter($button->props()));
+	}
+
+	/**
 	 * @covers ::props
 	 */
 	public function testProps()

--- a/tests/Panel/Ui/Buttons/ViewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonTest.php
@@ -20,6 +20,26 @@ class ViewButtonTest extends AreaTestCase
 	}
 
 	/**
+	 * @covers ::__construct
+	 */
+	public function testAttrs()
+	{
+		$button = new ViewButton(
+			text: 'Attrs',
+			foo: 'bar'
+		);
+
+		$this->assertSame([
+			'foo'        => 'bar',
+			'responsive' => true,
+			'size'       => 'sm',
+			'text'       => 'Attrs',
+			'type'       => 'button',
+			'variant'    => 'filled'
+		], array_filter($button->props()));
+	}
+
+	/**
 	 * @covers ::factory
 	 */
 	public function testFactoryFromClosure()

--- a/tests/Panel/Ui/ComponentTest.php
+++ b/tests/Panel/Ui/ComponentTest.php
@@ -16,7 +16,7 @@ class UiComponent extends Component
 class ComponentTest extends TestCase
 {
 	/**
-	 * @covers ::__contruct
+	 * @covers ::__construct
 	 */
 	public function testAttrs()
 	{

--- a/tests/Panel/Ui/ComponentTest.php
+++ b/tests/Panel/Ui/ComponentTest.php
@@ -16,6 +16,26 @@ class UiComponent extends Component
 class ComponentTest extends TestCase
 {
 	/**
+	 * @covers ::__contruct
+	 */
+	public function testAttrs()
+	{
+		$props = [
+			'component' => 'k-text',
+			'class'     => 'k-test',
+			'foo'       => 'bar'
+		];
+
+		$component = new UiComponent(...$props);
+
+		$this->assertSame([
+			'class' => 'k-test',
+			'style' => null,
+			'foo'   => 'bar',
+		], $component->props());
+	}
+
+	/**
 	 * @covers ::__call
 	 */
 	public function testGetterSetter()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- UI component classes (component, button, view button) now can accept props/blueprint options in addition that weren't defined in the PHP class. This allows e.g. to pass options from blueprint to a custom view button Vue component without the need for a custom PHP class.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - https://github.com/getkirby/sandbox/pull/17