### PR TITLE
Refactor convertTo to use ImmutableMemoryStorage

### DIFF
--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -305,6 +305,9 @@ class PlainTextStorage extends Storage
 	 */
 	protected function write(VersionId $versionId, Language $language, array $fields): void
 	{
+		// only store non-null value fields
+		$fields = array_filter($fields, fn ($field) => $field !== null);
+
 		// Content for files is only stored when there are any fields.
 		// Otherwise, the storage handler will take care here of cleaning up
 		// unnecessary content files.

--- a/tests/Cms/File/FileChangeTemplateTest.php
+++ b/tests/Cms/File/FileChangeTemplateTest.php
@@ -300,7 +300,7 @@ class FileChangeTemplateTest extends ModelTestCase
 		$this->assertSame('for-default-b', $back->template());
 		$this->assertSame('for-default-b', $back->content()->get('template')->value());
 
-		$modified = $file->changeTemplate(null);
+		$modified = $back->changeTemplate(null);
 		$this->assertSame('default', $modified->template());
 		$this->assertNull($modified->content()->get('template')->value());
 	}

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -614,6 +614,24 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
 	}
 
+	public function testUpdateForFileWithoutMetaDataAndFilteredNullValues()
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new PlainTextStorage($file);
+		$storage->update(VersionId::latest(), Language::single(), [
+			'a' => null,
+			'b' => null
+		]);
+
+		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
+	}
+
 	public function testUpdateForFileWithRemovedMetaFile()
 	{
 		$this->setUpSingleLanguage();


### PR DESCRIPTION
## Description

### Merge first

- [x] https://github.com/getkirby/kirby/pull/7060

### Summary of changes

The `ModelWithContent::convertTo()` method did not keep the old object in `ImmutableMemoryStorage` so far. This PR fixes this and refactors the method to also use the new `$model->versions()` method for the loop, together with some additional improvements. 

While testing, I stumbled across another issue in the `PlainTextStorage::write()` method for files. Meta data files should not be written when there are no fields to store. But when you pass multiple fields with null values, the check failed. This is now also fixed and tested. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
