### PR TITLE
Upgrade the `actions/cache` to 4.2.2

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,7 +91,7 @@ jobs:
           key: php-v1
 
       - name: Cache PHP extensions
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # pin@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4
         with:
           path: ${{ steps.ext-cache.outputs.dir }}
           key: ${{ steps.ext-cache.outputs.key }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Cache analysis data
         id: finishPrepare
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # pin@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4
         with:
           path: ~/.cache/psalm
           key: backend-analysis-${{ matrix.php }}
@@ -191,7 +191,7 @@ jobs:
           key: php-analysis-v1
 
       - name: Cache PHP extensions
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # pin@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4
         with:
           path: ${{ steps.ext-cache.outputs.dir }}
           key: ${{ steps.ext-cache.outputs.key }}
@@ -268,7 +268,7 @@ jobs:
 
       - name: Cache analysis data
         id: finishPrepare
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # pin@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4
         with:
           path: ~/.php-cs-fixer
           key: coding-style

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Setup PHP cache environment
         id: ext-cache
-        uses: shivammathur/cache-extensions@b5046118b75df28d2b24c968b417e81a6211a7fc # pin@v1
+        uses: shivammathur/cache-extensions@bbc38874818912d705835e232803362e231134d0 # pin@v1
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -98,7 +98,7 @@ jobs:
           restore-keys: ${{ steps.ext-cache.outputs.key }}
 
       - name: Setup PHP environment
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # pin@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # pin@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -135,7 +135,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           PHP: ${{ matrix.php }}
         if: env.token != ''
-        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # pin@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # pin@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # for better reliability if the GitHub API is down
           fail_ci_if_error: true
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload code scanning results to GitHub
         if: always() && steps.finishPrepare.outcome == 'success' && github.repository == 'getkirby/kirby' && matrix.php != '8.4'
-        uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # pin@v3
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # pin@v3
         with:
           sarif_file: sarif
 
@@ -184,7 +184,7 @@ jobs:
 
       - name: Setup PHP cache environment
         id: ext-cache
-        uses: shivammathur/cache-extensions@b5046118b75df28d2b24c968b417e81a6211a7fc # pin@v1
+        uses: shivammathur/cache-extensions@bbc38874818912d705835e232803362e231134d0 # pin@v1
         with:
           php-version: ${{ env.php }}
           extensions: ${{ env.extensions }}
@@ -199,7 +199,7 @@ jobs:
 
       - name: Setup PHP environment
         id: finishPrepare
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # pin@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # pin@v2
         with:
           php-version: ${{ env.php }}
           extensions: ${{ env.extensions }}
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload code scanning results to GitHub
         if: always() && steps.finishPrepare.outcome == 'success' && github.repository == 'getkirby/kirby'
-        uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # pin@v3
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # pin@v3
         with:
           sarif_file: sarif
 
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Setup PHP environment
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # pin@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # pin@v2
         with:
           php-version: ${{ env.php }}
           coverage: none

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Set up Node.js problem matchers and cache npm dependencies
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4
         with:
           cache: "npm"
           cache-dependency-path: panel/package-lock.json
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Set up Node.js problem matchers and cache npm dependencies
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4
         with:
           cache: "npm"
           cache-dependency-path: panel/package-lock.json


### PR DESCRIPTION
Related issue action: https://github.com/getkirby/kirby/actions/runs/13626821233

Read more: 
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

We should apply also for `develop/minor` branch. I'll create separate PR for it since afaik both workflow are not same.