### PR TITLE
Improvements for system view security checks

### DIFF
--- a/config/areas/system/views.php
+++ b/config/areas/system/views.php
@@ -73,7 +73,7 @@ return [
 			if ($isLocal === true) {
 				$security[] = [
 					'id'    => 'local',
-					'icon'  =>'info',
+					'icon'  => 'info',
 					'theme' => 'info',
 					'text'  => I18n::translate('system.issues.local')
 				];
@@ -108,7 +108,7 @@ return [
 					'theme' => 'notice'
 				];
 			}
-			
+
 			// sensitive URLs
 			if ($isLocal === false) {
 				$sensitive = [

--- a/config/areas/system/views.php
+++ b/config/areas/system/views.php
@@ -11,7 +11,7 @@ return [
 			$system       = $kirby->system();
 			$updateStatus = $system->updateStatus();
 			$license      = $system->license();
-			$debugMode    = $kirby->option('debug', false);
+			$debugMode    = $kirby->option('debug', false) === true;
 			$isLocal      = $system->isLocal();
 
 			$environment = [
@@ -47,10 +47,14 @@ return [
 			$plugins = $system->plugins()->values(function ($plugin) use (&$exceptions) {
 				$authors      = $plugin->authorsNames();
 				$updateStatus = $plugin->updateStatus();
-				$version      = $updateStatus?->toArray() ?? $plugin->version() ?? '–';
+				$version      = $updateStatus?->toArray();
+				$version    ??= $plugin->version() ?? '–';
 
 				if ($updateStatus !== null) {
-					$exceptions = array_merge($exceptions, $updateStatus->exceptionMessages());
+					$exceptions = [
+						...$exceptions,
+						...$updateStatus->exceptionMessages()
+					];
 				}
 
 				return [
@@ -66,17 +70,29 @@ return [
 
 			$security = $updateStatus?->messages() ?? [];
 
+			if ($isLocal === true) {
+				$security[] = [
+					'id'    => 'local',
+					'icon'  =>'info',
+					'theme' => 'info',
+					'text'  => I18n::translate('system.issues.local')
+				];
+			}
+
 			if ($debugMode === true) {
 				$security[] = [
 					'id'    => 'debug',
 					'icon'  => $isLocal ? 'info' : 'alert',
-					'text'  => I18n::translate('system.issues.debug'),
 					'theme' => $isLocal ? 'info' : 'negative',
+					'text'  => I18n::translate('system.issues.debug'),
 					'link'  => 'https://getkirby.com/security/debug'
 				];
 			}
 
-			if ($kirby->environment()->https() !== true) {
+			if (
+				$isLocal === false &&
+				$kirby->environment()->https() !== true
+			) {
 				$security[] = [
 					'id'   => 'https',
 					'text' => I18n::translate('system.issues.https'),
@@ -92,21 +108,26 @@ return [
 					'theme' => 'notice'
 				];
 			}
+			
+			// sensitive URLs
+			if ($isLocal === false) {
+				$sensitive = [
+					'content' => $system->exposedFileUrl('content'),
+					'git'     => $system->exposedFileUrl('git'),
+					'kirby'   => $system->exposedFileUrl('kirby'),
+					'site'    => $system->exposedFileUrl('site')
+				];
+			}
 
 			return [
 				'component' => 'k-system-view',
 				'props'     => [
 					'environment' => $environment,
-					'exceptions'  => $debugMode === true ? $exceptions : [],
+					'exceptions'  => $debugMode ? $exceptions : [],
 					'info'        => $system->info(),
 					'plugins'     => $plugins,
 					'security'    => $security,
-					'urls'        => [
-						'content' => $system->exposedFileUrl('content'),
-						'git'     => $system->exposedFileUrl('git'),
-						'kirby'   => $system->exposedFileUrl('kirby'),
-						'site'    => $system->exposedFileUrl('site')
-					]
+					'urls'        => $sensitive ?? null
 				]
 			];
 		}

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -640,6 +640,7 @@
 	"system.issues.git": "The .git folder seems to be exposed",
 	"system.issues.https": "We recommend HTTPS for all your sites",
 	"system.issues.kirby": "The kirby folder seems to be exposed",
+	"system.issues.local": "The site is running locally with relaxed security checks",
 	"system.issues.site": "The site folder seems to be exposed",
 	"system.issues.vue.compiler": "The Vue template compiler is enabled",
 	"system.issues.vulnerability.kirby": "Your installation might be affected by the following vulnerability ({ severity } severity): { description }",

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -82,7 +82,7 @@ class System
 			case 'git':
 				return $url . '/config';
 			case 'kirby':
-				return $url . '/composer.json';
+				return $url . '/LICENSE.md';
 			case 'site':
 				$root  = $this->app->root('site');
 				$files = glob($root . '/blueprints/*.yml');

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -224,7 +224,7 @@ class SystemTest extends TestCase
 		Dir::make(static::TMP . '/kirby');
 
 		$this->assertSame('/kirby', $system->folderUrl('kirby'));
-		$this->assertSame('/kirby/composer.json', $system->exposedFileUrl('kirby'));
+		$this->assertSame('/kirby/LICENSE.md', $system->exposedFileUrl('kirby'));
 	}
 
 	/**

--- a/tests/Panel/Areas/SystemTest.php
+++ b/tests/Panel/Areas/SystemTest.php
@@ -117,6 +117,32 @@ class SystemTest extends AreaTestCase
 		], $props['urls']);
 	}
 
+	public function testViewLocal(): void
+	{
+		$this->app([
+			'server' => [
+				'REMOTE_ADDR' => '127.0.0.1',
+			]
+		]);
+
+		$this->login();
+
+		$view  = $this->view('system');
+		$props = $view['props'];
+
+		$this->assertSame([], $props['exceptions']);
+		$this->assertSame([
+			$this->customWarning(),
+			[
+				'id'    => 'local',
+				'icon'  => 'info',
+				'theme' => 'info',
+				'text'  => 'The site is running locally with relaxed security checks'
+			],
+			$this->compilerWarning()
+		], $props['security']);
+	}
+
 	public function testViewDebug(): void
 	{
 		$this->app([
@@ -136,8 +162,8 @@ class SystemTest extends AreaTestCase
 			[
 				'id'    => 'debug',
 				'icon'  => 'alert',
-				'text'  => 'Debugging must be turned off in production',
 				'theme' => 'negative',
+				'text'  => 'Debugging must be turned off in production',
 				'link'  => 'https://getkirby.com/security/debug'
 			],
 			$this->compilerWarning()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Some security checks won't run for local installations, in this case an info message is displayed
  <img width="711" alt="Screenshot 2025-01-23 at 09 46 06" src="https://github.com/user-attachments/assets/8f69d1f3-69ed-41a5-b417-6293dfcf3880" />

- Debug warning is showing in info theme when on local, in negative theme when not local
- Checking for `LICENSE.md` instead of `composer.json`


## Changelog

### Enhancements
- Panel system view: Some security checks will be skipped on local setups
- The security check for an accessible `kirby` folder now uses the `LICENSE.md` file instead of `composer.json` to avoid false-positive blocks by web application firewalls #6878

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
