### PR TITLE
Support shared `site.contentType.php` controller

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -464,27 +464,24 @@ class App
 		$data = [];
 
 		// always use the site controller as defaults, if available
-		if ($controller = $this->controllerLookup('site')) {
-			$data = (array)$controller->call($this, $arguments);
+		$site   = $this->controllerLookup('site', $contentType);
+		$site ??= $this->controllerLookup('site');
+
+		if ($site !== null) {
+			$data = (array)$site->call($this, $arguments);
 		}
 
 		// try to find a specific representation controller
-		if ($controller = $this->controllerLookup($name, $contentType)) {
+		$controller   = $this->controllerLookup($name, $contentType);
+		// no luck for a specific representation controller?
+		// let's try the html controller instead
+		$controller ??= $this->controllerLookup($name);
+
+		if ($controller !== null) {
 			return [
 				...$data,
 				...(array)$controller->call($this, $arguments)
 			];
-		}
-
-		if ($contentType !== 'html') {
-			// no luck for a specific representation controller?
-			// let's try the html controller instead
-			if ($controller = $this->controllerLookup($name)) {
-				return [
-					...$data,
-					...(array)$controller->call($this, $arguments)
-				];
-			}
 		}
 
 		return $data;

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -1326,8 +1326,8 @@ class AppTest extends TestCase
 		]);
 
 		$this->assertSame([
-			'title' => 'Site',
-			'foo'   => 'bar'
+			'site' => 'html',
+			'test' => 'html'
 		], $app->controller('test'));
 	}
 
@@ -1342,17 +1342,20 @@ class AppTest extends TestCase
 				'index' => '/dev/null'
 			],
 			'controllers' => [
-				'test' => fn () => ['foo' => 'bar']
+				'test' => fn () => ['homer' => 'simpson']
 
 			]
 		]);
 
 		Page::factory([
-			'slug' => 'test',
+			'slug'     => 'test',
 			'template' => 'test'
 		]);
 
-		$this->assertSame(['foo' => 'bar'], $app->controller('test'));
+		$this->assertSame(
+			['homer' => 'simpson'],
+			$app->controller('test')
+		);
 	}
 
 	/**
@@ -1369,22 +1372,21 @@ class AppTest extends TestCase
 		]);
 
 		Page::factory([
-			'slug' => 'test',
+			'slug'     => 'test',
 			'template' => 'another'
 		]);
 
-		ob_start();
-		$app->controller('another.json', [], 'json');
-		$response = ob_get_clean();
-
-		$this->assertSame('{"foo":"bar"}', $response);
+		$this->assertSame([
+			'site'    => 'json',
+			'another' => 'json'
+		], $app->controller('another', contentType: 'json'));
 	}
 
 	/**
 	 * @covers ::controller
 	 * @covers ::controllerLookup
 	 */
-	public function testControllerHtmlRepresentation()
+	public function testControllerHtmlForMissingRepresentation()
 	{
 		$app = new App([
 			'roots' => [
@@ -1399,16 +1401,16 @@ class AppTest extends TestCase
 		]);
 
 		$this->assertSame([
-			'title' => 'Site',
-			'foo'   => 'bar'
-		], $app->controller('test', [], 'json'));
+			'site' => 'json',
+			'test' => 'html'
+		], $app->controller('test', contentType: 'json'));
 	}
 
 	/**
 	 * @covers ::controller
 	 * @covers ::controllerLookup
 	 */
-	public function testControllerFallbackRepresentation()
+	public function testControllerMissing()
 	{
 		$app = new App([
 			'roots' => [
@@ -1422,7 +1424,34 @@ class AppTest extends TestCase
 			'template' => 'none'
 		]);
 
-		$this->assertSame(['title' => 'Site'], $app->controller('none', [], 'json'));
+		$this->assertSame(
+			['site' => 'html'],
+			$app->controller('none')
+		);
+	}
+
+	/**
+	 * @covers ::controller
+	 * @covers ::controllerLookup
+	 */
+	public function testControllerMissingRepresentation()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+				'controllers' => static::FIXTURES . '/controllers'
+			]
+		]);
+
+		Page::factory([
+			'slug'     => 'test',
+			'template' => 'none'
+		]);
+
+		$this->assertSame(
+			['site' => 'json'],
+			$app->controller('none', contentType: 'json')
+		);
 	}
 
 	/**

--- a/tests/Cms/App/fixtures/controllers/another.json.php
+++ b/tests/Cms/App/fixtures/controllers/another.json.php
@@ -1,3 +1,5 @@
 <?php
 
-echo json_encode(['foo' => 'bar']);
+return function () {
+	return ['another' => 'json'];
+};

--- a/tests/Cms/App/fixtures/controllers/site.json.php
+++ b/tests/Cms/App/fixtures/controllers/site.json.php
@@ -1,5 +1,5 @@
 <?php
 
 return function () {
-	return ['test' => 'html'];
+	return ['site' => 'json'];
 };

--- a/tests/Cms/App/fixtures/controllers/site.php
+++ b/tests/Cms/App/fixtures/controllers/site.php
@@ -1,5 +1,5 @@
 <?php
 
 return function () {
-	return ['title' => 'Site'];
+	return ['site' => 'html'];
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Allows content representation-specific site controllers, e.g. `site.json.php`
- Either `site.php` or the more specific representation site controller get merged into any other controller, but never both


### Reasoning
Allows to globally provide data to all controllers/templates that only a specific content type needs.


### Additional context
- Please review the unit tests closely if each configuration ends in the results you would expect as well.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement
- Support for content representation specific site controllers, e.g. `site.rss.php`



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
