### PR TITLE
Version Cache

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Generator;
 use Kirby\Content\Storage;
+use Kirby\Content\VersionCache;
 use Kirby\Data\Data;
 use Kirby\Email\Email as BaseEmail;
 use Kirby\Exception\ErrorPageException;
@@ -97,6 +98,9 @@ class App
 	public function __construct(array $props = [], bool $setInstance = true)
 	{
 		$this->core = new Core($this);
+
+		// start with a fresh version cache
+		VersionCache::$cache = [];
 
 		// register all roots to be able to load stuff afterwards
 		$this->bakeRoots($props['roots'] ?? []);

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Content\MemoryStorage;
+use Kirby\Content\VersionCache;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
@@ -76,6 +77,10 @@ trait FileActions
 
 			// rename the main file
 			F::move($oldFile->root(), $newFile->root());
+
+			// hard reset for the version cache
+			// to avoid broken/overlapping file references
+			VersionCache::$cache = [];
 
 			// move the content storage versions
 			$oldFile->storage()->moveAll(to: $newFile->storage());

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Content\MemoryStorage;
+use Kirby\Content\VersionCache;
 use Kirby\Content\VersionId;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
@@ -118,6 +119,10 @@ trait PageActions
 						message: 'The page directory cannot be moved'
 					);
 				}
+
+				// hard reset for the version cache
+				// to avoid broken/overlapping page references
+				VersionCache::$cache = [];
 
 				// remove from the siblings
 				static::updateParentCollections($oldPage, 'remove');

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -124,14 +124,14 @@ class Version
 			(new Changes())->track($this->model);
 		}
 
-		// make sure that an older version does not exist in the cache
-		VersionCache::remove($this, $language);
-
 		$this->model->storage()->create(
 			versionId: $this->id,
 			language: $language,
 			fields: $this->prepareFieldsBeforeWrite($fields, $language)
 		);
