### PR TITLE
Site preview button: hide when no permissions

### DIFF
--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -10,14 +10,16 @@ use Kirby\Panel\Ui\Buttons\SettingsButton;
 
 return [
 	'site.preview' => function (Site $site) {
-		return new PreviewDropdownButton(
-			open: $site->url(),
-			preview: $site->panel()->url(true) . '/preview/compare',
-			copy: $site->url(),
-		);
+		if ($site->previewUrl() !== null) {
+			return new PreviewDropdownButton(
+				open: $site->previewUrl(),
+				preview: $site->panel()->url(true) . '/preview/compare',
+				copy: $site->previewUrl(),
+			);
+		}
 	},
 	'page.preview' => function (Page $page) {
-		if ($page->permissions()->can('preview') === true) {
+		if ($page->previewUrl() !== null) {
 			return new PreviewDropdownButton(
 				open: $page->previewUrl(),
 				preview: $page->panel()->url(true) . '/preview/compare',
@@ -25,19 +27,15 @@ return [
 			);
 		}
 	},
-	'page.settings' => function (Page $page) {
-		return new SettingsButton(model: $page);
-	},
-	'page.status' => function (Page $page) {
-		return new PageStatusButton($page);
-	},
+	'page.settings' => fn (Page $page) => new SettingsButton(model: $page),
+	'page.status'   => fn (Page $page) => new PageStatusButton($page),
+
 	// `languages` button needs to be in site area,
 	// as the  languages might be not loaded even in
 	// multilang mode when the `languages` option is deactivated
 	// (but content languages to switch between still can exist)
-	'languages' => function (ModelWithContent $model) {
-		return new LanguagesDropdown($model);
-	},
+	'languages' => fn (ModelWithContent $model) =>
+		new LanguagesDropdown($model),
 
 	// file buttons
 	...require __DIR__ . '/../files/buttons.php'

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -19,7 +19,7 @@
 					:has-changes="hasChanges"
 					:is-locked="isLocked"
 					:modified="modified"
-					:preview="api + '/preview/compare'"
+					:preview="permissions.preview ? api + '/preview/compare' : false"
 					@discard="onDiscard"
 					@submit="onSubmit"
 				/>

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -91,10 +91,14 @@ class Site extends Model
 
 		return [
 			...$props,
-			'blueprint'  => 'site',
-			'id'         => '/',
-			'model'      => $model,
-			'title'      => $model['title'],
+			'blueprint'   => 'site',
+			'id'          => '/',
+			'model'       => $model,
+			'title'       => $model['title'],
+			'permissions' => [
+				...$props['permissions'],
+				'preview' => $this->model->homePage()?->permissions()->can('preview') === true,
+			],
 		];
 	}
 

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -155,6 +155,36 @@ class SiteTest extends TestCase
 		$this->assertArrayHasKey('tabs', $props);
 	}
 
+	public function testPreviewPermissionsWithoutHomePage()
+	{
+		$props = $this->panel()->props();
+
+		$this->assertFalse($props['permissions']['preview']);
+	}
+
+	public function testPreviewPermissionsWithHomePage()
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'home']
+				]
+			]
+		]);
+
+		// without logged in user
+		$props = $this->app->site()->panel()->props();
+
+		$this->assertFalse($props['permissions']['preview']);
+
+		// with logged in user
+		$this->app->impersonate('kirby');
+
+		$props = $this->app->site()->panel()->props();
+
+		$this->assertTrue($props['permissions']['preview']);
+	}
+
 	/**
 	 * @covers ::view
 	 */


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Hide site preview button if no preview permission for home page
- Hide preview entry in form controls dropdown accordingly


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
