### PR TITLE
Fix picker list layout style when long info text available

### DIFF
--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -267,8 +267,8 @@ export default {
 	text-overflow: ellipsis;
 }
 /** Provides a consistent look when texts are long in small dialogs */
-@container (max-width: 30rem) {
-	.k-dialog .k-item[data-layout="list"] .k-item-content:has(.k-item-info) {
+@container (max-width: 25rem) {
+	.k-item[data-layout="list"] .k-item-content:has(.k-item-info) {
 		flex-direction: column;
 	}
 }

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -266,7 +266,12 @@ export default {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
-
+/** Provides a consistent look when texts are long in small dialogs */
+@container (max-width: 30rem) {
+	.k-dialog .k-item[data-layout="list"] .k-item-content:has(.k-item-info) {
+		flex-direction: column;
+	}
+}
 .k-item[data-layout="list"] .k-sort-button {
 	--button-width: calc(1.5rem + var(--spacing-1));
 	--button-height: var(--item-height);


### PR DESCRIPTION
## Description

In small dialogs (max 30rem width), if there is info text, it always shows as two lines. Thanks to @bastianallgeier giving solutions and ideas.

![v5-develop test_panel_pages_notes+exploring-the-universe (1)](https://github.com/user-attachments/assets/4d1994f6-4425-4f0c-91a0-3f4aa6b7b467)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Ensure same listing style (breaking or not) in list view  #6904

### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