+
+		// make sure that an older version does not exist in the cache
+		VersionCache::remove($this, $language);
 	}
 
 	/**
@@ -146,14 +146,14 @@ class Version
 
 		$this->model->storage()->delete($this->id, $language);
 
-		// Remove the version from the cache
-		VersionCache::remove($this, $language);
-
 		// untrack the changes if the version does no longer exist
 		// in any of the available languages
 		if ($this->id->is(VersionId::changes()) === true && $this->exists('*') === false) {
 			(new Changes())->untrack($this->model);
 		}
+
+		// Remove the version from the cache
+		VersionCache::remove($this, $language);
 	}
 
 	/**
@@ -319,10 +319,6 @@ class Version
 			toLanguage: $toLanguage
 		);
 
-		// remove both versions from the cache
-		VersionCache::remove($fromVersion, $fromLanguage);
-		VersionCache::remove($toVersion, $toLanguage);
-
 		$this->model->storage()->move(
 			fromVersionId: $fromVersion->id(),
 			fromLanguage: $fromLanguage,
@@ -330,6 +326,10 @@ class Version
 			toLanguage: $toLanguage,
 			toStorage: $toStorage
 		);
+
+		// remove both versions from the cache
+		VersionCache::remove($fromVersion, $fromLanguage);
+		VersionCache::remove($toVersion, $toLanguage);
 	}
 
 	/**
@@ -539,15 +539,15 @@ class Version
 		// check if replacing is allowed
 		VersionRules::replace($this, $fields, $language);
 
-		// remove the version from the cache to read
-		// a fresh version next time
-		VersionCache::remove($this, $language);
-
 		$this->model->storage()->update(
 			versionId: $this->id,
 			language: $language,
 			fields: $this->prepareFieldsBeforeWrite($fields, $language)
 		);
+
+		// remove the version from the cache to read
+		// a fresh version next time
+		VersionCache::remove($this, $language);
 	}
 
 	/**
@@ -608,15 +608,15 @@ class Version
 			...$fields
 		];
 
-		// remove the version from the cache to read
-		// a fresh version next time
-		VersionCache::remove($this, $language);
-
 		$this->model->storage()->update(
 			versionId: $this->id,
 			language: $language,
 			fields: $this->prepareFieldsBeforeWrite($fields, $language)
 		);
+
+		// remove the version from the cache to read
+		// a fresh version next time
+		VersionCache::remove($this, $language);
 	}
 
 	/**

--- a/src/Content/VersionCache.php
+++ b/src/Content/VersionCache.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Content;
 
-use Kirby\Cms\File;
 use Kirby\Cms\Language;
 
 /**
@@ -32,14 +31,7 @@ class VersionCache
 	 */
 	public static function key(Version $version, Language $language): string
 	{
-		$model = $version->model();
-
-		if ($model instanceof File) {
-			$parent = $model->parent();
-			return $parent::CLASS_ALIAS . '://' . ltrim($parent->id() . '/' . $model->filename(), '/') . '?version=' . $version->id() . '&language=' . $language;
-		}
-
-		return $model::CLASS_ALIAS . '://' . $model->id() . '?version=' . $version->id() . '&language=' . $language;
+		return spl_object_hash($version->model()) . ':' . $version->id() . ':' . $language->code();
 	}
 
 	/**

--- a/src/Content/VersionCache.php
+++ b/src/Content/VersionCache.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\Language;
+
+/**
+ * The Version cache class keeps content fields
+ * to avoid multiple storage reads for the same
+ * content.
+ *
+ * @internal
+ * @since 5.0.0
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class VersionCache
+{
+	/**
+	 * All cache values for all versions
+	 * and language combinations
+	 */
+	public static array $cache = [];
+
+	/**
+	 * Creates a unique cache key for any version/language combination
+	 */
+	public static function key(Version $version, Language $language): string
+	{
+		$model = $version->model();
+		return $model::CLASS_ALIAS . '://' . $model->id() . '?version=' . $version->id() . '&language=' . $language;
+	}
+
+	/**
+	 * Tries to receive a fields for a version/language combination
+	 */
+	public static function get(Version $version, Language $language): array|null
+	{
+		return static::$cache[static::key($version, $language)] ?? null;
+	}
+
+	/**
+	 * Removes fields for a version/language combination
+	 */
+	public static function remove(Version $version, Language $language): void
+	{
+		unset(static::$cache[static::key($version, $language)]);
+	}
+
+	/**
+	 * Keeps fields for a version/language combination
+	 */
+	public static function set(Version $version, Language $language, array $fields = []): void
+	{
+		static::$cache[static::key($version, $language)] = $fields;
+	}
+}

--- a/src/Content/VersionCache.php
+++ b/src/Content/VersionCache.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Content;
 
