### PR TITLE
Cancel running requests when discarding or publishing content

### DIFF
--- a/panel/src/helpers/throttle.js
+++ b/panel/src/helpers/throttle.js
@@ -15,7 +15,7 @@ export default (
 	let last = null;
 	let trailing = null;
 
-	return function (...args) {
+	function throttled(...args) {
 		if (timer) {
 			last = this;
 			trailing = args;
@@ -42,5 +42,17 @@ export default (
 		};
 
 		timer = setTimeout(cooled, delay);
+	}
+
+	// Add cancel method to clear the timeout
+	throttled.cancel = () => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+			last = null;
+			trailing = null;
+		}
 	};
+
+	return throttled;
 };


### PR DESCRIPTION
## Description

This PR makes sure that discard and publish requests cancel ongoing or schedule save requests properly, to avoid race conditions.

### Summary of changes

- The method to cancel throttled functions
- New `panel.content.cancelSaving()` method
- `panel.content.discard()` and `panel.content.publish()` cancel any ongoing or scheduled save requests. They also no longer can be executed for other views than the current one. 
- `panel.content.save()` no longer sets the `isProcessing` flag. Otherwise, discard and publish will be blocked. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
