### PR TITLE
Form fields improvements

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -670,12 +670,8 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			'language'       => $languageCode,
 		]);
 
-		// validate the input
-		if ($validate === true && $form->isInvalid() === true) {
-			throw new InvalidArgumentException(
-				fallback: 'Invalid form with errors',
-				details: $form->errors()
-			);
+		if ($validate === true) {
+			$form->validate();
 		}
 
 		return $this->commit(

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -270,6 +270,12 @@ class Field extends Component
 	 */
 	public function fill(mixed $value): static
 	{
+		// remember the current state to restore it afterwards
+		$attrs   = $this->attrs;
+		$methods = $this->methods;
+		$options = $this->options;
+		$type    = $this->type;
+
 		// overwrite the attribute value
 		$this->value = $this->attrs['value'] = $value;
 
@@ -281,6 +287,12 @@ class Field extends Component
 
 		// reset the errors cache
 		$this->errors = null;
+
+		// restore the original state
+		$this->attrs   = $attrs;
+		$this->methods = $methods;
+		$this->options = $options;
+		$this->type    = $type;
 
 		return $this;
 	}

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -381,6 +381,15 @@ class Field extends Component
 	}
 
 	/**
+	 * Submits a new value for the field
+	 * @since 5.0.0
+	 */
+	public function submit(mixed $value = null): static
+	{
+		return $this->fill($value);
+	}
+
+	/**
 	 * Converts the field to a plain array
 	 */
 	public function toArray(): array
@@ -401,7 +410,8 @@ class Field extends Component
 	}
 
 	/**
-	 * Returns the value of the field in a format to be stored by our storage classes
+	 * Returns the value of the field in a format
+	 * to be stored by our storage classes
 	 */
 	public function toStoredValue(bool $default = false): mixed
 	{

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -277,7 +277,7 @@ class Field extends Component
 		$this->applyProp('value', $this->options['props']['value'] ?? $value);
 
 		// reevaluate the computed props
-		$this->applyComputed($this->options['computed']);
+		$this->applyComputed($this->options['computed'] ?? []);
 
 		// reset the errors cache
 		$this->errors = null;

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -105,12 +105,14 @@ class BlocksField extends FieldClass
 		return $groups === [] ? null : $groups;
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();
 		$this->value  = $this->blocksToValues($blocks);
 		$this->errors = null;
+
+		return $this;
 	}
 
 	public function form(array $fields, array $input = []): Form

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -51,10 +51,12 @@ class EntriesField extends FieldClass
 		return $this->form()->fields()->first()->toArray();
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value = Data::decode($value ?? '', 'yaml');
 		parent::fill($value);
+
+		return $this;
 	}
 
 	public function form(array $values = []): Form

--- a/src/Form/Field/ExceptionField.php
+++ b/src/Form/Field/ExceptionField.php
@@ -6,6 +6,19 @@ use Kirby\Cms\App;
 use Kirby\Form\FieldClass;
 use Throwable;
 
