### PR TITLE
Add missing title for toolbar buttons

### DIFF
--- a/panel/src/components/Forms/Toolbar/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar/Toolbar.vue
@@ -9,7 +9,7 @@
 				:current="button.current"
 				:disabled="button.disabled"
 				:icon="button.icon"
-				:title="button.label"
+				:title="button.label ?? button.title"
 				:class="['k-toolbar-button', button.class]"
 				tabindex="0"
 				@keydown.native="button.key?.($event)"


### PR DESCRIPTION
## Description

The `<k-toolbar>` component ignored button titles so far, which led to unlabelled icon buttons (e.g. in the blocks field options)

### Summary of changes

- The button.title is now being used if no label is set.

### Fixes

- https://github.com/getkirby/kirby/issues/6998

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
