### PR TITLE
PHPUnit replace covers annotations with attributes

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -264,7 +264,7 @@ jobs:
         with:
           php-version: ${{ env.php }}
           coverage: none
-          tools: php-cs-fixer:3.52.1
+          tools: php-cs-fixer:3.65.0
 
       - name: Cache analysis data
         id: finishPrepare

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -59,6 +59,7 @@ return $config
 		'phpdoc_param_order' => true,
 		'phpdoc_scalar' => true,
 		'phpdoc_trim' => true,
+		'php_unit_attributes' => true,
 		'php_unit_fqcn_annotation' => true,
 		'single_line_comment_style' => true,
 		'single_quote' => true,

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -5,7 +5,9 @@ namespace Kirby\Api\Controller;
 use Kirby\Cms\Page;
 use Kirby\Data\Data;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Changes::class)]
 class ChangesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Api.Controller.Changes';

--- a/tests/Api/UploadTest.php
+++ b/tests/Api/UploadTest.php
@@ -11,10 +11,9 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Api\Upload
- */
+#[CoversClass(Upload::class)]
 class UploadTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Api.Upload';
@@ -59,9 +58,6 @@ class UploadTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::chunkId
-	 */
 	public function testChunkId()
 	{
 		$this->assertSame('abcd', Upload::chunkId('abcd'));
@@ -70,9 +66,6 @@ class UploadTest extends TestCase
 		$this->assertSame('abcd', Upload::chunkId('a-b/../cd.'));
 	}
 
-	/**
-	 * @covers ::chunkId
-	 */
 	public function testChunkIdInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -80,9 +73,6 @@ class UploadTest extends TestCase
 		Upload::chunkId('a-b-');
 	}
 
-	/**
-	 * @covers ::chunkSize
-	 */
 	public function testChunkSize()
 	{
 		ini_set('upload_max_filesize', '10M');
@@ -104,9 +94,6 @@ class UploadTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::cleanTmpDir
-	 */
 	public function testCleanTmpDir()
 	{
 		$dir = static::TMP . '/site/cache/.uploads';
@@ -133,9 +120,6 @@ class UploadTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError()
 	{
 		$this->expectException(Exception::class);
@@ -143,9 +127,6 @@ class UploadTest extends TestCase
 		Upload::error(UPLOAD_ERR_NO_FILE);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testErrorUnknown()
 	{
 		$this->expectException(Exception::class);
@@ -153,9 +134,6 @@ class UploadTest extends TestCase
 		Upload::error(999);
 	}
 
-	/**
-	 * @covers ::filename
-	 */
 	public function testFilename()
 	{
 		$this->assertSame('foo.md', Upload::filename(['name' => 'foo.md']));
@@ -165,9 +143,6 @@ class UploadTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcessSingle()
 	{
 		$upload = $this->upload([
@@ -202,9 +177,6 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcessMultiple()
 	{
 		$upload = $this->upload([
@@ -245,9 +217,6 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcessError()
 	{
 		$upload = $this->upload([
@@ -274,9 +243,6 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcessException()
 	{
 		$upload = $this->upload([
@@ -309,9 +275,6 @@ class UploadTest extends TestCase
 		$this->assertFalse(F::exists($tmp));
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcessWithChunk()
 	{
 		$source = static::TMP . '/test.md';
@@ -346,9 +309,6 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
 	public function testProcessChunkFirstChunkFullLength()
 	{
 		$source = static::TMP . '/test.md';
@@ -372,9 +332,6 @@ class UploadTest extends TestCase
 		$this->assertFileDoesNotExist('abcd-' . $file);
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
 	public function testProcessChunkFirstChunkPartialLength()
 	{
 		$source = static::TMP . '/test.md';
@@ -395,9 +352,6 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
 	public function testProcessChunkIdRemoveUnallowedCharacters()
 	{
 		$source = static::TMP . '/test.md';
@@ -418,9 +372,6 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
 	public function testProcessChunkFilenameNoDirectoryTraversal()
 	{
 		$source = static::TMP . '/test.md';
@@ -441,9 +392,6 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
 	public function testProcessChunkSuccesfulAll()
 	{
 		$source = static::TMP . '/test.md';
@@ -479,9 +427,6 @@ class UploadTest extends TestCase
 		$this->assertSame('abcdef', F::read($file));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse()
 	{
 		// nothing
@@ -516,9 +461,6 @@ class UploadTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkDuplicate()
 	{
 		$source = static::TMP . '/test.md';
@@ -539,9 +481,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkSubsequentInvalidOffset()
 	{
 		$source = static::TMP . '/a.md';
@@ -573,9 +512,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkSubsequentNoFirst()
 	{
 		$source = static::TMP . '/a.md';
@@ -595,9 +531,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkInvalidExtension()
 	{
 		$source = static::TMP . '/a.php';
@@ -616,9 +549,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkTooLargeTotal()
 	{
 		$source = static::TMP . '/a.md';
@@ -648,9 +578,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
 	public function testValidateChunkTooLargeCurrentChunk()
 	{
 		$dir    = static::TMP . '/site/cache/.uploads';
@@ -684,9 +611,6 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateFiles
-	 */
 	public function testValidateFilesEmpty()
 	{
 		ini_set('upload_max_filesize', '10M');

--- a/tests/Blueprint/NodeI18nTest.php
+++ b/tests/Blueprint/NodeI18nTest.php
@@ -2,43 +2,29 @@
 
 namespace Kirby\Blueprint;
 
-/**
- * @coversDefaultClass \Kirby\Blueprint\NodeI18n
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(NodeI18n::class)]
 class NodeI18nTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::render
-	 */
 	public function testConstructWithArray()
 	{
 		$translated = new NodeI18n(['en' => 'Test']);
 		$this->assertSame('Test', $translated->render($this->model()));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::render
-	 */
 	public function testConstructWithI18nKey()
 	{
 		$translated = new NodeI18n(['*' => 'avatar']);
 		$this->assertSame('Profile picture', $translated->render($this->model()));
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$translated = NodeI18n::factory('Test');
 		$this->assertSame(['en' => 'Test'], $translated->translations);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithNonEnglishFallback()
 	{
 		$translated = new NodeI18n(['de' => 'Täst']);

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\ApcuCache
- */
+#[CoversClass(ApcuCache::class)]
 class ApcuCacheTest extends TestCase
 {
 	public function setUp(): void
@@ -19,9 +18,6 @@ class ApcuCacheTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new ApcuCache();
@@ -29,12 +25,6 @@ class ApcuCacheTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::exists
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new ApcuCache([]);
@@ -54,12 +44,6 @@ class ApcuCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::exists
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new ApcuCache([
@@ -89,9 +73,6 @@ class ApcuCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new ApcuCache([]);
@@ -109,9 +90,6 @@ class ApcuCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlushWithPrefix()
 	{
 		$cache1 = new ApcuCache([

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -3,26 +3,18 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Cache\Cache
- */
+#[CoversClass(Cache::class)]
 class CacheTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::options
-	 */
 	public function testConstruct()
 	{
 		$cache = new TestCache(['some' => 'options']);
 		$this->assertSame(['some' => 'options'], $cache->options());
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$method = new ReflectionMethod(Cache::class, 'key');
@@ -37,9 +29,6 @@ class CacheTest extends TestCase
 		$this->assertSame('test/foo', $method->invoke($cache, 'foo'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		$cache = new TestCache();
@@ -67,9 +56,6 @@ class CacheTest extends TestCase
 		$this->assertFalse(isset($cache->store['expired']));
 	}
 
-	/**
-	 * @covers ::getOrSet
-	 */
 	public function testGetOrSet()
 	{
 		$cache = new TestCache();
@@ -87,9 +73,6 @@ class CacheTest extends TestCase
 		$this->assertSame(1, $count);
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new TestCache();
@@ -97,9 +80,6 @@ class CacheTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::expiration
-	 */
 	public function testExpiration()
 	{
 		$method = new ReflectionMethod(Cache::class, 'expiration');
@@ -111,9 +91,6 @@ class CacheTest extends TestCase
 		$this->assertSame(time() + 600, $method->invoke($cache, 10));
 	}
 
-	/**
-	 * @covers ::expires
-	 */
 	public function testExpires()
 	{
 		$cache = new TestCache();
@@ -127,9 +104,6 @@ class CacheTest extends TestCase
 		$this->assertFalse($cache->expires('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::expired
-	 */
 	public function testExpired()
 	{
 		$cache = new TestCache();
@@ -146,10 +120,6 @@ class CacheTest extends TestCase
 		$this->assertTrue($cache->expired('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::created
-	 * @covers ::modified
-	 */
 	public function testCreated()
 	{
 		$cache = new TestCache();
@@ -162,9 +132,6 @@ class CacheTest extends TestCase
 		$this->assertFalse($cache->modified('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$cache = new TestCache();

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -4,11 +4,10 @@ namespace Kirby\Cache;
 
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Cache\FileCache
- */
+#[CoversClass(FileCache::class)]
 class FileCacheTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cache.FileCache';
@@ -18,10 +17,6 @@ class FileCacheTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 */
 	public function testConstruct()
 	{
 		$cache = new FileCache([
@@ -32,10 +27,6 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 */
 	public function testConstructWithPrefix()
 	{
 		$cache = new FileCache([
@@ -47,9 +38,6 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root . '/test');
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new FileCache([
@@ -59,9 +47,6 @@ class FileCacheTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabledNotWritable()
 	{
 		$cache = new FileCache([
@@ -73,9 +58,6 @@ class FileCacheTest extends TestCase
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFile()
 	{
 		$method = new ReflectionMethod(FileCache::class, 'file');
@@ -208,12 +190,6 @@ class FileCacheTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new FileCache([
@@ -243,12 +219,6 @@ class FileCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithExtension()
 	{
 		$cache = new FileCache([
@@ -277,12 +247,6 @@ class FileCacheTest extends TestCase
 		$this->assertNull($cache->retrieve('foo'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new FileCache([
@@ -323,9 +287,6 @@ class FileCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new FileCache([
@@ -348,9 +309,6 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryDoesNotExist($root . '/d');
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlushWithPrefix()
 	{
 		$cache1 = new FileCache([
@@ -384,9 +342,6 @@ class FileCacheTest extends TestCase
 		$this->assertFileExists($root . '/test2/c/a');
 	}
 
-	/**
-	 * @covers ::removeEmptyDirectories
-	 */
 	public function testRemoveEmptyDirectories()
 	{
 		$cache = new FileCache([
@@ -408,9 +363,6 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root);
 	}
 
-	/**
-	 * @covers ::removeEmptyDirectories
-	 */
 	public function testRemoveEmptyDirectoriesWithNotEmptyDirs()
 	{
 		$cache = new FileCache([

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\MemCached
- */
+#[CoversClass(MemCached::class)]
 class MemCachedTest extends TestCase
 {
 	public function setUp(): void
@@ -30,9 +29,6 @@ class MemCachedTest extends TestCase
 		$connection->flush();
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new MemCached();
@@ -40,11 +36,6 @@ class MemCachedTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new MemCached([]);
@@ -64,11 +55,6 @@ class MemCachedTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new MemCached([
@@ -98,9 +84,6 @@ class MemCachedTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructServer()
 	{
 		$cache = new MemCached([
@@ -120,9 +103,6 @@ class MemCachedTest extends TestCase
 		$this->assertFalse($cache->remove('foo'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new MemCached([]);

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\MemoryCache
- */
+#[CoversClass(MemoryCache::class)]
 class MemoryCacheTest extends TestCase
 {
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new MemoryCache();
@@ -19,11 +15,6 @@ class MemoryCacheTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new MemoryCache();
@@ -43,11 +34,6 @@ class MemoryCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithMultipleInstances()
 	{
 		$cache1 = new MemoryCache();
@@ -73,9 +59,6 @@ class MemoryCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new MemoryCache();
@@ -93,9 +76,6 @@ class MemoryCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlushWithMultipleInstances()
 	{
 		$cache1 = new MemoryCache();
@@ -117,9 +97,6 @@ class MemoryCacheTest extends TestCase
 		$this->assertTrue($cache2->exists('b'));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		$cache = new MemoryCache();

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\NullCache
- */
+#[CoversClass(NullCache::class)]
 class NullCacheTest extends TestCase
 {
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new NullCache();
@@ -19,11 +15,6 @@ class NullCacheTest extends TestCase
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new NullCache();
@@ -34,9 +25,6 @@ class NullCacheTest extends TestCase
 		$this->assertTrue($cache->remove('foo'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new NullCache();

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\RedisCache
- */
+#[CoversClass(RedisCache::class)]
 class RedisCacheTest extends TestCase
 {
 	public function setUp(): void
@@ -30,10 +29,6 @@ class RedisCacheTest extends TestCase
 		$connection->flush();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::enabled
-	 */
 	public function testConstructServer()
 	{
 		// invalid port
@@ -49,9 +44,6 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::databaseNum
-	 */
 	public function testDatabase()
 	{
 		$cache = new RedisCache([
@@ -65,19 +57,12 @@ class RedisCacheTest extends TestCase
 		$this->assertSame('A basic value', $cache->retrieve('a')->value());
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$cache = new RedisCache();
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::flush
-	 */
 	public function testFlush()
 	{
 		$cache = new RedisCache();
@@ -96,13 +81,6 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::key
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperations()
 	{
 		$cache = new RedisCache();
@@ -122,14 +100,6 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::exists
-	 * @covers ::key
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
 	public function testOperationsWithPrefix()
 	{
 		$cache1 = new RedisCache([

--- a/tests/Cache/ValueTest.php
+++ b/tests/Cache/ValueTest.php
@@ -3,16 +3,11 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\Value
- */
+#[CoversClass(Value::class)]
 class ValueTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::created
-	 */
 	public function testCreated()
 	{
 		$value = new Value('foo');
@@ -22,9 +17,6 @@ class ValueTest extends TestCase
 		$this->assertSame(1000, $value->created());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
 	public function testExpires()
 	{
 		$value = new Value('foo');
@@ -46,10 +38,6 @@ class ValueTest extends TestCase
 		$this->assertSame(1234567890, $value->expires());
 	}
 
-	/**
-	 * @covers ::fromArray
-	 * @covers ::toArray
-	 */
 	public function testArrayConversion()
 	{
 		$data = [
@@ -106,9 +94,6 @@ class ValueTest extends TestCase
 		], $value->toArray());
 	}
 
-	/**
-	 * @covers ::fromArray
-	 */
 	public function testFromArrayInvalid()
 	{
 		$this->expectException(\TypeError::class);
@@ -121,10 +106,6 @@ class ValueTest extends TestCase
 		$value = Value::fromArray($data);
 	}
 
-	/**
-	 * @covers ::fromJson
-	 * @covers ::toJson
-	 */
 	public function testJsonConversion()
 	{
 		$data = json_encode([
@@ -179,9 +160,6 @@ class ValueTest extends TestCase
 		$this->assertNull(Value::fromJson($data));
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$value = new Value('foo');

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -4,13 +4,12 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\Exception;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
-/**
- * @coversDefaultClass \Kirby\Cms\AppErrors
- */
+#[CoversClass(AppErrors::class)]
 class AppErrorsTest extends TestCase
 {
 	protected App|null $originalApp;
@@ -48,9 +47,6 @@ class AppErrorsTest extends TestCase
 		App::$enableWhoops = false;
 	}
 
-	/**
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testExceptionHook()
 	{
 		$result = null;
@@ -80,9 +76,6 @@ class AppErrorsTest extends TestCase
 		$this->assertStringContainsString('Exception: Some error message in', ErrorLog::$log);
 	}
 
-	/**
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testExceptionHookDisableLogging()
 	{
 		$result = null;
@@ -113,10 +106,6 @@ class AppErrorsTest extends TestCase
 		$this->assertSame('', ErrorLog::$log);
 	}
 
-	/**
-	 * @covers ::handleCliErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleCliErrors()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -135,10 +124,6 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleErrors1()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -160,10 +145,6 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleErrors2()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -188,10 +169,6 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleErrors3()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -221,9 +198,6 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsGlobalSetting()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -254,10 +228,6 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(2, $handlers);
 	}
 
-	/**
-	 * @covers ::handleHtmlErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleHtmlErrors()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -332,10 +302,6 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(0, $handlers);
 	}
 
-	/**
-	 * @covers ::handleJsonErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testHandleJsonErrors()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -412,11 +378,6 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::setWhoopsHandler
-	 * @covers ::unsetWhoopsHandler
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
 	public function testSetUnsetWhoopsHandler()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
@@ -450,9 +411,6 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(0, $handlers);
 	}
 
-	/**
-	 * @covers ::whoops
-	 */
 	public function testWhoops()
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AppLanguagesTest extends TestCase
 {
@@ -63,11 +64,9 @@ class AppLanguagesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider detectedLanguageProvider
-	 * @backupGlobals enabled
-	 */
-	public function testDetectedLanguage($accept, $expected)
+	#[\PHPUnit\Framework\Attributes\BackupGlobals(true)]
+	#[DataProvider('detectedLanguageProvider')]
+	public function testDetectedLanguage(string $accept, string $expected)
 	{
 		// set the accepted visitor language
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -12,6 +12,7 @@ use Kirby\Image\Image;
 use Kirby\Plugin\Plugin;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class DummyAuthChallenge extends Challenge
 {
@@ -51,9 +52,7 @@ class DummyFilePreview
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\AppPlugins
- */
+#[CoversClass(AppPlugins::class)]
 class AppPluginsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -403,9 +402,6 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('shaw', $field->peter());
 	}
 
-	/**
-	 * @covers ::extendFilePreviews
-	 */
 	public function testFilePreviews()
 	{
 		$app = new App([
@@ -991,9 +987,6 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('https://getkirby.com/test', $kirby->nativeComponent('url')($kirby, 'test'));
 	}
 
-	/**
-	 * @covers ::extendAreas
-	 */
 	public function testAreas()
 	{
 		$kirby = new App([
@@ -1012,9 +1005,6 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf('Closure', $areas['todos'][0]);
 	}
 
-	/**
-	 * @covers ::extendFileTypes
-	 */
 	public function testFileTypes()
 	{
 		$kirby = new App([

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -3,18 +3,14 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\App
- */
+#[CoversClass(App::class)]
 class AppResolveTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppResolve';
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveHomePage()
 	{
 		$app = new App([
@@ -36,9 +32,6 @@ class AppResolveTest extends TestCase
 		$this->assertTrue($result->isHomePage());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveMainPage()
 	{
 		$app = new App([
@@ -60,9 +53,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveSubPage()
 	{
 		$app = new App([
@@ -87,9 +77,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/subpage', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveDraft()
 	{
 		$app = new App([
@@ -127,9 +114,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/a-draft', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolvePageRepresentation()
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
@@ -173,9 +157,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('png', $result->body());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolvePageHtmlRepresentation()
 	{
 		$app = new App([
@@ -198,9 +179,6 @@ class AppResolveTest extends TestCase
 
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveSiteFile()
 	{
 		$app = new App([
@@ -225,9 +203,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test.jpg', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolvePageFile()
 	{
 		$app = new App([
@@ -257,9 +232,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/test.jpg', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveMultilangPageRepresentation()
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
@@ -342,9 +314,6 @@ class AppResolveTest extends TestCase
 		$this->assertSame('en', $app->language()->code());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testRepresentationErrorType()
 	{
 		$this->app = new App([

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -10,11 +10,11 @@ use Kirby\Filesystem\F;
 use Kirby\Http\Route;
 use Kirby\Session\Session;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Cms\App
- */
+#[CoversClass(App::class)]
 class AppTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -33,9 +33,6 @@ class AppTest extends TestCase
 		$_SERVER = $this->_SERVER;
 	}
 
-	/**
-	 * @covers ::apply
-	 */
 	public function testApply()
 	{
 		$self = $this;
@@ -109,9 +106,6 @@ class AppTest extends TestCase
 		$this->assertSame(2, $app->apply('does-not-exist', ['value' => 2], 'value'));
 	}
 
-	/**
-	 * @covers ::apply
-	 */
 	public function testApplyWildcard()
 	{
 		$self = $this;
@@ -151,9 +145,6 @@ class AppTest extends TestCase
 		$this->assertSame(143, $app->apply('test.event:after', ['value' => 2], 'value'));
 	}
 
-	/**
-	 * @covers ::clone
-	 */
 	public function testClone()
 	{
 		$app = new App();
@@ -177,9 +168,6 @@ class AppTest extends TestCase
 		$this->assertSame('testtest', $clone->data['test']);
 	}
 
-	/**
-	 * @covers ::collection
-	 */
 	public function testCollection()
 	{
 		$app = new App([
@@ -202,9 +190,6 @@ class AppTest extends TestCase
 		$this->assertSame('test', $collection->first()->slug());
 	}
 
-	/**
-	 * @covers ::collection
-	 */
 	public function testCollectionWithOptions()
 	{
 		$test = $this;
@@ -260,9 +245,6 @@ class AppTest extends TestCase
 		$app->collection('overwrites', ['kirby' => 'foo']);
 	}
 
-	/**
-	 * @covers ::contentToken
-	 */
 	public function testContentToken()
 	{
 		$model = new class () {
@@ -307,9 +289,6 @@ class AppTest extends TestCase
 		$this->assertSame(hash_hmac('sha1', 'test', ' salt'), $app->contentToken(null, 'test'));
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrf()
 	{
 		$app = new App([
@@ -406,9 +385,6 @@ class AppTest extends TestCase
 		$this->assertInstanceOf(PHPMailer::class, $email);
 	}
 
-	/**
-	 * @covers ::environment
-	 */
 	public function testEnvironment()
 	{
 		$app = new App([
@@ -423,9 +399,6 @@ class AppTest extends TestCase
 		$this->assertSame($info, $app->environment()->info());
 	}
 
-	/**
-	 * @covers ::environment
-	 */
 	public function testEnvironmentBeforeInitialization()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -439,9 +412,6 @@ class AppTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImage()
 	{
 		$app = new App([
@@ -481,9 +451,6 @@ class AppTest extends TestCase
 		$this->assertNull($image);
 	}
 
-	/**
-	 * @covers ::models
-	 */
 	public function testModels()
 	{
 		$app = new App([
@@ -528,9 +495,6 @@ class AppTest extends TestCase
 		$this->assertSame('test@getkirby.com', $models->current()->email());
 	}
 
-	/**
-	 * @covers ::nonce
-	 */
 	public function testNonce()
 	{
 		$app = new App([
@@ -968,9 +932,6 @@ class AppTest extends TestCase
 		$this->assertSame($fileB, $app->file('test-b.jpg', $fileA));
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFindFileByUUID()
 	{
 		$app = new App([
@@ -1035,9 +996,6 @@ class AppTest extends TestCase
 		$this->assertSame($expected, $app->blueprints('files'));
 	}
 
-	/**
-	 * @covers ::trigger
-	 */
 	public function testTrigger()
 	{
 		$self  = $this;
@@ -1147,9 +1105,6 @@ class AppTest extends TestCase
 		$this->assertSame(10, $count);
 	}
 
-	/**
-	 * @covers ::trigger
-	 */
 	public function testTriggerWildcard()
 	{
 		$self  = $this;
@@ -1204,10 +1159,8 @@ class AppTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider urlProvider
-	 */
-	public function testUrl($url, $expected)
+	#[DataProvider('urlProvider')]
+	public function testUrl(string $url, string $expected)
 	{
 		$app = new App([
 			'roots' => [
@@ -1307,10 +1260,6 @@ class AppTest extends TestCase
 		$this->assertSame('ss', Str::$language['ß']);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testController()
 	{
 		$app = new App([
@@ -1331,10 +1280,6 @@ class AppTest extends TestCase
 		], $app->controller('test'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testControllerCallback()
 	{
 		$app = new App([
@@ -1358,10 +1303,6 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testControllerRepresentation()
 	{
 		$app = new App([
@@ -1382,10 +1323,6 @@ class AppTest extends TestCase
 		], $app->controller('another', contentType: 'json'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testControllerHtmlForMissingRepresentation()
 	{
 		$app = new App([
@@ -1406,10 +1343,6 @@ class AppTest extends TestCase
 		], $app->controller('test', contentType: 'json'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testControllerMissing()
 	{
 		$app = new App([
@@ -1430,10 +1363,6 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
 	public function testControllerMissingRepresentation()
 	{
 		$app = new App([
@@ -1454,9 +1383,6 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		$app = new App();
@@ -1494,9 +1420,6 @@ class AppTest extends TestCase
 		$this->assertSame('foo/bar', $app->path());
 	}
 
-	/**
-	 * @covers ::page
-	 */
 	public function testPageWithUUID()
 	{
 		$app = new App([
@@ -1517,9 +1440,6 @@ class AppTest extends TestCase
 		$this->assertIsPage($page, $app->page('page://my-page'));
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$app = new App([

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -10,11 +10,10 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Throwable;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthChallenge';
@@ -80,12 +79,6 @@ class AuthChallengeTest extends TestCase
 		$this->failedEmail = null;
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 * @covers ::status
-	 */
 	public function testCreateChallenge()
 	{
 		$this->app = $this->app->clone([
@@ -178,10 +171,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
 	public function testCreateChallengeDebugError()
 	{
 		$auth = $this->app->auth();
@@ -191,10 +180,6 @@ class AuthChallengeTest extends TestCase
 		$auth->createChallenge('error@getkirby.com');
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
 	public function testCreateChallengeDebugNotFound()
 	{
 		$this->expectException(NotFoundException::class);
@@ -203,11 +188,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->createChallenge('invalid@example.com');
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
 	public function testCreateChallengeDebugRateLimit()
 	{
 		$auth = $this->app->auth();
@@ -221,11 +201,6 @@ class AuthChallengeTest extends TestCase
 		$auth->createChallenge('marge@simpsons.com');
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 * @covers ::status
-	 */
 	public function testCreateChallengeCustomTimeout()
 	{
 		$this->app = $this->app->clone([
@@ -261,10 +236,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(MockTime::$time + 10, $session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::status
-	 */
 	public function testCreateChallengeLong()
 	{
 		$session = $this->app->session();
@@ -280,10 +251,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertFalse($session->timeout());
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::status
-	 */
 	public function testCreateChallengeWithPunycodeEmail()
 	{
 		$session = $this->app->session();
@@ -298,9 +265,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('test@exämple.com', $session->get('kirby.challenge.email'));
 	}
 
-	/**
-	 * @covers ::enabledChallenges
-	 */
 	public function testEnabledChallenges()
 	{
 		// default
@@ -334,10 +298,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(['totp', 'sms'], $app->auth()->enabledChallenges());
 	}
 
-	/**
-	 * @covers ::login2fa
-	 * @covers ::status
-	 */
 	public function testLogin2fa()
 	{
 		$session = $this->app->session();
@@ -358,10 +318,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::login2fa
-	 * @covers ::status
-	 */
 	public function testLogin2faLong()
 	{
 		$session = $this->app->session();
@@ -382,10 +338,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::login2fa
-	 */
 	public function testLogin2faInvalidUser()
 	{
 		$session = $this->app->session();
@@ -395,10 +347,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->login2fa('invalid@example.com', 'springfield123');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::login2fa
-	 */
 	public function testLogin2faInvalidPassword()
 	{
 		$session = $this->app->session();
@@ -408,9 +356,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->login2fa('marge@simpsons.com', 'springfield456');
 	}
 
-	/**
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallenge()
 	{
 		$session = $this->app->session();
@@ -427,10 +372,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(['kirby.userId' => 'marge'], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeNoChallenge1()
 	{
 		try {
@@ -444,10 +385,6 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeNoChallenge2()
 	{
 		try {
@@ -462,10 +399,6 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeNoChallengeNoDebug1()
 	{
 		$this->app = $this->app->clone([
@@ -488,10 +421,6 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeNoChallengeNoDebug2()
 	{
 		$this->app = $this->app->clone([
@@ -515,10 +444,6 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeInvalidEmail()
 	{
 		$this->expectException(NotFoundException::class);
@@ -529,11 +454,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('123456');
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeRateLimited()
 	{
 		$this->expectException(PermissionException::class);
@@ -551,10 +471,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('123456');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeTimeLimited()
 	{
 		$session = $this->app->session();
@@ -580,10 +496,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeTimeLimitedNoDebug()
 	{
 		$this->app = $this->app->clone([
@@ -617,10 +529,6 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeInvalidCode()
 	{
 		$this->expectException(PermissionException::class);
@@ -636,10 +544,6 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('654321');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
 	public function testVerifyChallengeInvalidChallenge()
 	{
 		$this->expectException(LogicException::class);

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthCsrfTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthCsrf';
@@ -31,9 +30,6 @@ class AuthCsrfTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromSession1()
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
@@ -42,9 +38,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromSession2()
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
@@ -53,9 +46,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromSession3()
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
@@ -64,9 +54,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertSame('session-csrf', $this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromSession4()
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
@@ -75,9 +62,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromOption1()
 	{
 		$this->app = $this->app->clone([
@@ -93,9 +77,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
 	public function testCsrfFromOption2()
 	{
 		$this->app = $this->app->clone([
@@ -111,10 +92,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertSame('option-csrf', $this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 * @covers ::csrfFromSession
-	 */
 	public function testCsrfFromOption3()
 	{
 		$this->app = $this->app->clone([
@@ -130,10 +107,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 * @covers ::csrfFromSession
-	 */
 	public function testCsrfFromOption4()
 	{
 		$this->app = $this->app->clone([
@@ -149,9 +122,6 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrfFromSession
-	 */
 	public function testCsrfFromSessionPanelDevOption()
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -6,10 +6,9 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthProtectionTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -62,17 +61,11 @@ class AuthProtectionTest extends TestCase
 		$this->failedEmail = null;
 	}
 
-	/**
-	 * @covers ::logfile
-	 */
 	public function testLogfile()
 	{
 		$this->assertSame(static::TMP . '/site/accounts/.logins', $this->auth->logfile());
 	}
 
-	/**
-	 * @covers ::log
-	 */
 	public function testLog()
 	{
 		copy(static::FIXTURES . '/logins.cleanup.json', static::TMP . '/site/accounts/.logins');
@@ -106,9 +99,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
 	}
 
-	/**
-	 * @covers ::ipHash
-	 */
 	public function testIpHash()
 	{
 		$this->app->visitor()->ip('10.1.123.234');
@@ -116,9 +106,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('87084f11690867b977a611dd2c943a918c3197f4c02b25ab59', $this->auth->ipHash());
 	}
 
-	/**
-	 * @covers ::isBlocked
-	 */
 	public function testIsBlocked()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -134,9 +121,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertTrue($this->auth->isBlocked('lisa@simpsons.com'));
 	}
 
-	/**
-	 * @covers ::track
-	 */
 	public function testTrack()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -192,9 +176,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame(json_encode($data), file_get_contents(static::TMP . '/site/accounts/.logins'));
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordValid()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -207,10 +188,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordInvalid1()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -230,10 +207,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('lisa@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordInvalid2()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -254,10 +227,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordBlocked()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -276,10 +245,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordDebugInvalid1()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -307,10 +272,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('lisa@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordDebugInvalid2()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -339,11 +300,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordDebugBlocked()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -370,9 +326,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordWithUnicodeEmail()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
@@ -384,9 +337,6 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('test@exämple.com', $user->email());
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
 	public function testValidatePasswordWithPunycodeEmail()
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -7,11 +7,10 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Session\AutoSession;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Throwable;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth';
@@ -65,12 +64,6 @@ class AuthTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::currentUserFromImpersonation
-	 * @covers ::impersonate
-	 * @covers ::status
-	 * @covers ::user
-	 */
 	public function testImpersonate()
 	{
 		$this->assertNull($this->auth->user());
@@ -141,9 +134,6 @@ class AuthTest extends TestCase
 		$this->assertNull($this->auth->user(null, false));
 	}
 
-	/**
-	 * @covers ::impersonate
-	 */
 	public function testImpersonateInvalidUser()
 	{
 		$this->expectException(NotFoundException::class);
@@ -152,9 +142,6 @@ class AuthTest extends TestCase
 		$this->auth->impersonate('lisa@simpsons.com');
 	}
 
-	/**
-	 * @covers ::login
-	 */
 	public function testLogin()
 	{
 		// set the status cache
@@ -171,9 +158,6 @@ class AuthTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->auth->status()->email());
 	}
 
-	/**
-	 * @covers ::login
-	 */
 	public function testLoginLong()
 	{
 		// set the status cache
@@ -190,9 +174,6 @@ class AuthTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->auth->status()->email());
 	}
 
-	/**
-	 * @covers ::login
-	 */
 	public function testLoginInvalidUser()
 	{
 		$this->expectException(PermissionException::class);
@@ -201,9 +182,6 @@ class AuthTest extends TestCase
 		$this->auth->login('lisa@simpsons.com', 'springfield123');
 	}
 
-	/**
-	 * @covers ::login
-	 */
 	public function testLoginInvalidPassword()
 	{
 		$this->expectException(PermissionException::class);
@@ -212,9 +190,6 @@ class AuthTest extends TestCase
 		$this->auth->login('marge@simpsons.com', 'springfield456');
 	}
 
-	/**
-	 * @covers ::login
-	 */
 	public function testLoginKirby()
 	{
 		$this->expectException(PermissionException::class);
@@ -226,9 +201,6 @@ class AuthTest extends TestCase
 		$this->auth->login('kirby@getkirby.com', 'somewhere-in-japan');
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeBasic1()
 	{
 		$app = $this->app->clone([
@@ -247,9 +219,6 @@ class AuthTest extends TestCase
 		$this->assertTrue($app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeBasic2()
 	{
 		// non-existing basic auth should
@@ -262,9 +231,6 @@ class AuthTest extends TestCase
 		$this->assertTrue($this->app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeBasic3()
 	{
 		// non-existing basic auth without
@@ -275,9 +241,6 @@ class AuthTest extends TestCase
 		$this->assertTrue($this->app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeBasic4()
 	{
 		$app = $this->app->clone([
@@ -298,9 +261,6 @@ class AuthTest extends TestCase
 		$this->assertFalse($app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeImpersonate()
 	{
 		$app = $this->app->clone([
@@ -316,9 +276,6 @@ class AuthTest extends TestCase
 		$this->assertSame('impersonate', $app->auth()->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeSession()
 	{
 		$app = $this->app->clone([
@@ -332,10 +289,6 @@ class AuthTest extends TestCase
 		$this->assertSame('session', $app->auth()->type());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
 	public function testUserSession()
 	{
 		$session = $this->app->session();
@@ -364,10 +317,6 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
 	public function testUserSessionManualSession()
 	{
 		$session = (new AutoSession($this->app->root('sessions')))->createManually();
@@ -383,9 +332,6 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::currentUserFromSession
-	 */
 	public function testUserSessionOldTimestamp()
 	{
 		$session = $this->app->session();
@@ -403,9 +349,6 @@ class AuthTest extends TestCase
 		$this->assertSame([], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::currentUserFromSession
-	 */
 	public function testUserSessionNoTimestamp()
 	{
 		$session = $this->app->session();
@@ -422,10 +365,6 @@ class AuthTest extends TestCase
 		$this->assertSame([], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
 	public function testUserBasicAuth()
 	{
 		$this->app->clone([
@@ -444,9 +383,6 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserBasicAuthInvalid1()
 	{
 		$this->expectException(PermissionException::class);
@@ -461,9 +397,6 @@ class AuthTest extends TestCase
 		$this->auth->user();
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserBasicAuthInvalid2()
 	{
 		$this->expectException(PermissionException::class);

--- a/tests/Cms/Auth/Challenge/ChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/ChallengeTest.php
@@ -7,6 +7,7 @@ use Kirby\Cms\TestCase;
 use Kirby\Cms\User;
 use Kirby\Filesystem\Dir;
 use Kirby\Session\Session;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class MockChallenge extends Challenge
 {
@@ -19,9 +20,7 @@ class MockChallenge extends Challenge
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\Challenge
- */
+#[CoversClass(Challenge::class)]
 class ChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.Challenge';
@@ -50,9 +49,6 @@ class ChallengeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::verify
-	 */
 	public function testVerify()
 	{
 		$user = $this->app->user('homer@simpsons.com');

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Email\Email;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\EmailChallenge
- */
+#[CoversClass(EmailChallenge::class)]
 class EmailChallengeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures';
@@ -57,18 +56,12 @@ class EmailChallengeTest extends TestCase
 		unset($_SERVER['SERVER_NAME']);
 	}
 
-	/**
-	 * @covers ::isAvailable
-	 */
 	public function testIsAvailable()
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$this->assertTrue(EmailChallenge::isAvailable($user, 'login'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateLogin()
 	{
 		$user = $this->app->user('homer@simpsons.com');
@@ -95,9 +88,6 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreatePathUrl()
 	{
 		$app = $this->app->clone([
@@ -126,9 +116,6 @@ class EmailChallengeTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate2FA()
 	{
 		$user = $this->app->user('homer@simpsons.com');
@@ -155,9 +142,6 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateReset()
 	{
 		$user = $this->app->user('marge@simpsons.com');
@@ -184,9 +168,6 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateResetUserLanguage()
 	{
 		$user = $this->app->user('bart@simpsons.com');
@@ -213,9 +194,6 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateCustom()
 	{
 		$this->app = $this->app->clone([
@@ -247,9 +225,6 @@ class EmailChallengeTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateCustomHtml()
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/Auth/Challenge/TotpChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/TotpChallengeTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\TotpChallenge
- */
+#[CoversClass(TotpChallenge::class)]
 class TotpChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.TotpChallenge';
@@ -36,9 +35,6 @@ class TotpChallengeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::isAvailable
-	 */
 	public function testIsAvailable()
 	{
 		$user = $this->app->user('homer@simpsons.com');
@@ -47,18 +43,12 @@ class TotpChallengeTest extends TestCase
 		$this->assertTrue(TotpChallenge::isAvailable($user, 'login'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate()
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$this->assertNull(TotpChallenge::create($user, []));
 	}
 
-	/**
-	 * @covers ::verify
-	 */
 	public function testVerify()
 	{
 		$user = $this->app->user('homer@simpsons.com');

--- a/tests/Cms/Auth/StatusTest.php
+++ b/tests/Cms/Auth/StatusTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Cms\Auth;
 use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\Status
- * @covers ::__construct
- */
+#[CoversClass(Status::class)]
 class StatusTest extends TestCase
 {
 	public function setUp(): void
@@ -27,9 +25,6 @@ class StatusTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$status = new Status([
@@ -40,9 +35,6 @@ class StatusTest extends TestCase
 		$this->assertSame('active', (string)$status);
 	}
 
-	/**
-	 * @covers ::challenge
-	 */
 	public function testChallenge()
 	{
 		// no challenge when not in pending status
@@ -82,9 +74,6 @@ class StatusTest extends TestCase
 		$this->assertNull($status->challenge(false));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmail()
 	{
 		$status = new Status([
@@ -101,9 +90,6 @@ class StatusTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $status->email());
 	}
 
-	/**
-	 * @covers ::status
-	 */
 	public function testStatus()
 	{
 		$status = new Status([
@@ -138,9 +124,6 @@ class StatusTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$status = new Status([
@@ -158,9 +141,6 @@ class StatusTest extends TestCase
 		], $status->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUser()
 	{
 		// only return active users

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -7,10 +7,9 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Blueprint
- */
+#[CoversClass(Blueprint::class)]
 class BlueprintTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Blueprint';
@@ -35,9 +34,6 @@ class BlueprintTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithoutModel()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -46,9 +42,6 @@ class BlueprintTest extends TestCase
 		new Blueprint([]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructInvalidModel()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -112,9 +105,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame($expected['main'], $blueprint->tab());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
 	public function testAcceptedFileTemplatesDefault()
 	{
 		$blueprint = new Blueprint([
@@ -130,9 +120,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['default'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
 	public function testAcceptedFileTemplatesFromFields()
 	{
 		$this->app = new App([
@@ -217,9 +204,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b', 'c', 'd', 'e'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
 	public function testAcceptedFileTemplatesFromFieldsAndSections()
 	{
 		$this->app = new App([
@@ -270,9 +254,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b', 'c'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
 	public function testAcceptedFileTemplatesFromSection()
 	{
 		$this->app = new App([
@@ -300,9 +281,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a'], $blueprint->acceptedFileTemplates('a'));
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
 	public function testAcceptedFileTemplatesFromSections()
 	{
 		$this->app = new App([
@@ -337,9 +315,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons()
 	{
 		$blueprint = new Blueprint([
@@ -351,9 +326,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['foo', 'bar'], $blueprint->buttons());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtonsDisabled()
 	{
 		$blueprint = new Blueprint([
@@ -365,9 +337,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame(false, $blueprint->buttons());
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 */
 	public function testDebugInfo()
 	{
 		$blueprint = new Blueprint([
@@ -460,9 +429,6 @@ class BlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitle()
 	{
 		$blueprint = new Blueprint([
@@ -473,9 +439,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitleTranslated()
 	{
 		$blueprint = new Blueprint([
@@ -486,9 +449,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitleTranslatedFallback()
 	{
 		I18n::$locale       = 'de';
@@ -536,9 +496,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('My custom role', $role);
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitleFromName()
 	{
 		$blueprint = new Blueprint([
@@ -555,9 +512,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtend()
 	{
 		new App([
@@ -576,9 +530,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Extension Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtendWithInvalidSnippet()
 	{
 		$blueprint = new Blueprint([
@@ -589,9 +540,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Default', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtendMultiple()
 	{
 		new App([
@@ -632,10 +580,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('1/3', $field['width']);
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
 	public function testFactory()
 	{
 		Blueprint::$loaded = [];
@@ -652,10 +596,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
 	public function testFactoryWithCallbackArray()
 	{
 		Blueprint::$loaded = [];
@@ -672,10 +612,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
 	public function testFactoryWithCallbackString()
 	{
 		Blueprint::$loaded = [];
@@ -698,19 +634,12 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryForMissingBlueprint()
 	{
 		$blueprint = Blueprint::factory('notFound', null, new Page(['slug' => 'test']));
 		$this->assertNull($blueprint);
 	}
 
-	/**
-	 * @covers ::fields
-	 * @covers ::field
-	 */
 	public function testFields()
 	{
 		$blueprint = new Blueprint([
@@ -729,9 +658,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame($fields['test'], $blueprint->field('test'));
 	}
 
-	/**
-	 * @covers ::fields
-	 */
 	public function testNestedFields()
 	{
 		$blueprint = new Blueprint([
@@ -784,9 +710,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Invalid section type for section "main"', $sections['main']['label']);
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
 	public function testIsDefault()
 	{
 		$blueprint = new Blueprint([
@@ -821,9 +744,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('info', $blueprint->sections()['info']->type());
 	}
 
-	/**
-	 * @covers ::preset
-	 */
 	public function testPreset()
 	{
 		$blueprint = new Blueprint([

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -2,12 +2,13 @@
 
 use Kirby\Cms\Blueprint;
 use Kirby\Cms\File;
+use Kirby\Cms\FileBlueprint;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\FileBlueprint
- */
+#[CoversClass(FileBlueprint::class)]
 class FileBlueprintTest extends TestCase
 {
 	public static function acceptAttributeProvider()
@@ -61,11 +62,8 @@ class FileBlueprintTest extends TestCase
 		unset(Blueprint::$loaded['files/acceptAttribute']);
 	}
 
-	/**
-	 * @covers ::acceptAttribute
-	 * @dataProvider acceptAttributeProvider
-	 */
-	public function testAcceptAttribute($accept, $expected, $notExpected)
+	#[DataProvider('acceptAttributeProvider')]
+	public function testAcceptAttribute(string|array $accept, array $expected, array $notExpected)
 	{
 		Blueprint::$loaded['files/acceptAttribute'] = [
 			'accept' => $accept

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Core
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Core::class)]
 class CoreTest extends TestCase
 {
 	protected Core $core;
@@ -15,9 +15,6 @@ class CoreTest extends TestCase
 		$this->core = new Core($this->app);
 	}
 
-	/**
-	 * @covers ::area
-	 */
 	public function testArea()
 	{
 		$area = $this->core->area('site');
@@ -25,9 +22,6 @@ class CoreTest extends TestCase
 		$this->assertSame('Site', $area['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreas()
 	{
 		$areas = $this->core->areas();
@@ -39,18 +33,12 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('users', $areas);
 	}
 
-	/**
-	 * @covers ::authChallenges
-	 */
 	public function testAuthChallenges()
 	{
 		$authChallenges = $this->core->authChallenges();
 		$this->assertArrayHasKey('email', $authChallenges);
 	}
 
-	/**
-	 * @covers ::blueprintPresets
-	 */
 	public function testBlueprintPresets()
 	{
 		$blueprintPresets = $this->core->blueprintPresets();
@@ -59,9 +47,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('files', $blueprintPresets);
 	}
 
-	/**
-	 * @covers ::blueprints
-	 */
 	public function testBlueprints()
 	{
 		$blueprints = $this->core->blueprints();
@@ -83,9 +68,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('site', $blueprints);
 	}
 
-	/**
-	 * @covers ::caches
-	 */
 	public function testCaches()
 	{
 		$caches = $this->core->caches();
@@ -94,9 +76,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('uuid', $caches);
 	}
 
-	/**
-	 * @covers ::cacheTypes
-	 */
 	public function testCacheTypes()
 	{
 		$cacheTypes = $this->core->cacheTypes();
@@ -107,9 +86,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('memory', $cacheTypes);
 	}
 
-	/**
-	 * @covers ::components
-	 */
 	public function testComponents()
 	{
 		$components = $this->core->components();
@@ -127,9 +103,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('url', $components);
 	}
 
-	/**
-	 * @covers ::fieldMethodAliases
-	 */
 	public function testFieldMethodAliases()
 	{
 		$aliases = $this->core->fieldMethodAliases();
@@ -149,9 +122,6 @@ class CoreTest extends TestCase
 		$this->assertSame('xml', $aliases['x']);
 	}
 
-	/**
-	 * @covers ::fieldMethods
-	 */
 	public function testFieldMethods()
 	{
 		$methods = $this->core->fieldMethods();
@@ -203,9 +173,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('yaml', $methods);
 	}
 
-	/**
-	 * @covers ::fieldMixins
-	 */
 	public function testFieldMixins()
 	{
 		$mixins = $this->core->fieldMixins();
@@ -221,9 +188,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('userpicker', $mixins);
 	}
 
-	/**
-	 * @covers ::fields
-	 */
 	public function testFields()
 	{
 		$fields = $this->core->fields();
@@ -259,18 +223,12 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('writer', $fields);
 	}
 
-	/**
-	 * @covers ::area
-	 */
 	public function testFilePreviews()
 	{
 		$previews = $this->core->filePreviews();
 		$this->assertCount(4, $previews);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad()
 	{
 		$loader = $this->core->load();
@@ -279,9 +237,6 @@ class CoreTest extends TestCase
 		$this->assertFalse($loader->withPlugins());
 	}
 
-	/**
-	 * @covers ::roots
-	 */
 	public function testRoots()
 	{
 		$roots = $this->core->roots();
@@ -314,9 +269,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('roles', $roots);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes()
 	{
 		$routes = $this->core->routes();
@@ -325,9 +277,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('after', $routes);
 	}
 
-	/**
-	 * @covers ::snippets
-	 */
 	public function testSnippets()
 	{
 		$snippets = $this->core->snippets();
@@ -345,9 +294,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('blocks/video', $snippets);
 	}
 
-	/**
-	 * @covers ::kirbyTagAliases
-	 */
 	public function testKirbyTagAliases()
 	{
 		$aliases = $this->core->kirbyTagAliases();
@@ -356,9 +302,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('vimeo', $aliases);
 	}
 
-	/**
-	 * @covers ::kirbyTags
-	 */
 	public function testKirbyTags()
 	{
 		$tags = $this->core->kirbyTags();
@@ -373,9 +316,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('video', $tags);
 	}
 
-	/**
-	 * @covers ::sectionMixins
-	 */
 	public function testSectionMixins()
 	{
 		$mixins = $this->core->sectionMixins();
@@ -390,9 +330,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('parent', $mixins);
 	}
 
-	/**
-	 * @covers ::sections
-	 */
 	public function testSections()
 	{
 		$sections = $this->core->sections();
@@ -403,9 +340,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('pages', $sections);
 	}
 
-	/**
-	 * @covers ::templates
-	 */
 	public function testTemplates()
 	{
 		$templates = $this->core->templates();
@@ -414,9 +348,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('emails/auth/password-reset', $templates);
 	}
 
-	/**
-	 * @covers ::urls
-	 */
 	public function testUrls()
 	{
 		$urls = $this->core->urls();

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -214,10 +214,8 @@ class EmailTest extends TestCase
 		], $email->toArray()['to']);
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 	public function testUserData()
 	{
 		$app = new App([

--- a/tests/Cms/EventTest.php
+++ b/tests/Cms/EventTest.php
@@ -3,20 +3,11 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Event
- */
+#[CoversClass(Event::class)]
 class EventTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::action
-	 * @covers ::arguments
-	 * @covers ::name
-	 * @covers ::state
-	 * @covers ::type
-	 */
 	public function testConstruct()
 	{
 		$args = ['arg1' => 'Arg1', 'arg2' => 123];
@@ -70,10 +61,6 @@ class EventTest extends TestCase
 		$this->assertSame($args, $event->arguments());
 	}
 
-	/**
-	 * @covers ::__call
-	 * @covers ::argument
-	 */
 	public function testArgument()
 	{
 		$event = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
@@ -87,9 +74,6 @@ class EventTest extends TestCase
 		$this->assertNull($event->arg3());
 	}
 
-	/**
-	 * @covers ::call
-	 */
 	public function testCall()
 	{
 		$self     = $this;
@@ -120,9 +104,6 @@ class EventTest extends TestCase
 		$this->assertSame('another value', $result);
 	}
 
-	/**
-	 * @covers ::nameWildcards
-	 */
 	public function testNameWildcards()
 	{
 		// event with full name
@@ -192,11 +173,6 @@ class EventTest extends TestCase
 		$this->assertSame([], $event->nameWildcards());
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toArray
-	 * @covers ::toString
-	 */
 	public function testExport()
 	{
 		$name       = 'page.create:after';
@@ -210,9 +186,6 @@ class EventTest extends TestCase
 		$this->assertSame(compact('name', 'arguments'), $event->__debugInfo());
 	}
 
-	/**
-	 * @covers ::updateArgument
-	 */
 	public function testUpdateArgument()
 	{
 		$event = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
@@ -226,9 +199,6 @@ class EventTest extends TestCase
 		$this->assertSame(456, $event->arg2());
 	}
 
-	/**
-	 * @covers ::updateArgument
-	 */
 	public function testUpdateArgumentDoesNotExist()
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Url
- */
+#[CoversClass(Url::class)]
 class UrlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Url';
@@ -28,9 +27,6 @@ class UrlTest extends TestCase
 		$this->assertSame('https://getkirby.com', Url::home());
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlug()
 	{
 		// default length

--- a/tests/Cms/Facades/VTest.php
+++ b/tests/Cms/Facades/VTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Toolkit\V;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class VTest extends TestCase
 {
@@ -53,10 +54,8 @@ class VTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider messageInput
-	 */
-	public function testMessage($validator, $args, $expected)
+	#[DataProvider('messageInput')]
+	public function testMessage(string $validator, array $args, string $expected)
 	{
 		$this->assertSame($expected, V::message($validator, ...$args));
 	}

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Form;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Fieldset
- */
+#[CoversClass(Fieldset::class)]
 class FieldsetTest extends TestCase
 {
 	public function testConstruct()
@@ -32,9 +31,6 @@ class FieldsetTest extends TestCase
 		$fieldset = new Fieldset();
 	}
 
-	/**
-	 * @covers ::disabled
-	 */
 	public function testDisabled()
 	{
 		$fieldset = new Fieldset([
@@ -45,9 +41,6 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->disabled());
 	}
 
-	/**
-	 * @covers ::editable
-	 */
 	public function testEditable()
 	{
 		$fieldset = new Fieldset([
@@ -62,9 +55,6 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->editable());
 	}
 
-	/**
-	 * @covers ::editable
-	 */
 	public function testEditableWhenDisabled()
 	{
 		$fieldset = new Fieldset([
@@ -80,9 +70,6 @@ class FieldsetTest extends TestCase
 		$this->assertFalse($fieldset->editable());
 	}
 
-	/**
-	 * @covers ::fields
-	 */
 	public function testFields()
 	{
 		$fieldset = new Fieldset([
@@ -97,9 +84,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
-	/**
-	 * @covers ::fields
-	 */
 	public function testFieldsInTabs()
 	{
 		$fieldset = new Fieldset([
@@ -118,9 +102,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
-	/**
-	 * @covers ::form
-	 */
 	public function testForm()
 	{
 		$fieldset = new Fieldset([
@@ -136,9 +117,6 @@ class FieldsetTest extends TestCase
 		$this->assertInstanceOf(Form::class, $form);
 	}
 
-	/**
-	 * @covers ::icon
-	 */
 	public function testIcon()
 	{
 		$fieldset = new Fieldset([
@@ -149,9 +127,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->icon());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel()
 	{
 		$fieldset = new Fieldset([
@@ -162,9 +137,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('Test', $fieldset->label());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabelWithTranslation()
 	{
 		$fieldset = new Fieldset([
@@ -178,9 +150,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English', $fieldset->label());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$fieldset = new Fieldset([
@@ -191,9 +160,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame($model, $fieldset->model());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$fieldset = new Fieldset([
@@ -204,9 +170,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testNameTranslated()
 	{
 		$fieldset = new Fieldset([
@@ -220,9 +183,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English name', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testNameFromTitle()
 	{
 		$fieldset = new Fieldset([
@@ -233,9 +193,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('Test Title', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testNameFromTitleTranslated()
 	{
 		$fieldset = new Fieldset([
@@ -249,9 +206,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English name', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::preview
-	 */
 	public function testPreview()
 	{
 		$fieldset = new Fieldset([
@@ -262,9 +216,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->preview());
 	}
 
-	/**
-	 * @covers ::tabs
-	 */
 	public function testTabs()
 	{
 		$fieldset = new Fieldset([
@@ -282,9 +233,6 @@ class FieldsetTest extends TestCase
 		$this->assertCount(2, $fieldset->tabs()['content']['fields']);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslate()
 	{
 		$fieldset = new Fieldset([
@@ -295,9 +243,6 @@ class FieldsetTest extends TestCase
 		$this->assertFalse($fieldset->translate());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$fieldset = new Fieldset([
@@ -307,9 +252,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->type());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$fieldset = new Fieldset([
@@ -337,9 +279,6 @@ class FieldsetTest extends TestCase
 		$this->assertSame($expected, $fieldset->toArray());
 	}
 
-	/**
-	 * @covers ::unset
-	 */
 	public function testUnset()
 	{
 		$fieldset = new Fieldset([
@@ -350,9 +289,6 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->unset());
 	}
 
-	/**
-	 * @covers ::wysiwyg
-	 */
 	public function testWysiwyg()
 	{
 		$fieldset = new Fieldset([

--- a/tests/Cms/Files/FileActionsTest.php
+++ b/tests/Cms/Files/FileActionsTest.php
@@ -8,6 +8,7 @@ use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
 use Kirby\Image\Image;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
 class FileActionsTest extends TestCase
@@ -97,9 +98,7 @@ class FileActionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
+	#[DataProvider('fileProvider')]
 	public function testChangeName(File $file)
 	{
 		// create an empty dummy file
@@ -130,9 +129,7 @@ class FileActionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider fileProviderMultiLang
-	 */
+	#[DataProvider('fileProviderMultiLang')]
 	public function testChangeNameMultiLang(File $file)
 	{
 		$app = static::appWithLanguages();
@@ -721,10 +718,8 @@ class FileActionsTest extends TestCase
 		$this->assertNotSame($oldUuid, $newUuid);
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreate($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreate(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::TMP . '/source.md';
 
@@ -746,10 +741,8 @@ class FileActionsTest extends TestCase
 		$this->assertIsString($result->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateDuplicate($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateDuplicate(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::TMP . '/source.md';
 
@@ -773,10 +766,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame($uuid, $duplicate->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateMove($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateMove(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::TMP . '/source.md';
 
@@ -798,10 +789,8 @@ class FileActionsTest extends TestCase
 		$this->assertIsString($result->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateWithDefaults($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateWithDefaults(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::TMP . '/source.md';
 
@@ -831,10 +820,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame('B', $result->b()->value());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateWithDefaultsAndContent($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateWithDefaultsAndContent(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::TMP . '/source.md';
 
@@ -867,10 +854,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame('B', $result->b()->value());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateImage($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateImage(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::FIXTURES . '/test.jpg';
 
@@ -885,10 +870,8 @@ class FileActionsTest extends TestCase
 		$this->assertInstanceOf(Image::class, $result->asset());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateImageAndManipulate($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateImageAndManipulate(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::FIXTURES . '/test.jpg';
 		$result = File::create([
@@ -913,10 +896,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame('test.webp', $result->filename());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateManipulateNonImage($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateManipulateNonImage(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$source = static::FIXTURES . '/test.pdf';
 
@@ -937,10 +918,8 @@ class FileActionsTest extends TestCase
 		$this->assertFileEquals($source, $result->root());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testCreateHooks($parent)
+	#[DataProvider('parentProvider')]
+	public function testCreateHooks(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$phpunit = $this;
 		$before  = false;
@@ -974,9 +953,7 @@ class FileActionsTest extends TestCase
 		$this->assertTrue($after);
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
+	#[DataProvider('fileProvider')]
 	public function testDelete(File $file)
 	{
 		// create an empty dummy file
@@ -995,10 +972,8 @@ class FileActionsTest extends TestCase
 		$this->assertFileDoesNotExist($file->version(VersionId::latest())->contentFile('default'));
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testPublish($file)
+	#[DataProvider('fileProvider')]
+	public function testPublish(\Kirby\Cms\File|null $file)
 	{
 		// create an empty dummy file
 		F::write($file->root(), '');
@@ -1010,10 +985,8 @@ class FileActionsTest extends TestCase
 		$this->assertFileExists($file->mediaRoot());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testReplace($parent)
+	#[DataProvider('parentProvider')]
+	public function testReplace(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$original    = static::TMP . '/original.md';
 		$replacement = static::TMP . '/replacement.md';
@@ -1040,10 +1013,8 @@ class FileActionsTest extends TestCase
 		$this->assertInstanceOf(BaseFile::class, $replacedFile->asset());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testReplaceMove($parent)
+	#[DataProvider('parentProvider')]
+	public function testReplaceMove(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$original    = static::TMP . '/original.md';
 		$replacement = static::TMP . '/replacement.md';
@@ -1070,10 +1041,8 @@ class FileActionsTest extends TestCase
 		$this->assertInstanceOf(BaseFile::class, $replacedFile->asset());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testReplaceImage($parent)
+	#[DataProvider('parentProvider')]
+	public function testReplaceImage(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$original    = static::FIXTURES . '/test.jpg';
 		$replacement = static::FIXTURES . '/cat.jpg';
@@ -1093,10 +1062,8 @@ class FileActionsTest extends TestCase
 		$this->assertInstanceOf(Image::class, $replacedFile->asset());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testReplaceManipulateNonImage($parent)
+	#[DataProvider('parentProvider')]
+	public function testReplaceManipulateNonImage(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$original    = static::FIXTURES . '/test.pdf';
 		$replacement = static::FIXTURES . '/doc.pdf';
@@ -1122,10 +1089,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame('pdf', $replacedFile->extension());
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testSave($file)
+	#[DataProvider('fileProvider')]
+	public function testSave(\Kirby\Cms\File|null $file)
 	{
 		// create an empty dummy file
 		F::write($file->root(), '');
@@ -1138,10 +1103,8 @@ class FileActionsTest extends TestCase
 		$this->assertFileExists($file->version(VersionId::latest())->contentFile('default'));
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testUnpublish($file)
+	#[DataProvider('fileProvider')]
+	public function testUnpublish(\Kirby\Cms\File|null $file)
 	{
 		// create an empty dummy file
 		F::write($file->root(), '');
@@ -1153,10 +1116,8 @@ class FileActionsTest extends TestCase
 		$this->assertFileDoesNotExist($file->mediaRoot());
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testUpdate($file)
+	#[DataProvider('fileProvider')]
+	public function testUpdate(\Kirby\Cms\File|null $file)
 	{
 		$file = $file->update([
 			'caption' => $caption = 'test',
@@ -1167,10 +1128,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame($template, $file->template());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testManipulate($parent)
+	#[DataProvider('parentProvider')]
+	public function testManipulate(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$originalFile = File::create([
 			'filename' => 'test.jpg',
@@ -1191,10 +1150,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame(100, $replacedFile->height());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testManipulateNonImage($parent)
+	#[DataProvider('parentProvider')]
+	public function testManipulateNonImage(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$originalFile = File::create([
 			'filename' => 'test.mp4',
@@ -1211,10 +1168,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame($originalFile, $replacedFile);
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testManipulateValidFormat($parent)
+	#[DataProvider('parentProvider')]
+	public function testManipulateValidFormat(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$originalFile = File::create([
 			'filename' => 'test.jpg',
@@ -1236,10 +1191,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame(100, $replacedFile->height());
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testManipulateInvalidValidFormat($parent)
+	#[DataProvider('parentProvider')]
+	public function testManipulateInvalidValidFormat(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$originalFile = File::create([
 			'filename' => 'test.mp4',
@@ -1332,10 +1285,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testDeleteHooks($parent)
+	#[DataProvider('parentProvider')]
+	public function testDeleteHooks(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$calls = 0;
 		$phpunit = $this;
@@ -1370,10 +1321,8 @@ class FileActionsTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @dataProvider parentProvider
-	 */
-	public function testReplaceHooks($parent)
+	#[DataProvider('parentProvider')]
+	public function testReplaceHooks(\Kirby\Cms\Site|\Kirby\Cms\Page $parent)
 	{
 		$calls = 0;
 		$phpunit = $this;

--- a/tests/Cms/Files/FileModificationsTest.php
+++ b/tests/Cms/Files/FileModificationsTest.php
@@ -6,6 +6,7 @@ use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Asset;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FileModificationsTest extends TestCase
 {
@@ -270,10 +271,8 @@ class FileModificationsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider cropOptionsProvider
-	 */
-	public function testCrop($args, $expected)
+	#[DataProvider('cropOptionsProvider')]
+	public function testCrop(array $args, array $expected)
 	{
 		$app = $this->app->clone([
 			'components' => [

--- a/tests/Cms/Files/FilePermissionsTest.php
+++ b/tests/Cms/Files/FilePermissionsTest.php
@@ -4,10 +4,11 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\FilePermissions
- */
+#[CoversClass(FilePermissions::class)]
+#[CoversClass(ModelPermissions::class)]
 class FilePermissionsTest extends TestCase
 {
 	public function setUp(): void
@@ -37,11 +38,8 @@ class FilePermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin(string $action)
 	{
 		$this->app->impersonate('kirby');
 
@@ -55,11 +53,8 @@ class FilePermissionsTest extends TestCase
 		$this->assertTrue($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action)
 	{
 		$page  = new Page(['slug' => 'test']);
 		$file  = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -68,9 +63,6 @@ class FilePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
-	 */
 	public function testCanFromCache()
 	{
 		$this->app->impersonate('bastian');
@@ -95,9 +87,6 @@ class FilePermissionsTest extends TestCase
 		$this->assertFalse(FilePermissions::canFromCache($file, 'list'));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
-	 */
 	public function testCanFromCacheDynamic()
 	{
 		$this->expectException(LogicException::class);
@@ -113,9 +102,6 @@ class FilePermissionsTest extends TestCase
 		FilePermissions::canFromCache($file, 'changeTemplate');
 	}
 
-	/**
-	 * @covers ::canChangeTemplate
-	 */
 	public function testCannotChangeTemplate()
 	{
 		$this->app->impersonate('kirby');
@@ -126,9 +112,6 @@ class FilePermissionsTest extends TestCase
 		$this->assertFalse($file->permissions()->can('changeTemplate'));
 	}
 
-	/**
-	 * @covers ::canChangeTemplate
-	 */
 	public function testCanChangeTemplate()
 	{
 		$this->app = new App([

--- a/tests/Cms/Files/FileRulesTest.php
+++ b/tests/Cms/Files/FileRulesTest.php
@@ -9,6 +9,7 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FileRulesTest extends TestCase
 {
@@ -523,10 +524,8 @@ class FileRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider extensionProvider
-	 */
-	public function testValidExtension($extension, $expected, $message = null)
+	#[DataProvider('extensionProvider')]
+	public function testValidExtension(string $extension, bool $expected, string|null $message = null)
 	{
 		$file = $this->createMock(File::class);
 		$file->method('filename')->willReturn('test');
@@ -582,10 +581,8 @@ class FileRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testValidFile($filename, $extension, $mime, $expected, $message = null)
+	#[DataProvider('fileProvider')]
+	public function testValidFile(string $filename, string $extension, string $mime, bool $expected, string|null $message = null)
 	{
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
@@ -636,10 +633,8 @@ class FileRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider filenameProvider
-	 */
-	public function testValidFilename($filename, $expected, $message = null)
+	#[DataProvider('filenameProvider')]
+	public function testValidFilename(string $filename, bool $expected, string|null $message = null)
 	{
 		$file = $this->createMock(File::class);
 		$file->method('filename')->willReturn($filename);
@@ -666,10 +661,8 @@ class FileRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider mimeProvider
-	 */
-	public function testValidMime($mime, $expected, $message = null)
+	#[DataProvider('mimeProvider')]
+	public function testValidMime(string $mime, bool $expected, string|null $message = null)
 	{
 		$file = $this->createMock(File::class);
 		$file->method('filename')->willReturn('test');

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -5,14 +5,13 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
 use Kirby\Panel\File as Panel;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class FileTestModel extends File
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\File
- */
+#[CoversClass(File::class)]
 class FileTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.File';
@@ -304,9 +303,6 @@ class FileTest extends TestCase
 		$this->assertSame($this->defaults()['filename'], $this->file()->filename());
 	}
 
-	/**
-	 * @covers ::contentFileData
-	 */
 	public function testContentFileData()
 	{
 		$file = $this->file();
@@ -705,9 +701,6 @@ class FileTest extends TestCase
 		$this->assertInstanceOf(Panel::class, $file->panel());
 	}
 
-	/**
-	 * @covers ::permalink
-	 */
 	public function testPermalink()
 	{
 		$page = new Page([

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -6,10 +6,9 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Files
- */
+#[CoversClass(Files::class)]
 class FilesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Files';
@@ -118,9 +117,6 @@ class FilesTest extends TestCase
 		$files->add($site);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$app = new App([
@@ -162,9 +158,6 @@ class FilesTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithInvalidIds()
 	{
 		$app = new App([
@@ -211,10 +204,6 @@ class FilesTest extends TestCase
 		$this->assertFileExists($b);
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByUuid
-	 */
 	public function testFindByUuid()
 	{
 		$app = $this->app->clone([
@@ -242,10 +231,6 @@ class FilesTest extends TestCase
 		Uuids::cache()->flush();
 	}
 
-	/**
-	 * @covers ::niceSize
-	 * @covers ::size
-	 */
 	public function testSize()
 	{
 		$app = new App([
@@ -272,9 +257,6 @@ class FilesTest extends TestCase
 		$this->assertSame('6 B', $files->niceSize());
 	}
 
-	/**
-	 * @covers ::sorted
-	 */
 	public function testSortedByFilename()
 	{
 		$app = new App([
@@ -295,9 +277,6 @@ class FilesTest extends TestCase
 		$this->assertSame('b.jpg', $files->last()->filename());
 	}
 
-	/**
-	 * @covers ::sorted
-	 */
 	public function testSortedBySort()
 	{
 		$app = new App([

--- a/tests/Cms/Files/HasFilesTest.php
+++ b/tests/Cms/Files/HasFilesTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\File as BaseFile;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HasFileTraitUser
 {
@@ -129,10 +130,8 @@ class HasFilesTest extends TestCase
 		$this->assertSame('mother/child/file.jpg', $file->id());
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testTypes($filename, $type, $expected)
+	#[DataProvider('fileProvider')]
+	public function testTypes(string $filename, string $type, bool $expected)
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -149,10 +148,8 @@ class HasFilesTest extends TestCase
 		}
 	}
 
-	/**
-	 * @dataProvider fileProvider
-	 */
-	public function testHas($filename, $type, $expected)
+	#[DataProvider('fileProvider')]
+	public function testHas(string $filename, string $type, bool $expected)
 	{
 		$page = new Page([
 			'slug' => 'test'

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Find
- */
+#[CoversClass(Find::class)]
 class FindTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Find';
@@ -24,9 +23,6 @@ class FindTest extends TestCase
 		Dir::make(static::TMP);
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForPage(): void
 	{
 		$app = $this->app->clone([
@@ -55,9 +51,6 @@ class FindTest extends TestCase
 		$this->assertSame('aa.jpg', Find::file('pages/a+aa', 'aa.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForSite(): void
 	{
 		$app = $this->app->clone([
@@ -72,9 +65,6 @@ class FindTest extends TestCase
 		$this->assertSame('test.jpg', Find::file('site', 'test.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForUser(): void
 	{
 		$app = $this->app->clone([
@@ -92,9 +82,6 @@ class FindTest extends TestCase
 		$this->assertSame('test.jpg', Find::file('users/test@getkirby.com', 'test.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileNotFound()
 	{
 		$this->expectException(NotFoundException::class);
@@ -103,9 +90,6 @@ class FindTest extends TestCase
 		Find::file('site', 'nope.jpg');
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileNotReadable()
 	{
 		$app = $this->app->clone([
@@ -125,9 +109,6 @@ class FindTest extends TestCase
 		Find::file('site', 'protected.jpg');
 	}
 
-	/**
-	 * @covers ::language
-	 */
 	public function testLanguage()
 	{
 		$app = $this->app->clone([
@@ -150,9 +131,6 @@ class FindTest extends TestCase
 		$this->assertSame('de', Find::language('de')->code());
 	}
 
-	/**
-	 * @covers ::language
-	 */
 	public function testLanguageNotFound()
 	{
 		$this->app->impersonate('kirby');
@@ -163,9 +141,6 @@ class FindTest extends TestCase
 		Find::language('en');
 	}
 
-	/**
-	 * @covers ::page
-	 */
 	public function testPage()
 	{
 		$app = $this->app->clone([
@@ -199,9 +174,6 @@ class FindTest extends TestCase
 		$this->assertSame($b, Find::page('page://my-uuid'));
 	}
 
-	/**
-	 * @covers ::page
-	 */
 	public function testPageNotReadable()
 	{
 		$app = $this->app->clone([
@@ -228,9 +200,6 @@ class FindTest extends TestCase
 		Find::page('a');
 	}
 
-	/**
-	 * @covers ::page
-	 */
 	public function testPageNotFound()
 	{
 		$this->expectException(NotFoundException::class);
@@ -239,9 +208,6 @@ class FindTest extends TestCase
 		Find::page('does-not-exist');
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParent()
 	{
 		$app = $this->app->clone([
@@ -302,9 +268,6 @@ class FindTest extends TestCase
 		$this->assertIsFile(Find::parent('users/test@getkirby.com/files/userfile.jpg'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParentWithInvalidModelType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -312,9 +275,6 @@ class FindTest extends TestCase
 		$this->assertNull(Find::parent('something/something'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParentNotFound()
 	{
 		$this->expectException(NotFoundException::class);
@@ -322,9 +282,6 @@ class FindTest extends TestCase
 		$this->assertNull(Find::parent('pages/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParentUndefined()
 	{
 		$this->expectException(NotFoundException::class);
@@ -332,9 +289,6 @@ class FindTest extends TestCase
 		$this->assertNull(Find::parent('users/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUser()
 	{
 		$app = $this->app->clone([
@@ -350,9 +304,6 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user('test@getkirby.com')->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserWithAuthentication()
 	{
 		$app = $this->app->clone([
@@ -372,9 +323,6 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user()->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserWithoutAllowedImpersonation()
 	{
 		$app = $this->app->clone([
@@ -393,9 +341,6 @@ class FindTest extends TestCase
 		Find::user()->email();
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserForAccountArea()
 	{
 		$app = $this->app->clone([
@@ -416,9 +361,6 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user('account')->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserNotFound()
 	{
 		$this->expectException(NotFoundException::class);

--- a/tests/Cms/Helpers/HelpersTest.php
+++ b/tests/Cms/Helpers/HelpersTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Obj;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Helpers
- */
+#[CoversClass(Helpers::class)]
 class HelpersTest extends HelpersTestCase
 {
 	protected array $deprecations = [];
@@ -27,9 +26,6 @@ class HelpersTest extends HelpersTestCase
 		Helpers::$deprecations = $this->deprecations;
 	}
 
-	/**
-	 * @covers ::deprecated
-	 */
 	public function testDeprecated()
 	{
 		$this->assertError(
@@ -39,9 +35,6 @@ class HelpersTest extends HelpersTestCase
 		);
 	}
 
-	/**
-	 * @covers ::deprecated
-	 */
 	public function testDeprecatedKeyUndefined()
 	{
 		$this->assertError(
@@ -51,9 +44,6 @@ class HelpersTest extends HelpersTestCase
 		);
 	}
 
-	/**
-	 * @covers ::deprecated
-	 */
 	public function testDeprecatedActivated()
 	{
 		$this->assertError(
@@ -66,9 +56,6 @@ class HelpersTest extends HelpersTestCase
 		);
 	}
 
-	/**
-	 * @covers ::deprecated
-	 */
 	public function testDeprecatedKeyDeactivated()
 	{
 		$result = $this->assertError(
@@ -83,9 +70,6 @@ class HelpersTest extends HelpersTestCase
 		$this->assertFalse($result);
 	}
 
-	/**
-	 * @covers ::dump
-	 */
 	public function testDumpOnCli()
 	{
 		$this->app = $this->app->clone([
@@ -99,9 +83,6 @@ class HelpersTest extends HelpersTestCase
 		Helpers::dump('test', true);
 	}
 
-	/**
-	 * @covers ::dump
-	 */
 	public function testDumpOnServer()
 	{
 		$this->app = $this->app->clone([
@@ -115,9 +96,6 @@ class HelpersTest extends HelpersTestCase
 		Helpers::dump('test2', true);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsNoWarning()
 	{
 		$this->assertSame('return', Helpers::handleErrors(
@@ -126,9 +104,6 @@ class HelpersTest extends HelpersTestCase
 		));
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsException()
 	{
 		$this->expectException(Exception::class);
@@ -144,9 +119,6 @@ class HelpersTest extends HelpersTestCase
 		);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsWarningCaught1()
 	{
 		$this->activeErrorHandlers++;
@@ -170,9 +142,6 @@ class HelpersTest extends HelpersTestCase
 		$this->assertFalse($called);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsWarningCaught2()
 	{
 		$this->activeErrorHandlers++;
@@ -200,9 +169,6 @@ class HelpersTest extends HelpersTestCase
 		$this->assertTrue($called);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsWarningCaughtCallbackValue()
 	{
 		$this->assertSame('handled', Helpers::handleErrors(
@@ -212,9 +178,6 @@ class HelpersTest extends HelpersTestCase
 		));
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
 	public function testHandleErrorsWarningNotCaught()
 	{
 		$this->assertError(
@@ -236,9 +199,6 @@ class HelpersTest extends HelpersTestCase
 		);
 	}
 
-	/**
-	 * @covers ::size
-	 */
 	public function testSize()
 	{
 		// number

--- a/tests/Cms/Html/HtmlTest.php
+++ b/tests/Cms/Html/HtmlTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
 use Kirby\Plugin\Plugin;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Html
- */
+#[CoversClass(Html::class)]
 class HtmlTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -27,9 +26,6 @@ class HtmlTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCss()
 	{
 		$result   = Html::css('assets/css/index.css');
@@ -38,9 +34,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithMediaOption()
 	{
 		$result   = Html::css('assets/css/index.css', 'print');
@@ -49,9 +42,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithAttrs()
 	{
 		$result   = Html::css('assets/css/index.css', ['integrity' => 'nope']);
@@ -60,9 +50,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithValidRelAttr()
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate stylesheet', 'title' => 'High contrast']);
@@ -71,9 +58,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithInvalidRelAttr()
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate', 'title' => 'High contrast']);
@@ -82,9 +66,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithRelAttrButNoTitle()
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate stylesheet']);
@@ -93,9 +74,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithArray()
 	{
 		$result = Html::css([
@@ -109,9 +87,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithPluginAssets()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -125,9 +100,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJs()
 	{
 		$result   = Html::js('assets/js/index.js');
@@ -136,9 +108,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithAsyncOption()
 	{
 		$result   = Html::js('assets/js/index.js', true);
@@ -147,9 +116,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithAttrs()
 	{
 		$result   = Html::js('assets/js/index.js', ['integrity' => 'nope']);
@@ -158,9 +124,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithArray()
 	{
 		$result = Html::js([
@@ -174,9 +137,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithPluginAssets()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -190,43 +150,28 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::svg
-	 */
 	public function testSvg()
 	{
 		$result = Html::svg('test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
 	public function testSvgWithAbsolutePath()
 	{
 		$result = Html::svg(static::TMP . '/test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
 	public function testSvgWithInvalidFileType()
 	{
 		$this->assertFalse(Html::svg(123));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
 	public function testSvgWithMissingFile()
 	{
 		$this->assertFalse(Html::svg('somefile.svg'));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
 	public function testSvgWithFileObject()
 	{
 		$file = $this->getMockBuilder(File::class)

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class RootsTest extends TestCase
 {
 	protected string|null $indexRoot;
@@ -55,9 +57,7 @@ class RootsTest extends TestCase
 		return static::rootProvider(realpath(__DIR__ . '/../../../../'));
 	}
 
-	/**
-	 * @dataProvider defaultRootProvider
-	 */
+	#[DataProvider('defaultRootProvider')]
 	public function testDefaultRoot($root, $method)
 	{
 		// fake the default behavior for this test
@@ -73,9 +73,7 @@ class RootsTest extends TestCase
 		return static::rootProvider('/var/www/getkirby.com');
 	}
 
-	/**
-	 * @dataProvider customIndexRootProvider
-	 */
+	#[DataProvider('customIndexRootProvider')]
 	public function testCustomIndexRoot($root, $method)
 	{
 		$app = new App([
@@ -103,10 +101,8 @@ class RootsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customRootProvider
-	 */
-	public function testCustomRoot($root, $method)
+	#[DataProvider('customRootProvider')]
+	public function testCustomRoot(string $root, string $method)
 	{
 		// public directory setup
 		$base   = '/var/www/getkirby.com';

--- a/tests/Cms/Ingredients/UrlsTest.php
+++ b/tests/Cms/Ingredients/UrlsTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class UrlsTest extends TestCase
 {
 	public static function defaultUrlProvider(): array
@@ -13,10 +15,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider defaultUrlProvider
-	 */
-	public function testDefaulUrl($url, $method)
+	#[DataProvider('defaultUrlProvider')]
+	public function testDefaulUrl(string $url, string $method)
 	{
 		$app  = new App([
 			'roots' => [
@@ -37,10 +37,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customBaseUrlProvider
-	 */
-	public function testWithCustomBaseUrl($url, $method)
+	#[DataProvider('customBaseUrlProvider')]
+	public function testWithCustomBaseUrl(string $url, string $method)
 	{
 		$app = new App([
 			'roots' => [
@@ -63,10 +61,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customUrlProvider
-	 */
-	public function testWithCustomUrl($url, $method)
+	#[DataProvider('customUrlProvider')]
+	public function testWithCustomUrl(string $url, string $method)
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Languages/LanguageConversionTest.php
+++ b/tests/Cms/Languages/LanguageConversionTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Language
- */
+#[CoversClass(Language::class)]
 class LanguageConversionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageConversion';

--- a/tests/Cms/Languages/LanguagePermissionsTest.php
+++ b/tests/Cms/Languages/LanguagePermissionsTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\LanguagePermissions
- */
+#[CoversClass(LanguagePermissions::class)]
+#[CoversClass(ModelPermissions::class)]
 class LanguagePermissionsTest extends TestCase
 {
 	public static function actionProvider(): array
@@ -18,11 +19,8 @@ class LanguagePermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin(string $action)
 	{
 		$kirby = new App([
 			'roots' => [
@@ -42,11 +40,8 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertTrue($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action)
 	{
 		new App([
 			'roots' => [
@@ -64,11 +59,8 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNoAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNoAdmin(string $action)
 	{
 		$app = new App([
 			'languages' => [
@@ -112,9 +104,6 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers ::canDelete
-	 */
 	public function testCanDeleteWhenNotDeletable()
 	{
 		$app = new App([

--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -7,10 +7,9 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\LanguageRules
- */
+#[CoversClass(LanguageRules::class)]
 class LanguageRulesTest extends TestCase
 {
 	public function setUp(): void
@@ -36,9 +35,6 @@ class LanguageRulesTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate()
 	{
 		$this->app->impersonate('admin@getkirby.com');
@@ -53,9 +49,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithInvalidCode()
 	{
 		$language = new Language([
@@ -68,9 +61,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithInvalidName()
 	{
 		$language = new Language([
@@ -84,9 +74,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWhenExists()
 	{
 		$language = $this->createMock(Language::class);
@@ -100,9 +87,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithoutCurrentUser()
 	{
 		$language = new Language([
@@ -116,9 +100,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithoutPermissions()
 	{
 		$this->app->impersonate('test@getkirby.com');
@@ -134,9 +115,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$this->app->impersonate('admin@getkirby.com');
@@ -151,9 +129,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWhenNotDeletable()
 	{
 		$language = $this->createMock(Language::class);
@@ -165,9 +140,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithoutCurrentUser()
 	{
 		$language = new Language([
@@ -181,9 +153,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithoutPermissions()
 	{
 		$this->app->impersonate('test@getkirby.com');
@@ -199,9 +168,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$this->app->impersonate('admin@getkirby.com');
@@ -216,9 +182,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutCode()
 	{
 		$language = $this->createMock(Language::class);
@@ -231,9 +194,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutName()
 	{
 		$language = $this->createMock(Language::class);
@@ -246,9 +206,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutCurrentUser()
 	{
 		$language = new Language([
@@ -262,9 +219,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutPermissions()
 	{
 		$this->app->impersonate('test@getkirby.com');
@@ -280,9 +234,6 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateDemoteDefault()
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -9,10 +9,10 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Language
- */
+#[CoversClass(Language::class)]
 class LanguageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Language';
@@ -33,9 +33,6 @@ class LanguageTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructNoCode()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -58,11 +55,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::baseUrl
-	 * @dataProvider baseUrlProvider
-	 */
-	public function testBaseUrl($kirbyUrl, $url, $expected)
+	#[DataProvider('baseUrlProvider')]
+	public function testBaseUrl(string $kirbyUrl, string|null $url, string $expected)
 	{
 		new App([
 			'roots' => [
@@ -82,9 +76,6 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->baseUrl());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate()
 	{
 		$this->app->impersonate('kirby');
@@ -100,9 +91,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('/en', $language->url());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateNoPermissions()
 	{
 		$app = $this->app->clone([
@@ -130,9 +118,6 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithoutLoggedUser()
 	{
 		$this->expectException(PermissionException::class);
@@ -143,9 +128,6 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateHooks()
 	{
 		$calls = 0;
@@ -177,10 +159,6 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::code
-	 * @covers ::id
-	 */
 	public function testCodeAndId()
 	{
 		$language = new Language(['code' => 'en']);
@@ -188,9 +166,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->id());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$this->app->impersonate('kirby');
@@ -199,9 +174,6 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->delete());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteNoPermissions()
 	{
 		$app = $this->app->clone([
@@ -229,9 +201,6 @@ class LanguageTest extends TestCase
 		$language->delete();
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithoutLoggedUser()
 	{
 		$this->app->impersonate('kirby');
@@ -245,9 +214,6 @@ class LanguageTest extends TestCase
 		$language->delete();
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteHooks()
 	{
 		$calls = 0;
@@ -285,9 +251,6 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::direction
-	 */
 	public function testDirection()
 	{
 		//default
@@ -371,9 +334,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->code());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		new App([
@@ -393,9 +353,6 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->exists());
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
 	public function testIsDefault()
 	{
 		// default
@@ -426,9 +383,6 @@ class LanguageTest extends TestCase
 		$this->assertFalse($language->isDefault());
 	}
 
-	/**
-	 * @covers ::isSingle
-	 */
 	public function testIsSingle()
 	{
 		// default
@@ -447,9 +401,6 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->isSingle());
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocale()
 	{
 		$language = new Language([
@@ -461,9 +412,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_ALL));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocaleArray1()
 	{
 		$language = new Language([
@@ -483,9 +431,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocaleArray2()
 	{
 		$language = new Language([
@@ -503,9 +448,6 @@ class LanguageTest extends TestCase
 		$this->assertNull($language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocaleArray3()
 	{
 		$language = new Language([
@@ -525,9 +467,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocaleInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -538,9 +477,6 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocaleDefault()
 	{
 		$language = new Language([
@@ -550,9 +486,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->locale(LC_ALL));
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$language = new Language([
@@ -584,11 +517,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::path
-	 * @dataProvider pathProvider
-	 */
-	public function testPath($input, $expected)
+	#[DataProvider('pathProvider')]
+	public function testPath(string|null $input, string $expected)
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -614,11 +544,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::pattern
-	 * @dataProvider patternProvider
-	 */
-	public function testPattern($input, $expected)
+	#[DataProvider('patternProvider')]
+	public function testPattern(string|null $input, string $expected)
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -628,9 +555,6 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->pattern());
 	}
 
-	/**
-	 * @covers ::root
-	 */
 	public function testRoot()
 	{
 		$app = new App([
@@ -646,9 +570,6 @@ class LanguageTest extends TestCase
 		$this->assertSame(static::TMP . '/site/languages/de.php', $language->root());
 	}
 
-	/**
-	 * @covers ::router
-	 */
 	public function testRouter()
 	{
 		$language = new Language([
@@ -658,9 +579,6 @@ class LanguageTest extends TestCase
 		$this->assertInstanceOf(LanguageRouter::class, $language->router());
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSave()
 	{
 		$app = new App([
@@ -732,9 +650,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('test', $data['custom']);
 	}
 
-	/**
-	 * @covers ::single
-	 */
 	public function testSingle()
 	{
 		$language = Language::single();
@@ -743,10 +658,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->name());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testToArrayAndDebuginfo()
 	{
 		$language = new Language([
@@ -769,9 +680,6 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->__debugInfo());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithRelativeValue()
 	{
 		$language = new Language([
@@ -782,9 +690,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('/super', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithAbsoluteValue()
 	{
 		$language = new Language([
@@ -795,9 +700,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('https://en.getkirby.com', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithDash()
 	{
 		$language = new Language([
@@ -808,9 +710,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('/', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlDefault()
 	{
 		$language = new Language([
@@ -820,9 +719,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('/en', $language->url());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		Dir::make(static::TMP . '/content');
@@ -838,9 +734,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('English', $language->name());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateDefault()
 	{
 		$app = new App([
@@ -889,9 +782,6 @@ class LanguageTest extends TestCase
 		$app->language('de')->update(['default' => false]);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateHooks()
 	{
 		$calls = 0;
@@ -935,9 +825,6 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateNoPermissions()
 	{
 		$app = $this->app->clone([
@@ -966,9 +853,6 @@ class LanguageTest extends TestCase
 		$language->update(['name' => 'English']);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutLoggedUser()
 	{
 		$this->app->impersonate('kirby');
@@ -982,9 +866,6 @@ class LanguageTest extends TestCase
 		$language->update(['name' => 'English']);
 	}
 
-	/**
-	 * @covers ::variable
-	 */
 	public function testVariable()
 	{
 		$language = new Language([
@@ -996,9 +877,6 @@ class LanguageTest extends TestCase
 		$this->assertSame('test', $variable->key());
 	}
 
-	/**
-	 * @covers ::variable
-	 */
 	public function testVariableDecode()
 	{
 		$language = new Language([

--- a/tests/Cms/Languages/LanguageVariableTest.php
+++ b/tests/Cms/Languages/LanguageVariableTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\LanguageVariable
- */
+#[CoversClass(LanguageVariable::class)]
 class LanguageVariableTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageVariable';
@@ -29,9 +28,6 @@ class LanguageVariableTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateEmptyKey()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -40,9 +36,6 @@ class LanguageVariableTest extends TestCase
 		LanguageVariable::create('');
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateInvalidKey()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -51,10 +44,6 @@ class LanguageVariableTest extends TestCase
 		LanguageVariable::create('0');
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$language = new Language(['code' => 'test']);

--- a/tests/Cms/Loader/LoaderTest.php
+++ b/tests/Cms/Loader/LoaderTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Loader
- */
+#[CoversClass(Loader::class)]
 class LoaderTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -19,9 +18,6 @@ class LoaderTest extends TestCase
 		$this->loader = new Loader($this->app);
 	}
 
-	/**
-	 * @covers ::area
-	 */
 	public function testArea()
 	{
 		$area = $this->loader->area('site');
@@ -29,10 +25,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Site', $area['label']);
 	}
 
-	/**
-	 * @covers ::area
-	 * @covers ::areas
-	 */
 	public function testAreaPlugin()
 	{
 		$this->app = $this->app->clone([
@@ -48,10 +40,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Todos', $area['label']);
 	}
 
-	/**
-	 * @covers ::area
-	 * @covers ::areas
-	 */
 	public function testAreaCorePlugin()
 	{
 		$this->app = $this->app->clone([
@@ -67,9 +55,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Seite', $area['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreaDropdownPlugin()
 	{
 		$this->app = $this->app->clone([
@@ -89,9 +74,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('foo', $dropdown['options']());
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreas()
 	{
 		$areas = $this->loader->areas();
@@ -104,9 +86,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Users', $areas['users']['label']);
 	}
 
-	/**
-	 * @covers ::component
-	 */
 	public function testComponent()
 	{
 		$component = $this->loader->component('url');
@@ -114,9 +93,6 @@ class LoaderTest extends TestCase
 		$this->assertInstanceOf('Closure', $component);
 	}
 
-	/**
-	 * @covers ::components
-	 */
 	public function testComponents()
 	{
 		$components = $this->loader->components();
@@ -124,9 +100,6 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('url', $components);
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtension()
 	{
 		$extension = $this->loader->extension('tags', 'video');
@@ -135,9 +108,6 @@ class LoaderTest extends TestCase
 		$this->assertInstanceOf('Closure', $extension['html']);
 	}
 
-	/**
-	 * @covers ::extensions
-	 */
 	public function testExtensions()
 	{
 		$extensions = $this->loader->extensions('tags');
@@ -146,9 +116,6 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('video', $extensions);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveArray()
 	{
 		$resolved = $this->loader->resolve([
@@ -158,9 +125,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolveArea
-	 */
 	public function testResolveArea()
 	{
 		$resolved = $this->loader->resolveArea([
@@ -176,9 +140,6 @@ class LoaderTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveClosure()
 	{
 		$resolved = $this->loader->resolve(fn () => [
@@ -188,9 +149,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolvePHPFile()
 	{
 		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.php');
@@ -198,9 +156,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveYamlFile()
 	{
 		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.yml');
@@ -208,9 +163,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolveAll
-	 */
 	public function testResolveAll()
 	{
 		$resolved = $this->loader->resolveAll([
@@ -220,9 +172,6 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']['test']);
 	}
 
-	/**
-	 * @covers ::section
-	 */
 	public function testSection()
 	{
 		$section = $this->loader->section('pages');
@@ -232,9 +181,6 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('methods', $section);
 	}
 
-	/**
-	 * @covers ::sections
-	 */
 	public function testSections()
 	{
 		$sections = $this->loader->sections();
@@ -243,9 +189,6 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('info', $sections);
 	}
 
-	/**
-	 * @covers ::withPlugins
-	 */
 	public function testWithPlugins()
 	{
 		$loader = new Loader($this->app);

--- a/tests/Cms/Models/ModelWithContentTest.php
+++ b/tests/Cms/Models/ModelWithContentTest.php
@@ -10,6 +10,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Page as PanelPage;
 use Kirby\Uuid\PageUuid;
 use Kirby\Uuid\SiteUuid;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass \Kirby\Cms\ModelWithContent
@@ -259,9 +260,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Original Title', $page->content()->title()->value());
 	}
 
-	/**
-	 * @dataProvider modelsProvider
-	 */
+	#[DataProvider('modelsProvider')]
 	public function testBlueprints(ModelWithContent $model)
 	{
 		$model = new BlueprintsModelWithContent($model);

--- a/tests/Cms/Pages/PageActionsTest.php
+++ b/tests/Cms/Pages/PageActionsTest.php
@@ -8,6 +8,7 @@ use Kirby\Content\VersionId;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
 class PageActionsTest extends TestCase
@@ -124,10 +125,8 @@ class PageActionsTest extends TestCase
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
 	}
 
-	/**
-	 * @dataProvider slugProvider
-	 */
-	public function testChangeSlug($input, $expected, $draft)
+	#[DataProvider('slugProvider')]
+	public function testChangeSlug(string $input, string $expected, bool $draft)
 	{
 		$site = $this->app->site();
 
@@ -170,10 +169,8 @@ class PageActionsTest extends TestCase
 		$this->assertSame($newRoot, $modified->root());
 	}
 
-	/**
-	 * @dataProvider slugProvider
-	 */
-	public function testChangeSlugMultiLang($input, $expected, $draft)
+	#[DataProvider('slugProvider')]
+	public function testChangeSlugMultiLang(string $input, string $expected, bool $draft)
 	{
 		$app = $this->app->clone([
 			'languages' => [
@@ -669,10 +666,8 @@ class PageActionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider languageProvider
-	 */
-	public function testUpdateMultilang($languageCode)
+	#[DataProvider('languageProvider')]
+	public function testUpdateMultilang(string|null $languageCode)
 	{
 		$app = $this->app->clone([
 			'languages' => [

--- a/tests/Cms/Pages/PageBlueprintTest.php
+++ b/tests/Cms/Pages/PageBlueprintTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\PageBlueprint
- */
+#[CoversClass(PageBlueprint::class)]
 class PageBlueprintTest extends TestCase
 {
 	public function tearDown(): void
@@ -135,10 +136,8 @@ class PageBlueprintTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider numProvider
-	 */
-	public function testNum($input, $expected)
+	#[DataProvider('numProvider')]
+	public function testNum(string|int $input, string $expected)
 	{
 		$blueprint = new PageBlueprint([
 			'model' => new Page(['slug' => 'test']),
@@ -357,9 +356,6 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtendNum()
 	{
 		new App([
@@ -381,9 +377,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('date', $blueprint->num());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18n()
 	{
 		$app = new App([
@@ -429,9 +423,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Simple Page', $page->blueprint()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18nWithFallbackLanguage()
 	{
 		$app = new App([
@@ -469,9 +461,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Thanks to fallback', $page->blueprint()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18nArray()
 	{
 		$app = new App([

--- a/tests/Cms/Pages/PageCopyTest.php
+++ b/tests/Cms/Pages/PageCopyTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\PageCopy
- */
+#[CoversClass(PageCopy::class)]
 class PageCopyTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.PageCopy';
@@ -31,9 +30,6 @@ class PageCopyTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildren(): void
 	{
 		$app = $this->app->clone([
@@ -59,11 +55,6 @@ class PageCopyTest extends TestCase
 		$this->assertCount(0, $copy->children());
 	}
 
-	/**
-	 * @covers ::convertUuids
-	 * @covers ::convertChildrenUuids
-	 * @covers ::convertFileUuids
-	 */
 	public function testConvertUuids(): void
 	{
 		$app = $this->app->clone([
@@ -158,9 +149,6 @@ class PageCopyTest extends TestCase
 		$this->assertSame([], array_keys($copy->uuids));
 	}
 
-	/**
-	 * @covers ::convertChildrenUuids
-	 */
 	public function testConvertUuidsClearChildren(): void
 	{
 		$app = $this->app->clone([
@@ -216,9 +204,6 @@ class PageCopyTest extends TestCase
 		$this->assertSame('', $copy->uuids['page://ab']);
 	}
 
-	/**
-	 * @covers ::convertFileUuids
-	 */
 	public function testConvertUuidsClearFiles(): void
 	{
 		$app = $this->app->clone([
@@ -260,9 +245,6 @@ class PageCopyTest extends TestCase
 		$this->assertSame('', $copy->uuids['file://file-b']);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles(): void
 	{
 		$app = $this->app->clone([
@@ -288,9 +270,6 @@ class PageCopyTest extends TestCase
 		$this->assertCount(0, $copy->files());
 	}
 
-	/**
-	 * @covers ::languages
-	 */
 	public function testLanguages(): void
 	{
 		$app = $this->app->clone([
@@ -320,9 +299,6 @@ class PageCopyTest extends TestCase
 		$this->assertCount(2, $copy->languages());
 	}
 
-	/**
-	 * @covers ::process
-	 */
 	public function testProcess(): void
 	{
 		$app = $this->app->clone([
@@ -355,9 +331,6 @@ class PageCopyTest extends TestCase
 		$this->assertNotSame('file://file-aa', $normalized->find('test-a')->file()->uuid()->toString());
 	}
 
-	/**
-	 * @covers ::removeSlug
-	 */
 	public function testRemoveSlug(): void
 	{
 		$app = $this->app->clone([
@@ -401,9 +374,6 @@ class PageCopyTest extends TestCase
 		$this->assertSame('test', $app->page('test')->slug('de'));
 	}
 
-	/**
-	 * @covers ::replaceUuids
-	 */
 	public function testReplaceUuids(): void
 	{
 		$app = $this->app->clone([

--- a/tests/Cms/Pages/PagePermissionsTest.php
+++ b/tests/Cms/Pages/PagePermissionsTest.php
@@ -4,11 +4,12 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Cms\PagePermissions
- */
+#[CoversClass(PagePermissions::class)]
+#[CoversClass(ModelPermissions::class)]
 class PagePermissionsTest extends TestCase
 {
 	public function setUp(): void
@@ -48,11 +49,8 @@ class PagePermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin(string $action)
 	{
 		$this->app->impersonate('bastian');
 
@@ -64,11 +62,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdminButDisabledOption($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdminButDisabledOption(string $action)
 	{
 		$this->app->impersonate('bastian');
 
@@ -86,11 +81,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithEditorAndPositiveWildcard($action)
+	#[DataProvider('actionProvider')]
+	public function testWithEditorAndPositiveWildcard(string $action)
 	{
 		$app = $this->app->clone([
 			'roles' => [
@@ -119,11 +111,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithEditorAndPositivePermission($action)
+	#[DataProvider('actionProvider')]
+	public function testWithEditorAndPositivePermission(string $action)
 	{
 		$app = $this->app->clone([
 			'roles' => [
@@ -153,11 +142,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithEditorAndNegativeWildcard($action)
+	#[DataProvider('actionProvider')]
+	public function testWithEditorAndNegativeWildcard(string $action)
 	{
 		$app = $this->app->clone([
 			'roles' => [
@@ -186,11 +172,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithEditorAndNegativePermission($action)
+	#[DataProvider('actionProvider')]
+	public function testWithEditorAndNegativePermission(string $action)
 	{
 		$app = $this->app->clone([
 			'roles' => [
@@ -220,11 +203,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdminAndNegativeOptionForOtherRole($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdminAndNegativeOptionForOtherRole(string $action)
 	{
 		$this->app->impersonate('bastian');
 
@@ -244,11 +224,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdminAndNegativeOptionForOtherRoleAndNegativeFallback($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdminAndNegativeOptionForOtherRoleAndNegativeFallback(string $action)
 	{
 		$this->app->impersonate('bastian');
 
@@ -269,11 +246,8 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action)
 	{
 		$page  = new Page(['slug' => 'test']);
 		$perms = $page->permissions();
@@ -281,9 +255,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
-	 */
 	public function testCanFromCache()
 	{
 		$this->app->impersonate('bastian');
@@ -307,9 +278,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse(PagePermissions::canFromCache($page, 'list'));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::canFromCache
-	 */
 	public function testCanFromCacheDynamic()
 	{
 		$this->expectException(LogicException::class);
@@ -324,9 +292,6 @@ class PagePermissionsTest extends TestCase
 		PagePermissions::canFromCache($page, 'changeTemplate');
 	}
 
-	/**
-	 * @covers ::canChangeTemplate
-	 */
 	public function testCannotChangeTemplate()
 	{
 		$this->app->impersonate('kirby');
@@ -338,9 +303,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can('changeTemplate'));
 	}
 
-	/**
-	 * @covers ::canChangeTemplate
-	 */
 	public function testCanChangeTemplate()
 	{
 		$this->app = new App([
@@ -374,9 +336,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can('changeTemplate'));
 	}
 
-	/**
-	 * @covers ::canChangeTemplate
-	 */
 	public function testCanChangeTemplateHomeError()
 	{
 		$this->app = new App([
@@ -427,9 +386,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($error->permissions()->can('changeTemplate'));
 	}
 
-	/**
-	 * @covers ::canSort
-	 */
 	public function testCanSortListedPages()
 	{
 		$this->app->impersonate('kirby');
@@ -442,9 +398,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can('sort'));
 	}
 
-	/**
-	 * @covers ::can
-	 */
 	public function testCanNotFoundDefault()
 	{
 		$this->app->impersonate('bastian');
@@ -458,9 +411,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertTrue($page->permissions()->can('foo', true));
 	}
 
-	/**
-	 * @covers ::canSort
-	 */
 	public function testCannotSortUnlistedPages()
 	{
 		$this->app->impersonate('kirby');
@@ -472,9 +422,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can('sort'));
 	}
 
-	/**
-	 * @covers ::canSort
-	 */
 	public function testCannotSortErrorPage()
 	{
 		$this->app->impersonate('kirby');
@@ -493,9 +440,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can('sort'));
 	}
 
-	/**
-	 * @covers ::canSort
-	 */
 	public function testCannotSortPagesWithSortMode()
 	{
 		$this->app->impersonate('kirby');
@@ -534,9 +478,6 @@ class PagePermissionsTest extends TestCase
 		$this->assertFalse($page->permissions()->can('sort'));
 	}
 
-	/**
-	 * @covers ::cannot
-	 */
 	public function testCannotNotFoundDefault()
 	{
 		$this->app->impersonate('bastian');

--- a/tests/Cms/Pages/PageRenderTest.php
+++ b/tests/Cms/Pages/PageRenderTest.php
@@ -8,10 +8,10 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Page
- */
+#[CoversClass(Page::class)]
 class PageRenderTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/PageRenderTest';
@@ -146,11 +146,8 @@ class PageRenderTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 * @dataProvider requestMethodProvider
-	 */
-	public function testIsCacheableRequestMethod($method, $expected)
+	#[DataProvider('requestMethodProvider')]
+	public function testIsCacheableRequestMethod(string $method, bool $expected)
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -163,11 +160,8 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('default')->isCacheable(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 * @dataProvider requestMethodProvider
-	 */
-	public function testIsCacheableRequestData($method)
+	#[DataProvider('requestMethodProvider')]
+	public function testIsCacheableRequestData(string $method)
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -179,9 +173,6 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('default')->isCacheable());
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 */
 	public function testIsCacheableRequestParams()
 	{
 		$app = $this->app->clone([
@@ -193,9 +184,6 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('default')->isCacheable());
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 */
 	public function testIsCacheableIgnoreId()
 	{
 		$app = $this->app->clone([
@@ -216,9 +204,6 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('data')->isCacheable(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 */
 	public function testIsCacheableIgnoreCallback()
 	{
 		$app = $this->app->clone([
@@ -237,9 +222,6 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('data')->isCacheable(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::isCacheable
-	 */
 	public function testIsCacheableDisabledCache()
 	{
 		// deactivate on top level
@@ -263,10 +245,6 @@ class PageRenderTest extends TestCase
 		$this->assertFalse($app->page('default')->isCacheable());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCache()
 	{
 		$cache = $this->app->cache('pages');
@@ -286,10 +264,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame($html1, $html2);
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCacheCustomExpiry()
 	{
 		$cache = $this->app->cache('pages');
@@ -305,10 +279,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame((int)$time, $value->expires());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCacheMetadata()
 	{
 		$cache = $this->app->cache('pages');
@@ -336,10 +306,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('text/plain', $this->app->response()->type());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCacheDisabled()
 	{
 		$cache = $this->app->cache('pages');
@@ -367,11 +333,7 @@ class PageRenderTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 * @dataProvider dynamicProvider
-	 */
+	#[DataProvider('dynamicProvider')]
 	public function testRenderCacheDynamicNonActive(string $slug, array $dynamicElements)
 	{
 		$cache = $this->app->cache('pages');
@@ -399,11 +361,7 @@ class PageRenderTest extends TestCase
 		$this->assertSame($html1, $html2);
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 * @dataProvider dynamicProvider
-	 */
+	#[DataProvider('dynamicProvider')]
 	public function testRenderCacheDynamicActiveOnFirstRender(string $slug, array $dynamicElements)
 	{
 		$_COOKIE['foo'] = $_COOKIE['kirby_session'] = 'bar';
@@ -431,11 +389,7 @@ class PageRenderTest extends TestCase
 		$this->assertNotSame($html1, $html2);
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 * @dataProvider dynamicProvider
-	 */
+	#[DataProvider('dynamicProvider')]
 	public function testRenderCacheDynamicActiveOnSecondRender(string $slug, array $dynamicElements)
 	{
 		$cache = $this->app->cache('pages');
@@ -467,10 +421,6 @@ class PageRenderTest extends TestCase
 		$this->assertNotSame($html1, $html2);
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCacheDataInitial()
 	{
 		$cache = $this->app->cache('pages');
@@ -484,10 +434,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull($cache->retrieve('data.latest.html'));
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderCacheDataPreCached()
 	{
 		$cache = $this->app->cache('pages');
@@ -513,10 +459,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull($value->expires());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderRepresentationDefault()
 	{
 		$page = $this->app->page('representation');
@@ -524,10 +466,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('<html>Some HTML: representation</html>', $page->render());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderRepresentationOverride()
 	{
 		$page = $this->app->page('representation');
@@ -536,10 +474,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('{"some json": "representation"}', $page->render(contentType: 'json'));
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderRepresentationMissing()
 	{
 		$this->expectException(NotFoundException::class);
@@ -549,10 +483,6 @@ class PageRenderTest extends TestCase
 		$page->render(contentType: 'txt');
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderTemplateMissing()
 	{
 		$this->expectException(NotFoundException::class);
@@ -562,10 +492,6 @@ class PageRenderTest extends TestCase
 		$page->render();
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderController()
 	{
 		$page = $this->app->page('controller');
@@ -574,10 +500,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('Data says TEST: controller and custom!', $page->render(['test' => 'override', 'test2' => 'custom']));
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderHookBefore()
 	{
 		$app = $this->app->clone([
@@ -593,10 +515,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('Bar Title : Test', $page->render());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderHookAfter()
 	{
 		$app = $this->app->clone([
@@ -611,10 +529,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('foo - Foo Title', $page->render());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderVersionDetectedFromRequest()
 	{
 		$page = $this->app->page('version');
@@ -635,10 +549,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame("Version: changes\nContent: Changes Title", $page->render());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderVersionDetectedFromRequestDraft()
 	{
 		$page = $this->app->page('version-draft');
@@ -661,10 +571,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame("Version: changes\nContent: Changes Title", $page->render());
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderVersionDetectedRecursive()
 	{
 		$versionPage = $this->app->page('version');
@@ -689,10 +595,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame("<recursive>\nVersion: latest\nContent: Latest Title\n</recursive>", $page->render(versionId: 'latest'));
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderVersionManual()
 	{
 		$page = $this->app->page('version');
@@ -707,10 +609,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull(VersionId::$render);
 	}
 
-	/**
-	 * @covers ::cacheId
-	 * @covers ::render
-	 */
 	public function testRenderVersionException()
 	{
 		$page = $this->app->page('version-exception');
@@ -725,9 +623,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull(VersionId::$render);
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestAuthenticated()
 	{
 		$page = $this->app->page('default');
@@ -755,9 +650,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('changes', $page->renderVersionFromRequest()->value());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestAuthenticatedDraft()
 	{
 		$page = $this->app->page('version-draft');
@@ -785,9 +677,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('changes', $page->renderVersionFromRequest()->value());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestMismatch()
 	{
 		$page = $this->app->page('default');
@@ -815,9 +704,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('latest', $page->renderVersionFromRequest()->value());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestInvalidId()
 	{
 		$page       = $this->app->page('default');
@@ -838,9 +724,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull($draftChild->renderVersionFromRequest());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestMissingId()
 	{
 		$page = $this->app->page('default');
@@ -856,9 +739,6 @@ class PageRenderTest extends TestCase
 		$this->assertSame('latest', $page->renderVersionFromRequest()->value());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestMissingToken()
 	{
 		$page       = $this->app->page('default');
@@ -891,9 +771,6 @@ class PageRenderTest extends TestCase
 		$this->assertNull($draftChild->renderVersionFromRequest());
 	}
 
-	/**
-	 * @covers ::renderVersionFromRequest
-	 */
 	public function testRenderVersionFromRequestInvalidToken()
 	{
 		$page       = $this->app->page('default');

--- a/tests/Cms/Pages/PageRulesTest.php
+++ b/tests/Cms/Pages/PageRulesTest.php
@@ -6,10 +6,10 @@ use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\PageRules
- */
+#[CoversClass(PageRules::class)]
 class PageRulesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.PageRules';
@@ -30,9 +30,6 @@ class PageRulesTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::changeNum
-	 */
 	public function testChangeNum()
 	{
 		$page = new Page([
@@ -46,9 +43,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeNum($page);
 	}
 
-	/**
-	 * @covers ::changeNum
-	 */
 	public function testInvalidChangeNum()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -62,9 +56,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeNum($page, -1);
 	}
 
-	/**
-	 * @covers ::changeSlug
-	 */
 	public function testChangeSlug()
 	{
 		$app = $this->appWithAdmin()->clone([
@@ -88,9 +79,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeSlug($page, 'test-b');
 	}
 
-	/**
-	 * @covers ::changeSlug
-	 */
 	public function testChangeSlugWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -106,9 +94,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeSlug($page, 'test');
 	}
 
-	/**
-	 * @covers ::changeSlug
-	 */
 	public function testChangeSlugWithHomepage()
 	{
 		$this->expectException(PermissionException::class);
@@ -130,9 +115,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeSlug($app->page('home'), 'test-a');
 	}
 
-	/**
-	 * @covers ::changeSlug
-	 */
 	public function testChangeSlugWithErrorPage()
 	{
 		$this->expectException(PermissionException::class);
@@ -154,10 +136,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeSlug($app->page('error'), 'test-a');
 	}
 
-	/**
-	 * @covers ::changeSlug
-	 * @covers ::validateSlugProtectedPaths
-	 */
 	public function testChangeSlugReservedPath()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -188,14 +166,8 @@ class PageRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::changeStatus
-	 * @covers ::changeStatusToDraft
-	 * @covers ::changeStatusToListed
-	 * @covers ::changeStatusToUnlisted
-	 * @dataProvider statusActionProvider
-	 */
-	public function testChangeStatusWithoutPermission($status, $args = [])
+	#[DataProvider('statusActionProvider')]
+	public function testChangeStatusWithoutPermission(string $status, array $args = [])
 	{
 		$permissions = $this->createMock(PagePermissions::class);
 		$permissions->method('can')->with('changeStatus')->willReturn(false);
@@ -210,10 +182,6 @@ class PageRulesTest extends TestCase
 		PageRules::{'changeStatusTo' . $status}($page, ...$args);
 	}
 
-	/**
-	 * @covers ::changeStatus
-	 * @covers ::changeStatusToDraft
-	 */
 	public function testChangeStatusToListedWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -229,10 +197,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeStatusToDraft($page);
 	}
 
-	/**
-	 * @covers ::changeStatus
-	 * @covers ::changeStatusToDraft
-	 */
 	public function testChangeStatusInvalid()
 	{
 		$this->expectException(PermissionException::class);
@@ -254,11 +218,8 @@ class PageRulesTest extends TestCase
 		PageRules::changeStatusToDraft($app->page('home'));
 	}
 
-	/**
-	 * @covers ::changeStatus
-	 * @dataProvider statusActionProvider
-	 */
-	public function testChangeStatus($status, $args = [])
+	#[DataProvider('statusActionProvider')]
+	public function testChangeStatus(string $status, array $args = [])
 	{
 		$app = $this->appWithAdmin()->clone([
 			'site' => [
@@ -278,9 +239,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeStatus($page, $status, ...$args);
 	}
 
-	/**
-	 * @covers ::changeTemplate
-	 */
 	public function testChangeTemplate()
 	{
 		$app = new App([
@@ -319,9 +277,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTemplate($page, 'b');
 	}
 
-	/**
-	 * @covers ::changeTemplate
-	 */
 	public function testChangeTemplateWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -337,9 +292,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTemplate($page, 'test');
 	}
 
-	/**
-	 * @covers ::changeTemplate
-	 */
 	public function testChangeTemplateTooFewTemplates()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -356,9 +308,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTemplate($page, 'c');
 	}
 
-	/**
-	 * @covers ::changeTemplate
-	 */
 	public function testChangeTemplateWithInvalidTemplateName()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -377,9 +326,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTemplate($page, 'c');
 	}
 
-	/**
-	 * @covers ::changeTitle
-	 */
 	public function testChangeTitleWithEmptyValue()
 	{
 		$page = new Page([
@@ -393,9 +339,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTitle($page, '');
 	}
 
-	/**
-	 * @covers ::changeTitle
-	 */
 	public function testChangeTitleWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -411,9 +354,6 @@ class PageRulesTest extends TestCase
 		PageRules::changeTitle($page, 'test');
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -429,9 +369,6 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateInvalidSlug()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -447,9 +384,6 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateDuplicateException()
 	{
 		$app = $this->appWithAdmin()->clone([
@@ -471,10 +405,6 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::validateSlugProtectedPaths
-	 */
 	public function testCreateSlugReservedPath()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -497,9 +427,6 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$page = new Page([
@@ -512,9 +439,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($page);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -530,9 +454,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($page);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteNotExists()
 	{
 		$page = new Page([
@@ -545,9 +466,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($page);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteHomepage()
 	{
 		$this->expectException(PermissionException::class);
@@ -569,9 +487,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($app->page('home'));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteErrorPage()
 	{
 		$this->expectException(PermissionException::class);
@@ -593,9 +508,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($app->page('error'));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithChildren()
 	{
 		$this->expectException(LogicException::class);
@@ -613,9 +525,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($page);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithChildrenForce()
 	{
 		$page = new Page([
@@ -632,9 +541,6 @@ class PageRulesTest extends TestCase
 		PageRules::delete($page, true);
 	}
 
-	/**
-	 * @covers ::duplicate
-	 */
 	public function testDuplicate()
 	{
 		$page = new Page([
@@ -647,9 +553,6 @@ class PageRulesTest extends TestCase
 		PageRules::duplicate($page, 'test-copy');
 	}
 
-	/**
-	 * @covers ::duplicate
-	 */
 	public function testDuplicateInvalid()
 	{
 		$page = new Page([
@@ -663,9 +566,6 @@ class PageRulesTest extends TestCase
 		PageRules::duplicate($page, '');
 	}
 
-	/**
-	 * @covers ::duplicate
-	 */
 	public function testDuplicateWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -681,9 +581,6 @@ class PageRulesTest extends TestCase
 		PageRules::duplicate($page, 'something');
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$page = new Page([
@@ -698,9 +595,6 @@ class PageRulesTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -716,9 +610,6 @@ class PageRulesTest extends TestCase
 		PageRules::update($page, []);
 	}
 
-	/**
-	 * @covers ::validateSlugLength
-	 */
 	public function testValidateSlugMaxlength()
 	{
 		$app = new App([
@@ -779,9 +670,6 @@ class PageRulesTest extends TestCase
 		PageRules::create($page);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMove()
 	{
 		$app = new App([
@@ -827,9 +715,6 @@ class PageRulesTest extends TestCase
 		PageRules::move($child, $parentB);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithoutPermissions()
 	{
 		$permissions = $this->createMock(PagePermissions::class);
@@ -845,9 +730,6 @@ class PageRulesTest extends TestCase
 		PageRules::move($page, new Page(['slug' => 'test']));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithDuplicate()
 	{
 		$app = new App([
@@ -887,9 +769,6 @@ class PageRulesTest extends TestCase
 		PageRules::move($child, $parentB);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithInvalidTemplate()
 	{
 		$app = new App([
@@ -943,9 +822,6 @@ class PageRulesTest extends TestCase
 		PageRules::move($child, $parentB);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithParentWithNoPagesSections()
 	{
 		$app = new App([
@@ -993,9 +869,6 @@ class PageRulesTest extends TestCase
 		PageRules::move($child, $parentB);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithParentWithNoTemplateRestrictions()
 	{
 		$app = new App([

--- a/tests/Cms/Pages/PageSortTest.php
+++ b/tests/Cms/Pages/PageSortTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PageSortTest extends TestCase
 {
@@ -521,10 +522,8 @@ class PageSortTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider sortProvider
-	 */
-	public function testSort($id, $position, $expected)
+	#[DataProvider('sortProvider')]
+	public function testSort(string $id, int $position, string $expected)
 	{
 		$site = new Site([
 			'children' => [

--- a/tests/Cms/Pages/PageTest.php
+++ b/tests/Cms/Pages/PageTest.php
@@ -5,15 +5,15 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Panel\Page as Panel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class PageTestModel extends Page
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\Page
- */
+#[CoversClass(Page::class)]
 class PageTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -221,9 +221,6 @@ class PageTest extends TestCase
 		new Page(['slug' => []]);
 	}
 
-	/**
-	 * @covers ::isDraft
-	 */
 	public function testIsDraft()
 	{
 		$page = new Page([
@@ -248,9 +245,6 @@ class PageTest extends TestCase
 		$this->assertTrue($page->isDraft());
 	}
 
-	/**
-	 * @covers ::isListed
-	 */
 	public function testIsListed()
 	{
 		$page = new Page([
@@ -275,9 +269,6 @@ class PageTest extends TestCase
 		$this->assertFalse($page->isListed());
 	}
 
-	/**
-	 * @covers ::isUnlisted
-	 */
 	public function testIsUnlisted()
 	{
 		$page = new Page([
@@ -622,13 +613,11 @@ class PageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider previewUrlProvider
-	 */
+	#[DataProvider('previewUrlProvider')]
 	public function testCustomPreviewUrl(
-		$input,
-		$expected,
-		$expectedUri,
+		bool|string|null $input,
+		string|null $expected,
+		string|null $expectedUri,
 		bool $draft,
 		bool $authenticated = true
 	): void {
@@ -948,9 +937,6 @@ class PageTest extends TestCase
 		Page::$models = [];
 	}
 
-	/**
-	 * @covers ::permalink
-	 */
 	public function testPermalink()
 	{
 		$page = Page::factory([

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Pages
- */
+#[CoversClass(Pages::class)]
 class PagesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Pages';
@@ -195,9 +194,6 @@ class PagesTest extends TestCase
 		$this->assertSame($expected, $pages->children()->keys());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$app = new App([
@@ -239,9 +235,6 @@ class PagesTest extends TestCase
 		$this->assertDirectoryDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWithInvalidIds()
 	{
 		$app = new App([

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -3,10 +3,10 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Permissions
- */
+#[CoversClass(Permissions::class)]
 class PermissionsTest extends TestCase
 {
 	public function tearDown(): void
@@ -68,12 +68,8 @@ class PermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::for
-	 * @dataProvider actionsProvider
-	 */
-	public function testActions(string $category, $action)
+	#[DataProvider('actionsProvider')]
+	public function testActions(string $category, string $action)
 	{
 		// default
 		$p = new Permissions();
@@ -151,9 +147,6 @@ class PermissionsTest extends TestCase
 		new Permissions();
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForDefault()
 	{
 		// exists

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Responder
- */
+#[CoversClass(Responder::class)]
 class ResponderTest extends TestCase
 {
 	public function setUp(): void
@@ -23,9 +22,6 @@ class ResponderTest extends TestCase
 		unset($_COOKIE['foo'], $_SERVER['HTTP_AUTHORIZATION']);
 	}
 
-	/**
-	 * @covers ::cache
-	 */
 	public function testCache()
 	{
 		$responder = new Responder();
@@ -38,9 +34,6 @@ class ResponderTest extends TestCase
 		$this->assertTrue($responder->cache());
 	}
 
-	/**
-	 * @covers ::cache
-	 */
 	public function testCacheUsesCookies()
 	{
 		$_COOKIE['foo'] = 'bar';
@@ -52,9 +45,6 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->cache());
 	}
 
-	/**
-	 * @covers ::cache
-	 */
 	public function testCacheUsesAuth()
 	{
 		$this->kirby([
@@ -70,9 +60,6 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->cache());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
 	public function testExpires()
 	{
 		$responder = new Responder();
@@ -118,9 +105,6 @@ class ResponderTest extends TestCase
 		$this->assertSame(1609459200, $responder->expires());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
 	public function testExpiresInvalidString()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -130,9 +114,6 @@ class ResponderTest extends TestCase
 		$responder->expires('abcde');
 	}
 
-	/**
-	 * @covers ::fromArray
-	 */
 	public function testFromArray()
 	{
 		$responder = new Responder();
@@ -160,9 +141,6 @@ class ResponderTest extends TestCase
 		$this->assertSame(['foo'], $responder->usesCookies());
 	}
 
-	/**
-	 * @covers ::header
-	 */
 	public function testHeader()
 	{
 		$responder = new Responder();
@@ -205,9 +183,6 @@ class ResponderTest extends TestCase
 		$this->assertSame('private', $responder->header('Cache-Control'));
 	}
 
-	/**
-	 * @covers ::headers
-	 */
 	public function testHeaders()
 	{
 		$responder = new Responder();
@@ -220,9 +195,6 @@ class ResponderTest extends TestCase
 		$this->assertSame($headers, $responder->headers());
 	}
 
-	/**
-	 * @covers ::headers
-	 */
 	public function testHeadersCacheBehavior()
 	{
 		$responder = new Responder();
@@ -252,9 +224,6 @@ class ResponderTest extends TestCase
 		$this->assertSame(['Cache-Control' => 'private'], $responder->headers());
 	}
 
-	/**
-	 * @covers ::isPrivate
-	 */
 	public function testIsPrivate()
 	{
 		$responder = new Responder();
@@ -287,9 +256,6 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->isPrivate(false, []));
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$responder = new Responder();
@@ -315,9 +281,6 @@ class ResponderTest extends TestCase
 		], $responder->toArray());
 	}
 
-	/**
-	 * @covers ::usesAuth
-	 */
 	public function testUsesAuth()
 	{
 		$responder = new Responder();
@@ -330,9 +293,6 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->usesAuth());
 	}
 
-	/**
-	 * @covers ::usesCookie
-	 */
 	public function testUsesCookie()
 	{
 		$responder = new Responder();
@@ -349,9 +309,6 @@ class ResponderTest extends TestCase
 		$this->assertSame(['foo', 'bar'], $responder->usesCookies());
 	}
 
-	/**
-	 * @covers ::usesCookies
-	 */
 	public function testUsesCookies()
 	{
 		$responder = new Responder();

--- a/tests/Cms/ResponseTest.php
+++ b/tests/Cms/ResponseTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Response
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Response::class)]
 class ResponseTest extends TestCase
 {
 	public function setUp(): void
@@ -16,9 +16,6 @@ class ResponseTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
 	public function testRedirect()
 	{
 		$response = Response::redirect();
@@ -27,9 +24,6 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://getkirby.test'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
 	public function testRedirectWithLocation()
 	{
 		$response = Response::redirect('https://getkirby.com');
@@ -38,9 +32,6 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
 	public function testRedirectWithInternationalLocation()
 	{
 		$response = Response::redirect('https://täst.de');
@@ -49,9 +40,6 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
 	public function testRedirectWithResponseCodeAndUri()
 	{
 		$response = Response::redirect('/uri', 301);

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouterTest extends TestCase
 {
@@ -304,10 +305,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customRouteProvider
-	 */
-	public function testCustomRoute($pattern, $path)
+	#[DataProvider('customRouteProvider')]
+	public function testCustomRoute(string $pattern, string $path)
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -428,10 +427,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multiDomainProvider
-	 */
-	public function testMultiLangHomeWithDifferentDomains($domain, $language)
+	#[DataProvider('multiDomainProvider')]
+	public function testMultiLangHomeWithDifferentDomains(string $domain, string $language)
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -469,10 +466,8 @@ class RouterTest extends TestCase
 		$this->assertSame($language, I18n::locale());
 	}
 
-	/**
-	 * @dataProvider multiDomainProvider
-	 */
-	public function testMultiLangHomeWithDifferentDomainsAndPath($domain, $language)
+	#[DataProvider('multiDomainProvider')]
+	public function testMultiLangHomeWithDifferentDomainsAndPath(string $domain, string $language)
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -523,10 +518,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider acceptedLanguageProvider
-	 */
-	public function testMultiLangHomeRouteWithoutLanguageCodeAndLanguageDetection($accept, $redirect)
+	#[DataProvider('acceptedLanguageProvider')]
+	public function testMultiLangHomeRouteWithoutLanguageCodeAndLanguageDetection(string $accept, string $redirect)
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Sections/FieldsSectionTest.php
+++ b/tests/Cms/Sections/FieldsSectionTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FieldsSectionTest extends TestCase
 {
@@ -39,10 +40,8 @@ class FieldsSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider modelProvider
-	 */
-	public function testSkipTitle($model, $skip)
+	#[DataProvider('modelProvider')]
+	public function testSkipTitle(\Kirby\Cms\Page|\Kirby\Cms\Site|\Kirby\Cms\File|\Kirby\Cms\User $model, bool $skip)
 	{
 		$fields = [
 			'text' => [

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -6,6 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Panel\Model;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PagesSectionTest extends TestCase
 {
@@ -174,10 +175,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider statusProvider
-	 */
-	public function testStatus($input, $expected)
+	#[DataProvider('statusProvider')]
+	public function testStatus(string|null $input, string $expected)
 	{
 		$section = new Section('pages', [
 			'name'   => 'test',
@@ -209,10 +208,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider addableStatusProvider
-	 */
-	public function testAddWhenStatusIs($input, $expected)
+	#[DataProvider('addableStatusProvider')]
+	public function testAddWhenStatusIs(string $input, bool $expected)
 	{
 		$section = new Section('pages', [
 			'name'   => 'test',
@@ -241,10 +238,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider addableStatusCreateProvider
-	 */
-	public function testAddWhenStatusCreatedMatchesStatusShown($create, $shown, $expected)
+	#[DataProvider('addableStatusCreateProvider')]
+	public function testAddWhenStatusCreatedMatchesStatusShown(string $create, string $shown, bool $expected)
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -463,10 +458,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider sortableStatusProvider
-	 */
-	public function testSortableStatus($input, $expected)
+	#[DataProvider('sortableStatusProvider')]
+	public function testSortableStatus(string $input, bool $expected)
 	{
 		$section = new Section('pages', [
 			'name'     => 'test',

--- a/tests/Cms/Site/SitePermissionsTest.php
+++ b/tests/Cms/Site/SitePermissionsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SitePermissionsTest extends TestCase
 {
@@ -14,10 +15,8 @@ class SitePermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin(string $action)
 	{
 		$kirby = new App([
 			'roots' => [
@@ -33,10 +32,8 @@ class SitePermissionsTest extends TestCase
 		$this->assertTrue($perms->can($action));
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action)
 	{
 		$kirby = new App([
 			'roots' => [

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
 use Kirby\Panel\Site as Panel;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SiteTest extends TestCase
 {
@@ -198,12 +199,10 @@ class SiteTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider previewUrlProvider
-	 */
+	#[DataProvider('previewUrlProvider')]
 	public function testCustomPreviewUrl(
-		$input,
-		$expected,
+		string|bool|null $input,
+		string|null $expected,
 		bool $authenticated = true
 	): void {
 		$app = new App([

--- a/tests/Cms/Site/SiteTranslationsTest.php
+++ b/tests/Cms/Site/SiteTranslationsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SiteTranslationsTest extends TestCase
 {
@@ -95,9 +96,7 @@ class SiteTranslationsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider visitProvider
-	 */
+	#[DataProvider('visitProvider')]
 	public function testVisit($languageCode, $siteTitle, $pageTitle)
 	{
 		$app = $this->app()->clone([

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -4,11 +4,11 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\License
- */
+#[CoversClass(License::class)]
 class LicenseTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/LicenseTest';
@@ -36,9 +36,6 @@ class LicenseTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::activation
-	 */
 	public function testActivation()
 	{
 		$license = new License(
@@ -50,9 +47,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('1/12/2023 00:00', $license->activation('d/M/yyyy HH:mm', 'intl'));
 	}
 
-	/**
-	 * @covers ::code
-	 */
 	public function testCode()
 	{
 		$license = new License(
@@ -63,10 +57,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('K-ENT-1234XXXXXXXXXXXXXXXXXXXXXX', $license->code(true));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
 	public function testContent()
 	{
 		$license = new License(
@@ -84,9 +74,6 @@ class LicenseTest extends TestCase
 		], $license->content());
 	}
 
-	/**
-	 * @covers ::date
-	 */
 	public function testDate()
 	{
 		$license = new License(
@@ -98,9 +85,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('1/12/2023 00:00', $license->date('d/M/yyyy HH:mm', 'intl'));
 	}
 
-	/**
-	 * @covers ::domain
-	 */
 	public function testDomain()
 	{
 		$license = new License(
@@ -110,9 +94,6 @@ class LicenseTest extends TestCase
 		$this->assertSame($domain, $license->domain());
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmail()
 	{
 		$license = new License(
@@ -122,9 +103,6 @@ class LicenseTest extends TestCase
 		$this->assertSame($email, $license->email());
 	}
 
-	/**
-	 * @covers ::hasValidEmailAddress
-	 */
 	public function testHasValidEmailAddress()
 	{
 		$license = new License(
@@ -140,17 +118,11 @@ class LicenseTest extends TestCase
 		$this->assertFalse($license->hasValidEmailAddress());
 	}
 
-	/**
-	 * @covers ::hub
-	 */
 	public function testHub()
 	{
 		$this->assertSame('https://hub.getkirby.com', License::hub());
 	}
 
-	/**
-	 * @covers ::isComplete
-	 */
 	public function testIsComplete()
 	{
 		// incomplete
@@ -170,9 +142,6 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isComplete());
 	}
 
-	/**
-	 * @covers ::isInactive
-	 */
 	public function testIsInactive()
 	{
 		MockTime::$time = strtotime('now');
@@ -194,9 +163,6 @@ class LicenseTest extends TestCase
 		MockTime::reset();
 	}
 
-	/**
-	 * @covers ::isLegacy
-	 */
 	public function testIsLegacy()
 	{
 		// legacy license type
@@ -230,9 +196,6 @@ class LicenseTest extends TestCase
 		$this->assertFalse($license->isLegacy());
 	}
 
-	/**
-	 * @covers ::isOnCorrectDomain
-	 */
 	public function testIsOnCorrectDomain()
 	{
 		$this->app = new App([
@@ -262,19 +225,12 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isOnCorrectDomain());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel()
 	{
 		$license = new License();
 		$this->assertSame('Unregistered', $license->label());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::normalizeEmail
-	 */
 	public function testNormalize()
 	{
 		$code = $this->code(LicenseType::Enterprise);
@@ -288,10 +244,7 @@ class LicenseTest extends TestCase
 		$this->assertSame('mail@getkirby.com', $license->email());
 	}
 
-	/**
-	 * @covers ::normalizeDomain
-	 * @dataProvider providerForLicenseUrls
-	 */
+	#[DataProvider('providerForLicenseUrls')]
 	public function testNormalizeDomain(string $domain, string $expected)
 	{
 		$reflector = new ReflectionClass(License::class);
@@ -303,9 +256,6 @@ class LicenseTest extends TestCase
 		$this->assertSame($expected, $normalize->invoke($license, $domain));
 	}
 
-	/**
-	 * @covers ::order
-	 */
 	public function testOrder()
 	{
 		$license = new License(
@@ -315,9 +265,6 @@ class LicenseTest extends TestCase
 		$this->assertSame($order, $license->order());
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
 	public function testPolyfill()
 	{
 		$this->assertSame([
@@ -334,9 +281,6 @@ class LicenseTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		// existing license
@@ -361,9 +305,6 @@ class LicenseTest extends TestCase
 		$this->assertNull($license->code());
 	}
 
-	/**
-	 * @covers ::register
-	 */
 	public function testRegisterWithInvalidDomain()
 	{
 		$license = new License(
@@ -377,9 +318,6 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::register
-	 */
 	public function testRegisterWithInvalidEmail()
 	{
 		$license = new License(
@@ -393,9 +331,6 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::register
-	 */
 	public function testRegisterWithInvalidLicenseKey()
 	{
 		$license = new License();
@@ -406,9 +341,6 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::renewal
-	 */
 	public function testRenewal()
 	{
 		// activated
@@ -425,9 +357,6 @@ class LicenseTest extends TestCase
 		$this->assertNull($license->renewal('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveWhenNotActivatable()
 	{
 		$license = new License();
@@ -438,9 +367,6 @@ class LicenseTest extends TestCase
 		$license->save();
 	}
 
-	/**
-	 * @covers ::signature
-	 */
 	public function testSignature()
 	{
 		$license = new License(
@@ -450,18 +376,12 @@ class LicenseTest extends TestCase
 		$this->assertSame('secret', $license->signature());
 	}
 
-	/**
-	 * @covers ::status
-	 */
 	public function testStatus()
 	{
 		$license = new License();
 		$this->assertSame(LicenseStatus::Missing, $license->status());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeKirby3()
 	{
 		$license = new License(
@@ -471,9 +391,6 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Legacy, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeKirbyBasic()
 	{
 		$license = new License(
@@ -483,9 +400,6 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Basic, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeKirbyEnterprise()
 	{
 		$license = new License(
@@ -495,9 +409,6 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Enterprise, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeUnregistered()
 	{
 		$license = new License();

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -7,10 +7,10 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\System
- */
+#[CoversClass(System::class)]
 class SystemTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/SystemTest';
@@ -135,10 +135,6 @@ class SystemTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForContentFolder()
 	{
 		$system = new System($this->app->clone([
@@ -159,10 +155,6 @@ class SystemTest extends TestCase
 		$this->assertSame('/content/site.txt', $system->exposedFileUrl('content'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForGitFolder()
 	{
 		$system = new System($this->app->clone([
@@ -182,10 +174,6 @@ class SystemTest extends TestCase
 		$this->assertSame('/.git/config', $system->exposedFileUrl('git'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForInsignificantFolder()
 	{
 		$system = new System($this->app->clone([
@@ -201,10 +189,6 @@ class SystemTest extends TestCase
 		$this->assertNull($system->exposedFileUrl('media'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForKirbyFolder()
 	{
 		$system = new System($this->app->clone([
@@ -225,10 +209,6 @@ class SystemTest extends TestCase
 		$this->assertSame('/kirby/LICENSE.md', $system->exposedFileUrl('kirby'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForSiteFolder()
 	{
 		$system = new System($this->app->clone([
@@ -264,10 +244,6 @@ class SystemTest extends TestCase
 		$this->assertSame('/site/snippets/header.php', $system->exposedFileUrl('site'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
 	public function testFolderUrlForUnknownFolder()
 	{
 		$system = new System($this->app->clone([
@@ -280,11 +256,8 @@ class SystemTest extends TestCase
 		$this->assertNull($system->exposedFileUrl('unknown'));
 	}
 
-	/**
-	 * @covers ::indexUrl
-	 * @dataProvider providerForIndexUrls
-	 */
-	public function testIndexUrl($indexUrl, $expected)
+	#[DataProvider('providerForIndexUrls')]
+	public function testIndexUrl(string $indexUrl, string $expected)
 	{
 		$system = new System($this->app->clone([
 			'options' => [
@@ -295,10 +268,10 @@ class SystemTest extends TestCase
 	}
 
 	/**
-	 * @dataProvider providerForRoots
 	 * @throws \Kirby\Exception\PermissionException
 	 */
-	public function testInitPermission($root)
+	#[DataProvider('providerForRoots')]
+	public function testInitPermission(string $root)
 	{
 		$this->subTmp = static::TMP . '/' . ucfirst($root) . 'Test';
 
@@ -322,9 +295,6 @@ class SystemTest extends TestCase
 		new System($app);
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfo()
 	{
 		$app = $this->app->clone([
@@ -342,9 +312,6 @@ class SystemTest extends TestCase
 		$this->assertSame(['en', 'de'], $info['languages']);
 	}
 
-	/**
-	 * @covers ::is2FA
-	 */
 	public function testIs2FA()
 	{
 		$app = $this->app->clone([
@@ -368,9 +335,6 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->is2FA());
 	}
 
-	/**
-	 * @covers ::is2FAwithTOTP
-	 */
 	public function testIs2FAWithTOTP()
 	{
 		$app = $this->app->clone([
@@ -405,9 +369,6 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->is2FAWithTOTP());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
 	public function testIsInstallableOnLocalhost()
 	{
 		$app = $this->app->clone([
@@ -421,9 +382,6 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
 	public function testIsInstallableOnPublicServer()
 	{
 		$app = $this->app->clone([
@@ -437,9 +395,6 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
 	public function testIsInstallableOnPublicServerWithOverride()
 	{
 		$app = $this->app->clone([
@@ -458,9 +413,6 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstalled
-	 */
 	public function testIsInstalled()
 	{
 		$system = new System($this->app);
@@ -474,9 +426,6 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstalled());
 	}
 
-	/**
-	 * @covers ::isLocal
-	 */
 	public function testIsLocal()
 	{
 		// yep
@@ -502,9 +451,6 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isLocal());
 	}
 
-	/**
-	 * @covers ::isOk
-	 */
 	public function testIsOk()
 	{
 		$app = $this->app->clone([
@@ -519,9 +465,6 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isOk());
 	}
 
-	/**
-	 * @covers ::isOk
-	 */
 	public function testIsOkContentMissingPermissions()
 	{
 		// reset permissions in `tearDown()`
@@ -534,28 +477,19 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isOk());
 	}
 
-	/**
-	 * @covers ::license
-	 */
 	public function testLicense()
 	{
 		$system = new System($this->app);
 		$this->assertInstanceOf(License::class, $system->license());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
 	public function testLoginMethods()
 	{
 		$this->assertSame(['password' => []], $this->app->system()->loginMethods());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 * @dataProvider providerForLoginMethods
-	 */
-	public function testLoginMethodsCustom($option, $expected)
+	#[DataProvider('providerForLoginMethods')]
+	public function testLoginMethodsCustom(string|array $option, array $expected)
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -565,9 +499,6 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $app->system()->loginMethods());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
 	public function testLoginMethodsDebug1()
 	{
 		$app = $this->app->clone([
@@ -582,9 +513,6 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
 	public function testLoginMethodsDebug2()
 	{
 		$app = $this->app->clone([
@@ -602,9 +530,6 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
 	public function testLoginMethodsDebug3()
 	{
 		$app = $this->app->clone([
@@ -622,18 +547,12 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::plugins
-	 */
 	public function testPlugins()
 	{
 		$system = new System($this->app);
 		$this->assertInstanceOf(Collection::class, $system->plugins());
 	}
 
-	/**
-	 * @covers ::serverSoftware
-	 */
 	public function testServerSoftware()
 	{
 		$app = $this->app->clone([
@@ -646,9 +565,6 @@ class SystemTest extends TestCase
 		$this->assertSame($software, $system->serverSoftware());
 	}
 
-	/**
-	 * @covers ::serverSoftware
-	 */
 	public function testServerSoftwareInvalid()
 	{
 		$app = $this->app->clone([
@@ -661,9 +577,6 @@ class SystemTest extends TestCase
 		$this->assertSame('–', $system->serverSoftware());
 	}
 
-	/**
-	 * @covers ::serverSoftwareShort
-	 */
 	public function testServerSoftwareShort()
 	{
 		$app = $this->app->clone([
@@ -685,18 +598,6 @@ class SystemTest extends TestCase
 		$this->assertSame('Apache/2.4.7', $system->serverSoftwareShort());
 	}
 
-	/**
-	 * @covers ::accounts
-	 * @covers ::content
-	 * @covers ::curl
-	 * @covers ::sessions
-	 * @covers ::mbstring
-	 * @covers ::media
-	 * @covers ::php
-	 * @covers ::status
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testStatus()
 	{
 		$system = new System($this->app);
@@ -715,10 +616,6 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $system->__debugInfo());
 	}
 
-	/**
-	 * @covers ::content
-	 * @covers ::status
-	 */
 	public function testStatusContentMissingPermissions()
 	{
 		// reset permissions in `tearDown()`
@@ -742,9 +639,6 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $system->__debugInfo());
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitle()
 	{
 		$app = $this->app->clone([
@@ -768,9 +662,6 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $app->system()->title());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatus()
 	{
 		$system       = new System($this->app);
@@ -787,9 +678,6 @@ class SystemTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled1()
 	{
 		$app = $this->app->clone([
@@ -806,9 +694,6 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled2()
 	{
 		$app = $this->app->clone([
@@ -823,9 +708,6 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusSecurity1()
 	{
 		$app = $this->app->clone([
@@ -850,9 +732,6 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusSecurity2()
 	{
 		$app = $this->app->clone([
@@ -875,9 +754,6 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusCustomData()
 	{
 		$system       = new System($this->app);

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -7,11 +7,12 @@ use Kirby\Data\Json;
 use Kirby\Filesystem\Dir;
 use Kirby\Plugin\Plugin;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Cms\System\UpdateStatus
- */
+#[CoversClass(UpdateStatus::class)]
+#[CoversClass(UpdateStatus::class)]
 class UpdateStatusTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/UpdateStatusTest';
@@ -36,9 +37,6 @@ class UpdateStatusTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadData()
 	{
 		$app = $this->app('88888.8.5');
@@ -80,9 +78,6 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataCacheKirby()
 	{
 		$app = $this->app('88888.8.5');
@@ -152,9 +147,6 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataCachePlugin()
 	{
 		$app = $this->app('88888.8.5');
@@ -227,9 +219,6 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('plugins/getkirby/public'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataCacheInvalid()
 	{
 		$app = $this->app('88888.8.5');
@@ -272,9 +261,6 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataCacheDisabled()
 	{
 		$app = $this->app('88888.8.5')->clone([
@@ -292,9 +278,6 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataNotFound()
 	{
 		$app    = $this->app('88888.8.8');
@@ -326,9 +309,6 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
 	public function testLoadDataNotJson()
 	{
 		$app    = $this->app('88888.8.8');
@@ -357,10 +337,7 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers \Kirby\Cms\System\UpdateStatus
-	 * @dataProvider logicProvider
-	 */
+	#[DataProvider('logicProvider')]
 	public function testLogic(
 		string $packageType,
 		array $packageData,
@@ -1656,9 +1633,6 @@ class UpdateStatusTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::messages
-	 */
 	public function testMessagesCache()
 	{
 		$updateStatus = new UpdateStatus($this->app('77777.6.0'), false, static::data('basic'));

--- a/tests/Cms/Translations/TranslationTest.php
+++ b/tests/Cms/Translations/TranslationTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Translation
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Translation::class)]
 class TranslationTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';

--- a/tests/Cms/Users/UserBlueprintTest.php
+++ b/tests/Cms/Users/UserBlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class UserBlueprintTest extends TestCase
 {
@@ -44,9 +45,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->options());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18n()
 	{
 		$app = new App([
@@ -91,9 +90,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18nWithFallbackLanguage()
 	{
 		$app = new App([
@@ -129,9 +126,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testTitleI18nArray()
 	{
 		$app = new App([

--- a/tests/Cms/Users/UserPermissionsTest.php
+++ b/tests/Cms/Users/UserPermissionsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UserPermissionsTest extends TestCase
 {
@@ -20,10 +21,8 @@ class UserPermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin(string $action)
 	{
 		$kirby = new App([
 			'roots' => [
@@ -43,10 +42,8 @@ class UserPermissionsTest extends TestCase
 		$this->assertTrue($perms->can($action));
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action)
 	{
 		new App([
 			'roots' => [
@@ -64,10 +61,8 @@ class UserPermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNoAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNoAdmin(string $action)
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Users/UserRulesTest.php
+++ b/tests/Cms/Users/UserRulesTest.php
@@ -7,6 +7,7 @@ use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UserRulesTest extends TestCase
 {
@@ -42,10 +43,8 @@ class UserRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider validDataProvider
-	 */
-	public function testChangeValid($key, $value)
+	#[DataProvider('validDataProvider')]
+	public function testChangeValid(string $key, string $value)
 	{
 		$kirby = $this->appWithAdmin();
 		$user  = $kirby->user('user@domain.com');
@@ -66,10 +65,8 @@ class UserRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider invalidDataProvider
-	 */
-	public function testChangeInvalid($key, $value, $message)
+	#[DataProvider('invalidDataProvider')]
+	public function testChangeInvalid(string $key, string $value, string $message)
 	{
 		$kirby = $this->appWithAdmin();
 		$user  = $kirby->user('user@domain.com');
@@ -90,10 +87,8 @@ class UserRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider missingPermissionProvider
-	 */
-	public function testChangeWithoutPermission($key, $value, $message)
+	#[DataProvider('missingPermissionProvider')]
+	public function testChangeWithoutPermission(string $key, string $value, string $message)
 	{
 		$permissions = $this->createMock(UserPermissions::class);
 		$permissions->method('can')->with('change' . $key)->willReturn(false);
@@ -504,9 +499,7 @@ class UserRulesTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider validIdProvider
-	 */
+	#[DataProvider('validIdProvider')]
 	public function testValidId(string $id)
 	{
 		$user = new User(['email' => 'test@getkirby.com']);

--- a/tests/Cms/Users/UserTest.php
+++ b/tests/Cms/Users/UserTest.php
@@ -6,15 +6,15 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class UserTestModel extends User
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\User
- */
+#[CoversClass(User::class)]
 class UserTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.User';
@@ -72,9 +72,6 @@ class UserTest extends TestCase
 		new User(['email' => []]);
 	}
 
-	/**
-	 * @covers ::isAdmin
-	 */
 	public function testIsAdmin()
 	{
 		$user = new User([
@@ -92,9 +89,6 @@ class UserTest extends TestCase
 		$this->assertFalse($user->isAdmin());
 	}
 
-	/**
-	 * @covers ::isKirby
-	 */
 	public function testIsKirby()
 	{
 		$user = new User([
@@ -119,9 +113,6 @@ class UserTest extends TestCase
 		$this->assertFalse($user->isKirby());
 	}
 
-	/**
-	 * @covers ::isLoggedIn
-	 */
 	public function testIsLoggedIn()
 	{
 		$app = new App([
@@ -151,9 +142,6 @@ class UserTest extends TestCase
 		$this->assertTrue($b->isLoggedIn());
 	}
 
-	/**
-	 * @covers ::isNobody
-	 */
 	public function testIsNobody()
 	{
 		$user = new User([
@@ -341,9 +329,6 @@ class UserTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::roles
-	 */
 	public function testRoles(): void
 	{
 		$app = new App([
@@ -400,9 +385,6 @@ class UserTest extends TestCase
 		$this->assertSame(['admin'], $roles);
 	}
 
-	/**
-	 * @covers ::roles
-	 */
 	public function testRolesWithPermissions(): void
 	{
 		$app = new App([
@@ -453,9 +435,6 @@ class UserTest extends TestCase
 		$this->assertSame(['guest'], $roles);
 	}
 
-	/**
-	 * @covers ::roles
-	 */
 	public function testRolesWithOptions(): void
 	{
 		$app = new App([
@@ -565,10 +544,8 @@ class UserTest extends TestCase
 		$user->secret('totp');
 	}
 
-	/**
-	 * @dataProvider passwordProvider
-	 */
-	public function testValidatePassword($input, $valid)
+	#[DataProvider('passwordProvider')]
+	public function testValidatePassword(string|null $input, bool $valid)
 	{
 		$user = new User([
 			'email'    => 'test@getkirby.com',

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -6,10 +6,9 @@ use Kirby\Cache\Cache;
 use Kirby\Cms\App;
 use Kirby\TestCase;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Changes
- */
+#[CoversClass(Changes::class)]
 class ChangesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Changes';
@@ -57,9 +56,6 @@ class ChangesTest extends TestCase
 		parent::tearDownTmp();
 	}
 
-	/**
-	 * @covers ::cache
-	 */
 	public function testCache()
 	{
 		$cache = $this->app->cache('changes');
@@ -67,10 +63,6 @@ class ChangesTest extends TestCase
 		$this->assertInstanceOf(Cache::class, $cache);
 	}
 
-	/**
-	 * @covers ::files
-	 * @covers ::ensure
-	 */
 	public function testFiles()
 	{
 		$this->app->cache('changes')->set('files', $cache = [
@@ -92,9 +84,6 @@ class ChangesTest extends TestCase
 		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
 	}
 
-	/**
-	 * @covers ::cacheKey
-	 */
 	public function testCacheKey()
 	{
 		$changes = new Changes();
@@ -108,10 +97,6 @@ class ChangesTest extends TestCase
 		$this->assertSame('users', $changes->cacheKey($user));
 	}
 
-	/**
-	 * @covers ::cacheExists
-	 * @covers ::generateCache
-	 */
 	public function testGenerateCache()
 	{
 		$changes = new Changes();
@@ -143,10 +128,6 @@ class ChangesTest extends TestCase
 		$this->assertSame(['user://test'], $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::pages
-	 * @covers ::ensure
-	 */
 	public function testPages()
 	{
 		$this->app->cache('changes')->set('pages', $cache = [
@@ -168,9 +149,6 @@ class ChangesTest extends TestCase
 		$this->assertSame('test', $changes->pages()->first()->id());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		$this->app->cache('changes')->set('files', [
@@ -192,9 +170,6 @@ class ChangesTest extends TestCase
 		$this->assertSame(['user://test'], $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::track
-	 */
 	public function testTrack()
 	{
 		$changes = new Changes();
@@ -216,9 +191,6 @@ class ChangesTest extends TestCase
 		$this->assertSame('user://test', $users[0]);
 	}
 
-	/**
-	 * @covers ::track
-	 */
 	public function testTrackDisabledUuids()
 	{
 		$this->app = $this->app->clone([
@@ -248,9 +220,6 @@ class ChangesTest extends TestCase
 		$this->assertSame('test', $users[0]);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$changes = new Changes();
@@ -280,9 +249,6 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::untrack
-	 */
 	public function testUntrack()
 	{
 		$changes = new Changes();
@@ -304,9 +270,6 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::untrack
-	 */
 	public function testUntrackDisabledUuids()
 	{
 		$this->app = $this->app->clone([
@@ -336,10 +299,6 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::users
-	 * @covers ::ensure
-	 */
 	public function testUsers()
 	{
 		$this->app->cache('changes')->set('users', $cache = [

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Content
- */
+#[CoversClass(Content::class)]
 class ContentTest extends TestCase
 {
 	protected Content $content;
@@ -26,9 +25,6 @@ class ContentTest extends TestCase
 		], $this->parent);
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCall()
 	{
 		$this->assertSame('a', $this->content->a()->key());
@@ -39,9 +35,6 @@ class ContentTest extends TestCase
 		$this->assertSame('MIXED', $this->content->mIXEd()->value());
 	}
 
-	/**
-	 * @covers ::convertTo
-	 */
 	public function testConvertTo()
 	{
 		$app = new App([
@@ -109,12 +102,6 @@ class ContentTest extends TestCase
 		$this->assertSame('keep this', $new['removed']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__debugInfo
-	 * @covers ::data
-	 * @covers ::toArray
-	 */
 	public function testData()
 	{
 		$expected = [
@@ -128,9 +115,6 @@ class ContentTest extends TestCase
 		$this->assertSame($expected, $this->content->toArray());
 	}
 
-	/**
-	 * @covers ::fields
-	 */
 	public function testFields()
 	{
 		$fields = $this->content->fields();
@@ -141,9 +125,6 @@ class ContentTest extends TestCase
 		$this->assertSame('MIXED', $fields['mixed']->value());
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		$field = $this->content->get('mixed');
@@ -170,9 +151,6 @@ class ContentTest extends TestCase
 		$this->assertSame('MIXED', $fields['mixed']->value());
 	}
 
-	/**
-	 * @covers ::has
-	 */
 	public function testHas()
 	{
 		$this->assertTrue($this->content->has('a'));
@@ -185,17 +163,11 @@ class ContentTest extends TestCase
 		$this->assertFalse($this->content->has('C'));
 	}
 
-	/**
-	 * @covers ::keys
-	 */
 	public function testKeys()
 	{
 		$this->assertSame(['a', 'b', 'mixed'], $this->content->keys());
 	}
 
-	/**
-	 * @covers ::not
-	 */
 	public function testNot()
 	{
 		$content1 = $this->content->not('a');
@@ -228,17 +200,11 @@ class ContentTest extends TestCase
 		$this->assertSame('B', $content5->get('b')->value());
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParent()
 	{
 		$this->assertSame($this->parent, $this->content->parent());
 	}
 
-	/**
-	 * @covers ::setParent
-	 */
 	public function testSetParent()
 	{
 		$page = new Page(['slug' => 'another-test']);
@@ -247,9 +213,6 @@ class ContentTest extends TestCase
 		$this->assertIsPage($page, $this->content->parent());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$this->content->update([

--- a/tests/Content/ContentTranslationTest.php
+++ b/tests/Content/ContentTranslationTest.php
@@ -5,18 +5,11 @@ namespace Kirby\Content;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\ContentTranslation
- */
+#[CoversClass(ContentTranslation::class)]
 class ContentTranslationTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::code
-	 * @covers ::id
-	 * @covers ::parent
-	 */
 	public function testParentAndCode()
 	{
 		$page = new Page([
@@ -33,11 +26,6 @@ class ContentTranslationTest extends TestCase
 		$this->assertSame('de', $translation->id());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 * @covers ::slug
-	 */
 	public function testContentAndSlug()
 	{
 		$page = new Page([
@@ -57,9 +45,6 @@ class ContentTranslationTest extends TestCase
 		$this->assertSame($content, $translation->content());
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentMerged()
 	{
 		$app = new App([
@@ -103,9 +88,6 @@ class ContentTranslationTest extends TestCase
 		], $translation->content());
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFile()
 	{
 		$app = new App([
@@ -136,9 +118,6 @@ class ContentTranslationTest extends TestCase
 		$this->assertSame('/content/test/project.de.txt', $translation->contentFile());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -160,9 +139,6 @@ class ContentTranslationTest extends TestCase
 		$this->assertTrue($translation->exists());
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
 	public function testIsDefault()
 	{
 		$app = new App([
@@ -197,9 +173,6 @@ class ContentTranslationTest extends TestCase
 		$this->assertFalse($translation->isDefault());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$page = new Page([
@@ -234,10 +207,6 @@ class ContentTranslationTest extends TestCase
 		], $translation->content());
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 * @covers ::toArray
-	 */
 	public function testToArrayAndDebugInfo()
 	{
 		$page = new Page(['slug' => 'test']);

--- a/tests/Content/FieldTest.php
+++ b/tests/Content/FieldTest.php
@@ -4,35 +4,26 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Content\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
-	/**
-	 * @covers ::__debugInfo
-	 */
 	public function test__debugInfo()
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame(['title' => 'Title'], $field->__debugInfo());
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('title', $field->key());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$parent = new Page([
@@ -46,9 +37,6 @@ class FieldTest extends TestCase
 		$this->assertFalse($parent->b()->exists());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$model = new Page(['slug' => 'test']);
@@ -57,9 +45,6 @@ class FieldTest extends TestCase
 		$this->assertSame($model, $field->model());
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParent()
 	{
 		$parent = new Page(['slug' => 'test']);
@@ -68,11 +53,6 @@ class FieldTest extends TestCase
 		$this->assertSame($parent, $field->parent());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
 	public function testToString()
 	{
 		$field = new Field(null, 'title', 'Title');
@@ -82,27 +62,18 @@ class FieldTest extends TestCase
 		$this->assertSame('Title', (string)$field);
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame(['title' => 'Title'], $field->toArray());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('Title', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValueSetter()
 	{
 		$field = new Field(null, 'title', 'Title');
@@ -111,9 +82,6 @@ class FieldTest extends TestCase
 		$this->assertSame('Modified', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValueCallbackSetter()
 	{
 		$field = new Field(null, 'title', 'Title');
@@ -122,9 +90,6 @@ class FieldTest extends TestCase
 		$this->assertSame('Modified', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testInvalidValueSetter()
 	{
 		$this->expectException(TypeError::class);
@@ -135,9 +100,6 @@ class FieldTest extends TestCase
 		$field->value(new stdClass());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCloningInMethods()
 	{
 		Field::$methods = [
@@ -174,29 +136,20 @@ class FieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @dataProvider emptyDataProvider
-	 */
-	public function testIsEmpty($input, $expected)
+	#[DataProvider('emptyDataProvider')]
+	public function testIsEmpty(string|int|bool|array|null $input, bool $expected)
 	{
 		$field = new Field(null, 'test', $input);
 		$this->assertSame($expected, $field->isEmpty());
 	}
 
-	/**
-	 * @covers ::isNotEmpty
-	 * @dataProvider emptyDataProvider
-	 */
-	public function testIsNotEmpty($input, $expected)
+	#[DataProvider('emptyDataProvider')]
+	public function testIsNotEmpty(string|int|bool|array|null $input, bool $expected)
 	{
 		$field = new Field(null, 'test', $input);
 		$this->assertSame(!$expected, $field->isNotEmpty());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCallNonExistingMethod()
 	{
 		$field  = new Field(null, 'test', 'value');
@@ -205,9 +158,6 @@ class FieldTest extends TestCase
 		$this->assertSame($field, $result);
 	}
 
-	/**
-	 * @covers ::or
-	 */
 	public function testOrWithFieldFallback()
 	{
 		$fallback = new Field(null, 'fallback', 'fallback value');
@@ -217,9 +167,6 @@ class FieldTest extends TestCase
 		$this->assertSame($fallback, $field->or($fallback));
 	}
 
-	/**
-	 * @covers ::or
-	 */
 	public function testOrWithStringFallback()
 	{
 		$fallback = 'fallback value';

--- a/tests/Content/ImmutableMemoryStorageTest.php
+++ b/tests/Content/ImmutableMemoryStorageTest.php
@@ -4,11 +4,9 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\ImmutableMemoryStorage
- * @covers ::__construct
- */
+#[CoversClass(ImmutableMemoryStorage::class)]
 class ImmutableMemoryStorageTest extends TestCase
 {
 	protected $storage;
@@ -21,10 +19,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage = new ImmutableMemoryStorage($this->model);
 	}
 
-	/**
-	 * @covers ::delete
-	 * @covers ::preventMutation
-	 */
 	public function testDelete()
 	{
 		$this->expectException(LogicException::class);
@@ -33,10 +27,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->delete(VersionId::latest(), Language::ensure());
 	}
 
-	/**
-	 * @covers ::move
-	 * @covers ::preventMutation
-	 */
 	public function testMove()
 	{
 		$this->expectException(LogicException::class);
@@ -49,10 +39,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::touch
-	 * @covers ::preventMutation
-	 */
 	public function testTouch()
 	{
 		$this->expectException(LogicException::class);
@@ -61,10 +47,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->touch(VersionId::latest(), Language::ensure());
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::preventMutation
-	 */
 	public function testUpdate()
 	{
 		$this->storage->create(VersionId::latest(), Language::ensure(), []);

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -6,11 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Lock
- * @covers ::__construct
- */
+#[CoversClass(Lock::class)]
 class LockTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.LockTest';
@@ -71,9 +69,6 @@ class LockTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForWithAuthenticatedUser()
 	{
 		$this->app->impersonate('admin');
@@ -87,9 +82,6 @@ class LockTest extends TestCase
 		$this->assertSame($this->app->user('admin'), $lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForWithDifferentUser()
 	{
 		// create the version with the admin user
@@ -108,9 +100,6 @@ class LockTest extends TestCase
 		$this->assertSame($this->app->user('admin'), $lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForWithoutUser()
 	{
 		// create the version with the admin user
@@ -122,9 +111,6 @@ class LockTest extends TestCase
 		$this->assertNull($lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForWithLanguageWildcard()
 	{
 		$this->app = $this->app->clone([
@@ -156,9 +142,6 @@ class LockTest extends TestCase
 		$this->assertSame('admin', $lock->user()->id());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForWithLegacyLock()
 	{
 		$page = $this->app->page('test');
@@ -178,9 +161,6 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
 	public function testIsActive()
 	{
 		// just modified
@@ -191,9 +171,6 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
 	public function testIsActiveWithOldModificationTimestamp()
 	{
 		// create a lock that has not been modified for 20 minutes
@@ -204,9 +181,6 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
 	public function testIsActiveWithoutModificationTimestamp()
 	{
 		// a lock without modification time should also be inactive
@@ -214,17 +188,11 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isEnabled
-	 */
 	public function testIsEnabled()
 	{
 		$this->assertTrue(Lock::isEnabled());
 	}
 
-	/**
-	 * @covers ::isEnabled
-	 */
 	public function testIsEnabledWhenDisabled()
 	{
 		$this->app = $this->app->clone([
@@ -238,9 +206,6 @@ class LockTest extends TestCase
 		$this->assertFalse(Lock::isEnabled());
 	}
 
-	/**
-	 * @covers ::isLegacy
-	 */
 	public function testIsLegacy()
 	{
 		$lock = new Lock();
@@ -250,18 +215,12 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLegacy());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLocked()
 	{
 		$lock = new Lock();
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLockedWithCurrentUser()
 	{
 		$this->app->impersonate('admin');
@@ -274,9 +233,6 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLockedWithDifferentUser()
 	{
 		$this->app->impersonate('admin');
@@ -289,9 +245,6 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLockedWhenDisabled()
 	{
 		$this->app = $this->app->clone([
@@ -312,9 +265,6 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLockedWithDifferentUserAndOldTimestamp()
 	{
 		$this->app->impersonate('admin');
@@ -327,9 +277,6 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
 	public function testLegacy()
 	{
 		$page = $this->app->page('test');
@@ -353,9 +300,6 @@ class LockTest extends TestCase
 		$this->assertSame($time, $lock->modified());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
 	public function testLegacyWithoutLockInfo()
 	{
 		$page = $this->app->page('test');
@@ -367,9 +311,6 @@ class LockTest extends TestCase
 		$this->assertNull($lock);
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
 	public function testLegacyWithOutdatedFile()
 	{
 		$page = $this->app->page('test');
@@ -390,9 +331,6 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
 	public function testLegacyWithUnlockedFile()
 	{
 		$page = $this->app->page('test');
@@ -412,9 +350,6 @@ class LockTest extends TestCase
 		$this->assertNull($lock);
 	}
 
-	/**
-	 * @covers ::legacyFile
-	 */
 	public function testLegacyFile()
 	{
 		$page = $this->app->page('test');
@@ -423,9 +358,6 @@ class LockTest extends TestCase
 		$this->assertSame($expected, Lock::legacyFile($page));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		$lock = new Lock(
@@ -436,9 +368,6 @@ class LockTest extends TestCase
 		$this->assertSame(date('c', $modified), $lock->modified('c'));
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$lock = new Lock(
@@ -460,9 +389,6 @@ class LockTest extends TestCase
 		], $lock->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUser()
 	{
 		$lock = new Lock(
@@ -472,9 +398,6 @@ class LockTest extends TestCase
 		$this->assertSame($user, $lock->user());
 	}
 
-	/**
-	 * @covers ::user
-	 */
 	public function testUserWithoutUser()
 	{
 		$lock = new Lock();

--- a/tests/Content/LockedContentExceptionTest.php
+++ b/tests/Content/LockedContentExceptionTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\User;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\LockedContentException
- */
+#[CoversClass(LockedContentException::class)]
 class LockedContentExceptionTest extends TestCase
 {
 	public function testException()

--- a/tests/Content/MemoryStorageTest.php
+++ b/tests/Content/MemoryStorageTest.php
@@ -3,12 +3,9 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\MemoryStorage
- * @covers ::__construct
- * @covers ::cacheId
- */
+#[CoversClass(MemoryStorage::class)]
 class MemoryStorageTest extends TestCase
 {
 	protected MemoryStorage $storage;
@@ -70,11 +67,6 @@ class MemoryStorageTest extends TestCase
 		$this->storage = new MemoryStorage($this->model);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -85,11 +77,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -100,11 +87,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -115,11 +97,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -130,10 +107,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 * @covers ::exists
-	 */
 	public function testDeleteNonExisting()
 	{
 		$this->setUpSingleLanguage();
@@ -149,9 +122,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists($versionId, $language));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -162,9 +132,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -175,9 +142,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -188,9 +152,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -201,9 +162,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -220,9 +178,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -237,9 +192,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $language));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -248,9 +200,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -258,9 +207,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -269,9 +215,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -280,9 +223,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -296,9 +236,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -312,9 +249,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -330,9 +264,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -348,10 +279,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::write
-	 */
 	public function testUpdateMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -362,10 +289,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndUpdate($versionId, $language);
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::write
-	 */
 	public function testUpdateSingleLang()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -8,11 +8,11 @@ use Kirby\Cms\Page;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Content\PlainTextStorage
- * @covers ::__construct
- */
+#[CoversClass(PlainTextStorage::class)]
 class PlainTextStorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.PlainTextStorage';
@@ -35,9 +35,6 @@ class PlainTextStorageTest extends TestCase
 		$this->storage = new PlainTextStorage($this->model);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -51,9 +48,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -67,9 +61,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -83,9 +74,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -99,9 +87,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteNonExisting()
 	{
 		$this->setUpSingleLanguage();
@@ -120,9 +105,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -137,9 +119,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -153,9 +132,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist($this->model->root() . '/_changes');
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -169,9 +145,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -185,9 +158,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -196,9 +166,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -206,9 +173,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -217,9 +181,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -228,9 +189,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -242,9 +200,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -256,9 +211,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testMove()
 	{
 		$this->setUpSingleLanguage();
@@ -285,9 +238,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testMoveNonExistingContentFile()
 	{
 		$this->setUpSingleLanguage();
@@ -307,9 +258,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -325,9 +273,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -343,9 +288,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -360,9 +302,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -377,9 +316,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -398,9 +334,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -419,9 +352,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.txt'));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -439,9 +369,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -459,9 +386,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -478,9 +402,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -497,9 +418,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -515,9 +433,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -533,10 +448,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
-	/**
-	 * @covers ::contentFile
-	 * @dataProvider contentFileProviderMultiLang
-	 */
+	#[DataProvider('contentFileProviderMultiLang')]
 	public function testContentFileMultiLang(string $type, VersionId $id, string $language, string $expected)
 	{
 		$this->setUpMultiLanguage();
@@ -578,10 +490,7 @@ class PlainTextStorageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::contentFile
-	 * @dataProvider contentFileProviderSingleLang
-	 */
+	#[DataProvider('contentFileProviderSingleLang')]
 	public function testContentFileSingleLang(string $type, VersionId $id, string $expected)
 	{
 		$this->setUpSingleLanguage();
@@ -623,9 +532,6 @@ class PlainTextStorageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileDraft()
 	{
 		$this->setUpSingleLanguage();
@@ -641,9 +547,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame(static::TMP . '/content/_drafts/a-page/_changes/article.txt', $storage->contentFile(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -654,9 +557,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -666,9 +566,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -679,9 +576,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::latest()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -7,18 +7,13 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Storage
- * @covers ::__construct
- */
+#[CoversClass(Storage::class)]
 class StorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Storage';
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllMultiLanguageForFile()
 	{
 		$this->setUpMultiLanguage();
@@ -51,9 +46,6 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllSingleLanguageForFile()
 	{
 		$this->setUpSingleLanguage();
@@ -81,9 +73,6 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllMultiLanguageForPage()
 	{
 		$this->setUpMultiLanguage();
@@ -111,9 +100,6 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllSingleLanguageForPage()
 	{
 		$this->setUpSingleLanguage();
@@ -137,9 +123,6 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -164,9 +147,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopySingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -188,9 +168,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopytoAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
@@ -213,9 +190,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::copyAll
-	 */
 	public function testCopyAll()
 	{
 		$this->setUpSingleLanguage();
@@ -239,9 +213,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::deleteLanguage
-	 */
 	public function testDeleteLanguageMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -261,9 +232,6 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::deleteLanguage
-	 */
 	public function testDeleteLanguageSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -287,9 +255,6 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $language));
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFrom()
 	{
 		$this->setUpMultiLanguage();
@@ -331,9 +296,6 @@ class StorageTest extends TestCase
 		$this->assertSame($changesDE, $handlerB->read($versionChanges, $de));
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$this->setUpSingleLanguage();
@@ -343,9 +305,6 @@ class StorageTest extends TestCase
 		$this->assertSame($this->model, $handler->model());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -370,9 +329,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -395,9 +351,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMovetoAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
@@ -420,9 +373,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::moveAll
-	 */
 	public function testMoveAll()
 	{
 		$this->setUpSingleLanguage();
@@ -446,9 +396,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::moveLanguage
-	 */
 	public function testMoveSingleLanguageToMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -475,9 +422,6 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.en.txt');
 	}
 
-	/**
-	 * @covers ::moveLanguage
-	 */
 	public function testMoveMultiLanguageToSingleLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -505,9 +449,6 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @covers ::replaceStrings
-	 */
 	public function testReplaceStrings()
 	{
 		$this->setUpMultiLanguage();
@@ -535,9 +476,6 @@ class StorageTest extends TestCase
 		$this->assertSame($expected, $handler->read($versionId, $language));
 	}
 
-	/**
-	 * @covers ::touchLanguage
-	 */
 	public function testTouchLanguageMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -5,17 +5,11 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Data\Data;
 use Kirby\Exception\Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Translation
- * @covers ::__construct
- */
+#[CoversClass(Translation::class)]
 class TranslationTest extends TestCase
 {
-	/**
-	 * @covers ::code
-	 * @covers ::id
-	 */
 	public function testCodeAndId()
 	{
 		$this->setUpMultiLanguage();
@@ -39,9 +33,6 @@ class TranslationTest extends TestCase
 		$this->assertSame('de', $translationDE->id());
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -64,9 +55,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected['de']['content'], $translationDE->version()->content($languageDE)->toArray());
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -82,9 +70,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected['content'], $translation->version()->content()->toArray());
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -98,9 +83,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model->root() . '/article.en.txt', $translation->version()->contentFile());
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -114,9 +96,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model->root() . '/article.txt', $translation->version()->contentFile());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate()
 	{
 		$this->setUpMultiLanguage();
@@ -137,9 +116,6 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translation->version()->exists());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWithSlug()
 	{
 		$this->setUpMultiLanguage();
@@ -158,9 +134,6 @@ class TranslationTest extends TestCase
 		$this->assertSame('foo', $translation->slug());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -191,9 +164,6 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translationDE->version()->exists($languageDE));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -208,9 +178,6 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translation->version()->exists());
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
 	public function testIsDefault()
 	{
 		$this->setUpMultiLanguage();
@@ -231,9 +198,6 @@ class TranslationTest extends TestCase
 		$this->assertFalse($de->language()->isDefault());
 	}
 
-	/**
-	 * @covers ::language
-	 */
 	public function testLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -254,9 +218,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($languageDE, $translationDE->language());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$this->setUpMultiLanguage();
@@ -270,9 +231,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model, $translation->model());
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParent()
 	{
 		$this->setUpSingleLanguage();
@@ -289,9 +247,6 @@ class TranslationTest extends TestCase
 		$translation->parent();
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlugExists()
 	{
 		$this->setUpMultiLanguage();
@@ -310,9 +265,6 @@ class TranslationTest extends TestCase
 		$this->assertSame('german-slug', $translation->slug());
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlugNotExists()
 	{
 		$this->setUpMultiLanguage();
@@ -330,9 +282,6 @@ class TranslationTest extends TestCase
 		$this->assertNull($translation->slug());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$this->setUpSingleLanguage();
@@ -349,9 +298,6 @@ class TranslationTest extends TestCase
 		$translation->update();
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$this->setUpSingleLanguage();
@@ -372,9 +318,6 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected, $translation->toArray());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersion()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -3,16 +3,11 @@
 namespace Kirby\Content;
 
 use Kirby\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Translations
- * @covers ::__construct
- */
+#[CoversClass(Translations::class)]
 class TranslationsTest extends TestCase
 {
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -41,9 +36,6 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -73,9 +65,6 @@ class TranslationsTest extends TestCase
 		$this->assertTrue($translations->first()->language()->isSingle());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
 	public function testFindByKeyMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -91,9 +80,6 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->findByKey('de')->language()->code());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
 	public function testFindByKeySingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -108,9 +94,6 @@ class TranslationsTest extends TestCase
 		$this->assertSame('en', $translations->findByKey('current')->language()->code());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
 	public function testFindByKeyWithInvalidLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -126,9 +109,6 @@ class TranslationsTest extends TestCase
 		$translations->findByKey('fr');
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -143,9 +123,6 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadSingleLanguage()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Content;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\VersionId
- */
+#[CoversClass(VersionId::class)]
 class VersionIdTest extends TestCase
 {
 	public function tearDown(): void
@@ -18,9 +17,6 @@ class VersionIdTest extends TestCase
 		VersionId::$render = null;
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAll()
 	{
 		$list = VersionId::all();
@@ -30,10 +26,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame('changes', $list[1]->value());
 	}
 
-	/**
-	 * @covers ::changes
-	 * @covers ::value
-	 */
 	public function testChanges()
 	{
 		$version = VersionId::changes();
@@ -41,9 +33,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame('changes', $version->value());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithInvalidId()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -52,29 +41,18 @@ class VersionIdTest extends TestCase
 		new VersionId('foo');
 	}
 
-	/**
-	 * @covers ::from
-	 * @covers ::value
-	 */
 	public function testFromString()
 	{
 		$version = VersionId::from('latest');
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::from
-	 * @covers ::value
-	 */
 	public function testFromInstance()
 	{
 		$version = VersionId::from(VersionId::latest());
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIs()
 	{
 		$version = VersionId::latest();
@@ -85,10 +63,6 @@ class VersionIdTest extends TestCase
 		$this->assertFalse($version->is(VersionId::CHANGES));
 	}
 
-	/**
-	 * @covers ::latest
-	 * @covers ::value
-	 */
 	public function testLatest()
 	{
 		$version = VersionId::latest();
@@ -96,9 +70,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderString()
 	{
 		$executed = 0;
@@ -127,9 +98,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderInstance()
 	{
 		$executed = 0;
@@ -158,9 +126,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderPreviousValue()
 	{
 		$executed = 0;
@@ -179,9 +144,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame(1, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderException()
 	{
 		$executed = 0;
@@ -204,9 +166,6 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$this->assertSame('latest', (string)VersionId::latest());

--- a/tests/Content/VersionRulesTest.php
+++ b/tests/Content/VersionRulesTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class ExistingVersion extends Version
 {
@@ -23,16 +24,11 @@ class LockedVersion extends Version
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Content\VersionRules
- */
+#[CoversClass(VersionRules::class)]
 class VersionRulesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.VersionRules';
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWhenTheVersionAlreadyExists()
 	{
 		$this->setUpSingleLanguage();
@@ -48,9 +44,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::create($version, [], Language::ensure());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateWhenLatestVersionDoesNotExist()
 	{
 		$this->setUpSingleLanguage();
@@ -69,9 +62,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::create($version, [], Language::ensure());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteWhenTheVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();
@@ -87,9 +77,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::delete($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -105,9 +92,6 @@ class VersionRulesTest extends TestCase
 		$this->assertNull(VersionRules::ensure($version, Language::ensure('de')));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -122,9 +106,6 @@ class VersionRulesTest extends TestCase
 		$this->assertNull(VersionRules::ensure($version, Language::ensure()));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWhenMissingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -140,9 +121,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure('de'));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWhenMissingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -158,9 +136,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWithInvalidLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -176,9 +151,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure('fr'));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWhenTheSourceVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();
@@ -202,9 +174,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::move($source, Language::ensure(), $target, Language::ensure());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWhenTheTargetVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();
@@ -229,9 +198,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::move($source, Language::ensure(), $target, Language::ensure());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
 	public function testPublishTheLatestVersion()
 	{
 		$this->setUpSingleLanguage();
@@ -247,9 +213,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::publish($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
 	public function testPublishWhenTheVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();
@@ -267,9 +230,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::publish($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadWhenMissing()
 	{
 		$this->setUpSingleLanguage();
@@ -289,9 +249,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::read($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::replace
-	 */
 	public function testReplaceWhenTheVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();
@@ -309,9 +266,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::replace($version, [], Language::ensure());
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchWhenMissing()
 	{
 		$this->setUpSingleLanguage();
@@ -331,9 +285,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::touch($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateWhenTheVersionIsLocked()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -9,18 +9,14 @@ use Kirby\Cms\Site;
 use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Content\Version
- * @covers ::__construct
- */
+#[CoversClass(Version::class)]
 class VersionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Version';
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -39,9 +35,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected['de']['content']['title'], $version->content($this->app->language('de'))->get('title')->value());
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -56,9 +49,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected['content']['title'], $version->content()->get('title')->value());
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContentWithFallback(): void
 	{
 		$this->setUpMultiLanguage();
@@ -81,10 +71,6 @@ class VersionTest extends TestCase
 		$this->assertSame($version->content('en')->toArray(), $version->content('de')->toArray());
 	}
 
-	/**
-	 * @covers ::content
-	 * @covers ::prepareFieldsForContent
-	 */
 	public function testContentPrepareFields(): void
 	{
 		$this->setUpSingleLanguage();
@@ -128,9 +114,6 @@ class VersionTest extends TestCase
 		], $version->content()->toArray());
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -147,9 +130,6 @@ class VersionTest extends TestCase
 		$this->assertSame($this->contentFile('de'), $version->contentFile($this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -162,9 +142,6 @@ class VersionTest extends TestCase
 		$this->assertSame($this->contentFile(), $version->contentFile());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -191,9 +168,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists('de');
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateMultiLanguageWhenLatestTranslationIsMissing(): void
 	{
 		$this->setUpMultiLanguage();
@@ -229,9 +203,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists('de', $changes->id());
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -250,11 +221,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists();
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsBeforeWrite
-	 */
 	public function testCreateWithDirtyFields(): void
 	{
 		$this->setUpMultiLanguage();
@@ -307,9 +273,6 @@ class VersionTest extends TestCase
 		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -338,9 +301,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist('de');
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -361,9 +321,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileDoesNotExist();
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsLatestMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -391,9 +348,6 @@ class VersionTest extends TestCase
 		$this->assertTrue($version->exists($this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsWithLanguageWildcard(): void
 	{
 		$this->setUpMultiLanguage();
@@ -420,9 +374,6 @@ class VersionTest extends TestCase
 		$this->assertTrue($version->exists('*'));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsLatestSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -439,9 +390,6 @@ class VersionTest extends TestCase
 		$this->assertTrue($version->exists());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId(): void
 	{
 		$this->setUpSingleLanguage();
@@ -454,9 +402,6 @@ class VersionTest extends TestCase
 		$this->assertSame($id, $version->id());
 	}
 
-	/**
-	 * @covers ::isIdentical
-	 */
 	public function testIsIdenticalMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -492,9 +437,6 @@ class VersionTest extends TestCase
 		$this->assertFalse($a->isIdentical(VersionId::changes(), 'de'));
 	}
 
-	/**
-	 * @covers ::isIdentical
-	 */
 	public function testIsIdenticalSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -522,9 +464,6 @@ class VersionTest extends TestCase
 		$this->assertFalse($a->isIdentical('changes'));
 	}
 
-	/**
-	 * @covers ::isIdentical
-	 */
 	public function testIsIdenticalWithoutChanges()
 	{
 		$this->setUpSingleLanguage();
@@ -552,9 +491,6 @@ class VersionTest extends TestCase
 		$this->assertTrue($a->isIdentical('changes'));
 	}
 
-	/**
-	 * @covers ::isIdentical
-	 */
 	public function testIsIdenticalWithSameVersion()
 	{
 		$this->setUpSingleLanguage();
@@ -572,9 +508,6 @@ class VersionTest extends TestCase
 		$this->assertTrue($a->isIdentical('latest'));
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
 	public function testIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
@@ -587,9 +520,6 @@ class VersionTest extends TestCase
 		$this->assertFalse($version->isLocked());
 	}
 
-	/**
-	 * @covers ::lock
-	 */
 	public function testLock(): void
 	{
 		$this->setUpSingleLanguage();
@@ -602,9 +532,6 @@ class VersionTest extends TestCase
 		$this->assertInstanceOf(Lock::class, $version->lock());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel(): void
 	{
 		$this->setUpSingleLanguage();
@@ -617,9 +544,6 @@ class VersionTest extends TestCase
 		$this->assertSame($this->model, $version->model());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -635,9 +559,6 @@ class VersionTest extends TestCase
 		$this->assertSame($modified, $version->modified($this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedMultiLanguageIfNotExists(): void
 	{
 		$this->setUpMultiLanguage();
@@ -653,9 +574,6 @@ class VersionTest extends TestCase
 		$this->assertNull($version->modified($this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -670,9 +588,6 @@ class VersionTest extends TestCase
 		$this->assertSame($modified, $version->modified());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSingleLanguageIfNotExists(): void
 	{
 		$this->setUpSingleLanguage();
@@ -685,9 +600,6 @@ class VersionTest extends TestCase
 		$this->assertNull($version->modified());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveToLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -727,9 +639,6 @@ class VersionTest extends TestCase
 		$this->assertSame($content, Data::read($fileEN));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveToVersion(): void
 	{
 		$this->setUpMultiLanguage();
@@ -787,11 +696,7 @@ class VersionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::previewToken
-	 * @covers ::previewTokenFromUrl
-	 * @dataProvider previewTokenIndexUrlProvider
-	 */
+	#[DataProvider('previewTokenIndexUrlProvider')]
 	public function testPreviewToken(string $indexUrl)
 	{
 		$this->setUpSingleLanguage();
@@ -827,9 +732,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	/**
-	 * @covers ::previewToken
-	 */
 	public function testPreviewTokenCustomSalt()
 	{
 		$this->setUpSingleLanguage();
@@ -851,9 +753,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	/**
-	 * @covers ::previewToken
-	 */
 	public function testPreviewTokenCustomSaltCallback()
 	{
 		$this->setUpSingleLanguage();
@@ -879,9 +778,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	/**
-	 * @covers ::previewToken
-	 */
 	public function testPreviewTokenInvalidModel()
 	{
 		$this->expectException(LogicException::class);
@@ -897,9 +793,6 @@ class VersionTest extends TestCase
 		$version->previewToken();
 	}
 
-	/**
-	 * @covers ::previewToken
-	 */
 	public function testPreviewTokenMissingHomePage()
 	{
 		$this->expectException(NotFoundException::class);
@@ -919,9 +812,6 @@ class VersionTest extends TestCase
 		$version->previewToken();
 	}
 
-	/**
-	 * @covers ::publish
-	 */
 	public function testPublish()
 	{
 		$this->setUpSingleLanguage();
@@ -950,9 +840,6 @@ class VersionTest extends TestCase
 		$this->assertSame('Title changes', Data::read($fileLatest)['title']);
 	}
 
-	/**
-	 * @covers ::publish
-	 */
 	public function testPublishAlreadyLatestVersion()
 	{
 		$this->setUpSingleLanguage();
@@ -970,11 +857,6 @@ class VersionTest extends TestCase
 		$version->publish();
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsAfterRead
-	 */
 	public function testReadMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -992,11 +874,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected['de']['content'], $version->read($this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsAfterRead
-	 */
 	public function testReadSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1011,9 +888,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected['content'], $version->read());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadLatestWithoutContentFile(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1029,11 +903,6 @@ class VersionTest extends TestCase
 		$this->assertSame([], $version->read());
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsAfterRead
-	 */
 	public function testReadWithDirtyFields(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1053,11 +922,6 @@ class VersionTest extends TestCase
 		$this->assertArrayHasKey('subtitle', $version->read());
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsAfterRead
-	 */
 	public function testReadWithInvalidLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1073,11 +937,6 @@ class VersionTest extends TestCase
 		$version->read('fr');
 	}
 
-	/**
-	 * @covers ::replace
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsBeforeWrite
-	 */
 	public function testReplaceMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1103,11 +962,6 @@ class VersionTest extends TestCase
 		$this->assertSame(['title' => 'Updated Title Deutsch'], Data::read($expected['de']['file']));
 	}
 
-	/**
-	 * @covers ::replace
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsBeforeWrite
-	 */
 	public function testReplaceSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1126,11 +980,6 @@ class VersionTest extends TestCase
 		$this->assertSame(['title' => 'Updated Title'], Data::read($expected['file']));
 	}
 
-	/**
-	 * @covers ::replace
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsBeforeWrite
-	 */
 	public function testReplaceWithDirtyFields(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1185,9 +1034,6 @@ class VersionTest extends TestCase
 		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1215,9 +1061,6 @@ class VersionTest extends TestCase
 		$this->assertSame('Subtitle Deutsch', Data::read($expected['de']['file'])['subtitle']);
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1237,9 +1080,6 @@ class VersionTest extends TestCase
 		$this->assertSame('Subtitle', Data::read($expected['file'])['subtitle']);
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveNonExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1266,9 +1106,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists('de');
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveNonExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1287,9 +1124,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists();
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveOverwriteMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1315,9 +1149,6 @@ class VersionTest extends TestCase
 		$this->assertSame(['title' => 'Updated Title Deutsch'], Data::read($expected['de']['file']));
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveOverwriteSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1336,9 +1167,6 @@ class VersionTest extends TestCase
 		$this->assertSame(['title' => 'Updated Title'], Data::read($expected['file']));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1368,9 +1196,6 @@ class VersionTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($rootDE));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1392,9 +1217,6 @@ class VersionTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1422,9 +1244,6 @@ class VersionTest extends TestCase
 		$this->assertSame('Subtitle Deutsch', Data::read($expected['de']['file'])['subtitle']);
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -1444,11 +1263,6 @@ class VersionTest extends TestCase
 		$this->assertSame('Subtitle', Data::read($expected['file'])['subtitle']);
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::convertFieldNamesToLowerCase
-	 * @covers ::prepareFieldsBeforeWrite
-	 */
 	public function testUpdateWithDirtyFields(): void
 	{
 		$this->setUpMultiLanguage();
@@ -1503,10 +1317,6 @@ class VersionTest extends TestCase
 		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 
-	/**
-	 * @covers ::url
-	 * @covers ::urlWithQueryParams
-	 */
 	public function testUrlPage()
 	{
 		$this->setUpSingleLanguage();
@@ -1522,9 +1332,6 @@ class VersionTest extends TestCase
 		$this->assertSame('/a-page', $version->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlPageUnauthenticated()
 	{
 		$this->setUpSingleLanguage();
@@ -1580,17 +1387,11 @@ class VersionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::previewTokenFromUrl
-	 * @covers ::url
-	 * @covers ::urlFromOption
-	 * @covers ::urlWithQueryParams
-	 * @dataProvider pageUrlProvider
-	 */
+	#[DataProvider('pageUrlProvider')]
 	public function testUrlPageCustom(
-		$input,
-		$expected,
-		$expectedUri,
+		bool|string|null $input,
+		string|null $expected,
+		string|null $expectedUri,
 		bool $draft,
 		string $versionId,
 		bool $authenticated = true
@@ -1660,10 +1461,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->url());
 	}
 
-	/**
-	 * @covers ::url
-	 * @covers ::urlWithQueryParams
-	 */
 	public function testUrlSite()
 	{
 		$this->setUpSingleLanguage();
@@ -1679,9 +1476,6 @@ class VersionTest extends TestCase
 		$this->assertSame('/', $version->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlSiteUnauthenticated()
 	{
 		$this->setUpSingleLanguage();
@@ -1713,16 +1507,10 @@ class VersionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::previewTokenFromUrl
-	 * @covers ::url
-	 * @covers ::urlFromOption
-	 * @covers ::urlWithQueryParams
-	 * @dataProvider siteUrlProvider
-	 */
+	#[DataProvider('siteUrlProvider')]
 	public function testUrlSiteCustom(
-		$input,
-		$expected,
+		string|bool|null $input,
+		string|null $expected,
 		string $versionId,
 		bool $authenticated = true
 	): void {
@@ -1790,9 +1578,6 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlInvalidModel()
 	{
 		$this->expectException(LogicException::class);

--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -6,17 +6,14 @@ use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Data\Data
- */
+#[CoversClass(Data::class)]
 class DataTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Data.Data';
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testDefaultHandlers()
 	{
 		$this->assertInstanceOf(Json::class, Data::handler('json'));
@@ -36,27 +33,18 @@ class DataTest extends TestCase
 		$this->assertInstanceOf(Json::class, Data::handler('JsOn'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testCustomHandler()
 	{
 		Data::$handlers['test'] = CustomHandler::class;
 		$this->assertInstanceOf(CustomHandler::class, Data::handler('test'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testCustomAlias()
 	{
 		Data::$aliases['plaintext'] = 'txt';
 		$this->assertInstanceOf(Txt::class, Data::handler('plaintext'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testMissingHandler()
 	{
 		$this->expectException(Exception::class);
@@ -65,9 +53,6 @@ class DataTest extends TestCase
 		Data::handler('foo');
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testInvalidHandler()
 	{
 		Data::$handlers['invalid'] = CustomInvalidHandler::class;
@@ -78,11 +63,7 @@ class DataTest extends TestCase
 		Data::handler('invalid');
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
+	#[DataProvider('handlerProvider')]
 	public function testEncodeDecode($handler)
 	{
 		$data = [
@@ -96,10 +77,7 @@ class DataTest extends TestCase
 		$this->assertSame($data, $decoded);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
+	#[DataProvider('handlerProvider')]
 	public function testDecodeInvalid1($handler)
 	{
 		// decode invalid integer value
@@ -108,10 +86,7 @@ class DataTest extends TestCase
 		Data::decode(1, $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
+	#[DataProvider('handlerProvider')]
 	public function testDecodeInvalid2($handler)
 	{
 		// decode invalid object value
@@ -120,10 +95,7 @@ class DataTest extends TestCase
 		Data::decode(new \stdClass(), $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
+	#[DataProvider('handlerProvider')]
 	public function testDecodeInvalid3($handler)
 	{
 		// decode invalid boolean value
@@ -132,10 +104,7 @@ class DataTest extends TestCase
 		Data::decode(true, $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
+	#[DataProvider('handlerProvider')]
 	public function testDecodeInvalidNoExceptions($handler)
 	{
 		$data = Data::decode(1, $handler, fail: false);
@@ -154,10 +123,6 @@ class DataTest extends TestCase
 		return array_map(fn ($handler) => [$handler], $handlers);
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testReadWrite()
 	{
 		$data = [
@@ -184,10 +149,6 @@ class DataTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::handler
-	 */
 	public function testReadInvalid()
 	{
 		$this->expectException(Exception::class);
@@ -196,19 +157,12 @@ class DataTest extends TestCase
 		Data::read(static::TMP . '/data.foo');
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadInvalidNoException()
 	{
 		$data = Data::read(static::TMP . '/data.foo', fail: false);
 		$this->assertSame([], $data);
 	}
 
-	/**
-	 * @covers ::write
-	 * @covers ::handler
-	 */
 	public function testWriteInvalid()
 	{
 		$this->expectException(Exception::class);

--- a/tests/Data/HandlerTest.php
+++ b/tests/Data/HandlerTest.php
@@ -5,18 +5,13 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Handler
- */
+#[CoversClass(Handler::class)]
 class HandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Data.Handler';
 
-	/**
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testReadWrite()
 	{
 		$data = [
@@ -34,9 +29,6 @@ class HandlerTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadFileMissing()
 	{
 		$file = static::TMP . '/does-not-exist.json';

--- a/tests/Data/JsonTest.php
+++ b/tests/Data/JsonTest.php
@@ -5,16 +5,11 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Json
- */
+#[CoversClass(Json::class)]
 class JsonTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$array = [
@@ -35,9 +30,6 @@ class JsonTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Json::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid1()
 	{
 		// pass invalid object
@@ -46,9 +38,6 @@ class JsonTest extends TestCase
 		Json::decode(new \stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid2()
 	{
 		// pass invalid int
@@ -57,9 +46,6 @@ class JsonTest extends TestCase
 		Json::decode(1);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeCorrupted1()
 	{
 		$this->expectException(Exception::class);
@@ -68,9 +54,6 @@ class JsonTest extends TestCase
 		Json::decode('some gibberish');
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeCorrupted2()
 	{
 		$this->expectException(Exception::class);
@@ -79,9 +62,6 @@ class JsonTest extends TestCase
 		Json::decode('true');
 	}
 
-	/**
-	 * @covers ::encode
-	 */
 	public function testEncodePretty()
 	{
 		$array = [
@@ -100,9 +80,6 @@ class JsonTest extends TestCase
 }', $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 */
 	public function testEncodeUnicode()
 	{
 		$string  = 'здравей';

--- a/tests/Data/PHPTest.php
+++ b/tests/Data/PHPTest.php
@@ -6,19 +6,14 @@ use Exception;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\PHP
- */
+#[CoversClass(PHP::class)]
 class PHPTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/php';
 	public const TMP      = KIRBY_TMP_DIR . '/Data.PHP';
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeArray
-	 */
 	public function testEncode()
 	{
 		$input    = static::FIXTURES . '/input.php';
@@ -32,9 +27,6 @@ class PHPTest extends TestCase
 		$this->assertSame('123', PHP::encode(123));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecode()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -44,9 +36,6 @@ class PHPTest extends TestCase
 		$result = PHP::decode($input);
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		$input  = static::FIXTURES . '/input.php';
@@ -55,9 +44,6 @@ class PHPTest extends TestCase
 		$this->assertSame($result, include $input);
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadFileMissing()
 	{
 		$file = static::TMP . '/does-not-exist.php';
@@ -68,9 +54,6 @@ class PHPTest extends TestCase
 		PHP::read($file);
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWrite()
 	{
 		$input = include static::FIXTURES . '/input.php';

--- a/tests/Data/TxtTest.php
+++ b/tests/Data/TxtTest.php
@@ -4,20 +4,13 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Txt
- */
+#[CoversClass(Txt::class)]
 class TxtTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 * @covers ::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$array = [
@@ -41,12 +34,6 @@ class TxtTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Txt::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 * @covers ::decode
-	 */
 	public function testEncodeDecodeMixedCase()
 	{
 		$array = [
@@ -69,11 +56,6 @@ class TxtTest extends TestCase
 		], $result);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeMissingValues()
 	{
 		$array = [
@@ -90,11 +72,6 @@ class TxtTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeMultiline()
 	{
 		$array = [
@@ -109,11 +86,6 @@ class TxtTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeDecodeDivider()
 	{
 		$array = [
@@ -131,11 +103,6 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($data));
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeArray()
 	{
 		$array = [
@@ -148,11 +115,6 @@ class TxtTest extends TestCase
 		$this->assertSame(file_get_contents(static::FIXTURES . '/test.txt'), $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeFloat()
 	{
 		$data = Txt::encode([
@@ -162,11 +124,6 @@ class TxtTest extends TestCase
 		$this->assertSame('Number: 3.2', $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
 	public function testEncodeFloatWithLocaleSetting()
 	{
 		$currentLocale = setlocale(LC_ALL, 0);
@@ -181,9 +138,6 @@ class TxtTest extends TestCase
 		setlocale(LC_ALL, $currentLocale);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeFile()
 	{
 		$array = [
@@ -195,9 +149,6 @@ class TxtTest extends TestCase
 		$this->assertSame($array, $data);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeBom1()
 	{
 		$string = "\xEF\xBB\xBFTitle: title field with BOM \xEF\xBB\xBF\n----\nText: text field";
@@ -209,9 +160,6 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($string));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeBom2()
 	{
 		$string = "\xEF\xBB\xBFTitle: title field with BOM\n--\xEF\xBB\xBF--\nand more text\n----\nText: text field";
@@ -223,9 +171,6 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($string));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid1()
 	{
 		// pass invalid object
@@ -234,9 +179,6 @@ class TxtTest extends TestCase
 		Txt::decode(new \stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid2()
 	{
 		// pass invalid int

--- a/tests/Data/XmlTest.php
+++ b/tests/Data/XmlTest.php
@@ -5,16 +5,11 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Xml
- */
+#[CoversClass(Xml::class)]
 class XmlTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$array = [
@@ -46,9 +41,6 @@ class XmlTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Xml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid1()
 	{
 		// pass invalid object
@@ -57,9 +49,6 @@ class XmlTest extends TestCase
 		Xml::decode(new \stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeInvalid2()
 	{
 		// pass invalid int
@@ -68,18 +57,12 @@ class XmlTest extends TestCase
 		Xml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 */
 	public function testEncodeScalar()
 	{
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<data>test</data>';
 		$this->assertSame($expected, Xml::encode('test'));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
 	public function testDecodeCorrupted()
 	{
 		$this->expectException(Exception::class);

--- a/tests/Data/YamlSymfonyTest.php
+++ b/tests/Data/YamlSymfonyTest.php
@@ -5,10 +5,10 @@ namespace Kirby\Data;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Yaml
- */
+#[CoversClass(Yaml::class)]
+#[CoversClass(YamlSymfony::class)]
 class YamlSymfonyTest extends TestCase
 {
 	public function setUp(): void
@@ -21,12 +21,6 @@ class YamlSymfonyTest extends TestCase
 		new App([]);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$array = [
@@ -50,10 +44,6 @@ class YamlSymfonyTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Yaml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
 	public function testDecodeInvalid1()
 	{
 		// pass invalid object
@@ -62,10 +52,6 @@ class YamlSymfonyTest extends TestCase
 		Yaml::decode(new \stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
 	public function testDecodeInvalid2()
 	{
 		// pass invalid int
@@ -74,10 +60,6 @@ class YamlSymfonyTest extends TestCase
 		Yaml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
 	public function testEncodeFloat()
 	{
 		$data = Yaml::encode([
@@ -87,10 +69,6 @@ class YamlSymfonyTest extends TestCase
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
 	public function testEncodeFloatWithNonUSLocale()
 	{
 		$locale = setlocale(LC_ALL, 0);
@@ -106,10 +84,6 @@ class YamlSymfonyTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
 	public function testEncodeNodeTypes()
 	{
 		$data = Yaml::encode(['test' => '']);

--- a/tests/Data/YamlTest.php
+++ b/tests/Data/YamlTest.php
@@ -4,18 +4,12 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Yaml
- */
+#[CoversClass(Yaml::class)]
+#[CoversClass(YamlSpyc::class)]
 class YamlTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$array = [
@@ -39,10 +33,6 @@ class YamlTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Yaml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
 	public function testDecodeInvalid1()
 	{
 		// pass invalid object
@@ -51,10 +41,6 @@ class YamlTest extends TestCase
 		Yaml::decode(new \stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
 	public function testDecodeInvalid2()
 	{
 		// pass invalid int
@@ -63,10 +49,6 @@ class YamlTest extends TestCase
 		Yaml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
 	public function testEncodeFloat()
 	{
 		$data = Yaml::encode([
@@ -76,10 +58,6 @@ class YamlTest extends TestCase
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
 	public function testEncodeFloatWithNonUSLocale()
 	{
 		$locale = setlocale(LC_ALL, 0);
@@ -95,10 +73,6 @@ class YamlTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
 	public function testEncodeNodeTypes()
 	{
 		$data = Yaml::encode(['test' => '']);

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database;
 use Kirby\Exception\InvalidArgumentException;
 use PDO;
 use PDOException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Database
- */
+#[CoversClass(Database::class)]
 class DatabaseTest extends TestCase
 {
 	public function setUp(): void
@@ -80,18 +79,12 @@ class DatabaseTest extends TestCase
 		], array_values(Database::instances()));
 	}
 
-	/**
-	 * @covers ::affected
-	 */
 	public function testAffected()
 	{
 		$this->database->table('users')->delete();
 		$this->assertSame(3, $this->database->affected());
 	}
 
-	/**
-	 * @covers ::lastId
-	 */
 	public function testLastId()
 	{
 		$id = $this->database->table('users')->insert([
@@ -106,18 +99,12 @@ class DatabaseTest extends TestCase
 		$this->assertSame($id, $this->database->lastId());
 	}
 
-	/**
-	 * @covers ::lastResult
-	 */
 	public function testLastResult()
 	{
 		$result = $this->database->table('users')->select('*')->all();
 		$this->assertSame($result, $this->database->lastResult());
 	}
 
-	/**
-	 * @covers ::lastError
-	 */
 	public function testLastError()
 	{
 		$this->assertNull($this->database->lastError());

--- a/tests/Database/DbTest.php
+++ b/tests/Database/DbTest.php
@@ -3,11 +3,11 @@
 namespace Kirby\Database;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Database\Db
- */
+#[CoversClass(Db::class)]
 class DbTest extends TestCase
 {
 	public function setUp(): void
@@ -59,9 +59,6 @@ class DbTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::connect
-	 */
 	public function testConnect()
 	{
 		$db = Db::connect();
@@ -88,17 +85,11 @@ class DbTest extends TestCase
 		$this->assertSame($db, Db::connect());
 	}
 
-	/**
-	 * @covers ::connection
-	 */
 	public function testConnection()
 	{
 		$this->assertInstanceOf(Database::class, Db::connection());
 	}
 
-	/**
-	 * @covers ::table
-	 */
 	public function testTable()
 	{
 		$tableProp = new ReflectionProperty(Query::class, 'table');
@@ -109,18 +100,12 @@ class DbTest extends TestCase
 		$this->assertSame('users', $tableProp->getValue($query));
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuery()
 	{
 		$result = Db::query('SELECT * FROM users WHERE username = :username', ['username' => 'paul'], ['fetch' => 'array', 'iterator' => 'array']);
 		$this->assertSame('paul', $result[0]['username']);
 	}
 
-	/**
-	 * @covers ::execute
-	 */
 	public function testExecute()
 	{
 		$result = Db::query('SELECT * FROM users WHERE username = :username', ['username' => 'paul'], ['fetch' => 'array', 'iterator' => 'array']);
@@ -133,9 +118,6 @@ class DbTest extends TestCase
 		$this->assertEmpty($result);
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
 	public function testCallStatic()
 	{
 		Db::connect([
@@ -152,9 +134,6 @@ class DbTest extends TestCase
 		$this->assertSame('myprefix_', Db::prefix());
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
 	public function testCallStaticInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -163,9 +142,7 @@ class DbTest extends TestCase
 		Db::thisIsInvalid();
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testSelect()
 	{
 		$result = Db::select('users');
@@ -184,9 +161,7 @@ class DbTest extends TestCase
 		$this->assertSame('george', $result->first()->username());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testFirst()
 	{
 		$result = Db::first('users');
@@ -205,9 +180,7 @@ class DbTest extends TestCase
 		$this->assertSame('john', $result->username());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testColumn()
 	{
 		$result = Db::column('users', 'username');
@@ -223,9 +196,7 @@ class DbTest extends TestCase
 		$this->assertSame(['john'], $result->toArray());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testInsert()
 	{
 		$result = Db::insert('users', [
@@ -241,9 +212,7 @@ class DbTest extends TestCase
 		$this->assertSame('0', Db::row('users', '*', ['username' => 'ringo'])->active());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testUpdate()
 	{
 		$result = Db::update('users', ['email' => 'john@gmail.com'], ['username' => 'john']);
@@ -257,9 +226,7 @@ class DbTest extends TestCase
 		$this->assertSame('1', Db::row('users', '*', ['username' => 'paul'])->active());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDelete()
 	{
 		$result = Db::delete('users', ['username' => 'john']);
@@ -268,41 +235,31 @@ class DbTest extends TestCase
 		$this->assertSame(2, Db::count('users'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testCount()
 	{
 		$this->assertSame(3, Db::count('users'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testMin()
 	{
 		$this->assertSame(1.0, Db::min('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testMax()
 	{
 		$this->assertSame(3.0, Db::max('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testAvg()
 	{
 		$this->assertSame(2.0, Db::avg('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testSum()
 	{
 		$this->assertSame(6.0, Db::sum('users', 'id'));

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -6,10 +6,9 @@ use InvalidArgumentException;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Pagination;
 use PDOException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Database
- */
+#[CoversClass(Database::class)]
 class QueryTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Database/Sql/MysqlTest.php
+++ b/tests/Database/Sql/MysqlTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Database\Sql;
 
 use Kirby\Database\Database;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql\Mysql
- */
+#[CoversClass(Mysql::class)]
 class MysqlTest extends TestCase
 {
 	public function setUp(): void
@@ -22,9 +21,6 @@ class MysqlTest extends TestCase
 		$this->sql = new Mysql($this->database);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
 	public function testColumns()
 	{
 		$result = $this->sql->columns('test');
@@ -32,9 +28,6 @@ class MysqlTest extends TestCase
 		$this->assertSame('test', A::last($result['bindings']));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
 	public function testTables()
 	{
 		$result = $this->sql->tables();
@@ -42,9 +35,6 @@ class MysqlTest extends TestCase
 		$this->assertSame(':memory:', A::first($result['bindings']));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
 	public function testValidateTable()
 	{
 		$this->assertTrue($this->database->validateTable('test'));

--- a/tests/Database/Sql/SqliteTest.php
+++ b/tests/Database/Sql/SqliteTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database\Sql;
 use Kirby\Database\Database;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql\Sqlite
- */
+#[CoversClass(Sqlite::class)]
 class SqliteTest extends TestCase
 {
 	public function setUp(): void
@@ -23,18 +22,12 @@ class SqliteTest extends TestCase
 		$this->sql = new Sqlite($this->database);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
 	public function testColumns()
 	{
 		$result = $this->sql->columns('test');
 		$this->assertSame('PRAGMA table_info("test")', $result['query']);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
 	public function testColumnsInvalidTable()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -43,9 +36,6 @@ class SqliteTest extends TestCase
 		$this->sql->columns('does-not-exist');
 	}
 
-	/**
-	 * @covers ::combineIdentifier
-	 */
 	public function testCombineIdentifier()
 	{
 		$this->assertSame('"test"."id"', $this->sql->combineIdentifier('test', 'id'));
@@ -56,9 +46,6 @@ class SqliteTest extends TestCase
 		$this->assertSame('"id"', $this->sql->combineIdentifier('test', 'id', true));
 	}
 
-	/**
-	 * @covers ::createTable
-	 */
 	public function testCreateTable()
 	{
 		// basic example
@@ -138,9 +125,6 @@ class SqliteTest extends TestCase
 		$this->assertSame([], $table['bindings']);
 	}
 
-	/**
-	 * @covers ::quoteIdentifier
-	 */
 	public function testQuoteIdentifier()
 	{
 		$this->assertSame('*', $this->sql->quoteIdentifier('*'));
@@ -150,9 +134,6 @@ class SqliteTest extends TestCase
 		$this->assertSame('"another\'test"', $this->sql->quoteIdentifier("another'test"));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
 	public function testTables()
 	{
 		$result = $this->sql->tables();
@@ -160,9 +141,6 @@ class SqliteTest extends TestCase
 		$this->assertSame([], $result['bindings']);
 	}
 
-	/**
-	 * @covers ::tables
-	 */
 	public function testValidateTable()
 	{
 		$this->assertTrue($this->database->validateTable('test'));

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database;
 use Kirby\Database\Sql\Sqlite;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql
- */
+#[CoversClass(Sql::class)]
 class SqlTest extends TestCase
 {
 	protected Sql $sql;
@@ -25,9 +24,6 @@ class SqlTest extends TestCase
 		$this->sql = new MockSql($this->database);
 	}
 
-	/**
-	 * @covers ::bindingName
-	 */
 	public function testBindingName()
 	{
 		$result = $this->sql->bindingName('test_binding1');
@@ -40,9 +36,6 @@ class SqlTest extends TestCase
 		$this->assertMatchesRegularExpression('/^:invalid_[a-zA-Z0-9]{8}$/', $result);
 	}
 
-	/**
-	 * @covers ::columnDefault
-	 */
 	public function testColumnDefault()
 	{
 		$this->assertSame([
@@ -55,9 +48,6 @@ class SqlTest extends TestCase
 		$this->assertSame('amazing default', A::first($result['bindings']));
 	}
 
-	/**
-	 * @covers ::columnName
-	 */
 	public function testColumnName()
 	{
 		// test with the SQLite class because of its more
@@ -71,9 +61,6 @@ class SqlTest extends TestCase
 		$this->assertNull($sql->columnName('test', 'invalid.id', true));
 	}
 
-	/**
-	 * @covers ::combineIdentifier
-	 */
 	public function testCombineIdentifier()
 	{
 		$this->assertSame('`test`.`id`', $this->sql->combineIdentifier('test', 'id'));
@@ -82,9 +69,6 @@ class SqlTest extends TestCase
 		$this->assertSame('`test`.`id`', $this->sql->combineIdentifier('test', 'id', true));
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
 	public function testCreateColumn()
 	{
 		// basic example
@@ -202,9 +186,6 @@ class SqlTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
 	public function testCreateColumnNoType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -213,9 +194,6 @@ class SqlTest extends TestCase
 		$this->sql->createColumn('test', []);
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
 	public function testCreateColumnInvalidType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -423,9 +401,6 @@ class SqlTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::quoteIdentifier
-	 */
 	public function testQuoteIdentifier()
 	{
 		$this->assertSame('*', $this->sql->quoteIdentifier('*'));
@@ -435,9 +410,6 @@ class SqlTest extends TestCase
 		$this->assertSame("`another'test`", $this->sql->quoteIdentifier("another'test"));
 	}
 
-	/**
-	 * @covers ::splitIdentifier
-	 */
 	public function testSplitIdentifier()
 	{
 		$result = $this->sql->splitIdentifier('table', 'table.column');
@@ -474,9 +446,6 @@ class SqlTest extends TestCase
 		$this->assertSame(['table.name', 'column.name'], $result);
 	}
 
-	/**
-	 * @covers ::splitIdentifier
-	 */
 	public function testSplitIdentifierInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Email/BodyTest.php
+++ b/tests/Email/BodyTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Email;
 
-/**
- * @coversDefaultClass \Kirby\Email\Body
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Body::class)]
 class BodyTest extends TestCase
 {
 	public function testConstruct()

--- a/tests/Exception/AuthExceptionTest.php
+++ b/tests/Exception/AuthExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class AuthExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDefaults()
 	{
 		$exception = new AuthException();

--- a/tests/Exception/BadMethodCallExceptionTest.php
+++ b/tests/Exception/BadMethodCallExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class BadMethodCallExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDefaults()
 	{
 		$exception = new BadMethodCallException();
@@ -18,9 +17,7 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => null], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testPlaceholders()
 	{
 		$exception = new BadMethodCallException(data: [
@@ -30,9 +27,7 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => 'get'], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testPlaceholdersWithNamedArguments()
 	{
 		$exception = new BadMethodCallException(

--- a/tests/Exception/DuplicateExceptionTest.php
+++ b/tests/Exception/DuplicateExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class DuplicateExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDefaults()
 	{
 		$exception = new DuplicateException();

--- a/tests/Exception/ErrorPageExceptionTest.php
+++ b/tests/Exception/ErrorPageExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class ErrorPageExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDefaults()
 	{
 		$exception = new ErrorPageException();

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class WillFail
 {
@@ -15,9 +16,7 @@ class WillFail
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Exception\Exception
- */
+#[CoversClass(Exception::class)]
 class ExceptionTest extends TestCase
 {
 	public function tearDown(): void
@@ -25,14 +24,6 @@ class ExceptionTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getKey
-	 * @covers ::getHttpCode
-	 * @covers ::getData
-	 * @covers ::getDetails
-	 * @covers ::isTranslated
-	 */
 	public function testException()
 	{
 		$exception = new Exception([
@@ -54,14 +45,6 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getKey
-	 * @covers ::getHttpCode
-	 * @covers ::getData
-	 * @covers ::getDetails
-	 * @covers ::isTranslated
-	 */
 	public function testExceptionWithNamedArguments()
 	{
 		$exception = new Exception(
@@ -83,9 +66,6 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testDefaults()
 	{
 		$exception = new Exception();
@@ -98,9 +78,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::getDetails
-	 */
 	public function testGetDetails()
 	{
 		$exception = new Exception(
@@ -115,9 +92,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame($details, $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::getDetails
-	 */
 	public function testGetDetailsWithExceptions()
 	{
 		$exception = new Exception(
@@ -136,9 +110,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame($expected, $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testJustMessage()
 	{
 		$exception = new Exception('Another error occurred');
@@ -150,9 +121,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getData());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testJustMessageWithNamedArgument()
 	{
 		$exception = new Exception(message: 'Another error occurred');
@@ -164,9 +132,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getData());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testPrevious()
 	{
 		$previous  = new Exception(message: 'Previous');
@@ -176,9 +141,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame($previous, $exception->getPrevious());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testPreviousWithNamedArgument()
 	{
 		$previous  = new Exception(message: 'Previous');
@@ -188,9 +150,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame($previous, $exception->getPrevious());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testPHPUnitTesting()
 	{
 		$this->expectException(Exception::class);
@@ -200,9 +159,6 @@ class ExceptionTest extends TestCase
 		$class->fail();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testTranslation()
 	{
 		I18n::$locale = 'test';
@@ -269,9 +225,6 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testTranslationWithNamedArguments()
 	{
 		I18n::$locale = 'test';
@@ -338,9 +291,6 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::getFileRelative
-	 */
 	public function testGetFileRelative()
 	{
 		$exception = new Exception();
@@ -363,9 +313,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame(F::filename(__FILE__), $exception->getFileRelative());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$exception = new Exception();

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class InvalidArgumentExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
 	public function testDefaults()
 	{
 		$exception = new InvalidArgumentException();
@@ -18,9 +17,6 @@ class InvalidArgumentExceptionTest extends TestCase
 		$this->assertSame(['argument' => null, 'method' => null], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testPlaceholders()
 	{
 		$exception = new InvalidArgumentException(data: [
@@ -34,9 +30,6 @@ class InvalidArgumentExceptionTest extends TestCase
 		], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testPlaceholdersWithNamedArguments()
 	{
 		$exception = new InvalidArgumentException(

--- a/tests/Exception/LogicExceptionTest.php
+++ b/tests/Exception/LogicExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class LogicExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
 	public function testDefaults()
 	{
 		$exception = new LogicException();

--- a/tests/Exception/NotFoundExceptionTest.php
+++ b/tests/Exception/NotFoundExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class NotFoundExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
 	public function testDefaults()
 	{
 		$exception = new NotFoundException();

--- a/tests/Exception/PermissionExceptionTest.php
+++ b/tests/Exception/PermissionExceptionTest.php
@@ -3,12 +3,11 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class PermissionExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
 	public function testDefaults()
 	{
 		$exception = new PermissionException();

--- a/tests/Field/FieldOptionsTest.php
+++ b/tests/Field/FieldOptionsTest.php
@@ -6,17 +6,13 @@ use Kirby\Cms\Page;
 use Kirby\Option\Options;
 use Kirby\Option\OptionsApi;
 use Kirby\Option\OptionsQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Field\FieldOptions
- */
+#[CoversClass(FieldOptions::class)]
 class FieldOptionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../Option/fixtures';
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$options = FieldOptions::factory([
@@ -52,9 +48,6 @@ class FieldOptionsTest extends TestCase
 		$this->assertSame($query, $options->options->query);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
 	public function testPolyfill()
 	{
 		$props = FieldOptions::polyfill(['options' => 'site.children']);
@@ -79,10 +72,6 @@ class FieldOptionsTest extends TestCase
 		$this->assertSame(['options' => ['type' => 'array', 'options' => $options]], $props);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::render
-	 */
 	public function testResolveRender()
 	{
 		$model = new Page(['slug' => 'test']);

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Filesystem;
 use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Asset
- */
+#[CoversClass(Asset::class)]
 class AssetTest extends TestCase
 {
 	public function setUp(): void
@@ -31,13 +30,6 @@ class AssetTest extends TestCase
 		return new Asset($file);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::id
-	 * @covers ::url
-	 * @covers ::path
-	 */
 	public function testConstruct()
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
@@ -61,9 +53,6 @@ class AssetTest extends TestCase
 		$this->assertSame('images', $asset->path());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCall()
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
@@ -83,12 +72,6 @@ class AssetTest extends TestCase
 		$asset->foo();
 	}
 
-	/**
-	 * @covers ::mediaHash
-	 * @covers ::mediaPath
-	 * @covers ::mediaRoot
-	 * @covers ::mediaUrl
-	 */
 	public function testMedia()
 	{
 		$asset = $this->_asset();

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -8,10 +8,9 @@ use Kirby\Cms\Page;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Dir
- */
+#[CoversClass(Dir::class)]
 class DirTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/dir';
@@ -37,9 +36,6 @@ class DirTest extends TestCase
 		return Dir::inventory(static::TMP, ...$args);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopy()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -54,9 +50,6 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyNonRecursive()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -71,9 +64,6 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyIgnore()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -89,9 +79,6 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyNoIgnore()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -107,9 +94,6 @@ class DirTest extends TestCase
 		$this->assertFileExists($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyMissingSource()
 	{
 		$this->expectException(Exception::class);
@@ -121,9 +105,6 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyExistingTarget()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -135,9 +116,6 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyInvalidTarget()
 	{
 		$src    = static::FIXTURES . '/copy';
@@ -149,9 +127,6 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$this->assertFalse(Dir::exists(static::TMP));
@@ -159,9 +134,6 @@ class DirTest extends TestCase
 		$this->assertTrue(Dir::exists(static::TMP));
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		Dir::make($dir = static::TMP);
@@ -179,9 +151,6 @@ class DirTest extends TestCase
 		$this->assertSame($expected, Dir::index($dir));
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndexRecursive()
 	{
 		Dir::make($dir = static::TMP);
@@ -203,9 +172,6 @@ class DirTest extends TestCase
 		$this->assertSame($expected, Dir::index($dir, true));
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndexIgnore()
 	{
 		Dir::$ignore = ['z.txt'];
@@ -261,9 +227,6 @@ class DirTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
 	public function testIsWritable()
 	{
 		Dir::make(static::TMP);
@@ -271,9 +234,6 @@ class DirTest extends TestCase
 		$this->assertSame(is_writable(static::TMP), Dir::isWritable(static::TMP));
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
 	public function testInventory()
 	{
 		$inventory = $this->create([
@@ -300,9 +260,6 @@ class DirTest extends TestCase
 		$this->assertSame('projects', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
 	public function testInventoryWithSkippedFiles()
 	{
 		$inventory = $this->create([
@@ -319,9 +276,6 @@ class DirTest extends TestCase
 		$this->assertSame($expected, A::pluck($inventory['files'], 'filename'));
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
 	public function testInventoryChildSorting()
 	{
 		$inventory = $this->create([
@@ -335,9 +289,6 @@ class DirTest extends TestCase
 		$this->assertSame('project-a', $inventory['children'][2]['slug']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
 	public function testInventoryChildWithLeadingZero()
 	{
 		$inventory = $this->create([
@@ -356,9 +307,6 @@ class DirTest extends TestCase
 		$this->assertSame(3, $inventory['children'][2]['num']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
 	public function testInventoryFileSorting()
 	{
 		$inventory = $this->create([
@@ -374,10 +322,6 @@ class DirTest extends TestCase
 		$this->assertSame('11-a.jpg', $files[2]['filename']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
 	public function testInventoryMissingTemplate()
 	{
 		$inventory = $this->create([
@@ -389,10 +333,6 @@ class DirTest extends TestCase
 		$this->assertSame('default', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
 	public function testInventoryTemplateWithDotInFilename()
 	{
 		$inventory = $this->create([
@@ -405,10 +345,6 @@ class DirTest extends TestCase
 		$this->assertSame('article.video', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
 	public function testInventoryExtension()
 	{
 		$inventory = $this->create([
@@ -421,10 +357,6 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
 	public function testInventoryIgnore()
 	{
 		$inventory = $this->create([
@@ -436,10 +368,6 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
 	public function testInventoryMultilang()
 	{
 		$inventory = $this->create([
@@ -453,10 +381,6 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryChild
-	 */
 	public function testInventoryChildModels()
 	{
 		Page::$models = [
@@ -477,10 +401,6 @@ class DirTest extends TestCase
 		Page::$models = [];
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryChild
-	 */
 	public function testInventoryChildMultilangModels()
 	{
 		new App([
@@ -521,18 +441,12 @@ class DirTest extends TestCase
 		Page::$models = [];
 	}
 
-	/**
-	 * @covers ::make
-	 */
 	public function testMake()
 	{
 		$this->assertTrue(Dir::make(static::TMP));
 		$this->assertFalse(Dir::make(''));
 	}
 
-	/**
-	 * @covers ::make
-	 */
 	public function testMakeFileExists()
 	{
 		$test = static::TMP . '/test';
@@ -544,9 +458,6 @@ class DirTest extends TestCase
 		Dir::make($test);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		Dir::make(static::TMP);
@@ -554,9 +465,6 @@ class DirTest extends TestCase
 		$this->assertIsInt(Dir::modified(static::TMP));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMove()
 	{
 		Dir::make(static::TMP . '/1');
@@ -564,17 +472,11 @@ class DirTest extends TestCase
 		$this->assertTrue(Dir::move(static::TMP . '/1', static::TMP . '/2'));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveNonExisting()
 	{
 		$this->assertFalse(Dir::move('/does-not-exist', static::TMP . '/2'));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink()
 	{
 		$source = static::TMP . '/source';
@@ -586,9 +488,6 @@ class DirTest extends TestCase
 		$this->assertTrue(is_link($link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkExistingLink()
 	{
 		$source = static::TMP . '/source';
@@ -600,9 +499,6 @@ class DirTest extends TestCase
 		$this->assertTrue(Dir::link($source, $link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkWithoutSource()
 	{
 		$source = static::TMP . '/source';
@@ -614,9 +510,6 @@ class DirTest extends TestCase
 		Dir::link($source, $link);
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		Dir::make(static::TMP);
@@ -655,9 +548,6 @@ class DirTest extends TestCase
 		$this->assertSame($expected, $files);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemove()
 	{
 		Dir::make(static::TMP);
@@ -667,9 +557,6 @@ class DirTest extends TestCase
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
 	public function testIsReadable()
 	{
 		Dir::make(static::TMP);
@@ -677,10 +564,6 @@ class DirTest extends TestCase
 		$this->assertSame(is_readable(static::TMP), Dir::isReadable(static::TMP));
 	}
 
-	/**
-	 * @covers ::dirs
-	 * @covers ::files
-	 */
 	public function testReadDirsAndFiles()
 	{
 		Dir::make(static::TMP);
@@ -730,10 +613,6 @@ class DirTest extends TestCase
 		$this->assertSame($expected, $files);
 	}
 
-	/**
-	 * @covers ::size
-	 * @covers ::niceSize
-	 */
 	public function testSize()
 	{
 		Dir::make(static::TMP);
@@ -749,9 +628,6 @@ class DirTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::size
-	 */
 	public function testSizeWithNestedFolders()
 	{
 		Dir::make(static::TMP);
@@ -769,17 +645,11 @@ class DirTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::size
-	 */
 	public function testSizeOfNonExistingDir()
 	{
 		$this->assertFalse(Dir::size('/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::wasModifiedAfter
-	 */
 	public function testWasModifiedAfter()
 	{
 		$time = time();

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -8,10 +8,9 @@ use Kirby\Http\HeadersSent;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\F
- */
+#[CoversClass(F::class)]
 class FTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/f';
@@ -42,18 +41,12 @@ class FTest extends TestCase
 		HeadersSent::$value = false;
 	}
 
-	/**
-	 * @covers ::append
-	 */
 	public function testAppend()
 	{
 		F::copy($this->sample, $this->test);
 		$this->assertTrue(F::append($this->test, ' is awesome'));
 	}
 
-	/**
-	 * @covers ::base64
-	 */
 	public function testBase64()
 	{
 		F::write($this->test, 'test');
@@ -62,9 +55,6 @@ class FTest extends TestCase
 		$this->assertSame($expected, F::base64($this->test));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopy()
 	{
 		$origin = static::TMP . '/a.txt';
@@ -75,44 +65,29 @@ class FTest extends TestCase
 		$this->assertFileExists($this->test);
 	}
 
-	/**
-	 * @covers ::dirname
-	 */
 	public function testDirname()
 	{
 		$this->assertSame(dirname($this->test), F::dirname($this->test));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		touch($this->test);
 		$this->assertTrue(F::exists($this->test));
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtension()
 	{
 		$this->assertSame('php', F::extension(__FILE__));
 		$this->assertSame('test.jpg', F::extension($this->sample, 'jpg'));
 	}
 
-	/**
-	 * @covers ::extensionToType
-	 */
 	public function testExtensionToType()
 	{
 		$this->assertSame('image', F::extensionToType('jpg'));
 		$this->assertFalse(F::extensionToType('something'));
 	}
 
-	/**
-	 * @covers ::extensions
-	 */
 	public function testExtensions()
 	{
 		$this->assertSame(array_keys(Mime::types()), F::extensions());
@@ -120,17 +95,11 @@ class FTest extends TestCase
 		$this->assertSame([], F::extensions('unknown-type'));
 	}
 
-	/**
-	 * @covers ::filename
-	 */
 	public function testFilename()
 	{
 		$this->assertSame('test.txt', F::filename($this->sample));
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIs()
 	{
 		F::write($this->test, 'test');
@@ -141,27 +110,18 @@ class FTest extends TestCase
 		$this->assertFalse(F::is($this->test, 'no-clue'));
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
 	public function testIsReadable()
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(is_readable($this->test), F::isReadable($this->test));
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
 	public function testIsWritable()
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(is_writable($this->test), F::isWritable($this->test));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink()
 	{
 		$src  = static::TMP . '/a.txt';
@@ -173,18 +133,12 @@ class FTest extends TestCase
 		$this->assertFileExists($link);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
 	public function testRealpath()
 	{
 		$path = F::realpath(__DIR__ . '/../Filesystem/FTest.php');
 		$this->assertSame(__FILE__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
 	public function testRealpathToMissingFile()
 	{
 		$path = __DIR__ . '/../does-not-exist.php';
@@ -195,9 +149,6 @@ class FTest extends TestCase
 		F::realpath($path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
 	public function testRealpathToParent()
 	{
 		$parent = __DIR__ . '/..';
@@ -207,9 +158,6 @@ class FTest extends TestCase
 		$this->assertSame(__FILE__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
 	public function testRealpathToNonExistingParent()
 	{
 		$parent = __DIR__ . '/../does-not-exist';
@@ -221,9 +169,6 @@ class FTest extends TestCase
 		F::realpath($file, $parent);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
 	public function testRealpathToInvalidParent()
 	{
 		$parent = __DIR__ . '/../Cms';
@@ -235,9 +180,6 @@ class FTest extends TestCase
 		F::realpath($file, $parent);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
 	public function testRelativePath()
 	{
 		$path = F::relativepath(__FILE__, __DIR__);
@@ -247,9 +189,6 @@ class FTest extends TestCase
 		$this->assertSame('/' . basename(__FILE__), $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
 	public function testRelativePathWithEmptyBase()
 	{
 		$path = F::relativepath(__FILE__, '');
@@ -259,9 +198,6 @@ class FTest extends TestCase
 		$this->assertSame(basename(__FILE__), $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
 	public function testRelativePathWithUnrelatedBase()
 	{
 		$path = F::relativepath(__DIR__ . '/fruits/apples/fuji.txt', __DIR__ . '/fruits/pineapples');
@@ -289,9 +225,6 @@ class FTest extends TestCase
 		$this->assertSame('../path-extra/file.txt', $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
 	public function testRelativePathOnWindows()
 	{
 		$file = 'C:\xampp\htdocs\index.php';
@@ -301,9 +234,6 @@ class FTest extends TestCase
 		$this->assertSame('/index.php', $path);
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkSymlink()
 	{
 		$src  = static::TMP . '/a.txt';
@@ -315,9 +245,6 @@ class FTest extends TestCase
 		$this->assertTrue(is_link($link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkExistingLink()
 	{
 		$src  = static::TMP . '/a.txt';
@@ -329,9 +256,6 @@ class FTest extends TestCase
 		$this->assertTrue(F::link($src, $link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkWithMissingSource()
 	{
 		$src  = static::TMP . '/a.txt';
@@ -343,9 +267,6 @@ class FTest extends TestCase
 		F::link($src, $link);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad()
 	{
 		// basic behavior
@@ -384,9 +305,6 @@ class FTest extends TestCase
 		$this->assertSame('foo', F::load($file));
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadAccidentalOutput()
 	{
 		$this->expectException(LogicException::class);
@@ -397,9 +315,6 @@ class FTest extends TestCase
 		F::load($file, allowOutput: false);
 	}
 
-	/**
-	 * @covers ::loadClasses
-	 */
 	public function testLoadClasses()
 	{
 		F::loadClasses([
@@ -420,9 +335,6 @@ class FTest extends TestCase
 		class_exists('FTest\\Output');
 	}
 
-	/**
-	 * @covers ::loadOnce
-	 */
 	public function testLoadOnce()
 	{
 		// basic behavior
@@ -441,9 +353,6 @@ class FTest extends TestCase
 		$this->assertTrue(F::loadOnce($file));
 	}
 
-	/**
-	 * @covers ::loadOnce
-	 */
 	public function testLoadOnceAccidentalOutput()
 	{
 		$this->expectException(LogicException::class);
@@ -454,9 +363,6 @@ class FTest extends TestCase
 		F::loadOnce($file, allowOutput: false);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMove()
 	{
 		F::write($origin = static::TMP . '/a.txt', 'test');
@@ -485,9 +391,6 @@ class FTest extends TestCase
 		$this->assertSame('test', file_get_contents($origin));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveAcrossDevices()
 	{
 		// try to find a suitable path on a different device (filesystem)
@@ -532,53 +435,35 @@ class FTest extends TestCase
 		$this->assertSame('test', file_get_contents($origin));
 	}
 
-	/**
-	 * @covers ::mime
-	 */
 	public function testMime()
 	{
 		F::write($this->test, 'test');
 		$this->assertSame('text/plain', F::mime($this->test));
 	}
 
-	/**
-	 * @covers ::mimeToExtension
-	 */
 	public function testMimeToExtension()
 	{
 		$this->assertSame('jpg', F::mimeToExtension('image/jpeg'));
 		$this->assertFalse(F::mimeToExtension('image/something'));
 	}
 
-	/**
-	 * @covers ::mimeToType
-	 */
 	public function testMimeToType()
 	{
 		$this->assertSame('image', F::mimeToType('image/jpeg'));
 		$this->assertFalse(F::mimeToType('image/something'));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(filemtime($this->test), F::modified($this->test));
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$this->assertSame('test', F::name($this->sample));
 	}
 
-	/**
-	 * @covers ::niceSize
-	 */
 	public function testNiceSize()
 	{
 		$locale = I18n::$locale;
@@ -616,9 +501,6 @@ class FTest extends TestCase
 		I18n::$locale = $locale;
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		file_put_contents($this->test, $content = 'my content is awesome');
@@ -630,9 +512,6 @@ class FTest extends TestCase
 		// $this->assertStringContainsString('Example Domain', F::read('https://example.com'));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemove()
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
@@ -644,9 +523,6 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveAlreadyRemoved()
 	{
 		$this->assertFileDoesNotExist($a = static::TMP . '/a.jpg');
@@ -656,9 +532,6 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveDirectory()
 	{
 		Dir::make($a = static::TMP . '/a');
@@ -670,9 +543,6 @@ class FTest extends TestCase
 		$this->assertDirectoryExists($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveLink()
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
@@ -687,9 +557,6 @@ class FTest extends TestCase
 		$this->assertTrue(is_link($b));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveGlob()
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
@@ -707,9 +574,6 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($c);
 	}
 
-	/**
-	 * @covers ::rename
-	 */
 	public function testRename()
 	{
 		F::write($origin = static::TMP . '/a.txt', 'test');
@@ -747,9 +611,6 @@ class FTest extends TestCase
 		$this->assertFileExists($origin);
 	}
 
-	/**
-	 * @covers ::safeName
-	 */
 	public function testSafeName()
 	{
 		// make sure no language rules are still set
@@ -777,9 +638,6 @@ class FTest extends TestCase
 		$this->assertSame('file.a@b_c-d.jpg', F::safeName('file.a@b_c-d.jpg'));
 	}
 
-	/**
-	 * @covers ::safeBasename
-	 */
 	public function testSafeBasename()
 	{
 		// make sure no language rules are still set
@@ -797,9 +655,6 @@ class FTest extends TestCase
 		$this->assertSame('super', F::safeBasename('-super.jpg'));
 	}
 
-	/**
-	 * @covers ::safeExtension
-	 */
 	public function testSafeExtension()
 	{
 		// make sure no language rules are still set
@@ -812,9 +667,6 @@ class FTest extends TestCase
 		$this->assertSame('jpg', F::safeExtension('-super.jpg'));
 	}
 
-	/**
-	 * @covers ::size
-	 */
 	public function testSize()
 	{
 		F::write($a = static::TMP . '/a.txt', 'test');
@@ -825,9 +677,6 @@ class FTest extends TestCase
 		$this->assertSame(8, F::size([$a, $b]));
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$this->assertSame('image', F::type('jpg'));
@@ -840,9 +689,6 @@ class FTest extends TestCase
 		$this->assertNull(F::type('foo'));
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeWithoutExtension()
 	{
 		F::write($file = static::TMP . '/test', '<?php echo "foo"; ?>');
@@ -851,9 +697,6 @@ class FTest extends TestCase
 		$this->assertSame('code', F::type($file));
 	}
 
-	/**
-	 * @covers ::typeToExtensions
-	 */
 	public function testTypeToExtensions()
 	{
 		$this->assertSame(F::$types['audio'], F::typeToExtensions('audio'));
@@ -861,9 +704,6 @@ class FTest extends TestCase
 		$this->assertNull(F::typeToExtensions('invalid'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
 	public function testUnlink()
 	{
 		touch(static::TMP . '/file');
@@ -879,17 +719,11 @@ class FTest extends TestCase
 		$this->assertFalse(is_link(static::TMP . '/link-invalid'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
 	public function testUnlinkAlredyDeleted()
 	{
 		$this->assertTrue(F::unlink(static::TMP . '/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
 	public function testUnlinkFolder()
 	{
 		$this->hasErrorHandler = true;
@@ -916,9 +750,6 @@ class FTest extends TestCase
 		$this->assertTrue($called);
 	}
 
-	/**
-	 * @covers ::uri
-	 */
 	public function testURI()
 	{
 		F::write($this->test, 'test');
@@ -930,25 +761,16 @@ class FTest extends TestCase
 		$this->assertSame($expected, F::uri($this->test));
 	}
 
-	/**
-	 * @covers ::uri
-	 */
 	public function testUriOfNonExistingFile()
 	{
 		$this->assertFalse(F::uri('/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWrite()
 	{
 		$this->assertTrue(F::write($this->test, 'my content'));
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWriteArray()
 	{
 		$input = ['a' => 'a'];
@@ -959,9 +781,6 @@ class FTest extends TestCase
 		$this->assertSame($input, $result);
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWriteObject()
 	{
 		$input = new \stdClass([
@@ -974,9 +793,6 @@ class FTest extends TestCase
 		$this->assertEquals($input, $result); // cannot use strict assertion (serialization)
 	}
 
-	/**
-	 * @covers ::similar
-	 */
 	public function testSimilar()
 	{
 		F::write($a = static::TMP . '/a.jpg', '');

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -11,15 +11,14 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class InvalidFileModel
 {
 	public string $foo = 'bar';
 }
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\File
- */
+#[CoversClass(File::class)]
 class FileTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/files';
@@ -53,11 +52,6 @@ class FileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
 	public function testConstruct()
 	{
 		$file = new File([
@@ -73,11 +67,6 @@ class FileTest extends TestCase
 		$this->assertNull($file->url());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
 	public function testLegacyConstruct()
 	{
 		$file = new File(
@@ -88,9 +77,6 @@ class FileTest extends TestCase
 		$this->assertSame('https://home.io/test.pdf', $file->url());
 	}
 
-	/**
-	 * @covers ::base64
-	 */
 	public function testBase64()
 	{
 		$file   = $this->_file('real.svg');
@@ -98,9 +84,6 @@ class FileTest extends TestCase
 		$this->assertSame($base64, $file->base64());
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopy()
 	{
 		$oldRoot = static::TMP . '/test.txt';
@@ -121,9 +104,6 @@ class FileTest extends TestCase
 		$this->assertSame($newRoot, $new->root());
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyToExisting()
 	{
 		$this->expectException(GlobalException::class);
@@ -133,9 +113,6 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/folder/b.txt');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyNonExisting()
 	{
 		$this->expectException(GlobalException::class);
@@ -145,9 +122,6 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/b.txt');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyFail()
 	{
 		$this->expectException(GlobalException::class);
@@ -158,9 +132,6 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/copied.txt');
 	}
 
-	/**
-	 * @covers ::dataUri
-	 */
 	public function testDataUri()
 	{
 		$file = $this->_file('real.svg');
@@ -168,9 +139,6 @@ class FileTest extends TestCase
 		$this->assertSame('data:image/svg+xml;base64,' . $base64, $file->dataUri());
 	}
 
-	/**
-	 * @covers ::dataUri
-	 */
 	public function testDataUriRaw()
 	{
 		$file = $this->_file('real.svg');
@@ -178,9 +146,6 @@ class FileTest extends TestCase
 		$this->assertSame('data:image/svg+xml,' . $encoded, $file->dataUri(false));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDelete()
 	{
 		$file = new File(static::TMP . '/test.txt');
@@ -192,9 +157,6 @@ class FileTest extends TestCase
 		$this->assertFalse($file->exists());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteNotExisting()
 	{
 		$file = new File('test.txt');
@@ -202,9 +164,6 @@ class FileTest extends TestCase
 		$this->assertTrue($file->delete());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteFail()
 	{
 		$this->expectException(GlobalException::class);
@@ -215,9 +174,6 @@ class FileTest extends TestCase
 		$file->delete();
 	}
 
-	/**
-	 * @covers ::download
-	 */
 	public function testDownload()
 	{
 		$file = $this->_file();
@@ -225,9 +181,6 @@ class FileTest extends TestCase
 		$this->assertIsString($file->download('meow.jpg'));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$file = $this->_file();
@@ -237,54 +190,36 @@ class FileTest extends TestCase
 		$this->assertFalse($file->exists());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtension()
 	{
 		$file = $this->_file();
 		$this->assertSame('js', $file->extension());
 	}
 
-	/**
-	 * @covers ::filename
-	 */
 	public function testFilename()
 	{
 		$file = $this->_file();
 		$this->assertSame('test.js', $file->filename());
 	}
 
-	/**
-	 * @covers ::hash
-	 */
 	public function testHash()
 	{
 		$file = $this->_file();
 		$this->assertIsString($file->hash());
 	}
 
-	/**
-	 * @covers ::header
-	 */
 	public function testHeader()
 	{
 		$file = $this->_file();
 		$this->assertInstanceOf(Response::class, $file->header(false));
 	}
 
-	/**
-	 * @covers ::header
-	 */
 	public function testHeaderSend()
 	{
 		$file = $this->_file();
 		$this->assertNull($file->header());
 	}
 
-	/**
-	 * @covers ::html
-	 */
 	public function testHtml()
 	{
 		$file = new File([
@@ -294,9 +229,6 @@ class FileTest extends TestCase
 		$this->assertSame('<a href="https://foo.bar/blank.pdf">foo.bar/blank.pdf</a>', $file->html());
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIs()
 	{
 		$file = $this->_file();
@@ -307,36 +239,24 @@ class FileTest extends TestCase
 		$this->assertFalse($file->is('jpg'));
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
 	public function testIsReadable()
 	{
 		$file = $this->_file();
 		$this->assertSame(is_readable($file->root()), $file->isReadable());
 	}
 
-	/**
-	 * @covers ::isResizable
-	 */
 	public function testIsResizable()
 	{
 		$file = $this->_file();
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::isViewable
-	 */
 	public function testIsViewable()
 	{
 		$file = $this->_file();
 		$this->assertFalse($file->isViewable());
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
 	public function testIsWritable()
 	{
 		$file = $this->_file();
@@ -349,9 +269,6 @@ class FileTest extends TestCase
 		$this->assertFalse($file->isWritable());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		$file = $this->_file();
@@ -362,9 +279,6 @@ class FileTest extends TestCase
 		$this->assertInstanceOf(App::class, $file->kirby());
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatch()
 	{
 		$rules = [
@@ -378,9 +292,6 @@ class FileTest extends TestCase
 		$this->assertTrue($this->_file('cat.jpg')->match($rules));
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatchMimeMissing()
 	{
 		$this->expectException(Exception::class);
@@ -389,9 +300,6 @@ class FileTest extends TestCase
 		$this->_file('doesnotexist.invalid')->match(['mime' => ['image/png', 'application/pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatchMimeInvalid()
 	{
 		$this->expectException(Exception::class);
@@ -403,9 +311,6 @@ class FileTest extends TestCase
 		$this->_file()->match(['mime' => ['image/png', 'application/pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatchExtensionException()
 	{
 		$this->expectException(Exception::class);
@@ -417,9 +322,6 @@ class FileTest extends TestCase
 		$this->_file()->match(['extension' => ['png', 'pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatchTypeException()
 	{
 		$this->expectException(Exception::class);
@@ -431,18 +333,12 @@ class FileTest extends TestCase
 		$this->_file()->match(['type' => ['document', 'video']]);
 	}
 
-	/**
-	 * @covers ::mime
-	 */
 	public function testMime()
 	{
 		$file = $this->_file();
 		$this->assertSame('text/plain', $file->mime());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$parent = Page::factory(['slug' => 'test']);
@@ -460,9 +356,6 @@ class FileTest extends TestCase
 		$this->assertSame($model, $file->model());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testParentModel()
 	{
 		$parent = Page::factory([
@@ -483,9 +376,6 @@ class FileTest extends TestCase
 		$this->assertSame($file->root(), $asset->root());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testInvalidModel()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -497,9 +387,6 @@ class FileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		// existing file
@@ -513,9 +400,6 @@ class FileTest extends TestCase
 		$this->assertFalse($file->modified());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMove()
 	{
 		$oldRoot = static::TMP . '/test.txt';
@@ -535,9 +419,6 @@ class FileTest extends TestCase
 		$this->assertSame($newRoot, $moved->root());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveToExisting()
 	{
 		$this->expectException(GlobalException::class);
@@ -547,9 +428,6 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/folder/b.txt');
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveNonExisting()
 	{
 		$this->expectException(GlobalException::class);
@@ -559,9 +437,6 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/b.txt');
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveFail()
 	{
 		$this->expectException(GlobalException::class);
@@ -572,18 +447,12 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/moved.txt');
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$file = $this->_file();
 		$this->assertSame('test', $file->name());
 	}
 
-	/**
-	 * @covers ::niceSize
-	 */
 	public function testNiceSize()
 	{
 		// existing file
@@ -595,27 +464,18 @@ class FileTest extends TestCase
 		$this->assertSame('0 KB', $file->niceSize());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		$file = $this->_file();
 		$this->assertSame(file_get_contents($file->root()), $file->read());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadNotExist()
 	{
 		$file = $this->_file('missing.txt');
 		$this->assertFalse($file->read());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadUnreadble()
 	{
 		$file = new File(static::TMP . '/unreadable.txt');
@@ -624,9 +484,6 @@ class FileTest extends TestCase
 		$this->assertFalse($file->read());
 	}
 
-	/**
-	 * @covers ::rename
-	 */
 	public function testRename()
 	{
 		$file = new File(static::TMP . '/test.js');
@@ -637,9 +494,6 @@ class FileTest extends TestCase
 		$this->assertSame('awesome', $renamed->name());
 	}
 
-	/**
-	 * @covers ::rename
-	 */
 	public function testRenameFail()
 	{
 		$this->expectException(GlobalException::class);
@@ -650,9 +504,6 @@ class FileTest extends TestCase
 		$renamed = $file->rename('awesome');
 	}
 
-	/**
-	 * @covers ::rename
-	 */
 	public function testRenameSameRoot()
 	{
 		$file = new File(static::TMP . '/test.txt');
@@ -663,10 +514,6 @@ class FileTest extends TestCase
 		$this->assertSame(static::TMP . '/test.txt', $file->root());
 	}
 
-	/**
-	 * @covers ::root
-	 * @covers ::realpath
-	 */
 	public function testRoot()
 	{
 		$file = $this->_file();
@@ -674,9 +521,6 @@ class FileTest extends TestCase
 		$this->assertSame(static::TMP . '/test.js', $file->realpath());
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
 	public function testSanitizeContentsValid()
 	{
 		$fixture = static::TMP . '/clean.svg';
@@ -691,9 +535,6 @@ class FileTest extends TestCase
 		$this->assertFileEquals($fixture, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
 	public function testSanitizeContentsWrongType()
 	{
 		$fixture = static::TMP . '/real.svg';
@@ -706,9 +547,6 @@ class FileTest extends TestCase
 		$this->assertFileEquals(static::TMP . '/real.sanitized.svg', $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
 	public function testSanitizeContentsMissingHandler()
 	{
 		$file = new File(static::TMP . '/test.js');
@@ -723,28 +561,18 @@ class FileTest extends TestCase
 		$file->sanitizeContents();
 	}
 
-	/**
-	 * @covers ::size
-	 */
 	public function testSize()
 	{
 		$file = $this->_file('test.js');
 		$this->assertSame(14, $file->size());
 	}
 
-	/**
-	 * @covers ::sha1
-	 */
 	public function testSha1()
 	{
 		$file = $this->_file('test.js');
 		$this->assertSame('25f2d6df4f2a30f29f6f80da1e95011044b0b8f7', $file->sha1());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testToArray()
 	{
 		$file = $this->_file('blank.pdf');
@@ -755,9 +583,6 @@ class FileTest extends TestCase
 		$this->assertSame($file->toArray(), $file->__debugInfo());
 	}
 
-	/**
-	 * @covers ::toJson
-	 */
 	public function testToJson()
 	{
 		$file = $this->_file();
@@ -765,9 +590,6 @@ class FileTest extends TestCase
 		$this->assertSame('test.js', json_decode($json)->filename);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$file = new File([
@@ -791,27 +613,18 @@ class FileTest extends TestCase
 		$this->assertSame('', $file->__toString());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$file = $this->_file();
 		$this->assertSame('code', $file->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeUnknown()
 	{
 		$file = $this->_file('test.kirby');
 		$this->assertNull($file->type());
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
 	public function testValidateContentsValid()
 	{
 		$file = new File(static::TMP . '/real.svg');
@@ -820,9 +633,6 @@ class FileTest extends TestCase
 		$this->assertNull($file->validateContents(false));
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
 	public function testValidateContentsWrongType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -832,9 +642,6 @@ class FileTest extends TestCase
 		$file->validateContents('xml');
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
 	public function testValidateContentsMissingHandler()
 	{
 		$file = new File(static::TMP . '/test.js');
@@ -849,9 +656,6 @@ class FileTest extends TestCase
 		$file->validateContents();
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWrite()
 	{
 		$root = static::TMP . '/test.txt';
@@ -864,9 +668,6 @@ class FileTest extends TestCase
 		$this->assertSame('test', file_get_contents($file->root()));
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWriteUnwritable()
 	{
 		$this->expectException(GlobalException::class);
@@ -878,9 +679,6 @@ class FileTest extends TestCase
 		$file->write('kirby');
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWriteFail()
 	{
 		$this->expectException(GlobalException::class);

--- a/tests/Filesystem/FilenameTest.php
+++ b/tests/Filesystem/FilenameTest.php
@@ -3,15 +3,12 @@
 namespace Kirby\Filesystem;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Filename
- */
+#[CoversClass(Filename::class)]
 class FilenameTest extends TestCase
 {
-	/**
-	 * @covers ::attributesToArray
-	 */
 	public function testAttributesToArray()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
@@ -78,20 +75,14 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::attributesToString
-	 * @dataProvider attributesToStringProvider
-	 */
-	public function testAttributesToString($expected, $options)
+	#[DataProvider('attributesToStringProvider')]
+	public function testAttributesToString(string $expected, array $options)
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', $options);
 
 		$this->assertSame($expected, $name->attributesToString('-'));
 	}
 
-	/**
-	 * @covers ::attributesToString
-	 */
 	public function testAttributesToStringWithoutAttrs()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', []);
@@ -109,11 +100,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::blur
-	 * @dataProvider blurOptionProvider
-	 */
-	public function testBlur($value, $expected)
+	#[DataProvider('blurOptionProvider')]
+	public function testBlur(bool|int|float|string $value, bool|int $expected)
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'blur' => $value
@@ -137,11 +125,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::crop
-	 * @dataProvider cropAnchorProvider
-	 */
-	public function testCrop($anchor, $expected)
+	#[DataProvider('cropAnchorProvider')]
+	public function testCrop(string $anchor, string $expected)
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'crop' => $anchor
@@ -150,18 +135,12 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
 	public function testCropEmpty()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertFalse($name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
 	public function testCropDisabled()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
@@ -171,9 +150,6 @@ class FilenameTest extends TestCase
 		$this->assertFalse($name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
 	public function testCropCustom()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
@@ -183,9 +159,6 @@ class FilenameTest extends TestCase
 		$this->assertSame('something', $name->crop());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
 	public function testDimensions()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', $dimensions = [
@@ -196,9 +169,6 @@ class FilenameTest extends TestCase
 		$this->assertSame($dimensions, $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
 	public function testDimensionsEmpty()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
@@ -206,9 +176,6 @@ class FilenameTest extends TestCase
 		$this->assertSame([], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
 	public function testDimensionsWithoutWidth()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
@@ -221,9 +188,6 @@ class FilenameTest extends TestCase
 		], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
 	public function testDimensionsWithoutHeight()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
@@ -236,27 +200,18 @@ class FilenameTest extends TestCase
 		], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtension()
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('jpg', $name->extension());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtensionUppercase()
 	{
 		$name = new Filename('/test/some-file.JPG', '{{ name }}.{{ extension }}');
 		$this->assertSame('jpg', $name->extension());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtensionJpeg()
 	{
 		$name = new Filename('/test/some-file.jpeg', '{{ name }}.{{ extension }}');
@@ -275,11 +230,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::grayscale
-	 * @dataProvider grayscaleOptionProvider
-	 */
-	public function testGrayscale($prop, $value, $expected)
+	#[DataProvider('grayscaleOptionProvider')]
+	public function testGrayscale(string $prop, bool $value, bool $expected)
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			$prop => $value
@@ -288,30 +240,18 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->grayscale());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
 	public function testName()
 	{
 		$name = new Filename('/var/www/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file', $name->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
 	public function testNameSanitization()
 	{
 		$name = new Filename('/var/www/söme file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file', $name->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
 	public function testNameSanitizationWithLanguageRules()
 	{
 		$name = new Filename(
@@ -334,11 +274,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::quality
-	 * @dataProvider qualityOptionProvider
-	 */
-	public function testQuality($value, $expected)
+	#[DataProvider('qualityOptionProvider')]
+	public function testQuality(bool|int|float|string $value, bool|int $expected)
 	{
 		$name = new Filename('/test/some-file.jpg', 'some-file.jpg', [
 			'quality' => $value
@@ -347,12 +284,8 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->quality());
 	}
 
-	/**
-	 * @covers ::toString
-	 * @covers ::__toString
-	 * @dataProvider attributesToStringProvider
-	 */
-	public function testToString($expected, $attributes)
+	#[DataProvider('attributesToStringProvider')]
+	public function testToString(string $expected, array $attributes)
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}{{ attributes }}.{{ extension }}', $attributes);
 
@@ -361,7 +294,6 @@ class FilenameTest extends TestCase
 	}
 
 	/**
-	 * @covers ::toString
 	 * @ocvers ::__toString
 	 */
 	public function testToStringWithFalsyAttributes()
@@ -381,7 +313,6 @@ class FilenameTest extends TestCase
 	}
 
 	/**
-	 * @covers ::toString
 	 * @ocvers ::__toString
 	 */
 	public function testToStringWithoutAttributes()

--- a/tests/Filesystem/IsFileTest.php
+++ b/tests/Filesystem/IsFileTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Image\Image;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class AFile
 {
@@ -14,9 +15,7 @@ class AFile
 	public string $foo = 'bar';
 }
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\IsFile
- */
+#[CoversClass(IsFile::class)]
 class IsFileTest extends TestCase
 {
 	protected function _asset($file = 'blank.pdf')
@@ -27,11 +26,6 @@ class IsFileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
 	public function testConstruct()
 	{
 		$asset = $this->_asset();
@@ -40,9 +34,6 @@ class IsFileTest extends TestCase
 		$this->assertSame('https://foo.bar/blank.pdf', $asset->url());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
 	public function testAsset()
 	{
 		$asset = $this->_asset();
@@ -52,9 +43,6 @@ class IsFileTest extends TestCase
 		$this->assertSame($file, $asset->asset());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
 	public function testAssetStringProp()
 	{
 		$asset = $this->_asset();
@@ -64,45 +52,30 @@ class IsFileTest extends TestCase
 		$this->assertSame('/dev/null/blank.pdf', $file->root());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
 	public function testAssetImage()
 	{
 		$asset = $this->_asset('cat.jpg');
 		$this->assertInstanceOf(Image::class, $asset->asset());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		$asset = $this->_asset();
 		$this->assertInstanceOf(App::class, $asset->kirby());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCall()
 	{
 		$asset = $this->_asset();
 		$this->assertSame('pdf', $asset->extension());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCallPublicProperty()
 	{
 		$asset = $this->_asset();
 		$this->assertSame('bar', $asset->foo());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCallNotExisting()
 	{
 		$asset = $this->_asset();

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -3,35 +3,25 @@
 namespace Kirby\Filesystem;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Mime
- */
+#[CoversClass(Mime::class)]
 class MimeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/mime';
 
-	/**
-	 * @covers ::fix
-	 */
 	public function testFixCss()
 	{
 		$this->assertSame('text/css', Mime::fix('something.css', 'text/x-asm', 'css'));
 		$this->assertSame('text/css', Mime::fix('something.css', 'text/plain', 'css'));
 	}
 
-	/**
-	 * @covers ::fix
-	 */
 	public function testFixMjs()
 	{
 		$this->assertSame('text/javascript', Mime::fix('something.mjs', 'text/x-java', 'mjs'));
 		$this->assertSame('text/javascript', Mime::fix('something.mjs', 'text/plain', 'mjs'));
 	}
 
-	/**
-	 * @covers ::fix
-	 */
 	public function testFixSvg()
 	{
 		$this->assertSame('image/svg+xml', Mime::fix('something.svg', 'image/svg', 'svg'));
@@ -39,45 +29,30 @@ class MimeTest extends TestCase
 		$this->assertSame('image/svg+xml', Mime::fix(static::FIXTURES . '/unoptimized.svg', 'text/html', 'svg'));
 	}
 
-	/**
-	 * @covers ::fromExtension
-	 */
 	public function testFromExtension()
 	{
 		$mime = Mime::fromExtension('jpg');
 		$this->assertSame('image/jpeg', $mime);
 	}
 
-	/**
-	 * @covers ::fromMimeContentType
-	 */
 	public function testFromMimeContentType()
 	{
 		$mime = Mime::fromMimeContentType(__FILE__);
 		$this->assertSame('text/x-php', $mime);
 	}
 
-	/**
-	 * @covers ::fromSvg
-	 */
 	public function testFromSvg()
 	{
 		$mime = Mime::fromSvg(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::fromSvg
-	 */
 	public function testFromSvgNonExistingFile()
 	{
 		$mime = Mime::fromSvg(__DIR__ . '/imaginary.svg');
 		$this->assertFalse($mime);
 	}
 
-	/**
-	 * @covers ::isAccepted
-	 */
 	public function testIsAccepted()
 	{
 		$pattern = 'text/html,text/plain;q=0.8,application/*;q=0.7';
@@ -90,9 +65,6 @@ class MimeTest extends TestCase
 		$this->assertFalse(Mime::isAccepted('text/xml', $pattern));
 	}
 
-	/**
-	 * @covers ::matches
-	 */
 	public function testMatches()
 	{
 		$this->assertTrue(Mime::matches('text/plain', 'text/plain'));
@@ -108,9 +80,6 @@ class MimeTest extends TestCase
 		$this->assertFalse(Mime::matches('text/xml', '*/plain'));
 	}
 
-	/**
-	 * @covers ::toExtension
-	 */
 	public function testToExtension()
 	{
 		$extension = Mime::toExtension('image/jpeg');
@@ -120,9 +89,6 @@ class MimeTest extends TestCase
 		$this->assertSame('css', $extensions);
 	}
 
-	/**
-	 * @covers ::toExtensions
-	 */
 	public function testToExtensions()
 	{
 		$extensions = Mime::toExtensions('image/jpeg');
@@ -132,9 +98,6 @@ class MimeTest extends TestCase
 		$this->assertSame(['css'], $extensions);
 	}
 
-	/**
-	 * @covers ::toExtensions
-	 */
 	public function testToExtensionsMatchWildcards()
 	{
 		// matchWildcards: false (default value)
@@ -159,36 +122,24 @@ class MimeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeWithOptimizedSvg()
 	{
 		$mime = Mime::type(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeWithUnoptimizedSvg()
 	{
 		$mime = Mime::type(static::FIXTURES . '/unoptimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testTypeWithJson()
 	{
 		$mime = Mime::type(static::FIXTURES . '/something.json');
 		$this->assertSame('application/json', $mime);
 	}
 
-	/**
-	 * @covers ::types
-	 */
 	public function testTypes()
 	{
 		$this->assertSame(Mime::$types, Mime::types());

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class DateFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -167,10 +169,8 @@ class DateFieldTest extends TestCase
 		$this->assertSame($now, $field->default());
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected, $step = null)
+	#[DataProvider('valueProvider')]
+	public function testValue(string $input, string $expected, int|null $step = null)
 	{
 		$field = $this->field('date', [
 			'value' => $input,

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -4,10 +4,10 @@ namespace Kirby\Form\Field;
 
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Form\Field\EntriesField
- */
+#[CoversClass(EntriesField::class)]
 class EntriesFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -215,10 +215,8 @@ class EntriesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider supportsProvider
-	 */
-	public function testSupportedFields($type, $expected)
+	#[DataProvider('supportsProvider')]
+	public function testSupportedFields(string $type, bool $expected)
 	{
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
@@ -262,10 +260,8 @@ class EntriesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider validationsProvider
-	 */
-	public function testValidations($type, $value, $expected)
+	#[DataProvider('validationsProvider')]
+	public function testValidations(string $type, string|int $value, bool $expected)
 	{
 		$field = $this->field('entries', [
 			'value'    => [

--- a/tests/Form/Field/NumberFieldTest.php
+++ b/tests/Form/Field/NumberFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class NumberFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -36,10 +38,8 @@ class NumberFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueProvider')]
+	public function testValue(string|bool|int|float|null $input, string|float $expected)
 	{
 		$field = $this->field('number', [
 			'value'   => $input,

--- a/tests/Form/Field/RadioFieldTest.php
+++ b/tests/Form/Field/RadioFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class RadioFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -26,10 +28,8 @@ class RadioFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue(string $input, string $expected)
 	{
 		$field = $this->field('radio', [
 			'options' => [

--- a/tests/Form/Field/SelectFieldTest.php
+++ b/tests/Form/Field/SelectFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class SelectFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -196,10 +198,8 @@ class SelectFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue(string $input, string $expected)
 	{
 		$field = $this->field('select', [
 			'options' => [

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TextFieldTest extends TestCase
 {
@@ -35,10 +36,8 @@ class TextFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider converterDataProvider
-	 */
-	public function testConverter($converter, $input, $expected)
+	#[DataProvider('converterDataProvider')]
+	public function testConverter(string $converter, string|null $input, string $expected)
 	{
 		$field = $this->field('text', [
 			'converter' => $converter,

--- a/tests/Form/Field/TimeFieldTest.php
+++ b/tests/Form/Field/TimeFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class TimeFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -160,10 +162,8 @@ class TimeFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected, $step = 1)
+	#[DataProvider('valueProvider')]
+	public function testValue(string|null $input, string $expected, int|array $step = 1)
 	{
 		$field = $this->field('time', [
 			'default' => $input,

--- a/tests/Form/Field/TogglesFieldTest.php
+++ b/tests/Form/Field/TogglesFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class TogglesFieldTest extends TestCase
 {
 	public function testDefaultProps()
@@ -73,10 +75,8 @@ class TogglesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue(string $input, string $expected)
 	{
 		$field = $this->field('toggles', [
 			'options' => [

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Exception;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestField extends FieldClass
 {
@@ -41,14 +42,9 @@ class ValidatedField extends FieldClass
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Form\FieldClass
- */
+#[CoversClass(FieldClass::class)]
 class FieldClassTest extends TestCase
 {
-	/**
-	 * @covers ::__call
-	 */
 	public function test__call()
 	{
 		$field = new TestField([
@@ -58,9 +54,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('bar', $field->foo());
 	}
 
-	/**
-	 * @covers ::after
-	 */
 	public function testAfter()
 	{
 		$field = new TestField();
@@ -73,18 +66,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->after());
 	}
 
-	/**
-	 * @covers ::api
-	 */
 	public function testApi()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->api());
 	}
 
-	/**
-	 * @covers ::autofocus
-	 */
 	public function testAutofocus()
 	{
 		$field = new TestField();
@@ -94,9 +81,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->autofocus());
 	}
 
-	/**
-	 * @covers ::before
-	 */
 	public function testBefore()
 	{
 		$field = new TestField();
@@ -109,9 +93,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->before());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testData()
 	{
 		$field = new TestField();
@@ -130,9 +111,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->data());
 	}
 
-	/**
-	 * @covers ::default
-	 */
 	public function testDefault()
 	{
 		$field = new TestField();
@@ -156,19 +134,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test title', $field->default());
 	}
 
-	/**
-	 * @covers ::dialogs
-	 */
 	public function testDialogs()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->dialogs());
 	}
 
-	/**
-	 * @covers ::disabled
-	 * @covers ::isDisabled
-	 */
 	public function testDisabled()
 	{
 		$field = new TestField();
@@ -180,20 +151,12 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isDisabled());
 	}
 
-	/**
-	 * @covers ::drawers
-	 */
 	public function testDrawers()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->drawers());
 	}
 
-	/**
-	 * @covers ::errors
-	 * @covers ::validate
-	 * @covers ::validations
-	 */
 	public function testErrors()
 	{
 		$field = new TestField();
@@ -212,9 +175,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['custom' => 'Please enter an a'], $field->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		$field = new TestField();
@@ -223,10 +183,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test value', $field->value());
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @covers ::isEmptyValue
-	 */
 	public function testIsEmpty()
 	{
 		$field = new TestField();
@@ -236,9 +192,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmpty());
 	}
 
-	/**
-	 * @covers ::isEmptyValue
-	 */
 	public function testIsEmptyValue()
 	{
 		$field = new TestField();
@@ -253,9 +206,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmptyValue('0'));
 	}
 
-	/**
-	 * @covers ::isHidden
-	 */
 	public function testIsHidden()
 	{
 		$field = new TestField();
@@ -265,10 +215,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isHidden());
 	}
 
-	/**
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
 	public function testInvalid()
 	{
 		$field = new TestField();
@@ -281,10 +227,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isInvalid());
 	}
 
-	/**
-	 * @covers ::isRequired
-	 * @covers ::required
-	 */
 	public function testIsRequired()
 	{
 		$field = new TestField();
@@ -296,9 +238,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
-	/**
-	 * @covers ::isSaveable
-	 */
 	public function testIsSaveable()
 	{
 		$field = new TestField();
@@ -308,9 +247,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSaveable());
 	}
 
-	/**
-	 * @covers ::help
-	 */
 	public function testHelp()
 	{
 		$field = new TestField();
@@ -338,9 +274,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('<p>A field for Test title</p>', $field->help());
 	}
 
-	/**
-	 * @covers ::icon
-	 */
 	public function testIcon()
 	{
 		$field = new TestField();
@@ -350,9 +283,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->icon());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$field = new TestField();
@@ -362,18 +292,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-id', $field->id());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		$field = new TestField();
 		$this->assertSame(kirby(), $field->kirby());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel()
 	{
 		$field = new TestField();
@@ -386,9 +310,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->label());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$field = new TestField();
@@ -400,9 +321,6 @@ class FieldClassTest extends TestCase
 		$this->assertIsPage($page, $field->model());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$field = new TestField();
@@ -412,9 +330,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-name', $field->name());
 	}
 
-	/**
-	 * @covers ::params
-	 */
 	public function testParams()
 	{
 		$field = new TestField($params = [
@@ -426,9 +341,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame($params, $field->params());
 	}
 
-	/**
-	 * @covers ::placeholder
-	 */
 	public function testPlaceholder()
 	{
 		$field = new TestField();
@@ -456,10 +368,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Placeholder for Test title', $field->placeholder());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::toArray
-	 */
 	public function testProps()
 	{
 		$field = new TestField($props = [
@@ -489,27 +397,18 @@ class FieldClassTest extends TestCase
 		$this->assertSame($props, $field->props());
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->routes());
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSave()
 	{
 		$field = new TestField();
 		$this->assertTrue($field->save());
 	}
 
-	/**
-	 * @covers ::siblings
-	 */
 	public function testSiblings()
 	{
 		$field = new TestField();
@@ -529,9 +428,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('b', $field->siblings()->last()->name());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 */
 	public function testToStoredValue()
 	{
 		$field = new TestField();
@@ -540,9 +436,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->toStoredValue());
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslate()
 	{
 		$field = new TestField();
@@ -552,18 +445,12 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->translate());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$field = new TestField();
 		$this->assertSame('test', $field->type());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$field = new TestField();
@@ -582,9 +469,6 @@ class FieldClassTest extends TestCase
 		$this->assertNull($field->value());
 	}
 
-	/**
-	 * @covers ::when
-	 */
 	public function testWhen()
 	{
 		$field = new TestField();
@@ -594,9 +478,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['a' => 'test'], $field->when());
 	}
 
-	/**
-	 * @covers ::width
-	 */
 	public function testWidth()
 	{
 		$field = new TestField();

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -6,10 +6,10 @@ use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Form\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
 	protected array $originalMixins;
@@ -35,9 +35,6 @@ class FieldTest extends TestCase
 		Field::$mixins = $this->originalMixins;
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructInvalidType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -88,10 +85,6 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->after);
 	}
 
-	/**
-	 * @covers ::api
-	 * @covers ::routes
-	 */
 	public function testApi()
 	{
 		// no defined as default
@@ -247,9 +240,6 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->data(true));
 	}
 
-	/**
-	 * @covers ::dialogs
-	 */
 	public function testDialogs()
 	{
 		// no defined as default
@@ -290,9 +280,6 @@ class FieldTest extends TestCase
 		$this->assertSame($routes, $field->dialogs());
 	}
 
-	/**
-	 * @covers ::drawers
-	 */
 	public function testDrawers()
 	{
 		// no defined as default
@@ -332,9 +319,6 @@ class FieldTest extends TestCase
 		$this->assertSame($routes, $field->drawers());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
 	public function testErrors()
 	{
 		Field::$types = [
@@ -363,9 +347,6 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		Field::$types = [
@@ -477,9 +458,6 @@ class FieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isDisabled
-	 */
 	public function testDisabled()
 	{
 		Field::$types = [
@@ -508,12 +486,8 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isDisabled());
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @covers ::isEmptyValue
-	 * @dataProvider emptyValuesProvider
-	 */
-	public function testIsEmpty($value, $expected)
+	#[DataProvider('emptyValuesProvider')]
+	public function testIsEmpty(string|int|array|null $value, bool $expected)
 	{
 		Field::$types = [
 			'test' => []
@@ -530,9 +504,6 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->isEmptyValue($value));
 	}
 
-	/**
-	 * @covers ::isEmptyValue
-	 */
 	public function testIsEmptyValueFromOption()
 	{
 		Field::$types = [
@@ -553,9 +524,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isEmptyValue('empty'));
 	}
 
-	/**
-	 * @covers ::isHidden
-	 */
 	public function testIsHidden()
 	{
 		// default
@@ -585,10 +553,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isHidden());
 	}
 
-	/**
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
 	public function testIsInvalidOrValid()
 	{
 		Field::$types = [
@@ -615,9 +579,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isInvalid());
 	}
 
-	/**
-	 * @covers ::isRequired
-	 */
 	public function testIsRequired()
 	{
 		Field::$types = [
@@ -640,10 +601,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isRequired());
 	}
 
-	/**
-	 * @covers ::isSaveable
-	 * @covers ::save
-	 */
 	public function testIsSaveable()
 	{
 		Field::$types = [
@@ -672,9 +629,6 @@ class FieldTest extends TestCase
 		$this->assertFalse($b->save());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		Field::$types = [
@@ -770,9 +724,6 @@ class FieldTest extends TestCase
 		$this->assertSame(5, $field->min());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		Field::$types = [
@@ -808,10 +759,6 @@ class FieldTest extends TestCase
 		$this->assertSame('mytest', $field->name());
 	}
 
-	/**
-	 * @covers ::needsValue
-	 * @covers ::errors
-	 */
 	public function testNeedsValue()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -954,11 +901,6 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->placeholder);
 	}
 
-	/**
-	 * @covers ::next
-	 * @covers ::prev
-	 * @covers ::siblingsCollection
-	 */
 	public function testPrevNext()
 	{
 		Field::$types = [
@@ -984,10 +926,6 @@ class FieldTest extends TestCase
 		$this->assertSame('a', $siblings->last()->prev()->name());
 	}
 
-	/**
-	 * @covers ::siblings
-	 * @covers ::formFields
-	 */
 	public function testSiblings()
 	{
 		Field::$types = [
@@ -1032,9 +970,6 @@ class FieldTest extends TestCase
 		$this->assertSame('b', $field->formFields()->last()->name());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		Field::$types = [
@@ -1060,10 +995,6 @@ class FieldTest extends TestCase
 		$this->assertArrayNotHasKey('model', $array);
 	}
 
-	/**
-	 * @covers ::toFormValue
-	 * @covers ::value
-	 */
 	public function testToFormValue()
 	{
 		Field::$types['test'] = [];
@@ -1093,10 +1024,6 @@ class FieldTest extends TestCase
 		$this->assertNull($field->value());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 * @covers ::data
-	 */
 	public function testToStoredValue()
 	{
 		Field::$types = [
@@ -1119,10 +1046,6 @@ class FieldTest extends TestCase
 		$this->assertSame('a, b, c', $field->data());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 * @covers ::data
-	 */
 	public function testToStoredValueWhenUnsaveable()
 	{
 		Field::$types = [
@@ -1142,11 +1065,6 @@ class FieldTest extends TestCase
 		$this->assertNull($field->data());
 	}
 
-	/**
-	 * @covers ::validate
-	 * @covers ::validations
-	 * @covers ::errors
-	 */
 	public function testValidate()
 	{
 		Field::$types = [
@@ -1197,11 +1115,6 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	/**
-	 * @covers ::validate
-	 * @covers ::validations
-	 * @covers ::isValid
-	 */
 	public function testValidateByAttr()
 	{
 		Field::$types = [
@@ -1257,12 +1170,6 @@ class FieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	/**
-	 * @covers ::validate
-	 * @covers ::validations
-	 * @covers ::errors
-	 * @covers ::isValid
-	 */
 	public function testValidateWithCustomValidator()
 	{
 		Field::$types = [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Form;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Form\Fields
- */
+#[CoversClass(Fields::class)]
 class FieldsTest extends TestCase
 {
 	protected App $app;
@@ -24,9 +23,6 @@ class FieldsTest extends TestCase
 		$this->model = new Page(['slug' => 'test']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$fields = new Fields([
@@ -44,9 +40,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithModel()
 	{
 		$fields = new Fields([
@@ -64,9 +57,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$fields = new Fields([
@@ -83,9 +73,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->defaults());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
 	public function testErrors()
 	{
 		$fields = new Fields([
@@ -131,9 +118,6 @@ class FieldsTest extends TestCase
 		], $fields->errors());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
 	public function testErrorsWithoutErrors()
 	{
 		$fields = new Fields([
@@ -148,9 +132,6 @@ class FieldsTest extends TestCase
 		$this->assertSame([], $fields->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		$fields = new Fields([
@@ -177,10 +158,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($input, $fields->toArray(fn ($field) => $field->value()));
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByKeyRecursive
-	 */
 	public function testFind()
 	{
 		Field::$types['test'] = [
@@ -209,10 +186,6 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+missing-child'));
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByKeyRecursive
-	 */
 	public function testFindWhenFieldHasNoForm()
 	{
 		$fields = new Fields([
@@ -224,9 +197,6 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+child'));
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$fields = new Fields([
@@ -241,9 +211,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn ($field) => $field->name()));
 	}
 
-	/**
-	 * @covers ::toFormValues
-	 */
 	public function testToFormValues()
 	{
 		$fields = new Fields([
@@ -260,9 +227,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'Value a', 'b' => 'Value b'], $fields->toFormValues());
 	}
 
-	/**
-	 * @covers ::toStoredValues
-	 */
 	public function testToStoredValues()
 	{
 		Field::$types['test'] = [

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -8,10 +8,9 @@ use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Form\Form
- */
+#[CoversClass(Form::class)]
 class FormTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Form.Form';
@@ -38,9 +37,6 @@ class FormTest extends TestCase
 		$this->tearDownTmp();
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContent()
 	{
 		$form = new Form([
@@ -54,10 +50,6 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->content());
 	}
 
-	/**
-	 * @covers ::content
-	 * @covers ::data
-	 */
 	public function testContentAndDataFromUnsaveableFields()
 	{
 		$form = new Form([
@@ -78,9 +70,6 @@ class FormTest extends TestCase
 		$this->assertArrayHasKey('info', $form->data());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithoutFields()
 	{
 		$form = new Form([
@@ -94,9 +83,6 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->data());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataFromUnsaveableFields()
 	{
 		$form = new Form([
@@ -114,9 +100,6 @@ class FormTest extends TestCase
 		$this->assertNull($form->data()['info']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataFromNestedFields()
 	{
 		$form = new Form([
@@ -143,10 +126,6 @@ class FormTest extends TestCase
 		$this->assertSame('a, b', $form->data()['structure'][0]['tags']);
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithCorrectFieldOrder()
 	{
 		$form = new Form([
@@ -173,10 +152,6 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->values());
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithStrictMode()
 	{
 		$form = new Form([
@@ -203,10 +178,6 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->values());
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithUntranslatedFields()
 	{
 		$this->setUpMultiLanguage();
@@ -258,11 +229,6 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->values());
 	}
 
-	/**
-	 * @covers ::errors
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
 	public function testErrors()
 	{
 		$form = new Form([
@@ -307,9 +273,6 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->errors());
 	}
 
-	/**
-	 * @covers ::exceptionField
-	 */
 	public function testExceptionField()
 	{
 		$form = new Form([
@@ -329,9 +292,6 @@ class FormTest extends TestCase
 		$this->assertSame('<p>Field "test": The field type "does-not-exist" does not exist</p>', $field->text());
 	}
 
-	/**
-	 * @covers ::exceptionField
-	 */
 	public function testExceptionFieldInDebugMode()
 	{
 		$exception = new Exception('This is an error');
@@ -364,9 +324,6 @@ class FormTest extends TestCase
 		$this->assertSame('negative', $field['theme']);
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForFileWithoutBlueprint()
 	{
 		$file = new File([
@@ -382,9 +339,6 @@ class FormTest extends TestCase
 		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->data());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPage()
 	{
 		$page = new Page([
@@ -420,9 +374,6 @@ class FormTest extends TestCase
 		$this->assertSame('', $values['date']);
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPageWithClosureValues()
 	{
 		$page = new Page([
@@ -445,9 +396,6 @@ class FormTest extends TestCase
 		$this->assertSame('B', $values['b']);
 	}
 
-	/**
-	 * @covers ::strings
-	 */
 	public function testStrings()
 	{
 		$form = new Form([
@@ -469,9 +417,6 @@ class FormTest extends TestCase
 		], $form->strings());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$form = new Form([
@@ -499,9 +444,6 @@ class FormTest extends TestCase
 		$this->assertFalse($form->toArray()['invalid']);
 	}
 
-	/**
-	 * @covers ::toFormValues
-	 */
 	public function testToFormValues()
 	{
 		$form = new Form([
@@ -522,9 +464,6 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->toFormValues());
 	}
 
-	/**
-	 * @covers ::toStoredValues
-	 */
 	public function testToStoredValues()
 	{
 		Field::$types['test'] = [
@@ -556,9 +495,6 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->toStoredValues());
 	}
 
-	/**
-	 * @covers ::values
-	 */
 	public function testValuesWithoutFields()
 	{
 		$form = new Form([

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -5,10 +5,10 @@ namespace Kirby\Http;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Http\Environment
- */
+#[CoversClass(Environment::class)]
 class EnvironmentTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/EnvironmentTest';
@@ -133,9 +133,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::baseUri
-	 */
 	public function testBaseUri()
 	{
 		// nothing given
@@ -143,9 +140,6 @@ class EnvironmentTest extends TestCase
 		$this->assertInstanceOf(Uri::class, $env->baseUri());
 	}
 
-	/**
-	 * @covers ::baseUrl
-	 */
 	public function testBaseUrl()
 	{
 		// nothing given
@@ -201,9 +195,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('https://getkirby.com:8888', $env->baseUrl());
 	}
 
-	/**
-	 * @covers ::cli
-	 */
 	public function testCli()
 	{
 		// enabled
@@ -223,9 +214,6 @@ class EnvironmentTest extends TestCase
 		$this->assertFalse($env->cli());
 	}
 
-	/**
-	 * @covers ::detect
-	 */
 	public function testDetect()
 	{
 		// empty server info
@@ -357,14 +345,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::detectForwarded
-	 * @covers ::detectForwardedHost
-	 * @covers ::detectForwardedHttps
-	 * @covers ::detectForwardedPort
-	 * @dataProvider detectForwardedProvider
-	 */
-	public function testDetectForwarded($info, $expected)
+	#[DataProvider('detectForwardedProvider')]
+	public function testDetectForwarded(array $info, string $expected)
 	{
 		$env = new Environment(['allowed' => '*'], $info);
 
@@ -396,9 +378,6 @@ class EnvironmentTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		$env = new Environment(null, $info = [
@@ -419,10 +398,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('lower case stuff', $env->get('argv'));
 	}
 
-	/**
-	 * @covers ::getGlobally
-	 * @backupGlobals enabled
-	 */
+	#[\PHPUnit\Framework\Attributes\BackupGlobals(true)]
 	public function testGetGlobally()
 	{
 		$_SERVER = [
@@ -463,9 +439,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('lower case stuff (app)', Environment::getGlobally('argv'));
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHost()
 	{
 		// via server name
@@ -483,9 +456,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('127.0.0.1', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostAllowedSingle()
 	{
 		$env = new Environment(['allowed' => 'https://getkirby.com']);
@@ -493,9 +463,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostAllowedMultiple()
 	{
 		$options = [
@@ -534,9 +501,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test.getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostForbidden()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -555,9 +519,6 @@ class EnvironmentTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostIgnoreInsecure()
 	{
 		// not possible via insecure header
@@ -581,9 +542,6 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostInsecure()
 	{
 		// insecure host header
@@ -629,12 +587,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::https
-	 * @covers ::detectHttps
-	 * @dataProvider httpsProvider
-	 */
-	public function testHttps($value, $expected)
+	#[DataProvider('httpsProvider')]
+	public function testHttps(string|int|bool|null $value, bool $expected)
 	{
 		// via server config
 		$env = new Environment(null, [
@@ -644,9 +598,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
 	public function testHttpsAllowedSingle()
 	{
 		$env = new Environment(['allowed' => 'http://getkirby.com']);
@@ -656,9 +607,6 @@ class EnvironmentTest extends TestCase
 		$this->assertTrue($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
 	public function testHttpsAllowedMultiple()
 	{
 		$options = [
@@ -737,9 +685,6 @@ class EnvironmentTest extends TestCase
 		$this->assertTrue($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
 	public function testHttpsForbidden()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -771,12 +716,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::https
-	 * @covers ::detectHttpsProtocol
-	 * @dataProvider httpsFromProtocolProvider
-	 */
-	public function testHttpsFromProtocol($value, $expected)
+	#[DataProvider('httpsFromProtocolProvider')]
+	public function testHttpsFromProtocol(string|null $value, bool $expected)
 	{
 		$env = new Environment(['allowed' => '*'], [
 			'HTTP_FORWARDED' => 'host=getkirby.com;proto="' . $value . '"',
@@ -792,9 +733,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
 	public function testHttpsIgnoreInsecure()
 	{
 		$env = new Environment(null, [
@@ -810,9 +748,6 @@ class EnvironmentTest extends TestCase
 		$this->assertFalse($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
 	public function testHttpsInsecure()
 	{
 		// insecure forwarded https header
@@ -846,9 +781,6 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfo()
 	{
 		// no info
@@ -884,10 +816,6 @@ class EnvironmentTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::address
-	 * @covers ::ip
-	 */
 	public function testIp()
 	{
 		// no ip
@@ -905,9 +833,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('127.0.0.1', $env->ip());
 	}
 
-	/**
-	 * @covers ::isBehindProxy
-	 */
 	public function testIsBehindProxy()
 	{
 		// no value given
@@ -1016,11 +941,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isLocal
-	 * @dataProvider isLocalWithIpProvider
-	 */
-	public function testIsLocalWithIp($address, $forwardedFor, $clientIp, bool $expected)
+	#[DataProvider('isLocalWithIpProvider')]
+	public function testIsLocalWithIp(string|null $address, string|null $forwardedFor, string|bool|null $clientIp, bool $expected)
 	{
 		$env = new Environment(null, [
 			'REMOTE_ADDR' => $address,
@@ -1051,11 +973,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isLocal
-	 * @dataProvider isLocalWithServerNameProvider
-	 */
-	public function testIsLocalWithServerName($name, $expected)
+	#[DataProvider('isLocalWithServerNameProvider')]
+	public function testIsLocalWithServerName(string $name, bool $expected)
 	{
 		$env = new Environment(null, [
 			'SERVER_NAME' => $name
@@ -1105,9 +1024,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test cli option', $env->options(static::FIXTURES)['test']);
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		// the path in cli requests is always empty
@@ -1131,10 +1047,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('subfolder', $env->path());
 	}
 
-	/**
-	 * @covers ::port
-	 * @covers ::detectPort
-	 */
 	public function testPort()
 	{
 		// no port given
@@ -1200,9 +1112,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(443, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
 	public function testPortAllowedSingle()
 	{
 		$env = new Environment(['allowed' => 'http://getkirby.com']);
@@ -1212,9 +1121,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(9999, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
 	public function testPortAllowedMultiple()
 	{
 		$options = [
@@ -1276,9 +1182,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(9999, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
 	public function testPortForbidden()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -1297,9 +1200,6 @@ class EnvironmentTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::port
-	 */
 	public function testPortIgnoreInsecure()
 	{
 		$env = new Environment(null, [
@@ -1315,9 +1215,6 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
 	public function testPortInsecure()
 	{
 		$env = new Environment(['allowed' => '*'], [
@@ -1421,11 +1318,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::requestUri
-	 * @dataProvider requestUriProvider
-	 */
-	public function testRequestUri($value, $expected)
+	#[DataProvider('requestUriProvider')]
+	public function testRequestUri(string|null $value, array $expected)
 	{
 		$env = new Environment(null, [
 			'REQUEST_URI' => $value,
@@ -1509,22 +1403,12 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::sanitize
-	 * @covers ::sanitizeHost
-	 * @covers ::sanitizePort
-	 * @dataProvider sanitizeProvider
-	 */
-	public function testSanitize($key, $value, $expected)
+	#[DataProvider('sanitizeProvider')]
+	public function testSanitize(string $key, string|int $value, string|int|null $expected)
 	{
 		$this->assertSame($expected, Environment::sanitize($key, $value));
 	}
 
-	/**
-	 * @covers ::sanitize
-	 * @covers ::sanitizeHost
-	 * @covers ::sanitizePort
-	 */
 	public function testSanitizeAll()
 	{
 		$input    = [];
@@ -1572,12 +1456,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::scriptPath
-	 * @covers ::sanitizeScriptPath
-	 * @dataProvider scriptPathProvider
-	 */
-	public function testScriptPath($value, $expected)
+	#[DataProvider('scriptPathProvider')]
+	public function testScriptPath(string|null $value, string $expected)
 	{
 		$env = new Environment(['cli' => false], [
 			'SCRIPT_NAME' => $value
@@ -1586,9 +1466,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->scriptPath());
 	}
 
-	/**
-	 * @covers ::scriptPath
-	 */
 	public function testScriptPathOnCli()
 	{
 		$env = new Environment(['cli' => true]);
@@ -1596,9 +1473,6 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('', $env->scriptPath());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$env = new Environment([

--- a/tests/Http/Exceptions/NextRouteExceptionTest.php
+++ b/tests/Http/Exceptions/NextRouteExceptionTest.php
@@ -4,12 +4,11 @@ namespace Kirby\Http\Exceptions;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class NextRouteExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
 	public function testException()
 	{
 		$exception = new NextRouteException(message: 'test');

--- a/tests/Http/PathTest.php
+++ b/tests/Http/PathTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Http\Path
- */
+#[CoversClass(Path::class)]
 class PathTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithArray()
 	{
 		$path = new Path(['docs', 'reference']);
@@ -21,9 +17,6 @@ class PathTest extends TestCase
 		$this->assertSame('reference', $path->last());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithString()
 	{
 		$path = new Path('/docs/reference');
@@ -33,10 +26,6 @@ class PathTest extends TestCase
 		$this->assertSame('reference', $path->last());
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
 	public function testToString()
 	{
 		$path = new Path('/docs/reference');
@@ -45,20 +34,12 @@ class PathTest extends TestCase
 		$this->assertSame('docs/reference', (string)$path);
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
 	public function testToStringWithLeadingSlash()
 	{
 		$path = new Path('/docs/reference');
 		$this->assertSame('/docs/reference', $path->toString(true));
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
 	public function testToStringWithLeadingAndTrailingSlash()
 	{
 		$path = new Path('/docs/reference');

--- a/tests/Http/Request/Auth/BasicAuthTest.php
+++ b/tests/Http/Request/Auth/BasicAuthTest.php
@@ -2,12 +2,12 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\BasicAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(BasicAuth::class)]
 class BasicAuthTest extends TestCase
 {
 	public function testInstance()

--- a/tests/Http/Request/Auth/BearerAuthTest.php
+++ b/tests/Http/Request/Auth/BearerAuthTest.php
@@ -2,12 +2,12 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\BearerAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(BearerAuth::class)]
 class BearerAuthTest extends TestCase
 {
 	public function testInstance()

--- a/tests/Http/Request/Auth/SessionAuthTest.php
+++ b/tests/Http/Request/Auth/SessionAuthTest.php
@@ -4,12 +4,12 @@ namespace Kirby\Http\Request\Auth;
 
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\SessionAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(SessionAuth::class)]
 class SessionAuthTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Http.Request.Auth.SessionAuth';

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -9,6 +9,7 @@ use Kirby\Http\Request\Body;
 use Kirby\Http\Request\Files;
 use Kirby\Http\Request\Query;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RequestTest extends TestCase
 {
@@ -178,10 +179,8 @@ class RequestTest extends TestCase
 		$this->assertTrue($app->response()->usesAuth());
 	}
 
-	/**
-	 * @dataProvider hasAuthProvider
-	 */
-	public function testHasAuth($option, $header, $expected)
+	#[DataProvider('hasAuthProvider')]
+	public function testHasAuth(string|null $option, string|null $header, bool $expected)
 	{
 		new App([
 			'server' => [

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Http;
 use Exception;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Http\Response
- */
+#[CoversClass(Response::class)]
 class ResponseTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -93,9 +92,6 @@ class ResponseTest extends TestCase
 		Response::download('does/not/exist.txt');
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
 	public function testGuardAgainstOutput()
 	{
 		$result = Response::guardAgainstOutput(
@@ -107,9 +103,6 @@ class ResponseTest extends TestCase
 		$this->assertSame('12-34', $result);
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
 	public function testGuardAgainstOutputWithSubsequentOutput()
 	{
 		HeadersSent::$value = true;
@@ -123,9 +116,6 @@ class ResponseTest extends TestCase
 		$this->assertSame('12-34', $result);
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
 	public function testGuardAgainstOutputWithFirstOutput()
 	{
 		$this->expectException(LogicException::class);
@@ -322,10 +312,8 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 	public function testSend()
 	{
 		$response = new Response([
@@ -348,10 +336,8 @@ class ResponseTest extends TestCase
 		$this->assertSame($code, 200);
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 	public function testToString()
 	{
 		$response = new Response([

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouteTest extends TestCase
 {
@@ -114,10 +115,8 @@ class RouteTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider patternProvider
-	 */
-	public function testParse($pattern, $input, $match)
+	#[DataProvider('patternProvider')]
+	public function testParse(string $pattern, string $input, bool $match)
 	{
 		$route = $this->_route();
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Http;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class UriTest extends TestCase
@@ -410,9 +411,7 @@ class UriTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider buildProvider
-	 */
+	#[DataProvider('buildProvider')]
 	public function testToString(string $url, array $props, string $expected)
 	{
 		$url = new Uri($url, $props);

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Http;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UrlTest extends TestCase
 {
@@ -206,10 +207,8 @@ class UrlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider scriptNameProvider
-	 */
-	public function testIndex($host, $scriptName, $expected)
+	#[DataProvider('scriptNameProvider')]
+	public function testIndex(string|null $host, string $scriptName, string $expected)
 	{
 		new App([
 			'cli' => false,

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Image\Darkroom;
 use claviska\SimpleImage;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
 class SimpleImageMock extends SimpleImage
@@ -19,9 +20,7 @@ class SimpleImageMock extends SimpleImage
 }
 
 
-/**
- * @coversDefaultClass \Kirby\Image\Darkroom\GdLib
- */
+#[CoversClass(GdLib::class)]
 class GdLibTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures/image';
@@ -59,9 +58,6 @@ class GdLibTest extends TestCase
 		], $gd->process($file));
 	}
 
-	/**
-	 * @covers ::mime
-	 */
 	public function testProcessWithFormat()
 	{
 		$gd = new GdLib(['format' => 'webp']);
@@ -69,9 +65,6 @@ class GdLibTest extends TestCase
 		$this->assertSame('webp', $gd->process($file)['format']);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
 	public function testSharpen()
 	{
 		$gd = new GdLib();
@@ -88,9 +81,6 @@ class GdLibTest extends TestCase
 		$this->assertSame(50, $result->sharpen);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
 	public function testSharpenWithoutValue()
 	{
 		$gd = new GdLib();

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -5,11 +5,11 @@ namespace Kirby\Image\Darkroom;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Image\Darkroom\ImageMagick
- */
+#[CoversClass(ImageMagick::class)]
 class ImageMagickTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures/image';
@@ -50,9 +50,6 @@ class ImageMagickTest extends TestCase
 		], $im->process($file));
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
 	public function testSharpen()
 	{
 		$im = new ImageMagick();
@@ -67,9 +64,6 @@ class ImageMagickTest extends TestCase
 		$this->assertSame("-sharpen '0x0.5'", $result);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
 	public function testSharpenWithoutValue()
 	{
 		$im = new ImageMagick();
@@ -84,9 +78,6 @@ class ImageMagickTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSaveWithFormat()
 	{
 		$im = new ImageMagick(['format' => 'webp']);
@@ -97,9 +88,7 @@ class ImageMagickTest extends TestCase
 		$this->assertTrue(F::exists($webp));
 	}
 
-	/**
-	 * @dataProvider keepColorProfileStripMetaProvider
-	 */
+	#[DataProvider('keepColorProfileStripMetaProvider')]
 	public function testKeepColorProfileStripMeta(string $basename, bool $crop)
 	{
 		$im = new ImageMagick([

--- a/tests/Image/DimensionsTest.php
+++ b/tests/Image/DimensionsTest.php
@@ -3,19 +3,14 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Image\Dimensions
- */
+#[CoversClass(Dimensions::class)]
 class DimensionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::width
-	 * @covers ::height
-	 */
 	public function testDimensions()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -23,9 +18,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(768, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
 	public function testCrop()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -39,9 +31,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(500, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fit
-	 */
 	public function testFit()
 	{
 		// zero dimensions
@@ -75,9 +64,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(200, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fit
-	 */
 	public function testFitForce()
 	{
 		// wider than tall
@@ -93,9 +79,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(2000, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitWidth
-	 */
 	public function testFitWidth()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -121,9 +104,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(1280, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitHeight
-	 */
 	public function testFitHeight()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -149,9 +129,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(2000, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitWidthAndHeight
-	 */
 	public function testFitWidthAndHeight()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -165,9 +142,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(781, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::forImage
-	 */
 	public function testForImage()
 	{
 		$image = new Image([
@@ -220,10 +194,7 @@ class DimensionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider imageOrientationProvider
-	 * @covers ::forImage
-	 */
+	#[DataProvider('imageOrientationProvider')]
 	public function testForImageOrientation(
 		string $filename,
 		int $width,
@@ -238,9 +209,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame($height, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::forSvg
-	 */
 	public function testForSvg()
 	{
 		$dimensions = Dimensions::forSvg(static::FIXTURES . '/dimensions/circle.svg');
@@ -256,9 +224,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(25, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::orientation
-	 */
 	public function testOrientation()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -275,9 +240,6 @@ class DimensionsTest extends TestCase
 		$this->assertFalse($dimensions->orientation());
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
 	public function testRatio()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -290,9 +252,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(0.0, $dimensions->ratio());
 	}
 
-	/**
-	 * @covers ::resize
-	 */
 	public function testResize()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -301,10 +260,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame(800, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testToArray()
 	{
 		$dimensions = new Dimensions(1200, 768);
@@ -318,9 +273,6 @@ class DimensionsTest extends TestCase
 		$this->assertSame($array, $dimensions->__debugInfo());
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$dimensions = new Dimensions(1200, 768);

--- a/tests/Image/FocusTest.php
+++ b/tests/Image/FocusTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\Focus
- */
+#[CoversClass(Focus::class)]
 class FocusTest extends TestCase
 {
-	/**
-	 * @covers ::coords
-	 */
 	public function testCoords()
 	{
 		$options = [
@@ -99,9 +95,6 @@ class FocusTest extends TestCase
 		$this->assertSame(906, $focus['y2']);
 	}
 
-	/**
-	 * @covers ::coords
-	 */
 	public function testCoordsSameRatio()
 	{
 		$options = [
@@ -115,9 +108,6 @@ class FocusTest extends TestCase
 		$this->assertNull(Focus::coords(...$options));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParse()
 	{
 		$this->assertSame([0.7, 0.3], Focus::parse('70%, 30%'));
@@ -129,9 +119,6 @@ class FocusTest extends TestCase
 		$this->assertSame([0.7, 0.3], Focus::parse('{"x":0.7,"y":0.3}'));
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
 	public function testRatio()
 	{
 		$this->assertSame(0.5, Focus::ratio(200, 400));

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\Page;
 use Kirby\Exception\Exception;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\Image
- */
+#[CoversClass(Image::class)]
 class ImageTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -23,9 +22,6 @@ class ImageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
 	public function testDimensions()
 	{
 		// jpg
@@ -56,9 +52,6 @@ class ImageTest extends TestCase
 		$this->assertInstanceOf(Dimensions::class, $file->dimensions());
 	}
 
-	/**
-	 * @covers ::exif
-	 */
 	public function testExif()
 	{
 		$file = $this->_image();
@@ -67,18 +60,12 @@ class ImageTest extends TestCase
 		$this->assertInstanceOf(Exif::class, $file->exif());
 	}
 
-	/**
-	 * @covers ::height
-	 */
 	public function testHeight()
 	{
 		$file = $this->_image();
 		$this->assertSame(500, $file->height());
 	}
 
-	/**
-	 * @covers ::html
-	 */
 	public function testHtml()
 	{
 		$file = $this->_image();
@@ -99,9 +86,6 @@ class ImageTest extends TestCase
 		$this->assertSame('<img alt="Test text" src="https://foo.bar/cat.jpg">', $image->html());
 	}
 
-	/**
-	 * @covers ::html
-	 */
 	public function testHtmlWithoutUrl()
 	{
 		$this->expectException(LogicException::class);
@@ -110,9 +94,6 @@ class ImageTest extends TestCase
 		$file->html();
 	}
 
-	/**
-	 * @covers ::imagesize
-	 */
 	public function testImagesize()
 	{
 		$file = $this->_image();
@@ -120,36 +101,24 @@ class ImageTest extends TestCase
 		$this->assertSame(500, $file->imagesize()[0]);
 	}
 
-	/**
-	 * @covers ::isPortrait
-	 */
 	public function testIsPortrait()
 	{
 		$file = $this->_image();
 		$this->assertFalse($file->isPortrait());
 	}
 
-	/**
-	 * @covers ::isLandscape
-	 */
 	public function testIsLandscape()
 	{
 		$file = $this->_image();
 		$this->assertFalse($file->isLandscape());
 	}
 
-	/**
-	 * @covers ::isSquare
-	 */
 	public function testIsSquare()
 	{
 		$file = $this->_image();
 		$this->assertTrue($file->isSquare());
 	}
 
-	/**
-	 * @covers ::isResizable
-	 */
 	public function testIsResizable()
 	{
 		$file = $this->_image();
@@ -159,9 +128,6 @@ class ImageTest extends TestCase
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::isViewable
-	 */
 	public function testIsViewable()
 	{
 		$file = $this->_image();
@@ -171,9 +137,6 @@ class ImageTest extends TestCase
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatch()
 	{
 		$rules = [
@@ -192,9 +155,6 @@ class ImageTest extends TestCase
 		$this->assertTrue($this->_image()->match($rules));
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatchOrientationException()
 	{
 		// Make sure i18n files are loaded
@@ -206,27 +166,18 @@ class ImageTest extends TestCase
 		$this->_image()->match(['orientation' => 'portrait']);
 	}
 
-	/**
-	 * @covers ::orientation
-	 */
 	public function testOrientation()
 	{
 		$file = $this->_image();
 		$this->assertSame('square', $file->orientation());
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
 	public function testRatio()
 	{
 		$image  = $this->_image();
 		$this->assertSame(1.0, $image->ratio());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$file = $this->_image();
@@ -235,9 +186,6 @@ class ImageTest extends TestCase
 		$this->assertIsArray($file->toArray()['dimensions']);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$file = $this->_image();
@@ -246,9 +194,6 @@ class ImageTest extends TestCase
 		$this->assertSame($expected, (string)$file);
 	}
 
-	/**
-	 * @covers ::width
-	 */
 	public function testWidth()
 	{
 		$file = $this->_image();

--- a/tests/Image/QrCodeTest.php
+++ b/tests/Image/QrCodeTest.php
@@ -6,10 +6,9 @@ use GdImage;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\QrCode
- */
+#[CoversClass(QrCode::class)]
 class QrCodeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/qr';
@@ -116,18 +115,12 @@ class QrCodeTest extends TestCase
 		$this->assertStringContainsString('<rect width="100%" height="100%" fill="#00ff00"/>', $svg);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$qr = new QrCode('https://getkirby.com');
 		$this->assertSame($qr->toSvg(), (string)$qr);
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWrite()
 	{
 		Dir::make(static::TMP);
@@ -171,9 +164,6 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expectedJpeg, $actualJpeg);
 	}
 
-	/**
-	 * @covers ::write
-	 */
 	public function testWriteInvalidFormat()
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Option/OptionTest.php
+++ b/tests/Option/OptionTest.php
@@ -3,16 +3,11 @@
 namespace Kirby\Option;
 
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\Option
- */
+#[CoversClass(Option::class)]
 class OptionTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::id
-	 */
 	public function testConstruct()
 	{
 		// string
@@ -34,9 +29,6 @@ class OptionTest extends TestCase
 		$this->assertSame(1.1, $option->text->translations['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithJustValue()
 	{
 		// string
@@ -52,9 +44,6 @@ class OptionTest extends TestCase
 		$this->assertSame(1.0, $option->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithValueAndText()
 	{
 		// string
@@ -78,9 +67,6 @@ class OptionTest extends TestCase
 		$this->assertSame('Test Option', $option->text->translations['de']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$option = Option::factory([

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -5,17 +5,13 @@ namespace Kirby\Option;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\OptionsApi
- */
+#[CoversClass(OptionsApi::class)]
 class OptionsApiTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$options = new OptionsApi($url = 'https://api.example.com');
@@ -25,9 +21,6 @@ class OptionsApiTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$options = new OptionsApi($url = 'https://api.example.com');
@@ -42,9 +35,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('{{ item.key }}', $options->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$options = OptionsApi::factory([
@@ -66,9 +56,6 @@ class OptionsApiTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadNoJson()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -78,9 +65,6 @@ class OptionsApiTest extends TestCase
 		$options->resolve($model);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
 	public function testPolyfill()
 	{
 		$api = 'https://api.example.com';
@@ -93,11 +77,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame(['query' => 'Companies'], OptionsApi::polyfill($api));
 	}
 
-	/**
-	 * @covers ::load
-	 * @covers ::render
-	 * @covers ::resolve
-	 */
 	public function testResolve()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -110,9 +89,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveSimple()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -125,9 +101,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveCustomKeys()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -144,9 +117,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveQuery()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -162,9 +132,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveCustomKeysAndQuery()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -182,9 +149,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveHtmlEscape()
 	{
 		$model = new Page(['slug' => 'test']);
@@ -262,9 +226,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveApplyFieldMethods()
 	{
 		$model   = new Page(['slug' => 'test']);
@@ -281,9 +242,6 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('company-b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveSimpleArrays()
 	{
 		$model   = new Page(['slug' => 'test']);

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class MyPage extends Page
 {
@@ -33,14 +35,9 @@ class MyPage extends Page
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Option\OptionsQuery
- */
+#[CoversClass(OptionsQuery::class)]
 class OptionsQueryTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$options = new OptionsQuery($query = 'site.children', '{{ page.slug }}');
@@ -49,9 +46,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testDefaults()
 	{
 		$options = new OptionsQuery($query = 'site.children');
@@ -60,9 +55,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$options = OptionsQuery::factory([
@@ -78,9 +70,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame($query, $options->query);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
 	public function testPolyfill()
 	{
 		$query = 'site.children';
@@ -93,10 +82,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame(['query' => 'site.children'], OptionsQuery::polyfill($query));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForArray()
 	{
 		$model   = new MyPage(['slug' => 'a']);
@@ -135,10 +120,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('tag3', $options[2]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForStructure()
 	{
 		$model = new Page([
@@ -171,10 +152,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForBlock()
 	{
 		$model = new Page([
@@ -199,10 +176,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForPages()
 	{
 		$app = new App([
@@ -228,10 +201,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('c', $options[2]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForFile()
 	{
 		$app = new App([
@@ -253,10 +222,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('b.pdf', $options[1]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForUser()
 	{
 		$app = new App([
@@ -275,10 +240,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('homer', $options[0]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
 	public function testResolveForOptions()
 	{
 		$model   = new MyPage(['slug' => 'a']);
@@ -291,9 +252,6 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveInvalid()
 	{
 		$app = new App([
@@ -310,9 +268,6 @@ class OptionsQueryTest extends TestCase
 		$options = (new OptionsQuery('site.foo'))->render($app->site());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveHtmlEscape()
 	{
 		$model   = new MyPage(['slug' => 'a']);

--- a/tests/Option/OptionsTest.php
+++ b/tests/Option/OptionsTest.php
@@ -4,15 +4,11 @@ namespace Kirby\Option;
 
 use Kirby\Cms\Page;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\Options
- */
+#[CoversClass(Options::class)]
 class OptionsTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$options = new Options([
@@ -27,9 +23,6 @@ class OptionsTest extends TestCase
 		$this->assertSame('b', $options->last()->text->translations['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$options = Options::factory(['a', 'b']);
@@ -41,9 +34,6 @@ class OptionsTest extends TestCase
 		$this->assertSame('b', $options->last()->text->translations['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithAssocArray()
 	{
 		$options = Options::factory([
@@ -58,9 +48,6 @@ class OptionsTest extends TestCase
 		$this->assertSame('Option B', $options->last()->text->translations['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithOptionArray()
 	{
 		$options = Options::factory([
@@ -75,9 +62,6 @@ class OptionsTest extends TestCase
 		$this->assertSame('Option B', $options->last()->text->translations['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithTranslatedOptions()
 	{
 		$options = Options::factory([
@@ -94,9 +78,6 @@ class OptionsTest extends TestCase
 		$this->assertSame('Variante B', $options->last()->text->translations['de']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$model = new Page(['slug' => 'test']);

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -8,10 +8,9 @@ use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Assets
- */
+#[CoversClass(Assets::class)]
 class AssetsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Assets';
@@ -74,9 +73,6 @@ class AssetsTest extends TestCase
 		F::write($app->roots()->panel() . '/.vite-running', '');
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCss(): void
 	{
 		// default asset setup
@@ -89,9 +85,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/media/plugins/index.css?0', $css['plugins']);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssInDevMode(): void
 	{
 		$this->setDevMode();
@@ -103,10 +96,6 @@ class AssetsTest extends TestCase
 		$this->assertSame(['plugins' => '/media/plugins/index.css?0'], $css);
 	}
 
-	/**
-	 * @covers ::css
-	 * @covers ::custom
-	 */
 	public function testCssWithCustomFile(): void
 	{
 		F::write(static::TMP . '/panel.css', '');
@@ -141,9 +130,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($url, $assets['custom-2']);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithCustomFileMissing(): void
 	{
 		$this->app->clone([
@@ -158,9 +144,6 @@ class AssetsTest extends TestCase
 		$this->assertEmpty($assets->custom('panel.css'));
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -174,10 +157,6 @@ class AssetsTest extends TestCase
 		$this->assertSame(['plugins' => '/media/plugins/index.css?0'], $css);
 	}
 
-	/**
-	 * @covers ::external
-	 * @covers ::custom
-	 */
 	public function testExternalWithCustomCssJs(): void
 	{
 		// custom panel css and js
@@ -201,9 +180,6 @@ class AssetsTest extends TestCase
 		$this->assertTrue(Str::contains($external['js']['custom-0']['src'], 'assets/panel.js'));
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFavicons(): void
 	{
 		// default asset setup
@@ -219,9 +195,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon-dark.png', $favicons[4]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsInDevMode(): void
 	{
 		$this->setDevMode();
@@ -237,9 +210,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon-dark.png', $favicons[4]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomArraySetup(): void
 	{
 		// array
@@ -271,9 +241,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/assets/my-favicon.png', $favicons[1]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomStringSetup(): void
 	{
 		// array
@@ -295,9 +262,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/assets/favicon.ico', $favicons[0]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomInvalidSetup(): void
 	{
 		// array
@@ -317,9 +281,6 @@ class AssetsTest extends TestCase
 		$assets->favicons();
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -335,9 +296,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon.svg', $favicons[2]['href']);
 	}
 
-	/**
-	 * @covers ::icons
-	 */
 	public function testIcons(): void
 	{
 		$assets = new Assets();
@@ -347,9 +305,6 @@ class AssetsTest extends TestCase
 		$this->assertTrue(str_contains($icons, '<svg'));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJs(): void
 	{
 		// default asset setup
@@ -373,9 +328,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('module', $js['index']['type']);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsInDevMode(): void
 	{
 		$this->setDevMode();
@@ -393,9 +345,6 @@ class AssetsTest extends TestCase
 		], array_map(fn ($js) => $js['src'], $js));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomFile(): void
 	{
 		F::write(static::TMP . '/panel.js', '');
@@ -431,9 +380,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($url, $assets['custom-2']);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomFileMissing(): void
 	{
 		$this->app->clone([
@@ -448,9 +394,6 @@ class AssetsTest extends TestCase
 		$this->assertEmpty($assets->custom('panel.js'));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -470,9 +413,6 @@ class AssetsTest extends TestCase
 		], array_map(fn ($js) => $js['src'], $js));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$assets = new Assets();

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -7,11 +7,9 @@ use Kirby\Content\Changes;
 use Kirby\Content\VersionId;
 use Kirby\Panel\Areas\AreaTestCase;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\ChangesDialog
- * @covers ::__construct
- */
+#[CoversClass(ChangesDialog::class)]
 class ChangesDialogTest extends AreaTestCase
 {
 	protected Changes $changes;
@@ -61,9 +59,6 @@ class ChangesDialogTest extends AreaTestCase
 		Uuids::populate();
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles(): void
 	{
 		$this->setUpModels();
@@ -79,18 +74,12 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test/files/test.jpg', $files[0]['link']);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();
 		$this->assertSame([], $dialog->files());
 	}
 
-	/**
-	 * @covers ::items
-	 */
 	public function testItems(): void
 	{
 		$this->setUpModels();
@@ -108,9 +97,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test', $items[0]['link']);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad(): void
 	{
 		$dialog = new ChangesDialog();
@@ -127,9 +113,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame($expected, $dialog->load());
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPages(): void
 	{
 		$this->setUpModels();
@@ -145,18 +128,12 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test', $pages[0]['link']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();
 		$this->assertSame([], $dialog->pages());
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsers(): void
 	{
 		$this->setUpModels();
@@ -172,9 +149,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/users/test', $users[0]['link']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsersWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();

--- a/tests/Panel/Controller/PageTreeTest.php
+++ b/tests/Panel/Controller/PageTreeTest.php
@@ -4,11 +4,9 @@ namespace Kirby\Panel\Controller;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Controller\PageTree
- * @covers ::__construct
- */
+#[CoversClass(PageTree::class)]
 class PageTreeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.PageTree';
@@ -78,9 +76,6 @@ class PageTreeTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenForSite(): void
 	{
 		$children = $this->tree->children(null);
@@ -89,9 +84,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('site://', $children[0]['value']);
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenForPage(): void
 	{
 		$children = $this->tree->children('/pages/articles');
@@ -105,9 +97,6 @@ class PageTreeTest extends TestCase
 		$this->assertFalse($children[2]['disabled']);
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenWithMoving(): void
 	{
 		$children = $this->tree->children(
@@ -124,9 +113,6 @@ class PageTreeTest extends TestCase
 		$this->assertTrue($children[2]['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithSite(): void
 	{
 		$entry = $this->tree->entry($this->app->site());
@@ -143,9 +129,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('site://', $entry['value']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithPage(): void
 	{
 		$entry = $this->tree->entry($this->app->page('articles'));
@@ -162,9 +145,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('page://articles', $entry['value']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithMoving(): void
 	{
 		$entry = $this->tree->entry(
@@ -182,9 +162,6 @@ class PageTreeTest extends TestCase
 		$this->assertTrue($entry['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWhenUuidsDisabled(): void
 	{
 		$this->app = $this->app->clone([
@@ -202,9 +179,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('articles', $entry['value']);
 	}
 
-	/**
-	 * @covers ::parents
-	 */
 	public function testParents(): void
 	{
 		$parents = $this->tree->parents(
@@ -228,9 +202,6 @@ class PageTreeTest extends TestCase
 		], $parents['data']);
 	}
 
-	/**
-	 * @covers ::parents
-	 */
 	public function testParentsWhenUuidsDisabled(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Panel/Controller/SearchTest.php
+++ b/tests/Panel/Controller/SearchTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel\Controller;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Controller\Search
- */
+#[CoversClass(Search::class)]
 class SearchTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.Search';
@@ -61,9 +60,6 @@ class SearchTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles(): void
 	{
 		$result = Search::files('fish');
@@ -87,9 +83,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesNotListable(): void
 	{
 		$this->app = new App([
@@ -147,9 +140,6 @@ class SearchTest extends TestCase
 		], array_column($result['results'], 'text'));
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesPaginated(): void
 	{
 		$result = Search::files('fish', limit: 1);
@@ -169,9 +159,6 @@ class SearchTest extends TestCase
 		$this->assertSame(5, $result['pagination']['total']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPages(): void
 	{
 		$result = Search::pages('beautiful');
@@ -193,9 +180,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesNotListable(): void
 	{
 		$this->app = new App([
@@ -256,9 +240,6 @@ class SearchTest extends TestCase
 		], array_column($result['results'], 'text'));
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesPaginated(): void
 	{
 		$result = Search::pages('beautiful', limit: 1);
@@ -278,9 +259,6 @@ class SearchTest extends TestCase
 		$this->assertSame(3, $result['pagination']['total']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsers(): void
 	{
 		$result = Search::users('simpson');
@@ -301,9 +279,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsersPaginated(): void
 	{
 		$result = Search::users('simpson', limit: 1);

--- a/tests/Panel/DialogTest.php
+++ b/tests/Panel/DialogTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\App;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Dialog
- */
+#[CoversClass(Dialog::class)]
 class DialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Dialog';
@@ -40,9 +39,6 @@ class DialogTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// default
@@ -58,9 +54,6 @@ class DialogTest extends TestCase
 		$this->assertSame('Test', $error['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		$response = Dialog::response([
@@ -82,9 +75,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromTrue(): void
 	{
 		$response = Dialog::response(true);
@@ -100,9 +90,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromInvalidData(): void
 	{
 		$response = Dialog::response(1234);
@@ -119,9 +106,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromException(): void
 	{
 		$exception = new Exception('Test');
@@ -139,9 +123,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromKirbyException(): void
 	{
 		$exception = new NotFoundException(message: 'Test');
@@ -159,9 +140,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes(): void
 	{
 		$area = [
@@ -197,9 +175,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesWithoutHandlers(): void
 	{
 		$area = [

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Document
- */
+#[CoversClass(Document::class)]
 class DocumentTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Document';
@@ -40,9 +39,6 @@ class DocumentTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		// create panel dist files first to avoid redirect
@@ -61,9 +57,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsSelf(): void
 	{
 		$this->app = $this->app->clone([
@@ -92,9 +85,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsArray(): void
 	{
 		$this->app = $this->app->clone([
@@ -125,9 +115,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsString(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\App;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Dropdown
- */
+#[CoversClass(Dropdown::class)]
 class DropdownTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Dropdown';
@@ -40,9 +39,6 @@ class DropdownTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// default
@@ -58,9 +54,6 @@ class DropdownTest extends TestCase
 		$this->assertSame('Test', $error['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		$response = Dropdown::response([
@@ -82,9 +75,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromInvalidData(): void
 	{
 		$response = Dropdown::response(1234);
@@ -101,9 +91,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromException(): void
 	{
 		$exception = new Exception('Test');
@@ -121,9 +108,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromKirbyException(): void
 	{
 		$exception = new NotFoundException(message: 'Test');
@@ -141,9 +125,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes(): void
 	{
 		$dropdown = [
@@ -176,9 +157,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
 		$area = [
@@ -210,9 +188,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
 		$area = [

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Panel;
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Field';
@@ -32,9 +31,6 @@ class FieldTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmail(): void
 	{
 		// default
@@ -55,9 +51,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::filePosition
-	 */
 	public function testFilePosition(): void
 	{
 		$this->app = $this->app->clone([
@@ -108,18 +101,12 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::hidden
-	 */
 	public function testHidden(): void
 	{
 		$field = Field::hidden();
 		$this->assertSame(['hidden' => true], $field);
 	}
 
-	/**
-	 * @covers ::pagePosition
-	 */
 	public function testPagePosition(): void
 	{
 		$this->app = $this->app->clone([
@@ -170,9 +157,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::pagePosition
-	 */
 	public function testPagePositionWithNotEnoughOptions(): void
 	{
 		$this->app = $this->app->clone([
@@ -190,9 +174,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['hidden']);
 	}
 
-	/**
-	 * @covers ::password
-	 */
 	public function testPassword(): void
 	{
 		// default
@@ -212,9 +193,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::role
-	 */
 	public function testRole(): void
 	{
 		$field = Field::role();
@@ -295,9 +273,6 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field);
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlug(): void
 	{
 		// default
@@ -318,9 +293,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitle(): void
 	{
 		// default
@@ -341,9 +313,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::template
-	 */
 	public function testTemplate(): void
 	{
 		// default = no templates available
@@ -407,9 +376,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::translation
-	 */
 	public function testTranslation(): void
 	{
 		// default
@@ -429,9 +395,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::username
-	 */
 	public function testUsername(): void
 	{
 		// default

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -10,6 +10,7 @@ use Kirby\Cms\User as ModelUser;
 use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class FileForceLocked extends ModelFile
 {
@@ -22,9 +23,8 @@ class FileForceLocked extends ModelFile
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\File
- */
+#[CoversClass(File::class)]
+#[CoversClass(Model::class)]
 class FileTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.File';
@@ -56,9 +56,6 @@ class FileTest extends TestCase
 		return new File($page->file('test.jpg'));
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForSiteFile(): void
 	{
 		$site = new ModelSite([
@@ -76,9 +73,6 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForPageFile(): void
 	{
 		$page = new ModelPage([
@@ -104,9 +98,6 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForUserFile(): void
 	{
 		$user = new ModelUser([
@@ -130,9 +121,6 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons()
 	{
 		$this->assertSame([
@@ -142,9 +130,6 @@ class FileTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragText()
 	{
 		$page = new ModelPage([
@@ -166,9 +151,6 @@ class FileTest extends TestCase
 		$this->assertSame('(image: test.jpg)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextMarkdown()
 	{
 		$app = $this->app->clone([
@@ -201,9 +183,6 @@ class FileTest extends TestCase
 		$this->assertSame('[test.pdf](test.pdf)', $file->panel()->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextAbsolute()
 	{
 		$page = new ModelPage([
@@ -216,9 +195,6 @@ class FileTest extends TestCase
 		$this->assertSame('(image: file://my-file)', $panel->dragText(null, true));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextAbsoluteMarkdown()
 	{
 		$app = $this->app->clone([
@@ -246,9 +222,6 @@ class FileTest extends TestCase
 		$this->assertSame('![](//@/file/my-file)', $file->panel()->dragText(null, true));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextCustomMarkdown()
 	{
 		$app = $this->app->clone([
@@ -288,9 +261,6 @@ class FileTest extends TestCase
 		$this->assertSame('![](test.heic)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextCustomKirbytext()
 	{
 		$app = $this->app->clone([
@@ -329,9 +299,6 @@ class FileTest extends TestCase
 		$this->assertSame('(image: test.heic)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption()
 	{
 		$page = new ModelPage([
@@ -349,12 +316,6 @@ class FileTest extends TestCase
 		$this->assertSame('/pages/test/files/test.jpg', $option['link']);
 	}
 
-	/**
-	 * @covers ::imageDefaults
-	 * @covers ::imageColor
-	 * @covers ::imageIcon
-	 * @covers ::imageSource
-	 */
 	public function testImage()
 	{
 		$page = new ModelPage([
@@ -373,10 +334,6 @@ class FileTest extends TestCase
 		$this->assertArrayHasKey('url', $image);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers ::imageSrcset
-	 */
 	public function testImageCover()
 	{
 		$app = $this->app->clone([
@@ -415,9 +372,6 @@ class FileTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
 	public function testImageStringQuery()
 	{
 		$page = new ModelPage([
@@ -433,9 +387,6 @@ class FileTest extends TestCase
 		$this->assertNotEmpty($image);
 	}
 
-	/**
-	 * @covers ::isFocusable
-	 */
 	public function testIsFocusable()
 	{
 		$this->app->clone([
@@ -512,9 +463,6 @@ class FileTest extends TestCase
 		$this->assertFalse((new File($file))->isFocusable());
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptions()
 	{
 		$page = new ModelPage([
@@ -545,9 +493,6 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptionsWithLockedFile()
 	{
 		$page = new ModelPage([
@@ -595,9 +540,6 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options(['delete']));
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptionsDefaultReplaceOption()
 	{
 		$page = new ModelPage([
@@ -627,9 +569,6 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptionsAllowedReplaceOption()
 	{
 		$this->app->clone([
@@ -670,9 +609,6 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptionsDisabledReplaceOption()
 	{
 		$this->app->clone([
@@ -715,9 +651,6 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		$page = new ModelPage([
@@ -731,10 +664,6 @@ class FileTest extends TestCase
 		$this->assertSame('files/test.jpg', $panel->path());
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
 	public function testPickerDataDefault()
 	{
 		$page = new ModelPage([
@@ -754,9 +683,6 @@ class FileTest extends TestCase
 		$this->assertSame('test.jpg', $data['text']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
 	public function testPickerDataWithParams()
 	{
 		$page = new ModelPage([
@@ -784,9 +710,6 @@ class FileTest extends TestCase
 		$this->assertSame('From foo to the bar', $data['text']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
 	public function testPickerDataSameModel()
 	{
 		$page = new ModelPage([
@@ -803,9 +726,6 @@ class FileTest extends TestCase
 		$this->assertSame('test.jpg', $data['id']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
 	public function testPickerDataDifferentModel()
 	{
 		$page = new ModelPage([
@@ -825,9 +745,6 @@ class FileTest extends TestCase
 		$this->assertSame('(image: file://test-file)', $data['dragText']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page = new ModelPage([
@@ -862,10 +779,6 @@ class FileTest extends TestCase
 		$this->assertArrayHasKey('tabs', $props);
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
 	public function testPropsPrevNext()
 	{
 		$page = new ModelPage([
@@ -890,10 +803,6 @@ class FileTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
 	public function testPropsPrevNextWithSort()
 	{
 		$page = new ModelPage([
@@ -918,10 +827,6 @@ class FileTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
 	public function testPropsPrevNextWithTab()
 	{
 		$page = new ModelPage([
@@ -942,9 +847,6 @@ class FileTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$app = $this->app->clone([
@@ -1003,9 +905,6 @@ class FileTest extends TestCase
 		$this->assertSame('/users/test/files/user-file.jpg', $panel->url(true));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNext()
 	{
 		$page = new ModelPage([
@@ -1030,9 +929,6 @@ class FileTest extends TestCase
 		$this->assertNull($prevNext['next']());
 	}
 
-	/**
-	 * @covers ::view
-	 */
 	public function testView()
 	{
 		$page = new ModelPage([

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -9,10 +9,10 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Uri;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Home
- */
+#[CoversClass(Home::class)]
 class HomeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Home';
@@ -45,9 +45,6 @@ class HomeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
 	public function testAlternative()
 	{
 		$this->app = $this->app->clone([
@@ -61,9 +58,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/site', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
 	public function testAlternativeWithLimitedAccess()
 	{
 		$this->app = $this->app->clone([
@@ -92,9 +86,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
 	public function testAlternativeWithOnlyAccessToAccounts()
 	{
 		$this->app = $this->app->clone([
@@ -125,9 +116,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/account', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
 	public function testAlternativeWithoutPanelAccess()
 	{
 		$this->app = $this->app->clone([
@@ -151,9 +139,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
 	public function testAlternativeWithoutViewAccess()
 	{
 		$this->app = $this->app->clone([
@@ -184,9 +169,6 @@ class HomeTest extends TestCase
 		Home::alternative($user);
 	}
 
-	/**
-	 * @covers ::hasAccess
-	 */
 	public function testHasAccess()
 	{
 		$this->app = $this->app->clone([
@@ -218,9 +200,6 @@ class HomeTest extends TestCase
 		$this->assertTrue(Home::hasAccess($user, 'browser'));
 	}
 
-	/**
-	 * @covers ::hasAccess
-	 */
 	public function testHasAccessWithLimitedAccess()
 	{
 		$this->app = $this->app->clone([
@@ -252,9 +231,6 @@ class HomeTest extends TestCase
 		$this->assertTrue(Home::hasAccess($user, 'account'));
 	}
 
-	/**
-	 * @covers ::hasValidDomain
-	 */
 	public function testHasValidDomain()
 	{
 		$uri = Uri::current();
@@ -267,9 +243,6 @@ class HomeTest extends TestCase
 		$this->assertFalse(Home::hasValidDomain($uri));
 	}
 
-	/**
-	 * @covers ::isPanelUrl
-	 */
 	public function testIsPanelUrl()
 	{
 		$this->assertTrue(Home::isPanelUrl('/panel'));
@@ -277,9 +250,6 @@ class HomeTest extends TestCase
 		$this->assertFalse(Home::isPanelUrl('test'));
 	}
 
-	/**
-	 * @covers ::panelPath
-	 */
 	public function testPanelPath()
 	{
 		$this->assertSame('site', Home::panelPath('/panel/site'));
@@ -287,26 +257,17 @@ class HomeTest extends TestCase
 		$this->assertSame('', Home::panelPath('/test/page'));
 	}
 
-	/**
-	 * @covers ::remembered
-	 */
 	public function testRemembered()
 	{
 		$this->assertNull(Home::remembered());
 	}
 
-	/**
-	 * @covers ::remembered
-	 */
 	public function testRememberedFromSession()
 	{
 		$this->app->session()->set('panel.path', 'users');
 		$this->assertSame('/panel/users', Home::remembered());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$this->app = $this->app->clone([
@@ -339,10 +300,8 @@ class HomeTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customHomeProvider
-	 */
-	public function testUrlWithCustomHome($url, $expected, $index = '/')
+	#[DataProvider('customHomeProvider')]
+	public function testUrlWithCustomHome(string $url, string $expected, string $index = '/')
 	{
 		$this->app = $this->app->clone([
 			'urls' => [
@@ -369,9 +328,6 @@ class HomeTest extends TestCase
 		$this->assertSame($expected, Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithInvalidCustomHome()
 	{
 		$this->app = $this->app->clone([
@@ -402,9 +358,6 @@ class HomeTest extends TestCase
 		Home::url();
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithRememberedPath()
 	{
 		$this->app = $this->app->clone([
@@ -419,9 +372,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithInvalidRememberedPath()
 	{
 		$this->app = $this->app->clone([
@@ -436,9 +386,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/site', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithMissingSiteAccess()
 	{
 		$this->app = $this->app->clone([
@@ -461,9 +408,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithAccountAccessOnly()
 	{
 		$this->app = $this->app->clone([
@@ -489,9 +433,6 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/account', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlWithoutUser()
 	{
 		$this->assertSame('/panel/login', Home::url());

--- a/tests/Panel/JsonTest.php
+++ b/tests/Panel/JsonTest.php
@@ -4,24 +4,17 @@ namespace Kirby\Panel;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Json
- */
+#[CoversClass(Json::class)]
 class JsonTest extends TestCase
 {
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseEmptyArray()
 	{
 		$response = Json::response([]);
 		$this->assertSame(404, $response->code());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseRedirect()
 	{
 		$redirect = new Redirect('https://getkirby.com');
@@ -33,9 +26,6 @@ class JsonTest extends TestCase
 		$this->assertSame('https://getkirby.com', $body['$response']['redirect']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseThrowable()
 	{
 		$data     = new Exception();
@@ -43,9 +33,6 @@ class JsonTest extends TestCase
 		$this->assertSame(500, $response->code());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseNoArray()
 	{
 		$data     = 'foo';

--- a/tests/Panel/MenuTest.php
+++ b/tests/Panel/MenuTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Panel;
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Menu
- * @covers ::__construct
- */
+#[CoversClass(Menu::class)]
 class MenuTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Menu';
@@ -39,9 +37,6 @@ class MenuTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreas()
 	{
 		$menu  = new Menu(
@@ -57,9 +52,6 @@ class MenuTest extends TestCase
 		$this->assertSame('site', $areas[0]['id']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreasDefaultOrder()
 	{
 		$menu  = new Menu(
@@ -79,9 +71,6 @@ class MenuTest extends TestCase
 		$this->assertSame(['site', 'foo'], array_column($areas, 'id'));
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreasConfigOption()
 	{
 		$this->app->clone([
@@ -132,9 +121,6 @@ class MenuTest extends TestCase
 		$this->assertSame('Buddies', $areas[3]['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreasConfigOptionClosure()
 	{
 		$test = $this;
@@ -155,9 +141,6 @@ class MenuTest extends TestCase
 		$this->assertCount(0, $areas);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntry()
 	{
 		$menu = new Menu([], [], 'account');
@@ -176,9 +159,6 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryDialog()
 	{
 		$menu = new Menu([], [], 'account');
@@ -197,9 +177,6 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryMenu()
 	{
 		$menu = new Menu([], [], 'account');
@@ -224,18 +201,12 @@ class MenuTest extends TestCase
 		$this->assertTrue($entry['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryNoPermission()
 	{
 		$menu = new Menu([], ['access' => ['account' => false]]);
 		$this->assertFalse($menu->entry(['id' => 'account']));
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryMultiLanguage()
 	{
 		$menu = new Menu([], [], 'account');
@@ -256,9 +227,6 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entries
-	 */
 	public function testEntries()
 	{
 		$menu = new Menu(
@@ -282,9 +250,6 @@ class MenuTest extends TestCase
 		$this->assertSame('logout', $entries[4]['link']);
 	}
 
-	/**
-	 * @covers ::hasPermission
-	 */
 	public function testHasPermission()
 	{
 		$menu = new Menu([], []);
@@ -297,9 +262,6 @@ class MenuTest extends TestCase
 		$this->assertFalse($menu->hasPermission('account'));
 	}
 
-	/**
-	 * @covers ::isCurrent
-	 */
 	public function testIsCurrent()
 	{
 		$menu = new Menu([], [], 'account');
@@ -319,9 +281,6 @@ class MenuTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptions()
 	{
 		$changes = [

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -9,6 +9,7 @@ use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class CustomPanelModel extends Model
 {
@@ -41,9 +42,7 @@ class ModelSiteWithImageMethod extends ModelSite
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Model
- */
+#[CoversClass(Model::class)]
 class ModelTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Model';
@@ -70,10 +69,6 @@ class ModelTest extends TestCase
 		return new CustomPanelModel($site);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
 	public function testContent()
 	{
 		$panel = $this->panel([
@@ -85,10 +80,6 @@ class ModelTest extends TestCase
 		$this->assertSame($content, $panel->content());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
 	public function testContentWithChanges()
 	{
 		$panel = new CustomPanelModel(
@@ -110,9 +101,6 @@ class ModelTest extends TestCase
 		], $panel->content());
 	}
 
-	/**
-	 * @covers ::dragTextFromCallback
-	 */
 	public function testDragTextFromCallbackMarkdown()
 	{
 		$app = $this->app->clone([
@@ -153,9 +141,6 @@ class ModelTest extends TestCase
 		$this->assertSame('![](test/test.heic)', $panel->dragTextFromCallback('markdown', $file, $file->filename()));
 	}
 
-	/**
-	 * @covers ::dragTextFromCallback
-	 */
 	public function testDragTextFromCallbackKirbytext()
 	{
 		$app = $this->app->clone([
@@ -196,9 +181,6 @@ class ModelTest extends TestCase
 		$this->assertSame('(image: test/test.heic)', $panel->dragTextFromCallback('kirbytext', $file, $file->filename()));
 	}
 
-	/**
-	 * @covers ::dragTextType
-	 */
 	public function testDragTextType()
 	{
 		$panel = $this->panel();
@@ -239,12 +221,6 @@ class ModelTest extends TestCase
 		$this->assertSame($expected, $option);
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::imageDefaults
-	 * @covers ::imageSource
-	 * @covers ::imageSrcset
-	 */
 	public function testImage()
 	{
 		$panel = $this->panel([
@@ -311,9 +287,6 @@ class ModelTest extends TestCase
 		$this->assertStringContainsString('test-76x76-crop.jpg 2x', $image['srcset']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImageWithNonResizableAsset()
 	{
 		$site  = new ModelSiteWithImageMethod([]);
@@ -323,9 +296,6 @@ class ModelTest extends TestCase
 		$this->assertSame('/tmp/test.svg', $image['src']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImageWithBlueprint()
 	{
 		$app  = $this->app->clone([
@@ -358,9 +328,6 @@ class ModelTest extends TestCase
 		$this->assertArrayNotHasKey('url', $image);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImageWithBlueprintFalse()
 	{
 		$app  = $this->app->clone([
@@ -390,9 +357,6 @@ class ModelTest extends TestCase
 		$this->assertNull($image);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImageWithBlueprintString()
 	{
 		$app  = $this->app->clone([
@@ -419,9 +383,6 @@ class ModelTest extends TestCase
 		$this->assertStringEndsWith('test.jpg', $image['url']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImageWithQuery()
 	{
 		$site  = new ModelSiteWithImageMethod();
@@ -430,27 +391,18 @@ class ModelTest extends TestCase
 		$this->assertSame('blue', $image['back']);
 	}
 
-	/**
-	 * @covers ::imagePlaceholder
-	 */
 	public function testImagePlaceholder()
 	{
 		$this->assertIsString(Model::imagePlaceholder());
 		$this->assertStringStartsWith('data:image/gif;base64,', Model::imagePlaceholder());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$panel  = $this->panel();
 		$this->assertInstanceOf(ModelSite::class, $panel->model());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$site = [
@@ -489,9 +441,6 @@ class ModelTest extends TestCase
 		$this->assertSame('main', $props['tab']['name']);
 	}
 
-	/**
-	 * @covers ::toLink
-	 */
 	public function testToLink()
 	{
 		$panel = $this->panel([
@@ -510,9 +459,6 @@ class ModelTest extends TestCase
 		$this->assertSame($author, $toLink['title']);
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$this->assertSame('/panel/custom', $this->panel()->url());

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\PageCreateDialog
- */
+#[CoversClass(PageCreateDialog::class)]
 class PageCreateDialogTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -17,9 +16,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->login();
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFields(): void
 	{
 		$dialog = new PageCreateDialog(
@@ -36,9 +32,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertSame('/', $fields['slug']['path']);
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFieldWithoutTitleSlug(): void
 	{
 		$this->app([
@@ -65,9 +58,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertArrayNotHasKey('slug', $fields);
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFieldInvalidTitleSlug(): void
 	{
 		$this->app([
@@ -93,9 +83,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$dialog->coreFields();
 	}
 
-	/**
-	 * @covers ::resolveFieldTemplates
-	 */
 	public function testResolveFieldTemplates(): void
 	{
 		$this->app([
@@ -129,9 +116,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], $input);
 	}
 
-	/**
-	 * @covers ::sanitize
-	 */
 	public function testSanitize(): void
 	{
 		$this->app([
@@ -179,9 +163,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], $input);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidTitle(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -197,9 +178,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$dialog->validate(['content' => ['title' => '']]);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidSlug(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -218,9 +196,6 @@ class PageCreateDialogTest extends AreaTestCase
 		]);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidFields(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -253,9 +228,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], 'listed');
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateValidFields(): void
 	{
 		$this->app([
@@ -286,9 +258,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertTrue($valid);
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue(): void
 	{
 		$this->app([

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -10,6 +10,7 @@ use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class PageForceLocked extends ModelPage
 {
@@ -22,9 +23,8 @@ class PageForceLocked extends ModelPage
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Page
- */
+#[CoversClass(Page::class)]
+#[CoversClass(Model::class)]
 class PageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Page';
@@ -51,9 +51,6 @@ class PageTest extends TestCase
 		return new Page($page);
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumb(): void
 	{
 		$site = new ModelSite([
@@ -97,9 +94,6 @@ class PageTest extends TestCase
 		], $page->breadcrumb());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons()
 	{
 		$this->assertSame([
@@ -110,9 +104,6 @@ class PageTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragText()
 	{
 		$page = new ModelPage([
@@ -136,9 +127,6 @@ class PageTest extends TestCase
 		$this->assertSame('(link: page://test-page text: Test Title)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextMarkdown()
 	{
 		$app = $this->app->clone([
@@ -171,9 +159,6 @@ class PageTest extends TestCase
 		$this->assertSame('[Test Title](//@/page/my-b)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextCustomMarkdown()
 	{
 		$app = $this->app->clone([
@@ -203,9 +188,6 @@ class PageTest extends TestCase
 		$this->assertSame('Links sind toll: /test', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
 	public function testDragTextCustomKirbytext()
 	{
 		$app = $this->app->clone([
@@ -234,9 +216,6 @@ class PageTest extends TestCase
 		$this->assertSame('Links sind toll: /test', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption()
 	{
 		$page = new ModelPage([
@@ -254,9 +233,6 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/test', $option['link']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testIconFromBlueprint()
 	{
 		$page = new ModelPage([
@@ -271,9 +247,6 @@ class PageTest extends TestCase
 		$this->assertSame('test', $image['icon']);
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$parent = new ModelPage(['slug' => 'foo']);
@@ -286,9 +259,6 @@ class PageTest extends TestCase
 		$this->assertSame('foo+bar', $id);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
 	public function testImage()
 	{
 		$page = new ModelPage([
@@ -303,10 +273,6 @@ class PageTest extends TestCase
 		$this->assertTrue(Str::endsWith($image['url'], '/test.jpg'));
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::imageDefaults
-	 */
 	public function testImageBlueprintIconWithEmoji()
 	{
 		$page = new ModelPage([
@@ -321,10 +287,6 @@ class PageTest extends TestCase
 		$this->assertSame($emoji, $image['icon']);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
 	public function testImageCover()
 	{
 		$app = $this->app->clone([
@@ -369,9 +331,6 @@ class PageTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
 	public function testOptions()
 	{
 		$page = new ModelPage([
@@ -401,9 +360,6 @@ class PageTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
 	public function testOptionsWithLockedPage()
 	{
 		$page = new PageForceLocked([
@@ -454,9 +410,6 @@ class PageTest extends TestCase
 		$this->assertSame($expected, $panel->options(['preview']));
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		$page = new ModelPage([
@@ -467,10 +420,6 @@ class PageTest extends TestCase
 		$this->assertSame('pages/test', $panel->path());
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
 	public function testPickerDataDefault()
 	{
 		$page = new ModelPage([
@@ -490,9 +439,6 @@ class PageTest extends TestCase
 		$this->assertSame('Test Title', $data['text']);
 	}
 
-	/**
-	 * @covers ::position
-	 */
 	public function testPosition()
 	{
 		$page = new ModelPage([
@@ -517,9 +463,6 @@ class PageTest extends TestCase
 		$this->assertSame(4, $panel->position());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page = new ModelPage([
@@ -548,10 +491,6 @@ class PageTest extends TestCase
 		$this->assertNull($props['prev']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
 	public function testPropsPrevNext()
 	{
 		$app = $this->app->clone([
@@ -578,10 +517,6 @@ class PageTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
 	public function testPropsPrevNextWithSameTemplate()
 	{
 		$app = $this->app->clone([
@@ -606,10 +541,6 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/foo', $props['prev']()['link']);
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
 	public function testPropsPrevNextWithSameStatus()
 	{
 		$app = $this->app->clone([
@@ -634,10 +565,6 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/foo', $props['prev']()['link']);
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
 	public function testPropsPrevNextWithTab()
 	{
 		$app = $this->app->clone([
@@ -660,9 +587,6 @@ class PageTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::view
-	 */
 	public function testView()
 	{
 		$page = new ModelPage([
@@ -678,9 +602,6 @@ class PageTest extends TestCase
 		$this->assertSame('test', $view['breadcrumb'][0]['label']);
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$app = $this->app->clone([
@@ -708,9 +629,6 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/mother+child', $panel->url(true));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNextOne()
 	{
 		$app = $this->app->clone([
@@ -774,9 +692,6 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNextTwo()
 	{
 		$app = $this->app->clone([
@@ -853,9 +768,6 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNextThree()
 	{
 		$app = $this->app->clone([
@@ -932,9 +844,6 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNextFour()
 	{
 		$app = $this->app->clone([

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -8,10 +8,9 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Panel
- */
+#[CoversClass(Panel::class)]
 class PanelTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Panel';
@@ -51,9 +50,6 @@ class PanelTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::area
-	 */
 	public function testArea(): void
 	{
 		// defaults
@@ -72,9 +68,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreas(): void
 	{
 		// unauthenticated / uninstalled
@@ -130,9 +123,6 @@ class PanelTest extends TestCase
 		$this->assertCount(8, $areas);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons(): void
 	{
 		$this->app = $this->app->clone([
@@ -167,10 +157,6 @@ class PanelTest extends TestCase
 		$this->assertSame(['component' => 'test-a'], array_pop($withCustoms));
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallWithoutUser(): void
 	{
 		$this->expectException(PermissionException::class);
@@ -181,10 +167,6 @@ class PanelTest extends TestCase
 		Panel::firewall();
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallWithoutAcceptedUser(): void
 	{
 		$this->expectException(PermissionException::class);
@@ -197,9 +179,6 @@ class PanelTest extends TestCase
 		Panel::firewall($this->app->user());
 	}
 
-	/**
-	 * @covers ::firewall
-	 */
 	public function testFirewallWithAcceptedUser(): void
 	{
 		// accepted user
@@ -220,10 +199,6 @@ class PanelTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallAreaAccess(): void
 	{
 		$app = $this->app->clone([
@@ -268,9 +243,6 @@ class PanelTest extends TestCase
 		Panel::firewall($app->user(), 'system');
 	}
 
-	/**
-	 * @covers ::go
-	 */
 	public function testGo()
 	{
 		$thrown = false;
@@ -284,9 +256,6 @@ class PanelTest extends TestCase
 		$this->assertTrue($thrown);
 	}
 
-	/**
-	 * @covers ::go
-	 */
 	public function testGoWithCustomCode()
 	{
 		try {
@@ -296,9 +265,6 @@ class PanelTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::go
-	 */
 	public function testGoWithCustomSlug()
 	{
 		$this->app = $this->app->clone([
@@ -317,9 +283,6 @@ class PanelTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::isFiberRequest
-	 */
 	public function testIsFiberRequest(): void
 	{
 		// standard request
@@ -361,9 +324,6 @@ class PanelTest extends TestCase
 		$this->assertFalse($result);
 	}
 
-	/**
-	 * @covers ::json
-	 */
 	public function testJson(): void
 	{
 		$response = Panel::json($data = ['foo' => 'bar']);
@@ -373,9 +333,6 @@ class PanelTest extends TestCase
 		$this->assertSame($data, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
 	public function testMultilang()
 	{
 		$this->app = $this->app->clone([
@@ -387,9 +344,6 @@ class PanelTest extends TestCase
 		$this->assertTrue(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
 	public function testMultilangWithImplicitLanguageInstallation()
 	{
 		$this->app = $this->app->clone([
@@ -407,17 +361,11 @@ class PanelTest extends TestCase
 		$this->assertTrue(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
 	public function testMultilangDisabled()
 	{
 		$this->assertFalse(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse()
 	{
 		$response = new Response('Test');
@@ -426,9 +374,6 @@ class PanelTest extends TestCase
 		$this->assertSame($response, Panel::response($response));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromNullOrFalse()
 	{
 		// fake json request for easier assertions
@@ -457,9 +402,6 @@ class PanelTest extends TestCase
 		$this->assertSame('The data could not be found', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromString()
 	{
 		// fake json request for easier assertions
@@ -480,9 +422,6 @@ class PanelTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::router
-	 */
 	public function testRouterWithDisabledPanel(): void
 	{
 		$app = $this->app->clone([
@@ -496,9 +435,6 @@ class PanelTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes()
 	{
 		$routes = Panel::routes([]);
@@ -510,9 +446,6 @@ class PanelTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::routesForDialogs
-	 */
 	public function testRoutesForDialogs(): void
 	{
 		$area = [
@@ -547,9 +480,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDialogs
-	 */
 	public function testRoutesForDialogsWithoutHandlers(): void
 	{
 		$area = [
@@ -564,9 +494,6 @@ class PanelTest extends TestCase
 		$this->assertSame('The submit handler is missing', $routes[1]['action']());
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdowns(): void
 	{
 		$area = [
@@ -598,9 +525,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
 		$area = [
@@ -632,9 +556,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
 		$area = [
@@ -663,9 +584,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForViews
-	 */
 	public function testRoutesForViews(): void
 	{
 		$area = [
@@ -692,9 +610,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageWithoutRequest(): void
 	{
 		$this->app = $this->app->clone([
@@ -724,9 +639,6 @@ class PanelTest extends TestCase
 		$this->assertNull($this->app->session()->get('panel.language'));
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguage(): void
 	{
 		$this->app = $this->app->clone([
@@ -761,9 +673,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->session()->get('panel.language'));
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageWithCustomDefault(): void
 	{
 		$this->app = $this->app->clone([
@@ -790,9 +699,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->language()->code());
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageViaGet(): void
 	{
 		// switch via get request
@@ -824,9 +730,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->language()->code());
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageInSingleLanguageSite(): void
 	{
 		$language = Panel::setLanguage();
@@ -835,9 +738,6 @@ class PanelTest extends TestCase
 		$this->assertNull($this->app->language());
 	}
 
-	/**
-	 * @covers ::setTranslation
-	 */
 	public function testSetTranslation(): void
 	{
 		$translation = Panel::setTranslation($this->app);

--- a/tests/Panel/PluginsTest.php
+++ b/tests/Panel/PluginsTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Plugins
- */
+#[CoversClass(Plugins::class)]
 class PluginsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Plugins';
@@ -74,9 +73,6 @@ class PluginsTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles()
 	{
 		$this->createPlugins();
@@ -102,18 +98,12 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->files());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedWithoutFiles()
 	{
 		$plugins = new Plugins();
 		$this->assertSame(0, $plugins->modified());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedWithFiles()
 	{
 		$time = $this->createPlugins();
@@ -125,9 +115,6 @@ class PluginsTest extends TestCase
 		$this->assertSame($time, $plugins->modified());
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testRead()
 	{
 		$this->createPlugins();
@@ -150,9 +137,6 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->read('mjs'));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadWithDevMjs()
 	{
 		$this->createPlugins(true);
@@ -175,9 +159,6 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->read('mjs'));
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		// css

--- a/tests/Panel/RedirectTest.php
+++ b/tests/Panel/RedirectTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Panel;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Redirect
- */
+#[CoversClass(Redirect::class)]
 class RedirectTest extends TestCase
 {
-	/**
-	 * @covers ::code
-	 */
 	public function testCode()
 	{
 		// default
@@ -27,9 +23,6 @@ class RedirectTest extends TestCase
 		$this->assertSame(302, $redirect->code());
 	}
 
-	/**
-	 * @covers ::location
-	 */
 	public function testLocation()
 	{
 		$redirect = new Redirect('https://getkirby.com');

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -7,10 +7,10 @@ use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Site
- */
+#[CoversClass(Site::class)]
+#[CoversClass(Model::class)]
 class SiteTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Site';
@@ -37,9 +37,6 @@ class SiteTest extends TestCase
 		return new Site($site);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons()
 	{
 		$this->assertSame([
@@ -48,9 +45,6 @@ class SiteTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption(): void
 	{
 		$model = $this->panel([
@@ -66,9 +60,6 @@ class SiteTest extends TestCase
 		$this->assertSame('/site', $option['link']);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
 	public function testImage()
 	{
 		$panel = $this->panel([
@@ -82,12 +73,6 @@ class SiteTest extends TestCase
 		$this->assertTrue(Str::endsWith($image['url'], '/test.jpg'));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::image
-	 * @covers \Kirby\Panel\Model::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
 	public function testImageCover()
 	{
 		$app = $this->app->clone([
@@ -127,17 +112,11 @@ class SiteTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		$this->assertSame('site', $this->panel()->path());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$props = $this->panel()->props();
@@ -155,9 +134,6 @@ class SiteTest extends TestCase
 		$this->assertArrayHasKey('tabs', $props);
 	}
 
-	/**
-	 * @covers ::view
-	 */
 	public function testView()
 	{
 		$view = $this->panel()->view();

--- a/tests/Panel/Ui/ButtonTest.php
+++ b/tests/Panel/Ui/ButtonTest.php
@@ -3,16 +3,11 @@
 namespace Kirby\Panel\Ui;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Button
- * @covers ::__construct
- */
+#[CoversClass(Button::class)]
 class ButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testAttrs()
 	{
 		$button = new Button(
@@ -28,9 +23,6 @@ class ButtonTest extends TestCase
 		], array_filter($button->props()));
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$component = new Button(
@@ -63,9 +55,6 @@ class ButtonTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testPropsWithI18n()
 	{
 		$component = new Button(

--- a/tests/Panel/Ui/Buttons/LanguageCreateButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageCreateButtonTest.php
@@ -4,15 +4,11 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageCreateButton
- */
+#[CoversClass(LanguageCreateButton::class)]
 class LanguageCreateButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButton()
 	{
 		$button = new LanguageCreateButton();
@@ -21,9 +17,6 @@ class LanguageCreateButtonTest extends TestCase
 		$this->assertSame('Add a new language', $button->text);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testDisabled()
 	{
 		$app = new App([

--- a/tests/Panel/Ui/Buttons/LanguageDeleteButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageDeleteButtonTest.php
@@ -5,15 +5,11 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageDeleteButton
- */
+#[CoversClass(LanguageDeleteButton::class)]
 class LanguageDeleteButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButton()
 	{
 		$language = new Language(['code' => 'en']);
@@ -22,9 +18,6 @@ class LanguageDeleteButtonTest extends TestCase
 		$this->assertSame('languages/en/delete', $button->dialog);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testDisabled()
 	{
 		$app = new App([

--- a/tests/Panel/Ui/Buttons/LanguageSettingsButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageSettingsButtonTest.php
@@ -5,15 +5,11 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageSettingsButton
- */
+#[CoversClass(LanguageSettingsButton::class)]
 class LanguageSettingsButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButton()
 	{
 		$language = new Language(['code' => 'en']);
@@ -22,9 +18,6 @@ class LanguageSettingsButtonTest extends TestCase
 		$this->assertSame('languages/en/update', $button->dialog);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testDisabled()
 	{
 		$app = new App([

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -5,16 +5,11 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguagesDropdown
- * @covers ::__construct
- */
+#[CoversClass(LanguagesDropdown::class)]
 class LanguagesDropdownTest extends AreaTestCase
 {
-	/**
-	 * @covers ::hasChanges
-	 */
 	public function testHasChanges()
 	{
 		$this->install();
@@ -37,9 +32,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertTrue($button->hasChanges());
 	}
 
-	/**
-	 * @covers ::option
-	 */
 	public function testOption()
 	{
 		$page     = new Page(['slug' => 'test']);
@@ -55,10 +47,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		], $button->option($language));
 	}
 
-	/**
-	 * @covers ::options
-	 * @
-	 */
 	public function testOptionsSingleLang()
 	{
 		$page   = new Page(['slug' => 'test']);
@@ -66,9 +54,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertSame([], $button->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
 	public function testOptionsMultiLang()
 	{
 		$this->enableMultilang();
@@ -97,9 +82,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		], $button->options());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page   = new Page(['slug' => 'test']);
@@ -108,9 +90,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertFalse($props['hasChanges']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderDefault()
 	{
 		$page   = new Page(['slug' => 'test']);
@@ -118,9 +97,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertNull($button->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderSingleLang()
 	{
 		$this->enableMultilang();
@@ -139,10 +115,6 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertNull($button->render());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::render
-	 */
 	public function testRenderMultiLang()
 	{
 		$this->enableMultilang();

--- a/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
+++ b/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
@@ -5,15 +5,11 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\PageStatusButton
- */
+#[CoversClass(PageStatusButton::class)]
 class PageStatusButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButtonDraftDisabled()
 	{
 
@@ -31,9 +27,6 @@ class PageStatusButtonTest extends TestCase
 		$this->assertSame('negative-icon', $button->theme);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButtonUnlisted()
 	{
 		App::instance()->impersonate('kirby');

--- a/tests/Panel/Ui/Buttons/PreviewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/PreviewButtonTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\PreviewButton
- */
+#[CoversClass(PreviewButton::class)]
 class PreviewButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButton()
 	{
 		$button = new PreviewButton(link: 'https://getkirby.com');

--- a/tests/Panel/Ui/Buttons/SettingsButtonTest.php
+++ b/tests/Panel/Ui/Buttons/SettingsButtonTest.php
@@ -4,15 +4,11 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\SettingsButton
- */
+#[CoversClass(SettingsButton::class)]
 class SettingsButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testButton()
 	{
 		$page   = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/Buttons/ViewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\ViewButton
- * @covers ::__construct
- */
+#[CoversClass(ViewButton::class)]
 class ViewButtonTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -19,9 +17,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->login();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testAttrs()
 	{
 		$button = new ViewButton(
@@ -39,9 +34,6 @@ class ViewButtonTest extends AreaTestCase
 		], array_filter($button->props()));
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryFromClosure()
 	{
 		$button = ViewButton::factory(
@@ -56,9 +48,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-foo-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryFromDefinition()
 	{
 		$button = ViewButton::factory(
@@ -70,9 +59,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-test-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryFromStringName()
 	{
 		$app = $this->app->clone([
@@ -102,9 +88,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertNull($button);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithNameArg()
 	{
 		$button = ViewButton::factory(
@@ -117,9 +100,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-foo-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::find
-	 */
 	public function testFind(): void
 	{
 		$app = $this->app->clone([
@@ -149,9 +129,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame(['component' => 'k-foo-view-button'], $result);
 	}
 
-	/**
-	 * @covers ::normalize
-	 */
 	public function testNormalize(): void
 	{
 		$result = ViewButton::normalize([
@@ -174,9 +151,6 @@ class ViewButtonTest extends AreaTestCase
 		], $result);
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$component = new ViewButton(
@@ -211,9 +185,6 @@ class ViewButtonTest extends AreaTestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testPropsWithQueries()
 	{
 		$model     = new Page(['slug' => 'test']);
@@ -228,9 +199,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('https://getkirby.com/test', $props['link']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve(): void
 	{
 		$test   = $this;

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\ViewButtons
- */
+#[CoversClass(ViewButtons::class)]
 class ViewButtonsTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -31,9 +30,6 @@ class ViewButtonsTest extends AreaTestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		// no buttons
@@ -49,9 +45,6 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertCount(4, $buttons->buttons);
 	}
 
-	/**
-	 * @covers ::bind
-	 */
 	public function testBind()
 	{
 		$buttons = new ViewButtons('foo');
@@ -65,9 +58,6 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame(['foo' => 'bar', 'homer' => 'simpson'], $buttons->data);
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$buttons = new ViewButtons('foo');
@@ -77,9 +67,6 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertCount(2, $buttons->buttons);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$buttons = new ViewButtons('test', buttons: ['a', 'b']);
@@ -90,9 +77,6 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame('k-b-view-button', $result[1]['component']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderFromConfig()
 	{
 		$buttons = new ViewButtons('test');
@@ -104,18 +88,12 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame('result-c', $result[2]['component']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderNoButtons()
 	{
 		$buttons = new ViewButtons('test', buttons: false);
 		$this->assertSame([], $buttons->render());
 	}
 
-	/**
-	 * @covers ::view
-	 */
 	public function testView()
 	{
 		// view name

--- a/tests/Panel/Ui/ComponentTest.php
+++ b/tests/Panel/Ui/ComponentTest.php
@@ -4,20 +4,15 @@ namespace Kirby\Panel\Ui;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class UiComponent extends Component
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Component
- * @covers ::__construct
- */
+#[CoversClass(Component::class)]
 class ComponentTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testAttrs()
 	{
 		$props = [
@@ -35,9 +30,6 @@ class ComponentTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testGetterSetter()
 	{
 		$component = new UiComponent(component: 'k-test');
@@ -49,9 +41,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('my-class', $component->class());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testGetterSetterInvalid()
 	{
 		$this->expectException(Exception::class);
@@ -60,9 +49,6 @@ class ComponentTest extends TestCase
 		$component->foo('my-class');
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$component = new UiComponent(component: 'k-test');
@@ -71,9 +57,6 @@ class ComponentTest extends TestCase
 		$this->assertSame($component->render()['key'], $component->key());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$component = new UiComponent(
@@ -87,9 +70,6 @@ class ComponentTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$component = new UiComponent(

--- a/tests/Panel/Ui/FilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviewTest.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Ui\FilePreviews\DefaultFilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class DummyFilePreview extends FilePreview
 {
@@ -27,10 +28,7 @@ class InvalidFilePreview
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreview
- * @covers ::__construct
- */
+#[CoversClass(FilePreview::class)]
 class FilePreviewTest extends TestCase
 {
 	public function setUp(): void
@@ -45,9 +43,6 @@ class FilePreviewTest extends TestCase
 		$this->app->impersonate('kirby');
 	}
 
-	/**
-	 * @covers ::details
-	 */
 	public function testDetails()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -76,9 +71,6 @@ class FilePreviewTest extends TestCase
 		], $details);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -88,9 +80,6 @@ class FilePreviewTest extends TestCase
 		$this->assertInstanceOf(DefaultFilePreview::class, $preview);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithCustomHandler()
 	{
 		new App([
@@ -113,9 +102,6 @@ class FilePreviewTest extends TestCase
 		$this->assertInstanceOf(DummyFilePreview::class, $preview);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithCustomHandlerInvalid()
 	{
 		new App([
@@ -137,9 +123,6 @@ class FilePreviewTest extends TestCase
 		FilePreview::factory($file);
 	}
 
-	/**
-	 * @covers ::image
-	 */
 	public function testImage()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -152,9 +135,6 @@ class FilePreviewTest extends TestCase
 		$this->assertIsString($image['src']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -167,9 +147,6 @@ class FilePreviewTest extends TestCase
 		$this->assertIsString($props['url']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$page    = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/FilePreviews/AudioFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/AudioFilePreviewTest.php
@@ -6,15 +6,11 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\AudioFilePreview
- */
+#[CoversClass(AudioFilePreview::class)]
 class AudioFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
 	public function testAccepts()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -26,9 +22,6 @@ class AudioFilePreviewTest extends TestCase
 		$this->assertFalse(AudioFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$page    = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/FilePreviews/DefaultFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/DefaultFilePreviewTest.php
@@ -6,16 +6,11 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\DefaultFilePreview
- * @covers ::__construct
- */
+#[CoversClass(DefaultFilePreview::class)]
 class DefaultFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
 	public function testAccepts()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -24,9 +19,6 @@ class DefaultFilePreviewTest extends TestCase
 		$this->assertTrue(DefaultFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -37,10 +29,6 @@ class DefaultFilePreviewTest extends TestCase
 		$this->assertSame('k-default-file-preview', $preview->component);
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page      = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/FilePreviews/ImageFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/ImageFilePreviewTest.php
@@ -6,15 +6,11 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\ImageFilePreview
- */
+#[CoversClass(ImageFilePreview::class)]
 class ImageFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
 	public function testAccepts()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -26,9 +22,6 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertFalse(ImageFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::details
-	 */
 	public function testDetails()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -43,9 +36,6 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertSame('Dimensions', $detail['title']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$page    = new Page(['slug' => 'test']);
@@ -56,9 +46,6 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertSame('k-image-file-preview', $preview->component);
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$page    = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/FilePreviews/PdfFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/PdfFilePreviewTest.php
@@ -6,15 +6,11 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\PdfFilePreview
- */
+#[CoversClass(PdfFilePreview::class)]
 class PdfFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
 	public function testAccepts()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -26,9 +22,6 @@ class PdfFilePreviewTest extends TestCase
 		$this->assertFalse(PdfFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$page    = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/FilePreviews/VideoFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/VideoFilePreviewTest.php
@@ -6,15 +6,11 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\VideoFilePreview
- */
+#[CoversClass(VideoFilePreview::class)]
 class VideoFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
 	public function testAccepts()
 	{
 		$page = new Page(['slug' => 'test']);
@@ -26,9 +22,6 @@ class VideoFilePreviewTest extends TestCase
 		$this->assertFalse(VideoFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$page    = new Page(['slug' => 'test']);

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -9,6 +9,7 @@ use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class UserForceLocked extends ModelUser
 {
@@ -21,9 +22,8 @@ class UserForceLocked extends ModelUser
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\User
- */
+#[CoversClass(User::class)]
+#[CoversClass(Model::class)]
 class UserTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.User';
@@ -53,9 +53,6 @@ class UserTest extends TestCase
 		return new User($user);
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumb(): void
 	{
 		$model = new ModelUser([
@@ -67,9 +64,6 @@ class UserTest extends TestCase
 		$this->assertStringStartsWith('/users/', $breadcrumb[0]['link']);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons()
 	{
 		$this->assertSame([
@@ -79,9 +73,6 @@ class UserTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dropdown
-	 */
 	public function testDropdownTotp(): void
 	{
 		$this->app = new App([
@@ -110,9 +101,6 @@ class UserTest extends TestCase
 		$this->assertSame('/account/totp/disable', $dropdown[7]['dialog']);
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption(): void
 	{
 		$model = new ModelUser([
@@ -126,9 +114,6 @@ class UserTest extends TestCase
 		$this->assertSame('/users/test', $option['link']);
 	}
 
-	/**
-	 * @covers ::home
-	 */
 	public function testHome()
 	{
 		$user = new ModelUser([
@@ -139,9 +124,6 @@ class UserTest extends TestCase
 		$this->assertSame('/panel/site', $panel->home());
 	}
 
-	/**
-	 * @covers ::home
-	 */
 	public function testHomeWithCustomPath()
 	{
 		$this->app = new App([
@@ -165,9 +147,6 @@ class UserTest extends TestCase
 		$this->assertSame('/blog', $panel->home());
 	}
 
-	/**
-	 * @covers ::home
-	 */
 	public function testHomeWithCustomPathQuery()
 	{
 		$this->app = new App([
@@ -196,10 +175,6 @@ class UserTest extends TestCase
 		$this->assertSame('/panel/pages/test', $panel->home());
 	}
 
-	/**
-	 * @covers ::imageDefaults
-	 * @covers ::imageSource
-	 */
 	public function testImage()
 	{
 		$user = new ModelUser([
@@ -211,9 +186,6 @@ class UserTest extends TestCase
 		$this->assertFalse(isset($image['url']));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
 	public function testImageStringQuery()
 	{
 		$user = new ModelUser([
@@ -225,12 +197,6 @@ class UserTest extends TestCase
 		$this->assertNotEmpty($image);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::image
-	 * @covers \Kirby\Panel\Model::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
 	public function testImageCover()
 	{
 		$app = $this->app->clone([
@@ -278,9 +244,6 @@ class UserTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
 	public function testOptions()
 	{
 		$user = new ModelUser([
@@ -304,9 +267,6 @@ class UserTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
 	public function testOptionsWithLockedUser()
 	{
 		$user = new UserForceLocked([
@@ -345,9 +305,6 @@ class UserTest extends TestCase
 		$this->assertSame($expected, $panel->options(['changeEmail']));
 	}
 
-	/**
-	 * @covers ::path
-	 */
 	public function testPath()
 	{
 		$user = new ModelUser([
@@ -358,10 +315,6 @@ class UserTest extends TestCase
 		$this->assertTrue(Str::startsWith($panel->path(), 'users/'));
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
 	public function testPickerDataDefault()
 	{
 		$user = new ModelUser([
@@ -376,9 +329,6 @@ class UserTest extends TestCase
 		$this->assertSame('test@getkirby.com', $data['text']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps()
 	{
 		$user = new ModelUser([
@@ -410,9 +360,6 @@ class UserTest extends TestCase
 		$this->assertNull($props['prev']());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testPropsPrevNext()
 	{
 		$app = $this->app->clone([
@@ -436,9 +383,6 @@ class UserTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::translation
-	 */
 	public function testTranslation()
 	{
 		// existing
@@ -464,9 +408,6 @@ class UserTest extends TestCase
 		$this->assertNull($translations->get('translation.name'));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
 	public function testPrevNext()
 	{
 		$app = $this->app->clone([
@@ -490,10 +431,6 @@ class UserTest extends TestCase
 		$this->assertNull($prevNext['next']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
 	public function testPrevNextWithTab()
 	{
 		$app = $this->app->clone([
@@ -513,9 +450,6 @@ class UserTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::view
-	 */
 	public function testView()
 	{
 		$user = new ModelUser([

--- a/tests/Panel/UserTotpDisableDialogTest.php
+++ b/tests/Panel/UserTotpDisableDialogTest.php
@@ -8,10 +8,9 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\UserTotpDisableDialog
- */
+#[CoversClass(UserTotpDisableDialog::class)]
 class UserTotpDisableDialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpDisableDialog';
@@ -50,9 +49,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct(): void
 	{
 		$dialog = new UserTotpDisableDialog();
@@ -63,9 +59,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertSame('homer@simpson.com', $dialog->user->email());
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad(): void
 	{
 		// current admin user for themselves
@@ -85,9 +78,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertSame('k-form-dialog', $state['component']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmit(): void
 	{
 		$user     = $this->app->user();
@@ -106,9 +96,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertIsString($state['message']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitWrongPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -124,9 +111,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$dialog->submit();
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitNonAdminAnotherUser(): void
 	{
 		$this->expectException(PermissionException::class);

--- a/tests/Panel/UserTotpEnableDialogTest.php
+++ b/tests/Panel/UserTotpEnableDialogTest.php
@@ -8,10 +8,9 @@ use Kirby\Filesystem\Dir;
 use Kirby\Image\QrCode;
 use Kirby\TestCase;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\UserTotpEnableDialog
- */
+#[CoversClass(UserTotpEnableDialog::class)]
 class UserTotpEnableDialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpEnableDialog';
@@ -44,9 +43,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -55,11 +51,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertSame('test@getkirby.com', $dialog->user->email());
 	}
 
-	/**
-	 * @covers ::load
-	 * @covers ::secret
-	 * @covers ::totp
-	 */
 	public function testLoad(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -70,10 +61,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertIsString($state['props']['qr']);
 	}
 
-	/**
-	 * @covers ::qr
-	 * @covers ::totp
-	 */
 	public function testQr(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -83,10 +70,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertStringContainsString('otpauth://totp/:test%40getkirby.com?secret=', $qr->data);
 	}
 
-	/**
-	 * @covers ::submit
-	 * @covers ::totp
-	 */
 	public function testSubmit(): void
 	{
 		$totp            = new Totp();
@@ -102,9 +85,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertIsString($state['message']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitNoConfirmCode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -117,9 +97,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$dialog->submit();
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitWrongConfirmCode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -10,10 +10,9 @@ use Kirby\Http\Response;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\View
- */
+#[CoversClass(View::class)]
 class ViewTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.View';
@@ -43,9 +42,6 @@ class ViewTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::apply
-	 */
 	public function testApply()
 	{
 		$data = [
@@ -59,10 +55,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyGlobals
-	 */
 	public function testApplyGlobals(): void
 	{
 		// not included
@@ -98,10 +90,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, View::applyGlobals($data, ''));
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnly(): void
 	{
 		// via get
@@ -145,10 +133,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, View::applyOnly($data, ''));
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithGlobal(): void
 	{
 		// simulate a simple partial request
@@ -178,10 +162,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithNestedData(): void
 	{
 		// simulate a simple partial request
@@ -211,10 +191,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithNestedGlobal(): void
 	{
 		// simulate a simple partial request
@@ -243,9 +219,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testData(): void
 	{
 		// without custom data
@@ -276,9 +249,6 @@ class ViewTest extends TestCase
 		$this->assertArrayNotHasKey('dialogs', $view);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithCustomRequestUrl(): void
 	{
 		$this->app = $this->app->clone([
@@ -297,9 +267,6 @@ class ViewTest extends TestCase
 		$this->assertSame('https://localhost.com:8888/foo/bar?foo=bar', $data['$url']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithCustomProps(): void
 	{
 		$data = View::data([
@@ -313,9 +280,6 @@ class ViewTest extends TestCase
 		$this->assertSame($props, $data['$view']['props']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithLanguages(): void
 	{
 		$this->app = $this->app->clone([
@@ -362,9 +326,6 @@ class ViewTest extends TestCase
 		$this->assertNull($data['$direction']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithDirection(): void
 	{
 		$this->app = $this->app->clone([
@@ -394,9 +355,6 @@ class ViewTest extends TestCase
 		$this->assertSame('rtl', $data['$direction']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithAuthenticatedUser(): void
 	{
 		// authenticate pseudo user
@@ -421,9 +379,6 @@ class ViewTest extends TestCase
 		$this->assertSame($this->app->user()->role()->permissions()->toArray(), $data['$permissions']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// without user
@@ -455,18 +410,12 @@ class ViewTest extends TestCase
 		$this->assertSame('outside', $error['props']['layout']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testErrorWithCustomCode(): void
 	{
 		$error = View::error('Test', 403);
 		$this->assertSame(403, $error['code']);
 	}
 
-	/**
-	 * @covers ::globals
-	 */
 	public function testGlobals(): void
 	{
 		// defaults
@@ -510,9 +459,6 @@ class ViewTest extends TestCase
 		$this->assertSame('/', $urls['site']);
 	}
 
-	/**
-	 * @covers ::globals
-	 */
 	public function testGlobalsWithUser(): void
 	{
 		$this->app = $this->app->clone([
@@ -531,9 +477,6 @@ class ViewTest extends TestCase
 		$this->assertSame('de', $globals['$translation']['code']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseAsHTML(): void
 	{
 		// create panel dist files first to avoid redirect
@@ -551,9 +494,6 @@ class ViewTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseAsJSON(): void
 	{
 		$this->app = $this->app->clone([
@@ -573,9 +513,6 @@ class ViewTest extends TestCase
 		$this->assertSame('true', $response->header('X-Fiber'));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromRedirect()
 	{
 		// fake json request for easier assertions
@@ -596,9 +533,6 @@ class ViewTest extends TestCase
 		$this->assertSame('https://getkirby.com', $response->header('Location'));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromKirbyException()
 	{
 		// fake json request for easier assertions
@@ -619,9 +553,6 @@ class ViewTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromException()
 	{
 		// fake json request for easier assertions
@@ -642,9 +573,6 @@ class ViewTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromUnsupportedResult()
 	{
 		// fake json request for easier assertions
@@ -664,9 +592,6 @@ class ViewTest extends TestCase
 		$this->assertSame('Invalid Panel response', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::searches
-	 */
 	public function testSearches()
 	{
 		$areas  = [

--- a/tests/Parsley/ElementTest.php
+++ b/tests/Parsley/ElementTest.php
@@ -4,15 +4,11 @@ namespace Kirby\Parsley;
 
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Element
- */
+#[CoversClass(Element::class)]
 class ElementTest extends TestCase
 {
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttr()
 	{
 		$dom     = new Dom('<p class="test">test</p>');
@@ -22,9 +18,6 @@ class ElementTest extends TestCase
 		$this->assertSame('test', $element->attr('class'));
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildren()
 	{
 		$dom     = new Dom('<p class="test"><span>A</span><span>B</span></p>');
@@ -36,9 +29,6 @@ class ElementTest extends TestCase
 		$this->assertCount(2, $children);
 	}
 
-	/**
-	 * @covers ::classList
-	 */
 	public function testClassList()
 	{
 		$dom     = new Dom('<p class="a b">test</p>');
@@ -48,9 +38,6 @@ class ElementTest extends TestCase
 		$this->assertSame(['a', 'b'], $element->classList());
 	}
 
-	/**
-	 * @covers ::className
-	 */
 	public function testClassName()
 	{
 		$dom     = new Dom('<p class="a b">test</p>');
@@ -60,9 +47,6 @@ class ElementTest extends TestCase
 		$this->assertSame('a b', $element->className());
 	}
 
-	/**
-	 * @covers ::element
-	 */
 	public function testElement()
 	{
 		$dom     = new Dom('test');
@@ -72,9 +56,6 @@ class ElementTest extends TestCase
 		$this->assertSame($body, $element->element());
 	}
 
-	/**
-	 * @covers ::filter
-	 */
 	public function testFilter()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -86,9 +67,6 @@ class ElementTest extends TestCase
 		$this->assertSame('Bold', $children[0]->innerText());
 	}
 
-	/**
-	 * @covers ::find
-	 */
 	public function testFind()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -99,9 +77,6 @@ class ElementTest extends TestCase
 		$this->assertSame('Bold', $child->innerText());
 	}
 
-	/**
-	 * @covers ::find
-	 */
 	public function testFindWithoutResult()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -111,9 +86,6 @@ class ElementTest extends TestCase
 		$this->assertNull($element->find('//a'));
 	}
 
-	/**
-	 * @covers ::innerHtml
-	 */
 	public function testInnerHtml()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -123,9 +95,6 @@ class ElementTest extends TestCase
 		$this->assertSame('ItalicBold', $element->innerHtml());
 	}
 
-	/**
-	 * @covers ::innerHtml
-	 */
 	public function testInnerHtmlWithMarks()
 	{
 		$marks = [
@@ -150,9 +119,6 @@ class ElementTest extends TestCase
 		$this->assertSame('<i>Italic</i><b>Bold</b>', $element->innerHtml());
 	}
 
-	/**
-	 * @covers ::innerText
-	 */
 	public function testInnerText()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -162,9 +128,6 @@ class ElementTest extends TestCase
 		$this->assertSame('ItalicBold', $element->innerText());
 	}
 
-	/**
-	 * @covers ::outerHtml
-	 */
 	public function testOuterHtml()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -174,9 +137,6 @@ class ElementTest extends TestCase
 		$this->assertSame('<p><i>Italic</i><b>Bold</b></p>', $element->outerHtml());
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuery()
 	{
 		$dom = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -186,9 +146,6 @@ class ElementTest extends TestCase
 		$this->assertSame('b', $dom->query('//p/b')[0]->tagName);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemove()
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
@@ -199,9 +156,6 @@ class ElementTest extends TestCase
 		$this->assertNull($dom->query('//p/i')[0]);
 	}
 
-	/**
-	 * @covers ::tagName
-	 */
 	public function testTagName()
 	{
 		$dom     = new Dom('<p>Test</p>');

--- a/tests/Parsley/InlineTest.php
+++ b/tests/Parsley/InlineTest.php
@@ -4,15 +4,11 @@ namespace Kirby\Parsley;
 
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Inline
- */
+#[CoversClass(Inline::class)]
 class InlineTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructTrim()
 	{
 		$dom    = new Dom('<span> Test </span>');
@@ -26,9 +22,6 @@ class InlineTest extends TestCase
 		$this->assertSame(' ', $inline->innerHtml());
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
 	public function testParseAttrs()
 	{
 		$dom    = new Dom('<b class="foo">Test</b>');
@@ -42,9 +35,6 @@ class InlineTest extends TestCase
 		$this->assertSame(['class' => 'foo'], $attrs);
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
 	public function testParseAttrsWithDefaults()
 	{
 		$dom    = new Dom('<b>Test</b>');
@@ -59,9 +49,6 @@ class InlineTest extends TestCase
 		$this->assertSame(['class' => 'foo'], $attrs);
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
 	public function testParseAttrsWithIgnoredAttrs()
 	{
 		$dom    = new Dom('<b class="foo">Test</b>');
@@ -73,9 +60,6 @@ class InlineTest extends TestCase
 		$this->assertSame([], $attrs);
 	}
 
-	/**
-	 * @covers ::parseInnerHtml
-	 */
 	public function testParseInnerHtml()
 	{
 		$dom    = new Dom('<p><b>Bold</b> <i>Italic</i></p>');
@@ -88,9 +72,6 @@ class InlineTest extends TestCase
 		$this->assertSame('<b>Bold</b> <i>Italic</i>', $html);
 	}
 
-	/**
-	 * @covers ::parseInnerHtml
-	 */
 	public function testParseInnerHtmlWithEmptyParagraph()
 	{
 		$dom  = new Dom('<p> </p>');
@@ -100,9 +81,6 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithComment()
 	{
 		$dom = new \DOMDocument();
@@ -114,9 +92,6 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithEmptyParagraph()
 	{
 		$dom  = new Dom('<p> </p>');
@@ -128,9 +103,6 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithKnownMarks()
 	{
 		$dom  = new Dom('<p><b>Test</b> <i>Test</i></p>');
@@ -143,9 +115,6 @@ class InlineTest extends TestCase
 		$this->assertSame('<b>Test</b> <i>Test</i>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithKnownMarksWithAttrs()
 	{
 		$dom  = new Dom('<p><a href="https://getkirby.com">Test</a></p>');
@@ -159,9 +128,6 @@ class InlineTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com">Test</a>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithKnownMarksWithAttrDefaults()
 	{
 		$dom  = new Dom('<p><a href="https://getkirby.com">Test</a></p>');
@@ -178,9 +144,6 @@ class InlineTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com" rel="test">Test</a>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithUnkownMarks()
 	{
 		$dom     = new Dom('<p><b>Test</b> <i>Test</i></p>');
@@ -190,9 +153,6 @@ class InlineTest extends TestCase
 		$this->assertSame('Test Test', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithSelfClosingElement()
 	{
 		$dom  = new Dom('<p><br></p>');
@@ -204,9 +164,6 @@ class InlineTest extends TestCase
 		$this->assertSame('<br />', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithText()
 	{
 		$dom  = new Dom('Test');
@@ -216,9 +173,6 @@ class InlineTest extends TestCase
 		$this->assertSame('Test', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithTextEncoded()
 	{
 		$dom  = new Dom('Test & Test');

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -6,6 +6,8 @@ use Kirby\Filesystem\F;
 use Kirby\Parsley\Schema\Blocks;
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TestableParsley extends Parsley
 {
@@ -16,9 +18,7 @@ class TestableParsley extends Parsley
 }
 
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Parsley
- */
+#[CoversClass(Parsley::class)]
 class ParsleyTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -28,12 +28,6 @@ class ParsleyTest extends TestCase
 		return new TestableParsley($html, new Blocks());
 	}
 
-	/**
-	 * @covers ::blocks
-	 * @covers ::endInlineBlock
-	 * @covers ::fallback
-	 * @covers ::mergeOrAppend
-	 */
 	public function testBlocks()
 	{
 		$examples = glob(static::FIXTURES . '/*.html');
@@ -59,11 +53,8 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider containsBlockProvider
-	 * @covers ::containsBlock
-	 */
-	public function testContainsBlock($html, $query, $expected)
+	#[DataProvider('containsBlockProvider')]
+	public function testContainsBlock(string $html, string $query, bool $expected)
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -71,9 +62,6 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $this->parser()->containsBlock($element));
 	}
 
-	/**
-	 * @covers ::containsBlock
-	 */
 	public function testContainsBlockWithText()
 	{
 		$dom     = new Dom('Test');
@@ -90,19 +78,13 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackWithEmptyInput()
 	{
 		$this->assertNull($this->parser()->fallback(''));
 	}
 
-	/**
-	 * @dataProvider isBlockProvider
-	 * @covers ::isBlock
-	 */
-	public function testIsBlock($html, $query, $expected)
+	#[DataProvider('isBlockProvider')]
+	public function testIsBlock(string $html, string $query, bool $expected)
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -120,11 +102,8 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isInlineProvider
-	 * @covers ::isInline
-	 */
-	public function testIsInline($html, $query, $expected)
+	#[DataProvider('isInlineProvider')]
+	public function testIsInline(string $html, string $query, bool $expected)
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -132,9 +111,6 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $this->parser()->isInline($element));
 	}
 
-	/**
-	 * @covers ::isInline
-	 */
 	public function testIsInlineWithComment()
 	{
 		$dom     = new Dom('<p><!-- test --></p>');
@@ -143,9 +119,6 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->isInline($comment));
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
 	public function testMergeOrAppendExpectMerge()
 	{
 		$parser = $this->parser();
@@ -174,9 +147,6 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
 	public function testMergeOrAppendExpectAppend()
 	{
 		$parser = $this->parser();
@@ -211,9 +181,6 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
 	public function testMergeOrAppendWithoutBlocks()
 	{
 		$parser = $this->parser();
@@ -237,9 +204,6 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithBlock()
 	{
 		$dom = new Dom('<p>Test</p>');
@@ -249,9 +213,6 @@ class ParsleyTest extends TestCase
 		$this->assertTrue($this->parser()->parseNode($p));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithComment()
 	{
 		$dom = new \DOMDocument();
@@ -263,9 +224,6 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->parseNode($comment));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithDoctype()
 	{
 		$dom = new \DOMDocument();
@@ -274,9 +232,6 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->parseNode($dom->doctype));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithSkippableElement()
 	{
 		$dom    = new Dom('<script src="/test.js"></script>');
@@ -286,9 +241,6 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->parseNode($script));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
 	public function testParseNodeWithText()
 	{
 		$dom = new Dom('Test');

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -4,10 +4,10 @@ namespace Kirby\Parsley\Schema;
 
 use Kirby\Parsley\Element;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema\Blocks
- */
+#[CoversClass(Blocks::class)]
 class BlocksTest extends TestCase
 {
 	public function setUp(): void
@@ -104,9 +104,6 @@ class BlocksTest extends TestCase
 		return $this->assertSame($expected, $this->schema->blockquote($element));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallback()
 	{
 		$expected = [
@@ -119,9 +116,6 @@ class BlocksTest extends TestCase
 		return $this->assertSame($expected, $this->schema->fallback('Test'));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForDomElement()
 	{
 		$dom = new Dom('<p><b>Bold</b> <i>Italic</i></p>');
@@ -143,9 +137,6 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForDomElementWithParagraphs()
 	{
 		$dom = new Dom('<div><p>A</p><p>B</p></div>');
@@ -167,17 +158,11 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForEmptyContent()
 	{
 		return $this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForInvalidContent()
 	{
 		return $this->assertNull($this->schema->fallback(''));
@@ -210,10 +195,8 @@ class BlocksTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider headingLevelProvider
-	 */
-	public function testHeadingLevel($level)
+	#[DataProvider('headingLevelProvider')]
+	public function testHeadingLevel(string $level)
 	{
 		$html = <<<HTML
 			<$level>
@@ -588,9 +571,6 @@ class BlocksTest extends TestCase
 		return $this->assertSame($expected, $this->schema->pre($element));
 	}
 
-	/**
-	 * @covers ::skip
-	 */
 	public function testSkip()
 	{
 		return $this->assertSame([

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Parsley\Schema;
 
 use Kirby\Parsley\Element;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema\Plain
- */
+#[CoversClass(Plain::class)]
 class PlainTest extends TestCase
 {
 	public function setUp(): void
@@ -15,9 +14,6 @@ class PlainTest extends TestCase
 		$this->schema = new Plain();
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallback()
 	{
 		$expected = [
@@ -30,17 +26,11 @@ class PlainTest extends TestCase
 		return $this->assertSame($expected, $this->schema->fallback('Test'));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForEmptyContent()
 	{
 		return $this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForDomElement()
 	{
 		$dom      = new Dom('<p>Test</p>');
@@ -58,33 +48,21 @@ class PlainTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallbackForInvalidContent()
 	{
 		$this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::marks
-	 */
 	public function testMarks()
 	{
 		return $this->assertSame([], $this->schema->marks());
 	}
 
-	/**
-	 * @covers ::nodes
-	 */
 	public function testNodes()
 	{
 		return $this->assertSame([], $this->schema->nodes());
 	}
 
-	/**
-	 * @covers ::skip
-	 */
 	public function testSkip()
 	{
 		return $this->assertSame([

--- a/tests/Parsley/SchemaTest.php
+++ b/tests/Parsley/SchemaTest.php
@@ -3,42 +3,29 @@
 namespace Kirby\Parsley;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema
- */
+#[CoversClass(Schema::class)]
 class SchemaTest extends TestCase
 {
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallback()
 	{
 		$schema = new Schema();
 		return $this->assertNull($schema->fallback('test'));
 	}
 
-	/**
-	 * @covers ::marks
-	 */
 	public function testMarks()
 	{
 		$schema = new Schema();
 		return $this->assertSame([], $schema->marks());
 	}
 
-	/**
-	 * @covers ::nodes
-	 */
 	public function testNodes()
 	{
 		$schema = new Schema();
 		return $this->assertSame([], $schema->nodes());
 	}
 
-	/**
-	 * @covers ::skip
-	 */
 	public function testSkip()
 	{
 		$schema = new Schema();

--- a/tests/Plugin/AssetTest.php
+++ b/tests/Plugin/AssetTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Asset
- */
+#[CoversClass(Asset::class)]
 class AssetTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
@@ -28,9 +27,6 @@ class AssetTest extends TestCase
 		touch(static::TMP . '/test-plugin/assets/test.css', 1337000000);
 	}
 
-	/**
-	 * @covers ::extension
-	 */
 	public function testExtension()
 	{
 		$asset = new Asset(
@@ -42,9 +38,6 @@ class AssetTest extends TestCase
 		$this->assertSame('css', $asset->extension());
 	}
 
-	/**
-	 * @covers ::filename
-	 */
 	public function testFilename()
 	{
 		$asset = new Asset(
@@ -56,13 +49,6 @@ class AssetTest extends TestCase
 		$this->assertSame('test.css', $asset->filename());
 	}
 
-	/**
-	 * @covers ::mediaHash
-	 * @covers ::mediaRoot
-	 * @covers ::mediaUrl
-	 * @covers ::url
-	 * @covers ::__toString
-	 */
 	public function testMedia()
 	{
 		$asset = new Asset(
@@ -78,9 +64,6 @@ class AssetTest extends TestCase
 		$this->assertSame($url, (string)$asset);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModified()
 	{
 		$asset = new Asset(
@@ -92,12 +75,6 @@ class AssetTest extends TestCase
 		$this->assertSame(1337000000, $asset->modified());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::path
-	 * @covers ::plugin
-	 * @covers ::root
-	 */
 	public function testPathRoot()
 	{
 		$asset = new Asset(
@@ -111,9 +88,6 @@ class AssetTest extends TestCase
 		$this->assertSame($root, $asset->root());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
 	public function testPublish()
 	{
 		$asset = new Asset(

--- a/tests/Plugin/AssetsTest.php
+++ b/tests/Plugin/AssetsTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Assets
- */
+#[CoversClass(Assets::class)]
 class AssetsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
@@ -41,9 +40,6 @@ class AssetsTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::clean
-	 */
 	public function testClean()
 	{
 		// create orphans
@@ -65,10 +61,6 @@ class AssetsTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::css
-	 * @covers ::js
-	 */
 	public function testCss()
 	{
 		// assets defined in plugin config
@@ -88,9 +80,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('test.js', $assets->js()->first()->path());
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		// assets defined in plugin config
@@ -149,9 +138,6 @@ class AssetsTest extends TestCase
 		$this->assertSame(static::FIXTURES . '/assets/test.css', $assets->get('test.css')->root());
 	}
 
-	/**
-	 * @covers ::plugin
-	 */
 	public function testPlugin()
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -162,9 +148,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($plugin, $assets->plugin());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve()
 	{
 		touch(static::TMP . '/site/plugins/b/foo/bar.css', 1337000000);

--- a/tests/Plugin/LicenseStatusTest.php
+++ b/tests/Plugin/LicenseStatusTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\LicenseStatus
- */
+#[CoversClass(LicenseStatus::class)]
 class LicenseStatusTest extends TestCase
 {
 	public function test__toString(): void
@@ -33,9 +32,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('active', $status->value());
 	}
 
-	/**
-	 * @covers ::dialog
-	 */
 	public function testDialog(): void
 	{
 		$status = new LicenseStatus(
@@ -48,9 +44,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($dialog, $status->dialog());
 	}
 
-	/**
-	 * @covers ::drawer
-	 */
 	public function testDrawer(): void
 	{
 		$status = new LicenseStatus(
@@ -63,9 +56,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($drawer, $status->drawer());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromInstance(): void
 	{
 		$status = LicenseStatus::from(new LicenseStatus(
@@ -78,9 +68,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('active', $status->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromNull(): void
 	{
 		$status = LicenseStatus::from(null);
@@ -89,9 +76,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('unknown', $status->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromString(): void
 	{
 		$status = LicenseStatus::from('active');
@@ -114,9 +98,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('unknown', $status->value());
 	}
 
-	/**
-	 * @covers ::icon
-	 */
 	public function testIcon(): void
 	{
 		$status = new LicenseStatus(
@@ -128,9 +109,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('check', $status->icon());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel(): void
 	{
 		$status = new LicenseStatus(
@@ -142,9 +120,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('Valid license', $status->label());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$status = new LicenseStatus(
@@ -157,9 +132,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($url, $status->link());
 	}
 
-	/**
-	 * @covers ::theme
-	 */
 	public function testTheme(): void
 	{
 		$status = new LicenseStatus(
@@ -172,9 +144,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('success', $status->theme());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray(): void
 	{
 		$status = new LicenseStatus(
@@ -194,9 +163,6 @@ class LicenseStatusTest extends TestCase
 		], $status->toArray());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue(): void
 	{
 		$status = new LicenseStatus(

--- a/tests/Plugin/LicenseTest.php
+++ b/tests/Plugin/LicenseTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\License
- */
+#[CoversClass(License::class)]
 class LicenseTest extends TestCase
 {
 	protected function plugin(): Plugin
@@ -16,9 +15,6 @@ class LicenseTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function test__toString(): void
 	{
 		$license = new License(
@@ -29,9 +25,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('Custom license', (string)$license);
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromArray(): void
 	{
 		$license = License::from($this->plugin(), [
@@ -44,9 +37,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('missing', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromClosure(): void
 	{
 		$license = License::from($this->plugin(), function ($plugin) {
@@ -61,9 +51,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('active', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromString(): void
 	{
 		$license = License::from($this->plugin(), 'Custom license');
@@ -71,9 +58,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('active', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromNull(): void
 	{
 		$license = License::from($this->plugin(), null);
@@ -81,9 +65,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('unknown', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$license = new License(
@@ -95,9 +76,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('https://getkirby.com', $license->link());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName(): void
 	{
 		$license = new License(
@@ -108,9 +86,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('Custom license', $license->name());
 	}
 
-	/**
-	 * @covers ::status
-	 */
 	public function testStatus(): void
 	{
 		$license = new License(
@@ -123,9 +98,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('missing', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray(): void
 	{
 		$license = new License(

--- a/tests/Plugin/PluginTest.php
+++ b/tests/Plugin/PluginTest.php
@@ -8,11 +8,9 @@ use Kirby\Cms\System\UpdateStatus;
 use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Plugin
- * @covers ::__construct
- */
+#[CoversClass(Plugin::class)]
 class PluginTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -56,9 +54,6 @@ class PluginTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function test__call()
 	{
 		$plugin = new Plugin(
@@ -69,9 +64,6 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->homepage());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
 	public function testAsset()
 	{
 		$root   = static::FIXTURES . '/plugin-assets';
@@ -89,9 +81,6 @@ class PluginTest extends TestCase
 		$this->assertSame($b, $plugin->asset('d.css')->root());
 	}
 
-	/**
-	 * @covers ::assets
-	 */
 	public function testAssets()
 	{
 		$root = static::FIXTURES . '/plugin-assets';
@@ -111,9 +100,6 @@ class PluginTest extends TestCase
 		$this->assertSame($root . '/a.css', $plugin->asset('c.css')->root());
 	}
 
-	/**
-	 * @covers ::authors
-	 */
 	public function testAuthors()
 	{
 		$plugin = new Plugin(
@@ -135,9 +121,6 @@ class PluginTest extends TestCase
 		$this->assertSame($authors, $plugin->authors());
 	}
 
-	/**
-	 * @covers ::authorsNames
-	 */
 	public function testAuthorsNames()
 	{
 		$plugin = new Plugin(
@@ -148,9 +131,6 @@ class PluginTest extends TestCase
 		$this->assertSame('A, B', $plugin->authorsNames());
 	}
 
-	/**
-	 * @covers ::extends
-	 */
 	public function testExtends()
 	{
 		$plugin = new Plugin(
@@ -165,18 +145,12 @@ class PluginTest extends TestCase
 		$this->assertSame($extends, $plugin->extends());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$plugin = new Plugin($id = 'abc-1234/DEF-56789');
 		$this->assertSame($id, $plugin->id());
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfo()
 	{
 		$plugin = new Plugin(
@@ -203,9 +177,6 @@ class PluginTest extends TestCase
 		$this->assertSame($authors, $plugin->info()['authors']);
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfoFromProps()
 	{
 		$plugin = new Plugin(
@@ -229,9 +200,6 @@ class PluginTest extends TestCase
 		$this->assertSame('A, B', $plugin->authorsNames());
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfoFromPropAndManifest()
 	{
 		$plugin = new Plugin(
@@ -248,9 +216,6 @@ class PluginTest extends TestCase
 		$this->assertSame('5.3.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::info
-	 */
 	public function testInfoWhenEmpty()
 	{
 		$plugin = new Plugin(
@@ -274,9 +239,6 @@ class PluginTest extends TestCase
 		$this->assertSame('mit', $plugin->license()->name());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkFromHomepage()
 	{
 		$plugin = new Plugin(
@@ -289,9 +251,6 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkFromInvalidHomepage()
 	{
 		$plugin = new Plugin(
@@ -304,9 +263,6 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkFromSupportDocs()
 	{
 		$plugin = new Plugin(
@@ -321,9 +277,6 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkFromSupportSource()
 	{
 		$plugin = new Plugin(
@@ -338,18 +291,12 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLinkWhenEmpty()
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertNull($plugin->link());
 	}
 
-	/**
-	 * @covers ::mediaRoot
-	 */
 	public function testMediaRoot()
 	{
 		$this->app->clone([
@@ -363,9 +310,6 @@ class PluginTest extends TestCase
 		$this->assertSame($media . '/plugins/getkirby/test-plugin', $plugin->mediaRoot());
 	}
 
-	/**
-	 * @covers ::mediaUrl
-	 */
 	public function testMediaUrl()
 	{
 		$this->app->clone([
@@ -379,9 +323,6 @@ class PluginTest extends TestCase
 		$this->assertSame('/media/plugins/getkirby/test-plugin', $plugin->mediaUrl());
 	}
 
-	/**
-	 * @covers ::manifest
-	 */
 	public function testManifest()
 	{
 		$plugin = new Plugin(
@@ -392,29 +333,18 @@ class PluginTest extends TestCase
 		$this->assertSame(__DIR__ . '/composer.json', $plugin->manifest());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::validateName
-	 */
 	public function testName()
 	{
 		$plugin = new Plugin($name = 'abc-1234/DEF-56789');
 		$this->assertSame($name, $plugin->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::validateName
-	 */
 	public function testNameWithInvalidInput()
 	{
 		$this->expectException(InvalidArgumentException::class);
 		new Plugin('äöü/!!!');
 	}
 
-	/**
-	 * @covers ::option
-	 */
 	public function testOption()
 	{
 		App::plugin(
@@ -432,27 +362,18 @@ class PluginTest extends TestCase
 		$this->assertSame('bar', $app->option('developer.plugin.foo'));
 	}
 
-	/**
-	 * @covers ::prefix
-	 */
 	public function testPrefix()
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertSame('getkirby.test-plugin', $plugin->prefix());
 	}
 
-	/**
-	 * @covers ::root
-	 */
 	public function testRoot()
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertSame(__DIR__, $plugin->root());
 	}
 
-	/**
-	 * @covers ::root
-	 */
 	public function testRootWithCustomSetup()
 	{
 		$plugin = new Plugin(
@@ -463,9 +384,6 @@ class PluginTest extends TestCase
 		$this->assertSame($custom, $plugin->root());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$plugin = new Plugin(
@@ -501,9 +419,6 @@ class PluginTest extends TestCase
 		$this->assertSame($expected, $plugin->toArray());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatus()
 	{
 		$plugin = new Plugin(
@@ -524,9 +439,6 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusWithPrefix()
 	{
 		$plugin = new Plugin(
@@ -547,9 +459,6 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusWithoutVersion()
 	{
 		$plugin = new Plugin(
@@ -572,9 +481,6 @@ class PluginTest extends TestCase
 		$this->assertSame([], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusUnknownPlugin()
 	{
 		$plugin = new Plugin(
@@ -600,9 +506,6 @@ class PluginTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled1()
 	{
 		$this->app->clone([
@@ -622,9 +525,6 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled2()
 	{
 		$this->app->clone([
@@ -650,9 +550,6 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled3()
 	{
 		$this->app->clone([
@@ -671,9 +568,6 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusDisabled4()
 	{
 		// the plugin update check does not support the
@@ -696,9 +590,6 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusNoCustomConfig()
 	{
 		$this->app->clone([
@@ -729,9 +620,6 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
 	public function testUpdateStatusCustomData()
 	{
 		$plugin = new Plugin(
@@ -768,9 +656,6 @@ class PluginTest extends TestCase
 		$this->assertSame('https://other-domain.com/releases/87654', $updateStatus->url());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersion()
 	{
 		$plugin = new Plugin(
@@ -781,9 +666,6 @@ class PluginTest extends TestCase
 		$this->assertSame('1.0.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionFromArgument()
 	{
 		$plugin = new Plugin(
@@ -795,9 +677,6 @@ class PluginTest extends TestCase
 		$this->assertSame('1.2.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionFromInfo()
 	{
 		$plugin = new Plugin(
@@ -811,9 +690,6 @@ class PluginTest extends TestCase
 		$this->assertSame('1.1.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionMissing()
 	{
 		$plugin = new Plugin(
@@ -824,9 +700,6 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionPrefixed()
 	{
 		$plugin = new Plugin(
@@ -837,9 +710,6 @@ class PluginTest extends TestCase
 		$this->assertSame('1.0.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionInvalid()
 	{
 		$plugin = new Plugin(
@@ -850,9 +720,6 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionComposer()
 	{
 		$plugin = new Plugin(
@@ -863,9 +730,6 @@ class PluginTest extends TestCase
 		$this->assertSame('5.2.3', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionComposerNoVersionSet()
 	{
 		$plugin = new Plugin(
@@ -876,9 +740,6 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
 	public function testVersionComposerOverride()
 	{
 		$plugin = new Plugin(

--- a/tests/Query/ArgumentTest.php
+++ b/tests/Query/ArgumentTest.php
@@ -4,16 +4,11 @@ namespace Kirby\Query;
 
 use Closure;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Query\Argument
- */
+#[CoversClass(Argument::class)]
 class ArgumentTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		// strings
@@ -63,9 +58,6 @@ class ArgumentTest extends TestCase
 		$this->assertSame('foo', $argument->value);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve()
 	{
 		// strings
@@ -81,10 +73,6 @@ class ArgumentTest extends TestCase
 		$this->assertSame('bar', $argument);
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::resolve
-	 */
 	public function testWithClosure()
 	{
 		$argument = Argument::factory('() => site.children');

--- a/tests/Query/ArgumentsTest.php
+++ b/tests/Query/ArgumentsTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Query;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Query\Arguments
- */
+#[CoversClass(Arguments::class)]
 class ArgumentsTest extends TestCase
 {
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$arguments = Arguments::factory('1, 2, 3');
@@ -30,9 +26,6 @@ class ArgumentsTest extends TestCase
 		$this->assertCount(3, $arguments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve()
 	{
 		$arguments = Arguments::factory('1, 2.3, 3');

--- a/tests/Query/ExpressionTest.php
+++ b/tests/Query/ExpressionTest.php
@@ -4,16 +4,12 @@ namespace Kirby\Query;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Query\Expression
- */
+#[CoversClass(Expression::class)]
 class ExpressionTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$expression = Expression::factory('a ? b : c');
@@ -25,9 +21,6 @@ class ExpressionTest extends TestCase
 		$this->assertInstanceOf(Argument::class, $expression->parts[4]);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactoryWithoutComparison()
 	{
 		$expression = Expression::factory('foo.bar(true).url');
@@ -72,10 +65,7 @@ class ExpressionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
+	#[DataProvider('parseProvider')]
 	public function testParse(string $expression, array $result)
 	{
 		$parts = Expression::parse($expression);
@@ -96,19 +86,13 @@ class ExpressionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider resolveProvider
-	 */
+	#[DataProvider('resolveProvider')]
 	public function testResolve(string $input, mixed $result)
 	{
 		$expression = Expression::factory($input);
 		$this->assertSame($result, $expression->resolve());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObject()
 	{
 		$expression = Expression::factory('user.isYello(true) ? user.says("me") : "you"');
@@ -116,9 +100,6 @@ class ExpressionTest extends TestCase
 		$this->assertSame('me', $expression->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveIncompleteTernary()
 	{
 		$expression = Expression::factory('"a" ? "b"');

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -4,34 +4,23 @@ namespace Kirby\Query;
 
 use Closure;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Query\Query
- */
+#[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$query = Query::factory(' user.me ');
 		$this->assertSame('user.me', $query->query);
 	}
 
-	/**
-	 * @covers ::intercept
-	 */
 	public function testIntercept()
 	{
 		$query = new Query('kirby');
 		$this->assertSame('foo', $query->intercept('foo'));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve()
 	{
 		$query = new Query("user.self.likes(['(', ')']).self.drink");
@@ -39,9 +28,6 @@ class QueryTest extends TestCase
 		$this->assertSame(['gin', 'tonic', 'cucumber'], $query->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithEmptyQuery()
 	{
 		$query = new Query('');
@@ -49,9 +35,6 @@ class QueryTest extends TestCase
 		$this->assertSame($data, $query->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithComparisonExpresion()
 	{
 		$query = new Query('user.nothing ?? (user.nothing ?? user.isYello(false)) ? user.says("error") : (user.nothing ?? user.says("success"))');
@@ -59,9 +42,6 @@ class QueryTest extends TestCase
 		$this->assertSame('success', $query->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithExactArrayMatch()
 	{
 		$query = new Query('user');
@@ -74,9 +54,6 @@ class QueryTest extends TestCase
 		$this->assertSame('homer', $query->resolve(['user.callback' => fn () => 'homer']));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithClosureArgument()
 	{
 		$query = new Query('foo.bar(() => foo.homer)');

--- a/tests/Query/SegmentTest.php
+++ b/tests/Query/SegmentTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class MyObj
@@ -34,9 +36,7 @@ class MyGetObj
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Query\Segment
- */
+#[CoversClass(Segment::class)]
 class SegmentTest extends TestCase
 {
 	public static function scalarProvider(): array
@@ -51,11 +51,8 @@ class SegmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::error
-	 * @dataProvider scalarProvider
-	 */
-	public function testErrorWithScalars($scalar, $label)
+	#[DataProvider('scalarProvider')]
+	public function testErrorWithScalars(string|int|float|bool|null $scalar, string $label)
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method "foo" on ' . $label);
@@ -63,9 +60,6 @@ class SegmentTest extends TestCase
 		Segment::error($scalar, 'foo', 'method');
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testErrorWithObject()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -74,10 +68,6 @@ class SegmentTest extends TestCase
 		Segment::error(new stdClass(), 'foo', 'method');
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$segment = Segment::factory('foo');
@@ -93,9 +83,6 @@ class SegmentTest extends TestCase
 		$this->assertCount(2, $segment->arguments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveFirst()
 	{
 		// without parameters
@@ -107,10 +94,6 @@ class SegmentTest extends TestCase
 		$this->assertSame('2bar', $segment->resolve(null, ['foo' => fn (int $a, string $b) => $a . $b]));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
 	public function testResolveFirstWithDataObject()
 	{
 		$obj      = new stdClass();
@@ -120,10 +103,6 @@ class SegmentTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
 	public function testResolveArray()
 	{
 		$segment = Segment::factory('foo', 1);
@@ -131,10 +110,6 @@ class SegmentTest extends TestCase
 		$this->assertSame($expected, $segment->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
 	public function testResolveArrayClosure()
 	{
 		$segment = Segment::factory('foo', 0);
@@ -142,10 +117,6 @@ class SegmentTest extends TestCase
 		$this->assertSame('bar', $segment->resolve(null, $data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
 	public function testResolveArrayInvalidKey()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -155,10 +126,6 @@ class SegmentTest extends TestCase
 		$segment->resolve(['bar' => 2]);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
 	public function testResolveArrayArgOnNonClosure()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -168,20 +135,12 @@ class SegmentTest extends TestCase
 		$segment->resolve(['foo' => 'bar']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveArray
-	 */
 	public function testResolveArrayFromGlobalEntry()
 	{
 		$segment = Segment::factory('kirby');
 		$this->assertSame(App::instance(), $segment->resolve(null, []));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
 	public function testResolveObject()
 	{
 		$obj     = new MyObj();
@@ -201,10 +160,6 @@ class SegmentTest extends TestCase
 		$this->assertSame('simpson', $segment->resolve($obj));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
 	public function testResolveObjectInvalid()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -214,10 +169,6 @@ class SegmentTest extends TestCase
 		$segment->resolve('bar');
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
 	public function testResolveObjectInvalidMethod()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -228,10 +179,6 @@ class SegmentTest extends TestCase
 		$segment->resolve($obj);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveObject
-	 */
 	public function testResolveObjectMethodWithoutArgs()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -242,9 +189,6 @@ class SegmentTest extends TestCase
 		$segment->resolve($obj);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayNullValueError()
 	{
 		$this->expectException(BadMethodCallException::class);

--- a/tests/Query/SegmentsTest.php
+++ b/tests/Query/SegmentsTest.php
@@ -5,17 +5,13 @@ namespace Kirby\Query;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Query\Segments
- */
+#[CoversClass(Segments::class)]
 class SegmentsTest extends TestCase
 {
-	/**
-	 * @covers ::factory
-	 * @covers ::__construct
-	 */
 	public function testFactory()
 	{
 		$segments = Segments::factory('a.b.c');
@@ -54,19 +50,13 @@ class SegmentsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
+	#[DataProvider('parseProvider')]
 	public function testParse(string $string, array $result)
 	{
 		$segments = Segments::parse($string);
 		$this->assertSame($result, $segments);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveNestedArray1Level()
 	{
 		$segments = Segments::factory('user.username');
@@ -79,9 +69,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveNestedNumericKeys()
 	{
 		$segments = Segments::factory('user.0');
@@ -98,9 +85,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('marge', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveNestedArrayWithNumericMethods()
 	{
 		$segments = Segments::factory('user0.profiles1.mastodon');
@@ -115,9 +99,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('@homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveNestedArray2Levels()
 	{
 		$segments = Segments::factory('user.profiles.mastodon');
@@ -143,22 +124,16 @@ class SegmentsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValue($scalar)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValue(string|int|float|bool $scalar)
 	{
 		$segments = Segments::factory('value');
 		$data     = ['value' => $scalar];
 		$this->assertSame($scalar, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValue2Level($scalar)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValue2Level(string|int|float|bool $scalar)
 	{
 		$segments = Segments::factory('parent.value');
 		$data     =  [
@@ -169,11 +144,8 @@ class SegmentsTest extends TestCase
 		$this->assertSame($scalar, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @dataProvider scalarProvider
-	 */
-	public function testResolveWithArrayScalarValueError($scalar, $type)
+	#[DataProvider('scalarProvider')]
+	public function testResolveWithArrayScalarValueError(string|int|float|bool $scalar, string $type)
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Access to method/property "method" on ' . $type);
@@ -183,9 +155,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayNullValue()
 	{
 		$segments = Segments::factory('value');
@@ -193,9 +162,6 @@ class SegmentsTest extends TestCase
 		$this->assertNull($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayNullValueError()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -206,9 +172,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayCallClosure()
 	{
 		$segments = Segments::factory('closure("test")');
@@ -216,9 +179,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('TEST', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayCallError()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -229,9 +189,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayMissingKey1()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -241,9 +198,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve();
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithArrayMissingKey2()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -253,9 +207,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve();
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObject1Level()
 	{
 		$segments = Segments::factory('user.username');
@@ -263,9 +214,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function tesResolvetWithObject2Level()
 	{
 		$segments = Segments::factory('user.profiles.mastodon');
@@ -273,9 +221,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('@homer', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectProperty()
 	{
 		$obj = new stdClass();
@@ -284,9 +229,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('testtest', $segments->resolve(compact('obj')));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectPropertyCallError()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -298,9 +240,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve(compact('obj'));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithInteger()
 	{
 		$segments = Segments::factory('user.age(12)');
@@ -308,9 +247,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame(12, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithBoolean()
 	{
 		// true
@@ -324,9 +260,6 @@ class SegmentsTest extends TestCase
 		$this->assertFalse($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithNull()
 	{
 		$segments = Segments::factory('user.brainDump(null)');
@@ -334,9 +267,6 @@ class SegmentsTest extends TestCase
 		$this->assertNull($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithString()
 	{
 		// double quotes
@@ -350,9 +280,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello world', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithEmptyString()
 	{
 		// double quotes
@@ -366,9 +293,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithStringEscape()
 	{
 		// double quotes
@@ -382,9 +306,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame("hello ' world", $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithMultipleArguments()
 	{
 		$segments = Segments::factory('user.says("hello", "world")');
@@ -402,9 +323,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello\' : world"', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithMultipleArgumentsAndComma()
 	{
 		$segments = Segments::factory('user.says("hello,", "world")');
@@ -417,9 +335,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello," : world', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithMultipleArgumentsAndDot()
 	{
 		$segments = Segments::factory('user.says("I like", "love.jpg")');
@@ -432,9 +347,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('I " like : love."jpg', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithTrickyCharacters()
 	{
 		$segments = Segments::factory("user.likes(['(', ',', ']', '[', ')']).self.brainDump('hello')");
@@ -442,9 +354,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame('hello', $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithArray()
 	{
 		$segments = Segments::factory('user.self.check("gin", "tonic", ["gin", "tonic", "cucumber"])');
@@ -452,9 +361,6 @@ class SegmentsTest extends TestCase
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithObjectMethodAsParameter()
 	{
 		$segments = Segments::factory('user.self.check("gin", "tonic", user.drink)');
@@ -462,9 +368,6 @@ class SegmentsTest extends TestCase
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithNestedMethodCall()
 	{
 		$segments = Segments::factory('user.check("gin", "tonic", user.array("gin", "tonic").args)');
@@ -472,9 +375,6 @@ class SegmentsTest extends TestCase
 		$this->assertTrue($segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMethodWithObjectMethodAsParameterAndMoreLevels()
 	{
 		$segments = Segments::factory("user.likes([',']).likes(user.brainDump(['(', ',', ']', ')', '['])).self");
@@ -482,9 +382,6 @@ class SegmentsTest extends TestCase
 		$this->assertSame($user, $segments->resolve($data));
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMissingMethod1()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -495,9 +392,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithObjectMissingMethod2()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -508,9 +402,6 @@ class SegmentsTest extends TestCase
 		$segments->resolve($data);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolveWithOptionalChaining()
 	{
 		$segments = Segments::factory('user?.says("hi")');

--- a/tests/Sane/DomHandlerTest.php
+++ b/tests/Sane/DomHandlerTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Sane\DomHandler
- */
+#[CoversClass(DomHandler::class)]
 class DomHandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.DomHandler';

--- a/tests/Sane/HandlerTest.php
+++ b/tests/Sane/HandlerTest.php
@@ -4,20 +4,15 @@ namespace Kirby\Sane;
 
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Sane\Handler
- */
+#[CoversClass(Handler::class)]
 class HandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Handler';
 
 	protected static string $type = 'sane';
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::readFile
-	 */
 	public function testSanitizeFile()
 	{
 		$expected = $this->fixture('doctype-valid.svg');
@@ -42,10 +37,6 @@ class HandlerTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::readFile
-	 */
 	public function testSanitizeFileMissing()
 	{
 		$file = $this->fixture('does-not-exist.svg');
@@ -56,10 +47,6 @@ class HandlerTest extends TestCase
 		CustomHandler::sanitizeFile($file);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
 	public function testValidateFile()
 	{
 		$this->assertNull(
@@ -67,10 +54,6 @@ class HandlerTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
 	public function testValidateFileError()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -79,10 +62,6 @@ class HandlerTest extends TestCase
 		CustomHandler::validateFile($this->fixture('external-source-1.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
 	public function testValidateFileErrorExternalFile()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -91,10 +70,6 @@ class HandlerTest extends TestCase
 		CustomHandler::validateFile($this->fixture('xlink-subfolder.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
 	public function testValidateFileMissing()
 	{
 		$file = $this->fixture('does-not-exist.svg');

--- a/tests/Sane/HtmlTest.php
+++ b/tests/Sane/HtmlTest.php
@@ -3,20 +3,20 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @covers \Kirby\Sane\Html
  * @todo Add more tests from DOMPurify and the other test classes
  */
+#[CoversClass(Html::class)]
 class HtmlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Html';
 
 	protected static string $type = 'html';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
+	#[DataProvider('allowedProvider')]
 	public function testAllowed(string $file)
 	{
 		$fixture = $this->fixture($file);

--- a/tests/Sane/SaneTest.php
+++ b/tests/Sane/SaneTest.php
@@ -6,37 +6,27 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Sane\Sane
- */
+#[CoversClass(Sane::class)]
 class SaneTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Sane';
 
 	protected static string $type = 'sane';
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testCustomAlias()
 	{
 		Sane::$aliases['scalable'] = 'svg';
 		$this->assertInstanceOf(Svg::class, Sane::handler('scalable'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testCustomHandler()
 	{
 		Sane::$handlers['test'] = CustomHandler::class;
 		$this->assertInstanceOf(CustomHandler::class, Sane::handler('test'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testDefaultHandlers()
 	{
 		$this->assertInstanceOf(Html::class, Sane::handler('html'));
@@ -54,9 +44,6 @@ class SaneTest extends TestCase
 		$this->assertInstanceOf(Svg::class, Sane::handler('svG', true));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testDefaultAliases()
 	{
 		$this->assertInstanceOf(Html::class, Sane::handler('text/html'));
@@ -65,9 +52,6 @@ class SaneTest extends TestCase
 		$this->assertInstanceOf(Xml::class, Sane::handler('text/xml'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testMissingHandler()
 	{
 		$this->expectException(NotFoundException::class);
@@ -76,17 +60,11 @@ class SaneTest extends TestCase
 		Sane::handler('foo');
 	}
 
-	/**
-	 * @covers ::handler
-	 */
 	public function testMissingHandlerLazy()
 	{
 		$this->assertNull(Sane::handler('foo', true));
 	}
 
-	/**
-	 * @covers ::sanitize
-	 */
 	public function testSanitize()
 	{
 		$this->assertSame('<svg><path d="123"/></svg>', Sane::sanitize('<svg><path d="123" onclick="alert(1)"></path></svg>', 'svg'));
@@ -96,10 +74,6 @@ class SaneTest extends TestCase
 		$this->assertSame('<svg><a>Very malicious</a></svg>', Sane::sanitize($string, 'svg', isExternal: true));
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
 	public function testSanitizeFile()
 	{
 		$expected = $this->fixture('doctype-valid.svg');
@@ -124,9 +98,6 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 */
 	public function testSanitizeFileExplicitHandler()
 	{
 		$expected = $this->fixture('doctype-valid.svg');
@@ -144,10 +115,6 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
 	public function testSanitizeFileLazyHandler()
 	{
 		$this->assertNull(
@@ -155,10 +122,6 @@ class SaneTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
 	public function testSanitizeFileMultipleHandlers()
 	{
 		$fixture = $this->fixture('script-2.xml', true);
@@ -169,9 +132,6 @@ class SaneTest extends TestCase
 		Sane::sanitizeFile($fixture);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 */
 	public function testSanitizeFileMultipleHandlersExplicit()
 	{
 		$expected = $this->fixture('script-2.sanitized.xml');
@@ -181,17 +141,11 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidate()
 	{
 		$this->assertNull(Sane::validate('<svg></svg>', 'svg'));
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateError()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -200,9 +154,6 @@ class SaneTest extends TestCase
 		Sane::validate('<html></html>', 'svg');
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateMissingHandler()
 	{
 		$this->expectException(NotFoundException::class);
@@ -211,10 +162,6 @@ class SaneTest extends TestCase
 		Sane::validate('foo', 'foo');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFile()
 	{
 		$file = $this->fixture('doctype-valid.svg');
@@ -223,9 +170,6 @@ class SaneTest extends TestCase
 		$this->assertNull(Sane::validateFile($file, 'svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
 	public function testValidateFileError()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -234,9 +178,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('external-source-1.svg'), 'svg');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
 	public function testValidateFileErrorExternalFile()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -245,10 +186,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('xlink-subfolder.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMime1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -257,10 +194,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('script-1.xml'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMime2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -269,19 +202,11 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('script-2.xml'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMime3()
 	{
 		$this->assertNull(Sane::validateFile($this->fixture('compressed.svgz'), true));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMime4()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -290,10 +215,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('doctype-entity-attack.svgz'), true);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMissing()
 	{
 		$file = $this->fixture('does-not-exist.svg');
@@ -304,9 +225,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($file);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
 	public function testValidateFileMissingHandler1()
 	{
 		$this->expectException(NotFoundException::class);
@@ -315,10 +233,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('doctype-valid.svg'), 'foo');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMissingHandler2()
 	{
 		$this->expectException(NotFoundException::class);
@@ -327,10 +241,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('unknown.xyz'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMissingHandler3()
 	{
 		$this->expectException(NotFoundException::class);
@@ -339,10 +249,6 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('unknown.xyz'), false);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
 	public function testValidateFileMissingHandler4()
 	{
 		$this->assertNull(Sane::validateFile($this->fixture('unknown.xyz'), true));

--- a/tests/Sane/SvgTest.php
+++ b/tests/Sane/SvgTest.php
@@ -3,19 +3,17 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Svg
- */
+#[CoversClass(Svg::class)]
 class SvgTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Svg';
 
 	protected static string $type = 'svg';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
+	#[DataProvider('allowedProvider')]
 	public function testAllowed(string $file)
 	{
 		$fixture = $this->fixture($file);
@@ -50,9 +48,7 @@ class SvgTest extends TestCase
 		$this->assertSame($cleaned, Svg::sanitize($fixture));
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
+	#[DataProvider('invalidProvider')]
 	public function testInvalid(string $file)
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -130,6 +126,7 @@ class SvgTest extends TestCase
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The namespace "https://malicious.com/script.php" is not allowed (around line 1)');
+
 		Svg::validateFile($fixture);
 	}
 
@@ -142,6 +139,7 @@ class SvgTest extends TestCase
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The namespace "https://malicious.com/script.php" is not allowed (around line 1)');
+
 		Svg::validateFile($fixture);
 	}
 

--- a/tests/Sane/SvgzTest.php
+++ b/tests/Sane/SvgzTest.php
@@ -3,19 +3,17 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Svgz
- */
+#[CoversClass(Svgz::class)]
 class SvgzTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Svgz';
 
 	protected static string $type = 'svgz';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
+	#[DataProvider('allowedProvider')]
 	public function testAllowed(string $file)
 	{
 		$fixture = $this->fixture($file);
@@ -35,9 +33,7 @@ class SvgzTest extends TestCase
 		return static::fixtureList('allowed', 'svgz');
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
+	#[DataProvider('invalidProvider')]
 	public function testInvalid(string $file)
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Sane/XmlTest.php
+++ b/tests/Sane/XmlTest.php
@@ -3,10 +3,10 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Xml
- */
+#[CoversClass(Xml::class)]
 class XmlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Xml';
@@ -18,9 +18,7 @@ class XmlTest extends TestCase
 		Xml::$allowedDomains = true;
 	}
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
+	#[DataProvider('allowedProvider')]
 	public function testAllowed(string $file)
 	{
 		$fixture = $this->fixture($file);
@@ -48,9 +46,7 @@ class XmlTest extends TestCase
 		$this->assertStringEqualsFile($fixture, $sanitized);
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
+	#[DataProvider('invalidProvider')]
 	public function testInvalid(string $file)
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -201,7 +197,6 @@ class XmlTest extends TestCase
 	{
 		$fixture   = $this->fixture('disallowed/namespace-xhtml-1.xml');
 		$sanitized = $this->fixture('sanitized/namespace-xhtml-1.xml');
-
 		$this->assertStringEqualsFile($sanitized, Xml::sanitize(file_get_contents($fixture)));
 
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -5,11 +5,10 @@ namespace Kirby\Session;
 use Kirby\Cms\App;
 use Kirby\Http\Cookie;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\AutoSession
- */
+#[CoversClass(AutoSession::class)]
 class AutoSessionTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/store';
@@ -29,9 +28,6 @@ class AutoSessionTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSessionsOptions()
 	{
 		$autoSessionReflector = new ReflectionClass(AutoSession::class);
@@ -68,9 +64,6 @@ class AutoSessionTest extends TestCase
 		$this->assertFalse($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
@@ -229,9 +222,6 @@ class AutoSessionTest extends TestCase
 		$session->commit();
 	}
 
-	/**
-	 * @covers ::createManually
-	 */
 	public function testCreateManually()
 	{
 		$autoSession = new AutoSession($this->store);
@@ -242,9 +232,6 @@ class AutoSessionTest extends TestCase
 		$this->assertSame('manual', $session->mode());
 	}
 
-	/**
-	 * @covers ::getManually
-	 */
 	public function testGetManually()
 	{
 		$autoSession = new AutoSession($this->store);
@@ -254,9 +241,6 @@ class AutoSessionTest extends TestCase
 		$this->assertSame('9999999999.valid.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
 	public function testCollectGarbage()
 	{
 		$this->store->collectedGarbage = false;

--- a/tests/Session/FileSessionStoreTest.php
+++ b/tests/Session/FileSessionStoreTest.php
@@ -8,12 +8,11 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Session\FileSessionStore
- */
+#[CoversClass(FileSessionStore::class)]
 class FileSessionStoreTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Session.FileSessionStore';
@@ -60,9 +59,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorNotWritable()
 	{
 		$this->expectException(Exception::class);
@@ -74,11 +70,6 @@ class FileSessionStoreTest extends TestCase
 		new FileSessionStore(static::TMP);
 	}
 
-	/**
-	 * @covers ::createId
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testCreateId()
 	{
 		$id = $this->store->createId(1234567890);
@@ -90,11 +81,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertLocked('1234567890.' . $id);
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testExists()
 	{
 		$this->assertTrue($this->store->exists(1234567890, 'abcdefghijabcdefghij'));
@@ -111,11 +97,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleNotExists('9999999999.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::lock
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testLock()
 	{
 		$this->store->lock(1234567890, 'abcdefghijabcdefghij');
@@ -128,11 +109,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::lock
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testLockNonExistingFile()
 	{
 		$this->expectException(NotFoundException::class);
@@ -141,11 +117,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->lock(1234567890, 'someotherid');
 	}
 
-	/**
-	 * @covers ::unlock
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testUnlock()
 	{
 		// unlock an unlocked file
@@ -171,11 +142,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertNotLocked('1357913579.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testGet()
 	{
 		$this->assertSame('1234567890', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
@@ -184,11 +150,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertSame('', $this->store->get(8888888888, 'abcdefghijabcdefghij'));
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testGetNonExistingFile()
 	{
 		$this->expectException(NotFoundException::class);
@@ -197,12 +158,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->get(1234567890, 'someotherid');
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::handle
-	 */
 	public function testGetUnreadableFile()
 	{
 		$this->expectException(Exception::class);
@@ -213,11 +168,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->get(1234567890, 'abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testSet()
 	{
 		$this->assertSame('1234567890', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
@@ -231,11 +181,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertSame('some other data', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testSetNonExistingFile()
 	{
 		$this->expectException(NotFoundException::class);
@@ -244,11 +189,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'someotherid', 'some other data');
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testSetWithoutLock()
 	{
 		$this->expectException(LogicException::class);
@@ -259,12 +199,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'abcdefghijabcdefghij', 'some other data');
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::closeHandle
-	 */
 	public function testDestroy()
 	{
 		$this->assertFileExists(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
@@ -278,12 +212,6 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleNotExists('1234567890.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::closeHandle
-	 */
 	public function testDestroyAlreadyDestroyed()
 	{
 		// make sure we get a handle
@@ -297,11 +225,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->destroy(1234567890, 'abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::handle
-	 * @covers ::name
-	 * @covers ::path
-	 */
 	public function testAccessAfterDestroy()
 	{
 		$this->expectException(NotFoundException::class);
@@ -319,9 +242,6 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'abcdefghijabcdefghij', 'something else');
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
 	public function testCollectGarbage()
 	{
 		$this->assertFileExists(static::TMP . '/.gitignore');

--- a/tests/Session/SessionDataTest.php
+++ b/tests/Session/SessionDataTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Session;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\SessionData
- */
+#[CoversClass(SessionData::class)]
 class SessionDataTest extends TestCase
 {
 	protected Session $session;
@@ -27,9 +26,6 @@ class SessionDataTest extends TestCase
 		unset($this->session, $this->sessionData);
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSet()
 	{
 		// string as key
@@ -60,9 +56,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame('someValue2', $this->sessionData->get('someKey2'));
 	}
 
-	/**
-	 * @covers ::increment
-	 */
 	public function testIncrement()
 	{
 		$this->session->ensuredToken = false;
@@ -88,9 +81,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame(155, $this->sessionData->get('someInt'));
 	}
 
-	/**
-	 * @covers ::increment
-	 */
 	public function testIncrementNonIntValue()
 	{
 		$this->expectException(LogicException::class);
@@ -99,9 +89,6 @@ class SessionDataTest extends TestCase
 		$this->sessionData->increment('someString', 10);
 	}
 
-	/**
-	 * @covers ::decrement
-	 */
 	public function testDecrement()
 	{
 		$this->session->ensuredToken = false;
@@ -127,9 +114,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame(85, $this->sessionData->get('someInt'));
 	}
 
-	/**
-	 * @covers ::decrement
-	 */
 	public function testDecrementNonIntValue()
 	{
 		$this->expectException(LogicException::class);
@@ -138,9 +122,6 @@ class SessionDataTest extends TestCase
 		$this->sessionData->decrement('someString', 10);
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		// string as key
@@ -156,9 +137,6 @@ class SessionDataTest extends TestCase
 		], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::pull
-	 */
 	public function testPull()
 	{
 		$this->session->ensuredToken = false;
@@ -172,9 +150,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame('someDefault', $this->sessionData->pull('someOtherString', 'someDefault'));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemove()
 	{
 		// string as key
@@ -194,9 +169,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame([], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::clear
-	 */
 	public function testClear()
 	{
 		$this->session->ensuredToken = false;
@@ -207,9 +179,6 @@ class SessionDataTest extends TestCase
 		$this->assertSame([], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::reload
-	 */
 	public function testReload()
 	{
 		$newData = ['someOtherString' => 'someOtherValue'];

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Session;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\SessionStore
- */
+#[CoversClass(SessionStore::class)]
 class SessionStoreTest extends TestCase
 {
-	/**
-	 * @covers ::generateId
-	 */
 	public function testGenerateId()
 	{
 		// get a reference to the protected method

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -11,12 +11,11 @@ use Kirby\TestCase;
 use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\SymmetricCrypto;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Session\Session
- */
+#[CoversClass(Session::class)]
 class SessionTest extends TestCase
 {
 	protected SessionStore $store;
@@ -35,9 +34,6 @@ class SessionTest extends TestCase
 		unset($this->sessions, $this->store);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructInvalidToken()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -45,14 +41,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, 123, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 * @covers ::destroy
-	 * @covers ::ensureToken
-	 */
 	public function testCreate()
 	{
 		$reflector = new ReflectionClass(Session::class);
@@ -118,9 +106,6 @@ class SessionTest extends TestCase
 		$this->assertTrue(isset($this->store->sessions[$token[0] . '.' . $token[1]]));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testCreateInvalidExpiry()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -131,9 +116,6 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testCreateInvalidDuration()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -144,9 +126,6 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testCreateInvalidTimeout()
 	{
 		$this->expectException(TypeError::class);
@@ -156,9 +135,6 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testCreateInvalidRenewable()
 	{
 		$this->expectException(TypeError::class);
@@ -168,9 +144,6 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::mode
-	 */
 	public function testMode()
 	{
 		$session = new Session($this->sessions, null, [
@@ -182,10 +155,6 @@ class SessionTest extends TestCase
 		$this->assertSame('cookie', $session->mode());
 	}
 
-	/**
-	 * @covers ::mode
-	 * @covers ::data
-	 */
 	public function testModeStartedSession()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -199,13 +168,6 @@ class SessionTest extends TestCase
 		$session->mode('cookie');
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
 	public function testExpiryTime()
 	{
 		$session = new Session($this->sessions, null, [
@@ -231,9 +193,6 @@ class SessionTest extends TestCase
 		$this->assertNotSame($originalToken, $session->token());
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
 	public function testExpiryTimeInvalidType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -245,9 +204,6 @@ class SessionTest extends TestCase
 		$session->expiryTime(false);
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
 	public function testExpiryTimeInvalidString()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -259,9 +215,6 @@ class SessionTest extends TestCase
 		$session->expiryTime('some gibberish that is definitely no valid time');
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
 	public function testExpiryTimeInvalidTime1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -273,9 +226,6 @@ class SessionTest extends TestCase
 		$session->expiryTime(time() - 1);
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
 	public function testExpiryTimeInvalidTime2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -287,13 +237,6 @@ class SessionTest extends TestCase
 		$session->expiryTime(time());
 	}
 
-	/**
-	 * @covers ::duration
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
 	public function testDuration()
 	{
 		$session = new Session($this->sessions, null, [
@@ -314,9 +257,6 @@ class SessionTest extends TestCase
 		$this->assertNotSame($originalToken, $session->token());
 	}
 
-	/**
-	 * @covers ::duration
-	 */
 	public function testDurationInvalidTime1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -328,9 +268,6 @@ class SessionTest extends TestCase
 		$session->duration(-1);
 	}
 
-	/**
-	 * @covers ::duration
-	 */
 	public function testDurationInvalidTime2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -342,11 +279,6 @@ class SessionTest extends TestCase
 		$session->duration(0);
 	}
 
-	/**
-	 * @covers ::timeout
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 */
 	public function testTimeout()
 	{
 		$reflector = new ReflectionClass(Session::class);
@@ -371,9 +303,6 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
 	public function testTimeoutInvalidType()
 	{
 		$this->expectException(TypeError::class);
@@ -384,9 +313,6 @@ class SessionTest extends TestCase
 		$session->timeout('after an hour');
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
 	public function testTimeoutInvalidTimeout1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -397,9 +323,6 @@ class SessionTest extends TestCase
 		$session->timeout(-10);
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
 	public function testTimeoutInvalidTimeout2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -410,14 +333,6 @@ class SessionTest extends TestCase
 		$session->timeout(0);
 	}
 
-	/**
-	 * @covers ::renewable
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::autoRenew
-	 * @covers ::needsRenewal
-	 */
 	public function testRenewable()
 	{
 		$session = new Session($this->sessions, null, [
@@ -459,10 +374,6 @@ class SessionTest extends TestCase
 		$this->assertSame($newToken, $session->token());
 	}
 
-	/**
-	 * @covers ::__call
-	 * @covers ::data
-	 */
 	public function testDataMethods()
 	{
 		$session = new Session($this->sessions, null, []);
@@ -499,9 +410,6 @@ class SessionTest extends TestCase
 		$this->assertSame([], $session->get());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testInvalidMethod()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -510,11 +418,6 @@ class SessionTest extends TestCase
 		$session->someGibberish();
 	}
 
-	/**
-	 * @covers ::commit
-	 * @covers ::data
-	 * @covers ::commit
-	 */
 	public function testCommit()
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
@@ -587,12 +490,6 @@ class SessionTest extends TestCase
 		], $this->store->sessions['9999999999.valid']);
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::data
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 */
 	public function testDestroy()
 	{
 		$token = '9999999999.valid2.' . $this->store->validKey;
@@ -622,13 +519,6 @@ class SessionTest extends TestCase
 		$this->assertFalse(isset($this->store->sessions['9999999999.valid']));
 	}
 
-	/**
-	 * @covers ::renew
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
 	public function testRenew()
 	{
 		$session = new Session($this->sessions, null, [
@@ -667,9 +557,6 @@ class SessionTest extends TestCase
 		$this->assertSame($expected, $actual);
 	}
 
-	/**
-	 * @covers ::renew
-	 */
 	public function testRenewNotRenewable()
 	{
 		$this->expectException(LogicException::class);
@@ -681,11 +568,6 @@ class SessionTest extends TestCase
 		$session->renew();
 	}
 
-	/**
-	 * @covers ::regenerateToken
-	 * @covers ::token
-	 * @covers ::startTime
-	 */
 	public function testRegenerateToken()
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
@@ -733,10 +615,6 @@ class SessionTest extends TestCase
 		$this->assertSame($session, $cache->getValue($this->sessions)[$newToken]);
 	}
 
-	/**
-	 * @covers ::regenerateToken
-	 * @covers ::needsRetransmission
-	 */
 	public function testRegenerateTokenHeaderMode()
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
@@ -758,10 +636,6 @@ class SessionTest extends TestCase
 		$this->assertSame($session, $cache->getValue($this->sessions)[$newToken]);
 	}
 
-	/**
-	 * @covers ::__destruct
-	 * @covers ::data
-	 */
 	public function testDestruct()
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
@@ -776,10 +650,6 @@ class SessionTest extends TestCase
 		$this->assertSame(1, $this->store->sessions['9999999999.valid']['data']['someId']);
 	}
 
-	/**
-	 * @covers ::prepareForWriting
-	 * @covers ::data
-	 */
 	public function testPrepareForWriting()
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
@@ -802,10 +672,6 @@ class SessionTest extends TestCase
 		$this->assertSame(124, $session->data()->get('someId'));
 	}
 
-	/**
-	 * @covers ::prepareForWriting
-	 * @covers ::data
-	 */
 	public function testPrepareForWritingReadonly()
 	{
 		$this->expectException(LogicException::class);
@@ -817,10 +683,6 @@ class SessionTest extends TestCase
 		$session->data()->set('someId', 1);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 * @covers ::token
-	 */
 	public function testParseToken()
 	{
 		$reflector = new ReflectionClass(Session::class);
@@ -843,9 +705,6 @@ class SessionTest extends TestCase
 		$this->assertNull($tokenKey->getValue($session));
 	}
 
-	/**
-	 * @covers ::parseToken
-	 */
 	public function testParseTokenInvalidToken1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -854,9 +713,6 @@ class SessionTest extends TestCase
 		$session = new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 */
 	public function testParseTokenInvalidToken2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -865,10 +721,6 @@ class SessionTest extends TestCase
 		$session = new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 * @covers ::token
-	 */
 	public function testParseTokenInvalidToken3()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -883,9 +735,6 @@ class SessionTest extends TestCase
 		$parseToken->invoke($session, '1234567890.thisIsMyAwesomeId.' . $this->store->validKey, true);
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
 	public function testTimeToTimestamp()
 	{
 		$reflector = new ReflectionClass(Session::class);
@@ -899,9 +748,6 @@ class SessionTest extends TestCase
 		$this->assertSame(strtotime('tomorrow', 1357924680), $timeToTimestamp->invoke(null, 'tomorrow', 1357924680));
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
 	public function testTimeToTimestampInvalidParam()
 	{
 		$this->expectException(TypeError::class);
@@ -913,9 +759,6 @@ class SessionTest extends TestCase
 		$timeToTimestamp->invoke(null, ['tomorrow']);
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
 	public function testTimeToTimestampInvalidTimeString()
 	{
 		$this->expectException(TypeError::class);
@@ -927,15 +770,6 @@ class SessionTest extends TestCase
 		$timeToTimestamp->invoke(null, ['some gibberish that is definitely no valid time']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 * @covers ::autoRenew
-	 * @covers ::needsRenewal
-	 */
 	public function testInit()
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
@@ -950,12 +784,6 @@ class SessionTest extends TestCase
 		$this->assertSame('valid', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::data
-	 * @covers ::commit
-	 */
 	public function testInitSerializedObject()
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
@@ -981,10 +809,6 @@ class SessionTest extends TestCase
 		$this->assertFalse($obj === $session->data()->get('obj'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitNonExisting()
 	{
 		$this->expectException(NotFoundException::class);
@@ -994,10 +818,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitWrongKey()
 	{
 		$this->expectException(LogicException::class);
@@ -1007,10 +827,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitMissingKey()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -1020,10 +836,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitInvalidSerialization()
 	{
 		$this->expectException(LogicException::class);
@@ -1033,10 +845,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitInvalidStructure()
 	{
 		$this->expectException(LogicException::class);
@@ -1046,10 +854,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitExpired()
 	{
 		$this->expectException(LogicException::class);
@@ -1059,10 +863,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitNotStarted()
 	{
 		$this->expectException(LogicException::class);
@@ -1072,13 +872,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitMoved()
 	{
 		// moved session: data should be identical to the actual one
@@ -1094,13 +887,6 @@ class SessionTest extends TestCase
 		$this->assertSame('valid', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitMovedRenewal()
 	{
 		// moved session: data should be identical to the actual one
@@ -1119,10 +905,6 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(false, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitMovedManualRenewal()
 	{
 		$this->expectException(LogicException::class);
@@ -1134,12 +916,6 @@ class SessionTest extends TestCase
 		$session->renew();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitMovedRenewalWithKey()
 	{
 		if (SymmetricCrypto::isAvailable() !== true) {
@@ -1161,13 +937,6 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitTimeoutActivity()
 	{
 		// moved session: data should be identical to the actual one
@@ -1186,12 +955,6 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(false, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitTimeoutActivityWithKey()
 	{
 		if (SymmetricCrypto::isAvailable() !== true) {
@@ -1213,10 +976,6 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitMovedExpired()
 	{
 		$this->expectException(LogicException::class);
@@ -1226,10 +985,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitMovedInvalid()
 	{
 		$this->expectException(NotFoundException::class);
@@ -1239,10 +994,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitMovedWrongKey()
 	{
 		$this->expectException(LogicException::class);
@@ -1252,10 +1003,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
 	public function testInitExpiredTimeout()
 	{
 		$this->expectException(LogicException::class);
@@ -1265,13 +1012,6 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitAutoActivity1()
 	{
 		$token = '9999999999.timeoutActivity1.' . $this->store->validKey;
@@ -1291,13 +1031,6 @@ class SessionTest extends TestCase
 		$this->assertSame($session->data()->get('expectedActivity'), $activityProperty->getValue($session));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitAutoActivity2()
 	{
 		$token = '9999999999.timeoutActivity2.' . $this->store->validKey;
@@ -1319,13 +1052,6 @@ class SessionTest extends TestCase
 		$this->assertLessThan($session->data()->get('expectedActivity') + 5, $newActivity);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitAutoRenew()
 	{
 		$token = '.renewal.' . $this->store->validKey;
@@ -1343,13 +1069,6 @@ class SessionTest extends TestCase
 		$this->assertSame('renewal', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
 	public function testInitNonRenewable()
 	{
 		$token = '2000000000.nonRenewable.' . $this->store->validKey;

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -8,12 +8,11 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Cookie;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Session\Sessions
- */
+#[CoversClass(Sessions::class)]
 class SessionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/store';
@@ -35,10 +34,6 @@ class SessionsTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::store
-	 */
 	public function testConstructorStores()
 	{
 		// mock store
@@ -59,19 +54,12 @@ class SessionsTest extends TestCase
 		$this->assertSame($path, $pathProperty->getValue($sessions->store()));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorInvalidStore()
 	{
 		$this->expectException(TypeError::class);
 		new Sessions(new InvalidSessionStore());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::cookieName
-	 */
 	public function testConstructorOptions()
 	{
 		$sessions = new Sessions(static::FIXTURES, [
@@ -87,9 +75,6 @@ class SessionsTest extends TestCase
 		$this->assertSame('header', $modeProperty->getValue($sessions));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorInvalidMode()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -97,9 +82,6 @@ class SessionsTest extends TestCase
 		new Sessions(static::FIXTURES, ['mode' => 'invalid']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorInvalidCookieName()
 	{
 		$this->expectException(TypeError::class);
@@ -107,9 +89,6 @@ class SessionsTest extends TestCase
 		new Sessions(static::FIXTURES, ['cookieName' => ['foo']]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorGarbageCollector()
 	{
 		// collect garbage every time
@@ -123,9 +102,6 @@ class SessionsTest extends TestCase
 		$this->assertFalse($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructorInvalidGcInterval()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -133,9 +109,6 @@ class SessionsTest extends TestCase
 		new Sessions(static::FIXTURES, ['gcInterval' => 0]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreate()
 	{
 		$sessions = new Sessions($this->store, ['mode' => 'header']);
@@ -164,9 +137,6 @@ class SessionsTest extends TestCase
 		$this->assertFalse($session->renewable());
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		$sessions = new Sessions($this->store, ['mode' => 'header']);
@@ -184,9 +154,6 @@ class SessionsTest extends TestCase
 		$this->assertSame('someValue', $session2->data()->get('someKey'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetInvalid()
 	{
 		$this->expectException(NotFoundException::class);
@@ -195,9 +162,6 @@ class SessionsTest extends TestCase
 		$this->sessions->get('9999999999.doesNotExist.' . $this->store->validKey);
 	}
 
-	/**
-	 * @covers ::current
-	 */
 	public function testCurrent()
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
@@ -226,9 +190,6 @@ class SessionsTest extends TestCase
 		$this->assertSame('9999999999.valid2.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::current
-	 */
 	public function testCurrentManualMode()
 	{
 		$this->expectException(LogicException::class);
@@ -238,9 +199,6 @@ class SessionsTest extends TestCase
 		$sessions->current();
 	}
 
-	/**
-	 * @covers ::currentDetected
-	 */
 	public function testCurrentDetected()
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
@@ -269,9 +227,6 @@ class SessionsTest extends TestCase
 		$this->assertSame('9999999999.valid2.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
 	public function testCollectGarbage()
 	{
 		$this->store->collectedGarbage = false;
@@ -279,9 +234,6 @@ class SessionsTest extends TestCase
 		$this->assertTrue($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::updateCache
-	 */
 	public function testUpdateCache()
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
@@ -302,9 +254,6 @@ class SessionsTest extends TestCase
 		$this->assertSame($session, $cache->getValue($sessions)['9999999999.valid.new-key']);
 	}
 
-	/**
-	 * @covers ::tokenFromCookie
-	 */
 	public function testTokenFromCookie()
 	{
 		$reflector = new ReflectionClass(Sessions::class);
@@ -320,9 +269,6 @@ class SessionsTest extends TestCase
 		Cookie::remove('kirby_session');
 	}
 
-	/**
-	 * @covers ::tokenFromHeader
-	 */
 	public function testTokenFromHeader()
 	{
 		$reflector = new ReflectionClass(Sessions::class);

--- a/tests/Template/SlotTest.php
+++ b/tests/Template/SlotTest.php
@@ -3,18 +3,12 @@
 namespace Kirby\Template;
 
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Template\Slot
- */
+#[CoversClass(Slot::class)]
 class SlotTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::isOpen
-	 * @covers ::name
-	 */
 	public function testConstruct()
 	{
 		$slot = new Slot('test');
@@ -26,10 +20,6 @@ class SlotTest extends TestCase
 		$this->assertSame('', $slot->__toString());
 	}
 
-	/**
-	 * @covers ::begin
-	 * @covers ::end
-	 */
 	public function testHelpers()
 	{
 		$this->assertNull(Snippet::$current);
@@ -54,10 +44,6 @@ class SlotTest extends TestCase
 		$this->assertCount(1, $slotsProp->getValue($snippet));
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
 	public function testOpenClose()
 	{
 		// all output must be captured
@@ -77,9 +63,6 @@ class SlotTest extends TestCase
 		$this->assertSame($content, $slot->content);
 	}
 
-	/**
-	 * @covers ::close
-	 */
 	public function testCloseWhenNotOpen()
 	{
 		$slot = new Slot('test');
@@ -90,10 +73,6 @@ class SlotTest extends TestCase
 		$slot->close();
 	}
 
-	/**
-	 * @covers ::render
-	 * @covers ::__toString
-	 */
 	public function testRender()
 	{
 		// all output must be captured

--- a/tests/Template/SlotsTest.php
+++ b/tests/Template/SlotsTest.php
@@ -2,17 +2,11 @@
 
 namespace Kirby\Template;
 
-/**
- * @coversDefaultClass \Kirby\Template\Slots
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Slots::class)]
 class SlotsTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::__get
-	 * @covers ::__call
-	 * @covers ::count
-	 */
 	public function testSlots()
 	{
 		$header = new Slot('header');

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -5,18 +5,15 @@ namespace Kirby\Template;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Template\Snippet
- */
+#[CoversClass(Snippet::class)]
 class SnippetTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::close
-	 */
 	public function testCloseWhenNotOpen()
 	{
 		$snippet = new Snippet('test.php');
@@ -27,9 +24,6 @@ class SnippetTest extends TestCase
 		$snippet->close();
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		// all output must be captured
@@ -67,9 +61,6 @@ class SnippetTest extends TestCase
 		$snippet->close(); // close output buffers to reset global state
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFile()
 	{
 		App::plugin('test/d', [
@@ -90,10 +81,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('bar.php', Snippet::file('foo'));
 	}
 
-	/**
-	 * @covers ::begin
-	 * @covers ::end
-	 */
 	public function testHelpers()
 	{
 		ob_start();
@@ -107,11 +94,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('Nice', ob_get_clean());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 * @covers ::parent
-	 */
 	public function testNestedComponents()
 	{
 		$a = new Snippet(file: 'a.php');
@@ -134,10 +116,6 @@ class SnippetTest extends TestCase
 		$this->assertSame($a, $b->parent());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
 	public function testOpenCloseWithSlotsAndSwallowedDefaultContent()
 	{
 		// all output must be captured
@@ -159,10 +137,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('Default content', $slots->default()->render());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
 	public function testOpenCloseWithDefaultSlotContent()
 	{
 		// all output must be captured
@@ -187,10 +161,7 @@ class SnippetTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::render
-	 * @dataProvider renderWithSlotsProvider
-	 */
+	#[DataProvider('renderWithSlotsProvider')]
 	public function testRenderWithSlots(string|null $file, string $expected)
 	{
 		// all output must be captured
@@ -220,9 +191,6 @@ class SnippetTest extends TestCase
 		$this->assertSame($expected, $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithoutClosing()
 	{
 		// all output must be captured
@@ -235,9 +203,6 @@ class SnippetTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\ncontent<footer>with other stuff</footer>\n", $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithoutClosingAndMultipleSlots()
 	{
 		// all output must be captured
@@ -256,9 +221,6 @@ class SnippetTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\n<header>Header content</header>\n<main>Body content</main>\n", $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithLazySlots()
 	{
 		$snippet = new Snippet(static::FIXTURES . '/slots.php');
@@ -276,10 +238,6 @@ class SnippetTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::render
-	 */
 	public function testRenderWithData()
 	{
 		$snippet = new Snippet(
@@ -290,9 +248,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('hello', $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithLazyData()
 	{
 		$snippet = new Snippet(
@@ -302,9 +257,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('hello', $snippet->render(data: ['message' => 'hello']));
 	}
 
-	/**
-	 * @covers ::root
-	 */
 	public function testRoot()
 	{
 		new App([
@@ -316,9 +268,6 @@ class SnippetTest extends TestCase
 		$this->assertSame($root, Snippet::root());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
 	public function testScope()
 	{
 		$closure = function ($scope) use (&$data) {
@@ -344,9 +293,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $snippet->render());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
 	public function testScopeWithDefaultSlot()
 	{
 		$closure = function ($scope) use (&$data, &$slot) {
@@ -376,9 +322,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $snippet->render());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
 	public function testScopeWithoutSlots()
 	{
 		new App([
@@ -430,9 +373,6 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $result);
 	}
 
-	/**
-	 * @covers ::scope
-	 */
 	public function testScopeWithInvalidData()
 	{
 		new App([
@@ -452,11 +392,6 @@ class SnippetTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::slots
-	 * @covers ::slot
-	 * @covers ::endslot
-	 */
 	public function testSlots()
 	{
 		// all output must be captured

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -3,22 +3,13 @@
 namespace Kirby\Template;
 
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Template\Template
- */
+#[CoversClass(Template::class)]
 class TemplateTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::name
-	 * @covers ::type
-	 * @covers ::defaultType
-	 * @covers ::extension
-	 * @covers ::__toString
-	 */
 	public function testTemplate()
 	{
 		$template = new Template('Test', 'foo', 'bar');
@@ -30,9 +21,6 @@ class TemplateTest extends TestCase
 		$this->assertSame('php', $template->extension());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		new App([
@@ -54,9 +42,6 @@ class TemplateTest extends TestCase
 		$this->assertFalse($template->exists());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFile()
 	{
 		App::plugin('test/c', [
@@ -84,9 +69,6 @@ class TemplateTest extends TestCase
 		$this->assertSame('plugin.php', $template->file());
 	}
 
-	/**
-	 * @covers ::hasDefaultType
-	 */
 	public function testHasDefaultType()
 	{
 		$template = new Template('test');
@@ -99,10 +81,6 @@ class TemplateTest extends TestCase
 		$this->assertFalse($template->hasDefaultType());
 	}
 
-	/**
-	 * @covers ::store
-	 * @covers ::root
-	 */
 	public function testRoot()
 	{
 		new App([
@@ -116,9 +94,6 @@ class TemplateTest extends TestCase
 		$this->assertSame($root, $template->root());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		new App([
@@ -131,9 +106,6 @@ class TemplateTest extends TestCase
 		$this->assertSame('Test', $template->render(['slot' => 'Test']));
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderOpenLayoutSnippet()
 	{
 		new App([
@@ -147,9 +119,6 @@ class TemplateTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\nMy content\n<footer>with other stuff</footer>\n", $template->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderOpenParentSnippet1()
 	{
 		$app = new App([
@@ -167,9 +136,6 @@ class TemplateTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderOpenParentSnippet2()
 	{
 		$app = new App([
@@ -190,9 +156,6 @@ class TemplateTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderOpenParentSnippet3()
 	{
 		$app = new App([

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -6,10 +6,10 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Text\KirbyTag
- */
+#[CoversClass(KirbyTag::class)]
 class KirbyTagTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Text.KirbyTag';
@@ -42,9 +42,6 @@ class KirbyTagTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		KirbyTag::$aliases = [];
@@ -57,9 +54,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('foo', $tag->value);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructAliasedTagType()
 	{
 		KirbyTag::$aliases = ['foo' => 'test'];
@@ -69,9 +63,6 @@ class KirbyTagTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructMissingTagType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -79,9 +70,6 @@ class KirbyTagTest extends TestCase
 		KirbyTag::parse('invalid: test');
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function test__call()
 	{
 		$attr = [
@@ -101,9 +89,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('dataC', $tag->c());
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
 	public function test__callStatic()
 	{
 		$attr = [
@@ -115,10 +100,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: test value-attrA-attrB', $result);
 	}
 
-	/**
-	 * @covers ::__get
-	 * @covers ::attr
-	 */
 	public function testAttr()
 	{
 		$tag = new KirbyTag('test', 'test value', [
@@ -135,10 +116,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('attrB', $tag->attr('b', 'fallback'));
 	}
 
-	/**
-	 * @covers ::__get
-	 * @covers ::attr
-	 */
 	public function testAttrFallback()
 	{
 		$tag = new KirbyTag('test', 'test value', [
@@ -149,9 +126,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('fallback', $tag->attr('b', 'fallback'));
 	}
 
-	/**
-	 * @covers ::factory
-	 */
 	public function testFactory()
 	{
 		$attr = [
@@ -163,9 +137,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: test value-attrA-attrB', $result);
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFile()
 	{
 		$app = new App([
@@ -192,9 +163,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a/a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileInParent()
 	{
 		$app = new App([
@@ -223,9 +191,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileInFileParent()
 	{
 		$app = new App([
@@ -254,9 +219,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileFromUuid()
 	{
 		$app = new App([
@@ -290,9 +252,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('file://image-uuid'));
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		$app = new App([
@@ -305,9 +264,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($app, $tag->kirby());
 	}
 
-	/**
-	 * @covers ::option
-	 */
 	public function testOption()
 	{
 		$attr = [
@@ -332,9 +288,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('optionC', $tag->option('c', 'optionC'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
 	public function testParent()
 	{
 		$app = new App([
@@ -514,10 +467,7 @@ class KirbyTagTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
+	#[DataProvider('parseProvider')]
 	public function testParse(string $string, array $data, array $options, array $expected)
 	{
 		$tag = KirbyTag::parse($string, $data, $options);
@@ -526,9 +476,6 @@ class KirbyTagTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$tag = new KirbyTag('test', 'test value', [
@@ -543,9 +490,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: -attrA-', $tag->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderNoHtml()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -558,9 +502,6 @@ class KirbyTagTest extends TestCase
 		$tag->render();
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderInvalidHtml()
 	{
 		$this->expectException(BadMethodCallException::class);
@@ -573,9 +514,6 @@ class KirbyTagTest extends TestCase
 		$tag->render();
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$tag = new KirbyTag('test', 'test value');

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -8,10 +8,11 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Text\KirbyTags
- */
+#[CoversClass(KirbyTags::class)]
 class KirbyTagsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -47,9 +48,6 @@ class KirbyTagsTest extends TestCase
 		return $tests;
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParse()
 	{
 		KirbyTag::$types = [
@@ -64,9 +62,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('test', KirbyTags::parse('(tEsT: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithValue()
 	{
 		KirbyTag::$types = [
@@ -80,9 +75,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('foo', KirbyTags::parse('(TEST: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithAttribute()
 	{
 		KirbyTag::$types = [
@@ -97,9 +89,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('foo|bar', KirbyTags::parse('(TEST: foo a: bar)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithException()
 	{
 		KirbyTag::$types = [
@@ -123,9 +112,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithExceptionDebug1()
 	{
 		$this->expectException(Exception::class);
@@ -140,9 +126,6 @@ class KirbyTagsTest extends TestCase
 		KirbyTags::parse('(test: foo)', [], ['debug' => true]);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithExceptionDebug2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -157,9 +140,6 @@ class KirbyTagsTest extends TestCase
 		KirbyTags::parse('(invalidargument: foo)', [], ['debug' => true]);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithExceptionDebug3()
 	{
 		KirbyTag::$types = [
@@ -173,9 +153,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)', [], ['debug' => true]));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithBrackets()
 	{
 		KirbyTag::$types = [
@@ -203,10 +180,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(test: foo (bar)', KirbyTags::parse('(test: foo (bar)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider dataProvider
-	 */
+	#[DataProvider('dataProvider')]
 	public function testWithMarkdown($kirbytext, $expected)
 	{
 		$kirby = $this->app->clone([
@@ -220,10 +194,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider dataProvider
-	 */
+	#[DataProvider('dataProvider')]
 	public function testWithMarkdownExtra($kirbytext, $expected)
 	{
 		$kirby = $this->app->clone([
@@ -237,9 +208,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
-	/**
-	 * @coversNothing
-	 */
+	#[CoversNothing]
 	public function testHooks()
 	{
 		$app = $this->app->clone([
@@ -281,11 +250,9 @@ class KirbyTagsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @coversNothing
-	 * @dataProvider globalOptionsProvider
-	 */
-	public function testGlobalOptions($kirbytext, $expected)
+	#[CoversNothing]
+	#[DataProvider('globalOptionsProvider')]
+	public function testGlobalOptions(string $kirbytext, string $expected)
 	{
 		$kirby = $this->app->clone([
 			'options' => [

--- a/tests/Text/MarkdownTest.php
+++ b/tests/Text/MarkdownTest.php
@@ -3,17 +3,13 @@
 namespace Kirby\Text;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Text\Markdown
- */
+#[CoversClass(Markdown::class)]
 class MarkdownTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$markdown = new Markdown();
@@ -25,9 +21,6 @@ class MarkdownTest extends TestCase
 		], $markdown->defaults());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testWithOptions()
 	{
 		$markdown = new Markdown([
@@ -38,9 +31,6 @@ class MarkdownTest extends TestCase
 		$this->assertInstanceOf(Markdown::class, $markdown);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSafeModeDisabled()
 	{
 		$markdown = new Markdown([
@@ -50,9 +40,6 @@ class MarkdownTest extends TestCase
 		$this->assertSame('<div>Custom HTML</div>', $markdown->parse('<div>Custom HTML</div>'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSafeModeEnabled()
 	{
 		$markdown = new Markdown([
@@ -62,9 +49,6 @@ class MarkdownTest extends TestCase
 		$this->assertSame('<p>&lt;div&gt;Custom HTML&lt;/div&gt;</p>', $markdown->parse('<div>Custom HTML</div>'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParse()
 	{
 		$markdown = new Markdown();
@@ -73,9 +57,6 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseInline()
 	{
 		$markdown = new Markdown();
@@ -84,9 +65,6 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md, true));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithExtra()
 	{
 		$markdown = new Markdown(['extra' => true]);
@@ -95,9 +73,6 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseWithoutBreaks()
 	{
 		$markdown = new Markdown(['breaks' => false]);

--- a/tests/Text/SmartyPantsTest.php
+++ b/tests/Text/SmartyPantsTest.php
@@ -3,15 +3,11 @@
 namespace Kirby\Text;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Text\SmartyPants
- */
+#[CoversClass(SmartyPants::class)]
 class SmartyPantsTest extends TestCase
 {
-	/**
-	 * @covers ::parse
-	 */
 	public function testParse()
 	{
 		$parser   = new SmartyPants();
@@ -21,9 +17,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseEmpty()
 	{
 		$parser = new SmartyPants();
@@ -32,9 +25,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('', $parser->parse(''));
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$expected = [
@@ -71,9 +61,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame($expected, $parser->defaults());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testDoubleQuotesOption()
 	{
 		$parser = new SmartyPants([
@@ -85,9 +72,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('<test>', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSingleQuotesOption()
 	{
 		$parser = new SmartyPants([
@@ -99,9 +83,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('<test>', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testEmDashOption()
 	{
 		$parser = new SmartyPants([
@@ -112,9 +93,6 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('emdash', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testEllipsisOption()
 	{
 		$parser = new SmartyPants([

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -5,10 +5,9 @@ namespace Kirby\Toolkit;
 use Exception;
 use InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\A
- */
+#[CoversClass(A::class)]
 class ATest extends TestCase
 {
 	protected function _array(): array
@@ -20,9 +19,6 @@ class ATest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::append
-	 */
 	public function testAppend()
 	{
 		// associative
@@ -47,9 +43,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 */
 	public function testApply()
 	{
 		$array = [
@@ -76,9 +69,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, A::apply($array, 'b', 'c'));
 	}
 
-	/**
-	 * @covers ::count
-	 */
 	public function testCount()
 	{
 		$this->assertSame(3, A::count($this->_array()));
@@ -86,9 +76,6 @@ class ATest extends TestCase
 		$this->assertSame(0, A::count([]));
 	}
 
-	/**
-	 * @covers ::every
-	 */
 	public function testEvery()
 	{
 		// The value should be passed to the callback
@@ -148,9 +135,6 @@ class ATest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::find
-	 */
 	public function testFind()
 	{
 		$array = $this->_array();
@@ -218,9 +202,6 @@ class ATest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGet()
 	{
 		$array = $this->_array();
@@ -255,9 +236,6 @@ class ATest extends TestCase
 		], A::get($array, ['cat', 'elephant'], 'toot'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetWithDotNotation()
 	{
 		$data = [
@@ -294,9 +272,6 @@ class ATest extends TestCase
 		$this->assertSame('default', A::get($data, 'grand.ma.cousins.4.name', 'default'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetWithNonexistingOptions()
 	{
 		$data = [
@@ -308,9 +283,6 @@ class ATest extends TestCase
 		$this->assertSame('not great yet', A::get($data, 'alexander'));
 	}
 
-	/**
-	 * @covers ::has
-	 */
 	public function testHas()
 	{
 		$array = $this->_array();
@@ -321,9 +293,6 @@ class ATest extends TestCase
 		$this->assertFalse(A::has($array, ['miao']));
 	}
 
-	/**
-	 * @covers ::implode
-	 */
 	public function testImplode()
 	{
 		$array = ['a', 'b', 'c'];
@@ -337,9 +306,6 @@ class ATest extends TestCase
 		$this->assertSame('ABCD', A::implode($array));
 	}
 
-	/**
-	 * @covers ::map
-	 */
 	public function testMap()
 	{
 		$array = [
@@ -374,9 +340,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, A::map($array, 'Str::upper'));
 	}
 
-	/**
-	 * @covers ::merge
-	 */
 	public function testMerge()
 	{
 		// simple non-associative arrays
@@ -431,9 +394,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::merge
-	 */
 	public function testMergeMultiples()
 	{
 		// simple non-associative arrays
@@ -461,9 +421,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::merge
-	 */
 	public function testMergeModes()
 	{
 		// simple non-associative arrays
@@ -516,9 +473,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::prepend
-	 */
 	public function testPrepend()
 	{
 		// associative
@@ -540,9 +494,6 @@ class ATest extends TestCase
 		$this->assertSame(['d', 'e', 'f', 'a' => 'A', 'b' => 'B', 'c' => 'C'], $result);
 	}
 
-	/**
-	 * @covers ::pluck
-	 */
 	public function testPluck()
 	{
 		$array = [
@@ -558,9 +509,6 @@ class ATest extends TestCase
 		], A::pluck($array, 'username'));
 	}
 
-	/**
-	 * @covers ::shuffle
-	 */
 	public function testShuffle()
 	{
 		$array = $this->_array();
@@ -571,9 +519,6 @@ class ATest extends TestCase
 		$this->assertSame($array['bird'], $shuffled['bird']);
 	}
 
-	/**
-	 * @covers ::reduce
-	 */
 	public function testReduce()
 	{
 		$array = $this->_array();
@@ -592,9 +537,6 @@ class ATest extends TestCase
 		$this->assertSame(null, $reduced);
 	}
 
-	/**
-	 * @covers ::slice
-	 */
 	public function testSlice()
 	{
 		$array = $this->_array();
@@ -606,9 +548,6 @@ class ATest extends TestCase
 		$this->assertSame($array, A::slice($array, 0));
 	}
 
-	/**
-	 * @covers ::some
-	 */
 	public function testSome()
 	{
 		// The value should be passed to the callback
@@ -660,9 +599,6 @@ class ATest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::sum
-	 */
 	public function testSum()
 	{
 		$array = $this->_array();
@@ -673,25 +609,16 @@ class ATest extends TestCase
 		$this->assertSame(6.0, A::sum([1.2, 2.4, 2.4]));
 	}
 
-	/**
-	 * @covers ::first
-	 */
 	public function testFirst()
 	{
 		$this->assertSame('miao', A::first($this->_array()));
 	}
 
-	/**
-	 * @covers ::last
-	 */
 	public function testLast()
 	{
 		$this->assertSame('tweet', A::last($this->_array()));
 	}
 
-	/**
-	 * @covers ::random
-	 */
 	public function testRandom()
 	{
 		$array       = $this->_array();
@@ -717,9 +644,6 @@ class ATest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::random
-	 */
 	public function testRandomInvalidCount()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -727,9 +651,6 @@ class ATest extends TestCase
 		A::random([1, 2, 3], 4);
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		$array = [
@@ -772,9 +693,6 @@ class ATest extends TestCase
 		$this->assertSame([false, true, false], A::fill([], 3, [V::class, 'accepted']));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMove()
 	{
 		$input = [
@@ -794,9 +712,6 @@ class ATest extends TestCase
 		$this->assertSame(['b', 'a', 'c', 'd'], A::move($input, 1, 0));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithInvalidFrom()
 	{
 		$this->expectException(Exception::class);
@@ -805,9 +720,6 @@ class ATest extends TestCase
 		A::move(['a', 'b', 'c'], -1, 2);
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveWithInvalidTo()
 	{
 		$this->expectException(Exception::class);
@@ -816,9 +728,6 @@ class ATest extends TestCase
 		A::move(['a', 'b', 'c'], 0, 4);
 	}
 
-	/**
-	 * @covers ::missing
-	 */
 	public function testMissing()
 	{
 		$required = ['cat', 'elephant'];
@@ -827,9 +736,6 @@ class ATest extends TestCase
 		$this->assertSame([], A::missing($this->_array(), ['cat']));
 	}
 
-	/**
-	 * @covers ::nest
-	 */
 	public function testNest()
 	{
 		// simple example
@@ -1003,9 +909,6 @@ class ATest extends TestCase
 		$this->assertSame($expected, A::nest($input));
 	}
 
-	/**
-	 * @covers ::nestByKeys
-	 */
 	public function testNestByKeys()
 	{
 		$this->assertSame('test', A::nestByKeys('test', []));
@@ -1013,9 +916,6 @@ class ATest extends TestCase
 		$this->assertSame(['a' => ['b' => 'test']], A::nestByKeys('test', ['a', 'b']));
 	}
 
-	/**
-	 * @covers ::sort
-	 */
 	public function testSort()
 	{
 		$array = [
@@ -1060,9 +960,6 @@ class ATest extends TestCase
 		$this->assertSame(3, array_search('img12.png', array_column($natural, 'file')));
 	}
 
-	/**
-	 * @covers ::isAssociative
-	 */
 	public function testIsAssociative()
 	{
 		$yes = $this->_array();
@@ -1072,9 +969,6 @@ class ATest extends TestCase
 		$this->assertFalse(A::isAssociative($no));
 	}
 
-	/**
-	 * @covers ::average
-	 */
 	public function testAverage()
 	{
 		$array = [5, 2, 4, 7, 9.7];
@@ -1085,9 +979,6 @@ class ATest extends TestCase
 		$this->assertNull(A::average([]));
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtend()
 	{
 		// simple
@@ -1128,9 +1019,6 @@ class ATest extends TestCase
 		$this->assertSame($merged, A::extend($a, $b));
 	}
 
-	/**
-	 * @covers ::join
-	 */
 	public function testJoin()
 	{
 		$array = ['a', 'b', 'c'];
@@ -1142,9 +1030,6 @@ class ATest extends TestCase
 		$this->assertSame('a/b/c', A::join('a/b/c'));
 	}
 
-	/**
-	 * @covers ::keyBy
-	 */
 	public function testKeyBy()
 	{
 		$array = [
@@ -1182,9 +1067,6 @@ class ATest extends TestCase
 		$this->assertSame($array_by_id, A::keyBy($array_by_cb, 'id'));
 	}
 
-	/**
-	 * @covers ::keyBy
-	 */
 	public function testKeyByWithNonexistentKeys()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -1199,9 +1081,6 @@ class ATest extends TestCase
 		A::keyBy($array, 'nonexistent');
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdate()
 	{
 		$array = $this->_array();
@@ -1221,9 +1100,6 @@ class ATest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::wrap
-	 */
 	public function testWrap()
 	{
 		$result = A::wrap($expected = ['a', 'b']);
@@ -1237,9 +1113,6 @@ class ATest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::filter
-	 */
 	public function testFilter()
 	{
 		$associativeArray = $this->_array();
@@ -1267,9 +1140,6 @@ class ATest extends TestCase
 		$this->assertSame([1 => 'dog', 2 => 'bird'], $result);
 	}
 
-	/**
-	 * @covers ::without
-	 */
 	public function testWithout()
 	{
 		$associativeArray = $this->_array();

--- a/tests/Toolkit/CollectionFilterTest.php
+++ b/tests/Toolkit/CollectionFilterTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Toolkit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class MockCollectionEntry
 {
 	public function __construct(
@@ -651,10 +653,8 @@ class CollectionFilterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider filterDataProvider
-	 */
-	public function testFilter($attributes, $operator, $test, $expected, $split)
+	#[DataProvider('filterDataProvider')]
+	public function testFilter(array $attributes, string $operator, string|bool|int|float|array $test, array $expected, bool|string $split)
 	{
 		$data = [];
 

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class StringObject
 {
@@ -17,9 +18,7 @@ class StringObject
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Collection
- */
+#[CoversClass(Collection::class)]
 class CollectionTest extends TestCase
 {
 	protected Collection $collection;
@@ -42,18 +41,12 @@ class CollectionTest extends TestCase
 		$this->assertSame($this->sampleData, $this->collection->toArray());
 	}
 
-	/**
-	 * @covers ::__debuginfo
-	 */
 	public function test__debuginfo()
 	{
 		$collection = new Collection(['a' => 'A', 'b' => 'B']);
 		$this->assertSame(['a', 'b'], $collection->__debugInfo());
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function test__toString()
 	{
 		$collection = new Collection(['a' => 'A', 'b' => 'B']);
@@ -61,9 +54,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('a<br />b', (string)$collection);
 	}
 
-	/**
-	 * @covers ::append
-	 */
 	public function testAppend()
 	{
 		// simple
@@ -94,11 +84,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['A', 'B', 'C'], $collection->values());
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::set
-	 * @covers ::remove
-	 */
 	public function testCaseSensitive()
 	{
 		$normalCollection = new Collection([
@@ -143,18 +128,12 @@ class CollectionTest extends TestCase
 		$this->assertNull($sensitiveCollection->get('another'));
 	}
 
-	/**
-	 * @covers ::count
-	 */
 	public function testCount()
 	{
 		$this->assertSame(3, $this->collection->count());
 		$this->assertCount(3, $this->collection);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testData()
 	{
 		$collection = new Collection($data = ['a' => 'A', 'b' => 'B']);
@@ -164,9 +143,6 @@ class CollectionTest extends TestCase
 		$this->assertSame($data, $collection->data());
 	}
 
-	/**
-	 * @covers ::empty
-	 */
 	public function testEmpty()
 	{
 		$collection = new Collection($data = ['a' => 'A', 'b' => 'B']);
@@ -176,9 +152,6 @@ class CollectionTest extends TestCase
 		$this->assertSame([], $collection->data());
 	}
 
-	/**
-	 * @covers ::filter
-	 */
 	public function testFilter()
 	{
 		$filtered = $this->collection->filter(
@@ -191,17 +164,11 @@ class CollectionTest extends TestCase
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::first
-	 */
 	public function testFirst()
 	{
 		$this->assertSame('My first element', $this->collection->first());
 	}
 
-	/**
-	 * @covers ::flip
-	 */
 	public function testFlip()
 	{
 		$this->assertSame(array_reverse($this->sampleData, true), $this->collection->flip()->toArray());
@@ -209,9 +176,6 @@ class CollectionTest extends TestCase
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::getAttribute
-	 */
 	public function testGetAttributeFromArray()
 	{
 		$collection = new Collection([
@@ -233,9 +197,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['simpson', 'female'], $collection->getAttribute($collection->last(), 'tags', true));
 	}
 
-	/**
-	 * @covers ::getAttribute
-	 */
 	public function testGetAttributeFromObject()
 	{
 		$collection = new Collection([
@@ -251,11 +212,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('Marge', $collection->getAttribute($collection->last(), 'username'));
 	}
 
-	/**
-	 * @covers ::__get
-	 * @covers ::__call
-	 * @covers ::get
-	 */
 	public function testGetters()
 	{
 		$this->assertSame('My first element', $this->collection->first);
@@ -273,11 +229,6 @@ class CollectionTest extends TestCase
 		$this->assertNull($this->collection->get('fourth'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__get
-	 * @covers ::get
-	 */
 	public function testGettersCaseSensitive()
 	{
 		$collection = new Collection($this->sampleData, true);
@@ -286,10 +237,6 @@ class CollectionTest extends TestCase
 		$this->assertNull($collection->get('FIRst'));
 	}
 
-	/**
-	 * @covers ::group
-	 * @covers ::groupBy
-	 */
 	public function testGroup()
 	{
 		$collection = new Collection();
@@ -322,9 +269,6 @@ class CollectionTest extends TestCase
 		$this->assertCount(1, $groups->client());
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupWithInvalidKey()
 	{
 		$collection = new Collection(['a' => 'A']);
@@ -335,9 +279,6 @@ class CollectionTest extends TestCase
 		$collection->group(fn ($item) => false);
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupArray()
 	{
 		$collection = new Collection(['a' => 'A']);
@@ -348,9 +289,6 @@ class CollectionTest extends TestCase
 		$collection->group(fn ($item) => ['a' => 'b']);
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupObject()
 	{
 		$collection = new Collection(['a' => 'A']);
@@ -361,9 +299,6 @@ class CollectionTest extends TestCase
 		$collection->group(fn ($item) => new Obj(['a' => 'b']));
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupStringObject()
 	{
 		$collection = new Collection();
@@ -391,9 +326,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('peter', $firstAdmin['username']);
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupBy()
 	{
 		$collection = new Collection();
@@ -422,9 +354,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('peter', $firstAdmin['username']);
 	}
 
-	/**
-	 * @covers ::group
-	 */
 	public function testGroupByWithInvalidKey()
 	{
 		$collection = new Collection(['a' => 'A']);
@@ -435,17 +364,11 @@ class CollectionTest extends TestCase
 		$collection->group(1);
 	}
 
-	/**
-	 * @covers ::indexOf
-	 */
 	public function testIndexOf()
 	{
 		$this->assertSame(1, $this->collection->indexOf('My second element'));
 	}
 
-	/**
-	 * @covers ::intersection
-	 */
 	public function testIntersection()
 	{
 		$collection1 = new Collection([
@@ -491,9 +414,6 @@ class CollectionTest extends TestCase
 		$this->assertSame($d, $result->first());
 	}
 
-	/**
-	 * @covers ::intersects
-	 */
 	public function testIntersects()
 	{
 		$collection1 = new Collection([
@@ -526,9 +446,6 @@ class CollectionTest extends TestCase
 		$this->assertTrue($collection3->intersects($collection2));
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 */
 	public function testIsEmpty()
 	{
 		$collection = new Collection([
@@ -540,9 +457,6 @@ class CollectionTest extends TestCase
 		$this->assertFalse($collection->isEmpty());
 	}
 
-	/**
-	 * @covers ::isEven
-	 */
 	public function testIsEven()
 	{
 		$collection = new Collection(['a' => 'a']);
@@ -552,9 +466,6 @@ class CollectionTest extends TestCase
 		$this->assertTrue($collection->isEven());
 	}
 
-	/**
-	 * @covers ::isNotEmpty
-	 */
 	public function testIsNotEmpty()
 	{
 		$collection = new Collection([]);
@@ -563,9 +474,6 @@ class CollectionTest extends TestCase
 		$this->assertFalse($collection->isNotEmpty());
 	}
 
-	/**
-	 * @covers ::isOdd
-	 */
 	public function testIsOdd()
 	{
 		$collection = new Collection(['a' => 'a']);
@@ -575,42 +483,27 @@ class CollectionTest extends TestCase
 		$this->assertFalse($collection->isOdd());
 	}
 
-	/**
-	 * @covers ::__get
-	 */
 	public function testIsset()
 	{
 		$this->assertTrue(isset($this->collection->first));
 		$this->assertFalse(isset($this->collection->super));
 	}
 
-	/**
-	 * @covers ::keyOf
-	 */
 	public function testKeyOf()
 	{
 		$this->assertSame('second', $this->collection->keyOf('My second element'));
 	}
 
-	/**
-	 * @covers ::keys
-	 */
 	public function testKeys()
 	{
 		$this->assertSame(['first', 'second', 'third'], $this->collection->keys());
 	}
 
-	/**
-	 * @covers ::last
-	 */
 	public function testLast()
 	{
 		$this->assertSame('My third element', $this->collection->last());
 	}
 
-	/**
-	 * @covers ::map
-	 */
 	public function testMap()
 	{
 		$collection = new Collection(['a' => 1, 'b' => 2]);
@@ -618,10 +511,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['a' => 2, 'b' => 4], $collection->data());
 	}
 
-	/**
-	 * @covers ::next
-	 * @covers ::prev
-	 */
 	public function testNextAndPrev()
 	{
 		$this->assertSame('My second element', $this->collection->next());
@@ -629,10 +518,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('My second element', $this->collection->prev());
 	}
 
-	/**
-	 * @covers ::not
-	 * @covers ::without
-	 */
 	public function testNotAndWithout()
 	{
 		// remove elements
@@ -648,9 +533,6 @@ class CollectionTest extends TestCase
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::nth
-	 */
 	public function testNth()
 	{
 		$this->assertSame('My first element', $this->collection->nth(0));
@@ -659,10 +541,6 @@ class CollectionTest extends TestCase
 		$this->assertNull($this->collection->nth(3));
 	}
 
-	/**
-	 * @covers ::offset
-	 * @covers ::limit
-	 */
 	public function testOffsetAndLimit()
 	{
 		$this->assertSame(array_slice($this->sampleData, 1), $this->collection->offset(1)->toArray());
@@ -671,9 +549,6 @@ class CollectionTest extends TestCase
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::prepend
-	 */
 	public function testPrepend()
 	{
 		// simple
@@ -698,9 +573,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['A', 'B', 'C'], $collection->values());
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuery()
 	{
 		$collection = new Collection([
@@ -720,9 +592,6 @@ class CollectionTest extends TestCase
 		])->toArray());
 	}
 
-	/**
-	 * @covers ::paginate
-	 */
 	public function testQueryPaginate()
 	{
 		$collection = new Collection([
@@ -743,9 +612,6 @@ class CollectionTest extends TestCase
 		])->toArray());
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQueryFilter()
 	{
 		$collection = new Collection([
@@ -775,9 +641,6 @@ class CollectionTest extends TestCase
 		])->toArray());
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuerySortBy()
 	{
 		$collection = new Collection([
@@ -799,9 +662,6 @@ class CollectionTest extends TestCase
 		])->first()['name']);
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuerySortByComma()
 	{
 		$collection = new Collection([
@@ -821,9 +681,6 @@ class CollectionTest extends TestCase
 		], array_keys($results));
 	}
 
-	/**
-	 * @covers ::random
-	 */
 	public function testRandom()
 	{
 		$collection = new Collection([
@@ -851,9 +708,6 @@ class CollectionTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::__unset
-	 */
 	public function testRemoveMultiple()
 	{
 		$collection = new Collection();
@@ -871,9 +725,6 @@ class CollectionTest extends TestCase
 		$this->assertCount(0, $collection);
 	}
 
-	/**
-	 * @covers ::__set
-	 */
 	public function testSetters()
 	{
 		$this->collection->fourth = 'My fourth element';
@@ -889,18 +740,12 @@ class CollectionTest extends TestCase
 		$this->assertSame('My fifth element', $this->collection->get('fifth'));
 	}
 
-	/**
-	 * @covers ::shuffle
-	 */
 	public function testShuffle()
 	{
 		$this->assertInstanceOf(Collection::class, $this->collection->shuffle());
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::slice
-	 */
 	public function testSlice()
 	{
 		$this->assertSame(array_slice($this->sampleData, 1), $this->collection->slice(1)->toArray());
@@ -910,9 +755,6 @@ class CollectionTest extends TestCase
 		$this->assertIsUntouched();
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		// associative
@@ -928,9 +770,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn ($item) => $item * 2));
 	}
 
-	/**
-	 * @covers ::toJson
-	 */
 	public function testToJson()
 	{
 		// associative
@@ -942,9 +781,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('["a","b","c"]', $collection->toJson());
 	}
 
-	/**
-	 * @covers ::toString
-	 */
 	public function testToString()
 	{
 		// associative
@@ -956,9 +792,6 @@ class CollectionTest extends TestCase
 		$this->assertSame('0<br />1<br />2', $collection->toString());
 	}
 
-	/**
-	 * @covers ::values
-	 */
 	public function testValues()
 	{
 		$this->assertSame([
@@ -968,9 +801,6 @@ class CollectionTest extends TestCase
 		], $this->collection->values());
 	}
 
-	/**
-	 * @covers ::values
-	 */
 	public function testValuesMap()
 	{
 		$values = $this->collection->values(
@@ -984,9 +814,6 @@ class CollectionTest extends TestCase
 		], $values);
 	}
 
-	/**
-	 * @covers ::when
-	 */
 	public function testWhen()
 	{
 		$collection = new Collection([

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -5,11 +5,10 @@ namespace Kirby\Toolkit;
 use ArgumentCountError;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Component
- */
+#[CoversClass(Component::class)]
 class ComponentTest extends TestCase
 {
 	public function tearDown(): void
@@ -18,12 +17,6 @@ class ComponentTest extends TestCase
 		Component::$mixins = [];
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 * @covers ::applyProp
-	 * @covers ::applyProps
-	 */
 	public function testProp()
 	{
 		Component::$types = [
@@ -40,10 +33,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('prop value', $component->prop);
 	}
 
-	/**
-	 * @covers ::applyProp
-	 * @covers ::applyProps
-	 */
 	public function testPropWithDefaultValue()
 	{
 		Component::$types = [
@@ -60,10 +49,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('default value', $component->prop);
 	}
 
-	/**
-	 * @covers ::applyProp
-	 * @covers ::applyProps
-	 */
 	public function testPropWithFixedValue()
 	{
 		Component::$types = [
@@ -80,10 +65,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('test', $component->prop);
 	}
 
-	/**
-	 * @covers ::applyProp
-	 * @covers ::applyProps
-	 */
 	public function testPropWithInvalidValue()
 	{
 		Component::$types = [
@@ -100,10 +81,6 @@ class ComponentTest extends TestCase
 		new Component('test', ['prop' => [1, 2, 3]]);
 	}
 
-	/**
-	 * @covers ::applyProp
-	 * @covers ::applyProps
-	 */
 	public function testPropWithMissingValue()
 	{
 		Component::$types = [
@@ -120,9 +97,6 @@ class ComponentTest extends TestCase
 		new Component('test');
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testAttrs()
 	{
 		Component::$types = [
@@ -135,11 +109,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('bar', $component->foo);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 * @covers ::applyComputed
-	 */
 	public function testComputed()
 	{
 		Component::$types = [
@@ -156,11 +125,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('computed prop', $component->prop);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 * @covers ::applyComputed
-	 */
 	public function testComputedFromProp()
 	{
 		Component::$types = [
@@ -179,10 +143,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('computed: prop value', $component->prop());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 */
 	public function testMethod()
 	{
 		Component::$types = [
@@ -198,10 +158,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('hello world', $component->say());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 */
 	public function testPropsInMethods()
 	{
 		Component::$types = [
@@ -220,10 +176,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('hello world', $component->say());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__call
-	 */
 	public function testComputedPropsInMethods()
 	{
 		Component::$types = [
@@ -245,10 +197,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('HELLO WORLD', $component->say());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testToArray()
 	{
 		Component::$types = [
@@ -272,10 +220,6 @@ class ComponentTest extends TestCase
 		$this->assertSame($expected, $component->__debugInfo());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
 	public function testCustomToArray()
 	{
 		Component::$types = [
@@ -291,9 +235,6 @@ class ComponentTest extends TestCase
 		$this->assertSame(['foo' => 'bar'], $component->toArray());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testInvalidType()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -302,9 +243,6 @@ class ComponentTest extends TestCase
 		new Component('test');
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadInvalidFile()
 	{
 		Component::$types = ['foo' => 'bar'];
@@ -314,10 +252,6 @@ class ComponentTest extends TestCase
 		Component::load('foo');
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::setup
-	 */
 	public function testMixins()
 	{
 		Component::$mixins = [
@@ -343,9 +277,6 @@ class ComponentTest extends TestCase
 		$this->assertSame('HELLO WORLD', $component->message);
 	}
 
-	/**
-	 * @covers ::__get
-	 */
 	public function testGetInvalidProp()
 	{
 		Component::$types = [
@@ -356,9 +287,6 @@ class ComponentTest extends TestCase
 		$this->assertNull($component->foo);
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		Component::$types = [

--- a/tests/Toolkit/ControllerTest.php
+++ b/tests/Toolkit/ControllerTest.php
@@ -2,16 +2,13 @@
 
 namespace Kirby\Toolkit;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Controller
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Controller::class)]
 class ControllerTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::arguments
-	 */
 	public function testArguments()
 	{
 		$controller = new Controller(fn ($a, $b) => $a . $b);
@@ -22,9 +19,6 @@ class ControllerTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::arguments
-	 */
 	public function testArgumentsOrder()
 	{
 		$controller = new Controller(fn ($b, $a) => $b . $a);
@@ -35,9 +29,6 @@ class ControllerTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::arguments
-	 */
 	public function testArgumentsVariadic()
 	{
 		$controller = new Controller(fn ($c, ...$args) => $c . '/' . implode('', $args));
@@ -49,9 +40,6 @@ class ControllerTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::arguments
-	 */
 	public function testArgumentsNoDefaultNull()
 	{
 		$controller = new Controller(fn ($a, $b = 'foo') => ($a === null ? 'null' : $a) . ($b === null ? 'null' : $b));
@@ -59,19 +47,12 @@ class ControllerTest extends TestCase
 		$this->assertSame('nullfoo', $controller->call());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::call
-	 */
 	public function testCall()
 	{
 		$controller = new Controller(fn () => 'test');
 		$this->assertSame('test', $controller->call());
 	}
 
-	/**
-	 * @covers ::call
-	 */
 	public function testCallBind()
 	{
 		$model = new Obj(['foo' => 'bar']);
@@ -80,18 +61,12 @@ class ControllerTest extends TestCase
 		$this->assertSame($model, $controller->call($model));
 	}
 
-	/**
-	 * @covers ::call
-	 */
 	public function testCallMissingParameter()
 	{
 		$controller = new Controller(fn ($a) => $a);
 		$this->assertNull($controller->call());
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad()
 	{
 		$root       = static::FIXTURES . '/controller/controller.php';
@@ -99,9 +74,6 @@ class ControllerTest extends TestCase
 		$this->assertSame('loaded', $controller->call());
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadNonExisting()
 	{
 		$root       = static::FIXTURES . '/controller/does-not-exist.php';
@@ -109,9 +81,6 @@ class ControllerTest extends TestCase
 		$this->assertNull($controller);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoadInvalidController()
 	{
 		$root       = static::FIXTURES . '/controller/invalid.php';

--- a/tests/Toolkit/DateTest.php
+++ b/tests/Toolkit/DateTest.php
@@ -7,10 +7,10 @@ use IntlDateFormatter;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Date
- */
+#[CoversClass(Date::class)]
 class DateTest extends TestCase
 {
 	public function tearDown(): void
@@ -18,45 +18,30 @@ class DateTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function test__constructWithString()
 	{
 		$date = new Date('2021-12-12');
 		$this->assertSame('2021-12-12', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function test__constructWithInt()
 	{
 		$date = new Date(strtotime('2021-12-12'));
 		$this->assertSame('2021-12-12', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function test__constructWithDate()
 	{
 		$date = new Date(new Date('2021-12-12'));
 		$this->assertSame('2021-12-12', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function test__toString()
 	{
 		$date = new Date('2021-12-12 12:12:12');
 		$this->assertSame('2021-12-12 12:12:12+00:00', (string)$date);
 	}
 
-	/**
-	 * @covers ::ceil
-	 */
 	public function testCeil()
 	{
 		$date = new Date('2021-12-12 12:12:12');
@@ -84,9 +69,6 @@ class DateTest extends TestCase
 		$date->ceil('foo');
 	}
 
-	/**
-	 * @covers ::compare
-	 */
 	public function testCompare()
 	{
 		$date = new Date('2021-12-12');
@@ -97,9 +79,6 @@ class DateTest extends TestCase
 		$this->assertSame(2, $diff->days);
 	}
 
-	/**
-	 * @covers ::day
-	 */
 	public function testDay()
 	{
 		$date = new Date('2021-12-12');
@@ -108,9 +87,6 @@ class DateTest extends TestCase
 		$this->assertSame('2021-12-13', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::firstWeekday
-	 */
 	public function testFirstWeekday()
 	{
 		$this->assertSame(1, Date::firstWeekday('de_DE'));
@@ -131,9 +107,6 @@ class DateTest extends TestCase
 		$this->assertSame(4, Date::firstWeekday('en_US'));
 	}
 
-	/**
-	 * @covers ::floor
-	 */
 	public function testFloor()
 	{
 		$date = new Date('2021-12-12 12:12:12');
@@ -161,9 +134,6 @@ class DateTest extends TestCase
 		$date->floor('foo');
 	}
 
-	/**
-	 * @covers ::hour
-	 */
 	public function testHour()
 	{
 		$date = new Date('12:12');
@@ -172,9 +142,6 @@ class DateTest extends TestCase
 		$this->assertSame('13:12', $date->format('H:i'));
 	}
 
-	/**
-	 * @covers ::formatWithHandler
-	 */
 	public function testFormatWithHandler()
 	{
 		$date = new Date('2020-01-29 01:01');
@@ -220,9 +187,6 @@ class DateTest extends TestCase
 		$this->assertSame('29.01.2020', $date->formatWithHandler('%d.%m.%Y', 'strftime'));
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIs()
 	{
 		$date = new Date('2021-12-12');
@@ -230,9 +194,6 @@ class DateTest extends TestCase
 		$this->assertFalse($date->is('2021-12-13'));
 	}
 
-	/**
-	 * @covers ::isAfter
-	 */
 	public function testIsAfter()
 	{
 		$date = new Date('2021-12-12');
@@ -240,9 +201,6 @@ class DateTest extends TestCase
 		$this->assertFalse($date->isAfter('2021-12-13'));
 	}
 
-	/**
-	 * @covers ::isBefore
-	 */
 	public function testIsBefore()
 	{
 		$date = new Date('2021-12-12');
@@ -250,9 +208,6 @@ class DateTest extends TestCase
 		$this->assertTrue($date->isBefore('2021-12-13'));
 	}
 
-	/**
-	 * @covers ::isBetween
-	 */
 	public function testIsBetween()
 	{
 		$date = new Date('2021-12-12');
@@ -261,9 +216,6 @@ class DateTest extends TestCase
 		$this->assertFalse($date->isBetween('2021-12-13', '2021-12-14'));
 	}
 
-	/**
-	 * @covers ::isMax
-	 */
 	public function testIsMax()
 	{
 		$date = new Date('2021-12-12');
@@ -271,9 +223,6 @@ class DateTest extends TestCase
 		$this->assertFalse($date->isMax('2021-12-11'));
 	}
 
-	/**
-	 * @covers ::isMin
-	 */
 	public function testIsMin()
 	{
 		$date = new Date('2021-12-12');
@@ -281,9 +230,6 @@ class DateTest extends TestCase
 		$this->assertFalse($date->isMin('2021-12-13'));
 	}
 
-	/**
-	 * @covers ::microsecond
-	 */
 	public function testMicrosecond()
 	{
 		$date = new Date('2021-12-12');
@@ -292,9 +238,6 @@ class DateTest extends TestCase
 		$this->assertSame(500000, $date->microsecond());
 	}
 
-	/**
-	 * @covers ::millisecond
-	 */
 	public function testMillisecond()
 	{
 		$date = new Date('2021-12-12');
@@ -303,9 +246,6 @@ class DateTest extends TestCase
 		$this->assertSame(500, $date->millisecond());
 	}
 
-	/**
-	 * @covers ::minute
-	 */
 	public function testMinute()
 	{
 		$date = new Date('12:12');
@@ -314,9 +254,6 @@ class DateTest extends TestCase
 		$this->assertSame('12:13', $date->format('H:i'));
 	}
 
-	/**
-	 * @covers ::month
-	 */
 	public function testMonth()
 	{
 		$date = new Date('2021-12-12');
@@ -325,9 +262,6 @@ class DateTest extends TestCase
 		$this->assertSame('2021-11-12', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::nearest
-	 */
 	public function testNearest()
 	{
 		$date = new Date('2021-12-12');
@@ -338,9 +272,6 @@ class DateTest extends TestCase
 		$this->assertSame($a, $date->nearest($a, $b, $c));
 	}
 
-	/**
-	 * @covers ::now
-	 */
 	public function testNow()
 	{
 		$date = Date::now();
@@ -349,9 +280,6 @@ class DateTest extends TestCase
 		$this->assertInstanceOf(Date::class, $date);
 	}
 
-	/**
-	 * @covers ::optional
-	 */
 	public function testOptional()
 	{
 		$this->assertNull(Date::optional(null));
@@ -360,10 +288,7 @@ class DateTest extends TestCase
 		$this->assertInstanceOf(Date::class, Date::optional('2021-12-12'));
 	}
 
-	/**
-	 * @covers ::round
-	 * @dataProvider roundProvider
-	 */
+	#[DataProvider('roundProvider')]
 	public function testRound(string $unit, int $size, string $input, string $expected, string $timezone)
 	{
 		$date = new Date($input, new DateTimeZone($timezone));
@@ -423,10 +348,7 @@ class DateTest extends TestCase
 		return $data;
 	}
 
-	/**
-	 * @covers ::round
-	 * @dataProvider roundUnsupportedSizeProvider
-	 */
+	#[DataProvider('roundUnsupportedSizeProvider')]
 	public function testRoundUnsupportedSize(string $unit, int $size)
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -448,10 +370,6 @@ class DateTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::round
-	 * @covers ::validateUnit
-	 */
 	public function testRoundUnsupportedUnit()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -461,18 +379,12 @@ class DateTest extends TestCase
 		$date->round('foo', 1);
 	}
 
-	/**
-	 * @covers ::roundedTimestamp
-	 */
 	public function testRoundedTimestamp()
 	{
 		$result = Date::roundedTimestamp('2021-12-12 12:12:12');
 		$this->assertSame('2021-12-12 12:12:12', date('Y-m-d H:i:s', $result));
 	}
 
-	/**
-	 * @covers ::roundedTimestamp
-	 */
 	public function testRoundedTimestampWithStep()
 	{
 		$result = Date::roundedTimestamp('2021-12-12 12:12:12', [
@@ -483,18 +395,12 @@ class DateTest extends TestCase
 		$this->assertSame('2021-12-12 12:10:00', date('Y-m-d H:i:s', $result));
 	}
 
-	/**
-	 * @covers ::roundedTimestamp
-	 */
 	public function testRoundedTimestampWithInvalidDate()
 	{
 		$result = Date::roundedTimestamp('invalid date');
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::second
-	 */
 	public function testSecond()
 	{
 		$date = new Date('12:12:12');
@@ -503,9 +409,6 @@ class DateTest extends TestCase
 		$this->assertSame('12:12:13', $date->format('H:i:s'));
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSet()
 	{
 		$date = new Date('2021-12-12');
@@ -524,9 +427,6 @@ class DateTest extends TestCase
 		$this->assertSame('2021-12-13', $date->format('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfig()
 	{
 		$config = Date::stepConfig();
@@ -537,9 +437,6 @@ class DateTest extends TestCase
 		], $config);
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfigWithArray()
 	{
 		$config = Date::stepConfig([
@@ -553,9 +450,6 @@ class DateTest extends TestCase
 		], $config);
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfigWithInt()
 	{
 		$config = Date::stepConfig(5);
@@ -566,9 +460,6 @@ class DateTest extends TestCase
 		], $config);
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfigWithInvalidInput()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -577,9 +468,6 @@ class DateTest extends TestCase
 		Date::stepConfig(new Date());
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfigWithString()
 	{
 		$config = Date::stepConfig('Minute');
@@ -590,9 +478,6 @@ class DateTest extends TestCase
 		], $config);
 	}
 
-	/**
-	 * @covers ::stepConfig
-	 */
 	public function testStepConfigWithCustomDefault()
 	{
 		$config = Date::stepConfig(null, $default = [
@@ -603,18 +488,12 @@ class DateTest extends TestCase
 		$this->assertSame($default, $config);
 	}
 
-	/**
-	 * @covers ::time
-	 */
 	public function testTime()
 	{
 		$date = new Date('2021-12-12 12:12:12');
 		$this->assertSame('12:12:12', $date->time());
 	}
 
-	/**
-	 * @covers ::timestamp
-	 */
 	public function testTimestamp()
 	{
 		$date = new Date('2021-12-12');
@@ -623,18 +502,12 @@ class DateTest extends TestCase
 		$this->assertSame($timestamp, $date->timestamp());
 	}
 
-	/**
-	 * @covers ::timezone
-	 */
 	public function testTimezone()
 	{
 		$date = new Date();
 		$this->assertInstanceOf('DateTimeZone', $date->timezone());
 	}
 
-	/**
-	 * @covers ::today
-	 */
 	public function testToday()
 	{
 		$date = Date::today();
@@ -642,9 +515,6 @@ class DateTest extends TestCase
 		$this->assertSame($timestamp, $date->timestamp());
 	}
 
-	/**
-	 * @covers ::toString
-	 */
 	public function testToStringModeDate()
 	{
 		// with timezone
@@ -655,9 +525,6 @@ class DateTest extends TestCase
 		$this->assertSame('2021-12-12', $date->toString('date', false));
 	}
 
-	/**
-	 * @covers ::toString
-	 */
 	public function testToStringModeDatetime()
 	{
 		// with timezone
@@ -669,9 +536,6 @@ class DateTest extends TestCase
 		$this->assertSame('2021-12-12 12:12:12', $date->toString('datetime', false));
 	}
 
-	/**
-	 * @covers ::toString
-	 */
 	public function testToStringModeTime()
 	{
 		// with timezone
@@ -682,9 +546,6 @@ class DateTest extends TestCase
 		$this->assertSame('12:12:12', $date->toString('time', false));
 	}
 
-	/**
-	 * @covers ::toString
-	 */
 	public function testToStringWithInvalidMode()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -694,9 +555,6 @@ class DateTest extends TestCase
 		$date->toString('foo');
 	}
 
-	/**
-	 * @covers ::year
-	 */
 	public function testYear()
 	{
 		$date = new Date('2021-12-12');

--- a/tests/Toolkit/DomTest.php
+++ b/tests/Toolkit/DomTest.php
@@ -11,10 +11,10 @@ use Exception;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Dom
- */
+#[CoversClass(Dom::class)]
 class DomTest extends TestCase
 {
 	protected static array $testClosures = [];
@@ -223,13 +223,7 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider parseSaveProvider
-	 * @covers ::__construct
-	 * @covers ::toString
-	 * @covers ::exportHtml
-	 * @covers ::exportXml
-	 */
+	#[DataProvider('parseSaveProvider')]
 	public function testParseSave(string $type, string $code, string|null $expected = null)
 	{
 		$dom = new Dom($code, $type);
@@ -360,22 +354,13 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider parseSaveNormalizeProvider
-	 * @covers ::__construct
-	 * @covers ::toString
-	 * @covers ::exportHtml
-	 * @covers ::exportXml
-	 */
+	#[DataProvider('parseSaveNormalizeProvider')]
 	public function testParseSaveNormalize(string $type, string $code, string|null $expected = null)
 	{
 		$dom = new Dom($code, $type);
 		$this->assertSame($expected ?? $code, $dom->toString(true));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testParseInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -384,9 +369,6 @@ class DomTest extends TestCase
 		new Dom('{"this": "is not XML"}', 'XML');
 	}
 
-	/**
-	 * @covers ::body
-	 */
 	public function testBody()
 	{
 		// with full document input
@@ -409,9 +391,6 @@ class DomTest extends TestCase
 		$this->assertNull($dom->body());
 	}
 
-	/**
-	 * @covers ::document
-	 */
 	public function testDocument()
 	{
 		$dom = new Dom('<p>This is a test</p>', 'HTML');
@@ -495,10 +474,7 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider extractUrlsProvider
-	 * @covers ::extractUrls
-	 */
+	#[DataProvider('extractUrlsProvider')]
 	public function testExtractUrls(string $url, array $expected)
 	{
 		$this->assertSame($expected, Dom::extractUrls($url));
@@ -639,12 +615,8 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isAllowedAttrProvider
-	 * @covers ::isAllowedAttr
-	 * @covers ::normalizeSanitizeOptions
-	 */
-	public function testIsAllowedAttr(string $tag, string $attr, $allowedAttrs, $allowedAttrPrefixes, $allowedTags, $expected)
+	#[DataProvider('isAllowedAttrProvider')]
+	public function testIsAllowedAttr(string $tag, string $attr, array $allowedAttrs, array $allowedAttrPrefixes, bool|array $allowedTags, bool|string $expected)
 	{
 		$doc = new DOMDocument();
 		$element = $doc->createElement($tag);
@@ -799,12 +771,8 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isAllowedGlobalAttrProvider
-	 * @covers ::isAllowedGlobalAttr
-	 * @covers ::normalizeSanitizeOptions
-	 */
-	public function testIsAllowedGlobalAttr(string $name, $allowedAttrs, $allowedAttrPrefixes, $expected)
+	#[DataProvider('isAllowedGlobalAttrProvider')]
+	public function testIsAllowedGlobalAttr(string $name, bool|array $allowedAttrs, array $allowedAttrPrefixes, bool|string $expected)
 	{
 		$attr    = new DOMAttr($name);
 		$options = [
@@ -951,12 +919,8 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isAllowedUrlProvider
-	 * @covers ::isAllowedUrl
-	 * @covers ::normalizeSanitizeOptions
-	 */
-	public function testIsAllowedUrl(string $url, $expected, array $options = [])
+	#[DataProvider('isAllowedUrlProvider')]
+	public function testIsAllowedUrl(string $url, bool|string $expected, array $options = [])
 	{
 		$this->assertSame($expected, Dom::isAllowedUrl($url, $options));
 	}
@@ -996,10 +960,7 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isAllowedUrlCmsProvider
-	 * @covers ::isAllowedUrl
-	 */
+	#[DataProvider('isAllowedUrlCmsProvider')]
 	public function testIsAllowedUrlCms(string $indexUrl, string $url, bool $allowHostRelativeUrls, string|bool $expected)
 	{
 		new App([
@@ -1011,9 +972,6 @@ class DomTest extends TestCase
 		$this->assertSame($expected, Dom::isAllowedUrl($url, compact('allowHostRelativeUrls')));
 	}
 
-	/**
-	 * @covers ::innerMarkup
-	 */
 	public function testInnerMarkup()
 	{
 		// XML markup
@@ -1264,12 +1222,8 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider listContainsNameProvider
-	 * @covers ::listContainsName
-	 * @covers ::normalizeSanitizeOptions
-	 */
-	public function testListContainsName(array $list, array $node, $allowedNamespaces, string|null $compare, $expected)
+	#[DataProvider('listContainsNameProvider')]
+	public function testListContainsName(array $list, array $node, bool|array $allowedNamespaces, string|null $compare, string|bool $expected)
 	{
 		if ($compare !== null) {
 			$compare = static::$testClosures[$compare];
@@ -1287,9 +1241,6 @@ class DomTest extends TestCase
 		$this->assertSame($expected, Dom::listContainsName($list, $element, $options, $compare));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemove()
 	{
 		$dom = new Dom('<p>Test <strong id="strong">Test test</strong>!</p>', 'HTML');
@@ -1298,9 +1249,6 @@ class DomTest extends TestCase
 		$this->assertSame('<p>Test !</p>', $dom->toString());
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuery()
 	{
 		$dom = new Dom('<span>Test <span>Test test</span>!</span>', 'HTML');
@@ -1839,15 +1787,7 @@ class DomTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider sanitizeProvider
-	 * @covers ::sanitize
-	 * @covers ::sanitizeAttr
-	 * @covers ::sanitizeDoctype
-	 * @covers ::sanitizeElement
-	 * @covers ::sanitizePI
-	 * @covers ::validateDoctype
-	 */
+	#[DataProvider('sanitizeProvider')]
 	public function testSanitize(string $code, array $options, string $expectedCode, array $expectedErrors)
 	{
 		// hydrate the closures in the options from the static closures
@@ -1867,11 +1807,6 @@ class DomTest extends TestCase
 		$this->assertSame($expectedCode, $dom->toString());
 	}
 
-	/**
-	 * @covers ::sanitize
-	 * @covers ::sanitizeDoctype
-	 * @covers ::validateDoctype
-	 */
 	public function testSanitizeDoctypeCallbackException()
 	{
 		$this->expectException(Exception::class);
@@ -1887,9 +1822,6 @@ class DomTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::unwrap
-	 */
 	public function testUnwrap()
 	{
 		$dom = new Dom('<body><p>This is a test</p><invalid>And this is <p>Awesome<strong>!</strong></p> but contains text</invalid></body>', 'HTML');

--- a/tests/Toolkit/EscapeTest.php
+++ b/tests/Toolkit/EscapeTest.php
@@ -2,9 +2,10 @@
 
 namespace Kirby\Toolkit;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Escape
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(Escape::class)]
 class EscapeTest extends TestCase
 {
 	/**
@@ -160,9 +161,6 @@ class EscapeTest extends TestCase
 	];
 
 
-	/**
-	 * @covers ::html
-	 */
 	public function testHtmlEscapingConvertsSpecialChars()
 	{
 		foreach ($this->htmlSpecialChars as $key => $value) {
@@ -174,9 +172,6 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testHtmlAttributeEscapingConvertsSpecialChars()
 	{
 		foreach ($this->htmlAttrSpecialChars as $key => $value) {
@@ -188,9 +183,6 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJavascriptEscapingConvertsSpecialChars()
 	{
 		foreach ($this->jsSpecialChars as $key => $value) {
@@ -202,25 +194,16 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJavascriptEscapingReturnsStringIfZeroLength()
 	{
 		$this->assertSame('', Escape::js(''));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJavascriptEscapingReturnsStringIfContainsOnlyDigits()
 	{
 		$this->assertSame('123', Escape::js('123'));
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssEscapingConvertsSpecialChars()
 	{
 		foreach ($this->cssSpecialChars as $key => $value) {
@@ -232,25 +215,16 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssEscapingReturnsStringIfZeroLength()
 	{
 		$this->assertSame('', Escape::css(''));
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssEscapingReturnsStringIfContainsOnlyDigits()
 	{
 		$this->assertSame('123', Escape::css('123'));
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrlEscapingConvertsSpecialChars()
 	{
 		foreach ($this->urlSpecialChars as $key => $value) {
@@ -310,9 +284,6 @@ class EscapeTest extends TestCase
 		throw new \Exception('Codepoint requested outside of Unicode range');
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJavascriptEscapingEscapesOwaspRecommendedRanges()
 	{
 		$immune = [',', '.', '_']; // Exceptions to escaping ranges
@@ -339,9 +310,6 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testHtmlAttributeEscapingEscapesOwaspRecommendedRanges()
 	{
 		$immune = [',', '.', '-', '_']; // Exceptions to escaping ranges
@@ -368,9 +336,6 @@ class EscapeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssEscapingEscapesOwaspRecommendedRanges()
 	{
 		$immune = []; // CSS has no exceptions to escaping ranges
@@ -404,11 +369,8 @@ class EscapeTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::xml
-	 * @dataProvider xmlStringProvider
-	 */
-	public function testXml($input, $expected)
+	#[DataProvider('xmlStringProvider')]
+	public function testXml(string $input, string $expected)
 	{
 		$this->assertSame($expected, Escape::xml($input));
 	}

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -3,15 +3,12 @@
 namespace Kirby\Toolkit;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Html
- */
+#[CoversClass(Html::class)]
 class HtmlTest extends TestCase
 {
-	/**
-	 * @covers ::__callStatic()
-	 */
 	public function testCallStatic()
 	{
 		$this->assertSame('<div>test</div>', Html::div('test'));
@@ -19,10 +16,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('<hr class="test">', Html::hr(['class' => 'test']));
 	}
 
-	/**
-	 * @covers ::a
-	 * @covers ::link
-	 */
 	public function testA()
 	{
 		$html = Html::a('https://getkirby.com');
@@ -41,10 +34,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::a
-	 * @covers ::link
-	 */
 	public function testAWithText()
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby');
@@ -62,10 +51,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::a
-	 * @covers ::link
-	 */
 	public function testAWithAttributes()
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby', ['class' => 'test']);
@@ -83,10 +68,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::a
-	 * @covers ::link
-	 */
 	public function testAWithTarget()
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby', ['target' => '_blank']);
@@ -94,10 +75,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::a
-	 * @covers ::link
-	 */
 	public function testAWithTargetAndRel()
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby', ['target' => '_blank', 'rel' => 'noopener']);
@@ -105,11 +82,8 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers       ::attr
-	 * @dataProvider attrProvider
-	 */
-	public function testAttr($input, $value, $expected)
+	#[DataProvider('attrProvider')]
+	public function testAttr(array $input, bool|null $value, string|null $expected)
 	{
 		$this->assertSame($expected, Html::attr($input, $value));
 	}
@@ -130,9 +104,6 @@ class HtmlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttrArrayValue()
 	{
 		$result = Html::attr('a', ['a', 'b']);
@@ -151,44 +122,29 @@ class HtmlTest extends TestCase
 		$this->assertSame('a="&"', $result);
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttrWithBeforeValue()
 	{
 		$attr = Html::attr(['test' => 'test'], null, ' ');
 		$this->assertSame(' test="test"', $attr);
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttrWithAfterValue()
 	{
 		$attr = Html::attr(['test' => 'test'], null, null, ' ');
 		$this->assertSame('test="test" ', $attr);
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttrWithoutValues()
 	{
 		$attr = Html::attr([]);
 		$this->assertNull($attr);
 	}
 
-	/**
-	 * @covers ::breaks
-	 */
 	public function testBreaks()
 	{
 		$this->assertSame("line 1<br />\nline 2", Html::breaks("line 1\nline 2"));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmail()
 	{
 		$html = Html::email('mail@company.com?subject=Test');
@@ -199,9 +155,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('mail@company.com', Html::decode($matches[2]));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmailWithText()
 	{
 		$html = Html::email('mail@company.com', '<b>Email</b>');
@@ -211,9 +164,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('mail@company.com', Html::decode($matches[1]));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmailWithArrayText()
 	{
 		$html = Html::email('mail@company.com', ['<b>Email</b>']);
@@ -223,18 +173,12 @@ class HtmlTest extends TestCase
 		$this->assertSame('mail@company.com', Html::decode($matches[1]));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmailWithoutAddress()
 	{
 		$html = Html::email('');
 		$this->assertSame('', $html);
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmailWithAttributes()
 	{
 		$html = Html::email('mail@company.com', 'Email', ['class' => 'email']);
@@ -244,9 +188,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('mail@company.com', Html::decode($matches[1]));
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmailWithTarget()
 	{
 		$html = Html::email('mail@company.com', 'Email', ['target' => '_blank']);
@@ -256,9 +197,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('mail@company.com', Html::decode($matches[1]));
 	}
 
-	/**
-	 * @covers ::encode
-	 */
 	public function testEncode()
 	{
 		$html = Html::encode('äöü');
@@ -277,9 +215,6 @@ class HtmlTest extends TestCase
 		$this->assertSame('', Html::encode(null));
 	}
 
-	/**
-	 * @covers ::entities
-	 */
 	public function testEntities()
 	{
 		Html::$entities = null;
@@ -294,9 +229,6 @@ class HtmlTest extends TestCase
 		Html::$entities = null;
 	}
 
-	/**
-	 * @covers ::figure
-	 */
 	public function testFigure()
 	{
 		$html = Html::figure('test');
@@ -312,9 +244,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::gist
-	 */
 	public function testGist()
 	{
 		$html = Html::gist($url = 'https://gist.github.com/bastianallgeier/dfb2a889ae73c7c318ea300efd2df6ff');
@@ -326,9 +255,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::iframe
-	 */
 	public function testIframe()
 	{
 		$html = Html::iframe($url = 'https://getkirby.com');
@@ -336,9 +262,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::img
-	 */
 	public function testImg()
 	{
 		$html = Html::img($src = 'https://getkirby.com/image.jpg');
@@ -346,9 +269,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::isVoid
-	 */
 	public function testIsVoid()
 	{
 		$original = Html::$voidList;
@@ -363,9 +283,6 @@ class HtmlTest extends TestCase
 		Html::$voidList = $original;
 	}
 
-	/**
-	 * @covers ::rel
-	 */
 	public function testRel()
 	{
 		$html = Html::rel('me');
@@ -381,10 +298,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::tel
-	 * @covers ::link
-	 */
 	public function testTel()
 	{
 		$html = Html::tel('1234');
@@ -392,10 +305,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::tel
-	 * @covers ::link
-	 */
 	public function testTelWithText()
 	{
 		$html = Html::tel('1234', 'Tel');
@@ -403,10 +312,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::tel
-	 * @covers ::link
-	 */
 	public function testTelWithArrayText()
 	{
 		$html = Html::tel('1234', ['<b>Tel</b>']);
@@ -414,9 +319,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::tag
-	 */
 	public function testTag()
 	{
 		$html = Html::tag('p', 'test');
@@ -458,11 +360,8 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers       ::value
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueProvider')]
+	public function testValue(bool|int|string|null $input, string|null $expected)
 	{
 		$this->assertSame($expected, Html::value($input));
 	}
@@ -480,14 +379,8 @@ class HtmlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers       ::video
-	 * @covers       ::youtube
-	 * @covers       ::vimeo
-	 * @covers       ::videoAttr
-	 * @dataProvider videoProvider
-	 */
-	public function testVideo($url, $src)
+	#[DataProvider('videoProvider')]
+	public function testVideo(string $url, string|bool $src)
 	{
 		// invalid URLs
 		if ($src === false) {
@@ -545,9 +438,6 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::video
-	 */
 	public function testVideoFile()
 	{
 		$html = Html::video('https://getkirby.com/myvideo.mp4');
@@ -744,17 +634,11 @@ class HtmlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::vimeo
-	 */
 	public function testVimeoInvalidUrl()
 	{
 		$this->assertNull(Html::vimeo('https://getkirby.com'));
 	}
 
-	/**
-	 * @covers ::youtube
-	 */
 	public function testYoutubeInvalidUrl()
 	{
 		$this->assertNull(Html::youtube('https://getkirby.com'));

--- a/tests/Toolkit/I18nTest.php
+++ b/tests/Toolkit/I18nTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Toolkit;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\I18n
- */
+#[CoversClass(I18n::class)]
 class I18nTest extends TestCase
 {
 	public function setUp(): void
@@ -17,9 +16,6 @@ class I18nTest extends TestCase
 		I18n::$translations = [];
 	}
 
-	/**
-	 * @covers ::fallbacks
-	 */
 	public function testFallbacks()
 	{
 		I18n::$fallback = 'de';
@@ -44,9 +40,6 @@ class I18nTest extends TestCase
 		$this->assertSame(['de', 'en'], I18n::fallbacks());
 	}
 
-	/**
-	 * @covers ::form
-	 */
 	public function testForm()
 	{
 		$this->assertSame('singular', I18n::form(1));
@@ -59,10 +52,6 @@ class I18nTest extends TestCase
 		$this->assertSame('none', I18n::form(0, true));
 	}
 
-	/**
-	 * @covers ::formatNumber
-	 * @covers ::decimalNumberFormatter
-	 */
 	public function testFormatNumber()
 	{
 		$this->assertSame('2', I18n::formatNumber(2));
@@ -78,9 +67,6 @@ class I18nTest extends TestCase
 		$this->assertSame('1.234.567,89', I18n::formatNumber(1234567.89, 'de'));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
 	public function testLocale()
 	{
 		I18n::$locale = 'de';
@@ -93,9 +79,6 @@ class I18nTest extends TestCase
 		$this->assertSame('en', I18n::locale());
 	}
 
-	/**
-	 * @covers ::template
-	 */
 	public function testTemplate()
 	{
 		I18n::$translations = [
@@ -139,9 +122,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateI18nKey()
 	{
 		I18n::$translations = [
@@ -152,9 +132,6 @@ class I18nTest extends TestCase
 		$this->assertNull(I18n::translate('invalid'));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateI18nKeyShortLocale()
 	{
 		I18n::$translations = [
@@ -166,17 +143,11 @@ class I18nTest extends TestCase
 		$this->assertSame('Vamos', I18n::translate('go'));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateI18nKeyWithFallbackStringArgument()
 	{
 		$this->assertSame('My fallback', I18n::translate('not.exist', 'My fallback'));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateI18nKeyWithFallbackArrayArgument()
 	{
 		$this->assertSame('My fallback in array', I18n::translate('not.exist', [
@@ -185,9 +156,6 @@ class I18nTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateI18nKeyWithFallbackLocales()
 	{
 		I18n::$translations = [
@@ -211,26 +179,17 @@ class I18nTest extends TestCase
 		$this->assertSame('Save2', I18n::translate('save2'));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArray()
 	{
 		$this->assertSame('Save', I18n::translate(['en' => 'Save']));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayShortLocale()
 	{
 		I18n::$locale = 'es_ES';
 		$this->assertSame('Vamos', I18n::translate(['es' => 'Vamos']));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayWildcard()
 	{
 		I18n::$locale = 'de';
@@ -242,9 +201,6 @@ class I18nTest extends TestCase
 		$this->assertSame('Speichern', I18n::translate(['*' => 'save']));
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayWithFallbackArray()
 	{
 		// English is current locale, not in first array,
@@ -255,9 +211,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayWithFallbackArrayShortLocale()
 	{
 		I18n::$locale = 'es_ES';
@@ -267,9 +220,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayFallbackLocales()
 	{
 		I18n::$locale = 'fr';
@@ -292,9 +242,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayFallbackLocalesFromFallbackArray()
 	{
 		I18n::$locale = 'fr';
@@ -317,9 +264,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayWithFallbackString()
 	{
 		$this->assertSame(
@@ -328,9 +272,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslateArrayWithFallbackFirstKey()
 	{
 		$this->assertSame(
@@ -350,9 +291,6 @@ class I18nTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::translateCount
-	 */
 	public function testTranslateCount()
 	{
 		I18n::$translations = [
@@ -368,9 +306,6 @@ class I18nTest extends TestCase
 		$this->assertSame('Many cars', I18n::translateCount('car', 4));
 	}
 
-	/**
-	 * @covers ::translateCount
-	 */
 	public function testTranslateCountWithPlaceholders()
 	{
 		I18n::$translations = [
@@ -393,9 +328,6 @@ class I18nTest extends TestCase
 		$this->assertSame('1234567 Autos', I18n::translateCount('car', 1234567, 'de', false));
 	}
 
-	/**
-	 * @covers ::translateCount
-	 */
 	public function testTranslateCountWithMissingTranslation()
 	{
 		I18n::$translations = [
@@ -405,9 +337,6 @@ class I18nTest extends TestCase
 		$this->assertNull(I18n::translateCount('car', 1));
 	}
 
-	/**
-	 * @covers ::translateCount
-	 */
 	public function testTranslateCountWithStringTranslation()
 	{
 		I18n::$translations = [
@@ -423,9 +352,6 @@ class I18nTest extends TestCase
 		$this->assertSame('2 bike(s)', I18n::translateCount('bike', 2));
 	}
 
-	/**
-	 * @covers ::translateCount
-	 */
 	public function testTranslateCountWithCallback()
 	{
 		I18n::$translations = [
@@ -445,9 +371,6 @@ class I18nTest extends TestCase
 		$this->assertSame('Many cars', I18n::translateCount('car', 5));
 	}
 
-	/**
-	 * @covers ::translation
-	 */
 	public function testTranslation()
 	{
 		I18n::$translations = [
@@ -470,9 +393,6 @@ class I18nTest extends TestCase
 		$this->assertNull(I18n::translate('test'));
 	}
 
-	/**
-	 * @covers ::translation
-	 */
 	public function testTranslationLoad()
 	{
 		$translations = [
@@ -493,9 +413,6 @@ class I18nTest extends TestCase
 		$this->assertNull(I18n::translate('test'));
 	}
 
-	/**
-	 * @covers ::translations
-	 */
 	public function testTranslations()
 	{
 		$this->assertSame([], I18n::translations());

--- a/tests/Toolkit/IteratorTest.php
+++ b/tests/Toolkit/IteratorTest.php
@@ -2,14 +2,11 @@
 
 namespace Kirby\Toolkit;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Iterator
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Iterator::class)]
 class IteratorTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$iterator = new Iterator($expected = [
@@ -20,9 +17,6 @@ class IteratorTest extends TestCase
 		$this->assertSame($expected, $iterator->data);
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$iterator = new Iterator([
@@ -33,9 +27,6 @@ class IteratorTest extends TestCase
 		$this->assertSame('one', $iterator->key());
 	}
 
-	/**
-	 * @covers ::keys
-	 */
 	public function testKeys()
 	{
 		$iterator = new Iterator([
@@ -51,9 +42,6 @@ class IteratorTest extends TestCase
 		], $iterator->keys());
 	}
 
-	/**
-	 * @covers ::current
-	 */
 	public function testCurrent()
 	{
 		$iterator = new Iterator([
@@ -64,11 +52,6 @@ class IteratorTest extends TestCase
 		$this->assertSame('eins', $iterator->current());
 	}
 
-	/**
-	 * @covers ::current
-	 * @covers ::next
-	 * @covers ::prev
-	 */
 	public function testPrevNext()
 	{
 		$iterator = new Iterator([
@@ -92,9 +75,6 @@ class IteratorTest extends TestCase
 		$this->assertSame('eins', $iterator->current());
 	}
 
-	/**
-	 * @covers ::rewind
-	 */
 	public function testRewind()
 	{
 		$iterator = new Iterator([
@@ -111,9 +91,6 @@ class IteratorTest extends TestCase
 		$this->assertSame('eins', $iterator->current());
 	}
 
-	/**
-	 * @covers ::valid
-	 */
 	public function testValid()
 	{
 		$iterator = new Iterator([]);
@@ -123,9 +100,6 @@ class IteratorTest extends TestCase
 		$this->assertTrue($iterator->valid());
 	}
 
-	/**
-	 * @covers ::count
-	 */
 	public function testCount()
 	{
 		$iterator = new Iterator([
@@ -142,9 +116,6 @@ class IteratorTest extends TestCase
 		$this->assertSame(0, $iterator->count());
 	}
 
-	/**
-	 * @covers ::indexOf
-	 */
 	public function testIndexOf()
 	{
 		$iterator = new Iterator([
@@ -158,9 +129,6 @@ class IteratorTest extends TestCase
 		$this->assertSame(2, $iterator->indexOf('drei'));
 	}
 
-	/**
-	 * @covers ::keyOf
-	 */
 	public function testKeyOf()
 	{
 		$iterator = new Iterator([
@@ -174,9 +142,6 @@ class IteratorTest extends TestCase
 		$this->assertSame('three', $iterator->keyOf('drei'));
 	}
 
-	/**
-	 * @covers ::has
-	 */
 	public function testHas()
 	{
 		$iterator = new Iterator([
@@ -189,9 +154,6 @@ class IteratorTest extends TestCase
 		$this->assertFalse($iterator->has('three'));
 	}
 
-	/**
-	 * @covers ::__isset
-	 */
 	public function testIsset()
 	{
 		$iterator = new Iterator([
@@ -204,9 +166,6 @@ class IteratorTest extends TestCase
 		$this->assertFalse(isset($iterator->three));
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 */
 	public function testDebugInfo()
 	{
 		$array = [

--- a/tests/Toolkit/LazyValueTest.php
+++ b/tests/Toolkit/LazyValueTest.php
@@ -4,16 +4,11 @@ namespace Kirby\Toolkit;
 
 use Closure;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\LazyValue
- */
+#[CoversClass(LazyValue::class)]
 class LazyValueTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::resolve
-	 */
 	public function testValue()
 	{
 		$expected = 'test';
@@ -24,9 +19,6 @@ class LazyValueTest extends TestCase
 		$this->assertSame($expected, $value->resolve());
 	}
 
-	/**
-	 * @covers ::unwrap
-	 */
 	public function testUnwrap()
 	{
 		$value = LazyValue::unwrap($expected = 'a');

--- a/tests/Toolkit/LocaleTest.php
+++ b/tests/Toolkit/LocaleTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Toolkit;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Locale
- */
+#[CoversClass(Locale::class)]
 class LocaleTest extends TestCase
 {
 	protected array $locales = [];
@@ -39,10 +38,6 @@ class LocaleTest extends TestCase
 		Locale::set($this->locales);
 	}
 
-	/**
-	 * @covers ::export
-	 * @covers ::supportedConstants
-	 */
 	public function testExport()
 	{
 		// valid array
@@ -69,11 +64,6 @@ class LocaleTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::normalizeConstant
-	 * @covers ::supportedConstants
-	 */
 	public function testGet()
 	{
 		// default case (all locales are set to the same value)
@@ -100,11 +90,6 @@ class LocaleTest extends TestCase
 		$this->assertSame('C', Locale::get('LC_CTYPE'));
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::normalizeConstant
-	 * @covers ::supportedConstants
-	 */
 	public function testGetInvalid1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -113,11 +98,6 @@ class LocaleTest extends TestCase
 		Locale::get('KIRBY_AWESOME_LOCALE');
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::normalizeConstant
-	 * @covers ::supportedConstants
-	 */
 	public function testGetInvalid2()
 	{
 		$this->expectException(Exception::class);
@@ -126,10 +106,6 @@ class LocaleTest extends TestCase
 		Locale::get(987654321);
 	}
 
-	/**
-	 * @covers ::normalize
-	 * @covers ::normalizeConstant
-	 */
 	public function testNormalize()
 	{
 		// empty array
@@ -155,9 +131,6 @@ class LocaleTest extends TestCase
 		Locale::normalize(123);
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSetString()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
@@ -168,9 +141,6 @@ class LocaleTest extends TestCase
 		$this->assertSame('de_DE.' . $this->localeSuffix, locale_get_default());
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSetArray1()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
@@ -187,9 +157,6 @@ class LocaleTest extends TestCase
 		$this->assertSame('de_AT.' . $this->localeSuffix, locale_get_default());
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSetArray2()
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));

--- a/tests/Toolkit/ObjTest.php
+++ b/tests/Toolkit/ObjTest.php
@@ -3,15 +3,13 @@
 namespace Kirby\Toolkit;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Obj
- */
+#[CoversClass(Obj::class)]
 class ObjTest extends TestCase
 {
 	/**
 	 * covers ::__construct
-	 * @covers ::__call
 	 */
 	public function test__call()
 	{
@@ -19,18 +17,12 @@ class ObjTest extends TestCase
 		$this->assertSame('bar', $obj->foo());
 	}
 
-	/**
-	 * @covers ::__get
-	 */
 	public function test__get()
 	{
 		$obj = new Obj();
 		$this->assertNull($obj->foo);
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetMultiple()
 	{
 		$obj = new Obj([
@@ -50,9 +42,6 @@ class ObjTest extends TestCase
 		$this->assertSame($obj->toArray(), $obj->get(['one', 'two', 'three']));
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetMultipleInvalidFallback()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -62,18 +51,12 @@ class ObjTest extends TestCase
 		$obj->get(['two'], 'invalid fallback');
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray()
 	{
 		$obj = new Obj($expected = ['foo' => 'bar']);
 		$this->assertSame($expected, $obj->toArray());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArrayWithChild()
 	{
 		$parent = new Obj([
@@ -89,18 +72,12 @@ class ObjTest extends TestCase
 		$this->assertSame($expected, $parent->toArray());
 	}
 
-	/**
-	 * @covers ::toJson
-	 */
 	public function testToJson()
 	{
 		$obj = new Obj($expected = ['foo' => 'bar']);
 		$this->assertSame(json_encode($expected), $obj->toJson());
 	}
 
-	/**
-	 * @covers ::toKeys
-	 */
 	public function testToKeys()
 	{
 		$obj = new Obj(['foo' => 'bar']);
@@ -110,9 +87,6 @@ class ObjTest extends TestCase
 		$this->assertSame(['foo', 'one'], $obj->toKeys());
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 */
 	public function test__debugInfo()
 	{
 		$obj = new Obj($expected = ['foo' => 'bar']);

--- a/tests/Toolkit/PaginationTest.php
+++ b/tests/Toolkit/PaginationTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Toolkit;
 use Kirby\Exception\ErrorPageException;
 use Kirby\Exception\Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PaginationTest extends TestCase
 {
@@ -339,10 +340,8 @@ class PaginationTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider rangeProvider
-	 */
-	public function testRange($case)
+	#[DataProvider('rangeProvider')]
+	public function testRange(array $case)
 	{
 		$pagination = new Pagination([
 			'page'  => $case['page'],

--- a/tests/Toolkit/SiloTest.php
+++ b/tests/Toolkit/SiloTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Toolkit;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Silo
- */
+#[CoversClass(Silo::class)]
 class SiloTest extends TestCase
 {
 	public function setUp(): void
@@ -14,19 +13,12 @@ class SiloTest extends TestCase
 		Silo::$data = [];
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::set
-	 */
 	public function testSetAndGet()
 	{
 		Silo::set('foo', 'bar');
 		$this->assertSame('bar', Silo::get('foo'));
 	}
 
-	/**
-	 * @covers ::set
-	 */
 	public function testSetArray()
 	{
 		Silo::set([
@@ -37,9 +29,6 @@ class SiloTest extends TestCase
 		$this->assertSame(['a' => 'A', 'b' => 'B'], Silo::get());
 	}
 
-	/**
-	 * @covers ::get
-	 */
 	public function testGetArray()
 	{
 		Silo::set('a', 'A');
@@ -48,9 +37,6 @@ class SiloTest extends TestCase
 		$this->assertSame(['a' => 'A', 'b' => 'B'], Silo::get());
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveByKey()
 	{
 		Silo::set('a', 'A');
@@ -59,9 +45,6 @@ class SiloTest extends TestCase
 		$this->assertNull(Silo::get('a'));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
 	public function testRemoveAll()
 	{
 		Silo::set('a', 'A');

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -8,11 +8,10 @@ use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Query\TestUser as QueryTestUser;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Str
- */
+#[CoversClass(Str::class)]
 class StrTest extends TestCase
 {
 	public static function setUpBeforeClass(): void
@@ -25,9 +24,6 @@ class StrTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::accepted
-	 */
 	public function testAccepted()
 	{
 		$this->assertSame([
@@ -36,9 +32,6 @@ class StrTest extends TestCase
 		], Str::accepted('image/jpeg,  image/png;q=0.7'));
 	}
 
-	/**
-	 * @covers ::ascii
-	 */
 	public function testAscii()
 	{
 		$this->assertSame('aouss', Str::ascii('äöüß'));
@@ -47,9 +40,6 @@ class StrTest extends TestCase
 		$this->assertSame('Nashata istorija', Str::ascii('Нашата история'));
 	}
 
-	/**
-	 * @covers ::after
-	 */
 	public function testAfter()
 	{
 		$string = 'Hellö Wörld';
@@ -68,9 +58,6 @@ class StrTest extends TestCase
 		$this->assertSame('', Str::after('string', '.'), 'string with non-existing character should return false');
 	}
 
-	/**
-	 * @covers ::after
-	 */
 	public function testAfterWithEmptyNeedle()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -78,9 +65,6 @@ class StrTest extends TestCase
 		Str::after('test', '');
 	}
 
-	/**
-	 * @covers ::afterStart
-	 */
 	public function testAfterStart()
 	{
 		$string = 'Hellö Wörld';
@@ -100,9 +84,6 @@ class StrTest extends TestCase
 		$this->assertSame('Hellö Wörld', Str::afterStart($string, '', true));
 	}
 
-	/**
-	 * @covers ::before
-	 */
 	public function testBefore()
 	{
 		$string = 'Hellö Wörld';
@@ -118,9 +99,6 @@ class StrTest extends TestCase
 		$this->assertSame('', Str::before($string, 'x', true));
 	}
 
-	/**
-	 * @covers ::before
-	 */
 	public function testBeforeWithEmptyNeedle()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -128,9 +106,6 @@ class StrTest extends TestCase
 		Str::before('test', '');
 	}
 
-	/**
-	 * @covers ::beforeEnd
-	 */
 	public function testBeforeEnd()
 	{
 		$string = 'Hellö Wörld';
@@ -150,9 +125,6 @@ class StrTest extends TestCase
 		$this->assertSame('Hellö Wörld', Str::beforeEnd($string, '', true));
 	}
 
-	/**
-	 * @covers ::between
-	 */
 	public function testBetween()
 	{
 		$this->assertSame('trin', Str::between('string', 's', 'g'), 'string between s and g should be trin');
@@ -160,9 +132,6 @@ class StrTest extends TestCase
 		$this->assertSame('', Str::between('string', '.', 'g'), 'function with non-existing character should return false');
 	}
 
-	/**
-	 * @covers ::camel
-	 */
 	public function testCamel()
 	{
 		$string = 'foo_bar';
@@ -181,9 +150,6 @@ class StrTest extends TestCase
 		$this->assertSame('fòôBàř', Str::camel($string));
 	}
 
-	/**
-	 * @covers ::camelToKebab
-	 */
 	public function testCamelToKebab()
 	{
 		$string = 'foobar';
@@ -199,9 +165,6 @@ class StrTest extends TestCase
 		$this->assertSame('foo-bar-with-string', Str::camelToKebab($string));
 	}
 
-	/**
-	 * @covers ::contains
-	 */
 	public function testContains()
 	{
 		$string = 'Hellö Wörld';
@@ -222,9 +185,6 @@ class StrTest extends TestCase
 		$this->assertTrue(Str::contains($string, ''));
 	}
 
-	/**
-	 * @covers ::date
-	 */
 	public function testDate()
 	{
 		$time = mktime(1, 1, 1, 1, 29, 2020);
@@ -269,9 +229,6 @@ class StrTest extends TestCase
 		$this->assertSame('29.01.2020', Str::date($time, '%d.%m.%Y', 'strftime'));
 	}
 
-	/**
-	 * @covers ::convert
-	 */
 	public function testConvert()
 	{
 		$source = 'ÖÄÜ';
@@ -287,26 +244,17 @@ class StrTest extends TestCase
 		$this->assertSame('ISO-8859-1', Str::encoding($result));
 	}
 
-	/**
-	 * @covers ::encode
-	 */
 	public function testEncode()
 	{
 		$email = 'test@getkirby.com';
 		$this->assertSame($email, Html::decode(Str::encode($email)));
 	}
 
-	/**
-	 * @covers ::encoding
-	 */
 	public function testEncoding()
 	{
 		$this->assertSame('UTF-8', Str::encoding('ÖÄÜ'));
 	}
 
-	/**
-	 * @covers ::endsWith
-	 */
 	public function testEndsWith()
 	{
 		$string = 'Hellö Wörld';
@@ -326,9 +274,6 @@ class StrTest extends TestCase
 		$this->assertTrue(Str::endsWith($string, 'WÖRLD', true));
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerpt()
 	{
 		$string   = 'This is a long text<br>with some html';
@@ -338,9 +283,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithoutChars()
 	{
 		$string   = 'This is a long text<br>with some html';
@@ -350,9 +292,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithZeroLength()
 	{
 		$string = 'This is a long text with some html';
@@ -361,9 +300,6 @@ class StrTest extends TestCase
 		$this->assertSame($string, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithoutStripping()
 	{
 		$string   = 'This is a long text<br>with some html';
@@ -373,9 +309,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithDifferentRep()
 	{
 		$string   = 'This is a long text<br>with some html';
@@ -385,9 +318,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithSpaces()
 	{
 		$string   = 'This is a long text   <br>with some html';
@@ -397,9 +327,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithoutSpaces()
 	{
 		$string   = 'ThisIsALongTextWithSomeHtml';
@@ -409,9 +336,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithLineBreaks()
 	{
 		$string   = 'This is a long text ' . PHP_EOL . ' with some html';
@@ -421,9 +345,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithUnicodeChars()
 	{
 		$string   = 'Hellö Wörld text<br>with söme htmäl';
@@ -433,9 +354,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::excerpt
-	 */
 	public function testExcerptWithTagFollowedByInterpunctuation()
 	{
 		$string   = 'Why not <a href="https://getkirby.com/">Get Kirby</a>?';
@@ -445,9 +363,6 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::float
-	 */
 	public function testFloat()
 	{
 		$this->assertSame('0', Str::float(false));
@@ -474,9 +389,6 @@ class StrTest extends TestCase
 		$this->assertSame('0.00000001', Str::float(0.00000001));
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFrom()
 	{
 		$string = 'Hellö Wörld';
@@ -492,9 +404,6 @@ class StrTest extends TestCase
 		$this->assertSame('', Str::from($string, 'x'));
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromWithEmptyNeedle()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -502,9 +411,6 @@ class StrTest extends TestCase
 		Str::from('test', '');
 	}
 
-	/**
-	 * @covers ::increment
-	 */
 	public function testIncrement()
 	{
 		$string = 'Pöst';
@@ -547,9 +453,6 @@ class StrTest extends TestCase
 		$this->assertSame('Pöst-16', Str::increment($string, '-', 10));
 	}
 
-	/**
-	 * @covers ::kebab
-	 */
 	public function testKebab()
 	{
 		$string = 'KingCobra';
@@ -559,9 +462,6 @@ class StrTest extends TestCase
 		$this->assertSame('king-cobra', Str::kebab($string));
 	}
 
-	/**
-	 * @covers ::length
-	 */
 	public function testLength()
 	{
 		$this->assertSame(0, Str::length(''));
@@ -570,18 +470,12 @@ class StrTest extends TestCase
 		$this->assertSame(6, Str::length('Aœ?_ßö'));
 	}
 
-	/**
-	 * @covers ::lower
-	 */
 	public function testLower()
 	{
 		$this->assertSame('öäü', Str::lower('ÖÄÜ'));
 		$this->assertSame('öäü', Str::lower('Öäü'));
 	}
 
-	/**
-	 * @covers ::ltrim
-	 */
 	public function testLtrim()
 	{
 		$this->assertSame('test', Str::ltrim(' test'));
@@ -589,27 +483,18 @@ class StrTest extends TestCase
 		$this->assertSame('jpg', Str::ltrim('test.jpg', 'test.'));
 	}
 
-	/**
-	 * @covers ::match
-	 */
 	public function testMatch()
 	{
 		$this->assertSame(['test', 'es'], Str::match('test', '/t(es)t/'));
 		$this->assertNull(Str::match('one two three', '/(four)/'));
 	}
 
-	/**
-	 * @covers ::matches
-	 */
 	public function testMatches()
 	{
 		$this->assertTrue(Str::matches('test', '/t(es)t/'));
 		$this->assertFalse(Str::matches('one two three', '/(four)/'));
 	}
 
-	/**
-	 * @covers ::matchAll
-	 */
 	public function testMatchAll()
 	{
 		$longText = <<<TEXT
@@ -626,9 +511,6 @@ class StrTest extends TestCase
 		$this->assertNull(Str::matchAll('one two three', '/(four)/'));
 	}
 
-	/**
-	 * @covers ::pool
-	 */
 	public function testPool()
 	{
 		// alpha
@@ -690,9 +572,6 @@ class StrTest extends TestCase
 		$this->assertIsArray(Str::pool('alpha'));
 	}
 
-	/**
-	 * @covers ::position
-	 */
 	public function testPosition()
 	{
 		$string = 'Hellö Wörld';
@@ -710,9 +589,6 @@ class StrTest extends TestCase
 		$this->assertTrue(Str::position($string, 'Ö', true) === 4);
 	}
 
-	/**
-	 * @covers ::position
-	 */
 	public function testPositionWithEmptyNeedle()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -720,18 +596,12 @@ class StrTest extends TestCase
 		Str::position('test', '');
 	}
 
-	/**
-	 * @covers ::query
-	 */
 	public function testQuery()
 	{
 		$result = Str::query('data.1', ['data' => ['foo', 'bar']]);
 		$this->assertSame('bar', $result);
 	}
 
-	/**
-	 * @covers ::random
-	 */
 	public function testRandom()
 	{
 		// choose a high length for a high probability of occurrence of a character of any type
@@ -752,9 +622,6 @@ class StrTest extends TestCase
 		$this->assertFalse(Str::random($length, 'something invalid'));
 	}
 
-	/**
-	 * @covers ::replace
-	 */
 	public function testReplace()
 	{
 		// simple strings with limits
@@ -811,9 +678,6 @@ class StrTest extends TestCase
 		$this->assertSame('apearpearle pear', Str::replace('a p', ['a', 'p'], ['apple', 'pear'], [1, 3]));
 	}
 
-	/**
-	 * @covers ::replace
-	 */
 	public function testReplaceInvalid1()
 	{
 		$this->expectException(Exception::class);
@@ -821,18 +685,12 @@ class StrTest extends TestCase
 		Str::replace('some string', 'string', ['array'], 1);
 	}
 
-	/**
-	 * @covers ::replace
-	 */
 	public function testReplaceInvalid2()
 	{
 		$this->expectException(TypeError::class);
 		Str::replace('some string', 'string', 'other string', 'some invalid string as limit');
 	}
 
-	/**
-	 * @covers ::replace
-	 */
 	public function testReplaceInvalid3()
 	{
 		$this->expectException(Exception::class);
@@ -840,9 +698,6 @@ class StrTest extends TestCase
 		Str::replace('some string', ['some', 'string'], 'other string', [1, 'string']);
 	}
 
-	/**
-	 * @covers ::replacements
-	 */
 	public function testReplacements()
 	{
 		// simple example
@@ -884,9 +739,6 @@ class StrTest extends TestCase
 		], Str::replacements(['a', 'b'], ['c', 'd'], [2]));
 	}
 
-	/**
-	 * @covers ::replacements
-	 */
 	public function testReplacementsInvalid()
 	{
 		$this->expectException(Exception::class);
@@ -894,9 +746,6 @@ class StrTest extends TestCase
 		Str::replacements('string', ['array'], 1);
 	}
 
-	/**
-	 * @covers ::replaceReplacements
-	 */
 	public function testReplaceReplacements()
 	{
 		$this->assertSame(
@@ -934,9 +783,6 @@ class StrTest extends TestCase
 		// edge cases are tested in the Str::replace() unit test
 	}
 
-	/**
-	 * @covers ::replaceReplacements
-	 */
 	public function testReplaceReplacementsInvalid()
 	{
 		$this->expectException(Exception::class);
@@ -950,9 +796,6 @@ class StrTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::rtrim
-	 */
 	public function testRtrim()
 	{
 		$this->assertSame('test', Str::rtrim('test '));
@@ -960,9 +803,6 @@ class StrTest extends TestCase
 		$this->assertSame('test', Str::rtrim('test.jpg', '.jpg'));
 	}
 
-	/**
-	 * @covers ::safeTemplate
-	 */
 	public function testSafeTemplate()
 	{
 		$original = 'This is a {{ test }} with {< html >} and {{ normal }} text.';
@@ -1046,9 +886,6 @@ class StrTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::short
-	 */
 	public function testShort()
 	{
 		$string = 'Super Äwesøme String';
@@ -1078,9 +915,6 @@ class StrTest extends TestCase
 		$this->assertSame('12345…', Str::short(123456, 5));
 	}
 
-	/**
-	 * @covers ::similarity
-	 */
 	public function testSimilarity()
 	{
 		$this->assertSame([
@@ -1150,9 +984,6 @@ class StrTest extends TestCase
 		], Str::similarity('Kirby', 'KIRBY', true));
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlug()
 	{
 		// Double dashes
@@ -1204,9 +1035,6 @@ class StrTest extends TestCase
 		Str::$language = [];
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlugMaxLength()
 	{
 		// default
@@ -1228,9 +1056,6 @@ class StrTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::snake
-	 */
 	public function testSnake()
 	{
 		$string = 'KingCobra';
@@ -1240,9 +1065,6 @@ class StrTest extends TestCase
 		$this->assertSame('king_cobra', Str::snake($string));
 	}
 
-	/**
-	 * @covers ::split
-	 */
 	public function testSplit()
 	{
 		// default separator
@@ -1271,9 +1093,6 @@ class StrTest extends TestCase
 		$this->assertSame($string, Str::split($string));
 	}
 
-	/**
-	 * @covers ::startsWith
-	 */
 	public function testStartsWith()
 	{
 		$string = 'Hellö Wörld';
@@ -1293,9 +1112,6 @@ class StrTest extends TestCase
 		$this->assertTrue(Str::startsWith($string, 'hellö', true));
 	}
 
-	/**
-	 * @covers ::studly
-	 */
 	public function testStudly()
 	{
 		$string = 'foo_bar';
@@ -1314,9 +1130,6 @@ class StrTest extends TestCase
 		$this->assertSame('FòôBàř', Str::studly($string));
 	}
 
-	/**
-	 * @covers ::substr
-	 */
 	public function testSubstr()
 	{
 		$string = 'äöü';
@@ -1329,9 +1142,6 @@ class StrTest extends TestCase
 		$this->assertSame('ü', Str::substr($string, -1));
 	}
 
-	/**
-	 * @covers ::template
-	 */
 	public function testTemplate()
 	{
 		// query with a string
@@ -1417,9 +1227,6 @@ class StrTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::toBytes
-	 */
 	public function testToBytes()
 	{
 		$this->assertSame(0, Str::toBytes(''));
@@ -1437,9 +1244,6 @@ class StrTest extends TestCase
 		$this->assertSame(2 * 1024 * 1024 * 1024, Str::toBytes('2g'));
 	}
 
-	/**
-	 * @covers ::toType
-	 */
 	public function testToType()
 	{
 		// string to string
@@ -1476,9 +1280,6 @@ class StrTest extends TestCase
 		$this->assertSame(1, Str::toType('1', 1));
 	}
 
-	/**
-	 * @covers ::trim
-	 */
 	public function testTrim()
 	{
 		$this->assertSame('test', Str::trim(' test '));
@@ -1486,9 +1287,6 @@ class StrTest extends TestCase
 		$this->assertSame('test', Str::trim('.test.', '.'));
 	}
 
-	/**
-	 * @covers ::ucfirst
-	 */
 	public function testUcfirst()
 	{
 		$this->assertSame('Hello world', Str::ucfirst('hello world'));
@@ -1498,9 +1296,6 @@ class StrTest extends TestCase
 		$this->assertSame('Hello WORLD', Str::ucfirst('hello WORLD'));
 	}
 
-	/**
-	 * @covers ::ucwords
-	 */
 	public function testUcwords()
 	{
 		$this->assertSame('Hello World', Str::ucwords('hello world'));
@@ -1508,18 +1303,12 @@ class StrTest extends TestCase
 		$this->assertSame('Hello World', Str::ucwords('HELLO WORLD'));
 	}
 
-	/**
-	 * @covers ::unhtml
-	 */
 	public function testUnhtml()
 	{
 		$string = 'some <em>crazy</em> stuff';
 		$this->assertSame('some crazy stuff', Str::unhtml($string));
 	}
 
-	/**
-	 * @covers ::until
-	 */
 	public function testUntil()
 	{
 		$string = 'Hellö Wörld';
@@ -1535,9 +1324,6 @@ class StrTest extends TestCase
 		$this->assertSame('', Str::until($string, 'x'));
 	}
 
-	/**
-	 * @covers ::until
-	 */
 	public function testUntilWithEmptyNeedle()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -1545,18 +1331,12 @@ class StrTest extends TestCase
 		Str::until('test', '');
 	}
 
-	/**
-	 * @covers ::upper
-	 */
 	public function testUpper()
 	{
 		$this->assertSame('ÖÄÜ', Str::upper('öäü'));
 		$this->assertSame('ÖÄÜ', Str::upper('Öäü'));
 	}
 
-	/**
-	 * @covers ::widont
-	 */
 	public function testWidont()
 	{
 		$this->assertSame('Test', Str::widont('Test'));
@@ -1571,9 +1351,6 @@ class StrTest extends TestCase
 		$this->assertSame('Omelette du&nbsp;fromage&nbsp;?', Str::widont('Omelette du fromage ?'));
 	}
 
-	/**
-	 * @covers ::wrap
-	 */
 	public function testWrap()
 	{
 		$string = 'Pöst title';

--- a/tests/Toolkit/SymmetricCryptoTest.php
+++ b/tests/Toolkit/SymmetricCryptoTest.php
@@ -6,10 +6,9 @@ use Closure;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\SymmetricCrypto
- */
+#[CoversClass(SymmetricCrypto::class)]
 class SymmetricCryptoTest extends TestCase
 {
 	public function setUp(): void
@@ -19,9 +18,6 @@ class SymmetricCryptoTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructKeyAndPassword()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -30,9 +26,6 @@ class SymmetricCryptoTest extends TestCase
 		new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop', password: 'super secure');
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructKeyLength()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -41,9 +34,6 @@ class SymmetricCryptoTest extends TestCase
 		new SymmetricCrypto(secretKey: 'not secure');
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 */
 	public function testDebugInfo()
 	{
 		$crypto = new SymmetricCrypto();
@@ -70,9 +60,6 @@ class SymmetricCryptoTest extends TestCase
 		], $crypto->__debugInfo());
 	}
 
-	/**
-	 * @covers ::__destruct
-	 */
 	public function testDestruct()
 	{
 		// helper to access protected props by reference
@@ -105,9 +92,6 @@ class SymmetricCryptoTest extends TestCase
 		$this->assertSame(['password' => '', 'secretKey' => null, 'secretKeysByOptions' => []], $values);
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecrypt()
 	{
 		$crypto = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
@@ -118,9 +102,6 @@ class SymmetricCryptoTest extends TestCase
 		$this->assertSame('a very confidential message', $crypto->decrypt($input));
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptInvalidJson()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -130,9 +111,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt('not JSON!');
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptInvalidMode()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -146,9 +124,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt($input);
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptMissingProps()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -158,9 +133,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt('{"mode":"secretbox","data":"this is set","nonce":"this is also set"}');
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptTampered1()
 	{
 		$this->expectException(LogicException::class);
@@ -175,9 +147,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt($input);
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptTampered2()
 	{
 		$this->expectException(LogicException::class);
@@ -192,9 +161,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt($input);
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptTampered3()
 	{
 		$this->expectException(LogicException::class);
@@ -209,9 +175,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt($input);
 	}
 
-	/**
-	 * @covers ::decrypt
-	 */
 	public function testDecryptTampered4()
 	{
 		$this->expectException(LogicException::class);
@@ -226,9 +189,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->decrypt($input);
 	}
 
-	/**
-	 * @covers ::encrypt
-	 */
 	public function testEncrypt()
 	{
 		$crypto1    = new SymmetricCrypto(secretKey: 'abcdefghijklmnopabcdefghijklmnop');
@@ -258,26 +218,17 @@ class SymmetricCryptoTest extends TestCase
 		$this->assertNotSame($props1['salt'], $props2['salt']);
 	}
 
-	/**
-	 * @covers ::isAvailable
-	 */
 	public function testIsAvailable()
 	{
 		$this->assertTrue(SymmetricCrypto::isAvailable());
 	}
 
-	/**
-	 * @covers ::secretKey
-	 */
 	public function testSecretKeyFromKey()
 	{
 		$crypto = new SymmetricCrypto(secretKey: $key = 'abcdefghijklmnopabcdefghijklmnop');
 		$this->assertSame($key, $crypto->secretKey());
 	}
 
-	/**
-	 * @covers ::secretKey
-	 */
 	public function testSecretKeyFromPassword()
 	{
 		$crypto = new SymmetricCrypto(password: 'super secure');
@@ -293,9 +244,6 @@ class SymmetricCryptoTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::secretKey
-	 */
 	public function testSecretKeyFromPasswordNoSalt()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -305,9 +253,6 @@ class SymmetricCryptoTest extends TestCase
 		$crypto->secretKey();
 	}
 
-	/**
-	 * @covers ::secretKey
-	 */
 	public function testSecretKeyRandom()
 	{
 		$crypto1 = new SymmetricCrypto();

--- a/tests/Toolkit/TotpTest.php
+++ b/tests/Toolkit/TotpTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Toolkit;
 
 use Base32\Base32;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Totp
- */
+#[CoversClass(Totp::class)]
 class TotpTest extends TestCase
 {
 	public function tearDown(): void
@@ -15,9 +14,6 @@ class TotpTest extends TestCase
 		MockTime::$time = 1337000000;
 	}
 
-	/**
-	 * @covers ::generate
-	 */
 	public function testGenerate()
 	{
 		// test cases taken from the appendix of RFC6238:
@@ -45,10 +41,6 @@ class TotpTest extends TestCase
 		$this->assertSame('353130', $totp->generate());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::secret
-	 */
 	public function testSecret()
 	{
 		// randomly generated secret
@@ -68,9 +60,6 @@ class TotpTest extends TestCase
 		$this->assertSame($secret, $totp4->secret());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSecretInvalid1()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -79,9 +68,6 @@ class TotpTest extends TestCase
 		new Totp('');
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSecretInvalid2()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -90,9 +76,6 @@ class TotpTest extends TestCase
 		new Totp('TOOSHORT');
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testSecretInvalid3()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -101,9 +84,6 @@ class TotpTest extends TestCase
 		new Totp('ABcDEfGHiJKlMNoPQRStuVWXYZ012345'); // invalid Base32 digits
 	}
 
-	/**
-	 * @covers ::uri
-	 */
 	public function testUri()
 	{
 		$totp = new Totp('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
@@ -115,9 +95,6 @@ class TotpTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::verify
-	 */
 	public function testVerify()
 	{
 		MockTime::$time = 1111111111;

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -7,6 +7,8 @@ use Kirby\Cms\App;
 use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class CanBeCounted implements \Countable
@@ -25,9 +27,7 @@ class HasCount
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\V
- */
+#[CoversClass(V::class)]
 class VTest extends TestCase
 {
 	public function tearDown(): void
@@ -35,18 +35,12 @@ class VTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::validators
-	 */
 	public function testValidators()
 	{
 		$this->assertNotEmpty(V::$validators);
 		$this->assertNotEmpty(V::validators());
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
 	public function testCustomValidator()
 	{
 		V::$validators['me'] = function ($name): bool {
@@ -59,9 +53,6 @@ class VTest extends TestCase
 		$this->assertFalse(V::me('you'));
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
 	public function testCallInvalidMethod()
 	{
 		$this->expectException(Exception::class);
@@ -298,9 +289,6 @@ class VTest extends TestCase
 		$this->assertFalse(V::in('bastian', []));
 	}
 
-	/**
-	 * @covers ::invalid
-	 */
 	public function testInvalid()
 	{
 		$data = [
@@ -341,9 +329,6 @@ class VTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	/**
-	 * @covers ::invalid
-	 */
 	public function testInvalidSimple()
 	{
 		$data   = ['homer', null];
@@ -352,9 +337,6 @@ class VTest extends TestCase
 		$this->assertSame(1, $result[1]);
 	}
 
-	/**
-	 * @covers ::invalid
-	 */
 	public function testInvalidRequired()
 	{
 		$rules    = ['email' => ['required']];
@@ -385,9 +367,6 @@ class VTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	/**
-	 * @covers ::invalid
-	 */
 	public function testInvalidOptions()
 	{
 		$rules = [
@@ -418,9 +397,6 @@ class VTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	/**
-	 * @covers ::invalid
-	 */
 	public function testInvalidWithMultipleMessages()
 	{
 		$data     = ['username' => ''];
@@ -848,13 +824,8 @@ class VTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::input
-	 * @covers ::message
-	 * @covers ::value
-	 * @dataProvider inputProvider
-	 */
-	public function testInput($input, $rules, $result, $message = null)
+	#[DataProvider('inputProvider')]
+	public function testInput(array $input, array $rules, bool $result, string|null $message = null)
 	{
 		// load the translation strings
 		new App();
@@ -867,9 +838,6 @@ class VTest extends TestCase
 		$this->assertTrue(V::input($input, $rules));
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$result = V::value('test@getkirby.com', [
@@ -881,9 +849,6 @@ class VTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValueFails()
 	{
 		// load the translation strings

--- a/tests/Toolkit/ViewTest.php
+++ b/tests/Toolkit/ViewTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Toolkit;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\View
- */
+#[CoversClass(View::class)]
 class ViewTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/view';
@@ -17,10 +16,6 @@ class ViewTest extends TestCase
 		return new View(static::FIXTURES . '/view.php', $data);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::data
-	 */
 	public function testData()
 	{
 		$view = $this->view();
@@ -30,9 +25,6 @@ class ViewTest extends TestCase
 		$this->assertSame(['test'], $view->data());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExists()
 	{
 		$view = $this->view();
@@ -42,28 +34,18 @@ class ViewTest extends TestCase
 		$this->assertFalse($view->exists());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::file
-	 */
 	public function testFile()
 	{
 		$view = $this->view();
 		$this->assertSame(static::FIXTURES . '/view.php', $view->file());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRender()
 	{
 		$view = $this->view(['name' => 'Homer']);
 		$this->assertSame('Hello Homer', $view->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithMissingFile()
 	{
 		$this->expectException(Exception::class);
@@ -73,9 +55,6 @@ class ViewTest extends TestCase
 		$view->render();
 	}
 
-	/**
-	 * @covers ::render
-	 */
 	public function testRenderWithException()
 	{
 		$this->expectException(Exception::class);
@@ -85,10 +64,6 @@ class ViewTest extends TestCase
 		$view->render();
 	}
 
-	/**
-	 * @covers ::toString
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$view = $this->view(['name' => 'Tester']);

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -3,19 +3,16 @@
 namespace Kirby\Toolkit;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Toolkit\Xml
- */
+#[CoversClass(Xml::class)]
 class XmlTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/xml';
 
-	/**
-	 * @covers       ::attr
-	 * @dataProvider attrProvider
-	 */
-	public function testAttr($input, $value, $expected)
+	#[DataProvider('attrProvider')]
+	public function testAttr(array $input, bool|null $value, string $expected)
 	{
 		$this->assertSame($expected, Xml::attr($input, $value));
 	}
@@ -36,9 +33,6 @@ class XmlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::attr
-	 */
 	public function testAttrArrayValue()
 	{
 		$result = Xml::attr('a', ['a', 'b']);
@@ -57,11 +51,6 @@ class XmlTest extends TestCase
 		$this->assertSame('a="&"', $result);
 	}
 
-	/**
-	 * @covers ::parse
-	 * @covers ::simplify
-	 * @covers ::create
-	 */
 	public function testParseSimplifyCreate()
 	{
 		$this->assertSame('<name>Homer</name>', Xml::create('Homer', 'name', false));
@@ -130,6 +119,7 @@ class XmlTest extends TestCase
 				]
 			]
 		];
+
 		$this->assertSame($data, Xml::parse(file_get_contents(static::FIXTURES . '/simpsons.xml')));
 		$this->assertStringEqualsFile(static::FIXTURES . '/simpsons.xml', Xml::create($data, 'invalid'));
 		$this->assertStringEqualsFile(static::FIXTURES . '/simpsons_4spaces.xml', Xml::create($data, 'invalid', true, '    '));
@@ -140,9 +130,6 @@ class XmlTest extends TestCase
 		$this->assertNull(Xml::parse('<this>is invalid</that>'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseEntities()
 	{
 		$xml   = '<!DOCTYPE d [<!ENTITY e "bar">]><x>this is a file: foo &e; (with entities)</x>';
@@ -154,18 +141,12 @@ class XmlTest extends TestCase
 		], $array);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseRecursiveEntities()
 	{
 		$xml = file_get_contents(static::FIXTURES . '/billion-laughs.xml');
 		$this->assertNull(Xml::parse($xml));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
 	public function testParseXXE()
 	{
 		$xml   = '<!DOCTYPE d [<!ENTITY e SYSTEM "' . __FILE__ . '">]><x>this is a file: &e; with an XXE vulnerability</x>';
@@ -177,10 +158,6 @@ class XmlTest extends TestCase
 		], $array);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 */
 	public function testEncodeDecode()
 	{
 		$expected = 'S&#252;per &#214;nenc&#339;ded &#223;tring';
@@ -195,17 +172,11 @@ class XmlTest extends TestCase
 		$this->assertSame('', Xml::encode(null));
 	}
 
-	/**
-	 * @covers ::entities
-	 */
 	public function testEntities()
 	{
 		$this->assertSame(Xml::$entities, Xml::entities());
 	}
 
-	/**
-	 * @covers ::tag
-	 */
 	public function testTag()
 	{
 		$tag = Xml::tag('name', 'content');
@@ -233,11 +204,8 @@ class XmlTest extends TestCase
 		$this->assertSame('  <name foo="bar">' . PHP_EOL . '   Test' . PHP_EOL . '   Test2' . PHP_EOL . '  </name>', $tag);
 	}
 
-	/**
-	 * @covers       ::value
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueProvider')]
+	public function testValue(bool|int|string|null $input, string|null $expected)
 	{
 		$this->assertSame($expected, Xml::value($input));
 	}

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -4,17 +4,14 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\FileUuid
- */
+#[CoversClass(FileUuid::class)]
 class FileUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.FileUuid';
 
-	/**
-	 * @covers ::findByCache
-	 */
 	public function testFindByCache()
 	{
 		$file = $this->app->file('page-a/test.pdf');
@@ -32,9 +29,6 @@ class FileUuidTest extends TestCase
 		$this->assertIsFile($file, $uuid->model(true));
 	}
 
-	/**
-	 * @covers ::findByIndex
-	 */
 	public function testFindByIndex()
 	{
 		$file = $this->app->file('page-a/test.pdf');
@@ -49,18 +43,12 @@ class FileUuidTest extends TestCase
 		$this->assertNull($uuid->model());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$uuid = new FileUuid('file://just-a-file');
 		$this->assertSame('just-a-file', $uuid->id());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testIdGenerate()
 	{
 		$file = $this->app->file('page-b/foo.pdf');
@@ -70,9 +58,6 @@ class FileUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testIdGenerateExistingButEmpty()
 	{
 		$file = $this->app->file('page-b/foo.pdf');
@@ -83,9 +68,6 @@ class FileUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		$index = FileUuid::index();
@@ -94,18 +76,12 @@ class FileUuidTest extends TestCase
 		$this->assertSame(4, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
 	public function testRetrieveId()
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$this->assertSame('my-file', ModelUuid::retrieveId($file));
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$file = $this->app->file('page-a/test.pdf');
@@ -113,9 +89,6 @@ class FileUuidTest extends TestCase
 		$this->assertSame($url, $file->uuid()->url());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$file = $this->app->file('page-a/test.pdf');
@@ -132,10 +105,7 @@ class FileUuidTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multilangProvider
-	 * @covers ::id
-	 */
+	#[DataProvider('multilangProvider')]
 	public function testMultilang(string $language, string $title)
 	{
 		$app = new App([

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -4,17 +4,14 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\PageUuid
- */
+#[CoversClass(PageUuid::class)]
 class PageUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.PageUuid';
 
-	/**
-	 * @covers ::findByCache
-	 */
 	public function testFindByCache()
 	{
 		$page = $this->app->page('page-a');
@@ -32,9 +29,6 @@ class PageUuidTest extends TestCase
 		$this->assertIsPage($page, $uuid->model(true));
 	}
 
-	/**
-	 * @covers ::findByIndex
-	 */
 	public function testFindByIndex()
 	{
 		$page = $this->app->page('page-a');
@@ -49,18 +43,12 @@ class PageUuidTest extends TestCase
 		$this->assertNull($uuid->model());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$uuid = new PageUuid('page://just-a-file');
 		$this->assertSame('just-a-file', $uuid->id());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testIdGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -70,9 +58,6 @@ class PageUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testIdGenerateExistingButEmpty()
 	{
 		$page = $this->app->page('page-b');
@@ -83,9 +68,6 @@ class PageUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		$index = PageUuid::index();
@@ -94,18 +76,12 @@ class PageUuidTest extends TestCase
 		$this->assertSame(3, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
 	public function testRetrieveId()
 	{
 		$page = $this->app->page('page-a');
 		$this->assertSame('my-page', ModelUuid::retrieveId($page));
 	}
 
-	/**
-	 * @covers ::url
-	 */
 	public function testUrl()
 	{
 		$page = $this->app->page('page-a');
@@ -121,11 +97,7 @@ class PageUuidTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multilangProvider
-	 * @covers ::id
-	 * @covers ::url
-	 */
+	#[DataProvider('multilangProvider')]
 	public function testMultilang(string $language, string $title)
 	{
 		$app = new App([

--- a/tests/Uuid/SiteUuidTest.php
+++ b/tests/Uuid/SiteUuidTest.php
@@ -3,26 +3,19 @@
 namespace Kirby\Uuid;
 
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\SiteUuid
- */
+#[CoversClass(SiteUuid::class)]
 class SiteUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.SiteUuid';
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$site = $this->app->site();
 		$this->assertSame('', $site->uuid()->id());
 	}
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		$index = SiteUuid::index();
@@ -31,28 +24,18 @@ class SiteUuidTest extends TestCase
 		$this->assertSame(1, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$site = $this->app->site();
 		$this->assertIsSite($site, Uuid::for('site://')->model());
 	}
 
-	/**
-	 * @covers ::populate
-	 */
 	public function testPopulate()
 	{
 		$uuid = $this->app->site()->uuid();
 		$this->assertTrue($uuid->populate());
 	}
 
-	/**
-	 * @covers ::toString
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		$uuid = $this->app->site()->uuid();

--- a/tests/Uuid/UriTest.php
+++ b/tests/Uuid/UriTest.php
@@ -2,9 +2,10 @@
 
 namespace Kirby\Uuid;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uri
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(Uri::class)]
 class UriTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uri';
@@ -36,29 +37,20 @@ class UriTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::domain
-	 * @dataProvider provider
-	 */
+	#[DataProvider('provider')]
 	public function testDomain(string $input, string $scheme, string|null $domain)
 	{
 		$uri = new Uri($input);
 		$this->assertSame($domain, $uri->domain());
 	}
 
-	/**
-	 * @covers ::host
-	 * @dataProvider provider
-	 */
+	#[DataProvider('provider')]
 	public function testHost(string $input, string $scheme, string|null $domain, string|null $path)
 	{
 		$uri = new Uri($input);
 		$this->assertSame($domain ?? '', $uri->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
 	public function testHostSet()
 	{
 		$uri = new Uri('page://my-id');
@@ -68,31 +60,21 @@ class UriTest extends TestCase
 		$this->assertSame('page://my-other-id', $uri->toString());
 	}
 
-	/**
-	 * @dataProvider provider
-	 */
+	#[DataProvider('provider')]
 	public function testPath(string $input, string $scheme, string|null $domain, string|null $path)
 	{
 		$uri = new Uri($input);
 		$this->assertSame($path ?? '', $uri->path()->toString());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::base
-	 * @covers ::toString
-	 * @dataProvider provider
-	 */
+	#[DataProvider('provider')]
 	public function testToString(string $input)
 	{
 		$uri = new Uri($input);
 		$this->assertSame($input, $uri->toString());
 	}
 
-	/**
-	 * @covers ::type
-	 * @dataProvider provider
-	 */
+	#[DataProvider('provider')]
 	public function testType(string $input, string $scheme)
 	{
 		$uri = new Uri($input);

--- a/tests/Uuid/UserUuidTest.php
+++ b/tests/Uuid/UserUuidTest.php
@@ -3,17 +3,13 @@
 namespace Kirby\Uuid;
 
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\UserUuid
- */
+#[CoversClass(UserUuid::class)]
 class UserUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.UserUuid';
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		$index = UserUuid::index();
@@ -22,18 +18,12 @@ class UserUuidTest extends TestCase
 		$this->assertSame(1, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$user = $this->app->user('my-user');
 		$this->assertIsUser($user, Uuid::for('user://my-user')->model());
 	}
 
-	/**
-	 * @covers ::populate
-	 */
 	public function testPopulate()
 	{
 		$uuid = $this->app->user('my-user')->uuid();

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestUuid extends Uuid
 {
@@ -16,16 +17,11 @@ class TestUuid extends Uuid
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uuid
- */
+#[CoversClass(Uuid::class)]
 class UuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuid';
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructUuidString()
 	{
 		$uuid = new TestUuid($uri = 'page://my-page-uuid');
@@ -35,9 +31,6 @@ class UuidTest extends TestCase
 		$this->assertNull($uuid->context);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructModel()
 	{
 		$app      = $this->app;
@@ -53,9 +46,6 @@ class UuidTest extends TestCase
 		$this->assertSame($siblings, $uuid->context);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructModelStringNoMatch()
 	{
 		$app  = $this->app;
@@ -75,9 +65,6 @@ class UuidTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructConfigDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
@@ -86,11 +73,6 @@ class UuidTest extends TestCase
 		new TestUuid('page://my-page-uuid');
 	}
 
-	/**
-	 * @covers ::clear
-	 * @covers ::isCached
-	 * @covers ::populate
-	 */
 	public function testCache()
 	{
 		$page    = $this->app->page('page-a');
@@ -121,9 +103,6 @@ class UuidTest extends TestCase
 		$this->assertFalse($subpage->isCached());
 	}
 
-	/**
-	 * @covers ::clear
-	 */
 	public function testClearNotGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -134,9 +113,6 @@ class UuidTest extends TestCase
 		$this->assertNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::context
-	 */
 	public function testContext()
 	{
 		$uuid = $this->app->page('page-a')->uuid();
@@ -151,9 +127,6 @@ class UuidTest extends TestCase
 		$this->assertSame(2, iterator_count($uuid->context()));
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForUuidString()
 	{
 		$this->assertInstanceOf(PageUuid::class, Uuid::for('page://my-id'));
@@ -165,9 +138,6 @@ class UuidTest extends TestCase
 		// $this->assertInstanceOf(StructureUuid::class, Uuid::for('struct://my-id'));
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForUuidStringInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -175,18 +145,12 @@ class UuidTest extends TestCase
 		Uuid::for('foo://my-id');
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPermalinkString()
 	{
 		$this->assertInstanceOf(PageUuid::class, Uuid::for('/@/page/my-id'));
 		$this->assertInstanceOf(FileUuid::class, Uuid::for('/@/file/my-id'));
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPermalinkStringInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -194,9 +158,6 @@ class UuidTest extends TestCase
 		Uuid::for('/@/foo/my-id');
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForStringInvalid()
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -204,9 +165,6 @@ class UuidTest extends TestCase
 		Uuid::for('foo˜bar');
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForObject()
 	{
 		$site   = $this->app->site();
@@ -225,18 +183,12 @@ class UuidTest extends TestCase
 		// $this->assertInstanceOf(StructureUuid::class, Uuid::for($struct));
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForConfigDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 		$this->assertNull(Uuid::for('page://my-page-uuid'));
 	}
 
-	/**
-	 * @covers ::generate
-	 */
 	public function testGenerate()
 	{
 		// default length
@@ -280,9 +232,6 @@ class UuidTest extends TestCase
 		Uuid::$generator = null;
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$uuid = new TestUuid('page://my-uuid-id');
@@ -293,18 +242,12 @@ class UuidTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::index
-	 */
 	public function testIndex()
 	{
 		$this->assertInstanceOf(Generator::class, Uuid::index());
 		$this->assertSame(0, iterator_count(Uuid::index()));
 	}
 
-	/**
-	 * @covers ::indexes
-	 */
 	public function testIndexes()
 	{
 		$uuid = new TestUuid('page://my-uuid');
@@ -319,9 +262,6 @@ class UuidTest extends TestCase
 		$this->assertSame(2, iterator_count($uuid->indexes()));
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIs()
 	{
 		$this->assertTrue(Uuid::is('site://'));
@@ -357,9 +297,6 @@ class UuidTest extends TestCase
 		$this->assertFalse(Uuid::is('not a page://something'));
 	}
 
-	/**
-	 * @covers ::isCached
-	 */
 	public function testIsCachedNotGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -370,9 +307,6 @@ class UuidTest extends TestCase
 		$this->assertNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::is
-	 */
 	public function testIsConfigDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
@@ -383,18 +317,12 @@ class UuidTest extends TestCase
 		$this->assertFalse(Uuid::is('file://something/else'));
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKey()
 	{
 		$uuid = $this->app->page('page-a')->uuid();
 		$this->assertSame('page/my/-page', $uuid->key());
 	}
 
-	/**
-	 * @covers ::key
-	 */
 	public function testKeyGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -404,9 +332,6 @@ class UuidTest extends TestCase
 		$this->assertSame($key, $uuid->key());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		// for Uuid that was constructed from model
@@ -431,9 +356,6 @@ class UuidTest extends TestCase
 		$this->assertTrue($uuid->isCached());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModelNotFound()
 	{
 		$this->assertNull(Uuid::for('page://something')->model());
@@ -441,9 +363,6 @@ class UuidTest extends TestCase
 		$this->assertNull(Uuid::for('file://something')->model());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModelNotFoundIndexLookupDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => ['index' => false]]]]);
@@ -452,9 +371,6 @@ class UuidTest extends TestCase
 		Uuid::for('page://something')->model();
 	}
 
-	/**
-	 * @covers ::isCached
-	 */
 	public function testPopulateGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -464,20 +380,12 @@ class UuidTest extends TestCase
 		$this->assertNotNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
 	public function testRetrieveId()
 	{
 		$page = $this->app->page('page-a');
 		$this->assertSame('page-a', Uuid::retrieveId($page));
 	}
 
-	/**
-	 * @covers ::id
-	 * @covers ::toString
-	 * @covers ::__toString
-	 */
 	public function testToString()
 	{
 		// with ID already stored in content
@@ -492,19 +400,12 @@ class UuidTest extends TestCase
 		$this->assertSame(Str::after($id, '://'), $this->app->page('page-b')->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$page = $this->app->page($dir = 'page-a/subpage-a');
 		$this->assertSame($dir, $page->uuid()->value());
 	}
 
-	/**
-	 * @covers ::model
-	 * @covers ::populate
-	 */
 	public function testCacheInvalidModelId()
 	{
 		$page = $this->app->page('page-a');

--- a/tests/Uuid/UuidsTest.php
+++ b/tests/Uuid/UuidsTest.php
@@ -6,17 +6,13 @@ use Kirby\Cache\Cache;
 use Kirby\Cache\MemoryCache;
 use Kirby\Cache\NullCache;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uuids
- */
+#[CoversClass(Uuids::class)]
 class UuidsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuids';
 
-	/**
-	 * @covers ::cache
-	 */
 	public function testCache()
 	{
 		$this->assertInstanceOf(Cache::class, Uuids::cache());
@@ -40,9 +36,6 @@ class UuidsTest extends TestCase
 		$this->assertInstanceOf(NullCache::class, Uuids::cache());
 	}
 
-	/**
-	 * @covers ::each
-	 */
 	public function testEach()
 	{
 		$models = 0;
@@ -52,9 +45,6 @@ class UuidsTest extends TestCase
 		$this->assertSame(7, $models);
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
 	public function testEnabled()
 	{
 		$this->assertTrue(Uuids::enabled());
@@ -62,9 +52,6 @@ class UuidsTest extends TestCase
 		$this->assertFalse(Uuids::enabled());
 	}
 
-	/**
-	 * @covers ::generate
-	 */
 	public function testGenerate()
 	{
 		$page = $this->app->page('page-b');
@@ -80,9 +67,6 @@ class UuidsTest extends TestCase
 		$this->assertNotNull($file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::generate
-	 */
 	public function testGenerateIfDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
@@ -93,9 +77,6 @@ class UuidsTest extends TestCase
 		Uuids::generate();
 	}
 
-	/**
-	 * @covers ::populate
-	 */
 	public function testPopulate()
 	{
 		$page     = $this->app->page('page-a');
@@ -199,9 +180,6 @@ class UuidsTest extends TestCase
 		Uuids::cache()->flush();
 	}
 
-	/**
-	 * @covers ::populate
-	 */
 	public function testPopulateIfDisabled()
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] https://github.com/getkirby/kirby/pull/6986
- [ ] Figure out why we're losing coverage %

### Summary of changes
- Replaces PHPUnit `@covers`/`@coversDefaultClass` and `@dataProvider` annotations with PHP attributes


### Reasoning
PHPUnit will remove docblock annotation support in v12, already throwing deprecation notices in v11.

PHPUnit does offer a `CoversMethod` attribute. However, this can only be applied per class, not to a specific test method. As such, I don't think there is much value in it. That's why I followed a only `CoversClass` approach (which is also the preferred one by the maintainer of PHPUnit).

### Additional context
Doesn't remove all PHPUnit deprecation errors but the biggest chunk.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Housekeeping
- PHPUnit: use attributes for coverage and data providers



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