+/**
+ * Exception fields are internal fields that replace a broken field
+ * to help debug the issue by displaying a useful error message
+ * in the Panel. The use the info field component to display the error message.
+ *
+ * @package   Kirby Form
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since 5.0.0
+ * @internal
+ */
 class ExceptionField extends FieldClass
 {
 	public function __construct(

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,7 +30,7 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value   = Data::decode($value, type: 'json', fail: false);
 		$layouts = Layouts::factory($value, ['parent' => $this->model])->toArray();
@@ -47,6 +47,8 @@ class LayoutField extends BlocksField
 
 		$this->value  = $layouts;
 		$this->errors = null;
+
+		return $this;
 	}
 
 	public function attrsForm(array $input = []): Form

--- a/src/Form/Field/UnknownField.php
+++ b/src/Form/Field/UnknownField.php
@@ -23,7 +23,9 @@ class UnknownField extends FieldClass
 {
 	public function __construct(string $name)
 	{
-		$this->name = $name;
+		parent::__construct([
+			'name' => $name,
+		]);
 	}
 
 	public function props(): array

--- a/src/Form/Field/UnknownField.php
+++ b/src/Form/Field/UnknownField.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\FieldClass;
+
+/**
+ * Unknown fields are fields that are not part of the blueprint
+ * schema but are submitted or filled in. This can happen if
+ * a model has additional fields that are not managed via the
+ * Panel. E.g. they are only stored in the text file, but should not
+ * be shown and modified by the editors.
+ *
+ * @package   Kirby Form
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since 5.0.0
+ * @internal
+ */
+class UnknownField extends FieldClass
+{
+	public function __construct(string $name)
+	{
+		$this->name = $name;
+	}
+
+	public function props(): array
+	{
+		return [
+			'name'   => $this->name(),
+			'hidden' => $this->isHidden(),
+		];
+	}
+
+	public function isHidden(): bool
+	{
+		return true;
+	}
+
+	public function isSaveable(): bool
+	{
+		return true;
+	}
+
+	public function type(): string
+	{
+		return 'unknown';
+	}
+}

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -121,10 +121,12 @@ abstract class FieldClass
 	/**
 	 * Sets a new value for the field
 	 */
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$this->value = $value;
 		$this->errors = null;
+
+		return $this;
 	}
 
 	/**

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -348,6 +348,18 @@ abstract class FieldClass
 	}
 
 	/**
+	 * Submits a new value for the field
+	 * @since 5.0.0
+	 */
+	public function submit(mixed $value = null): static
+	{
+		$this->value  = $value;
+		$this->errors = null;
+
+		return $this;
+	}
+
+	/**
 	 * Converts the field to a plain array
 	 */
 	public function toArray(): array

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -271,6 +271,28 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Returns an array with the props of each field
+	 * for the frontend
+	 */
+	public function toProps(): array
+	{
+		$props    = [];
+		$language = $this->language();
+
+		foreach ($this->data as $name => $field) {
+			$props[$name] = $field->toArray();
+
+			if ($field->isTranslatable($language) === false) {
+				$props[$name]['disabled'] = true;
+			}
+
+			unset($props[$name]['value']);
+		}
+
+		return $props;
+	}
+
+	/**
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
 	 */

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -25,13 +25,6 @@ class Fields extends Collection
 {
 	protected Language $language;
 
-	/**
-	 * Cache for the errors array
-	 *
-	 * @var array<string, array<string, string>>|null
-	 */
-	protected array|null $errors = null;
-
 	public function __construct(
 		array $fields = [],
 		protected ModelWithContent|null $model = null,
@@ -61,9 +54,6 @@ class Fields extends Collection
 		}
 
 		parent::__set($field->name(), $field);
-
-		// reset the errors cache if new fields are added
-		$this->errors = null;
 	}
 
 	/**
@@ -99,24 +89,20 @@ class Fields extends Collection
 	 */
 	public function errors(): array
 	{
-		if ($this->errors !== null) {
-			return $this->errors; // @codeCoverageIgnore
-		}
-
-		$this->errors = [];
+		$errors = [];
 
 		foreach ($this->data as $name => $field) {
-			$errors = $field->errors();
+			$fieldErrors = $field->errors();
 
-			if ($errors !== []) {
-				$this->errors[$name] = [
+			if ($fieldErrors !== []) {
+				$errors[$name] = [
 					'label'   => $field->label(),
-					'message' => $errors
+					'message' => $fieldErrors
 				];
 			}
 		}
 
-		return $this->errors;
+		return $errors;
 	}
 
 	/**
@@ -141,9 +127,6 @@ class Fields extends Collection
 
 			$field->fill($value);
 		}
-
-		// reset the errors cache
-		$this->errors = null;
 
 		return $this;
 	}
@@ -253,7 +236,6 @@ class Fields extends Collection
 		}
 
 		// reset the errors cache
-		$this->errors = null;
 		return $this;
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -109,8 +109,14 @@ class Fields extends Collection
 	/**
 	 * Sets the value for each field with a matching key in the input array
 	 */
-	public function fill(array $input): static
-	{
+	public function fill(
+		array $input,
+		bool $strict = true
+	): static {
+		if ($strict === false) {
+			$this->appendUnknownFields($input);
+		}
+
 		foreach ($input as $name => $value) {
 			if (!$field = $this->get($name)) {
 				continue;
@@ -211,9 +217,15 @@ class Fields extends Collection
 	 * but only if the field is not disabled
 	 * @since 5.0.0
 	 */
-	public function submit(array $input): static
-	{
+	public function submit(
+		array $input,
+		bool $strict = true
+	): static {
 		$language = $this->language();
+
+		if ($strict === false) {
+			$this->appendUnknownFields($input);
+		}
 
 		foreach ($input as $name => $value) {
 			if (!$field = $this->get($name)) {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -289,13 +289,14 @@ class Fields extends Collection
 	 */
 	public function toProps(): array
 	{
-		$props    = [];
-		$language = $this->language();
+		$props       = [];
+		$language    = $this->language();
+		$permissions = $this->model->permissions()->can('update');
 
 		foreach ($this->data as $name => $field) {
 			$props[$name] = $field->toArray();
 
-			if ($field->isTranslatable($language) === false) {
+			if ($permissions === false || $field->isTranslatable($language) === false) {
 				$props[$name]['disabled'] = true;
 			}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -255,7 +255,19 @@ class Fields extends Collection
 	 */
 	public function toFormValues(bool $defaults = false): array
 	{
-		return $this->toArray(fn ($field) => $field->toFormValue($defaults));
+		$values   = [];
+		$language = $this->language();
+
+		foreach ($this->data as $name => $field) {
+			// don't add non-fillable fields
+			if ($field->isFillable($language) === false) {
+				continue;
+			}
+
+			$values[$name] = $field->toFormValue($defaults);
+		}
+
+		return $values;
 	}
 
 	/**
@@ -264,22 +276,18 @@ class Fields extends Collection
 	 */
 	public function toStoredValues(bool $defaults = false): array
 	{
-		$store    = [];
+		$values   = [];
 		$language = $this->language();
 
 		foreach ($this->data as $name => $field) {
-			// don't add non-saveable fields to the store
-			if ($field->isSaveable() === false) {
+			// don't add non-storable fields to the store
+			if ($field->isStorable($language) === false) {
 				continue;
 			}
 
-			if ($field->isTranslatable($language) === true) {
-				$value = $field->toStoredValue($defaults);
-			}
-
-			$store[$name] = $value ?? null;
+			$values[$name] = $field->toStoredValue($defaults);
 		}
 
-		return $store;
+		return $values;
 	}
 }

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -251,7 +251,7 @@ class Fields extends Collection
 				$value = $field->toStoredValue($defaults);
 			}
 
-			$store[$name] = $value ??null;
+			$store[$name] = $value ?? null;
 		}
 
 		return $store;

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -134,6 +134,11 @@ class Fields extends Collection
 				continue;
 			}
 
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($field->value());
+			}
+
 			$field->fill($value);
 		}
 
@@ -234,6 +239,11 @@ class Fields extends Collection
 			// don't change the value of non-submittable fields
 			if ($field->isSubmittable($language) === false) {
 				continue;
+			}
+
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($field->value());
 			}
 
 			// submit the value to the field

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Closure;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Form\Field\UnknownField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Str;
@@ -63,6 +64,26 @@ class Fields extends Collection
 
 		// reset the errors cache if new fields are added
 		$this->errors = null;
+	}
+
+	/**
+	 * Goes through the given input and appends hidden fields
+	 * for each key that is not already present in the collection.
+	 * This is useful for forms that are used to update models
+	 * with additional fields that are not part of the original
+	 * blueprint.
+	 *
+	 * @since 5.0.0
+	 */
+	public function appendUnknownFields(array $input): static
+	{
+		foreach ($input as $name => $value) {
+			if ($this->get($name) === null) {
+				$this->data[$name] = new UnknownField(name: $name);
+			}
+		}
+
+		return $this;
 	}
 
 	/**
@@ -181,6 +202,19 @@ class Fields extends Collection
 	public function language(): Language
 	{
 		return $this->language;
+	}
+
+	/**
+	 * Removes all unknown fields from the collection.
+	 * This is useful if you want to be strict about
+	 * the submitted or filled in values.
+	 *
+	 * @since 5.0.0
+	 */
+	public function removeUnknownFields(): static
+	{
+		$this->data = array_filter($this->data, fn ($field) => $field instanceof UnknownField === false);
+		return $this;
 	}
 
 	/**

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Closure;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field\UnknownField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
@@ -311,5 +312,23 @@ class Fields extends Collection
 		}
 
 		return $values;
+	}
+
+	/**
+	 * Checks for errors in all fields and throws an
+	 * exception if there are any
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
+	 */
+	public function validate(): void
+	{
+		$errors = $this->errors();
+
+		if ($errors !==	[]) {
+			throw new InvalidArgumentException(
+				fallback: 'Invalid form with errors',
+				details: $errors
+			);
+		}
 	}
 }

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -171,6 +171,7 @@ class Fields extends Collection
 
 	/**
 	 * Returns an array with the form value of each field
+	 * (e.g. used as data for Panel Vue components)
 	 */
 	public function toFormValues(bool $defaults = false): array
 	{
@@ -179,6 +180,7 @@ class Fields extends Collection
 
 	/**
 	 * Returns an array with the stored value of each field
+	 * (e.g. used for saving to content storage)
 	 */
 	public function toStoredValues(bool $defaults = false): array
 	{

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -5,6 +5,8 @@ namespace Kirby\Form;
 use Closure;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field\UnknownField;
 use Kirby\Toolkit\A;
@@ -289,11 +291,21 @@ class Fields extends Collection
 	 */
 	public function toProps(): array
 	{
+		$fields      = $this->data;
 		$props       = [];
 		$language    = $this->language();
 		$permissions = $this->model->permissions()->can('update');
 
-		foreach ($this->data as $name => $field) {
+		if (
+			$this->model instanceof Page ||
+			$this->model instanceof Site
+		) {
+			// the title should never be updated directly via
+			// fields section to avoid conflicts with the rename dialog
+			unset($fields['title']);
+		}
+
+		foreach ($fields as $name => $field) {
 			$props[$name] = $field->toArray();
 
 			if ($permissions === false || $field->isTranslatable($language) === false) {

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -285,6 +285,7 @@ class Form
 
 	/**
 	 * Returns an array with the form value of each field
+	 * (e.g. used as data for Panel Vue components)
 	 */
 	public function toFormValues(bool $defaults = false): array
 	{
@@ -293,6 +294,7 @@ class Form
 
 	/**
 	 * Returns an array with the stored value of each field
+	 * (e.g. used for saving to content storage)
 	 */
 	public function toStoredValues(bool $defaults = false): array
 	{

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -302,6 +302,16 @@ class Form
 	}
 
 	/**
+	 * Validates the form and throws an exception if there are any errors
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
+	 */
+	public function validate(): void
+	{
+		$this->fields->validate();
+	}
+
+	/**
 	 * Returns form values
 	 */
 	public function values(): array

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Cms\Language;
+
 /**
  * @package   Kirby Form
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -12,6 +14,18 @@ namespace Kirby\Form\Mixin;
 trait Translatable
 {
 	protected bool $translate = true;
+
+	/**
+	 * Should the field be translatable into the given language?
+	 */
+	public function isTranslatable(Language $language): bool
+	{
+		if ($this->translate() === false && $language->isDefault() === false) {
+			return false;
+		}
+
+		return true;
+	}
 
 	/**
 	 * Set the translatable status

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -109,7 +109,7 @@ trait Value
 
 	/**
 	 * Returns the value of the field in a format to be used in forms
-	 * @alias for `::value()`
+	 * (e.g. used as data for Panel Vue components)
 	 */
 	public function toFormValue(bool $default = false): mixed
 	{
@@ -125,7 +125,8 @@ trait Value
 	}
 
 	/**
-	 * Returns the value of the field in a format to be stored by our storage classes
+	 * Returns the value of the field in a format
+	 * to be stored by our storage classes
 	 */
 	public function toStoredValue(bool $default = false): mixed
 	{
@@ -136,7 +137,8 @@ trait Value
 	 * Returns the value of the field if saveable
 	 * otherwise it returns null
 	 *
-	 * @alias for `::toFormValue()` might get deprecated or reused later
+	 * @see `self::toFormValue()`
+	 * @todo might get deprecated or reused later
 	 */
 	public function value(bool $default = false): mixed
 	{

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Cms\Language;
+
 /**
  * @package   Kirby Form
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -45,6 +47,42 @@ trait Value
 	public function isEmptyValue(mixed $value = null): bool
 	{
 		return in_array($value, [null, '', []], true);
+	}
+
+	/**
+	 * Checks if the field is fillable. "Fillable" means that
+	 * the field can receive a value for its initial state
+	 * when the field is being rendered in the panel.
+	 */
+	public function isFillable(): bool
+	{
+		return $this->isSaveable() === true;
+	}
+
+	/**
+	 * A field might be saveable, but can still not be submitted
+	 * because it is disabled, not translatable into the given
+	 * language or not active due to a `when` rule.
+	 */
+	public function isSubmittable(Language $language): bool
+	{
+		if ($this->isSaveable() === false) {
+			return false;
+		}
+
+		if ($this->isDisabled() === true) {
+			return false;
+		}
+
+		if ($this->isTranslatable($language) === false) {
+			return false;
+		}
+
+		if ($this->isActive() === false) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -60,6 +60,29 @@ trait Value
 	}
 
 	/**
+	 * Checks if the field can be stored in the given language.
+	 */
+	public function isStorable(Language $language): bool
+	{
+		// the field cannot be saved at all
+		if ($this->isSaveable() === false) {
+			return false;
+		}
+
+		// the field cannot be translated into the given language
+		if ($this->isTranslatable($language) === false) {
+			return false;
+		}
+
+		// the field is hidden by a `when` rule
+		if ($this->isActive() === false) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * A field might be saveable, but can still not be submitted
 	 * because it is disabled, not translatable into the given
 	 * language or not active due to a `when` rule.

--- a/tests/Form/Field/UnknownFieldTest.php
+++ b/tests/Form/Field/UnknownFieldTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+class UnknownFieldTest extends TestCase
+{
+	public function testDefaultProps()
+	{
+		$field = new UnknownField(name: 'unknown');
+
+		$this->assertSame(['name' => 'unknown', 'hidden' => true], $field->props());
+		$this->assertSame('unknown', $field->type());
+		$this->assertSame('unknown', $field->name());
+		$this->assertTrue($field->isHidden());
+		$this->assertTrue($field->isSaveable());
+	}
+}

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -3,8 +3,10 @@
 namespace Kirby\Form;
 
 use Exception;
+use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestField extends FieldClass
 {
@@ -41,14 +43,9 @@ class ValidatedField extends FieldClass
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Form\FieldClass
- */
+#[CoversClass(FieldClass::class)]
 class FieldClassTest extends TestCase
 {
-	/**
-	 * @covers ::__call
-	 */
 	public function test__call()
 	{
 		$field = new TestField([
@@ -58,9 +55,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('bar', $field->foo());
 	}
 
-	/**
-	 * @covers ::after
-	 */
 	public function testAfter()
 	{
 		$field = new TestField();
@@ -73,18 +67,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->after());
 	}
 
-	/**
-	 * @covers ::api
-	 */
 	public function testApi()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->api());
 	}
 
-	/**
-	 * @covers ::autofocus
-	 */
 	public function testAutofocus()
 	{
 		$field = new TestField();
@@ -94,9 +82,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->autofocus());
 	}
 
-	/**
-	 * @covers ::before
-	 */
 	public function testBefore()
 	{
 		$field = new TestField();
@@ -109,9 +94,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->before());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testData()
 	{
 		$field = new TestField();
@@ -130,9 +112,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->data());
 	}
 
-	/**
-	 * @covers ::default
-	 */
 	public function testDefault()
 	{
 		$field = new TestField();
@@ -156,19 +135,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test title', $field->default());
 	}
 
-	/**
-	 * @covers ::dialogs
-	 */
 	public function testDialogs()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->dialogs());
 	}
 
-	/**
-	 * @covers ::disabled
-	 * @covers ::isDisabled
-	 */
 	public function testDisabled()
 	{
 		$field = new TestField();
@@ -180,20 +152,12 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isDisabled());
 	}
 
-	/**
-	 * @covers ::drawers
-	 */
 	public function testDrawers()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->drawers());
 	}
 
-	/**
-	 * @covers ::errors
-	 * @covers ::validate
-	 * @covers ::validations
-	 */
 	public function testErrors()
 	{
 		$field = new TestField();
@@ -212,9 +176,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['custom' => 'Please enter an a'], $field->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		$field = new TestField();
@@ -223,10 +184,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test value', $field->value());
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @covers ::isEmptyValue
-	 */
 	public function testIsEmpty()
 	{
 		$field = new TestField();
@@ -236,9 +193,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmpty());
 	}
 
-	/**
-	 * @covers ::isEmptyValue
-	 */
 	public function testIsEmptyValue()
 	{
 		$field = new TestField();
@@ -253,9 +207,15 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmptyValue('0'));
 	}
 
-	/**
-	 * @covers ::isHidden
-	 */
+	public function testIsFillable()
+	{
+		$field = new TestField();
+		$this->assertTrue($field->isFillable());
+
+		$field = new UnsaveableField();
+		$this->assertFalse($field->isFillable());
+	}
+
 	public function testIsHidden()
 	{
 		$field = new TestField();
@@ -265,10 +225,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isHidden());
 	}
 
-	/**
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
 	public function testInvalid()
 	{
 		$field = new TestField();
@@ -281,10 +237,6 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isInvalid());
 	}
 
-	/**
-	 * @covers ::isRequired
-	 * @covers ::required
-	 */
 	public function testIsRequired()
 	{
 		$field = new TestField();
@@ -296,9 +248,6 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
-	/**
-	 * @covers ::isSaveable
-	 */
 	public function testIsSaveable()
 	{
 		$field = new TestField();
@@ -308,9 +257,97 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSaveable());
 	}
 
-	/**
-	 * @covers ::help
-	 */
+	public function testIsSubmittable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isSubmittable($language));
+
+		$field = new UnsaveableField();
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithDisabledField()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField(['disabled' => true]);
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithNonDefailtLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isSubmittable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithWhenQueryAndMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'b']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertTrue($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithWhenQueryAndNonMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'something-else']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsTranslatable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isTranslatable($language));
+	}
+
+	public function testIsTranslatableWithNonDefaultLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isTranslatable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isTranslatable($language));
+	}
+
 	public function testHelp()
 	{
 		$field = new TestField();
@@ -338,9 +375,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('<p>A field for Test title</p>', $field->help());
 	}
 
-	/**
-	 * @covers ::icon
-	 */
 	public function testIcon()
 	{
 		$field = new TestField();
@@ -350,9 +384,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->icon());
 	}
 
-	/**
-	 * @covers ::id
-	 */
 	public function testId()
 	{
 		$field = new TestField();
@@ -362,18 +393,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-id', $field->id());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
 	public function testKirby()
 	{
 		$field = new TestField();
 		$this->assertSame(kirby(), $field->kirby());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel()
 	{
 		$field = new TestField();
@@ -386,9 +411,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->label());
 	}
 
-	/**
-	 * @covers ::model
-	 */
 	public function testModel()
 	{
 		$field = new TestField();
@@ -400,9 +422,6 @@ class FieldClassTest extends TestCase
 		$this->assertIsPage($page, $field->model());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName()
 	{
 		$field = new TestField();
@@ -412,9 +431,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-name', $field->name());
 	}
 
-	/**
-	 * @covers ::params
-	 */
 	public function testParams()
 	{
 		$field = new TestField($params = [
@@ -426,9 +442,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame($params, $field->params());
 	}
 
-	/**
-	 * @covers ::placeholder
-	 */
 	public function testPlaceholder()
 	{
 		$field = new TestField();
@@ -456,10 +469,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Placeholder for Test title', $field->placeholder());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::toArray
-	 */
 	public function testProps()
 	{
 		$field = new TestField($props = [
@@ -489,27 +498,18 @@ class FieldClassTest extends TestCase
 		$this->assertSame($props, $field->props());
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes()
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->routes());
 	}
 
-	/**
-	 * @covers ::save
-	 */
 	public function testSave()
 	{
 		$field = new TestField();
 		$this->assertTrue($field->save());
 	}
 
-	/**
-	 * @covers ::siblings
-	 */
 	public function testSiblings()
 	{
 		$field = new TestField();
@@ -529,9 +529,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('b', $field->siblings()->last()->name());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 */
 	public function testToStoredValue()
 	{
 		$field = new TestField();
@@ -540,9 +537,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->toStoredValue());
 	}
 
-	/**
-	 * @covers ::translate
-	 */
 	public function testTranslate()
 	{
 		$field = new TestField();
@@ -552,18 +546,12 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->translate());
 	}
 
-	/**
-	 * @covers ::type
-	 */
 	public function testType()
 	{
 		$field = new TestField();
 		$this->assertSame('test', $field->type());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue()
 	{
 		$field = new TestField();
@@ -582,9 +570,6 @@ class FieldClassTest extends TestCase
 		$this->assertNull($field->value());
 	}
 
-	/**
-	 * @covers ::when
-	 */
 	public function testWhen()
 	{
 		$field = new TestField();
@@ -594,9 +579,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['a' => 'test'], $field->when());
 	}
 
-	/**
-	 * @covers ::width
-	 */
 	public function testWidth()
 	{
 		$field = new TestField();

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -290,6 +290,42 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isStorable($language));
 	}
 
+	public function testIsStorableWithWhenQueryAndMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'b']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertTrue($field->isStorable($language));
+	}
+
+	public function testIsStorableWithWhenQueryAndNonMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'something-else']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertFalse($field->isStorable($language));
+	}
+
 	public function testIsSubmittable()
 	{
 		$language = Language::ensure('current');

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -529,6 +529,14 @@ class FieldClassTest extends TestCase
 		$this->assertSame('b', $field->siblings()->last()->name());
 	}
 
+	public function testSubmit(): void
+	{
+		$field = new TestField();
+		$this->assertNull($field->value());
+		$field->submit('Test value');
+		$this->assertSame('Test value', $field->value());
+	}
+
 	public function testToStoredValue()
 	{
 		$field = new TestField();

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -257,6 +257,39 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSaveable());
 	}
 
