### PR TITLE
Menu/MenuItem as Ui Components

### DIFF
--- a/panel/src/components/View/Inside.vue
+++ b/panel/src/components/View/Inside.vue
@@ -1,6 +1,15 @@
 <template>
 	<k-panel class="k-panel-inside">
-		<k-panel-menu />
+		<k-panel-menu
+			v-bind="$panel.menu.props"
+			:hover="$panel.menu.hover"
+			:is-open="$panel.menu.isOpen"
+			:license="$panel.license"
+			:searches="$panel.searches"
+			@hover="$panel.menu.hover = $event"
+			@search="$panel.search()"
+			@toggle="$panel.menu.toggle()"
+		/>
 		<main class="k-panel-main">
 			<k-topbar :breadcrumb="$panel.view.breadcrumb" :view="$panel.view">
 				<!-- @slot Additional content for the Topbar  -->

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -2,9 +2,9 @@
 	<nav
 		class="k-panel-menu"
 		:aria-label="$t('menu')"
-		:data-hover="$panel.menu.hover"
-		@mouseenter="$panel.menu.hover = true"
-		@mouseleave="$panel.menu.hover = false"
+		:data-hover="hover"
+		@mouseenter="$emit('hover', true)"
+		@mouseleave="$emit('hover', false)"
 	>
 		<div class="k-panel-menu-body">
 			<!-- Search button -->
@@ -13,7 +13,7 @@
 				:text="$t('search')"
 				icon="search"
 				class="k-panel-menu-search k-panel-menu-button"
-				@click="$panel.search()"
+				@click="$emit('search')"
 			/>
 
 			<!-- Menus -->
@@ -23,13 +23,14 @@
 				:data-second-last="menuIndex === menus.length - 2"
 				class="k-panel-menu-buttons"
 			>
-				<k-button
-					v-for="entry in menu"
-					:key="entry.id"
-					v-bind="entry"
-					:title="entry.title ?? entry.text"
-					class="k-panel-menu-button"
-				/>
+				<template v-for="entry in menu">
+					<component
+						:is="entry.component"
+						:key="entry.key"
+						v-bind="entry.props"
+						class="k-panel-menu-button"
+					/>
+				</template>
 			</menu>
 
 			<menu v-if="activationButton">
@@ -40,17 +41,17 @@
 					theme="love"
 					variant="filled"
 				/>
-				<k-activation :status="$panel.license" />
+				<k-activation :status="license" />
 			</menu>
 		</div>
 
 		<!-- Collapse/expand toggle -->
 		<k-button
-			:icon="$panel.menu.isOpen ? 'angle-left' : 'angle-right'"
-			:title="$panel.menu.isOpen ? $t('collapse') : $t('expand')"
+			:icon="isOpen ? 'angle-left' : 'angle-right'"
+			:title="isOpen ? $t('collapse') : $t('expand')"
 			size="xs"
 			class="k-panel-menu-toggle"
-			@click="$panel.menu.toggle()"
+			@click="$emit('toggle')"
 		/>
 	</nav>
 </template>
