### PR TITLE
Fix writer update issue

### DIFF
--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -201,16 +201,6 @@ export default {
 						return;
 					}
 
-					// if no steps are recorded, this is a selection change
-					// and we don't need to update the content
-					if (payload.transaction.steps.length === 0) {
-						return;
-					}
-
-					if (payload.transaction.meta.preventUpdate === true) {
-						return;
-					}
-
 					// compare documents to avoid minor HTML differences
 					// to cause unwanted updates
 					const jsonNew = JSON.stringify(this.editor.getJSON());

--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -207,6 +207,10 @@ export default {
 						return;
 					}
 
+					if (payload.transaction.meta.preventUpdate === true) {
+						return;
+					}
+
 					// compare documents to avoid minor HTML differences
 					// to cause unwanted updates
 					const jsonNew = JSON.stringify(this.editor.getJSON());

--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -201,6 +201,12 @@ export default {
 						return;
 					}
 
+					// if no steps are recorded, this is a selection change
+					// and we don't need to update the content
+					if (payload.transaction.steps.length === 0) {
+						return;
+					}
+
 					// compare documents to avoid minor HTML differences
 					// to cause unwanted updates
 					const jsonNew = JSON.stringify(this.editor.getJSON());

--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -396,7 +396,7 @@ export default class Editor extends Emitter {
 		// give extensions access to our view
 		this.extensions.view = this.view;
 
-		this.setContent(this.options.content, true);
+		this.setContent(this.options.content);
 	}
 
 	insertText(text, selected = false) {

--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -285,7 +285,11 @@ export default class Editor extends Emitter {
 
 		// Only emit an update if the doc has changed and
 		// an update has not been actively prevented
-		if (transaction.docChanged || !transaction.getMeta("preventUpdate")) {
+		if (
+			transaction.docChanged &&
+			!transaction.getMeta("preventUpdate") &&
+			transaction.steps.length > 0
+		) {
 			this.emit("update", payload);
 		}
 


### PR DESCRIPTION
## Description

The writer input records transactions for actual state updates but also for selections. So far, we don't check before we emit an input event. This leads to a quite nasty situation where selections or even just a focus even also emit an input event at the same time. With the new changes setup, this means that every selection change or focus event will send an update to the backend. This PR fixes this by checking for the involved steps in the transaction object. If there are no steps, there's no need to emit something. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- https://github.com/getkirby/kirby/issues/6959

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