+	public function testIsStorable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isStorable($language));
+
+		$field = new UnsaveableField();
+		$this->assertFalse($field->isStorable($language));
+	}
+
+	public function testIsStorableWithDisabledField()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField(['disabled' => true]);
+		$this->assertTrue($field->isStorable($language), 'The value of a storable field must not be changed on submit, but can still be stored.');
+	}
+
+	public function testIsStorableWithNonDefaultLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isStorable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isStorable($language));
+	}
+
 	public function testIsSubmittable()
 	{
 		$language = Language::ensure('current');
@@ -276,7 +309,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSubmittable($language));
 	}
 
-	public function testIsSubmittableWithNonDefailtLanguage()
+	public function testIsSubmittableWithNonDefaultLanguage()
 	{
 		$language = new Language([
 			'code'    => 'de',

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -394,6 +394,37 @@ class FieldTest extends TestCase
 		$this->assertSame('test2 computed', $field->computedValue());
 	}
 
+	public function testFillWithRestoredState()
+	{
+		Field::$types = [
+			'test' => $definition = [
+				'computed' => [
+					'options' => fn () => ['a', 'b', 'c']
+				],
+				'methods' => [
+					'optionsDebugger' => fn () => $this->options
+				]
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page,
+			'value' => 'test'
+		]);
+
+		$this->assertSame(['a', 'b', 'c'], $field->options());
+		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+
+		// filling a new value must not break the mandatory
+		// component definition properties
+		$field->fill('test2');
+
+		$this->assertSame(['a', 'b', 'c'], $field->options());
+		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+	}
+
 	public function testHelp()
 	{
 		Field::$types = [

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -1033,6 +1033,27 @@ class FieldTest extends TestCase
 	}
 
 	/**
+	 * @covers ::submit
+	 */
+	public function testSubmit(): void
+	{
+		Field::$types = [
+			'test' => []
+		];
+
+		$page = new Page(['slug' => 'test']);
+		$field = new Field('test', [
+			'model' => $page,
+			'value' => 'test'
+		]);
+
+		$this->assertSame('test', $field->value());
+
+		$field->submit('test2');
+		$this->assertSame('test2', $field->value());
+	}
+
+	/**
 	 * @covers ::toArray
 	 */
 	public function testToArray()

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -532,6 +532,67 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testToProps(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A'
+				]
+			],
+			model: $this->model
+		);
+
+		$this->assertSame([
+			'a' => [
+				'autofocus'  => false,
+				'counter'    => true,
+				'disabled'   => false,
+				'font'       => 'sans-serif',
+				'hidden'     => false,
+				'name'       => 'a',
+				'required'   => false,
+				'saveable'   => true,
+				'spellcheck' => false,
+				'translate'  => true,
+				'type'       => 'text',
+				'width'      => '1/1',
+			],
+		], $fields->toProps());
+	}
+
+	public function testToPropsForNonTranslatableField(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'translate' => false,
+					'type'      => 'text',
+					'value'     => 'A',
+				],
+				'b' => [
+					'type'      => 'text',
+					'value'     => 'B',
+				]
+			],
+			model: $this->model,
+			language: $this->app->language('de')
+		);
+
+		$props = $fields->toProps();
+
+		$this->assertTrue($props['a']['disabled']);
+		$this->assertFalse($props['a']['translate']);
+
+		$this->assertFalse($props['b']['disabled']);
+		$this->assertTrue($props['b']['translate']);
+	}
+
 	public function testToStoredValues(): void
 	{
 		$this->setUpSingleLanguage();

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -190,6 +190,24 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testFillWithClosureValues(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'A'
+			],
+		], $this->model);
+
+		$fields->fill([
+			'a' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated'
+		], $fields->toFormValues());
+	}
+
 	public function testFind(): void
 	{
 		Field::$types['test'] = [
@@ -305,6 +323,24 @@ class FieldsTest extends TestCase
 			'b' => 'B updated',
 			'd' => 'D'
 		], $fields->toStoredValues());
