### PR TITLE
Fix overwritten props in our Component class

### DIFF
--- a/config/fields/object.php
+++ b/config/fields/object.php
@@ -39,14 +39,14 @@ return [
 	],
 	'computed' => [
 		'default' => function () {
-			if (empty($this->default) === true) {
+			if (empty($default = $this->default) === true) {
 				return '';
 			}
 
-			return $this->form($this->default)->values();
+			return $this->form($default)->values();
 		},
 		'fields' => function () {
-			if (empty($this->fields) === true) {
+			if (empty($fields = $this->fields) === true) {
 				return [];
 			}
 

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -101,7 +101,7 @@ return [
 			return $this->rows($this->value);
 		},
 		'fields' => function () {
-			if (empty($this->fields) === true) {
+			if (empty($fields = $this->fields) === true) {
 				return [];
 			}
 

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -15,7 +15,7 @@ return [
 		 * Default value which will be saved when a new page/user/file is created
 		 */
 		'default' => function ($default = null) {
-			return $this->default = $default;
+			return $default;
 		},
 		/**
 		 * Sets the text next to the toggle. The text can be a string or an array of two options. The first one is the negative text and the second one the positive. The text will automatically switch when the toggle is triggered.

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -164,6 +164,12 @@ class Field extends Component
 				'width' => function (string $width = '1/1') {
 					return $width;
 				},
+				/**	
+				 * Custom validation rules for the field
+				 */
+				'validate' => function (string|array|null $validate = null) {
+					return $validate;
+				},
 				'value' => function ($value = null) {
 					return $value;
 				}

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -164,7 +164,7 @@ class Field extends Component
 				'width' => function (string $width = '1/1') {
 					return $width;
 				},
-				/**	
+				/**
 				 * Custom validation rules for the field
 				 */
 				'validate' => function (string|array|null $validate = null) {

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -42,7 +42,9 @@ abstract class FieldClass
 	protected string|null $placeholder;
 	protected bool $required;
 	protected Fields $siblings;
+	protected array|string|null $validate = null;
 	protected mixed $value = null;
+	protected array|null $when = null;
 	protected string|null $width;
 
 	public function __construct(

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -51,7 +51,7 @@ trait Validation
 	/**
 	 * Runs the validations defined for the field
 	 */
-	protected function validate(): array
+	public function validate(): array
 	{
 		$validations = $this->validations();
 		$value       = $this->value();
@@ -82,11 +82,13 @@ trait Validation
 			}
 		}
 
+		$validate = $this->validate;
+
 		if (
-			empty($this->validate) === false &&
+			empty($validate) === false &&
 			($this->isEmpty() === false || $this->isRequired() === true)
 		) {
-			$rules = A::wrap($this->validate);
+			$rules = A::wrap($validate);
 
 			$errors = [
 				...$errors,

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -11,8 +11,6 @@ namespace Kirby\Form\Mixin;
  */
 trait When
 {
-	protected array|null $when = null;
-
 	/**
 	 * Checks if the field is currently active
 	 * or hidden because of a `when` condition


### PR DESCRIPTION
WIP

## Description

The Component class keeps being a trouble-maker. We store component definitions in the $options object property. But when the component itself defines an option prop or computed prop, this will get overwritten when we run `applyProps` or `applyComputed` again. The collision is not avoidable as long as we keep dynamically setting those object properties. We should instead keep them only in the $attrs, $props and $computed arrays and access them directly from there or via magic getters or callers. 

### Summary of changes



### Reasoning



### Additional context



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes



### Breaking changes



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
