### PR TITLE
Blocks field: fix empty display

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -54,18 +54,12 @@
 					@split="split(block, index, $event)"
 					@update="update(block, $event)"
 				/>
-
-				<!-- No blocks -->
-				<template v-if="blocks.length === 0" #footer>
-					<k-empty
-						class="k-blocks-empty"
-						icon="box"
-						@click="choose(blocks.length)"
-					>
-						{{ empty ?? $t("field.blocks.empty") }}
-					</k-empty>
-				</template>
 			</k-draggable>
+
+			<!-- No blocks -->
+			<k-empty class="k-blocks-empty" icon="box" @click="choose(blocks.length)">
+				{{ empty ?? $t("field.blocks.empty") }}
+			</k-empty>
 		</template>
 
 		<!-- No fieldsets -->
@@ -728,7 +722,7 @@ export default {
 .k-blocks {
 	border-radius: var(--rounded);
 }
-.k-blocks:not([data-empty="true"], [data-disabled="true"]) {
+.k-blocks:not(:has(> .k-blocks-list:empty), [data-disabled="true"]) {
 	background: var(--block-color-back);
 	box-shadow: var(--shadow);
 }
@@ -749,8 +743,12 @@ export default {
 	cursor: -moz-grabbing;
 	cursor: -webkit-grabbing;
 }
-.k-blocks-list > .k-blocks-empty {
+
+.k-blocks > .k-blocks-empty {
 	display: flex;
 	align-items: center;
+}
+.k-blocks > .k-blocks-list:not(:empty) + .k-blocks-empty {
+	display: none;
 }
 </style>

--- a/panel/src/components/Forms/Layouts/LayoutColumn.vue
+++ b/panel/src/components/Forms/Layouts/LayoutColumn.vue
@@ -88,7 +88,7 @@ export default {
 	> .k-block-container:last-of-type {
 	flex-grow: 1;
 }
-.k-layout-column > .k-blocks > .k-blocks-list > .k-blocks-empty.k-box {
+.k-layout-column > .k-blocks > .k-blocks-list + .k-blocks-empty.k-box {
 	--box-color-back: transparent;
 	position: absolute;
 	inset: 0;
@@ -97,7 +97,7 @@ export default {
 	transition: opacity 0.3s;
 	border: 0;
 }
-.k-layout-column > .k-blocks > .k-blocks-list > .k-blocks-empty:hover {
+.k-layout-column > .k-blocks > .k-blocks-list + .k-blocks-empty:hover {
 	opacity: 1;
 }
 </style>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
The blocks field is currently glitchy when showing the empty placeholder. As it so far relies on `data-empty` attribute, it still gets shown even when a block from another blocks field is moved over (as it technically is only the sortable ghost and not present yet in the blocks data array).

This PR tries to solve this rather by utilizing CSS `:empty` and `:has()` to decide when the `.-k-blocks-list` is truly empty of blocks but also sortable ghosts and spending on that show/hide the empty placeholder.

With this change (and the previous sortable change), the ancient https://github.com/getkirby/kirby/issues/5290 seems to be solved.

### Additional context
I didn't run into any errors with this last state. But would feel better if @afbora hits it hard with your bug finding skills.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Blocks field: drag & drop between different blocks fields now functional


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
