### PR TITLE
Add missing `reset` option for radio field

### DIFF
--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -17,6 +17,12 @@ return [
 		'columns' => function (int $columns = 1) {
 			return $columns;
 		},
+		/**
+		 * A radio button can be deactivated on click. If reset is `false` deactivating a radio button is no longer possible.
+		 */
+		'reset' => function (bool $reset = true) {
+			return $reset;
+		}
 	],
 	'computed' => [
 		'default' => function () {


### PR DESCRIPTION
Should fix https://github.com/getkirby/getkirby.com/issues/2410

## Description
This is my attempt at fixing https://github.com/getkirby/getkirby.com/issues/2410. This might not be correct as I might have misunderstood how the field properties table is generated. Hopefully it's correct.