### PR TITLE
Clean up delete actions

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -285,13 +285,16 @@ trait FileActions
 	public function delete(): bool
 	{
 		return $this->commit('delete', ['file' => $this], function ($file) {
-			// remove all public versions, lock and clear UUID cache
+			// remove all public versions and clear the UUID cache
 			$file->unpublish();
 
-			foreach ($file->storage()->all() as $version => $lang) {
-				$file->storage()->delete($version, $lang);
-			}
+			// delete all changes first
+			$file->version('changes')->delete('*');
 
+			// delete all latest versions as last step.
+			$file->version('latest')->delete('*');
+
+			// delete the file from disk
 			F::remove($file->root());
 
 			return true;

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -561,24 +561,13 @@ trait PageActions
 				$child->delete(true);
 			}
 
-			// actually remove the page from disc
-			if ($page->exists() === true) {
-				// delete all public media files
-				Dir::remove($page->mediaRoot());
+			// delete all changes first
+			$page->version('changes')->delete('*');
 
-				// delete the content folder for this page
-				Dir::remove($page->root());
-
-				// if the page is a draft and the _drafts folder
-				// is now empty. clean it up.
-				if ($page->isDraft() === true) {
-					$draftsDir = dirname($page->root());
-
-					if (Dir::isEmpty($draftsDir) === true) {
-						Dir::remove($draftsDir);
-					}
-				}
-			}
+			// delete all latest versions as last step.
+			// the plain text storage handler will then clean
+			// up the directory if it's empty.
+			$page->version('latest')->delete('*');
 
 			if ($page->isDraft() === false) {
 				$page->resortSiblingsAfterUnlisting();

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -255,6 +255,12 @@ trait UserActions
 			// up the directory if it's empty.
 			$user->version('latest')->delete('*');
 
+			// delete the user directory to get rid
+			// of the .htpasswd and index.php files.
+			// we need to solve this at a later point with
+			// something like a credential storage
+			Dir::remove($user->root());
+
 			return true;
 		});
 	}

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -144,9 +144,18 @@ class PlainTextStorage extends Storage
 		}
 		// @codeCoverageIgnoreEnd
 
-		// clean up empty _changes directories
-		if ($versionId->is(VersionId::changes()) === true) {
-			$this->deleteEmptyDirectory(dirname($contentFile));
+		$contentDirectory = $this->contentDirectory($versionId);
+
+		// clean up empty content directories (_changes or the page/user directory)
+		$this->deleteEmptyDirectory($contentDirectory);
+
+		// delete empty _drafts directories for pages
+		if (
+			$versionId->is(VersionId::latest()) === true &&
+			$this->model instanceof Page &&
+			$this->model->isDraft() === true
+		) {
+			$this->deleteEmptyDirectory(dirname($contentDirectory));
 		}
 	}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -139,6 +139,14 @@ class Version
 	 */
 	public function delete(Language|string $language = 'default'): void
 	{
+		if ($language === '*') {
+			foreach (Languages::ensure() as $language) {
+				$this->delete($language);
+			}
+
+			return;
+		}
+
 		$language = Language::ensure($language);
 
 		// check if deleting is allowed

--- a/tests/Cms/User/UserDeleteTest.php
+++ b/tests/Cms/User/UserDeleteTest.php
@@ -33,6 +33,20 @@ class UserDeleteTest extends ModelTestCase
 		$this->assertFileDoesNotExist($user->root() . '/user.txt');
 	}
 
+	public function testDeleteWithFiles(): void
+	{
+		$user = User::create(['email' => 'editor@domain.com']);
+
+		touch($user->root() . '/test.jpg');
+
+		$this->assertCount(1, $user->files());
+
+		$user->delete();
+
+		$this->assertFileDoesNotExist($user->root() . '/test.jpg');
+		$this->assertDirectoryDoesNotExist($user->root());
+	}
+
 	public function testDeleteHooks(): void
 	{
 		$calls = 0;

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -372,6 +372,29 @@ class VersionTest extends TestCase
 	/**
 	 * @covers ::delete
 	 */
+	public function testDeleteMultiLanguageWithWildcard(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$this->createContentMultiLanguage();
+
+		$this->assertContentFileExists('en');
+		$this->assertContentFileExists('de');
+
+		$version->delete('*');
+
+		$this->assertContentFileDoesNotExist('en');
+		$this->assertContentFileDoesNotExist('de');
+	}
+
+	/**
+	 * @covers ::delete
+	 */
 	public function testDeleteSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -388,6 +411,27 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists();
 
 		$version->delete();
+
+		$this->assertContentFileDoesNotExist();
+	}
+
+	/**
+	 * @covers ::delete
+	 */
+	public function testDeleteSingleLanguageWithWildcard(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::latest()
+		);
+
+		$this->createContentSingleLanguage();
+
+		$this->assertContentFileExists();
+
+		$version->delete('*');
 
 		$this->assertContentFileDoesNotExist();
 	}


### PR DESCRIPTION
### Merge first

- [x] https://github.com/getkirby/kirby/pull/7038

### Summary of changes

- New wildcard option for `Version::delete()`
- Move the folder clean up logic into the PlainTextStorage handler
- New unit tests 
- Refactor`User::delete()`, `Page::delete()` and `File::delete()` to delete the Versions properly and let the PlainTextStorage handler take care of cleaning up the disk. 

### Reasoning

- The delete actions were completely buggy so far for virtual pages and it makes sense in my opinion to also refactor the other model delete actions at the same time. 

### Fixes

- `User::delete()` will now properly call `file.delete` hooks for deleted user files. 
- Versions will be properly deleted for all storage handlers. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
