### PR TITLE
New ExceptionField class

### DIFF
--- a/src/Form/Field/ExceptionField.php
+++ b/src/Form/Field/ExceptionField.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Cms\App;
+use Kirby\Form\FieldClass;
+use Throwable;
+
+class ExceptionField extends FieldClass
+{
+	public function __construct(
+		string $name,
+		protected Throwable $exception
+	) {
+		$this->name = $name;
+	}
+
+	public function label(): string
+	{
+		return 'Error in "' . $this->name() . '" field.';
+	}
+
+	public function props(): array
+	{
+		return [
+			'label' => $this->label(),
+			'name'  => $this->name(),
+			'text'  => $this->text(),
+			'theme' => $this->theme(),
+			'type'  => $this->type(),
+		];
+	}
+
+	public function text(): string
+	{
+		$message = $this->exception->getMessage();
+
+		if (App::instance()->option('debug') === true) {
+			$message .= ' in file: ' . $this->exception->getFile();
+			$message .= ' line: ' . $this->exception->getLine();
+		}
+
+		return strip_tags($message);
+	}
+
+	public function theme(): string
+	{
+		return 'negative';
+	}
+
+	public function type(): string
+	{
+		return 'info';
+	}
+}

--- a/src/Form/Field/ExceptionField.php
+++ b/src/Form/Field/ExceptionField.php
@@ -15,6 +15,11 @@ class ExceptionField extends FieldClass
 		$this->name = $name;
 	}
 
