### PR TITLE
Require current password when user changes own pwd

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -714,6 +714,7 @@
 	"user.changeLanguage": "Change language",
 	"user.changeName": "Rename this user",
 	"user.changePassword": "Change password",
+	"user.changePassword.current": "Current password",
 	"user.changePassword.new": "New password",
 	"user.changePassword.new.confirm": "Confirm the new password…",
 	"user.changeRole": "Change role",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -714,7 +714,7 @@
 	"user.changeLanguage": "Change language",
 	"user.changeName": "Rename this user",
 	"user.changePassword": "Change password",
-	"user.changePassword.current": "Current password",
+	"user.changePassword.current": "Your current password",
 	"user.changePassword.new": "New password",
 	"user.changePassword.new.confirm": "Confirm the new password…",
 	"user.changeRole": "Change role",

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -96,6 +96,9 @@ trait UserActions
 
 	/**
 	 * Changes the user password
+	 *
+	 * If this method is used with user input, it is recommended to also
+	 * confirm the current password by the user via `::validatePassword()`
 	 */
 	public function changePassword(
 		#[SensitiveParameter]

--- a/tests/Panel/Areas/AccountDialogsTest.php
+++ b/tests/Panel/Areas/AccountDialogsTest.php
@@ -97,6 +97,7 @@ class AccountDialogsTest extends AreaTestCase
 
 		$this->assertFormDialog($dialog);
 
+		$this->assertSame('Your current password', $props['fields']['currentPassword']['label']);
 		$this->assertSame('New password', $props['fields']['password']['label']);
 		$this->assertSame('Confirm the new password…', $props['fields']['passwordConfirmation']['label']);
 		$this->assertSame('Change', $props['submitButton']);
@@ -105,8 +106,9 @@ class AccountDialogsTest extends AreaTestCase
 	public function testChangePasswordOnSubmit(): void
 	{
 		$this->submit([
-			'password'             => '12345678',
-			'passwordConfirmation' => '12345678'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefgh'
 		]);
 
 		$dialog = $this->dialog('account/changePassword');
@@ -114,14 +116,29 @@ class AccountDialogsTest extends AreaTestCase
 		$this->assertSame('user.changePassword', $dialog['event']);
 		$this->assertSame(200, $dialog['code']);
 
-		$this->assertTrue($this->app->user('test')->validatePassword(12345678));
+		$this->assertTrue($this->app->user('test')->validatePassword('abcdefgh'));
+	}
+
+	public function testChangePasswordOnSubmitWithInvalidCurrentPassword(): void
+	{
+		$this->submit([
+			'currentPassword'      => '123456',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefgh'
+		]);
+
+		$dialog = $this->dialog('account/changePassword');
+
+		$this->assertSame(400, $dialog['code']);
+		$this->assertSame('Wrong password', $dialog['error']);
 	}
 
 	public function testChangePasswordOnSubmitWithInvalidPassword(): void
 	{
 		$this->submit([
-			'password'             => '1234567',
-			'passwordConfirmation' => '1234567'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdef',
+			'passwordConfirmation' => 'abcdef'
 		]);
 
 		$dialog = $this->dialog('account/changePassword');
@@ -133,8 +150,9 @@ class AccountDialogsTest extends AreaTestCase
 	public function testChangePasswordOnSubmitWithInvalidConfirmation(): void
 	{
 		$this->submit([
-			'password'             => '12345678',
-			'passwordConfirmation' => '1234567'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefg'
 		]);
 
 		$dialog = $this->dialog('account/changePassword');

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Areas;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Blueprint;
+use Kirby\Cms\User;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\Panel\Panel;
@@ -82,9 +83,10 @@ abstract class AreaTestCase extends TestCase
 		$this->app([
 			'users' => [
 				[
-					'id'    => 'test',
-					'email' => 'test@getkirby.com',
-					'role'  => 'admin',
+					'id'       => 'test',
+					'email'    => 'test@getkirby.com',
+					'role'     => 'admin',
+					'password' => User::hashPassword('12345678')
 				]
 			]
 		]);

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -160,6 +160,7 @@ class UsersDialogsTest extends AreaTestCase
 
 		$this->assertFormDialog($dialog);
 
+		$this->assertSame('Your current password', $props['fields']['currentPassword']['label']);
 		$this->assertSame('New password', $props['fields']['password']['label']);
 		$this->assertSame('Confirm the new password…', $props['fields']['passwordConfirmation']['label']);
 		$this->assertSame('Change', $props['submitButton']);
@@ -168,8 +169,9 @@ class UsersDialogsTest extends AreaTestCase
 	public function testChangePasswordOnSubmit(): void
 	{
 		$this->submit([
-			'password'             => '12345678',
-			'passwordConfirmation' => '12345678'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefgh'
 		]);
 
 		$dialog = $this->dialog('users/test/changePassword');
@@ -177,14 +179,29 @@ class UsersDialogsTest extends AreaTestCase
 		$this->assertSame('user.changePassword', $dialog['event']);
 		$this->assertSame(200, $dialog['code']);
 
-		$this->assertTrue($this->app->user('test')->validatePassword(12345678));
+		$this->assertTrue($this->app->user('test')->validatePassword('abcdefgh'));
+	}
+
+	public function testChangePasswordOnSubmitWithInvalidCurrentPassword(): void
+	{
+		$this->submit([
+			'currentPassword'      => '123456',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefgh'
+		]);
+
+		$dialog = $this->dialog('users/test/changePassword');
+
+		$this->assertSame(400, $dialog['code']);
+		$this->assertSame('Wrong password', $dialog['error']);
 	}
 
 	public function testChangePasswordOnSubmitWithInvalidPassword(): void
 	{
 		$this->submit([
-			'password'             => '1234567',
-			'passwordConfirmation' => '1234567'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdef',
+			'passwordConfirmation' => 'abcdef'
 		]);
 
 		$dialog = $this->dialog('users/test/changePassword');
@@ -196,8 +213,9 @@ class UsersDialogsTest extends AreaTestCase
 	public function testChangePasswordOnSubmitWithInvalidConfirmation(): void
 	{
 		$this->submit([
-			'password'             => '12345678',
-			'passwordConfirmation' => '1234567'
+			'currentPassword'      => '12345678',
+			'password'             => 'abcdefgh',
+			'passwordConfirmation' => 'abcdefg'
 		]);
 
 		$dialog = $this->dialog('users/test/changePassword');


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Panel: user needs to confirm current password when changing their own password



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