+	}
+
+	public function testSubmitWithClosureValues(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'A'
+			],
+		], $this->model);
+
+		$fields->submit([
+			'a' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated'
+		], $fields->toFormValues());
 	}
 
 	public function testToArray(): void

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -536,6 +536,7 @@ class FieldsTest extends TestCase
 	public function testToProps(): void
 	{
 		$this->setUpSingleLanguage();
+		$this->app->impersonate('kirby');
 
 		$fields = new Fields(
 			fields: [
@@ -565,9 +566,27 @@ class FieldsTest extends TestCase
 		], $fields->toProps());
 	}
 
+	public function testToPropsWithoutUpdatePermission(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A'
+				]
+			],
+			model: $this->model
+		);
+
+		$this->assertTrue($fields->toProps()['a']['disabled']);
+	}
+
 	public function testToPropsForNonTranslatableField(): void
 	{
 		$this->setUpMultiLanguage();
+		$this->app->impersonate('kirby');
 
 		$fields = new Fields(
 			fields: [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -273,7 +273,7 @@ class FieldsTest extends TestCase
 			'a' => 'A',
 		], $fields->toFormValues(), 'Unknown fields are not included');
 
-		$fields->appendUnknownFields($input)->fill($input);
+		$fields->fill($input, strict: false);
 
 		$this->assertSame([
 			'a' => 'A',
@@ -457,7 +457,7 @@ class FieldsTest extends TestCase
 			'a' => 'A',
 		], $fields->toStoredValues(), 'Unknown fields are not included');
 
-		$fields->appendUnknownFields($input)->submit($input);
+		$fields->submit($input, strict: false);
 
 		$this->assertSame([
 			'a' => 'A',

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use Kirby\Form\Field\UnknownField;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Fields::class)]
@@ -16,6 +17,24 @@ class FieldsTest extends TestCase
 	{
 		parent::setUp();
 		$this->model = new Page(['slug' => 'test']);
+	}
+
+	public function testAppendUnknownFields(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type' => 'text',
+			],
+		], $this->model);
+
+		$fields->appendUnknownFields([
+			'a' => 'A',
+			'b' => 'B',
+		]);
+
+		$this->assertCount(2, $fields);
+		$this->assertInstanceOf(Field::class, $fields->get('a'));
+		$this->assertInstanceOf(UnknownField::class, $fields->get('b'));
 	}
 
 	public function testConstruct(): void
