### PR TITLE
Redirect `html` representation URLs

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1214,8 +1214,10 @@ class App
 	 * @internal
 	 * @throws \Kirby\Exception\NotFoundException if the home page cannot be found
 	 */
-	public function resolve(string|null $path = null, string|null $language = null): mixed
-	{
+	public function resolve(
+		string|null $path = null,
+		string|null $language = null
+	): mixed {
 		// set the current translation
 		$this->setCurrentTranslation($language);
 
@@ -1263,6 +1265,12 @@ class App
 		// only try to return a representation
 		// when the page has been found
 		if ($page) {
+			// if extension is the default content type,
+			// redirect to page URL without extension
+			if ($extension === 'html') {
+				return Response::redirect($page->url(), 301);
+			}
+
 			try {
 				$response = $this->response();
 				$output   = $page->render([], $extension);

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -4,11 +4,17 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
 
+/**
+ * @coversDefaultClass \Kirby\Cms\App
+ */
 class AppResolveTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppResolve';
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveHomePage()
 	{
 		$app = new App([
@@ -30,6 +36,9 @@ class AppResolveTest extends TestCase
 		$this->assertTrue($result->isHomePage());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveMainPage()
 	{
 		$app = new App([
@@ -51,6 +60,9 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test', $result->id());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveSubPage()
 	{
 		$app = new App([
@@ -75,6 +87,9 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/subpage', $result->id());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolvePageRepresentation()
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
@@ -118,6 +133,34 @@ class AppResolveTest extends TestCase
 		$this->assertSame('png', $result->body());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
+	public function testResolvePageHtmlRepresentation()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		$response = $app->resolve('test.html');
+		$this->assertSame(301, $response->code());
+		$this->assertSame('/test', $response->header('Location'));
+
+	}
+
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveSiteFile()
 	{
 		$app = new App([
@@ -142,6 +185,9 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test.jpg', $result->id());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolvePageFile()
 	{
 		$app = new App([
@@ -171,6 +217,9 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/test.jpg', $result->id());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testResolveMultilangPageRepresentation()
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
@@ -253,6 +302,9 @@ class AppResolveTest extends TestCase
 		$this->assertSame('en', $app->language()->code());
 	}
 
+	/**
+	 * @covers ::resolve
+	 */
 	public function testRepresentationErrorType()
 	{
 		$this->app = new App([


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Requests for a page's `html` representation get redirected to the normal page URL without extension


### Reasoning
Avoiding duplicate content, e.g. at `https://getkirby.com/docs` as well as `https://getkirby.com/docs.html`.

I have explained in https://github.com/getkirby/kirby/issues/6509#issuecomment-2350977276 why I think making Kirby stricter here and just delivering content if a `docs.html.php` template exists would be the wrong direction IMO, considering that within the Kirby system the one without any extension is directly tied to `html` as type. Having the option to have a `docs.php` alongside `docs.html.php` would be a contradiction.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Requests for a page's `html` representation get redirected to the normal page URL without extension


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
