### PR TITLE
Languages dropdown: fix changing language

### DIFF
--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -10,13 +10,13 @@
 			ref="dropdown"
 			:options="$dropdown(options)"
 			align-x="end"
-			@action="$emit('action', $event)"
 		>
 			<template #item="{ item: language, index }">
 				<k-button
 					:key="'item-' + index"
 					v-bind="language"
 					class="k-dropdown-item k-languages-dropdown-item"
+					@click="change(language)"
 				>
 					{{ language.text }}
 
@@ -72,6 +72,15 @@ export default {
 			}
 
 			return null;
+		}
+	},
+	methods: {
+		change(language) {
+			this.$reload({
+				query: {
+					language: language.code
+				}
+			});
 		}
 	}
 };

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -67,7 +67,6 @@ class LanguagesDropdown extends ViewButton
 		return [
 			'text'    => $language->name(),
 			'code'    => $language->code(),
-			'link'    => $this->model->panel()->url(true) . '?language=' . $language->code(),
 			'current' => $language->code() === $this->kirby->language()?->code(),
 			'default' => $language->isDefault(),
 			'changes' => $changes->exists($language),

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -48,7 +48,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertSame([
 			'text'    => 'Deutsch',
 			'code'    => 'de',
-			'link'    => '/pages/test?language=de',
 			'current' => false,
 			'default' => false,
 			'changes' => false,
@@ -81,7 +80,6 @@ class LanguagesDropdownTest extends AreaTestCase
 			[
 				'text'    => 'English',
 				'code'    => 'en',
-				'link'    => '/pages/test?language=en',
 				'current' => true,
 				'default' => true,
 				'changes' => false,
@@ -91,7 +89,6 @@ class LanguagesDropdownTest extends AreaTestCase
 			[
 				'text'    => 'Deutsch',
 				'code'    => 'de',
-				'link'    => '/pages/test?language=de',
 				'current' => false,
 				'default' => false,
 				'changes' => false,


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
We cannot just simply use links for the languages dropdown, as we thought initially, as these would not include the current tab. This PR reverts part of it to the v4 logic, where we utilize `this.$reload` when changing a language.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
