### PR TITLE
Tweaks for ModelCommit and ModelState

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -387,4 +387,18 @@ class Collection extends BaseCollection
 			$map ?? fn ($object) => $object->toArray()
 		);
 	}
+
+	/**
+	 * Updates an object in the collection
+	 *
+	 * @return $this
+	 */
+	public function update(string|object $key, $object = null): static
+	{
+		if (is_object($key) === true) {
+			return $this->update($key->id(), $key);
+		}
+
+		return $this->set($key, $object);
+	}
 }

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -411,7 +411,7 @@ trait FileActions
 	): static {
 		$file = parent::save($data, $languageCode, $overwrite);
 
-		ModelState::updateFile(
+		ModelState::update(
 			method: 'set',
 			current: $this,
 			next: $file

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -233,7 +233,7 @@ class ModelCommit
 			$this->model instanceof Page => PageRules::class,
 			$this->model instanceof Site => SiteRules::class,
 			$this->model instanceof User => UserRules::class,
-			default => throw new Exception('Invalid model class')
+			default => throw new Exception('Invalid model class') // @codeCoverageIgnore
 		};
 
 		if (method_exists($rules, $this->action) === true) {

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -36,7 +36,8 @@ class ModelCommit
 	public function after(mixed $state): mixed
 	{
 		// run the `after` hook
-		$hook = $this->hook('after', $this->afterHookArguments($state));
+		$arguments = $this->afterHookArguments($state);
+		$hook      = $this->hook('after', $arguments);
 
 		// flush the page cache after any model action
 		$this->kirby->cache('pages')->flush();
@@ -57,7 +58,7 @@ class ModelCommit
 			$this->model instanceof Page =>
 				$this->afterHookArgumentsForPageActions($this->model, $this->action, $state),
 			$this->model instanceof Site =>
-				$this->afterHookArgumentsForSiteActions($this->model, $this->action, $state),
+				$this->afterHookArgumentsForSiteActions($this->model, $state),
 			$this->model instanceof User =>
 				$this->afterHookArgumentsForUserActions($this->model, $this->action, $state),
 			default =>
@@ -69,8 +70,11 @@ class ModelCommit
 	 * Returns the appropriate arguments for the `after` hook
 	 * for the given page action.
 	 */
-	protected function afterHookArgumentsForPageActions(Page $model, string $action, mixed $state): array
-	{
+	protected function afterHookArgumentsForPageActions(
+		Page $model,
+		string $action,
+		mixed $state
+	): array {
 		return match ($action) {
 			'create' => [
 				'page' => $state
@@ -94,8 +98,11 @@ class ModelCommit
 	 * Returns the appropriate arguments for the `after` hook
 	 * for the given file action.
 	 */
-	protected function afterHookArgumentsForFileActions(File $model, string $action, mixed $state): array
-	{
+	protected function afterHookArgumentsForFileActions(
+		File $model,
+		string $action,
+		mixed $state
+	): array {
 		return match ($action) {
 			'create' => [
 				'file' => $state
@@ -115,8 +122,10 @@ class ModelCommit
 	 * Returns the appropriate arguments for the `after` hook
 	 * for the given site action.
 	 */
-	protected function afterHookArgumentsForSiteActions(Site $model, string $action, mixed $state): array
-	{
+	protected function afterHookArgumentsForSiteActions(
+		Site $model,
+		mixed $state
+	): array {
 		return [
 			'newSite' => $state,
 			'oldSite' => $model
@@ -127,8 +136,11 @@ class ModelCommit
 	 * Returns the appropriate arguments for the `after` hook
 	 * for the given user action.
 	 */
-	protected function afterHookArgumentsForUserActions(User $model, string $action, mixed $state): array
-	{
+	protected function afterHookArgumentsForUserActions(
+		User $model,
+		string $action,
+		mixed $state
+	): array {
 		return match ($action) {
 			'create' =>	[
 				'user' => $state

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -211,29 +211,21 @@ class ModelCommit
 	}
 
 	/**
-	 * Returns the appropriate rules class for the given model.
-	 */
-	public function rules(): FileRules|PageRules|SiteRules|UserRules
-	{
-		return match (true) {
-			$this->model instanceof File => new FileRules(),
-			$this->model instanceof Page => new PageRules(),
-			$this->model instanceof Site => new SiteRules(),
-			$this->model instanceof User => new UserRules(),
-			default => throw new Exception('Invalid model class')
-		};
-	}
-
-	/**
 	 * Checks the model rules for the given action
 	 * if there's a matching rule method.
 	 */
 	public function validate(array $arguments): void
 	{
-		$rules = $this->rules();
+		$rules = match (true) {
+			$this->model instanceof File => FileRules::class,
+			$this->model instanceof Page => PageRules::class,
+			$this->model instanceof Site => SiteRules::class,
+			$this->model instanceof User => UserRules::class,
+			default => throw new Exception('Invalid model class')
+		};
 
 		if (method_exists($rules, $this->action) === true) {
-			$rules->{$this->action}(...array_values($arguments));
+			$rules::{$this->action}(...array_values($arguments));
 		}
 	}
 }

--- a/src/Cms/ModelState.php
+++ b/src/Cms/ModelState.php
@@ -17,17 +17,6 @@ namespace Kirby\Cms;
 class ModelState
 {
 	/**
-	 * Returns the appropriate method arguments
-	 * for the given method. Removing models needs a
-	 * different set of arguments.
-	 */
-	public static function args(ModelWithContent $next, string $method): array
-	{
-		// method arguments depending on the called method
-		return $method === 'remove' ? [$next] : [$next->id(), $next];
-	}
-
-	/**
 	 * Updates the state of the given model.
 	 */
 	public static function update(
@@ -41,7 +30,7 @@ class ModelState
 			'append', 'create' => 'append',
 			'remove', 'delete' => 'remove',
 			'duplicate'        => false, // The models need to take care of this
-			default            => 'set'
+			default            => 'update'
 		};
 
 		if ($method === false) {
@@ -66,11 +55,8 @@ class ModelState
 	): void {
 		$next = $next instanceof File ? $next : $current;
 
-		// method arguments depending on the called method
-		$args = static::args($next, $method);
-
 		// update the files collection
-		$next->parent()->files()->$method(...$args);
+		$next->parent()->files()->$method($next);
 	}
 
 	/**
@@ -85,17 +71,14 @@ class ModelState
 		$next     = $next instanceof Page ? $next : $current;
 		$parent ??= $next->parentModel();
 
-		// method arguments depending on the called method
-		$args = static::args($next, $method);
-
 		if ($next->isDraft() === true) {
-			$parent->drafts()->$method(...$args);
+			$parent->drafts()->$method($next);
 		} else {
-			$parent->children()->$method(...$args);
+			$parent->children()->$method($next);
 		}
 
 		// update the childrenAndDrafts() cache
-		$parent->childrenAndDrafts()->$method(...$args);
+		$parent->childrenAndDrafts()->$method($next);
 	}
 
 	/**
@@ -118,10 +101,7 @@ class ModelState
 	): void {
 		$next = $next instanceof User ? $next : $current;
 
-		// method arguments depending on the called method
-		$args = static::args($next, $method);
-
 		// update the users collection
-		App::instance()->users()->$method(...$args);
+		App::instance()->users()->$method($next);
 	}
 }

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -125,7 +125,7 @@ trait PageActions
 				VersionCache::$cache = [];
 
 				// remove from the siblings
-				ModelState::updatePage(
+				ModelState::update(
 					method: 'remove',
 					current: $oldPage,
 				);
@@ -399,7 +399,7 @@ trait PageActions
 		);
 
 		// add copy to siblings
-		ModelState::updatePage(
+		ModelState::update(
 			method: 'append',
 			current: $copy,
 			parent: $parentModel
@@ -833,7 +833,7 @@ trait PageActions
 	): static {
 		$page = parent::save($data, $languageCode, $overwrite);
 
-		ModelState::updatePage(
+		ModelState::update(
 			method: 'set',
 			current: $this,
 			next: $page
@@ -916,14 +916,14 @@ trait PageActions
 	 * Updates parent collections with the new page object
 	 * after a page action
 	 *
-	 * @deprecated 5.0.0 Use ModelState::updatePage instead
+	 * @deprecated 5.0.0 Use ModelState::update instead
 	 */
 	protected static function updateParentCollections(
 		Page $page,
 		string|false $method,
 		Page|Site|null $parentModel = null
 	): void {
-		ModelState::updatePage(
+		ModelState::update(
 			method: $method,
 			current: $page,
 			next: $page,

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -348,7 +348,7 @@ trait UserActions
 		if ($user->isLoggedIn() === true) {
 			$this->kirby()->auth()->setUser($user);
 
-			ModelState::updateUser(
+			ModelState::update(
 				method: 'set',
 				current: $user,
 			);

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Exception;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Obj;
+use PHPUnit\Framework\Attributes\CoversClass;
 use stdClass;
 
 class MockObject
@@ -39,6 +40,7 @@ class MockObject
 	}
 }
 
+#[CoversClass(Collection::class)]
 class CollectionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Collection';
@@ -507,5 +509,22 @@ class CollectionTest extends TestCase
 			'b' => 'b',
 			'c' => 'c'
 		]);
+	}
+
+	public function testUpdate(): void
+	{
+		$collection = new Collection([
+			new MockObject(['id' => 'a', 'group' => 'a']),
+			new MockObject(['id' => 'b', 'group' => 'a'])
+		]);
+
+		$this->assertSame('a', $collection->first()->group());
+		$this->assertSame('a', $collection->last()->group());
+
+		$new = new MockObject(['id' => 'b', 'group' => 'b']);
+		$collection->update($new);
+
+		$this->assertSame('a', $collection->first()->group());
+		$this->assertSame('b', $collection->last()->group());
 	}
 }

--- a/tests/Cms/ModelCommitTest.php
+++ b/tests/Cms/ModelCommitTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use PHPUnit\Framework\Attributes\CoversDefaultClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversDefaultClass(ModelCommit::class)]
 class ModelCommitTest extends TestCase

--- a/tests/Cms/ModelCommitTest.php
+++ b/tests/Cms/ModelCommitTest.php
@@ -542,17 +542,4 @@ class ModelCommitTest extends TestCase
 		$this->assertSame('Modified Title', $this->app->page('test')->title()->value());
 		$this->assertSame('Modified Subtitle', $this->app->page('test')->subtitle()->value());
 	}
-
-	#[DataProvider('modelProvider')]
-	public function testRules(ModelWithContent $model, string $rulesClass)
-	{
-		$commit = new ModelCommit(
-			model: $model,
-			action: 'create'
-		);
-
-		$rules = $commit->rules();
-
-		$this->assertInstanceOf($rulesClass, $rules);
-	}
 }

--- a/tests/Cms/ModelCommitTest.php
+++ b/tests/Cms/ModelCommitTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-use PHPUnit\Framework\Attributes\CoversDefaultClass;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversDefaultClass(ModelCommit::class)]
+#[CoversClass(ModelCommit::class)]
 class ModelCommitTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.ModelCommit';

--- a/tests/Cms/ModelCommitTest.php
+++ b/tests/Cms/ModelCommitTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\PermissionException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ModelCommit::class)]
@@ -540,5 +541,20 @@ class ModelCommitTest extends TestCase
 		$this->assertSame('Modified Subtitle', $state['result']->subtitle()->value());
 		$this->assertSame('Modified Title', $this->app->page('test')->title()->value());
 		$this->assertSame('Modified Subtitle', $this->app->page('test')->subtitle()->value());
+	}
+
+	public function testValidate(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$commit = new ModelCommit(
+			model: $page,
+			action: 'create'
+		);
+
+		$this->expectException(PermissionException::class);
+
+		$commit->validate(arguments: [
+			'page' => $page
+		]);
 	}
 }

--- a/tests/Cms/ModelStateTest.php
+++ b/tests/Cms/ModelStateTest.php
@@ -7,25 +7,6 @@ use PHPUnit\Framework\Attributes\CoversDefaultClass;
 #[CoversDefaultClass(ModelState::class)]
 class ModelStateTest extends TestCase
 {
-	public function testArgs()
-	{
-		$page = new Page([
-			'slug' => 'test',
-		]);
-
-		$this->assertEquals([$page->id(), $page], ModelState::args($page, 'changeSlug'));
-		$this->assertEquals([$page->id(), $page], ModelState::args($page, 'changeTitle'));
-	}
-
-	public function testArgsForRemoveAction()
-	{
-		$page = new Page([
-			'slug' => 'test',
-		]);
-
-		$this->assertEquals([$page], ModelState::args($page, 'remove'));
-	}
-
 	public function testUpdateFile()
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/ModelStateTest.php
+++ b/tests/Cms/ModelStateTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-use PHPUnit\Framework\Attributes\CoversDefaultClass;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversDefaultClass(ModelState::class)]
+#[CoversClass(ModelState::class)]
 class ModelStateTest extends TestCase
 {
 	public function testUpdateFile()

--- a/tests/Cms/ModelStateTest.php
+++ b/tests/Cms/ModelStateTest.php
@@ -26,20 +26,6 @@ class ModelStateTest extends TestCase
 		$this->assertEquals([$page], ModelState::args($page, 'remove'));
 	}
 
-	public function testNormalizeMethod()
-	{
-		$this->assertEquals('append', ModelState::normalizeMethod('append'));
-		$this->assertEquals('append', ModelState::normalizeMethod('create'));
-
-		$this->assertEquals('remove', ModelState::normalizeMethod('remove'));
-		$this->assertEquals('remove', ModelState::normalizeMethod('delete'));
-
-		$this->assertEquals('set', ModelState::normalizeMethod('changeTitle'));
-		$this->assertEquals('set', ModelState::normalizeMethod('changeSlug'));
-
-		$this->assertEquals(false, ModelState::normalizeMethod('duplicate'));
-	}
-
 	public function testUpdateFile()
 	{
 		$this->app = $this->app->clone([
@@ -65,7 +51,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updateFile(
+		ModelState::update(
 			method: 'update',
 			current: $current,
 			next: $next
@@ -99,7 +85,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updateFile(
+		ModelState::update(
 			method: 'duplicate',
 			current: $current,
 			next: $next
@@ -131,7 +117,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updatePage(
+		ModelState::update(
 			method: 'changeTitle',
 			current: $current,
 			next: $next
@@ -163,7 +149,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updatePage(
+		ModelState::update(
 			method: 'duplicate',
 			current: $current,
 			next: $next
@@ -188,7 +174,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updateSite(
+		ModelState::update(
 			method: 'changeTitle',
 			current: $this->app->site(),
 			next: $next
@@ -214,7 +200,7 @@ class ModelStateTest extends TestCase
 			]
 		]);
 
-		ModelState::updateSite(
+		ModelState::update(
 			method: 'duplicate',
 			current: $current,
 			next: $next
@@ -239,7 +225,7 @@ class ModelStateTest extends TestCase
 			'email' => 'next@example.com'
 		]);
 
-		ModelState::updateUser(
+		ModelState::update(
 			method: 'changeEmail',
 			current: $this->app->user('admin'),
 			next: $next
@@ -265,7 +251,7 @@ class ModelStateTest extends TestCase
 			'email' => 'next@example.com'
 		]);
 
-		ModelState::updateUser(
+		ModelState::update(
 			method: 'duplicate',
 			current: $current,
 			next: $next

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -9,10 +9,10 @@ use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
 
-use PHPUnit\Framework\Attributes\CoversDefaultClass;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversDefaultClass(PlainTextStorage::class)]
+#[CoversClass(PlainTextStorage::class)]
 class PlainTextStorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.PlainTextStorage';


### PR DESCRIPTION
## Summary
- Removed `ModelCommit::rules()` and moved code directly to `::validate()` incl statically calling the rules class method
- Removed `ModelState::args()` as we don't need it anymore with the new `Collection::update()` method
- Removed `ModelState::normalizeMethod()` and moved the code into `::update()` which centrally takes care of the method normalization and check
- All other `ModelState::update*()` are now protected, they should be called via `::update()`

## Changelog

### Enhancements
- New `Kirby\Cms\Collection::update($object)` method