### PR TITLE
Enforce `pages.preview` permission

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -888,6 +888,10 @@ class Page extends ModelWithContent
 	 */
 	public function previewUrl(VersionId|string $versionId = 'latest'): string|null
 	{
+		if ($this->permissions()->can('preview') !== true) {
+			return null;
+		}
+
 		return $this->version($versionId)->url();
 	}
 

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -362,6 +362,11 @@ class Site extends ModelWithContent
 	 */
 	public function previewUrl(VersionId|string $versionId = 'latest'): string|null
 	{
+		// the site previews the home page and thus needs to check permissions for it
+		if ($this->homePage()?->permissions()->can('preview') !== true) {
+			return null;
+		}
+
 		return $this->version($versionId)->url();
 	}
 

--- a/tests/Cms/Page/PagePreviewUrlTest.php
+++ b/tests/Cms/Page/PagePreviewUrlTest.php
@@ -96,6 +96,40 @@ class PagePreviewUrlTest extends ModelTestCase
 		$this->assertSame($expected, $page->previewUrl());
 	}
 
+	public function testPreviewUrlMissingPermission(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'          => 'editor',
+					'name'        => 'editor',
+					'permissions' => [
+						'pages' => [
+							'preview' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		$page = new Page([
+			'slug' => 'test'
+		]);
+
+		$this->assertNull($page->previewUrl());
+		$this->assertNull($page->previewUrl('latest'));
+		$this->assertNull($page->previewUrl('changes'));
+	}
+
 	public function testPreviewUrlUnauthenticated(): void
 	{
 		// log out

--- a/tests/Cms/Site/SitePreviewUrlTest.php
+++ b/tests/Cms/Site/SitePreviewUrlTest.php
@@ -64,9 +64,69 @@ class SitePreviewUrlTest extends ModelTestCase
 			'blueprint' => [
 				'name'    => 'site',
 				'options' => $options
+			],
+			'children' => [
+				['slug' => 'home']
 			]
 		]);
 
 		$this->assertSame($expected, $site->previewUrl());
+	}
+
+	public function testPreviewUrlMissingHomePage(): void
+	{
+		$site = new Site();
+
+		$this->assertNull($site->previewUrl());
+	}
+
+	public function testPreviewUrlMissingPermission(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+			'roles' => [
+				[
+					'id'          => 'editor',
+					'name'        => 'editor',
+					'permissions' => [
+						'pages' => [
+							'preview' => false
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		$site = new Site([
+			'children' => [
+				['slug' => 'home']
+			]
+		]);
+
+		$this->assertNull($site->previewUrl());
+		$this->assertNull($site->previewUrl('latest'));
+		$this->assertNull($site->previewUrl('changes'));
+	}
+
+	public function testPreviewUrlUnauthenticated(): void
+	{
+		// log out
+		$this->app->impersonate();
+
+		$site = new Site([
+			'children' => [
+				['slug' => 'home']
+			]
+		]);
+
+		$this->assertNull($site->previewUrl());
 	}
 }

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -159,6 +159,13 @@ class SiteTest extends AreaTestCase
 	{
 		$this->login();
 
+		$site = $this->app->site();
+
+		$site->createChild([
+			'slug'    => 'home',
+			'isDraft' => false
+		]);
+
 		$view  = $this->view('site');
 		$props = $view['props'];
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Ensure that the preview URL (especially of drafts and changes versions) is not accessible to users without `pages.preview` permission.

### Reasoning

Ensures that users don't get access to protected preview URLs with token via Panel and/or API

### Additional context

The permission check seems to have gone missing in v5. In v4.6.1 this works as expected and I cannot access the preview URL of drafts, only of public pages (which isn't a vulnerability).

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes since v5 alphas

- Enforce `pages.preview` permission again

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

*None*

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
