### PR TITLE
Fix entries field issues

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -98,6 +98,10 @@
 	"error.content.lock.replace": "The version is locked and cannot be replaced",
 	"error.content.lock.update": "The version is locked and cannot be updated",
 
+	"error.entries.max.plural": "You must not add more than {max} entries",
+	"error.entries.max.singular": "You must not add more than one entry",
+	"error.entries.min.plural": "You must add at least {min} entries",
+	"error.entries.min.singular": "You must add at least one entry",
 	"error.entries.supports": "\"{type}\" field type is not supported for the entries field",
 	"error.entries.validation": "There's an error on the \"{field}\" field in row {index}",
 

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -30,18 +30,18 @@
 			</k-button-group>
 		</template>
 
-		<!-- Empty State -->
-		<k-empty v-if="entries.length === 0" icon="list-bullet" @click="add()">
-			{{ empty ?? $t("field.entries.empty") }}
-		</k-empty>
-
-		<!-- Entries -->
 		<k-input-validator
-			v-else
 			v-bind="{ min, max, required }"
 			:value="JSON.stringify(entries)"
 		>
+			<!-- Empty State -->
+			<k-empty v-if="entries.length === 0" icon="list-bullet" @click="add()">
+				{{ empty ?? $t("field.entries.empty") }}
+			</k-empty>
+
+			<!-- Entries -->
 			<k-draggable
+				v-else
 				v-bind="dragOptions"
 				class="k-entries-field-items"
 				@sort="save"

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -374,13 +374,15 @@ export default {
 }
 
 .k-entries-field-item {
-	--input-color-border: transparent;
-
 	height: var(--input-height);
 	display: flex;
 	align-items: center;
 	background: var(--input-color-back);
 	border-radius: var(--rounded);
+}
+
+.k-entries-field:not([data-disabled="true"]) .k-entries-field-item {
+	--input-color-border: transparent;
 	box-shadow: var(--shadow);
 }
 

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -10,8 +10,8 @@
 		<template v-if="!disabled" #options>
 			<k-button-group layout="collapsed">
 				<k-button
+					v-if="more"
 					:autofocus="autofocus"
-					:disabled="!more"
 					:responsive="true"
 					:text="$t('add')"
 					icon="add"

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -246,6 +246,8 @@ export default {
 				return;
 			}
 
+			value ??= this.$helper.field.form({ field: this.field })?.field;
+
 			const entry = {
 				id: this.$helper.uuid(),
 				value: value ?? ""

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -64,6 +64,7 @@
 					<component
 						:is="`k-${field.type}-field`"
 						:ref="'entry-' + index + '-input'"
+						:disabled="disabled"
 						:value="entry.value"
 						v-bind="field"
 						class="k-entries-field-item-input"

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -147,15 +147,29 @@ class EntriesField extends FieldClass
 	public function validations(): array
 	{
 		return [
-			'min',
-			'max',
-			'entries' => function ($values) {
-				if (empty($values) === true) {
-					return true;
+			'entries' => function ($value) {
+				if ($this->min && count($value) < $this->min) {
+					throw new InvalidArgumentException(
+						key: match ($this->min) {
+							1       => 'entries.min.singular',
+							default => 'entries.min.plural'
+						},
+						data: ['min' => $this->min]
+					);
 				}
 
-				foreach ($values as $index => $value) {
-					$form = $this->form([$value]);
+				if ($this->max && count($value) > $this->max) {
+					throw new InvalidArgumentException(
+						key: match ($this->max) {
+							1       => 'entries.max.singular',
+							default => 'entries.max.plural'
+						},
+						data: ['max' => $this->max]
+					);
+				}
+
+				foreach ($value as $index => $val) {
+					$form = $this->form([$val]);
 
 					foreach ($form->fields() as $field) {
 						$errors = $field->errors();

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -8,11 +8,26 @@ trait Min
 
 	public function min(): int|null
 	{
+		// set min to at least 1, if required
+		if ($this->required === true) {
+			return $this->min ?? 1;
+		}
+
 		return $this->min;
 	}
 
 	protected function setMin(int|null $min = null)
 	{
 		$this->min = $min;
+	}
+
+	public function isRequired(): bool
+	{
+		// set required to true if min is set
+		if ($this->min) {
+			return true;
+		}
+
+		return $this->required;
 	}
 }

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -175,6 +175,7 @@ class EntriesFieldTest extends TestCase
 		]);
 
 		$this->assertSame(3, $field->min());
+		$this->assertTrue($field->isRequired());
 		$this->assertFalse($field->isValid());
 		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
@@ -190,6 +191,7 @@ class EntriesFieldTest extends TestCase
 		]);
 
 		$this->assertSame(2, $field->min());
+		$this->assertTrue($field->isRequired());
 		$this->assertTrue($field->isValid());
 	}
 
@@ -203,6 +205,7 @@ class EntriesFieldTest extends TestCase
 		]);
 
 		$this->assertSame(3, $field->min());
+		$this->assertTrue($field->isRequired());
 		$this->assertFalse($field->isValid());
 		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
@@ -217,6 +220,7 @@ class EntriesFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->isValid());
+		$this->assertSame(1, $field->min());
 	}
 
 	public function testRequiredInvalid()
