### PR TITLE
Set mobile menu backdrop z index

### DIFF
--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -194,6 +194,7 @@ export default {
 	background: var(--color-backdrop);
 	display: var(--menu-display-backdrop);
 	pointer-events: none;
+	z-index: var(--z-drawer);
 }
 
 /* The toggle button builds a full-height strip on the side of the menu */


### PR DESCRIPTION
## Description
Kirby's mobile menu has a "backdrop" that darkens the rest of the panel when open. However, it seems to have a lower z index than the titlebar: 
![](https://github.com/user-attachments/assets/5dea71d8-e8db-4522-8417-ec45da293f96)
(Screenshot taken from fresh demo instance on trykirby.com. Kirby version 4.6.1)

### Summary of changes

In `Menu.vue`, specify the z index of the menu backdrop. I set it to `var(--z-drawer)`, as that seems appropriate, but I realize it might require it's own CSS variable.

Thanks!
