### PR TITLE
More refactoring

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -164,10 +164,6 @@ trait FileActions
 	): mixed {
 		$kirby = $this->kirby();
 
-		// store copy of the model to be passed
-		// to the `after` hook for comparison
-		$old = $this->hardcopy();
-
 		// check file rules
 		$this->rules()->$action(...array_values($arguments));
 
@@ -196,8 +192,8 @@ trait FileActions
 		// determine arguments for `after` hook depending on the action
 		$argumentsAfter = match ($action) {
 			'create' => ['file' => $result],
-			'delete' => ['status' => $result, 'file' => $old],
-			default  => ['newFile' => $result, 'oldFile' => $old]
+			'delete' => ['status' => $result, 'file' => $this],
+			default  => ['newFile' => $result, 'oldFile' => $this]
 		};
 
 		// run `after` hook and apply return to action result

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -534,8 +534,7 @@ trait PageActions
 				// the $format needs to produce only digits,
 				// so it can be converted to integer below
 				$format = $mode === 'date' ? 'Ymd' : 'YmdHi';
-				$lang   = $this->kirby()->defaultLanguage() ?? null;
-				$field  = $this->content($lang)->get('date');
+				$field  = $this->content('default')->get('date');
 				$date   = $field->isEmpty() ? 'now' : $field;
 				return (int)date($format, strtotime($date));
 			case 'default':
@@ -568,7 +567,7 @@ trait PageActions
 
 				$template = Str::template($mode, [
 					'kirby' => $app,
-					'page'  => $app->page($this->id()),
+					'page'  => $this,
 					'site'  => $app->site(),
 				], ['fallback' => '']);
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -459,7 +459,7 @@ trait PageActions
 		}
 
 		// create a temporary page object
-		$page = Page::factory($props);
+		$page = static::factory($props);
 
 		// always create pages in the default language
 		$languageCode = match ($page->kirby()->multilang()) {
@@ -514,7 +514,7 @@ trait PageActions
 			'site'   => $this->site(),
 		];
 
