### PR TITLE
Support legacy model modification in model hooks

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -251,7 +251,8 @@ class App
 				// bind the App object to the hook
 				$newValue = $event->call($this, $function);
 
-				// update value if one was returned
+				// update value if one was returned or the
+				// provided object was cloned in the hook
 				$event->updateArgument($modify, $newValue);
 			}
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -252,9 +252,7 @@ class App
 				$newValue = $event->call($this, $function);
 
 				// update value if one was returned
-				if ($newValue !== null) {
-					$event->updateArgument($modify, $newValue);
-				}
+				$event->updateArgument($modify, $newValue);
 			}
 
 			$level--;

--- a/src/Cms/Event.php
+++ b/src/Cms/Event.php
@@ -267,9 +267,9 @@ class Event implements Stringable
 			if (
 				$state instanceof ModelWithContent &&
 				$state->storage() instanceof ImmutableMemoryStorage &&
-				$state->storage()->modelClone() !== null
+				$state->storage()->nextModel() !== null
 			) {
-				$this->arguments[$name] = $state->storage()->modelClone();
+				$this->arguments[$name] = $state->storage()->nextModel();
 			}
 
 			// Otherwise, there's no need to update the argument

--- a/src/Cms/Hooks.php
+++ b/src/Cms/Hooks.php
@@ -3,6 +3,10 @@
 namespace Kirby\Cms;
 
 /**
+ * The Hooks class outsources the logic of
+ * `App::apply()` and `App::trigger()` methods
+ * and makes them easier and more predictable to test.
+ *
  * @package   Kirby Cms
  * @author    Bastian Allgeier <bastian@getkirby.com>
  * @link      https://getkirby.com

--- a/src/Cms/Hooks.php
+++ b/src/Cms/Hooks.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Kirby\Cms;
+
+/**
+ * @package   Kirby Cms
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @internal
+ */
+class Hooks
+{
+	protected array $applied = [];
+	protected int $appliedLevel = 0;
+	protected array $triggered = [];
+	protected int $triggeredLevel = 0;
+	protected App|self $bind;
+
+	public function __construct(
+		protected array $hooks,
+		App|null $bind = null
+	) {
+		$this->bind = $bind ?? $this;
+	}
+
+	/**
+	 * Runs the hook and applies the result to the argument
+	 * specified by the $modify parameter. By default, the
+	 * first argument is modified.
+	 */
+	public function apply(
+		Event $event,
+		string|null $modify = null,
+	): mixed {
+		$name     = $event->name();
+		$hooks    = $this->hooks($event);
+		$modify ??= array_key_first($event->arguments());
+
+		if ($hooks === []) {
+			return $event->argument($modify);
+		}
+
+		$this->appliedLevel++;
+
+		foreach ($hooks as $hook) {
+			if (in_array($hook, $this->applied[$name] ?? []) === true) {
+				continue;
+			}
+
+			// mark the hook as applied, to avoid endless loops
+			$this->applied[$name][] = $hook;
+
+			// bind the Kirby instance to the hook
+			$newValue = $event->call($this->bind, $hook);
+
+			// update value if one was returned
+			$event->updateArgument($modify, $newValue);
+		}
+
+		$this->appliedLevel--;
+
+		if ($this->appliedLevel === 0) {
+			$this->applied = [];
+		}
+
+		return $event->argument($modify);
+	}
+
+	/**
+	 * Returns a list of all matching handlers
+	 */
+	public function hooks(Event $event): array
+	{
+		$name  = $event->name();
+		$hooks = [];
+
+		if (isset($this->hooks[$name]) === true) {
+			$hooks = $this->hooks[$name];
+		}
+
+		foreach ($event->nameWildcards() as $wildcard) {
+			if (isset($this->hooks[$wildcard]) === true) {
+				$hooks = [
+					...$hooks,
+					...$this->hooks[$wildcard]
+				];
+			}
+		}
+
+		return $hooks;
+	}
+
+	/**
+	 * Runs the hook without modifying the arguments
+	 */
+	public function trigger(
+		Event $event
+	): void {
+		$name  = $event->name();
+		$hooks = $this->hooks($event);
+
+		if ($hooks === []) {
+			return;
+		}
+
+		$this->triggeredLevel++;
+
+		foreach ($hooks as $index => $hook) {
+			if (in_array($hook, $this->triggered[$name] ?? []) === true) {
+				continue;
+			}
+
+			// mark the hook as triggered, to avoid endless loops
+			$this->triggered[$name][] = $hook;
+
+			// bind the Kirby instance to the hook
+			$event->call($this->bind, $hook);
+		}
+
+		$this->triggeredLevel--;
+
+		if ($this->triggeredLevel === 0) {
+			$this->triggered = [];
+		}
+	}
+}

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Closure;
-use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Exception\Exception;
 
 /**
@@ -210,20 +209,12 @@ class ModelCommit
 		$appliedTo = array_key_first($arguments);
 
 		// run the hook and modify the first argument
-		$arguments[$appliedTo] = $state = $this->kirby->apply(
+		$arguments[$appliedTo] = $this->kirby->apply(
 			// e.g. page.create:before
 			$this->prefix . '.' . $this->action . ':' . $hook,
 			$arguments,
 			$appliedTo
 		);
-
-		if (
-			$state instanceof ModelWithContent &&
-			$state->storage() instanceof ImmutableMemoryStorage &&
-			$state->storage()->modelClone() !== null
-		) {
-			$arguments[$appliedTo] = $state->storage()->modelClone();
-		}
 
 		return [
 			'arguments' => $arguments,

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Exception\Exception;
 
 /**
@@ -209,12 +210,20 @@ class ModelCommit
 		$appliedTo = array_key_first($arguments);
 
 		// run the hook and modify the first argument
-		$arguments[$appliedTo] = $this->kirby->apply(
+		$arguments[$appliedTo] = $state = $this->kirby->apply(
 			// e.g. page.create:before
 			$this->prefix . '.' . $this->action . ':' . $hook,
 			$arguments,
 			$appliedTo
 		);
+
+		if (
+			$state instanceof ModelWithContent &&
+			$state->storage() instanceof ImmutableMemoryStorage &&
+			$state->storage()->modelClone() !== null
+		) {
+			$arguments[$appliedTo] = $state->storage()->modelClone();
+		}
 
 		return [
 			'arguments' => $arguments,

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -218,7 +218,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			toStorage: new ImmutableMemoryStorage(
 				model: $this,
 				modelClone: $new
-			), 
+			),
 			copy: true
 		);
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -214,7 +214,13 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		// Copy this instance into immutable storage.
 		// Moving the content would prematurely delete the old content storage entries.
 		// But we need to keep them until the new content is written.
-		$this->changeStorage(ImmutableMemoryStorage::class, copy: true);
+		$this->changeStorage(
+			toStorage: new ImmutableMemoryStorage(
+				model: $this,
+				modelClone: $new
+			), 
+			copy: true
+		);
 
 		// Get all languages to loop through
 		$languages = Languages::ensure();
@@ -449,7 +455,10 @@ abstract class ModelWithContent implements Identifiable, Stringable
 
 		// move the old model into memory
 		$this->changeStorage(
-			toStorage: ImmutableMemoryStorage::class,
+			toStorage: new ImmutableMemoryStorage(
+				model: $this,
+				modelClone: $clone
+			),
 			copy: true
 		);
 

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -217,7 +217,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$this->changeStorage(
 			toStorage: new ImmutableMemoryStorage(
 				model: $this,
-				modelClone: $new
+				nextModel: $new
 			),
 			copy: true
 		);
@@ -457,7 +457,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$this->changeStorage(
 			toStorage: new ImmutableMemoryStorage(
 				model: $this,
-				modelClone: $clone
+				nextModel: $clone
 			),
 			copy: true
 		);

--- a/src/Content/ImmutableMemoryStorage.php
+++ b/src/Content/ImmutableMemoryStorage.php
@@ -17,7 +17,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 {
 	public function __construct(
 		protected ModelWithContent $model,
-		protected ModelWithContent|null $modelClone = null
+		protected ModelWithContent|null $nextModel = null
 	) {
 		parent::__construct($model);
 	}
@@ -33,15 +33,6 @@ class ImmutableMemoryStorage extends MemoryStorage
 	}
 
 	/**
-	 * Returns the clone of the model if the
-	 * reference is given
-	 */
-	public function modelClone(): ModelWithContent|null
-	{
-		return $this->modelClone;
-	}
-
-	/**
 	 * Immutable storage entries cannot be moved
 	 *
 	 * @throws \Kirby\Exception\LogicException
@@ -54,6 +45,15 @@ class ImmutableMemoryStorage extends MemoryStorage
 		Storage|null $toStorage = null
 	): void {
 		$this->preventMutation('moved');
+	}
+
+	/**
+	 * Returns the next state of the model if the
+	 * reference is given
+	 */
+	public function nextModel(): ModelWithContent|null
+	{
+		return $this->nextModel;
 	}
 
 	/**

--- a/src/Content/ImmutableMemoryStorage.php
+++ b/src/Content/ImmutableMemoryStorage.php
@@ -3,8 +3,8 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\LogicException;
-
 /**
  * @package   Kirby Content
  * @author    Nico Hoffmann <nico@getkirby.com>
@@ -14,9 +14,21 @@ use Kirby\Exception\LogicException;
  */
 class ImmutableMemoryStorage extends MemoryStorage
 {
+	public function __construct(
+		protected ModelWithContent $model,
+		protected ModelWithContent|null $modelClone = null
+	) {
+		parent::__construct($model);
+	}
+
 	public function delete(VersionId $versionId, Language $language): void
 	{
 		$this->preventMutation('deleted');
+	}
+
+	public function modelClone(): ModelWithContent|null
+	{
+		return $this->modelClone;
 	}
 
 	public function move(

--- a/src/Content/ImmutableMemoryStorage.php
+++ b/src/Content/ImmutableMemoryStorage.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\LogicException;
+
 /**
  * @package   Kirby Content
  * @author    Nico Hoffmann <nico@getkirby.com>
@@ -21,16 +22,30 @@ class ImmutableMemoryStorage extends MemoryStorage
 		parent::__construct($model);
 	}
 
+	/**
+	 * Immutable storage entries cannot be deleted
+	 *
+	 * @throws \Kirby\Exception\LogicException
+	 */
 	public function delete(VersionId $versionId, Language $language): void
 	{
 		$this->preventMutation('deleted');
 	}
 
+	/**
+	 * Returns the clone of the model if the
+	 * reference is given
+	 */
 	public function modelClone(): ModelWithContent|null
 	{
 		return $this->modelClone;
 	}
 
+	/**
+	 * Immutable storage entries cannot be moved
+	 *
+	 * @throws \Kirby\Exception\LogicException
+	 */
 	public function move(
 		VersionId $fromVersionId,
 		Language $fromLanguage,
@@ -53,11 +68,21 @@ class ImmutableMemoryStorage extends MemoryStorage
 		);
 	}
 
+	/**
+	 * Immutable storage entries cannot be touched
+	 *
+	 * @throws \Kirby\Exception\LogicException
+	 */
 	public function touch(VersionId $versionId, Language $language): void
 	{
 		$this->preventMutation('touched');
 	}
 
+	/**
+	 * Immutable storage entries cannot be updated
+	 *
+	 * @throws \Kirby\Exception\LogicException
+	 */
 	public function update(VersionId $versionId, Language $language, array $fields): void
 	{
 		$this->preventMutation('updated');

--- a/tests/Cms/App/AppApplyTest.php
+++ b/tests/Cms/App/AppApplyTest.php
@@ -27,13 +27,12 @@ class AppApplyTest extends TestCase
 	public function testApplyEventWithCustomEventObject()
 	{
 		$self        = $this;
-		$customEvent = new Event('custom', ['value' => 10]);
+		$customEvent = new Event('test', ['value' => 10]);
 
 		$this->app = $this->app->clone([
 			'hooks' => [
 				'test' => function (Event $event) use ($self, $customEvent) {
 					$self->assertSame($event, $customEvent);
-					$self->assertSame('custom', $event->name());
 					$self->assertSame(['value' => 10], $event->arguments());
 
 					// should modify the value of the custom event

--- a/tests/Cms/App/AppApplyTest.php
+++ b/tests/Cms/App/AppApplyTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversDefaultClass;
 
 #[CoversDefaultClass(App::class)]
@@ -45,6 +46,20 @@ class AppApplyTest extends TestCase
 		$this->app->apply('test', [], 'value', $customEvent);
 
 		$this->assertSame(20, $customEvent->argument('value'), 'The custom event value should have been modified');
+	}
+
+	public function testApplyWithInvalidModifyArgument()
+	{
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'test' => fn () => null
+			]
+		]);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The argument unused does not exist');
+
+		$this->app->apply('test', ['foo' => 'bar'], 'unused');
 	}
 
 	public function testApplyWithMultipleParameters()
@@ -175,21 +190,6 @@ class AppApplyTest extends TestCase
 
 		$this->assertSame(11, $this->app->apply('test.event:after', ['value' => 1], 'value'));
 		$this->assertSame(4, $calls);
-	}
-
-	public function testApplyWithoutArguments()
-	{
-		$self = $this;
-
-		$this->app = $this->app->clone([
-			'hooks' => [
-				'test' => function (Event $event) use ($self) {
-					$self->assertCount(0, $event->arguments());
-				}
-			]
-		]);
-
-		$this->assertNull($this->app->apply('test', [], 'unused'));
 	}
 
 	public function testApplyWithoutHandler()

--- a/tests/Cms/App/AppTriggerTest.php
+++ b/tests/Cms/App/AppTriggerTest.php
@@ -26,13 +26,12 @@ class AppTriggerTest extends TestCase
 	public function testTriggerEventWithCustomEventObject()
 	{
 		$self        = $this;
-		$customEvent = new Event('custom', ['value' => 10]);
+		$customEvent = new Event('test', ['value' => 10]);
 
 		$this->app = $this->app->clone([
 			'hooks' => [
 				'test' => function (Event $event) use ($self, $customEvent) {
 					$self->assertSame($event, $customEvent);
-					$self->assertSame('custom', $event->name());
 					$self->assertSame(['value' => 10], $event->arguments());
 				}
 			]

--- a/tests/Cms/HooksTest.php
+++ b/tests/Cms/HooksTest.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Hooks::class)]
 class HooksTest extends TestCase
 {
 	public function testApply()

--- a/tests/Cms/HooksTest.php
+++ b/tests/Cms/HooksTest.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace Kirby\Cms;
+
+class HooksTest extends TestCase
+{
+	public function testApply()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function (string $message) {
+						return 'message: ' . $message;
+					}
+				]
+			]
+		);
+
+		$result = $hooks->apply(new Event('test', ['message' => 'hello']));
+
+		$this->assertSame('message: hello', $result);
+	}
+
+	public function testApplyNesting()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'a' => [
+					function (string $message) {
+						return 'a: ' . $this->apply(new Event('b', ['message' => $message]));
+					}
+				],
+				'b' => [
+					function (string $message) {
+						return 'b: ' . $message;
+					}
+				]
+			]
+		);
+
+		$result = $hooks->apply(new Event('a', ['message' => 'hello']));
+
+		$this->assertSame('a: b: hello', $result);
+	}
+
+	public function testApplyWithLoopProtection()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function (string $message) {
+						return 'message: ' . $this->apply(new Event('test', ['message' => $message]));
+					}
+				]
+			]
+		);
+
+		$result = $hooks->apply(new Event('test', ['message' => 'hello']));
+
+		$this->assertSame('message: hello', $result);
+	}
+
+	public function testApplyWithWildcard()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test.*' => [
+					function (string $message) {
+						return 'message: ' . $message;
+					}
+				]
+			]
+		);
+
+		$a = $hooks->apply(new Event('test.a', ['message' => 'hello']));
+		$b = $hooks->apply(new Event('test.b', ['message' => 'hello']));
+
+		$this->assertSame('message: hello', $a);
+		$this->assertSame('message: hello', $b);
+	}
+
+	public function testApplyWithBoundApp()
+	{
+		$self  = $this;
+		$hooks = new Hooks(
+			bind: $app = $this->app,
+			hooks: [
+				'test' => [
+					function () use ($self, $app) {
+						$self->assertSame($this, $app);
+					}
+				]
+			]
+		);
+
+		$hooks->apply(new Event('test', ['message' => 'hello']));
+	}
+
+	public function testApplyWithoutHooks()
+	{
+		$hooks = new Hooks(
+			hooks: []
+		);
+
+		$result = $hooks->apply(new Event('test', ['message' => 'hello']));
+
+		$this->assertSame('hello', $result);
+	}
+
+	public function testApplyWithoutModifier()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function ($a, $b) {
+						return 'message: ' . $a . ' ' . $b;
+					}
+				]
+			]
+		);
+
+		$name = 'test';
+		$args = ['a' => 'hello', 'b' => 'world'];
+
+		$event  = new Event($name, $args);
+		$result = $hooks->apply($event);
+
+		$this->assertSame('message: hello world', $result);
+		$this->assertSame('message: hello world', $event->argument('a'), 'The first argument should have been modified by default');
+	}
+
+	public function testApplyWithModifier()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function ($a, $b) {
+						return 'message: ' . $a . ' ' . $b;
+					}
+				]
+			]
+		);
+
+		$name = 'test';
+		$args = ['a' => 'hello', 'b' => 'world'];
+
+		// the custom event is needed to test the modified argument
+		$event  = new Event($name, $args);
+		$result = $hooks->apply($event, 'b');
+
+		$this->assertSame('message: hello world', $result);
+		$this->assertSame('message: hello world', $event->argument('b'), 'The given argument should have been modified');
+	}
+
+	public function testHooksWithSingleHandler()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => $handlers = [
+					function () {
+						return 'test';
+					}
+				]
+			]
+		);
+
+		$this->assertSame($handlers, $hooks->hooks(new Event('test')));
+	}
+
+	public function testHooksWithMultipleHandlers()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'test' => $handlers = [
+					function () {
+						return 'a';
+					},
+					function () {
+						return 'b';
+					}
+				]
+			]
+		);
+
+		$this->assertSame($handlers, $hooks->hooks(new Event('test')));
+	}
+
+	public function testHooksWithWildcards()
+	{
+		$hooks = new Hooks(
+			hooks: [
+				'type.action:state' => $typeAndActionAndState = [
+					function () {
+						return 'test';
+					}
+				],
+				'type.action:*' => $typeAndAction = [
+					function () {
+						return 'test';
+					}
+				],
+				'type.*:*' => $type = [
+					function () {
+						return 'test';
+					}
+				],
+				'*' => $any = [
+					function () {
+						return 'test';
+					}
+				]
+			]
+		);
+
+		// full match
+		$this->assertSame([
+			...$typeAndActionAndState,
+			...$typeAndAction,
+			...$type,
+			...$any
+		], $hooks->hooks(new Event('type.action:state')));
+
+		// no state match
+		$this->assertSame([
+			...$typeAndAction,
+			...$type,
+			...$any
+		], $hooks->hooks(new Event('type.action:differentState')));
+
+		// no action and no state match
+		$this->assertSame([
+			...$type,
+			...$any
+		], $hooks->hooks(new Event('type.differentAction:differentState')));
+
+		// no match
+		$this->assertSame([
+			...$any
+		], $hooks->hooks(new Event('differentType.differentAction:differentState')));
+	}
+
+	public function testHooksWithoutHandlers()
+	{
+		$hooks = new Hooks(
+			hooks: []
+		);
+
+		$this->assertSame([], $hooks->hooks(new Event('test')));
+	}
+
+	public function testTrigger()
+	{
+		$count = 0;
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function () use (&$count) {
+						$count++;
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('test'));
+
+		$this->assertSame(1, $count);
+	}
+
+	public function testTriggerNesting()
+	{
+		$message = '';
+		$hooks = new Hooks(
+			hooks: [
+				'a' => [
+					function () use (&$message) {
+						$message .= 'a';
+						$this->trigger(new Event('b'));
+					}
+				],
+				'b' => [
+					function () use (&$message) {
+						$message .= 'b';
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('a'));
+
+		$this->assertSame('ab', $message);
+	}
+
+	public function testTriggerWithLoopProtection()
+	{
+		$count = 0;
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function () use (&$count) {
+						$count++;
+						$this->trigger(new Event('test'));
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('test'));
+		$this->assertSame(1, $count);
+	}
+
+	public function testTriggerWithWildcard()
+	{
+		$count = 0;
+		$hooks = new Hooks(
+			hooks: [
+				'test.*' => [
+					function () use (&$count) {
+						$count++;
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('test.a'));
+		$hooks->trigger(new Event('test.b'));
+
+		$this->assertSame(2, $count);
+	}
+
+	public function testTriggerWithBoundApp()
+	{
+		$self  = $this;
+		$hooks = new Hooks(
+			bind: $app = $this->app,
+			hooks: [
+				'test' => [
+					function () use ($self, $app) {
+						$self->assertSame($this, $app);
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('test'));
+	}
+
+	public function testTriggerWithMultipleHandlers()
+	{
+		$count = 0;
+		$hooks = new Hooks(
+			hooks: [
+				'test' => [
+					function () use (&$count) {
+						$count++;
+					},
+					function () use (&$count) {
+						$count++;
+					}
+				]
+			]
+		);
+
+		$hooks->trigger(new Event('test'));
+
+		$this->assertSame(2, $count);
+	}
+}

--- a/tests/Content/ImmutableMemoryStorageTest.php
+++ b/tests/Content/ImmutableMemoryStorageTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use Kirby\Cms\Page;
 use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -25,6 +26,29 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
 
 		$this->storage->delete(VersionId::latest(), Language::ensure());
+	}
+
+	public function testModelClone()
+	{
+		$model      = new Page(['slug' => 'test']);
+		$modelClone = $model->clone();
+
+		$storage = new ImmutableMemoryStorage(
+			model: $model,
+			modelClone: $modelClone
+		);
+
+		$this->assertSame($modelClone, $storage->modelClone());
+	}
+
+	public function testModelCloneWithoutClone()
+	{
+		$model   = new Page(['slug' => 'test']);
+		$storage = new ImmutableMemoryStorage(
+			model: $model,
+		);
+
+		$this->assertNull($storage->modelClone());
 	}
 
 	public function testMove()

--- a/tests/Content/ImmutableMemoryStorageTest.php
+++ b/tests/Content/ImmutableMemoryStorageTest.php
@@ -28,29 +28,6 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->delete(VersionId::latest(), Language::ensure());
 	}
 
-	public function testModelClone()
-	{
-		$model      = new Page(['slug' => 'test']);
-		$modelClone = $model->clone();
-
-		$storage = new ImmutableMemoryStorage(
-			model: $model,
-			modelClone: $modelClone
-		);
-
-		$this->assertSame($modelClone, $storage->modelClone());
-	}
-
-	public function testModelCloneWithoutClone()
-	{
-		$model   = new Page(['slug' => 'test']);
-		$storage = new ImmutableMemoryStorage(
-			model: $model,
-		);
-
-		$this->assertNull($storage->modelClone());
-	}
-
 	public function testMove()
 	{
 		$this->expectException(LogicException::class);
@@ -61,6 +38,29 @@ class ImmutableMemoryStorageTest extends TestCase
 			fromLanguage: Language::ensure(),
 			toVersionId: VersionId::changes()
 		);
+	}
+
+	public function testNextModel()
+	{
+		$model      = new Page(['slug' => 'test']);
+		$nextModel = $model->clone();
+
+		$storage = new ImmutableMemoryStorage(
+			model: $model,
+			nextModel: $nextModel
+		);
+
+		$this->assertSame($nextModel, $storage->nextModel());
+	}
+
+	public function testNextModelWithoutClone()
+	{
+		$model   = new Page(['slug' => 'test']);
+		$storage = new ImmutableMemoryStorage(
+			model: $model,
+		);
+
+		$this->assertNull($storage->nextModel());
 	}
 
 	public function testTouch()


### PR DESCRIPTION
## Description

### Merge first

- [x] https://github.com/getkirby/kirby/pull/7060
- [x] https://github.com/getkirby/kirby/pull/7062

### Summary of changes

- New `ImmutableStorageHandle::$newModel` property to store a reference to the latest version of the model
- Support for the legacy model modification in `Event::updateArgument()`
- New `Kirby\Cms\Hooks` class to take care of the apply and trigger logic 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