@@ -226,6 +230,7 @@ class EntriesFieldTest extends TestCase
 		]);
 
 		$this->assertFalse($field->isValid());
+		$this->assertSame(1, $field->min());
 	}
 
 	public static function supportsProvider(): array

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -128,6 +128,32 @@ class EntriesFieldTest extends TestCase
 	public function testMax()
 	{
 		$field = $this->field('entries', [
+			'max'   => 3,
+			'value' => [],
+		]);
+
+		$this->assertSame(3, $field->max());
+		$this->assertTrue($field->isValid());
+	}
+
+	public function testMaxValid()
+	{
+		$field = $this->field('entries', [
+			'max'   => 3,
+			'value' => [
+				'https://getkirby.com',
+				'https://forum.getkirby.com',
+				'https://plugins.getkirby.com',
+			],
+		]);
+
+		$this->assertSame(3, $field->max());
+		$this->assertTrue($field->isValid());
+	}
+
+	public function testMaxInvalid()
+	{
+		$field = $this->field('entries', [
 			'max'   => 1,
 			'value' => [
 				'https://getkirby.com',
@@ -153,7 +179,21 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
 
-	public function testMinValue()
+	public function testMinValid()
+	{
+		$field = $this->field('entries', [
+			'min'   => 2,
+			'value' => [
+				'https://getkirby.com',
+				'https://forum.getkirby.com'
+			]
+		]);
+
+		$this->assertSame(2, $field->min());
+		$this->assertTrue($field->isValid());
+	}
+
+	public function testMinInvalid()
 	{
 		$field = $this->field('entries', [
 			'min'   => 3,

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -138,7 +138,7 @@ class EntriesFieldTest extends TestCase
 
 		$this->assertSame(1, $field->max());
 		$this->assertFalse($field->isValid());
-		$this->assertSame($field->errors()['max'], 'Please enter a value equal to or lower than 1');
+		$this->assertSame($field->errors()['entries'], 'You must not add more than one entry');
 	}
 
 	public function testMin()
@@ -152,7 +152,7 @@ class EntriesFieldTest extends TestCase
 
 		$this->assertSame(3, $field->min());
 		$this->assertFalse($field->isValid());
-		$this->assertSame($field->errors()['min'], 'Please enter a value equal to or greater than 3');
+		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
 
 	public function testRequiredValid()

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -145,9 +145,21 @@ class EntriesFieldTest extends TestCase
 	{
 		$field = $this->field('entries', [
 			'min'   => 3,
+			'value' => '[]'
+		]);
+
+		$this->assertSame(3, $field->min());
+		$this->assertFalse($field->isValid());
+		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
+	}
+
+	public function testMinValue()
+	{
+		$field = $this->field('entries', [
+			'min'   => 3,
 			'value' => [
 				'https://getkirby.com'
-			],
+			]
 		]);
 
 		$this->assertSame(3, $field->min());


### PR DESCRIPTION
### Fixes

- [x] Min/max validation
- [x] Default value for the field form
- [x] Disabled state
- [X] Input validator when empty state
- [x] Consistency with min trait and array

### Breaking changes
- `isRequired()` method of blocks/layout fields that use the `min` prop now returns `true` for empty state and `min` returns `1` for fields that no defined `min` prop and `requried: true`.