@@ -61,6 +62,20 @@
  * @internal
  */
 export default {
+	props: {
+		hover: Boolean,
+		isOpen: Boolean,
+		items: {
+			type: Array,
+			default: () => []
+		},
+		license: String,
+		searches: {
+			type: Object,
+			default: () => ({})
+		}
+	},
+	emits: ["search", "toggle"],
 	data() {
 		return {
 			over: false
@@ -68,14 +83,14 @@ export default {
 	},
 	computed: {
 		activationButton() {
-			if (this.$panel.license === "missing") {
+			if (this.license === "missing") {
 				return {
 					click: () => this.$dialog("registration"),
 					text: this.$t("activate")
 				};
 			}
 
-			if (this.$panel.license === "legacy") {
+			if (this.license === "legacy") {
 				return {
 					click: () => this.$dialog("license"),
 					text: this.$t("renew")
@@ -85,10 +100,10 @@ export default {
 			return false;
 		},
 		hasSearch() {
-			return this.$helper.object.length(this.$panel.searches) > 0;
+			return this.$helper.object.length(this.searches) > 0;
 		},
 		menus() {
-			return this.$helper.array.split(this.$panel.menu.entries, "-");
+			return this.$helper.array.split(this.items, "-");
 		}
 	}
 };

--- a/panel/src/panel/menu.js
+++ b/panel/src/panel/menu.js
@@ -3,7 +3,7 @@ import State from "./state.js";
 
 export const defaults = () => {
 	return {
-		entries: [],
+		props: {},
 		hover: false,
 		isOpen: false
 	};
@@ -100,8 +100,8 @@ export default (panel) => {
 		 *
 		 * @param {Array} entries
 		 */
-		set(entries) {
-			this.entries = entries;
+		set(menu) {
+			this.props = menu.props;
 			this.resize();
 			return this.state();
 		},

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -150,11 +150,11 @@ class Area
 		// create a new menu item instance for the area
 		$item = new MenuItem(
 			current: $this->isCurrent($current),
-			icon: $this->icon() ?? $this->id(),
-			text: $this->label(),
-			dialog: $this->dialog(),
-			drawer: $this->drawer(),
-			link: $this->link(),
+			icon:    $this->icon() ?? $this->id(),
+			text:    $this->label(),
+			dialog:  $this->dialog(),
+			drawer:  $this->drawer(),
+			link:    $this->link(),
 		);
 
 		// add the custom menu settings

--- a/src/Panel/Fiber.php
+++ b/src/Panel/Fiber.php
@@ -215,7 +215,8 @@ class Fiber
 		$menu = new Menu(
 			areas:       $this->areas,
 			permissions: $this->permissions,
-			current:     $this->area?->id()
+			current:     $this->area?->id(),
+			config: 	 $this->kirby->option('panel.menu', null)
 		);
 
 		return $menu->render();

--- a/src/Panel/Fiber.php
+++ b/src/Panel/Fiber.php
@@ -213,12 +213,12 @@ class Fiber
 	public function menu(): array
 	{
 		$menu = new Menu(
-			$this->areas,
-			$this->permissions,
-			$this->area?->id()
+			areas:       $this->areas,
+			permissions: $this->permissions,
+			current:     $this->area?->id()
 		);
 
-		return $menu->items();
+		return $menu->render();
 	}
 
 	public function multilang(): bool

--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -73,22 +73,22 @@ class Home
 			}
 
 			// skip disabled items
-			if (($menuItem['disabled'] ?? false) === true) {
+			if (($menuItem['props']['disabled'] ?? false) === true) {
 				continue;
 			}
 
 			// skip buttons that don't open a link
 			// (but e.g. a dialog)
-			if (isset($menuItem['link']) === false) {
+			if (isset($menuItem['props']['link']) === false) {
 				continue;
 			}
 
 			// skip the logout button
-			if ($menuItem['link'] === 'logout') {
+			if ($menuItem['props']['link'] === 'logout') {
 				continue;
 			}
 
-			return Panel::url($menuItem['link']);
+			return Panel::url($menuItem['props']['link']);
 		}
 
 		throw new NotFoundException(

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -25,7 +25,8 @@ class Menu extends Component
 	public function __construct(
 		array $areas = [],
 		protected array $permissions = [],
-		protected string|null $current = null
+		protected string|null $current = null,
+		protected Closure|array|null $config = null
 	) {
 		foreach ($areas as $area) {
 			$this->areas[$area->id()] = $area;
@@ -102,11 +103,11 @@ class Menu extends Component
 	public function config(): array
 	{
 		// get from config option which areas should be listed in the menu
-		$kirby = App::instance();
-		$items = $kirby->option('panel.menu');
+		$items = $this->config;
 
 		// lazy-load items
 		if ($items instanceof Closure) {
+			$kirby = App::instance();
 			$items = $items($kirby);
 		}
 

--- a/src/Panel/Ui/Menu.php
+++ b/src/Panel/Ui/Menu.php
@@ -59,6 +59,12 @@ class Menu extends Component
 				continue;
 			}
 
+			// [$areaId => Ui() ]
+			if ($area instanceof Component) {
+				$areas[] = $area;
+				continue;
+			}
+
 			// [0 => $areaId]
 			if (is_numeric($id) === true) {
 				$areas[] = $this->area($area);
@@ -68,12 +74,6 @@ class Menu extends Component
 			// [$areaId => true]
 			if ($area === true) {
 				$areas[] = $this->area($id);
-				continue;
-			}
-
-			// [$areaId => Ui() ]
-			if ($area instanceof Component) {
-				$areas[] = $area;
 				continue;
 			}
 

--- a/src/Panel/Ui/MenuItem.php
+++ b/src/Panel/Ui/MenuItem.php
@@ -3,27 +3,35 @@
 namespace Kirby\Panel\Ui;
 
 use Kirby\Exception\Exception;
-use Kirby\Toolkit\I18n;
 
-class MenuItem
+class MenuItem extends Button
 {
 	public function __construct(
-		protected string $icon,
-		protected array|string $text,
-		protected bool $current = false,
-		protected string|null $dialog = null,
-		protected bool $disabled = false,
-		protected string|null $drawer = null,
-		protected string|null $link = null,
+		string $icon,
+		array|string $text,
+		bool $current = false,
+		string|null $dialog = null,
+		bool $disabled = false,
+		string|null $drawer = null,
+		string|null $link = null,
 	) {
-		if ($this->dialog === null && $this->drawer === null && $this->link === null) {
+		if (
+			$dialog === null &&
+			$drawer === null &&
+			$link === null
+		) {
 			throw new Exception('You must define a dialog, drawer or link for the menu item');
 		}
-	}
 
-	public function __call(string $name, array $args = [])
-	{
-		return $this->{$name};
+		parent::__construct(
+			current:  $current,
+			dialog:   $dialog,
+			disabled: $disabled,
+			drawer:   $drawer,
+			icon:     $icon,
+			link:     $link,
+			text:     $text
+		);
 	}
 
 	public function link(): string|null
@@ -47,27 +55,11 @@ class MenuItem
 		return $this;
 	}
 
-	/**
-	 * Returns the translated button text
-	 */
-	public function text(): string
+	public function props(): array
 	{
-		return I18n::translate($this->text, $this->text);
-	}
-
-	/**
-	 * Returns all props for the menu button
-	 */
-	public function toArray(): array
-	{
-		return array_filter([
-			'current'  => $this->current(),
-			'dialog'   => $this->dialog(),
-			'disabled' => $this->disabled(),
-			'drawer'   => $this->drawer(),
-			'icon'     => $this->icon(),
-			'link'     => $this->link(),
-			'text'     => $this->text(),
-		]);
+		return [
+			...parent::props(),
+			'link' => $this->link()
+		];
 	}
 }

--- a/tests/Panel/Ui/MenuItemTest.php
+++ b/tests/Panel/Ui/MenuItemTest.php
@@ -22,15 +22,18 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('edit', $menuItem->icon());
-		$this->assertSame('Test', $menuItem->text());
-		$this->assertFalse($menuItem->current());
-		$this->assertNull($menuItem->dialog());
-		$this->assertFalse($menuItem->disabled());
-		$this->assertNull($menuItem->drawer());
-		$this->assertSame('site', $menuItem->link());
+		$this->assertSame('edit', $menuItem->icon);
+		$this->assertSame('Test', $menuItem->text);
+		$this->assertFalse($menuItem->current);
+		$this->assertNull($menuItem->dialog);
+		$this->assertFalse($menuItem->disabled);
+		$this->assertNull($menuItem->drawer);
+		$this->assertSame('site', $menuItem->link);
 	}
 
+	/**
+	 * @covers ::__construct
+	 */
 	public function testConstructWithMissingLink()
 	{
 		$this->expectException(Exception::class);
@@ -42,22 +45,6 @@ class MenuItemTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCall()
-	{
-		$menuItem = new MenuItem(
-			icon: 'edit',
-			link: 'test',
-			text: 'Test',
-		);
-
-		$this->assertSame('edit', $menuItem->icon());
-		$this->assertSame('test', $menuItem->link());
-		$this->assertSame('Test', $menuItem->text());
-	}
-
 	public function testCurrent()
 	{
 		$menuItem = new MenuItem(
@@ -66,7 +53,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->current());
+		$this->assertFalse($menuItem->current);
 
 		$menuItem = new MenuItem(
 			current: true,
@@ -75,7 +62,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertTrue($menuItem->current());
+		$this->assertTrue($menuItem->current);
 	}
 
 	public function testDialog()
@@ -86,7 +73,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->dialog());
+		$this->assertSame('test', $menuItem->dialog);
 	}
 
 	public function testDisabled()
@@ -97,7 +84,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->disabled());
+		$this->assertFalse($menuItem->disabled);
 
 		$menuItem = new MenuItem(
 			disabled: true,
@@ -106,7 +93,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertTrue($menuItem->disabled());
+		$this->assertTrue($menuItem->disabled);
 	}
 
 	public function testDrawer()
@@ -117,7 +104,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->drawer());
+		$this->assertSame('test', $menuItem->drawer);
 	}
 
 	/**
@@ -146,7 +133,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->dialog());
+		$this->assertSame('test', $menuItem->dialog);
 		$this->assertNull($menuItem->link());
 	}
 
@@ -162,7 +149,7 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('test', $menuItem->drawer());
+		$this->assertSame('test', $menuItem->drawer);
 		$this->assertNull($menuItem->link());
 	}
 
@@ -177,19 +164,19 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertFalse($menuItem->disabled());
+		$this->assertFalse($menuItem->disabled);
 
 		$menuItem->merge([
 			'disabled' => true
 		]);
 
-		$this->assertTrue($menuItem->disabled());
+		$this->assertTrue($menuItem->disabled);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testText()
+	public function testPropsText()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -197,13 +184,13 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$this->assertSame('Test', $menuItem->text());
+		$this->assertSame('Test', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testTextWithTranslationKey()
+	public function testPropsTextWithTranslationKey()
 	{
 		I18n::$translations = [
 			'en' => [
@@ -217,13 +204,13 @@ class MenuItemTest extends TestCase
 			text: 'logout',
 		);
 
-		$this->assertSame('Logout', $menuItem->text());
+		$this->assertSame('Logout', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::text
+	 * @covers ::props
 	 */
-	public function testTextWithTranslationArray()
+	public function testPropsTextWithTranslationArray()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -234,13 +221,13 @@ class MenuItemTest extends TestCase
 			],
 		);
 
-		$this->assertSame('Logout', $menuItem->text());
+		$this->assertSame('Logout', $menuItem->props()['text']);
 	}
 
 	/**
-	 * @covers ::toArray
+	 * @covers ::render
 	 */
-	public function testToArray()
+	public function testRender()
 	{
 		$menuItem = new MenuItem(
 			icon: 'edit',
@@ -248,12 +235,14 @@ class MenuItemTest extends TestCase
 			text: 'Test',
 		);
 
-		$expected = [
-			'icon' => 'edit',
-			'link' => 'site',
-			'text' => 'Test'
-		];
-
-		$this->assertSame($expected, $menuItem->toArray());
+		$result = $menuItem->render();
+		$this->assertSame('k-button', $result['component']);
+		$this->assertSame([
+			'icon'       => 'edit',
+			'link'       => 'site',
+			'responsive' => true,
+			'text'       => 'Test',
+			'type'       => 'button'
+		], $result['props']);
 	}
 }

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -60,78 +60,203 @@ class MenuTest extends TestCase
 	/**
 	 * @covers ::areas
 	 */
-	public function testAreasDefaultOrder()
-	{
-		$menu = new Menu(areas: [
-			new Area(id: 'foo'),
-			new Area(id: 'site'),
-		]);
-
-		$areas = $menu->areas();
-
-		$this->assertSame('site', $areas[0]->id());
-		$this->assertSame('foo', $areas[1]->id());
-	}
-
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreasConfigOption()
+	public function testAreasFromMenuOptionWithDivider()
 	{
 		$this->app->clone([
 			'options' => [
 				'panel' => [
 					'menu' => [
-						'site',
-						'-',
-						'todos' => [
-							'label' => 'todos',
-							'link'  => 'todos'
-						],
-						'gone',
-						'users' => [
-							'label' => 'Buddies'
+						'-'
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame('-', $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithUiComponent()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						$menuItem = new MenuItem(
+							icon: 'test',
+							text: 'test',
+							link: 'test'
+						)
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($menuItem, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithId()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site'
+					]
+				]
+			]
+		]);
+
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithIdKey()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site' => true
+					]
+				]
+			]
+		]);
+
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithInvalidId()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'does-not-exist'
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(0, $areas);
+	}
+
+	/**
+	 * @covers ::areas
+	 */
+	public function testAreasFromMenuOptionWithArray()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'site' => [
+							'icon' => 'edit'
 						]
 					]
 				]
 			]
 		]);
 
