### PR TITLE
Image preview: fix coords input squeezing image

### DIFF
--- a/panel/src/components/Forms/Input/CoordsInput.vue
+++ b/panel/src/components/Forms/Input/CoordsInput.vue
@@ -187,9 +187,6 @@ export default {
 	position: relative;
 	display: block !important;
 }
-.k-coords-input img {
-	width: 100%;
-}
 .k-coords-input-thumb {
 	position: absolute;
 	aspect-ratio: 1/1;


### PR DESCRIPTION
I don't think the coords input should define how the image is rendered - otherwise we have to reset/overwrite that in other contexts. The coords input should simply wrap around the image in whatever form/sizes its rendered.