+use Kirby\Cms\File;
 use Kirby\Cms\Language;
 
 /**
@@ -32,6 +33,12 @@ class VersionCache
 	public static function key(Version $version, Language $language): string
 	{
 		$model = $version->model();
+
+		if ($model instanceof File) {
+			$parent = $model->parent();
+			return $parent::CLASS_ALIAS . '://' . ltrim($parent->id() . '/' . $model->filename(), '/') . '?version=' . $version->id() . '&language=' . $language;
+		}
+
 		return $model::CLASS_ALIAS . '://' . $model->id() . '?version=' . $version->id() . '&language=' . $language;
 	}
 

--- a/tests/Content/VersionCacheTest.php
+++ b/tests/Content/VersionCacheTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\VersionCache
- */
+#[CoversClass(VersionCache::class)]
 class VersionCacheTest extends TestCase
 {
 	public function setUp(): void
@@ -19,90 +18,47 @@ class VersionCacheTest extends TestCase
 		$this->setUpMultiLanguage();
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKeyForPage()
-	{
-		$model = new Page(['slug' => 'test']);
-
-		$this->assertSame('page://test?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('page://test?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('page://test?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	/**
-	 * @covers ::key
-	 */
-	public function testKeyForPageFile()
+	public function testKeyForFile()
 	{
 		$parent = new Page(['slug' => 'test']);
 		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
+		$hash   = spl_object_hash($model);
 
-		$this->assertSame('page://test/test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('page://test/test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('page://test/test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
 	}
 
-	/**
-	 * @covers ::key
-	 */
+	public function testKeyForPage()
+	{
+		$model = new Page(['slug' => 'test']);
+		$hash  = spl_object_hash($model);
+
+		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
 	public function testKeyForSite()
 	{
 		$model = new Site();
-		$key   = VersionCache::key($model->version(), Language::ensure());
+		$hash  = spl_object_hash($model);
 
-		$this->assertSame('site://?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('site://?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('site://?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKeyForSiteFile()
-	{
-		$parent = new Site();
-		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
-		$key    = VersionCache::key($model->version(), Language::ensure());
-
-		$this->assertSame('site://test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('site://test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('site://test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	/**
-	 * @covers ::key
-	 */
 	public function testKeyForUser()
 	{
 		$model = new User(['id' => 'test']);
-		$key   = VersionCache::key($model->version(), Language::ensure());
+		$hash  = spl_object_hash($model);
 
-		$this->assertSame('user://test?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('user://test?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('user://test?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKeyForUserFile()
-	{
-		$parent = new User(['id' => 'test']);
-		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
-		$key    = VersionCache::key($model->version(), Language::ensure());
-
-		$this->assertSame('user://test/test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame('user://test/test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame('user://test/test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	/**
-	 * @covers ::get
-	 * @covers ::set
-	 * @covers ::remove
-	 */
 	public function testGetSetAndRemove()
 	{
 		$model    = new Page(['slug' => 'test']);

--- a/tests/Content/VersionCacheTest.php
+++ b/tests/Content/VersionCacheTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Language;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+
+/**
+ * @coversDefaultClass \Kirby\Content\VersionCache
+ */
+class VersionCacheTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->setUpMultiLanguage();
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForPage()
+	{
+		$model = new Page(['slug' => 'test']);
+
+		$this->assertSame('page://test?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('page://test?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('page://test?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForPageFile()
+	{
+		$parent = new Page(['slug' => 'test']);
+		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
+
+		$this->assertSame('page://test/test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('page://test/test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('page://test/test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForSite()
+	{
+		$model = new Site();
+		$key   = VersionCache::key($model->version(), Language::ensure());
+
+		$this->assertSame('site://?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('site://?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('site://?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForSiteFile()
+	{
+		$parent = new Site();
+		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
+		$key    = VersionCache::key($model->version(), Language::ensure());
+
+		$this->assertSame('site://test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('site://test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('site://test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForUser()
+	{
+		$model = new User(['id' => 'test']);
+		$key   = VersionCache::key($model->version(), Language::ensure());
+
+		$this->assertSame('user://test?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('user://test?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('user://test?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::key
+	 */
+	public function testKeyForUserFile()
+	{
+		$parent = new User(['id' => 'test']);
+		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
+		$key    = VersionCache::key($model->version(), Language::ensure());
+
+		$this->assertSame('user://test/test.jpg?version=latest&language=en', VersionCache::key($model->version(), Language::ensure()));
+		$this->assertSame('user://test/test.jpg?version=latest&language=de', VersionCache::key($model->version(), Language::ensure('de')));
+		$this->assertSame('user://test/test.jpg?version=changes&language=en', VersionCache::key($model->version('changes'), Language::ensure()));
+	}
+
+	/**
+	 * @covers ::get
+	 * @covers ::set
+	 * @covers ::remove
+	 */
+	public function testGetSetAndRemove()
+	{
+		$model    = new Page(['slug' => 'test']);
+		$version  = $model->version();
+		$language = Language::ensure();
+		$fields   = [
+			'foo' => 'bar'
+		];
+
+		$this->assertNull(VersionCache::get($version, $language));
+
+		VersionCache::set($version, $language, [
+			'foo' => 'bar'
+		]);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		VersionCache::remove($version, $language);
+
+		$this->assertNull(VersionCache::get($version, $language));
+	}
+}

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
-use Kirby\Cms\Site;
 use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;


### PR DESCRIPTION
## Description

### Todos

- [x] Unit tests for the VersionCache class

### Summary of changes

- New Kirby\Content\VersionCache class
- The cache class is used in the Version class to avoid multiple reads
- The VersionCache is cleared whenever the App constructor is called

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Multiple storage reads are avoided with a new VersionCache class.

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