-		$menu  = new Menu(
-			areas: [
-				new Area(
-					id: 'license',
-					label: 'Register',
-					icon: 'key'
-				),
-				new Area(
-					id: 'site',
-					label: 'Site',
-					icon: 'home'
-				),
-				new Area(
-					id: 'users',
-					label: 'Users',
-					icon: 'users'
-				),
-			]
-		);
+		$menu = new Menu(areas: [
+			$area = new Area(id: 'site')
+		]);
+
+		// the area does not have the edit icon by default
+		$this->assertNotSame('edit', $area->icon());
+
+		// once the areas are loaded, the edit icon
+		// should have been injected
 		$areas = $menu->areas();
 
-		$this->assertSame('site', $areas[0]->id());
-		$this->assertSame('home', $areas[0]->icon());
-		$this->assertSame('-', $areas[1]);
-		$this->assertSame('todos', $areas[2]->id());
-		$this->assertTrue($areas[2]->menu());
-		$this->assertSame('users', $areas[3]->id());
-		$this->assertSame('users', $areas[3]->icon());
-		$this->assertSame('Buddies', $areas[3]->label());
+		$this->assertCount(1, $areas);
+		$this->assertSame($area, $areas[0]);
+		$this->assertSame('edit', $areas[0]->icon());
 	}
 
 	/**
 	 * @covers ::areas
 	 */
