### PR TITLE
Show info text when variable is an array 

### DIFF
--- a/config/areas/languages/dialogs.php
+++ b/config/areas/languages/dialogs.php
@@ -244,7 +244,9 @@ return [
 
 			// shows info text when variable is an array
 			// TODO: 5.0: use entries field instead showing info text
-			if (is_array($variable->value()) === true) {
+			$isVariableArray = is_array($variable->value()) === true;
+
+			if ($isVariableArray === true) {
 				$fields['value'] = [
 					'label' => I18n::translate('info'),
 					'type'  => 'info',
@@ -254,10 +256,12 @@ return [
 
 			return [
 				'component' => 'k-form-dialog',
-				'props' => [
-					'fields' => $fields,
-					'size'   => 'large',
-					'value'  => [
+				'props'     => [
+					'cancelButton' => $isVariableArray === false,
+					'fields'       => $fields,
+					'size'         => 'large',
+					'submitButton' => $isVariableArray === false,
+					'value'        => [
 						'key'   => $variable->key(),
 						'value' => $variable->value()
 					]

--- a/config/areas/languages/dialogs.php
+++ b/config/areas/languages/dialogs.php
@@ -242,6 +242,16 @@ return [
 			$fields['key']['disabled'] = true;
 			$fields['value']['autofocus'] = true;
 
+			// shows info text when variable is an array
+			// TODO: 5.0: use entries field instead showing info text
+			if (is_array($variable->value()) === true) {
+				$fields['value'] = [
+					'label' => I18n::translate('info'),
+					'type'  => 'info',
+					'text'  => 'You are using an array variable for this key. Please modify it in the language file in /site/languages',
+				];
+			}
+
 			return [
 				'component' => 'k-form-dialog',
 				'props' => [


### PR DESCRIPTION
## Description

Currently when variable is an array, error thrown. For now shows info text when variable is an array. We'll fix the issue permanently in K5.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- #6930


### Breaking changes
None


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
