### PR TITLE
Handle state updates in the ModelWithContent::save method

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -401,26 +401,6 @@ trait FileActions
 	}
 
 	/**
-	 * Stores the content on disk
-	 * @internal
-	 */
-	public function save(
-		array|null $data = null,
-		string|null $languageCode = null,
-		bool $overwrite = false
-	): static {
-		$file = parent::save($data, $languageCode, $overwrite);
-
-		ModelState::update(
-			method: 'set',
-			current: $this,
-			next: $file
-		);
-
-		return $file;
-	}
-
-	/**
 	 * Remove all public versions of this file
 	 *
 	 * @return $this

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -452,6 +452,12 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			$overwrite
 		);
 
+		ModelState::update(
+			method: 'set',
+			current: $this,
+			next: $clone
+		);
+
 		return $clone;
 	}
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -809,26 +809,6 @@ trait PageActions
 	}
 
 	/**
-	 * Stores the content on disk
-	 * @internal
-	 */
-	public function save(
-		array|null $data = null,
-		string|null $languageCode = null,
-		bool $overwrite = false
-	): static {
-		$page = parent::save($data, $languageCode, $overwrite);
-
-		ModelState::update(
-			method: 'set',
-			current: $this,
-			next: $page
-		);
-
-		return $page;
-	}
-
-	/**
 	 * Convert a page from listed or
 	 * unlisted to draft.
 	 * @internal


### PR DESCRIPTION
### Summary of changes

- `File::save()` and `Page::save()` have been removed and the model state update has been moved to the `ModelWithContent::save()` method

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