-		$modelClass = Page::$models[$props['template'] ?? null] ?? Page::class;
+		$modelClass = static::$models[$props['template'] ?? null] ?? static::class;
 		return $modelClass::create($props);
 	}
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -326,10 +326,6 @@ trait PageActions
 	): mixed {
 		$kirby = $this->kirby();
 
-		// store copy of the model to be passed
-		// to the `after` hook for comparison
-		$old = $this->hardcopy();
-
 		// check page rules
 		$this->rules()->$action(...array_values($arguments));
 
@@ -358,9 +354,9 @@ trait PageActions
 		// determine arguments for `after` hook depending on the action
 		$argumentsAfter = match ($action) {
 			'create'    => ['page' => $result],
-			'duplicate' => ['duplicatePage' => $result, 'originalPage' => $old],
-			'delete'    => ['status' => $result, 'page' => $old],
-			default     => ['newPage' => $result, 'oldPage' => $old]
+			'duplicate' => ['duplicatePage' => $result, 'originalPage' => $this],
+			'delete'    => ['status' => $result, 'page' => $this],
+			default     => ['newPage' => $result, 'oldPage' => $this]
 		};
 
 		// run `after` hook and apply return to action result

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -194,7 +194,9 @@ class Site extends ModelWithContent
 		array $data,
 		string|null $languageCode = null
 	): array {
-		return A::prepend($data, ['title' => $data['title'] ?? null]);
+		return A::prepend($data, [
+			'title' => $data['title'] ?? null
+		]);
 	}
 
 	/**

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -31,10 +31,6 @@ trait SiteActions
 	): mixed {
 		$kirby = $this->kirby();
 
-		// store copy of the model to be passed
-		// to the `after` hook for comparison
-		$old = $this->hardcopy();
-
 		// check site rules
 		$this->rules()->$action(...array_values($arguments));
 
@@ -58,7 +54,7 @@ trait SiteActions
 		// (first argument, usually the new model) if anything returned
 		$result = $kirby->apply(
 			'site.' . $action . ':after',
-			['newSite' => $result, 'oldSite' => $old],
+			['newSite' => $result, 'oldSite' => $this],
 			'newSite'
 		);
 

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -157,10 +157,6 @@ trait UserActions
 
 		$kirby = $this->kirby();
 
-		// store copy of the model to be passed
-		// to the `after` hook for comparison
-		$old = $this->hardcopy();
-
 		// check user rules
 		$this->rules()->$action(...array_values($arguments));
 
@@ -189,8 +185,8 @@ trait UserActions
 		// determine arguments for `after` hook depending on the action
 		$argumentsAfter = match ($action) {
 			'create' => ['user' => $result],
-			'delete' => ['status' => $result, 'user' => $old],
-			default  => ['newUser' => $result, 'oldUser' => $old]
+			'delete' => ['status' => $result, 'user' => $this],
+			default  => ['newUser' => $result, 'oldUser' => $this]
 		};
 
 		// run `after` hook and apply return to action result

--- a/src/Content/MemoryStorage.php
+++ b/src/Content/MemoryStorage.php
@@ -35,7 +35,7 @@ class MemoryStorage extends Storage
 	 */
 	protected function cacheId(VersionId $versionId, Language $language): string
 	{
-		return $versionId->value() . '/' . $language->code() . '/' . $this->model->id();
+		return $versionId->value() . '/' . $language->code() . '/' . $this->model->id() . '/' . spl_object_hash($this->model);
 	}
 
 	/**

--- a/src/Content/Translation.php
+++ b/src/Content/Translation.php
@@ -42,24 +42,18 @@ class Translation extends ContentTranslation
 	/**
 	 * Returns the language code of the
 	 * translation
-	 *
-	 * @deprecated 5.0.0 Use `::language()->code()` instead
 	 */
 	public function code(): string
 	{
-		Helpers::deprecated('`$translation->code()` has been deprecated. Use `$translation->language()->code()` instead.', 'translation-methods');
 		return $this->language->code();
 	}
 
 	/**
 	 * Returns the translation content
 	 * as plain array
-	 *
-	 * @deprecated 5.0.0 Use `::version()->content()->toArray()` instead
 	 */
 	public function content(): array
 	{
-		Helpers::deprecated('`$translation->content()->toArray()` has been deprecated. Use `$translation->version()->content()` instead.', 'translation-methods');
 		return $this->version->content($this->language)->toArray();
 	}
 
@@ -103,12 +97,9 @@ class Translation extends ContentTranslation
 
 	/**
 	 * Checks if the translation file exists
-	 *
-	 * @deprecated 5.0.0 Use `::version()->exists()` instead
 	 */
 	public function exists(): bool
 	{
-		Helpers::deprecated('`$translation->exists()` has been deprecated. Use `$translation->version()->exists()` instead.', 'translation-methods');
 		return $this->version->exists($this->language);
 	}
 

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\FileBlueprint
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FileBlueprint::class)]
 class FileBlueprintTest extends TestCase
 {
 	public function tearDown(): void

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(FileBlueprint::class)]
 class FileBlueprintTest extends TestCase
