### PR TITLE
Hide entry label for entries field as default

### DIFF
--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -64,6 +64,7 @@
 						:is="`k-${field.type}-field`"
 						:ref="'entry-' + index + '-input'"
 						:disabled="disabled"
+						:label="false"
 						:value="entry.value"
 						v-bind="field"
 						class="k-entries-field-item-input"

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -64,9 +64,9 @@
 						:is="`k-${field.type}-field`"
 						:ref="'entry-' + index + '-input'"
 						:disabled="disabled"
-						:label="false"
 						:value="entry.value"
 						v-bind="field"
+						:label="false"
 						class="k-entries-field-item-input"
 						@input="onInput(index, $event)"
 					/>

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -66,6 +66,7 @@
 						:disabled="disabled"
 						:value="entry.value"
 						v-bind="field"
+						:counter="false"
 						:label="false"
 						class="k-entries-field-item-input"
 						@input="onInput(index, $event)"

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -93,6 +93,9 @@ class EntriesField extends FieldClass
 			);
 		}
 
+		// remove the label from the entry field
+		unset($attrs['label']);
+
 		$this->field = $attrs;
 	}
 

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -93,8 +93,8 @@ class EntriesField extends FieldClass
 			);
 		}
 
-		// remove the label from the entry field
-		unset($attrs['label']);
+		// remove the unsupported props from the entry field
+		unset($attrs['counter'], $attrs['label']);
 
 		$this->field = $attrs;
 	}

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -115,6 +115,18 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('label', $field->field());
 	}
 
+	public function testFieldCounter()
+	{
+		$field = $this->field('entries', [
+			'field' => [
+				'type'    => 'text',
+				'counter' => true
+			]
+		]);
+
+		$this->assertArrayNotHasKey('counter', $field->field());
+	}
+
 	public function testDefaultValue()
 	{
 		$field = $this->field('entries', [

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -103,6 +103,18 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($props, $field->field());
 	}
 
+	public function testFieldLabel()
+	{
+		$field = $this->field('entries', [
+			'field' => [
+				'type'  => 'text',
+				'label' => 'Test'
+			]
+		]);
+
+		$this->assertArrayNotHasKey('label', $field->field());
+	}
+
 	public function testDefaultValue()
 	{
 		$field = $this->field('entries', [


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Entries Field breaks when field has label #7039


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
