### PR TITLE
Fix uuid permalinks for the default language

### DIFF
--- a/panel/src/components/Dialogs/LinkDialog.vue
+++ b/panel/src/components/Dialogs/LinkDialog.vue
@@ -61,7 +61,8 @@ export default {
 
 			if (
 				this.values.href.startsWith("page://") &&
-				window.panel.language.code
+				window.panel.language.code &&
+				window.panel.language.default === false
 			) {
 				permalink = "/" + window.panel.language.code + permalink;
 			}


### PR DESCRIPTION
## Description

Fixed the issue via removing language prefix for the default language. Since like `/@/page/D1yCxHPlHzgzBJI5` links without language code prefix always redirect to the default language content. Even if the default language has a custom URL setup (for ex: `'url' => '/custom-url'`)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- UUID permalinks still redirect to default language page #6865

### Breaking changes
None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