@@ -58,10 +59,7 @@ class FileBlueprintTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::acceptAttribute
-	 * @dataProvider acceptAttributeProvider
-	 */
+	#[DataProvider('acceptAttributeProvider')]
 	public function testAcceptAttribute($accept, $expected, $notExpected)
 	{
 		Blueprint::$loaded['files/acceptAttribute'] = [

--- a/tests/Cms/Blueprints/PageBlueprintTest.php
+++ b/tests/Cms/Blueprints/PageBlueprintTest.php
@@ -2,11 +2,9 @@
 
 namespace Kirby\Cms;
 
-use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\PageBlueprint
- */
+#[CoversClass(PageBlueprint::class)]
 class PageBlueprintTest extends TestCase
 {
 	public function tearDown(): void

--- a/tests/Cms/Blueprints/PageBlueprintTest.php
+++ b/tests/Cms/Blueprints/PageBlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(PageBlueprint::class)]
 class PageBlueprintTest extends TestCase
@@ -133,9 +134,7 @@ class PageBlueprintTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider numProvider
-	 */
+	#[DataProvider('numProvider')]
 	public function testNum($input, $expected)
 	{
 		$blueprint = new PageBlueprint([
@@ -355,9 +354,6 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
 	public function testExtendNum()
 	{
 		new App([
@@ -379,9 +375,6 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('date', $blueprint->num());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18n()
 	{
 		$app = new App([
@@ -427,9 +420,6 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Simple Page', $page->blueprint()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18nWithFallbackLanguage()
 	{
 		$app = new App([
@@ -467,9 +457,6 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Thanks to fallback', $page->blueprint()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18nArray()
 	{
 		$app = new App([

--- a/tests/Cms/Blueprints/SiteBlueprintTest.php
+++ b/tests/Cms/Blueprints/SiteBlueprintTest.php
@@ -2,11 +2,9 @@
 
 namespace Kirby\Cms;
 
-use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\SiteBlueprint
- */
+#[CoversClass(SiteBlueprint::class)]
 class SiteBlueprintTest extends TestCase
 {
 	public function testOptions()

--- a/tests/Cms/Blueprints/UserBlueprintTest.php
+++ b/tests/Cms/Blueprints/UserBlueprintTest.php
@@ -2,11 +2,9 @@
 
 namespace Kirby\Cms;
 
-use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\UserBlueprint
- */
+#[CoversClass(UserBlueprint::class)]
 class UserBlueprintTest extends TestCase
 {
 	public function tearDown(): void

--- a/tests/Cms/Blueprints/UserBlueprintTest.php
+++ b/tests/Cms/Blueprints/UserBlueprintTest.php
@@ -45,9 +45,6 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->options());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18n()
 	{
 		$app = new App([
@@ -92,9 +89,6 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18nWithFallbackLanguage()
 	{
 		$app = new App([
@@ -130,9 +124,6 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testTitleI18nArray()
 	{
 		$app = new App([

--- a/tests/Cms/Page/PageMethodsTest.php
+++ b/tests/Cms/Page/PageMethodsTest.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\TestCase;
-
 class PageMethodsTest extends TestCase
 {
 	public function setUp(): void
@@ -11,9 +9,6 @@ class PageMethodsTest extends TestCase
 		$this->app = new App([
 			'pageMethods' => [
 				'test' => fn () => 'page method'
-			],
-			'pagesMethods' => [
-				'test' => fn () => 'pages method'
 			],
 			'site' => [
 				'children' => [
@@ -34,11 +29,5 @@ class PageMethodsTest extends TestCase
 	{
 		$page = $this->app->page('test');
 		$this->assertSame('page method', $page->test());
-	}
-
-	public function testPagesMethod()
-	{
-		$pages = $this->app->site()->children();
-		$this->assertSame('pages method', $pages->test());
 	}
 }

--- a/tests/Cms/Pages/PagesMethodsTest.php
+++ b/tests/Cms/Pages/PagesMethodsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kirby\Cms;
+
+class PagesMethodsTest extends TestCase
+{
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'pagesMethods' => [
+				'test' => fn () => 'pages method'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+					]
+				]
+			]
+		]);
+	}
+
+	public function testPagesMethod()
+	{
+		$pages = $this->app->site()->children();
+		$this->assertSame('pages method', $pages->test());
+	}
+}


### PR DESCRIPTION
## Description

### Summary of changes

- Move pagesMethods tests into Pages/PagesMethodsTest.php
- Use PHPUnit attributes for Model Blueprint tests
- Improve the cache id in the MemoryStorage class
- Undeprecate useful methods in the Translation class
- Replace Page:: with static:: in PageActions
- Simplify Page::createNum
- Improve indentation in the Site class
- Remove ::hardcopy from ::commit in model actions

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