@@ -220,6 +239,25 @@ class FieldsTest extends TestCase
 		$fields = new Fields([], language: $language);
 		$this->assertSame('de', $fields->language()->code());
 		$this->assertFalse($fields->language()->isDefault());
+	}
+
+	public function testRemoveUnknownFields(): void
+	{
+		$fields = new Fields([
+			'a' => new Field('text', ['name' => 'a']),
+			'b' => new UnknownField(name: 'b'),
+		], $this->model);
+
+		$this->assertCount(2, $fields);
+
+		$this->assertInstanceOf(Field::class, $fields->get('a'));
+		$this->assertInstanceOf(UnknownField::class, $fields->get('b'));
+
+		$fields->removeUnknownFields();
+
+		$this->assertCount(1, $fields);
+		$this->assertInstanceOf(Field::class, $fields->get('a'));
+		$this->assertNull($fields->get('b'));
 	}
 
 	public function testSubmit(): void

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field\UnknownField;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -696,4 +697,35 @@ class FieldsTest extends TestCase
 		], $fields->toStoredValues());
 	}
 
+	public function testValidate(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'     => 'text',
+					'required' => true,
+				]
+			],
+			model: $this->model
+		);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid form with errors');
+
+		$fields->validate();
+	}
+
+	public function testValidateWithoutErrors(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				]
+			],
+			model: $this->model
+		);
+
+		$this->assertNull($fields->validate());
+	}
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Todos