+	public function isSaveable(): bool
+	{
+		return true;
+	}
+
 	public function label(): string
 	{
 		return 'Error in "' . $this->name() . '" field.';

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -83,7 +83,10 @@ class Form
 			try {
 				$field = Field::factory($props['type'], $props, $this->fields);
 			} catch (Throwable $e) {
-				$field = static::exceptionField($e, $props);
+				$field = new ExceptionField(
+					name: $props['name'],
+					exception: $e
+				);
 			}
 
 			if ($field->isSaveable() === true) {
@@ -143,19 +146,6 @@ class Form
 	public function errors(): array
 	{
 		return $this->fields->errors();
-	}
-
-	/**
-	 * Shows the error with the field
-	 */
-	public static function exceptionField(
-		Throwable $exception,
-		array $props = []
-	): FieldClass {
-		return new ExceptionField(
-			exception: $exception,
-			name: $props['name']
-		);
 	}
 
 	/**

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -8,6 +8,7 @@ use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;
 use Kirby\Exception\NotFoundException;
+use Kirby\Form\Field\ExceptionField;
 use Kirby\Toolkit\A;
 use Throwable;
 
@@ -150,20 +151,11 @@ class Form
 	public static function exceptionField(
 		Throwable $exception,
 		array $props = []
-	): Field {
-		$message = $exception->getMessage();
-
-		if (App::instance()->option('debug') === true) {
-			$message .= ' in file: ' . $exception->getFile();
-			$message .= ' line: ' . $exception->getLine();
-		}
-
-		return Field::factory('info', [
-			...$props,
-			'label' => 'Error in "' . $props['name'] . '" field.',
-			'theme' => 'negative',
-			'text'  => strip_tags($message),
-		]);
+	): FieldClass {
+		return new ExceptionField(
+			exception: $exception,
+			name: $props['name']
+		);
 	}
 
 	/**

--- a/tests/Form/Field/ExceptionFieldTest.php
+++ b/tests/Form/Field/ExceptionFieldTest.php
@@ -15,6 +15,12 @@ class ExceptionFieldTest extends TestCase
 		$this->app = new App();
 	}
 
+	public function testIsSaveable(): void
+	{
+		$field = new ExceptionField('test', new Exception());
+		$this->assertTrue($field->isSaveable());
+	}
+
 	public function testLabel(): void
 	{
 		$field = new ExceptionField('test', new Exception());

--- a/tests/Form/Field/ExceptionFieldTest.php
+++ b/tests/Form/Field/ExceptionFieldTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Exception;
+use Kirby\Cms\App;
+use Kirby\TestCase;
+
+/**
+ * @coversDefaultClass \Kirby\Form\Field\ExceptionField
+ */
+class ExceptionFieldTest extends TestCase
+{
+	public function setUp(): void
+	{
+		$this->app = new App();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::label
+	 */
+	public function testLabel(): void
+	{
+		$field = new ExceptionField('test', new Exception());
+		$this->assertSame('Error in "test" field.', $field->label());
+	}
+
+	/**
+	 * @covers ::props
+	 */
+	public function testProps(): void
+	{
+		$field = new ExceptionField('test', new Exception('Something went wrong'));
+		$props = $field->props();
+
+		$this->assertSame([
+			'label' => 'Error in "test" field.',
+			'name'  => 'test',
+			'text'  => 'Something went wrong',
+			'theme' => 'negative',
+			'type'  => 'info'
+		], $props);
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testTextWithoutDebug(): void
+	{
+		$field = new ExceptionField('test', new Exception('Something went wrong'));
+		$this->assertSame('Something went wrong', $field->text());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testTextWithDebug(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'debug' => true
+			]
+		]);
+
+		$exception = new Exception('Something went wrong');
+		$field = new ExceptionField('test', $exception);
+
+		$expected = 'Something went wrong in file: ' . $exception->getFile() . ' line: ' . $exception->getLine();
+		$this->assertSame($expected, $field->text());
+	}
+
+	/**
+	 * @covers ::text
+	 */
+	public function testTextStripsHtml(): void
+	{
+		$field = new ExceptionField('test', new Exception('<p>Something went wrong</p>'));
+		$this->assertSame('Something went wrong', $field->text());
+	}
+
+	/**
+	 * @covers ::theme
+	 */
+	public function testTheme(): void
+	{
+		$field = new ExceptionField('test', new Exception());
+		$this->assertSame('negative', $field->theme());
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testType(): void
+	{
+		$field = new ExceptionField('test', new Exception());
+		$this->assertSame('info', $field->type());
+	}
+}

--- a/tests/Form/Field/ExceptionFieldTest.php
+++ b/tests/Form/Field/ExceptionFieldTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Form\Field;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Form\Field\ExceptionField
- */
+#[CoversClass(ExceptionField::class)]
 class ExceptionFieldTest extends TestCase
 {
 	public function setUp(): void
@@ -16,19 +15,12 @@ class ExceptionFieldTest extends TestCase
 		$this->app = new App();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::label
-	 */
 	public function testLabel(): void
 	{
 		$field = new ExceptionField('test', new Exception());
 		$this->assertSame('Error in "test" field.', $field->label());
 	}
 
-	/**
-	 * @covers ::props
-	 */
 	public function testProps(): void
 	{
 		$field = new ExceptionField('test', new Exception('Something went wrong'));
@@ -43,18 +35,12 @@ class ExceptionFieldTest extends TestCase
 		], $props);
 	}
 
-	/**
-	 * @covers ::text
-	 */
 	public function testTextWithoutDebug(): void
 	{
 		$field = new ExceptionField('test', new Exception('Something went wrong'));
 		$this->assertSame('Something went wrong', $field->text());
 	}
 
-	/**
-	 * @covers ::text
-	 */
 	public function testTextWithDebug(): void
 	{
 		$this->app = $this->app->clone([
@@ -70,27 +56,18 @@ class ExceptionFieldTest extends TestCase
 		$this->assertSame($expected, $field->text());
 	}
 
-	/**
-	 * @covers ::text
-	 */
 	public function testTextStripsHtml(): void
 	{
 		$field = new ExceptionField('test', new Exception('<p>Something went wrong</p>'));
 		$this->assertSame('Something went wrong', $field->text());
 	}
 
-	/**
-	 * @covers ::theme
-	 */
 	public function testTheme(): void
 	{
 		$field = new ExceptionField('test', new Exception());
 		$this->assertSame('negative', $field->theme());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType(): void
 	{
 		$field = new ExceptionField('test', new Exception());

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -2,11 +2,11 @@
 
 namespace Kirby\Form;
 
-use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
+use Kirby\Form\Field\ExceptionField;
 use Kirby\TestCase;
 
 /**
@@ -321,47 +321,7 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$field = $form->fields()->first();
-
-		$this->assertSame('info', $field->type());
-		$this->assertSame('negative', $field->theme());
-		$this->assertSame('Error in "test" field.', $field->label());
-		$this->assertSame('<p>Field "test": The field type "does-not-exist" does not exist</p>', $field->text());
-	}
-
-	/**
-	 * @covers ::exceptionField
-	 */
-	public function testExceptionFieldInDebugMode()
-	{
-		$exception = new Exception('This is an error');
-
-		// debug mode off
-		$props = [
-			'name'  => 'test',
-			'model' => $this->app->site()
-		];
-
-		$field = Form::exceptionField($exception, $props)->toArray();
-		$this->assertSame('info', $field['type']);
-		$this->assertSame('Error in "test" field.', $field['label']);
-		$this->assertSame('<p>This is an error</p>', $field['text']);
-		$this->assertSame('negative', $field['theme']);
-
-		// debug mode on
-		$this->app->clone(['options' => ['debug' => true]]);
-
-		$props = [
-			'name'  => 'test',
-			'model' => $this->app->site()
-		];
-
-		$field = Form::exceptionField($exception, $props)->toArray();
-		$this->assertSame('info', $field['type']);
-		$this->assertSame('Error in "test" field.', $field['label']);
-		$this->assertStringContainsString('<p>This is an error in file:', $field['text']);
-		$this->assertStringContainsString('tests/Form/FormTest.php line:', $field['text']);
-		$this->assertSame('negative', $field['theme']);
+		$this->assertInstanceOf(ExceptionField::class, $form->fields()->first());
 	}
 
 	/**

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -308,7 +308,7 @@ class FormTest extends TestCase
 	}
 
 	/**
-	 * @covers ::exceptionField
+	 * @covers ::__construct
 	 */
 	public function testExceptionField()
 	{


### PR DESCRIPTION
## Description

This PR picks up the work on the Form classes again with a first small improvement to trim the logic in the Form class.

### Summary of changes

- New `KIrby\Form\Field\ExceptionField` to handle field errors
- Simplified logic in the Form class. 

### Breaking changes

- Removed `Kirby\Form\Form::exceptionField()`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
