### PR TITLE
Hard stuff

### DIFF
--- a/src/Cms/NewFile.php
+++ b/src/Cms/NewFile.php
@@ -13,6 +13,9 @@ class NewFile extends File
 {
 	use NewModelFixes;
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
 	public function changeTemplate(string|null $template): static
 	{
 		if ($template === $this->template()) {
@@ -34,7 +37,7 @@ class NewFile extends File
 			}
 
 			// Use the version class to update the template field.
-			// If we use the $file->update() method directly, we create yet 
+			// If we use the $file->update() method directly, we create yet
 			// anothere clone and we trigger the update hooks.
 			$file->version()->save(
 				['template' => $template],
@@ -104,7 +107,10 @@ class NewFile extends File
 		return $copy;
 	}
 
-	public static function create(array $props, bool $move = false): File
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
+	public static function create(array $props, bool $move = false): static
 	{
 		$props = static::normalizeProps($props);
 

--- a/src/Cms/NewFile.php
+++ b/src/Cms/NewFile.php
@@ -33,10 +33,9 @@ class NewFile extends File
 				$template = null;
 			}
 
-			// Use the version class to update the template
-			// If we use the $file->update() method directly, the Form class
-			// will still use the old blueprint and might write invalid data
-			// to the content file. We also don't want to trigger update hooks.
+			// Use the version class to update the template field.
+			// If we use the $file->update() method directly, we create yet 
+			// anothere clone and we trigger the update hooks.
 			$file->version()->save(
 				['template' => $template],
 				'default'

--- a/src/Cms/NewModelFixes.php
+++ b/src/Cms/NewModelFixes.php
@@ -70,7 +70,7 @@ trait NewModelFixes
 		// keep a copy of the old model in memory
 		$old = $this->clone()->changeStorage(MemoryStorage::class);
 
-		// first clone object with new blueprint as template
+		// first clone the object with the new blueprint as template
 		$new = $this->clone(['template' => $blueprint]);
 
 		// make sure to use the same storage class as the original model
@@ -93,7 +93,7 @@ trait NewModelFixes
 
 				// Delete the old versions. This will also remove the
 				// content files from the storage if this is a plain text
-				// storage instace.
+				// storage instance.
 				$this->version($versionId)->delete($language);
 
 				// Save to re-create the content file

--- a/src/Cms/NewModelFixes.php
+++ b/src/Cms/NewModelFixes.php
@@ -67,8 +67,14 @@ trait NewModelFixes
 	 */
 	protected function convertTo(string $blueprint): static
 	{
+		// keep a copy of the old model in memory
+		$old = $this->clone()->changeStorage(MemoryStorage::class);
+
 		// first clone object with new blueprint as template
 		$new = $this->clone(['template' => $blueprint]);
+
+		// make sure to use the same storage class as the original model
+		$new->changeStorage($this->storage()::class);
 
 		// loop through all versions
 		foreach (['latest', 'changes'] as $versionId) {
@@ -82,17 +88,26 @@ trait NewModelFixes
 					continue;
 				}
 
-				// convert the content to the new blueprint
+				// Convert the content to the new blueprint
 				$content = $version->content($language)->convertTo($blueprint);
 
-				// save to re-create the content file
+				// Delete the old versions. This will also remove the
+				// content files from the storage if this is a plain text
+				// storage instace.
+				$this->version($versionId)->delete($language);
+
+				// Save to re-create the content file
 				// with the converted/updated content
 				$new->version($versionId)->save($content, $language);
-
-				// delete the old text file
-				$version->delete($language);
 			}
 		}
+
+		$this->storage = new MemoryStorage($this);
+
+		// move the old storage entries over to the
+		// new in-memory instance for this object to keep it
+		// alive for hooks or other purposes
+		$old->storage()->copyAll(to: $this->storage);
 
 		return $new;
 	}

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -269,6 +269,14 @@ class PlainTextStorage extends Storage
 	 */
 	protected function write(VersionId $versionId, Language $language, array $fields): void
 	{
+		// Content for files is only stored when there are any fields.
+		// Otherwise, the storage handler will take care here of cleaning up
+		// unnecessary content files.
+		if ($this->model instanceof File && $fields === []) {
+			$this->delete($versionId, $language);
+			return;
+		}
+
 		$success = Data::write($this->contentFile($versionId, $language), $fields);
 
 		// @codeCoverageIgnoreStart

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -50,6 +50,7 @@ class Version
 		// in the future, to provide multi-language support with truly
 		// individual versions of pages and no longer enforce the fallback.
 		if ($language->isDefault() === false) {
+			// merge the fields with the default language
 			$fields = [
 				...$this->read('default') ?? [],
 				...$fields
@@ -372,7 +373,10 @@ class Version
 	 */
 	protected function prepareFieldsAfterRead(array $fields, Language $language): array
 	{
-		return $this->convertFieldNamesToLowerCase($fields);
+		$fields = $this->convertFieldNamesToLowerCase($fields);
+
+		// ignore all fields with null values
+		return array_filter($fields, fn ($field) => $field !== null);
 	}
 
 	/**

--- a/tests/Cms/File/FileActionsTest.php
+++ b/tests/Cms/File/FileActionsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Content\VersionId;
+use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -104,8 +105,16 @@ class FileActionsTest extends TestCase
 	{
 		// create an empty dummy file
 		F::write($file->root(), '');
+
 		// ...and an empty content file for it
-		F::write($file->version(VersionId::latest())->contentFile('default'), '');
+		$content = $file->version('latest')->contentFile('default');
+
+		// We need to create a file with fields here
+		// otherwise, our plain text storage handler will
+		// remove the file on save
+		Data::write($content, [
+			'alt' => 'Test'
+		]);
 
 		$this->assertFileExists($file->root());
 		$this->assertFileExists($file->version(VersionId::latest())->contentFile('default'));
@@ -140,9 +149,21 @@ class FileActionsTest extends TestCase
 
 		// create an empty dummy file
 		F::write($file->root(), '');
+
 		// ...and empty content files for it
-		F::write($file->version(VersionId::latest())->contentFile('en'), '');
-		F::write($file->version(VersionId::latest())->contentFile('de'), '');
+		$contentEn = $file->version('latest')->contentFile('en');
+		$contentDe = $file->version('latest')->contentFile('de');
+
+		// We need to create files with fields here
+		// otherwise, our plain text storage handler will
+		// remove the file on save
+		Data::write($contentEn, [
+			'alt' => 'Test EN'
+		]);
+
+		Data::write($contentDe, [
+			'alt' => 'Test DE'
+		]);
 
 		$this->assertFileExists($file->root());
 		$this->assertFileExists($file->version(VersionId::latest())->contentFile('en'));

--- a/tests/Cms/NewFile/NewFileChangeNameTest.php
+++ b/tests/Cms/NewFile/NewFileChangeNameTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Cms\NewFile as File;
+use Kirby\Data\Data;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -23,7 +24,13 @@ class NewFileChangeNameTest extends NewModelTestCase
 		F::write($root, '');
 		// ...and an empty content file for it
 		$content = $file->version('latest')->contentFile('default');
-		F::write($content, '');
+
+		// We need to create a file with fields here
+		// otherwise, our plain text storage handler will
+		// remove the file on save
+		Data::write($content, [
+			'alt' => 'Test'
+		]);
 
 		$this->assertFileExists($root);
 		$this->assertFileExists($content);
@@ -54,8 +61,17 @@ class NewFileChangeNameTest extends NewModelTestCase
 		// ...and empty content files for it
 		$contentEn = $file->version('latest')->contentFile('en');
 		$contentDe = $file->version('latest')->contentFile('de');
-		F::write($contentEn, '');
-		F::write($contentDe, '');
+
+		// We need to create files with fields here
+		// otherwise, our plain text storage handler will
+		// remove the file on save
+		Data::write($contentEn, [
+			'alt' => 'Test EN'
+		]);
+
+		Data::write($contentDe, [
+			'alt' => 'Test DE'
+		]);
 
 		$this->assertFileExists($file->root());
 		$this->assertFileExists($contentEn);

--- a/tests/Cms/NewFile/NewFileChangeTemplateTest.php
+++ b/tests/Cms/NewFile/NewFileChangeTemplateTest.php
@@ -211,7 +211,6 @@ class NewFileChangeTemplateTest extends NewModelTestCase
 		// make all tests below with real content files
 		$file->changeStorage(PlainTextStorage::class);
 
-		$this->assertInstanceOf(PlainTextStorage::class, $file->storage());
 		$this->assertSame('a', $file->template());
 
 		$contentEN = $file->content('en');

--- a/tests/Cms/NewFile/NewFileContentFileDataTest.php
+++ b/tests/Cms/NewFile/NewFileContentFileDataTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Cms\NewFile as File;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(File::class)]
+class NewFileContentFileDataTest extends NewModelTestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.NewFileContentFileData';
+
+	public function testContentFileDataInMultiLanguageMode(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg',
+			'template' => 'test'
+		]);
+
+		$this->assertSame(['template' => 'test'], $file->contentFileData([]));
+		$this->assertSame(['template' => 'test'], $file->contentFileData([], 'en'));
+		$this->assertSame([], $file->contentFileData([], 'de', 'The template should not be added in secondary languages'));
+	}
+
+	public function testContentFileDataInMultiLanguageModeWithSort(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg',
+		]);
+
+		$input = [
+			'sort' => 1
+		];
+
+		$this->assertSame($input, $file->contentFileData($input));
+		$this->assertSame($input, $file->contentFileData($input, 'en'));
+		$this->assertSame([], $file->contentFileData($input, 'de', 'The sort field should not be added in secondary languages'));
+	}
+
+	public function testContentFileDataInSingleLanguageMode(): void
+	{
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg'
+		]);
+
+		$this->assertSame([], $file->contentFileData([]));
+	}
+
+	public function testContentFileDataInSingleLanguageModeWithSort(): void
+	{
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg'
+		]);
+
+		$input = [
+			'sort' => 1
+		];
+
+		$this->assertSame($input, $file->contentFileData($input));
+	}
+
+	public function testContentFileDataInSingleLanguageModeWithTemplate(): void
+	{
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg',
+			'template' => 'test'
+		]);
+
+		$expected = [
+			'template' => 'test'
+		];
+
+		$this->assertSame($expected, $file->contentFileData([]));
+	}
+
+	public function testContentFileDataInSingleLanguageModeWithOverwrittenTemplate(): void
+	{
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'test.jpg',
+			'template' => 'test'
+		]);
+
+		$this->assertSame(['template' => null], $file->contentFileData([
+			'template' => null
+		]));
+	}
+
+}

--- a/tests/Cms/NewPage/NewPageContentTest.php
+++ b/tests/Cms/NewPage/NewPageContentTest.php
@@ -63,7 +63,6 @@ class NewPageContentTest extends NewModelTestCase
 		]);
 
 		$this->assertSame([
-			'title'        => null,
 			'lowercase'    => 'lowercase',
 			'uppercase'    => 'UPPERCASE',
 			'camelcase'    => 'camelCase',

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -83,9 +83,16 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->files());
 		$this->assertSame([], $this->app->cache('changes')->get('files'));
 
-		// in cache and changes exist in reality
-		$this->app->file('test/test.jpg')->version(VersionId::latest())->save([]);
-		$this->app->file('test/test.jpg')->version(VersionId::changes())->save([]);
+		// in cache and changes exist in reality. We need to save
+		// at least a single field here. Otherwise, the content file
+		// is not going to be created and the changes will not be detected.
+		$this->app->file('test/test.jpg')->version(VersionId::latest())->save([
+			'alt' => 'Test'
+		]);
+
+		$this->app->file('test/test.jpg')->version(VersionId::changes())->save([
+			'alt' => 'Test'
+		]);
 
 		$this->assertSame($cache, $this->app->cache('changes')->get('files'));
 		$this->assertCount(1, $changes->files());

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -533,6 +533,61 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
+	public function testUpdateForFileWithMetaData()
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new PlainTextStorage($file);
+
+		$storage->update(VersionId::latest(), Language::single(), $content = [
+			'alt' => 'Test'
+		]);
+
+		$this->assertSame($content, Data::read($file->parent()->root() . '/image.jpg.txt'));
+	}
+
+	public function testUpdateForFileWithoutMetaData()
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new PlainTextStorage($file);
+		$storage->update(VersionId::latest(), Language::single(), []);
+
+		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
+	}
+
+	public function testUpdateForFileWithRemovedMetaFile()
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new PlainTextStorage($file);
+
+		$storage->update(VersionId::latest(), Language::single(), [
+			'alt' => 'Test'
+		]);
+
+		$this->assertFileExists($file->parent()->root() . '/image.jpg.txt');
+
+		$storage->update(VersionId::latest(), Language::single(), []);
+
+		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
+	}
+
 	/**
 	 * @covers ::contentFile
 	 * @dataProvider contentFileProviderMultiLang

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -9,10 +9,10 @@ use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
 
-/**
- * @coversDefaultClass \Kirby\Content\PlainTextStorage
- * @covers ::__construct
- */
+use PHPUnit\Framework\Attributes\CoversDefaultClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversDefaultClass(PlainTextStorage::class)]
 class PlainTextStorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.PlainTextStorage';
@@ -35,9 +35,6 @@ class PlainTextStorageTest extends TestCase
 		$this->storage = new PlainTextStorage($this->model);
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -51,9 +48,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -67,9 +61,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -83,9 +74,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
 	public function testCreateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -99,9 +87,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteNonExisting()
 	{
 		$this->setUpSingleLanguage();
@@ -120,9 +105,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -137,9 +119,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -153,9 +132,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist($this->model->root() . '/_changes');
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -169,9 +145,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -185,9 +158,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -196,9 +166,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -206,9 +173,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -217,9 +181,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -228,9 +189,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -242,9 +200,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -256,9 +211,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testMove()
 	{
 		$this->setUpSingleLanguage();
@@ -285,9 +237,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @coversNothing
-	 */
 	public function testMoveNonExistingContentFile()
 	{
 		$this->setUpSingleLanguage();
@@ -307,9 +256,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -325,9 +271,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -343,9 +286,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -360,9 +300,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::read
-	 */
 	public function testReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -377,9 +314,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -398,9 +332,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -419,9 +350,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.txt'));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -439,9 +367,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -459,9 +384,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -478,9 +400,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -497,9 +416,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -515,9 +431,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	/**
-	 * @covers ::update
-	 */
 	public function testUpdateLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -588,10 +501,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
 	}
 
-	/**
-	 * @covers ::contentFile
-	 * @dataProvider contentFileProviderMultiLang
-	 */
+	#[DataProvider('contentFileProviderMultiLang')]
 	public function testContentFileMultiLang(string $type, VersionId $id, string $language, string $expected)
 	{
 		$this->setUpMultiLanguage();
@@ -633,10 +543,7 @@ class PlainTextStorageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::contentFile
-	 * @dataProvider contentFileProviderSingleLang
-	 */
+	#[DataProvider('contentFileProviderSingleLang')]
 	public function testContentFileSingleLang(string $type, VersionId $id, string $expected)
 	{
 		$this->setUpSingleLanguage();
@@ -678,9 +585,6 @@ class PlainTextStorageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::contentFile
-	 */
 	public function testContentFileDraft()
 	{
 		$this->setUpSingleLanguage();
@@ -696,9 +600,6 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame(static::TMP . '/content/_drafts/a-page/_changes/article.txt', $storage->contentFile(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -709,9 +610,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -721,9 +619,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -734,9 +629,6 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::latest()));
 	}
 
-	/**
-	 * @covers ::contentFiles
-	 */
 	public function testContentFilesLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -83,6 +83,38 @@ class VersionTest extends TestCase
 
 	/**
 	 * @covers ::content
+	 */
+	public function testContentWithNullValues(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$version->save($contentEN = [
+			'title'    => 'Title EN',
+			'subtitle' => 'Subtitle EN'
+		], 'en');
+
+		$version->save($contentDE = [
+			'title'    => null,
+			'subtitle' => 'Subtitle DE'
+		], 'de');
+
+		$expectedContentEN = $contentEN;
+		$expectedContentDE = [
+			'title'    => $contentEN['title'],
+			'subtitle' => $contentDE['subtitle']
+		];
+
+		$this->assertSame($expectedContentEN, $version->content('en')->toArray());
+		$this->assertSame($expectedContentDE, $version->content('de')->toArray());
+	}
+
+	/**
+	 * @covers ::content
 	 * @covers ::prepareFieldsForContent
 	 */
 	public function testContentPrepareFields(): void
@@ -1071,6 +1103,51 @@ class VersionTest extends TestCase
 		$this->expectExceptionMessage('Invalid language: fr');
 
 		$version->read('fr');
+	}
+
+	public function testReadWithNullValuesMultiLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$version->save($contentEN = [
+			'title'    => 'Title EN',
+			'subtitle' => 'Subtitle EN'
+		], 'en');
+
+		$version->save([
+			'title'    => null,
+			'subtitle' => 'Subtitle DE'
+		], 'de');
+
+
+		$this->assertSame($contentEN, $version->read('en'));
+		$this->assertSame(['subtitle' => 'Subtitle DE'], $version->read('de'));
+	}
+
+	public function testReadWithNullValuesSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$version->save([
+			'title' => null,
+			'subtitle' => 'Test'
+		]);
+
+		$expected = [
+			'subtitle' => 'Test'
+		];
+
+		$this->assertSame($expected, $version->read());
 	}
 
 	/**

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -68,8 +68,13 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->app->file('file://test')->version(VersionId::latest())->save([]);
-		$this->app->file('file://test')->version(VersionId::changes())->save([]);
+		$this->app->file('file://test')->version(VersionId::latest())->save([
+			'alt' => 'Test'
+		]);
+
+		$this->app->file('file://test')->version(VersionId::changes())->save([
+			'alt' => 'Test'
+		]);
 
 		$dialog = new ChangesDialog();
 		$files  = $dialog->files();


### PR DESCRIPTION
## Description

### Summary of changes

@distantnative This is a set of improvements that really make sense to me, but we need to go through them together. 

- `Version::prepareFieldsAfterRead()` will now filter null values from the array. This will remove the breaking empty title field that we had in one of the tests. It will also fix the issue that fallback content is not always correct when we merge a translation with the default language. This was a really important fix that only turned up in the `NewFile::changeTemplate` test. I've added additional tests to the Version test class for future safety. 
- The PlainTextStorage handler does now remove meta content files if there are no fields to store. This is a behavior that we had before, but was so far ignored in the new architecture. I think it's important, but it means that some of the tests need to be adjusted quite a bit. Let's discuss how comfortable we are with this. 
- The NewFile class uses the contentFileData method now to make sure that we don't pass template or sort fields to the storage handlers in non-default languages. This is another important step that we have been missing so far and also only turned up when looking closer at the `NewFile::changeTemplate` issues
- The `NewModel::convertTo` method still had a couple of issues. 
  - The old version was completely wiped. If you ever wanted to work with it in the hooks, there would be no content left for it in storage after this method. 
  - The clone method to create the $new method could lead to an unintended switch to MemoryStorage. This means that this method could unintentionally not move text files at all. 
- The `NewFile::changeTemplate` method used `$file->update()` to change the template in the meta file. But this would call the update hooks and create yet another clone, which isn't great. Using `$file->version()->save()` is a much better option here. 

### Breaking changes



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
