### PR TITLE
Moving Storage instead of copying, whenever possible

### DIFF
--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -308,6 +308,7 @@ class Language implements Stringable
 	/**
 	 * Checks if the language is the same
 	 * as the given language or language code
+	 * @since 5.0.0
 	 */
 	public function is(self|string $language): bool
 	{

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -306,6 +306,15 @@ class Language implements Stringable
 	}
 
 	/**
+	 * Checks if the language is the same
+	 * as the given language or language code
+	 */
+	public function is(self|string $language): bool
+	{
+		return $this->code() === static::ensure($language)->code();
+	}
+
+	/**
 	 * Checks if this is the default language
 	 * for the site.
 	 */

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -104,11 +104,11 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	}
 
 	/**
-	 * Copies the model to a new storage instance/type
+	 * Moves or copies the model to a new storage instance/type
 	 * @since 5.0.0
 	 * @internal
 	 */
-	public function changeStorage(Storage|string $toStorage): static
+	public function changeStorage(Storage|string $toStorage, bool $copy = false): static
 	{
 		if (is_string($toStorage) === true) {
 			if (is_subclass_of($toStorage, Storage::class) === false) {
@@ -118,7 +118,9 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			$toStorage = new $toStorage($this);
 		}
 
-		$this->storage()->copyAll(to: $toStorage);
+		$method = $copy ? 'copyAll' : 'moveAll';
+
+		$this->storage()->$method(to: $toStorage);
 		$this->storage = $toStorage;
 		return $this;
 	}
@@ -443,7 +445,10 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$clone = $this->clone();
 
 		// move the old model into memory
-		$this->changeStorage(ImmutableMemoryStorage::class);
+		$this->changeStorage(
+			toStorage: ImmutableMemoryStorage::class,
+			copy: true
+		);
 
 		// update the clone
 		$clone->version()->save(

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -198,7 +198,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	protected function convertTo(string $blueprint): static
 	{
 		// keep a copy of the old model in memory
-		$old = $this->clone()->changeStorage(MemoryStorage::class);
+		$old = $this->clone()->changeStorage(MemoryStorage::class, copy: true);
 
 		// first clone the object with the new blueprint as template
 		$new = $this->clone(['template' => $blueprint]);

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -217,6 +217,33 @@ class PlainTextStorage extends Storage
 	}
 
 	/**
+	 * Compare two version-language-storage combinations
+	 */
+	public function isSameStorageLocation(
+		VersionId $fromVersionId,
+		Language $fromLanguage,
+		VersionId|null $toVersionId = null,
+		Language|null $toLanguage = null,
+		Storage|null $toStorage = null
+	) {
+		// fallbacks to allow keeping the method call lean
+		$toVersionId ??= $fromVersionId;
+		$toLanguage  ??= $fromLanguage;
+		$toStorage   ??= $this;
+
+		// no need to compare content files if the new
+		// storage type is different
+		if ($toStorage instanceof self === false) {
+			return false;
+		}
+
+		$contentFileA = $this->contentFile($fromVersionId, $fromLanguage);
+		$contentFileB = $toStorage->contentFile($toVersionId, $toLanguage);
+
+		return $contentFileA === $contentFileB;
+	}
+
+	/**
 	 * Returns the modification timestamp of a version
 	 * if it exists
 	 */

--- a/src/Content/Storage.php
+++ b/src/Content/Storage.php
@@ -59,6 +59,17 @@ abstract class Storage
 		$toLanguage  ??= $fromLanguage;
 		$toStorage   ??= $this;
 
+		// don't copy content to the same version-language-storage combination
+		if ($this->isSameStorageLocation(
+			fromVersionId: $fromVersionId,
+			fromLanguage: $fromLanguage,
+			toVersionId: $toVersionId,
+			toLanguage: $toLanguage,
+			toStorage: $toStorage
+		)) {
+			return;
+		}
+
 		// read the existing fields
 		$content = $this->read($fromVersionId, $fromLanguage);
 
@@ -126,6 +137,32 @@ abstract class Storage
 	}
 
 	/**
+	 * Compare two version-language-storage combinations
+	 */
+	public function isSameStorageLocation(
+		VersionId $fromVersionId,
+		Language $fromLanguage,
+		VersionId|null $toVersionId = null,
+		Language|null $toLanguage = null,
+		Storage|null $toStorage = null
+	) {
+		// fallbacks to allow keeping the method call lean
+		$toVersionId ??= $fromVersionId;
+		$toLanguage  ??= $fromLanguage;
+		$toStorage   ??= $this;
+
+		if (
+			$fromVersionId->is($toVersionId) &&
+			$fromLanguage->is($toLanguage) &&
+			$this === $toStorage
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns the related model
 	 */
 	public function model(): ModelWithContent
@@ -152,6 +189,17 @@ abstract class Storage
 		$toVersionId ??= $fromVersionId;
 		$toLanguage  ??= $fromLanguage;
 		$toStorage   ??= $this;
+
+		// don't move content to the same version-language-storage combination
+		if ($this->isSameStorageLocation(
+			fromVersionId: $fromVersionId,
+			fromLanguage: $fromLanguage,
+			toVersionId: $toVersionId,
+			toLanguage: $toLanguage,
+			toStorage: $toStorage
+		)) {
+			return;
+		}
 
 		// copy content to new version
 		$this->copy(

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -394,6 +394,39 @@ class LanguageTest extends TestCase
 	}
 
 	/**
+	 * @covers ::is
+	 */
+	public function testIs()
+	{
+		$app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true,
+				],
+				[
+					'code'    => 'de',
+				],
+			]
+		]);
+
+		$en = new Language([
+			'code' => 'en'
+		]);
+
+		$de = new Language([
+			'code' => 'de'
+		]);
+
+		$this->assertTrue($en->is('en'));
+		$this->assertTrue($en->is($en));
+		$this->assertTrue($en->is(new Language(['code' => 'en'])));
+
+		$this->assertFalse($en->is('de'));
+		$this->assertFalse($en->is($de));
+	}
+
+	/**
 	 * @covers ::isDefault
 	 */
 	public function testIsDefault()