-	public function testAreasConfigOptionClosure()
+	public function testAreasFromMenuOptionWithNewArea()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => [
+						'todos' => [
+							'label' => 'Todos',
+							'link'  => 'todos'
+						]
+					]
+				]
+			]
+		]);
+
+		$menu  = new Menu();
+		$areas = $menu->areas();
+
+		$this->assertCount(1, $areas);
+		$this->assertSame('todos', $areas[0]->id());
+		$this->assertSame('Todos', $areas[0]->label());
+		$this->assertSame('todos', $areas[0]->link());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfig()
+	{
+		$menu = new Menu();
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system'
+		];
+
+		$this->assertSame($expected, $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithClosureAndNullAsReturnValue()
 	{
 		$test = $this;
 
@@ -140,15 +265,63 @@ class MenuTest extends TestCase
 				'panel' => [
 					'menu' => function ($kirby) use ($test) {
 						$test->assertInstanceOf(App::class, $kirby);
+						return null;
+					}
+				]
+			]
+		]);
+
+		$menu = new Menu();
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system'
+		];
+
+		$this->assertSame($expected, $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithClosureAndEmptyArrayAsReturnValue()
+	{
+		$this->app->clone([
+			'options' => [
+				'panel' => [
+					'menu' => function () {
 						return [];
 					}
 				]
 			]
 		]);
 
-		$menu  = new Menu();
-		$areas = $menu->areas();
-		$this->assertCount(0, $areas);
+		$menu = new Menu();
+
+		$this->assertSame([], $menu->config());
+	}
+
+	/**
+	 * @covers ::config
+	 */
+	public function testConfigWithDefaultOrder()
+	{
+		$menu = new Menu(areas: [
+			new Area(id: 'foo'),
+			new Area(id: 'site'),
+		]);
+
+		$expected = [
+			'site',
+			'languages',
+			'users',
+			'system',
+			'foo'
+		];
+
+		$this->assertSame($expected, $menu->config());
 	}
 
 	/**

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -199,12 +199,12 @@ class MenuTest extends TestCase
 
 		$items = $menu->items();
 
-		$this->assertSame('site', $items[0]['link']);
-		$this->assertTrue($items[0]['current']);
+		$this->assertSame('site', $items[0]['props']['link']);
+		$this->assertTrue($items[0]['props']['current']);
 		$this->assertSame('-', $items[1]);
-		$this->assertSame('changes', $items[2]['dialog']);
-		$this->assertSame('account', $items[3]['link']);
-		$this->assertSame('logout', $items[4]['link']);
+		$this->assertSame('changes', $items[2]['props']['dialog']);
+		$this->assertSame('account', $items[3]['props']['link']);
+		$this->assertSame('logout', $items[4]['props']['link']);
 	}
 
 	/**
@@ -213,28 +213,34 @@ class MenuTest extends TestCase
 	public function testOptions()
 	{
 		$changes = [
-			'dialog' => 'changes',
-			'icon'   => 'edit-line',
-			'text'   => 'Changes'
+			'dialog'     => 'changes',
+			'icon'       => 'edit-line',
+			'responsive' => true,
+			'text'       => 'Changes',
+			'type'       => 'button'
 		];
 
 		$account = [
-			'icon' => 'account',
-			'link' => 'account',
-			'text' => 'Your account'
+			'icon'       => 'account',
+			'link'       => 'account',
+			'responsive' => true,
+			'text'       => 'Your account',
+			'type'       => 'button'
 		];
 
 		$logout = [
-			'icon' => 'logout',
-			'link' => 'logout',
-			'text' => 'Log out'
+			'icon'       => 'logout',
+			'link'       => 'logout',
+			'responsive' => true,
+			'text'       => 'Log out',
+			'type'       => 'button'
 		];
 
 		$menu = new Menu();
 
 		$options = $menu->options();
-		$this->assertSame($changes, $options[0]);
-		$this->assertSame($account, $options[1]);
-		$this->assertSame($logout, $options[2]);
+		$this->assertSame($changes, $options[0]['props']);
+		$this->assertSame($account, $options[1]['props']);
+		$this->assertSame($logout, $options[2]['props']);
 	}
 }

--- a/tests/Panel/Ui/MenuTest.php
+++ b/tests/Panel/Ui/MenuTest.php
@@ -62,17 +62,12 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithDivider()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'-'
-					]
-				]
+		$menu = new Menu(
+			config: [
+				'-'
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -84,21 +79,16 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithUiComponent()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						$menuItem = new MenuItem(
-							icon: 'test',
-							text: 'test',
-							link: 'test'
-						)
-					]
-				]
+		$menu = new Menu(
+			config: [
+				$menuItem = new MenuItem(
+					icon: 'test',
+					text: 'test',
+					link: 'test'
+				)
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -110,19 +100,14 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithId()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site'
-					]
-				]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site'
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		$areas = $menu->areas();
 
@@ -135,19 +120,14 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithIdKey()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site' => true
-					]
-				]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site' => true
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		$areas = $menu->areas();
 
@@ -160,20 +140,13 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithInvalidId()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'does-not-exist'
-					]
-				]
+		$menu = new Menu(
+			config: [
+				'does-not-exist'
 			]
-		]);
+		);
 
-		$menu  = new Menu();
-		$areas = $menu->areas();
-
-		$this->assertCount(0, $areas);
+		$this->assertCount(0, $menu->areas());
 	}
 
 	/**
@@ -181,21 +154,16 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithArray()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'site' => [
-							'icon' => 'edit'
-						]
-					]
+		$menu = new Menu(
+			areas: [
+				$area = new Area(id: 'site')
+			],
+			config: [
+				'site' => [
+					'icon' => 'edit'
 				]
 			]
-		]);
-
-		$menu = new Menu(areas: [
-			$area = new Area(id: 'site')
-		]);
+		);
 
 		// the area does not have the edit icon by default
 		$this->assertNotSame('edit', $area->icon());
@@ -214,20 +182,15 @@ class MenuTest extends TestCase
 	 */
 	public function testAreasFromMenuOptionWithNewArea()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => [
-						'todos' => [
-							'label' => 'Todos',
-							'link'  => 'todos'
-						]
-					]
+		$menu = new Menu(
+			config: [
+				'todos' => [
+					'label' => 'Todos',
+					'link'  => 'todos'
 				]
 			]
-		]);
+		);
 
