### PR TITLE
enhancement: add a single space after colon in headers in Response class

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -287,7 +287,7 @@ class Response
 		}
 
 		// send the content type header
-		header('Content-Type:' . $this->type() . '; charset=' . $this->charset());
+		header('Content-Type: ' . $this->type() . '; charset=' . $this->charset());
 
 		// print the response body
 		return $this->body();


### PR DESCRIPTION
## Description
This PR adds a single space after the `:` in header responses for better server support. 

### Summary of changes
Add a single space after colon in headers in Response class.

Before:
```yml
Content-Type:foo/bar
```
After:
```yml
Content-Type: foo/bar
```

### Reasoning
That single space was expected in HTTP/1.0. 
While since HTTP/1.1 it's optional, some products still seem to rely on it being present. So, adding it broadens the support for servers (and **really old** browsers I guess).

### Additional context
HTTP/1.0: https://datatracker.ietf.org/doc/html/rfc1945#section-4.2
HTTP/1.1: https://datatracker.ietf.org/doc/html/rfc2616#section-4.2

## Changelog

### Fixes
 - https://github.com/getkirby/kirby/issues/6975

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
