### PR TITLE
 New Languages::migrateToSingleLang & Languages::migrateToMultiLang methods

### DIFF
--- a/src/Content/Storage.php
+++ b/src/Content/Storage.php
@@ -92,18 +92,6 @@ abstract class Storage
 	abstract public function delete(VersionId $versionId, Language $language): void;
 
 	/**
-	 * Deletes all versions when deleting a language
-	 * @internal
-	 * @todo Move to `Language` class
-	 */
-	public function deleteLanguage(Language $language): void
-	{
-		foreach (VersionId::all() as $versionId) {
-			$this->delete($versionId, $language);
-		}
-	}
-
-	/**
 	 * Checks if a version exists
 	 */
 	abstract public function exists(VersionId $versionId, Language $language): bool;
@@ -177,22 +165,6 @@ abstract class Storage
 	}
 
 	/**
-	 * Adapts all versions when converting languages
-	 * @internal
-	 * @todo Move to `Language` class
-	 */
-	public function moveLanguage(
-		Language $fromLanguage,
-		Language $toLanguage
-	): void {
-		foreach (VersionId::all() as $versionId) {
-			if ($this->exists($versionId, $fromLanguage) === true) {
-				$this->move($versionId, $fromLanguage, toLanguage: $toLanguage);
-			}
-		}
-	}
-
-	/**
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
@@ -227,20 +199,6 @@ abstract class Storage
 	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
 	 */
 	abstract public function touch(VersionId $versionId, Language $language): void;
-
-	/**
-	 * Touches all versions of a language
-	 * @internal
-	 * @todo Move to `Language` class
-	 */
-	public function touchLanguage(Language $language): void
-	{
-		foreach (VersionId::all() as $versionId) {
-			if ($this->exists($versionId, $language) === true) {
-				$this->touch($versionId, $language);
-			}
-		}
-	}
 
 	/**
 	 * Updates the content fields of an existing version


### PR DESCRIPTION
## Description

This PR is trying to clean up the last Storage and Version parts that we weren't super happy with so far. 

### Summary of changes

- New `Languages::migrateToSingleLang` method
- New `Languages::migrateToMultiLang` method
- Removed `Storage::deleteLanguage` method
- Removed `Storage::moveLanguage` method
- Removed `Storage::touchLanguage` method

### Reasoning

Keeping the logic parts in the Storage classes low means that they are easier to extend and adapt for multiple storage types. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes



### Breaking changes



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
