### PR TITLE
New Area and MenuItem classes

### DIFF
--- a/config/areas/logout.php
+++ b/config/areas/logout.php
@@ -5,7 +5,7 @@ use Kirby\Toolkit\I18n;
 
 return function ($kirby) {
 	return [
-		'icon'  => 'user',
+		'icon'  => 'logout',
 		'label' => I18n::translate('logout'),
 		'views' => [
 			'logout' => [

--- a/panel/src/components/View/Inside.vue
+++ b/panel/src/components/View/Inside.vue
@@ -1,6 +1,15 @@
 <template>
 	<k-panel class="k-panel-inside">
-		<k-panel-menu />
+		<k-panel-menu
+			v-bind="$panel.menu.props"
+			:hover="$panel.menu.hover"
+			:is-open="$panel.menu.isOpen"
+			:license="$panel.license"
+			:searches="$panel.searches"
+			@hover="$panel.menu.hover = $event"
+			@search="$panel.search()"
+			@toggle="$panel.menu.toggle()"
+		/>
 		<main class="k-panel-main">
 			<k-topbar :breadcrumb="$panel.view.breadcrumb" :view="$panel.view">
 				<!-- @slot Additional content for the Topbar  -->

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -2,9 +2,9 @@
 	<nav
 		class="k-panel-menu"
 		:aria-label="$t('menu')"
-		:data-hover="$panel.menu.hover"
-		@mouseenter="$panel.menu.hover = true"
-		@mouseleave="$panel.menu.hover = false"
+		:data-hover="hover"
+		@mouseenter="$emit('hover', true)"
+		@mouseleave="$emit('hover', false)"
 	>
 		<div class="k-panel-menu-body">
 			<!-- Search button -->
@@ -13,7 +13,7 @@
 				:text="$t('search')"
 				icon="search"
 				class="k-panel-menu-search k-panel-menu-button"
-				@click="$panel.search()"
+				@click="$emit('search')"
 			/>
 
 			<!-- Menus -->
@@ -23,13 +23,14 @@
 				:data-second-last="menuIndex === menus.length - 2"
 				class="k-panel-menu-buttons"
 			>
-				<k-button
-					v-for="entry in menu"
-					:key="entry.id"
-					v-bind="entry"
-					:title="entry.title ?? entry.text"
-					class="k-panel-menu-button"
-				/>
+				<template v-for="entry in menu">
+					<component
+						:is="entry.component"
+						:key="entry.key"
+						v-bind="entry.props"
+						class="k-panel-menu-button"
+					/>
+				</template>
 			</menu>
 
 			<menu v-if="activationButton">
@@ -40,17 +41,17 @@
 					theme="love"
 					variant="filled"
 				/>
-				<k-activation :status="$panel.license" />
+				<k-activation :status="license" />
 			</menu>
 		</div>
 
 		<!-- Collapse/expand toggle -->
 		<k-button
-			:icon="$panel.menu.isOpen ? 'angle-left' : 'angle-right'"
-			:title="$panel.menu.isOpen ? $t('collapse') : $t('expand')"
+			:icon="isOpen ? 'angle-left' : 'angle-right'"
+			:title="isOpen ? $t('collapse') : $t('expand')"
 			size="xs"
 			class="k-panel-menu-toggle"
-			@click="$panel.menu.toggle()"
+			@click="$emit('toggle')"
 		/>
 	</nav>
 </template>
@@ -61,6 +62,20 @@
  * @internal
  */
 export default {
+	props: {
+		hover: Boolean,
+		isOpen: Boolean,
+		items: {
+			type: Array,
+			default: () => []
+		},
+		license: String,
+		searches: {
+			type: Object,
+			default: () => ({})
+		}
+	},
+	emits: ["search", "toggle"],
 	data() {
 		return {
 			over: false
@@ -68,14 +83,14 @@ export default {
 	},
 	computed: {
 		activationButton() {
-			if (this.$panel.license === "missing") {
+			if (this.license === "missing") {
 				return {
 					click: () => this.$dialog("registration"),
 					text: this.$t("activate")
 				};
 			}
 
-			if (this.$panel.license === "legacy") {
+			if (this.license === "legacy") {
 				return {
 					click: () => this.$dialog("license"),
 					text: this.$t("renew")
@@ -85,10 +100,10 @@ export default {
 			return false;
 		},
 		hasSearch() {
-			return this.$helper.object.length(this.$panel.searches) > 0;
+			return this.$helper.object.length(this.searches) > 0;
 		},
 		menus() {
-			return this.$helper.array.split(this.$panel.menu.entries, "-");
+			return this.$helper.array.split(this.items, "-");
 		}
 	}
 };

--- a/panel/src/panel/menu.js
+++ b/panel/src/panel/menu.js
@@ -3,7 +3,7 @@ import State from "./state.js";
 
 export const defaults = () => {
 	return {
-		entries: [],
+		props: {},
 		hover: false,
 		isOpen: false
 	};
@@ -100,8 +100,8 @@ export default (panel) => {
 		 *
 		 * @param {Array} entries
 		 */
-		set(entries) {
-			this.entries = entries;
+		set(menu) {
+			this.props = menu.props;
 			this.resize();
 			return this.state();
 		},

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Closure;
+use Kirby\Panel\Ui\MenuItem;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -122,14 +123,14 @@ class Area
 	 * how the menu item for the area should be rendered
 	 * and if it should be rendered at all
 	 */
-	public function menuSettings(
+	public function menuItem(
 		array $areas = [],
 		array $permissions = [],
 		string|null $current = null
-	): array|false {
+	): MenuItem|null {
 		// areas without access permissions get skipped entirely
 		if ($this->isAccessible($permissions) === false) {
-			return false;
+			return null;
 		}
 
 		$menu = $this->menu;
@@ -143,14 +144,27 @@ class Area
 		// false will remove the area/entry entirely
 		// just like with disabled permissions
 		if ($menu === false) {
-			return false;
+			return null;
 		}
 
-		return match ($menu) {
+		// create a new menu item instance for the area
+		$item = new MenuItem(
+			current: $this->isCurrent($current),
+			icon: $this->icon() ?? $this->id(),
+			text: $this->label(),
+			dialog: $this->dialog(),
+			drawer: $this->drawer(),
+			link: $this->link(),
+		);
+
+		// add the custom menu settings
+		$item->merge(match ($menu) {
 			'disabled' => ['disabled' => true],
 			true       => [],
 			default    => $menu
-		};
+		});
+
+		return $item;
 	}
 
 	/**

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -27,84 +27,55 @@ class Area
 		protected array $drawers = [],
 		protected array $dropdowns = [],
 		protected string|null $icon = null,
-		protected array|string|null $label = null,
+		protected Closure|array|string|null $label = null,
 		protected string|null $link = null,
 		protected Closure|array|bool|string $menu = false,
 		protected string|null $search = null,
 		protected array $searches = [],
 		protected array $requests = [],
-		protected array|string|null $title = null,
+		protected Closure|array|string|null $title = null,
 		protected array $views = [],
 	) {
 	}
 
-	public function breadcrumb(): array
+	public function __call(string $name, array $args = [])
 	{
-		return $this->breadcrumb;
+		return $this->{$name};
 	}
 
+	/**
+	 * A custom breadcrumb label that will be used for the
+	 * breadcrumb instead of the default label
+	 */
 	public function breadcrumbLabel(): string
 	{
-		$label = $this->breadcrumbLabel ?? $this->label();
+		return $this->i18n($this->breadcrumbLabel ?? $this->label());
+	}
 
-		if ($label instanceof Closure) {
-			$label = $label();
+	/**
+	 * Translator for breadcrumbLabel, label & title
+	 */
+	protected function i18n(Closure|array|string|null $value): string|null
+	{
+		if ($value instanceof Closure) {
+			$value = $value();
 		}
 
-		return I18n::translate($label, $label);
+		return I18n::translate($value, $value);
 	}
 
-	public function buttons(): array
-	{
-		return $this->buttons;
-	}
-
-	public function current(): null
-	{
-		return $this->current;
-	}
-
-	public function dialog(): string|null
-	{
-		return $this->dialog;
-	}
-
-	public function dialogs(): array
-	{
-		return $this->dialogs;
-	}
-
-	public function drawer(): string|null
-	{
-		return $this->drawer;
-	}
-
-	public function drawers(): array
-	{
-		return $this->drawers;
-	}
-
-	public function dropdowns(): array
-	{
-		return $this->dropdowns;
-	}
-
-	public function icon(): string|null
-	{
-		return $this->icon;
-	}
-
-	public function id(): string
-	{
-		return $this->id;
-	}
-
+	/**
+	 * Checks for access permissions for this area
+	 */
 	public function isAccessible(array $permissions): bool
 	{
 		return ($permissions['access'][$this->id] ?? true) === true;
 	}
 
-	public function isCurrent(string|null $current): bool
+	/**
+	 * Checks if the area is currently active
+	 */
+	public function isCurrent(string|null $current = null): bool
 	{
 		if ($this->current === null) {
 			return $this->id === $current;
@@ -117,17 +88,26 @@ class Area
 		return $this->current;
 	}
 
+	/**
+	 * The label is used for the menu item and the breadcrumb
+	 * unless a custom breadcrumb label is defined
+	 */
 	public function label(): string
 	{
-		$label = $this->label ?? $this->id;
-		return I18n::translate($label, $label);
+		return $this->i18n($this->label ?? $this->id);
 	}
 
+	/**
+	 * Link for the menu item
+	 */
 	public function link(): string
 	{
 		return $this->link ?? $this->id;
 	}
 
+	/**
+	 * Set or overwrite additional props via array
+	 */
 	public function merge(array $props): static
 	{
 		foreach ($props as $key => $value) {
@@ -137,15 +117,15 @@ class Area
 		return $this;
 	}
 
-	public function menu(): Closure|array|bool|string
-	{
-		return $this->menu;
-	}
-
+	/**
+	 * Evaluate the menu settings to determine
+	 * how the menu item for the area should be rendered
+	 * and if it should be rendered at all
+	 */
 	public function menuSettings(
-		array $areas,
-		array $permissions,
-		string|null $current
+		array $areas = [],
+		array $permissions = [],
+		string|null $current = null
 	): array|false {
 		// areas without access permissions get skipped entirely
 		if ($this->isAccessible($permissions) === false) {
@@ -173,27 +153,20 @@ class Area
 		};
 	}
 
-	public function requests(): array
-	{
-		return $this->requests;
-	}
-
-	public function search(): string|null
-	{
-		return $this->search;
-	}
-
-	public function searches(): array
-	{
-		return $this->searches;
-	}
-
+	/**
+	 * The title is used for the browser title. It will fall back
+	 * to the label if no custom title is defined.
+	 */
 	public function title(): string
 	{
-		$title = $this->title ?? $this->label();
-		return I18n::translate($title, $title);
+		return $this->i18n($this->title ?? $this->label());
 	}
 
+	/**
+	 * Returns parameters that will be added to the
+	 * view response (one level above the props) to
+	 * render the view component properly
+	 */
 	public function toView(): array
 	{
 		return [
@@ -206,10 +179,5 @@ class Area
 			'search'          => $this->search(),
 			'title'           => $this->title(),
 		];
-	}
-
-	public function views(): array
-	{
-		return $this->views;
 	}
 }

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -137,7 +137,7 @@ class Area
 		return $this;
 	}
 
-	public function menu():	Closure|array|bool|string
+	public function menu(): Closure|array|bool|string
 	{
 		return $this->menu;
 	}

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Kirby\Panel;
+
+use Closure;
+use Kirby\Toolkit\I18n;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.0.0
+ */
+class Area
+{
+	public function __construct(
+		protected string $id,
+		protected array $breadcrumb = [],
+		protected Closure|array|string|null $breadcrumbLabel = null,
+		protected array $buttons = [],
+		protected Closure|bool|null $current = null,
+		protected string|null $dialog = null,
+		protected array $dialogs = [],
+		protected string|null $drawer = null,
+		protected array $drawers = [],
+		protected array $dropdowns = [],
+		protected string|null $icon = null,
+		protected array|string|null $label = null,
+		protected string|null $link = null,
+		protected Closure|array|bool|string $menu = false,
+		protected string|null $search = null,
+		protected array $searches = [],
+		protected array $requests = [],
+		protected array|string|null $title = null,
+		protected array $views = [],
+	) {
+	}
+
+	public function breadcrumb(): array
+	{
+		return $this->breadcrumb;
+	}
+
+	public function breadcrumbLabel(): string
+	{
+		$label = $this->breadcrumbLabel ?? $this->label();
+
+		if ($label instanceof Closure) {
+			$label = $label();
+		}
+
+		return I18n::translate($label, $label);
+	}
+
+	public function buttons(): array
+	{
+		return $this->buttons;
+	}
+
+	public function current(): null
+	{
+		return $this->current;
+	}
+
+	public function dialog(): string|null
+	{
+		return $this->dialog;
+	}
+
+	public function dialogs(): array
+	{
+		return $this->dialogs;
+	}
+
+	public function drawer(): string|null
+	{
+		return $this->drawer;
+	}
+
+	public function drawers(): array
+	{
+		return $this->drawers;
+	}
+
+	public function dropdowns(): array
+	{
+		return $this->dropdowns;
+	}
+
+	public function icon(): string|null
+	{
+		return $this->icon;
+	}
+
+	public function id(): string
+	{
+		return $this->id;
+	}
+
+	public function isAccessible(array $permissions): bool
+	{
+		return ($permissions['access'][$this->id] ?? true) === true;
+	}
+
+	public function isCurrent(string|null $current): bool
+	{
+		if ($this->current === null) {
+			return $this->id === $current;
+		}
+
+		if ($this->current instanceof Closure) {
+			return ($this->current)($current);
+		}
+
+		return $this->current;
+	}
+
+	public function label(): string
+	{
+		$label = $this->label ?? $this->id;
+		return I18n::translate($label, $label);
+	}
+
+	public function link(): string
+	{
+		return $this->link ?? $this->id;
+	}
+
+	public function merge(array $props): static
+	{
+		foreach ($props as $key => $value) {
+			$this->{$key} = $value;
+		}
+
+		return $this;
+	}
+
+	public function menu():	Closure|array|bool|string
+	{
+		return $this->menu;
+	}
+
+	public function menuSettings(
+		array $areas,
+		array $permissions,
+		string|null $current
+	): array|false {
+		// areas without access permissions get skipped entirely
+		if ($this->isAccessible($permissions) === false) {
+			return false;
+		}
+
+		$menu = $this->menu;
+
+		// menu setting can be a callback
+		// that returns true, false or 'disabled'
+		if ($menu instanceof Closure) {
+			$menu = $menu($areas, $permissions, $current);
+		}
+
+		// false will remove the area/entry entirely
+		// just like with disabled permissions
+		if ($menu === false) {
+			return false;
+		}
+
+		return match ($menu) {
+			'disabled' => ['disabled' => true],
+			true       => [],
+			default    => $menu
+		};
+	}
+
+	public function requests(): array
+	{
+		return $this->requests;
+	}
+
+	public function search(): string|null
+	{
+		return $this->search;
+	}
+
+	public function searches(): array
+	{
+		return $this->searches;
+	}
+
+	public function title(): string
+	{
+		$title = $this->title ?? $this->label();
+		return I18n::translate($title, $title);
+	}
+
+	public function toView(): array
+	{
+		return [
+			'breadcrumb'      => $this->breadcrumb(),
+			'breadcrumbLabel' => $this->breadcrumbLabel(),
+			'icon'            => $this->icon(),
+			'id'              => $this->id(),
+			'label'           => $this->label(),
+			'link'            => $this->link(),
+			'search'          => $this->search(),
+			'title'           => $this->title(),
+		];
+	}
+
+	public function views(): array
+	{
+		return $this->views;
+	}
+}

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -150,11 +150,11 @@ class Area
 		// create a new menu item instance for the area
 		$item = new MenuItem(
 			current: $this->isCurrent($current),
-			icon: $this->icon() ?? $this->id(),
-			text: $this->label(),
-			dialog: $this->dialog(),
-			drawer: $this->drawer(),
-			link: $this->link(),
+			icon:    $this->icon() ?? $this->id(),
+			text:    $this->label(),
+			dialog:  $this->dialog(),
+			drawer:  $this->drawer(),
+			link:    $this->link(),
 		);
 
 		// add the custom menu settings

--- a/src/Panel/Areas.php
+++ b/src/Panel/Areas.php
@@ -15,28 +15,21 @@ use Kirby\Toolkit\A;
  */
 class Areas
 {
+	protected array $areas;
 	protected App $kirby;
 
 	public function __construct()
 	{
 		$this->kirby = App::instance();
+		$this->areas = $this->load();
 	}
 
 	/**
 	 * Normalize a panel area
 	 */
-	public static function area(string $id, array $area): array
+	public static function area(string $id, array $area): Area
 	{
-		$area['id']                = $id;
-		$area['label']           ??= $id;
-		$area['breadcrumb']      ??= [];
-		$area['breadcrumbLabel'] ??= $area['label'];
-		$area['title']             = $area['label'];
-		$area['menu']            ??= false;
-		$area['link']            ??= $id;
-		$area['search']          ??= null;
-
-		return $area;
+		return new Area($id, ...$area);
 	}
 
 	/**
@@ -46,13 +39,13 @@ class Areas
 	{
 		return array_merge(...array_values(
 			A::map(
-				$this->toArray(),
-				fn ($area) => $area['buttons'] ?? []
+				$this->areas,
+				fn (Area $area) => $area->buttons()
 			)
 		));
 	}
 
-	public function toArray(): array
+	public function load(): array
 	{
 		$system = $this->kirby->system();
 		$user   = $this->kirby->user();
@@ -74,9 +67,9 @@ class Areas
 		// not yet authenticated
 		if (!$user) {
 			return [
-				'logout' => Areas::area('logout', $areas['logout']),
+				'logout' => static::area('logout', $areas['logout']),
 				// login area last because it defines a fallback route
-				'login'  => Areas::area('login', $areas['login']),
+				'login'  => static::area('login', $areas['login']),
 			];
 		}
 
@@ -96,5 +89,10 @@ class Areas
 		}
 
 		return $result;
+	}
+
+	public function toArray(): array
+	{
+		return $this->areas;
 	}
 }

--- a/src/Panel/Fiber.php
+++ b/src/Panel/Fiber.php
@@ -242,7 +242,7 @@ class Fiber
 			// by default, all areas are accessible unless
 			// the permissions are explicitly set to false
 			if ($area->isAccessible($this->permissions) !== false) {
-				foreach ($area->searches() ?? [] as $id => $params) {
+				foreach ($area->searches() as $id => $params) {
 					$searches[$id] = [
 						'icon'  => $params['icon'] ?? 'search',
 						'label' => $params['label'] ?? Str::ucfirst($id),

--- a/src/Panel/Fiber.php
+++ b/src/Panel/Fiber.php
@@ -215,7 +215,8 @@ class Fiber
 		$menu = new Menu(
 			areas:       $this->areas,
 			permissions: $this->permissions,
-			current:     $this->area?->id()
+			current:     $this->area?->id(),
+			config: 	 $this->kirby->option('panel.menu', null)
 		);
 
 		return $menu->render();

--- a/src/Panel/Fiber.php
+++ b/src/Panel/Fiber.php
@@ -213,12 +213,12 @@ class Fiber
 	public function menu(): array
 	{
 		$menu = new Menu(
-			$this->areas,
-			$this->permissions,
-			$this->area?->id()
+			areas:       $this->areas,
+			permissions: $this->permissions,
+			current:     $this->area?->id()
 		);
 
-		return $menu->items();
+		return $menu->render();
 	}
 
 	public function multilang(): bool

--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -73,22 +73,22 @@ class Home
 			}
 
 			// skip disabled items
-			if (($menuItem['disabled'] ?? false) === true) {
+			if (($menuItem['props']['disabled'] ?? false) === true) {
 				continue;
 			}
 
 			// skip buttons that don't open a link
 			// (but e.g. a dialog)
-			if (isset($menuItem['link']) === false) {
+			if (isset($menuItem['props']['link']) === false) {
 				continue;
 			}
 
 			// skip the logout button
-			if ($menuItem['link'] === 'logout') {
+			if ($menuItem['props']['link'] === 'logout') {
 				continue;
 			}
 
-			return Panel::url($menuItem['link']);
+			return Panel::url($menuItem['props']['link']);
 		}
 
 		throw new NotFoundException(

--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -61,8 +61,8 @@ class Home
 
 		// needed to create a proper menu
 		$areas = $this->kirby->panel()->areas()->toArray();
-		$menu  = new Menu($areas, $permissions->toArray());
-		$menu  = $menu->entries();
+		$menu  = new Menu(areas: $areas, permissions: $permissions->toArray());
+		$menu  = $menu->items();
 
 		// go through the menu and search for the first
 		// available view we can go to

--- a/src/Panel/Router.php
+++ b/src/Panel/Router.php
@@ -36,7 +36,7 @@ class Router
 		$this->garbage();
 
 		// collect areas
-		$areas  = $this->panel->areas()->toArray();
+		$areas = $this->panel->areas()->toArray();
 
 		// create a micro-router for the Panel
 		return BaseRouter::execute(
@@ -159,15 +159,15 @@ class Router
 		];
 
 		// register all routes from areas
-		foreach ($areas as $id => $area) {
+		foreach ($areas as $area) {
 			$routes = [
 				...$routes,
-				...static::routesForViews($id, $area),
-				...static::routesForSearches($id, $area),
-				...static::routesForDialogs($id, $area),
-				...static::routesForDrawers($id, $area),
-				...static::routesForDropdowns($id, $area),
-				...static::routesForRequests($id, $area),
+				...static::routesForViews($area),
+				...static::routesForSearches($area),
+				...static::routesForDialogs($area),
+				...static::routesForDrawers($area),
+				...static::routesForDropdowns($area),
+				...static::routesForRequests($area),
 			];
 		}
 
@@ -197,9 +197,10 @@ class Router
 	/**
 	 * Extract all routes from an area
 	 */
-	public static function routesForDialogs(string $areaId, array $area): array
+	public static function routesForDialogs(Area $area): array
 	{
-		$dialogs = $area['dialogs'] ?? [];
+		$areaId  = $area->id();
+		$dialogs = $area->dialogs();
 		$routes  = [];
 
 		foreach ($dialogs as $dialogId => $dialog) {
@@ -220,9 +221,10 @@ class Router
 	/**
 	 * Extract all routes from an area
 	 */
-	public static function routesForDrawers(string $areaId, array $area): array
+	public static function routesForDrawers(Area $area): array
 	{
-		$drawers = $area['drawers'] ?? [];
+		$areaId  = $area->id();
+		$drawers = $area->drawers();
 		$routes  = [];
 
 		foreach ($drawers as $drawerId => $drawer) {
@@ -243,9 +245,10 @@ class Router
 	/**
 	 * Extract all routes for dropdowns
 	 */
-	public static function routesForDropdowns(string $areaId, array $area): array
+	public static function routesForDropdowns(Area $area): array
 	{
-		$dropdowns = $area['dropdowns'] ?? [];
+		$areaId    = $area->id();
+		$dropdowns = $area->dropdowns();
 		$routes    = [];
 
 		foreach ($dropdowns as $dropdownId => $dropdown) {
@@ -266,9 +269,10 @@ class Router
 	/**
 	 * Extract all routes from an area
 	 */
-	public static function routesForRequests(string $areaId, array $area): array
+	public static function routesForRequests(Area $area): array
 	{
-		$routes = $area['requests'] ?? [];
+		$areaId = $area->id();
+		$routes = $area->requests();
 
 		foreach ($routes as $key => $route) {
 			$routes[$key]['area'] = $areaId;
@@ -281,9 +285,10 @@ class Router
 	/**
 	 * Extract all routes for searches
 	 */
-	public static function routesForSearches(string $areaId, array $area): array
+	public static function routesForSearches(Area $area): array
 	{
-		$searches = $area['searches'] ?? [];
+		$areaId   = $area->id();
+		$searches = $area->searches();
 		$routes   = [];
 
 		foreach ($searches as $name => $params) {
@@ -313,9 +318,10 @@ class Router
 	/**
 	 * Extract all views from an area
 	 */
-	public static function routesForViews(string $areaId, array $area): array
+	public static function routesForViews(Area $area): array
 	{
-		$views  = $area['views'] ?? [];
+		$areaId = $area->id();
+		$views  = $area->views();
 		$routes = [];
 
 		foreach ($views as $view) {

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -25,7 +25,8 @@ class Menu extends Component
 	public function __construct(
 		array $areas = [],
 		protected array $permissions = [],
-		protected string|null $current = null
+		protected string|null $current = null,
+		protected Closure|array|null $config = null
 	) {
 		foreach ($areas as $area) {
 			$this->areas[$area->id()] = $area;
@@ -102,11 +103,11 @@ class Menu extends Component
 	public function config(): array
 	{
 		// get from config option which areas should be listed in the menu
-		$kirby = App::instance();
-		$items = $kirby->option('panel.menu');
+		$items = $this->config;
 
 		// lazy-load items
 		if ($items instanceof Closure) {
+			$kirby = App::instance();
 			$items = $items($kirby);
 		}
 

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -32,7 +32,7 @@ class Menu
 	}
 
 	/**
-	 * Undocumented function
+	 * Helper to fetch an area instance and merge the given props
 	 */
 	public function area(string $id, array $props = []): Area|null
 	{

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -59,6 +59,12 @@ class Menu extends Component
 				continue;
 			}
 
+			// [$areaId => Ui() ]
+			if ($area instanceof Component) {
+				$areas[] = $area;
+				continue;
+			}
+
 			// [0 => $areaId]
 			if (is_numeric($id) === true) {
 				$areas[] = $this->area($area);
@@ -68,12 +74,6 @@ class Menu extends Component
 			// [$areaId => true]
 			if ($area === true) {
 				$areas[] = $this->area($id);
-				continue;
-			}
-
-			// [$areaId => Ui() ]
-			if ($area instanceof Component) {
-				$areas[] = $area;
 				continue;
 			}
 

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -121,26 +121,11 @@ class Menu
 			return null;
 		}
 
-		$menuSettings = $area->menuSettings(
+		return $area->menuItem(
 			areas: $this->areas,
 			permissions: $this->permissions,
 			current: $this->current
 		);
-
-		if ($menuSettings === false) {
-			return null;
-		}
-
-		$item = new MenuItem(
-			current: $area->isCurrent($this->current),
-			icon: $area->icon() ?? $area->id(),
-			text: $area->label(),
-			dialog: $area->dialog(),
-			drawer: $area->drawer(),
-			link: $area->link(),
-		);
-
-		return $item->merge($menuSettings);
 	}
 
 	/**

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Ui;
 use Closure;
 use Kirby\Cms\App;
 use Kirby\Panel\Area;
-use Kirby\Toolkit\I18n;
 
 /**
  * The Menu class takes care of gathering

--- a/src/Panel/Ui/MenuItem.php
+++ b/src/Panel/Ui/MenuItem.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Ui;
 
+use Kirby\Exception\Exception;
 use Kirby\Toolkit\I18n;
 
 class MenuItem
@@ -15,36 +16,19 @@ class MenuItem
 		protected string|null $drawer = null,
 		protected string|null $link = null,
 	) {
+		if ($this->dialog === null && $this->drawer === null && $this->link === null) {
+			throw new Exception('You must define a dialog, drawer or link for the menu item');
+		}
 	}
 
-	public function current(): bool
+	public function __call(string $name, array $args = [])
 	{
-		return $this->current;
-	}
-
-	public function dialog(): string|null
-	{
-		return $this->dialog;
-	}
-
-	public function disabled(): bool
-	{
-		return $this->disabled;
-	}
-
-	public function drawer(): string|null
-	{
-		return $this->drawer;
-	}
-
-	public function icon(): string
-	{
-		return $this->icon;
+		return $this->{$name};
 	}
 
 	public function link(): string|null
 	{
-		if ($this->dialog || $this->drawer) {
+		if ($this->dialog !== null || $this->drawer !== null) {
 			return null;
 		}
 

--- a/src/Panel/Ui/MenuItem.php
+++ b/src/Panel/Ui/MenuItem.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Toolkit\I18n;
+
+class MenuItem
+{
+	public function __construct(
+		protected string $icon,
+		protected array|string $text,
+		protected bool $current = false,
+		protected string|null $dialog = null,
+		protected bool $disabled = false,
+		protected string|null $drawer = null,
+		protected string|null $link = null,
+	) {
+	}
+
+	public function current(): bool
+	{
+		return $this->current;
+	}
+
+	public function dialog(): string|null
+	{
+		return $this->dialog;
+	}
+
+	public function disabled(): bool
+	{
+		return $this->disabled;
+	}
+
+	public function drawer(): string|null
+	{
+		return $this->drawer;
+	}
+
+	public function icon(): string
+	{
+		return $this->icon;
+	}
+
+	public function link(): string|null
+	{
+		if ($this->dialog || $this->drawer) {
+			return null;
+		}
+
+		return $this->link;
+	}
+
+	/**
+	 * Set additional props from an array
+	 */
+	public function merge(array $props): static
+	{
+		foreach ($props as $key => $value) {
+			$this->{$key} = $value;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Returns the translated button text
+	 */
+	public function text(): string
+	{
+		return I18n::translate($this->text, $this->text);
+	}
+
+	/**
+	 * Returns all props for the menu button
+	 */
+	public function toArray(): array
+	{
+		return array_filter([
+			'current'  => $this->current(),
+			'dialog'   => $this->dialog(),
+			'disabled' => $this->disabled(),
+			'drawer'   => $this->drawer(),
+			'icon'     => $this->icon(),
+			'link'     => $this->link(),
+			'text'     => $this->text(),
+		]);
+	}
+}

--- a/src/Panel/Ui/MenuItem.php
+++ b/src/Panel/Ui/MenuItem.php
@@ -3,27 +3,35 @@
 namespace Kirby\Panel\Ui;
 
 use Kirby\Exception\Exception;
-use Kirby\Toolkit\I18n;
 
-class MenuItem
+class MenuItem extends Button
 {
 	public function __construct(
-		protected string $icon,
-		protected array|string $text,
-		protected bool $current = false,
-		protected string|null $dialog = null,
-		protected bool $disabled = false,
-		protected string|null $drawer = null,
-		protected string|null $link = null,
+		string $icon,
+		array|string $text,
+		bool $current = false,
+		string|null $dialog = null,
+		bool $disabled = false,
+		string|null $drawer = null,
+		string|null $link = null,
 	) {
-		if ($this->dialog === null && $this->drawer === null && $this->link === null) {
+		if (
+			$dialog === null &&
+			$drawer === null &&
+			$link === null
+		) {
 			throw new Exception('You must define a dialog, drawer or link for the menu item');
 		}
-	}
 
-	public function __call(string $name, array $args = [])
-	{
-		return $this->{$name};
+		parent::__construct(
+			current:  $current,
+			dialog:   $dialog,
+			disabled: $disabled,
+			drawer:   $drawer,
+			icon:     $icon,
+			link:     $link,
+			text:     $text
+		);
 	}
 
 	public function link(): string|null
@@ -47,27 +55,11 @@ class MenuItem
 		return $this;
 	}
 
-	/**
-	 * Returns the translated button text
-	 */
-	public function text(): string
+	public function props(): array
 	{
-		return I18n::translate($this->text, $this->text);
-	}
-
-	/**
-	 * Returns all props for the menu button
-	 */
-	public function toArray(): array
-	{
-		return array_filter([
-			'current'  => $this->current(),
-			'dialog'   => $this->dialog(),
-			'disabled' => $this->disabled(),
-			'drawer'   => $this->drawer(),
-			'icon'     => $this->icon(),
-			'link'     => $this->link(),
-			'text'     => $this->text(),
-		]);
+		return [
+			...parent::props(),
+			'link' => $this->link()
+		];
 	}
 }

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -66,7 +66,11 @@ class View
 		}
 
 		// gather all Fiber data
-		$fiber = new Fiber(view: $data, options: $options);
+		$fiber = new Fiber(
+			area: $options['area'] ?? null,
+			areas: $options['areas'] ?? [],
+			view: $data,
+		);
 
 		// if requested, send $fiber data as JSON
 		if (Panel::isFiberRequest() === true) {

--- a/tests/Panel/AreaTest.php
+++ b/tests/Panel/AreaTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Panel\Ui\MenuItem;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 
@@ -296,30 +297,35 @@ class AreaTest extends TestCase
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
-	public function testMenuSettings()
+	public function testMenuItem()
 	{
 		$area = new Area(id: 'test');
 
-		$this->assertFalse($area->menuSettings());
+		$this->assertNull($area->menuItem());
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
-	public function testMenuSettingsWithEnabledMenu()
+	public function testMenuItemWithEnabledMenu()
 	{
 		$area = new Area(
 			id: 'test',
 			menu: true,
 		);
 
-		$this->assertSame([], $area->menuSettings());
+		$menuItem = $area->menuItem();
+
+		$this->assertInstanceOf(MenuItem::class, $menuItem);
+		$this->assertSame('test', $menuItem->icon());
+		$this->assertSame('test', $menuItem->text());
+		$this->assertSame('test', $menuItem->link());
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
 	public function testMenuSettingsWithDisabledAccess()
 	{
@@ -328,7 +334,7 @@ class AreaTest extends TestCase
 			menu: true,
 		);
 
-		$this->assertFalse($area->menuSettings(
+		$this->assertNull($area->menuItem(
 			permissions: [
 				'access' => [
 					'test' => false
@@ -338,9 +344,9 @@ class AreaTest extends TestCase
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
-	public function testMenuSettingsWithClosureDefinition()
+	public function testMenuItemWithClosureDefinition()
 	{
 		$menu = [
 			'icon' => 'edit'
@@ -367,39 +373,41 @@ class AreaTest extends TestCase
 			}
 		);
 
-		$this->assertSame($menu, $area->menuSettings(
+		$menuItem = $area->menuItem(
 			areas: $passedAreas,
 			permissions: $passedPermissions,
 			current: 'test'
-		));
+		);
+
+		$this->assertSame('edit', $menuItem->icon());
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
-	public function testMenuSettingsWithArrayDefinition()
+	public function testMenuItemWithArrayDefinition()
 	{
 		$area = new Area(
 			id: 'test',
-			menu: $menu = [
+			menu: [
 				'icon' => 'edit'
 			]
 		);
 
-		$this->assertSame($menu, $area->menuSettings());
+		$this->assertSame('edit', $area->menuItem()->icon());
 	}
 
 	/**
-	 * @covers ::menuSettings
+	 * @covers ::menuItem
 	 */
-	public function testMenuSettingsWithDisabledFlag()
+	public function testMenuItemWithDisabledFlag()
 	{
 		$area = new Area(
 			id: 'test',
 			menu: 'disabled'
 		);
 
-		$this->assertSame(['disabled' => true], $area->menuSettings());
+		$this->assertTrue($area->menuItem()->disabled());
 	}
 
 	/**

--- a/tests/Panel/AreaTest.php
+++ b/tests/Panel/AreaTest.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace Kirby\Panel;
+
+use Kirby\TestCase;
+use Kirby\Toolkit\I18n;
+
+/**
+ * @coversDefaultClass \Kirby\Panel\Area
+ */
+class AreaTest extends TestCase
+{
+	public function tearDown(): void
+	{
+		I18n::$translations = [];
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstruct()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertSame([], $area->breadcrumb());
+		$this->assertSame('test', $area->breadcrumbLabel());
+		$this->assertSame([], $area->buttons());
+		$this->assertNull($area->current());
+		$this->assertNull($area->dialog());
+		$this->assertSame([], $area->dialogs());
+		$this->assertNull($area->drawer());
+		$this->assertSame([], $area->drawers());
+		$this->assertSame([], $area->dropdowns());
+		$this->assertNull($area->icon());
+		$this->assertSame('test', $area->label());
+		$this->assertSame('test', $area->link());
+		$this->assertNull($area->search());
+		$this->assertSame([], $area->searches());
+		$this->assertSame([], $area->requests());
+		$this->assertSame('test', $area->title());
+		$this->assertSame([], $area->views());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabel()
+	{
+		$area = new Area(
+			id: 'test',
+			breadcrumbLabel: 'Label'
+		);
+
+		$this->assertSame('Label', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabelWithClosureDefinition()
+	{
+		$area = new Area(
+			id: 'test',
+			breadcrumbLabel: function () {
+				return 'Breadcrumb Label';
+			}
+		);
+
+		$this->assertSame('Breadcrumb Label', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabelWithIdAsDefault()
+	{
+		$area = new Area(
+			id: 'test',
+		);
+
+		$this->assertSame('test', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabelWithLabelAsDefault()
+	{
+		$area = new Area(
+			id: 'test',
+			label: 'Test Label',
+		);
+
+		$this->assertSame('Test Label', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabelWithTranslationString()
+	{
+		I18n::$translations = [
+			'en' => [
+				'test' => 'Test Label'
+			]
+		];
+
+		$area = new Area(
+			id: 'test',
+			breadcrumbLabel: 'test'
+		);
+
+		$this->assertSame('Test Label', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::breadcrumbLabel
+	 */
+	public function testBreadcrumbLabelWithTranslationArray()
+	{
+		$area = new Area(
+			id: 'test',
+			breadcrumbLabel: [
+				'en' => 'Test Label',
+				'de' => 'Töst Label'
+			]
+		);
+
+		$this->assertSame('Test Label', $area->breadcrumbLabel());
+	}
+
+	/**
+	 * @covers ::isAccessible
+	 */
+	public function testIsAccessible()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertTrue($area->isAccessible([]));
+		$this->assertFalse($area->isAccessible([
+			'access' => [
+				'test' => false
+			]
+		]));
+	}
+
+	/**
+	 * @covers ::isCurrent
+	 */
+	public function testIsCurrent()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertFalse($area->isCurrent());
+		$this->assertTrue($area->isCurrent('test'));
+	}
+
+	/**
+	 * @covers ::isCurrent
+	 */
+	public function testIsCurrentWithCustomCurrentSetting()
+	{
+		$area = new Area(
+			id: 'test',
+			current: true
+		);
+
+		$this->assertTrue($area->isCurrent());
+		$this->assertTrue($area->isCurrent('foo'));
+		$this->assertTrue($area->isCurrent('bar'));
+
+		$area = new Area(
+			id: 'test',
+			current: function ($current) {
+				return $current === 'foo';
+			}
+		);
+
+		$this->assertFalse($area->isCurrent());
+		$this->assertFalse($area->isCurrent('bar'));
+		$this->assertTrue($area->isCurrent('foo'));
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function testLabel()
+	{
+		$area = new Area(
+			id: 'test',
+			label: 'Label'
+		);
+
+		$this->assertSame('Label', $area->label());
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function testLabelWithClosureDefinition()
+	{
+		$area = new Area(
+			id: 'test',
+			label: function () {
+				return 'Label';
+			}
+		);
+
+		$this->assertSame('Label', $area->label());
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function testLabelWithIdAsDefault()
+	{
+		$area = new Area(
+			id: 'test',
+		);
+
+		$this->assertSame('test', $area->label());
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function testLabelWithTranslationString()
+	{
+		I18n::$translations = [
+			'en' => [
+				'test' => 'Test Label'
+			]
+		];
+
+		$area = new Area(
+			id: 'test',
+			label: 'test'
+		);
+
+		$this->assertSame('Test Label', $area->label());
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function testLabelWithTranslationArray()
+	{
+		$area = new Area(
+			id: 'test',
+			label: [
+				'en' => 'Test Label',
+				'de' => 'Töst Label'
+			]
+		);
+
+		$this->assertSame('Test Label', $area->label());
+	}
+
+	/**
+	 * @covers ::link
+	 */
+	public function testLink()
+	{
+		$area = new Area(
+			id: 'test',
+			link: 'custom-link'
+		);
+
+		$this->assertSame('custom-link', $area->link());
+	}
+
+	/**
+	 * @covers ::link
+	 */
+	public function testLinkWithIdAsDefault()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertSame('test', $area->link());
+	}
+
+	/**
+	 * @covers ::merge
+	 */
+	public function testMerge()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertSame('test', $area->link());
+
+		$area->merge([
+			'link' => 'custom-link'
+		]);
+
+		$this->assertSame('custom-link', $area->link());
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettings()
+	{
+		$area = new Area(id: 'test');
+
+		$this->assertFalse($area->menuSettings());
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettingsWithEnabledMenu()
+	{
+		$area = new Area(
+			id: 'test',
+			menu: true,
+		);
+
+		$this->assertSame([], $area->menuSettings());
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettingsWithDisabledAccess()
+	{
+		$area = new Area(
+			id: 'test',
+			menu: true,
+		);
+
+		$this->assertFalse($area->menuSettings(
+			permissions: [
+				'access' => [
+					'test' => false
+				]
+			]
+		));
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettingsWithClosureDefinition()
+	{
+		$menu = [
+			'icon' => 'edit'
+		];
+
+		$passedAreas = [
+			new Area('sibling')
+		];
+
+		$passedPermissions = [
+			'access' => [
+				'test' => true
+			]
+		];
+
+		$area = new Area(
+			id: 'test',
+			menu: function ($areas, $permissions, $current) use ($menu, $passedAreas, $passedPermissions) {
+				$this->assertSame($areas, $passedAreas);
+				$this->assertSame($permissions, $passedPermissions);
+				$this->assertSame($current, 'test');
+
+				return $menu;
+			}
+		);
+
+		$this->assertSame($menu, $area->menuSettings(
+			areas: $passedAreas,
+			permissions: $passedPermissions,
+			current: 'test'
+		));
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettingsWithArrayDefinition()
+	{
+		$area = new Area(
+			id: 'test',
+			menu: $menu = [
+				'icon' => 'edit'
+			]
+		);
+
+		$this->assertSame($menu, $area->menuSettings());
+	}
+
+	/**
+	 * @covers ::menuSettings
+	 */
+	public function testMenuSettingsWithDisabledFlag()
+	{
+		$area = new Area(
+			id: 'test',
+			menu: 'disabled'
+		);
+
+		$this->assertSame(['disabled' => true], $area->menuSettings());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitle()
+	{
+		$area = new Area(
+			id: 'test',
+			title: 'Title'
+		);
+
+		$this->assertSame('Title', $area->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleWithClosureDefinition()
+	{
+		$area = new Area(
+			id: 'test',
+			title: function () {
+				return 'Title';
+			}
+		);
+
+		$this->assertSame('Title', $area->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleWithIdAsDefault()
+	{
+		$area = new Area(
+			id: 'test',
+		);
+
+		$this->assertSame('test', $area->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleWithLabelAsDefault()
+	{
+		$area = new Area(
+			id: 'test',
+			label: 'Test Label'
+		);
+
+		$this->assertSame('Test Label', $area->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleWithTranslationString()
+	{
+		I18n::$translations = [
+			'en' => [
+				'test' => 'Test Title'
+			]
+		];
+
+		$area = new Area(
+			id: 'test',
+			title: 'test'
+		);
+
+		$this->assertSame('Test Title', $area->title());
+	}
+
+	/**
+	 * @covers ::title
+	 */
+	public function testTitleWithTranslationArray()
+	{
+		$area = new Area(
+			id: 'test',
+			title: [
+				'en' => 'Test Title',
+				'de' => 'Töst Title'
+			]
+		);
+
+		$this->assertSame('Test Title', $area->title());
+	}
+
+	/**
+	 * @covers ::toView
+	 */
+	public function testToView()
+	{
+		$area = new Area(
+			id: 'test'
+		);
+
+		$expected = [
+			'breadcrumb'      => [],
+			'breadcrumbLabel' => 'test',
+			'icon'            => null,
+			'id'              => 'test',
+			'label'           => 'test',
+			'link'            => 'test',
+			'search'          => null,
+			'title'           => 'test',
+		];
+
+		$this->assertSame($expected, $area->toView());
+	}
+
+}

--- a/tests/Panel/AreasTest.php
+++ b/tests/Panel/AreasTest.php
@@ -37,19 +37,16 @@ class AreasTest extends TestCase
 	public function testArea(): void
 	{
 		// defaults
-		$result = Areas::area('test', []);
-		$expected = [
-			'id' => 'test',
-			'label' => 'test',
-			'breadcrumb' => [],
-			'breadcrumbLabel' => 'test',
-			'title' => 'test',
-			'menu' => false,
-			'link' => 'test',
-			'search' => null
-		];
+		$area = Areas::area('test', []);
 
-		$this->assertSame($expected, $result);
+		$this->assertSame('test', $area->id());
+		$this->assertSame('test', $area->label());
+		$this->assertSame([], $area->breadcrumb());
+		$this->assertSame('test', $area->breadcrumbLabel());
+		$this->assertSame('test', $area->title());
+		$this->assertFalse($area->menu());
+		$this->assertSame('test', $area->link());
+		$this->assertNull($area->search());
 	}
 
 	/**

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -181,8 +181,9 @@ class DropdownTest extends TestCase
 	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
-		$area = [
-			'dropdowns' => [
+		$routes = Router::routesForDropdowns(new Area(
+			id: 'test',
+			dropdowns: [
 				'test' => [
 					'pattern' => 'test',
 					'options' => $action = fn () => [
@@ -193,9 +194,7 @@ class DropdownTest extends TestCase
 					]
 				]
 			]
-		];
-
-		$routes = Router::routesForDropdowns('test', $area);
+		));
 
 		$expected = [
 			[
@@ -215,8 +214,9 @@ class DropdownTest extends TestCase
 	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
-		$area = [
-			'dropdowns' => [
+		$routes = Router::routesForDropdowns(new Area(
+			id: 'test',
+			dropdowns: [
 				'test' => $action = fn () => [
 					[
 						'text' => 'Test',
@@ -224,9 +224,7 @@ class DropdownTest extends TestCase
 					]
 				]
 			]
-		];
-
-		$routes = Router::routesForDropdowns('test', $area);
+		));
 
 		$expected = [
 			[

--- a/tests/Panel/FiberTest.php
+++ b/tests/Panel/FiberTest.php
@@ -473,24 +473,27 @@ class FiberTest extends TestCase
 		$this->app->impersonate('test@getkirby.com');
 
 		$areas  = [
-			'a' => [
-				'searches' => [
+			new Area(
+				id: 'a',
+				searches: [
 					'foo' => [],
 				]
-			],
-			'b' => [
-				'searches' => [
+			),
+			new Area(
+				id: 'b',
+				searches: [
 					'bar' => [],
 				]
-			],
-			'c' => [
-				'searches' => [
+			),
+			new Area(
+				id: 'c',
+				searches: [
 					'test' => [],
 				]
-			]
+			)
 		];
 
-		$fiber    = new Fiber(options: ['areas' => $areas]);
+		$fiber    = new Fiber(areas: $areas);
 		$searches = $fiber->searches();
 
 		$this->assertArrayHasKey('foo', $searches);

--- a/tests/Panel/RouterTest.php
+++ b/tests/Panel/RouterTest.php
@@ -122,8 +122,9 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDialogs(): void
 	{
-		$area = [
-			'dialogs' => [
+		$routes = Router::routesForDialogs(new Area(
+			id: 'test',
+			dialogs: [
 				'test' => [
 					'load'   => $load   = function () {
 					},
@@ -131,9 +132,7 @@ class RouterTest extends TestCase
 					},
 				]
 			]
-		];
-
-		$routes = Router::routesForDialogs('test', $area);
+		));
 
 		$expected = [
 			[
@@ -159,13 +158,12 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDialogsWithoutHandlers(): void
 	{
-		$area = [
-			'dialogs' => [
+		$routes = Router::routesForDialogs(new Area(
+			id: 'test',
+			dialogs: [
 				'test' => []
 			]
-		];
-
-		$routes = Router::routesForDialogs('test', $area);
+		));
 
 		$this->assertSame('The load handler is missing', $routes[0]['action']());
 		$this->assertSame('The submit handler is missing', $routes[1]['action']());
@@ -176,8 +174,9 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDrawers(): void
 	{
-		$area = [
-			'drawers' => [
+		$routes = Router::routesForDrawers(new Area(
+			id: 'test',
+			drawers: [
 				'test' => [
 					'load'   => $load   = function () {
 					},
@@ -185,9 +184,7 @@ class RouterTest extends TestCase
 					},
 				]
 			]
-		];
-
-		$routes = Router::routesForDrawers('test', $area);
+		));
 
 		$expected = [
 			[
@@ -213,8 +210,9 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDropdowns(): void
 	{
-		$area = [
-			'dropdowns' => [
+		$routes = Router::routesForDropdowns(new Area(
+			id: 'test',
+			dropdowns: [
 				'test' => [
 					'pattern' => 'test',
 					'action'  => $action = fn () => [
@@ -225,9 +223,7 @@ class RouterTest extends TestCase
 					]
 				]
 			]
-		];
-
-		$routes = Router::routesForDropdowns('test', $area);
+		));
 
 		$expected = [
 			[
@@ -247,8 +243,9 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
-		$area = [
-			'dropdowns' => [
+		$routes = Router::routesForDropdowns(new Area(
+			id: 'test',
+			dropdowns: [
 				'test' => [
 					'pattern' => 'test',
 					'options' => $action = fn () => [
@@ -259,9 +256,7 @@ class RouterTest extends TestCase
 					]
 				]
 			]
-		];
-
-		$routes = Router::routesForDropdowns('test', $area);
+		));
 
 		$expected = [
 			[
@@ -281,8 +276,9 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
-		$area = [
-			'dropdowns' => [
+		$routes = Router::routesForDropdowns(new Area(
+			id: 'test',
+			dropdowns: [
 				'test' => $action = fn () => [
 					[
 						'text' => 'Test',
@@ -290,9 +286,7 @@ class RouterTest extends TestCase
 					]
 				]
 			]
-		];
-
-		$routes = Router::routesForDropdowns('test', $area);
+		));
 
 		$expected = [
 			[
@@ -312,17 +306,16 @@ class RouterTest extends TestCase
 	 */
 	public function testRoutesForViews(): void
 	{
-		$area = [
-			'views' => [
+		$routes = Router::routesForViews(new Area(
+			id: 'test',
+			views: [
 				[
 					'pattern' => 'test',
 					'action'  => $callback = function () {
 					}
 				]
 			]
-		];
-
-		$routes = Router::routesForViews('test', $area);
+		));
 
 		$expected = [
 			[

--- a/tests/Panel/Ui/MenuItemTest.php
+++ b/tests/Panel/Ui/MenuItemTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Exception\Exception;
+use Kirby\TestCase;
+use Kirby\Toolkit\I18n;
+
+/**
+ * @coversDefaultClass \Kirby\Panel\Ui\MenuItem
+ */
+class MenuItemTest extends TestCase
+{
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstruct()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'site',
+			text: 'Test',
+		);
+
+		$this->assertSame('edit', $menuItem->icon());
+		$this->assertSame('Test', $menuItem->text());
+		$this->assertFalse($menuItem->current());
+		$this->assertNull($menuItem->dialog());
+		$this->assertFalse($menuItem->disabled());
+		$this->assertNull($menuItem->drawer());
+		$this->assertSame('site', $menuItem->link());
+	}
+
+	public function testConstructWithMissingLink()
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('You must define a dialog, drawer or link for the menu item');
+
+		new MenuItem(
+			icon: 'edit',
+			text: 'Test',
+		);
+	}
+
+	/**
+	 * @covers ::__call
+	 */
+	public function testCall()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('edit', $menuItem->icon());
+		$this->assertSame('test', $menuItem->link());
+		$this->assertSame('Test', $menuItem->text());
+	}
+
+	/**
+	 * @covers ::link
+	 */
+	public function testLink()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('test', $menuItem->link());
+	}
+
+	/**
+	 * @covers ::link
+	 */
+	public function testLinkWithDialog()
+	{
+		$menuItem = new MenuItem(
+			dialog: 'test',
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('test', $menuItem->dialog());
+		$this->assertNull($menuItem->link());
+	}
+
+	/**
+	 * @covers ::link
+	 */
+	public function testLinkWithDrawer()
+	{
+		$menuItem = new MenuItem(
+			drawer: 'test',
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('test', $menuItem->drawer());
+		$this->assertNull($menuItem->link());
+	}
+
+	/**
+	 * @covers ::merge
+	 */
+	public function testMerge()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertFalse($menuItem->disabled());
+
+		$menuItem->merge([
+			'disabled' => true
+		]);
+
+		$this->assertTrue($menuItem->disabled());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testText()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('Test', $menuItem->text());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testTextWithTranslationKey()
+	{
+		I18n::$translations = [
+			'en' => [
+				'logout' => 'Logout'
+			]
+		];
+
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'logout',
+		);
+
+		$this->assertSame('Logout', $menuItem->text());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testTextWithTranslationArray()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: [
+				'en' => 'Logout',
+				'de' => 'Abmelden'
+			],
+		);
+
+		$this->assertSame('Logout', $menuItem->text());
+	}
+
+	/**
+	 * @covers ::toArray
+	 */
+	public function testToArray()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'site',
+			text: 'Test',
+		);
+
+		$expected = [
+			'icon' => 'edit',
+			'link' => 'site',
+			'text' => 'Test'
+		];
+
+		$this->assertSame($expected, $menuItem->toArray());
+	}
+}

--- a/tests/Panel/Ui/MenuItemTest.php
+++ b/tests/Panel/Ui/MenuItemTest.php
@@ -58,6 +58,68 @@ class MenuItemTest extends TestCase
 		$this->assertSame('Test', $menuItem->text());
 	}
 
+	public function testCurrent()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertFalse($menuItem->current());
+
+		$menuItem = new MenuItem(
+			current: true,
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertTrue($menuItem->current());
+	}
+
+	public function testDialog()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			dialog: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('test', $menuItem->dialog());
+	}
+
+	public function testDisabled()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertFalse($menuItem->disabled());
+
+		$menuItem = new MenuItem(
+			disabled: true,
+			icon: 'edit',
+			link: 'test',
+			text: 'Test',
+		);
+
+		$this->assertTrue($menuItem->disabled());
+	}
+
+	public function testDrawer()
+	{
+		$menuItem = new MenuItem(
+			icon: 'edit',
+			drawer: 'test',
+			text: 'Test',
+		);
+
+		$this->assertSame('test', $menuItem->drawer());
+	}
+
 	/**
 	 * @covers ::link
 	 */

--- a/tests/Panel/Ui/MenuItemTest.php
+++ b/tests/Panel/Ui/MenuItemTest.php
@@ -22,15 +22,18 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('edit', $menuItem->icon());
-		$this->assertSame('Test', $menuItem->text());
-		$this->assertFalse($menuItem->current());
-		$this->assertNull($menuItem->dialog());
-		$this->assertFalse($menuItem->disabled());
-		$this->assertNull($menuItem->drawer());
-		$this->assertSame('site', $menuItem->link());
+		$this->assertSame('edit', $menuItem->icon);
+		$this->assertSame('Test', $menuItem->text);
+		$this->assertFalse($menuItem->current);
+		$this->assertNull($menuItem->dialog);
+		$this->assertFalse($menuItem->disabled);
+		$this->assertNull($menuItem->drawer);
+		$this->assertSame('site', $menuItem->link);
 	}
 
+	/**
+	 * @covers ::__construct
+	 */
 	public function testConstructWithMissingLink()
 	{
 		$this->expectException(Exception::class);
@@ -42,22 +45,6 @@ class MenuItemTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCall()
-	{
-		$menuItem = new MenuItem(
-			icon: 'edit',
-			link: 'test',
-			text: 'Test',
-		);
-
-		$this->assertSame('edit', $menuItem->icon());
-		$this->assertSame('test', $menuItem->link());
-		$this->assertSame('Test', $menuItem->text());
-	}
-
 	public function testCurrent()
 	{
 		$menuItem = new MenuItem(
@@ -66,7 +53,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->current());
+		$this->assertFalse($menuItem->current);
 
 		$menuItem = new MenuItem(
 			current: true,
@@ -75,7 +62,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertTrue($menuItem->current());
+		$this->assertTrue($menuItem->current);
 	}
 
 	public function testDialog()
@@ -86,7 +73,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->dialog());
+		$this->assertSame('test', $menuItem->dialog);
 	}
 
 	public function testDisabled()
@@ -97,7 +84,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->disabled());
+		$this->assertFalse($menuItem->disabled);
 
 		$menuItem = new MenuItem(
 			disabled: true,
@@ -106,7 +93,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertTrue($menuItem->disabled());
+		$this->assertTrue($menuItem->disabled);
 	}
 
 	public function testDrawer()
@@ -117,7 +104,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->drawer());
+		$this->assertSame('test', $menuItem->drawer);
 	}
 
 	/**
@@ -146,7 +133,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->dialog());
+		$this->assertSame('test', $menuItem->dialog);
 		$this->assertNull($menuItem->link());
 	}
 
@@ -162,7 +149,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->drawer());
+		$this->assertSame('test', $menuItem->drawer);
 		$this->assertNull($menuItem->link());
 	}
 
@@ -177,19 +164,19 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->disabled());
+		$this->assertFalse($menuItem->disabled);
 
 		$menuItem->merge([
 			'disabled' => true
 		]);
 
-		$this->assertTrue($menuItem->disabled());
+		$this->assertTrue($menuItem->disabled);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testText()
+	public function testPropsText()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -197,13 +184,13 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('Test', $menuItem->text());
+		$this->assertSame('Test', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testTextWithTranslationKey()
+	public function testPropsTextWithTranslationKey()
 	{
 		I18n::$translations = [
 			'en' => [
@@ -217,13 +204,13 @@ class MenuItemTest extends TestCase
 			text: 'logout',
 		);
 
-		$this->assertSame('Logout', $menuItem->text());
+		$this->assertSame('Logout', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testTextWithTranslationArray()
+	public function testPropsTextWithTranslationArray()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -234,13 +221,13 @@ class MenuItemTest extends TestCase
 			],
 		);
 
-		$this->assertSame('Logout', $menuItem->text());
+		$this->assertSame('Logout', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::toArray
+	 * @covers ::render
 	 */
-	public function testToArray()
+	public function testRender()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -248,12 +235,14 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$expected = [
-			'icon' => 'edit',
-			'link' => 'site',
-			'text' => 'Test'
-		];
-
-		$this->assertSame($expected, $menuItem->toArray());
+		$result = $menuItem->render();
+		$this->assertSame('k-button', $result['component']);
+		$this->assertSame([
+			'icon'       => 'edit',
+			'link'       => 'site',
+			'responsive' => true,
+			'text'       => 'Test',
+			'type'       => 'button'
+		], $result['props']);
 	}
 }

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -60,78 +60,203 @@ class MenuTest extends TestCase
 	/**
 	 * @covers ::areas
 	 */
-	public function testAreasDefaultOrder()
-	{
-		$menu = new Menu(areas: [
-			new Area(id: 'foo'),
-			new Area(id: 'site'),
-		]);
-
-		$areas = $menu->areas();
-
-		$this->assertSame('site', $areas[0]->id());
-		$this->assertSame('foo', $areas[1]->id());
-	}
-
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreasConfigOption()
+	public function testAreasFromMenuOptionWithDivider()
 	{
 		$this->app->clone([
 			'options' => [
 				'panel' => [
 					'menu' => [
-						'site',
-						'-',
-						'todos' => [
-							'label' => 'todos',
-							'link'  => 'todos'
-						],
-						'gone',
-						'users' => [
-							'label' => 'Buddies'
+						'-'
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame('-', $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithUiComponent()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						$menuItem = new MenuItem(
+							icon: 'test',
+							text: 'test',
+							link: 'test'
+						)
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($menuItem, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithId()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site'
+					]
+				]
+			]
+		]);
+
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithIdKey()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site' => true
+					]
+				]
+			]
+		]);
+
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithInvalidId()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'does-not-exist'
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(0, $areas);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithArray()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site' => [
+							'icon' => 'edit'
 						]
 					]
 				]
 			]
 		]);
 
-		$menu  = new Menu(
-			areas: [
-				new Area(
-					id: 'license',
-					label: 'Register',
-					icon: 'key'
-				),
-				new Area(
-					id: 'site',
-					label: 'Site',
-					icon: 'home'
-				),
-				new Area(
-					id: 'users',
-					label: 'Users',
-					icon: 'users'
-				),
-			]
-		);
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		// the area does not have the edit icon by default
+		$this->assertNotSame('edit', $area->icon());
+
+		// once the areas are loaded, the edit icon
+		// should have been injected
 		$areas = $menu->areas();
 
-		$this->assertSame('site', $areas[0]->id());
-		$this->assertSame('home', $areas[0]->icon());
-		$this->assertSame('-', $areas[1]);
-		$this->assertSame('todos', $areas[2]->id());
-		$this->assertTrue($areas[2]->menu());
-		$this->assertSame('users', $areas[3]->id());
-		$this->assertSame('users', $areas[3]->icon());
-		$this->assertSame('Buddies', $areas[3]->label());
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+		$this->assertSame('edit', $areas[0]->icon());
 	}
 
 	/**
 	 * @covers ::areas
 	 */
-	public function testAreasConfigOptionClosure()
+	public function testAreasFromMenuOptionWithNewArea()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'todos' => [
+							'label' => 'Todos',
+							'link'  => 'todos'
+						]
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame('todos', $areas[0]->id());
+		$this->assertSame('Todos', $areas[0]->label());
+		$this->assertSame('todos', $areas[0]->link());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfig()
+	{
+		$menu = new Menu();
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system'
+		];
+
+		$this->assertSame($expected, $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithClosureAndNullAsReturnValue()
 	{
 		$test = $this;
 
@@ -140,15 +265,63 @@ class MenuTest extends TestCase
 				'panel' => [
 					'menu' => function ($kirby) use ($test) {
 						$test->assertInstanceOf(App::class, $kirby);
+						return null;
+					}
+				]
+			]
+		]);
+
+		$menu = new Menu();
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system'
+		];
+
+		$this->assertSame($expected, $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithClosureAndEmptyArrayAsReturnValue()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => function () {
 						return [];
 					}
 				]
 			]
 		]);
 
-		$menu  = new Menu();
-		$areas = $menu->areas();
-		$this->assertCount(0, $areas);
+		$menu = new Menu();
+
+		$this->assertSame([], $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithDefaultOrder()
+	{
+		$menu = new Menu(areas: [
+			new Area(id: 'foo'),
+			new Area(id: 'site'),
+		]);
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system',
+			'foo'
+		];
+
+		$this->assertSame($expected, $menu->config());
 	}
 
 	/**

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -156,7 +156,7 @@ class MenuTest extends TestCase
 	 */
 	public function testItem()
 	{
-		$menu = new Menu([], [], 'account');
+		$menu = new Menu();
 
 		$item = $menu->item(new Area(
 			id: 'account',
@@ -165,98 +165,18 @@ class MenuTest extends TestCase
 			menu: true
 		));
 
-		$this->assertSame([
-			'current' => true,
-			'icon'    => 'account',
-			'link'    => 'foo',
-			'text'    => 'Foo'
-		], $item->toArray());
+		$this->assertInstanceOf(MenuItem::class, $item);
 	}
 
 	/**
 	 * @covers ::item
 	 */
-	public function testItemDialog()
+	public function testItemWithoutArea()
 	{
-		$menu = new Menu([], [], 'account');
+		$menu = new Menu();
+		$item = $menu->item(null);
 
-		$item = $menu->item(new Area(
-			id: 'account',
-			link: 'foo',
-			label: 'Foo',
-			menu: ['dialog' => 'foo']
-		));
-
-		$this->assertSame([
-			'current' => true,
-			'dialog'  => 'foo',
-			'icon'    => 'account',
-			'text'    => 'Foo'
-		], $item->toArray());
-	}
-
-	/**
-	 * @covers ::item
-	 */
-	public function testItemMenu()
-	{
-		$menu = new Menu([], [], 'account');
-		$this->assertNull($menu->item(new Area(id: 'account')));
-		$this->assertNull($menu->item(new Area(id: 'account', menu: false)));
-		$this->assertNull($menu->item(new Area(id: 'account', menu: fn () => false)));
-
-		$test = $this;
-		$menu->item(new Area(id: 'account', menu: function ($areas, $permissions, $current) use ($test) {
-			$test->assertSame([], $areas);
-			$test->assertSame([], $permissions);
-			$test->assertSame('account', $current);
-			return false;
-		}));
-
-		$item = $menu->item(new Area(
-			id: 'account',
-			menu: 'disabled',
-		));
-		$this->assertTrue($item->disabled());
-	}
-
-	/**
-	 * @covers ::item
-	 */
-	public function testItemNoPermission()
-	{
-		$menu = new Menu([], ['access' => ['account' => false]]);
-		$area = new Area(id: 'account');
-		$this->assertNull($menu->item($area));
-	}
-
-	/**
-	 * @covers ::entry
-	 */
-	public function testItemMultiLanguage()
-	{
-		$menu = new Menu(
-			areas: [],
-			permissions: [],
-			current: 'account'
-		);
-
-		$item = $menu->item(new Area(
-			id: 'account',
-			link: 'foo',
-			label: [
-				'en' => 'My account',
-				'de' => 'Mein Account'
-			],
-			menu: true
-		));
-
-		$this->assertSame([
-			'current' => true,
-			'icon'    => 'account',
-			'link'    => 'foo',
-			'text'    => 'My account'
-		], $item->toArray());
+		$this->assertNull($item);
 	}
 
 	/**

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -199,12 +199,12 @@ class MenuTest extends TestCase
 
 		$items = $menu->items();
 
-		$this->assertSame('site', $items[0]['link']);
-		$this->assertTrue($items[0]['current']);
+		$this->assertSame('site', $items[0]['props']['link']);
+		$this->assertTrue($items[0]['props']['current']);
 		$this->assertSame('-', $items[1]);
-		$this->assertSame('changes', $items[2]['dialog']);
-		$this->assertSame('account', $items[3]['link']);
-		$this->assertSame('logout', $items[4]['link']);
+		$this->assertSame('changes', $items[2]['props']['dialog']);
+		$this->assertSame('account', $items[3]['props']['link']);
+		$this->assertSame('logout', $items[4]['props']['link']);
 	}
 
 	/**
@@ -213,28 +213,34 @@ class MenuTest extends TestCase
 	public function testOptions()
 	{
 		$changes = [
-			'dialog' => 'changes',
-			'icon'   => 'edit-line',
-			'text'   => 'Changes'
+			'dialog'     => 'changes',
+			'icon'       => 'edit-line',
+			'responsive' => true,
+			'text'       => 'Changes',
+			'type'       => 'button'
 		];
 
 		$account = [
-			'icon' => 'account',
-			'link' => 'account',
-			'text' => 'Your account'
+			'icon'       => 'account',
+			'link'       => 'account',
+			'responsive' => true,
+			'text'       => 'Your account',
+			'type'       => 'button'
 		];
 
 		$logout = [
-			'icon' => 'logout',
-			'link' => 'logout',
-			'text' => 'Log out'
+			'icon'       => 'logout',
+			'link'       => 'logout',
+			'responsive' => true,
+			'text'       => 'Log out',
+			'type'       => 'button'
 		];
 
 		$menu = new Menu();
 
 		$options = $menu->options();
-		$this->assertSame($changes, $options[0]);
-		$this->assertSame($account, $options[1]);
-		$this->assertSame($logout, $options[2]);
+		$this->assertSame($changes, $options[0]['props']);
+		$this->assertSame($account, $options[1]['props']);
+		$this->assertSame($logout, $options[2]['props']);
 	}
 }

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -62,17 +62,12 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithDivider()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'-'
-					]
-				]
+		$menu = new Menu(
+			config: [
+				'-'
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -84,21 +79,16 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithUiComponent()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						$menuItem = new MenuItem(
-							icon: 'test',
-							text: 'test',
-							link: 'test'
-						)
-					]
-				]
+		$menu = new Menu(
+			config: [
+				$menuItem = new MenuItem(
+					icon: 'test',
+					text: 'test',
+					link: 'test'
+				)
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -110,19 +100,14 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithId()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site'
-					]
-				]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site'
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		$areas = $menu->areas();
 
@@ -135,19 +120,14 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithIdKey()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site' => true
-					]
-				]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site' => true
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		$areas = $menu->areas();
 
@@ -160,20 +140,13 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithInvalidId()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'does-not-exist'
-					]
-				]
+		$menu = new Menu(
+			config: [
+				'does-not-exist'
 			]
-		]);
+		);
 
-		$menu  = new Menu();
-		$areas = $menu->areas();
-
-		$this->assertCount(0, $areas);
+		$this->assertCount(0, $menu->areas());
 	}
 
 	/**
@@ -181,21 +154,16 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithArray()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site' => [
-							'icon' => 'edit'
-						]
-					]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site' => [
+					'icon' => 'edit'
 				]
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		// the area does not have the edit icon by default
 		$this->assertNotSame('edit', $area->icon());
@@ -214,20 +182,15 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithNewArea()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'todos' => [
-							'label' => 'Todos',
-							'link'  => 'todos'
-						]
-					]
+		$menu = new Menu(
+			config: [
+				'todos' => [
+					'label' => 'Todos',
+					'link'  => 'todos'
 				]
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -259,19 +222,12 @@ class MenuTest extends TestCase
 	public function testConfigWithClosureAndNullAsReturnValue()
 	{
 		$test = $this;
-
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => function ($kirby) use ($test) {
-						$test->assertInstanceOf(App::class, $kirby);
-						return null;
-					}
-				]
-			]
-		]);
-
-		$menu = new Menu();
+		$menu = new Menu(
+			config: function ($kirby) use ($test) {
+				$test->assertInstanceOf(App::class, $kirby);
+				return null;
+			}
+		);
 
 		$expected = [
 			'site',
@@ -288,17 +244,11 @@ class MenuTest extends TestCase
 	 */
 	public function testConfigWithClosureAndEmptyArrayAsReturnValue()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => function () {
-						return [];
-					}
-				]
-			]
-		]);
-
-		$menu = new Menu();
+		$menu = new Menu(
+			config: function () {
+				return [];
+			}
+		);
 
 		$this->assertSame([], $menu->config());
 	}
@@ -355,29 +305,65 @@ class MenuTest extends TestCase
 	/**
 	 * @covers ::items
 	 */
-	public function testItems()
+	public function testItemsWithDivider()
 	{
 		$menu = new Menu(
 			areas: [
-				new Area(
-					id: 'site',
-					label: 'Site',
-					icon: 'home',
-					menu: true,
-					link: 'site'
-				)
+				'site'   => new Area(id: 'site', menu: true),
+				'system' => new Area(id: 'system', menu: true),
 			],
-			current: 'site'
+			config: [
+				'site',
+				'-',
+				'system',
+			],
+			permissions: [
+				'access' => [
+					'site'   => true,
+					'system' => true
+				]
+			]
 		);
 
 		$items = $menu->items();
 
 		$this->assertSame('site', $items[0]['props']['link']);
-		$this->assertTrue($items[0]['props']['current']);
 		$this->assertSame('-', $items[1]);
-		$this->assertSame('changes', $items[2]['props']['dialog']);
-		$this->assertSame('account', $items[3]['props']['link']);
-		$this->assertSame('logout', $items[4]['props']['link']);
+		$this->assertSame('system', $items[2]['props']['link']);
+	}
+
+	/**
+	 * @covers ::items
+	 */
+	public function testItemsWithComponent()
+	{
+		$menu = new Menu(
+			areas: [
+				'site'   => new Area(id: 'site', menu: true),
+				'system' => new Area(id: 'system', menu: true),
+			],
+			config: [
+				'site',
+				'test' => new MenuItem(
+					icon: 'test',
+					text: 'test',
+					link: 'test'
+				),
+				'system',
+			],
+			permissions: [
+				'access' => [
+					'site'   => true,
+					'system' => true
+				]
+			]
+		);
+
+		$items = $menu->items();
+
+		$this->assertSame('site', $items[0]['props']['link']);
+		$this->assertSame('test', $items[1]['props']['link']);
+		$this->assertSame('system', $items[2]['props']['link']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary 

- New `Kirby\Panel\Ui\MenuItem` class
- New `Kirby\Panel\Area` class
- Refactored Areas and Menu classes
- The Fiber class no longer takes a wildcard options array, but has new dedicated props for areas and area
- Other panel classes have been refactored to work with the new Area instances
- Unit tests have been adapted and new unit tests have been added.