- [x] Avoid broken field component state after fill or submit
- [ ] Error handling for non-existing field types
- [x] $strict handling
  - [x] New `UnknownFieldClass`
  - [x] New `Fields::appendUnknownFields()` and `Fields::removeUnknownFields()` methods 
- [x] Closure value handling
  Closure values are now resolved in `Fields::submit` and `Fields::fill`
- [x] ignoreDisabled logic
- [x] Null value and unset logic

### Moved into separate PRs

- [x] Return static from `FieldClass::fill()` to keep it consistent with `Field::fill()`. (moved to https://github.com/getkirby/kirby/pull/7117)
- [x] New `::isTranslatable($language)` method for fields, to check if a field can be translated into the given language (moved to https://github.com/getkirby/kirby/pull/7115)
- [x] New `Fields::validate()` and `Form::validate()` which will internally call `Fields::errors()` and then throw an exception if errors exist. This cleans up the `ModelWithContent::update()` code some more and could be handy in multiple places. (moved to https://github.com/getkirby/kirby/pull/7114)
- [x] Fixed a major potential issue in `Field::fill()` that could override ciritical properties in the class (mainly `Field::$options`) (moved to https://github.com/getkirby/kirby/pull/7113)
- [x] Fixed notice issue in the `Field::fill()` method (moved to https://github.com/getkirby/kirby/pull/7113)
- [x] New `::isSubmittable()` method for fields to check if a field can be submitted by the form: https://github.com/getkirby/kirby/pull/7126
- [x] New `::isStorable($language)` method for fields to check if a field can be stored in the backend in the given language. https://github.com/getkirby/kirby/pull/7128
- [x] New `Fields::$language` property, which is needed to render and submit fields correctly. https://github.com/getkirby/kirby/pull/7129
- [x] New `::submit` for fields to be used when a form is submitted in a request. `::fill()` is now only responsible for providing the values that the form should have on render.  https://github.com/getkirby/kirby/pull/7130
- [x] The `Fields::$errors` cache has been removed for better reliability in error checks. https://github.com/getkirby/kirby/pull/7131
- [x] Refactored the language handling in the Form class with `Language::ensure()` https://github.com/getkirby/kirby/pull/7132
- [x] New `Fields::toProps($language)` method which provides the needed props for the frontend. This takes care of removing the value prop and also disabling the field if it's not translatable into the given language. Check for update permissions in the `Fields::toProps()` method and disable fields when updating is not allowed. Skip title field in `Fields::toProps()` for Page and Site models. This was taken care of in the fields section so far. https://github.com/getkirby/kirby/pull/7133
- [x] ~~New `UnknownField` class which will be injected into the Fields collection when unknown input should be submittable. New `Fields::appendUnknownFields()` and `Fields::removeUnknownFields()`~~ New `::passthrough()` method for Fields https://github.com/getkirby/kirby/pull/7135
- [x] New `Fields::submit()` method. `Fields::submit()` and `Fields::fill()` can now resolve closure values https://github.com/getkirby/kirby/pull/7136


### No longer needed

- ~~New `::isFillable()` method for fields to check if a field can receive a value from the backend to be rendered in the form~~

## Docs

https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b?pvs=4

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