-		$menu  = new Menu();
 		$areas = $menu->areas();
 
 		$this->assertCount(1, $areas);
@@ -259,19 +222,12 @@ class MenuTest extends TestCase
 	public function testConfigWithClosureAndNullAsReturnValue()
 	{
 		$test = $this;
-
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => function ($kirby) use ($test) {
-						$test->assertInstanceOf(App::class, $kirby);
-						return null;
-					}
-				]
-			]
-		]);
-
-		$menu = new Menu();
+		$menu = new Menu(
+			config: function ($kirby) use ($test) {
+				$test->assertInstanceOf(App::class, $kirby);
+				return null;
+			}
+		);
 
 		$expected = [
 			'site',
@@ -288,17 +244,11 @@ class MenuTest extends TestCase
 	 */
 	public function testConfigWithClosureAndEmptyArrayAsReturnValue()
 	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'menu' => function () {
-						return [];
-					}
-				]
-			]
-		]);
-
-		$menu = new Menu();
+		$menu = new Menu(
+			config: function () {
+				return [];
+			}
+		);
 
 		$this->assertSame([], $menu->config());
 	}
@@ -355,29 +305,65 @@ class MenuTest extends TestCase
 	/**
 	 * @covers ::items
 	 */
-	public function testItems()
+	public function testItemsWithDivider()
 	{
 		$menu = new Menu(
 			areas: [
-				new Area(
-					id: 'site',
-					label: 'Site',
-					icon: 'home',
-					menu: true,
-					link: 'site'
-				)
+				'site'   => new Area(id: 'site', menu: true),
+				'system' => new Area(id: 'system', menu: true),
 			],
-			current: 'site'
+			config: [
+				'site',
+				'-',
+				'system',
+			],
+			permissions: [
+				'access' => [
+					'site'   => true,
+					'system' => true
+				]
+			]
 		);
 
 		$items = $menu->items();
 
 		$this->assertSame('site', $items[0]['props']['link']);
-		$this->assertTrue($items[0]['props']['current']);
 		$this->assertSame('-', $items[1]);
-		$this->assertSame('changes', $items[2]['props']['dialog']);
-		$this->assertSame('account', $items[3]['props']['link']);
-		$this->assertSame('logout', $items[4]['props']['link']);
+		$this->assertSame('system', $items[2]['props']['link']);
+	}
+
+	/**
+	 * @covers ::items
+	 */
+	public function testItemsWithComponent()
+	{
+		$menu = new Menu(
+			areas: [
+				'site'   => new Area(id: 'site', menu: true),
+				'system' => new Area(id: 'system', menu: true),
+			],
+			config: [
+				'site',
+				'test' => new MenuItem(
+					icon: 'test',
+					text: 'test',
+					link: 'test'
+				),
+				'system',
+			],
+			permissions: [
+				'access' => [
+					'site'   => true,
+					'system' => true
+				]
+			]
+		);
+
+		$items = $menu->items();
+
+		$this->assertSame('site', $items[0]['props']['link']);
+		$this->assertSame('test', $items[1]['props']['link']);
+		$this->assertSame('system', $items[2]['props']['link']);
 	}
 
 	/**


### PR DESCRIPTION
- `Menu` and `MenuItem` are `Ui\Component` classes
- Move all panel module specific code out of `k-panel-menu`
- Allow config options that include a `Ui\Component` object directly
  - Not really meant for anything now, but I could see this a way for customization for developers to include something else than menu buttons in the menu (e.g. headlines for button groups)