### PR TITLE
Consistent `@see` tags

### DIFF
--- a/src/Content/Field.php
+++ b/src/Content/Field.php
@@ -77,7 +77,7 @@ class Field implements Stringable
 	 * Simplifies the var_dump result
 	 * @codeCoverageIgnore
 	 *
-	 * @see Field::toArray
+	 * @see self::toArray()
 	 */
 	public function __debugInfo(): array
 	{
@@ -88,7 +88,7 @@ class Field implements Stringable
 	 * Makes it possible to simply echo
 	 * or stringify the entire object
 	 *
-	 * @see Field::toString
+	 * @see self::toString()
 	 */
 	public function __toString(): string
 	{
@@ -138,7 +138,7 @@ class Field implements Stringable
 	}
 
 	/**
-	 * @see Field::parent()
+	 * @see self::parent()
 	 */
 	public function model(): ModelWithContent|null
 	{

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -112,7 +112,7 @@ class Environment
 
 	/**
 	 * Returns the server's IP address
-	 * @see ::ip
+	 * @see self::ip()
 	 */
 	public function address(): string|null
 	{

--- a/src/Plugin/Asset.php
+++ b/src/Plugin/Asset.php
@@ -107,7 +107,7 @@ class Asset implements Stringable
 	}
 
 	/**
-	 * @see ::mediaUrl
+	 * @see self::mediaUrl()
 	 */
 	public function url(): string
 	{
@@ -115,7 +115,7 @@ class Asset implements Stringable
 	}
 
 	/**
-	 * @see ::url
+	 * @see self::url()
 	 */
 	public function __toString(): string
 	{

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -300,7 +300,7 @@ class Collection extends Iterator implements Stringable
 	}
 
 	/**
-	 * @see \Kirby\Toolkit\Collection::filter()
+	 * @see self::filter()
 	 */
 	public function filterBy(...$args): static
 	{
@@ -562,7 +562,7 @@ class Collection extends Iterator implements Stringable
 	}
 
 	/**
-	 * @see \Kirby\Toolkit\Collection::group()
+	 * @see self::group()
 	 */
 	public function groupBy(...$args)
 	{
@@ -1073,7 +1073,7 @@ class Collection extends Iterator implements Stringable
 	}
 
 	/**
-	 * @see \Kirby\Toolkit\Collection::sort()
+	 * @see self::sort()
 	 */
 	public function sortBy(...$args): static
 	{
@@ -1144,7 +1144,7 @@ class Collection extends Iterator implements Stringable
 	}
 
 	/**
-	 * @see \Kirby\Toolkit\Collection::not()
+	 * @see self::not()
 	 */
 	public function without(string ...$keys): static
 	{

--- a/src/Toolkit/View.php
+++ b/src/Toolkit/View.php
@@ -88,7 +88,7 @@ class View implements Stringable
 	}
 
 	/**
-	 * @see ::render()
+	 * @see self::render()
 	 */
 	public function toString(): string
 	{
@@ -99,7 +99,7 @@ class View implements Stringable
 	 * Magic string converter to enable
 	 * converting view objects to string
 	 *
-	 * @see ::render()
+	 * @see self::render()
 	 */
 	public function __toString(): string
 	{

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -418,7 +418,7 @@ abstract class Uuid implements Stringable
 	}
 
 	/**
-	 * @see ::render
+	 * @see self::render()
 	 */
 	public function __toString(): string
 	{


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Consistently use the `self::METHOD()` pattern for `@see` tags

### Reasoning

The reference to `Toolkit\Collection` breaks the aliases in the new reference (https://github.com/getkirby/getkirby.com/pull/2415) as e.g. `$pages->without()` will link to `Toolkit\Collection::not()`.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Housekeeping

- Clean up `@see` tag consistency in the core code

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