--- a/tests/Content/ImmutableMemoryStorageTest.php
+++ b/tests/Content/ImmutableMemoryStorageTest.php
@@ -4,11 +4,9 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\ImmutableMemoryStorage
- * @covers ::__construct
- */
+#[CoversClass(ImmutableMemoryStorage::class)]
 class ImmutableMemoryStorageTest extends TestCase
 {
 	protected $storage;
@@ -21,10 +19,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage = new ImmutableMemoryStorage($this->model);
 	}
 
-	/**
-	 * @covers ::delete
-	 * @covers ::preventMutation
-	 */
 	public function testDelete()
 	{
 		$this->expectException(LogicException::class);
@@ -33,10 +27,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->delete(VersionId::latest(), Language::ensure());
 	}
 
-	/**
-	 * @covers ::move
-	 * @covers ::preventMutation
-	 */
 	public function testMove()
 	{
 		$this->expectException(LogicException::class);
@@ -49,10 +39,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::touch
-	 * @covers ::preventMutation
-	 */
 	public function testTouch()
 	{
 		$this->expectException(LogicException::class);
@@ -61,10 +47,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->touch(VersionId::latest(), Language::ensure());
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::preventMutation
-	 */
 	public function testUpdate()
 	{
 		$this->storage->create(VersionId::latest(), Language::ensure(), []);

--- a/tests/Content/MemoryStorageTest.php
+++ b/tests/Content/MemoryStorageTest.php
@@ -313,6 +313,66 @@ class MemoryStorageTest extends TestCase
 	}
 
 	/**
+	 * @covers ::move
+	 */
+	public function testMoveToTheSameStorageLocation()
+	{
+		$this->setUpSingleLanguage();
+
+		$content   = ['title' => 'Test'];
+		$versionId = VersionId::latest();
+		$language  = Language::single();
+
+		// create some content to move
+		$this->storage->create($versionId, $language, $content);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+		$this->assertSame($content, $this->storage->read($versionId, $language));
+
+		$this->storage->move(
+			$versionId,
+			$language,
+			$versionId,
+			$language
+		);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+		$this->assertSame($content, $this->storage->read($versionId, $language), 'The content should still be the same');
+	}
+
+	/**
+	 * @covers ::move
+	 */
+	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance()
+	{
+		$this->setUpSingleLanguage();
+
+		$content   = ['title' => 'Test'];
+		$versionId = VersionId::latest();
+		$language  = Language::single();
+		$storage   = new MemoryStorage($this->model);
+
+		// create some content to move
+		$this->storage->create($versionId, $language, $content);
+
+		$this->assertTrue($this->storage->exists($versionId, $language));
+		$this->assertSame($content, $this->storage->read($versionId, $language));
+
+		$this->storage->move(
+			$versionId,
+			$language,
+			$versionId,
+			$language,
+			$storage
+		);
+
+		$this->assertFalse($this->storage->exists($versionId, $language), 'The old storage entry should be gone now');
+
+		$this->assertTrue($storage->exists($versionId, $language));
+		$this->assertSame($content, $storage->read($versionId, $language));
+	}
+
+	/**
 	 * @covers ::touch
 	 */
 	public function testTouchMultiLang()

--- a/tests/Content/MemoryStorageTest.php
+++ b/tests/Content/MemoryStorageTest.php
@@ -3,12 +3,9 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\MemoryStorage
- * @covers ::__construct
- * @covers ::cacheId
- */
+#[CoversClass(MemoryStorage::class)]
 class MemoryStorageTest extends TestCase
 {
 	protected MemoryStorage $storage;
@@ -70,11 +67,6 @@ class MemoryStorageTest extends TestCase
 		$this->storage = new MemoryStorage($this->model);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -85,11 +77,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -100,11 +87,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -115,11 +97,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::create
-	 * @covers ::read
-	 * @covers ::write
-	 */
 	public function testCreateAndReadLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -130,10 +107,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 * @covers ::exists
-	 */
 	public function testDeleteNonExisting()
 	{
 		$this->setUpSingleLanguage();
@@ -149,9 +122,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists($versionId, $language));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -162,9 +132,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteChangesSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -175,9 +142,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -188,9 +152,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
 	public function testDeleteLatestSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -201,9 +162,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -220,9 +178,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -237,9 +192,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $language));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -248,9 +200,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
 	public function testExistsNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -258,9 +207,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -269,9 +215,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedNoneExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -280,9 +223,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -296,9 +236,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
 	public function testModifiedSomeExistingSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -312,9 +249,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveToTheSameStorageLocation()
 	{
 		$this->setUpSingleLanguage();
@@ -340,9 +274,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertSame($content, $this->storage->read($versionId, $language), 'The content should still be the same');
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance()
 	{
 		$this->setUpSingleLanguage();
@@ -372,9 +303,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertSame($content, $storage->read($versionId, $language));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -390,9 +318,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	/**
-	 * @covers ::touch
-	 */
 	public function testTouchSingleLang()
 	{
 		$this->setUpSingleLanguage();
@@ -408,10 +333,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::write
-	 */
 	public function testUpdateMultiLang()
 	{
 		$this->setUpMultiLanguage();
@@ -422,10 +343,6 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndUpdate($versionId, $language);
 	}
 
-	/**
-	 * @covers ::update
-	 * @covers ::write
-	 */
 	public function testUpdateSingleLang()
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -7,18 +7,13 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Storage
- * @covers ::__construct
- */
+#[CoversClass(Storage::class)]
 class StorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Storage';
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllMultiLanguageForFile()
 	{
 		$this->setUpMultiLanguage();
@@ -51,9 +46,6 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllSingleLanguageForFile()
 	{
 		$this->setUpSingleLanguage();
@@ -81,9 +73,6 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllMultiLanguageForPage()
 	{
 		$this->setUpMultiLanguage();
@@ -111,9 +100,6 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	/**
-	 * @covers ::all
-	 */
 	public function testAllSingleLanguageForPage()
 	{
 		$this->setUpSingleLanguage();
@@ -137,9 +123,6 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopyMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -164,9 +147,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopySingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -188,9 +168,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
 	public function testCopytoAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
@@ -213,9 +190,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::copyAll
-	 */
 	public function testCopyAll()
 	{
 		$this->setUpSingleLanguage();
@@ -239,9 +213,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::deleteLanguage
-	 */
 	public function testDeleteLanguageMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -261,9 +232,6 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	/**
-	 * @covers ::deleteLanguage
-	 */
 	public function testDeleteLanguageSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -287,9 +255,6 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $language));
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFrom()
 	{
 		$this->setUpMultiLanguage();
@@ -389,9 +354,6 @@ class StorageTest extends TestCase
 		));
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$this->setUpSingleLanguage();
@@ -401,9 +363,6 @@ class StorageTest extends TestCase
 		$this->assertSame($this->model, $handler->model());
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -428,9 +387,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	/**
-	 * @covers ::move
-	 */
 	public function testMoveSingleLanguage()
 	{
 		$this->setUpSingleLanguage();
@@ -453,9 +409,34 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::move
-	 */
+	public function testMoveToTheSameStorageLocation()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestStorage(model: $this->model);
+
+		$content   = ['title' => 'Test'];
+		$versionId = VersionId::latest();
+		$language  = Language::single();
+
+		// create some content to move
+		$handler->create($versionId, $language, $content);
+
+		$this->assertTrue($handler->exists($versionId, $language));
+		$this->assertSame($content, $handler->read($versionId, $language));
+
+		$handler->move(
+			$versionId,
+			$language,
+			$versionId,
+			$language,
+			$handler
+		);
+
+		$this->assertTrue($handler->exists($versionId, $language));
+		$this->assertSame($content, $handler->read($versionId, $language), 'The content should still be the same');
+	}
+
 	public function testMoveToAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
@@ -478,9 +459,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::moveAll
-	 */
 	public function testMoveAll()
 	{
 		$this->setUpSingleLanguage();
@@ -504,9 +482,6 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	/**
-	 * @covers ::moveLanguage
-	 */
 	public function testMoveSingleLanguageToMultiLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -533,9 +508,6 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.en.txt');
 	}
 
-	/**
-	 * @covers ::moveLanguage
-	 */
 	public function testMoveMultiLanguageToSingleLanguage()
 	{
 		$this->setUpMultiLanguage();
@@ -563,9 +535,6 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	/**
-	 * @covers ::replaceStrings
-	 */
 	public function testReplaceStrings()
 	{
 		$this->setUpMultiLanguage();
@@ -593,9 +562,6 @@ class StorageTest extends TestCase
 		$this->assertSame($expected, $handler->read($versionId, $language));
 	}
 
-	/**
-	 * @covers ::replaceStrings
-	 */
 	public function testReplaceStringsWithNullValues()
 	{
 		$this->setUpSingleLanguage();
@@ -617,9 +583,6 @@ class StorageTest extends TestCase
 		], $handler->read(VersionId::latest(), Language::single()));
 	}
 
-	/**
-	 * @covers ::touchLanguage
-	 */
 	public function testTouchLanguageMultiLanguage()
 	{
 		$this->setUpMultiLanguage();

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -168,7 +168,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testCopytoAnotherStorage()
+	public function testCopyToAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
 
@@ -188,6 +188,34 @@ class StorageTest extends TestCase
 
 		$this->assertTrue($handler1->exists(VersionId::latest(), Language::single()));
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
+	}
+
+	public function testCopyToTheSameStorageLocation()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestStorage(model: $this->model);
+
+		$content   = ['title' => 'Test'];
+		$versionId = VersionId::latest();
+		$language  = Language::single();
+
+		// create some content to copy
+		$handler->create($versionId, $language, $content);
+
+		$this->assertTrue($handler->exists($versionId, $language));
+		$this->assertSame($content, $handler->read($versionId, $language));
+
+		$handler->copy(
+			$versionId,
+			$language,
+			$versionId,
+			$language,
+			$handler
+		);
+
+		$this->assertTrue($handler->exists($versionId, $language));
+		$this->assertSame($content, $handler->read($versionId, $language), 'The content should still be the same');
 	}
 
 	public function testCopyAll()

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -331,6 +331,64 @@ class StorageTest extends TestCase
 		$this->assertSame($changesDE, $handlerB->read($versionChanges, $de));
 	}
 
+	public function testIsSameStorageLocation()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestStorage(model: $this->model);
+
+		$this->assertTrue($handler->isSameStorageLocation(
+			VersionId::latest(),
+			Language::single(),
+			VersionId::latest(),
+			Language::single()
+		));
+	}
+
+	public function testIsSameStorageLocationWithDifferentVersionIds()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler = new TestStorage(model: $this->model);
+
+		$this->assertFalse($handler->isSameStorageLocation(
+			VersionId::latest(),
+			Language::single(),
+			VersionId::changes(),
+			Language::single()
+		));
+	}
+
+	public function testIsSameStorageLocationWithDifferentLanguages()
+	{
+		$this->setUpMultiLanguage();
+
+		$handler = new TestStorage(model: $this->model);
+
+		$this->assertFalse($handler->isSameStorageLocation(
+			VersionId::latest(),
+			Language::ensure('en'),
+			VersionId::latest(),
+			Language::ensure('de')
+		));
+	}
+
+	public function testIsSameStorageLocationWithDifferentStorageInstances()
+	{
+		$this->setUpSingleLanguage();
+
+		$handler1 = new TestStorage(model: $this->model);
+		$handler2 = new TestStorage(model: $this->model);
+
+		$this->assertFalse($handler1->isSameStorageLocation(
+			VersionId::latest(),
+			Language::single(),
+			VersionId::latest(),
+			Language::single(),
+			$handler2
+		));
+	}
+
 	/**
 	 * @covers ::model
 	 */

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -398,7 +398,7 @@ class StorageTest extends TestCase
 	/**
 	 * @covers ::move
 	 */
-	public function testMovetoAnotherStorage()
+	public function testMoveToAnotherStorage()
 	{
 		$this->setUpSingleLanguage();
 


### PR DESCRIPTION
## Description

So far, we copy the storage when we create clones. But this creates redundant storage instances that are not useful. (see @lukasbestle's comment on Notion) 

The `ModelWithContent::changeStorage()` method does now move storage by default, but has a new flag to copy instead if needed. We still need to copy storage when we create detached in-memory clones for our hooks. This happens in the `ModelWithContent::save()` method and in the `ModelWithContent:convertTo()` method. 

When changing this at first, a couple tests broke until I realized that we had quite a big logical issue in our `Storage::move()` and `Storage::copy()` methods. Both methods did move or copy, even if the storage location actually did not change. This is super bad for memory consumption but also for the disk usage. We basically deleted files and recreated them or added new in-memory cache entries every time. But there was an even bigger issue in the PlainTextStorage handler. Consider this code: 

```php

$language = Language::ensure('en');
$version = VersionId::latest();

$handler1 = new PlainTextStorage($page);
$handler2 = new PlainTextStorage($page);

$handler1->move(
  fromVersionId: $version,
  fromLanguage: $language,
  toVersionId: $version,
  toLanguage: $language,
  toStorage: $handler2
);
```

The move logic looks like this: 

```php
// copy content to new version
$this->copy(
  $fromVersionId,
  $fromLanguage,
  $toVersionId,
  $toLanguage,
  $toStorage
);

// clean up the old version
$this->delete($fromVersionId, $fromLanguage);
```

This makes perfect sense when we have unique locations for both handlers. In memory, we have unique cache instances for example. But in PlainTextStorage both handlers point to the exact same location on disk. E.g. `some-page/article.en.txt`

This means that we would copy the content from the same file to the same file and then afterwards delete that same file 🙈

I think I have a really stable fix for this now. 

### Summary of changes

- New `Language::is()` method to compare language objects. This is pretty much idential to what we do in `Page::is()` and useful in other places
- New `Storage::isSameStorageLocation()`, which is now used in `Storage::move()` and `Storage::copy()` to return early if the storage location did not change. 
- New `PlainTextStorage::isSameStorageLocation()` implementation, which compares text file locations for more accurate results. 
- `ModelWithContent::changeStorage()` has a new second, boolean `$copy` argument, which is false by default. Storage is thus moved by default, but can be copied on demand.
- `ModelWithContent::save()` and `ModelWithContent::convertTo()` use that new `$copy` flag to create a fully in-memory copy for the old instance. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
