### PR TITLE
Deprecate ModelWithContent::readContent and ModelWithContent::writeContent

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -395,11 +395,11 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	/**
 	 * Read the content from the content file
 	 * @internal
+	 * @deprecated 5.0.0 Use `->version()->read()` instead
 	 */
 	public function readContent(string|null $languageCode = null): array
 	{
-		Helpers::deprecated('$model->readContent() is deprecated. Use $model->version()->read() instead.');
-
+		Helpers::deprecated('$model->readContent() is deprecated. Use $model->version()->read() instead.'); // @codeCoverageIgnore
 		return $this->version()->read($languageCode ?? 'default') ?? [];
 	}
 
@@ -721,8 +721,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
-		Helpers::deprecated('$model->writeContent() is deprecated. Use $model->version()->save() instead.');
-
+		Helpers::deprecated('$model->writeContent() is deprecated. Use $model->version()->save() instead.'); // @codeCoverageIgnore
 		$this->version()->save($data, $languageCode ?? 'default', true);
 		return true;
 	}

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -398,6 +398,8 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function readContent(string|null $languageCode = null): array
 	{
+		Helpers::deprecated('$model->readContent() is deprecated. Use $model->version()->read() instead.');
+
 		return $this->version()->read($languageCode ?? 'default') ?? [];
 	}
 
@@ -435,8 +437,8 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		// merge the new data with the existing content
 		$clone->content()->update($data, $overwrite);
 
-		// send the full content array to the writer
-		$clone->writeContent($clone->content()->toArray());
+		// save the full content array
+		$clone->version()->save($clone->content()->toArray(), 'default', true);
 
 		return $clone;
 	}
@@ -485,8 +487,8 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			$translation->update($content, true);
 		}
 
-		// send the full translation array to the writer
-		$clone->writeContent($translation->content(), $languageCode);
+		// save the full translation array
+		$clone->version()->save($translation->content(), $languageCode);
 
 		// reset the content object
 		$clone->content = null;
@@ -715,9 +717,12 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 * Low level data writer method
 	 * to store the given data on disk or anywhere else
 	 * @internal
+	 * @deprecated 5.0.0 Use `->version()->save()` instead
 	 */
 	public function writeContent(array $data, string|null $languageCode = null): bool
 	{
+		Helpers::deprecated('$model->writeContent() is deprecated. Use $model->version()->save() instead.');
+
 		$this->version()->save($data, $languageCode ?? 'default', true);
 		return true;
 	}

--- a/src/Content/ContentTranslation.php
+++ b/src/Content/ContentTranslation.php
@@ -64,7 +64,7 @@ class ContentTranslation
 	public function content(): array
 	{
 		$parent  = $this->parent();
-		$content = $this->content ??= $parent->readContent($this->code());
+		$content = $this->content ??= $parent->version()->read($this->code()) ?? [];
 
 		// merge with the default content
 		if (

--- a/src/Uuid/ModelUuid.php
+++ b/src/Uuid/ModelUuid.php
@@ -82,7 +82,7 @@ abstract class ModelUuid extends Uuid
 		// just to be sure we don't lose content
 		if (empty($data) === true) {
 			usleep(1000);
-			$data = $this->model->readContent('default');
+			$data = $this->model->version()->read('default');
 		}
 
 		// add the UUID to the content array
@@ -103,6 +103,6 @@ abstract class ModelUuid extends Uuid
 
 		// overwrite the content in the file;
 		// use the most basic write method to avoid object cloning
-		$this->model->writeContent($data, 'default');
+		$this->model->version()->save($data, 'default');
 	}
 }

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -203,9 +203,9 @@ class FileUuidTest extends TestCase
 		$this->assertSame($file->translation('de')->content()['uuid'], $file->uuid()->id());
 
 		// the uuid must be stored in the primary language file
-		$this->assertSame($file->readContent('en')['uuid'], $file->uuid()->id());
+		$this->assertSame($file->version()->read('en')['uuid'], $file->uuid()->id());
 
 		// the secondary language must not have the uuid in the content file
-		$this->assertNull($file->readContent('de')['uuid'] ?? null);
+		$this->assertNull($file->version()->read('de')['uuid'] ?? null);
 	}
 }

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -188,10 +188,10 @@ class PageUuidTest extends TestCase
 		$this->assertSame($page->translation('de')->content()['uuid'], $page->uuid()->id());
 
 		// the uuid must be stored in the primary language file
-		$this->assertSame($page->readContent('en')['uuid'], $page->uuid()->id());
+		$this->assertSame($page->version()->read('en')['uuid'], $page->uuid()->id());
 
 		// the secondary language must not have the uuid in the content file
-		$this->assertNull($page->readContent('de')['uuid'] ?? null);
+		$this->assertNull($page->version()->read('de')['uuid'] ?? null);
 
 		$this->assertStringStartsWith('https://getkirby.com/' . $language . '/@/page/', $page->uuid()->url());
 	}


### PR DESCRIPTION
## Description

This is the start of a new series of PRs to refactor our ModelWithContent classes to finally reach the point where content and translations are no longe a mess.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Deprecated

- `ModelWithContent::readContent`: Use `$model->version()->read()` instead
- `ModelWithContent::writeContent` Use `$model->version()->write()` instead

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
