### PR TITLE
Fix block selector not closing after pasting block

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -122,7 +122,6 @@ export default {
 		paste(e) {
 			this.$emit("paste", e);
 			this.close();
-			this.close();
 		},
 		close() {
 			this.$emit("cancel");

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -66,7 +66,7 @@ export default {
 			type: String
 		}
 	},
-	emits: ["cancel", "input", "paste", "submit"],
+	emits: ["cancel", "close", "input", "paste", "submit"],
 	data() {
 		return {
 			selected: null
@@ -121,10 +121,7 @@ export default {
 	methods: {
 		paste(e) {
 			this.$emit("paste", e);
-			this.close();
-		},
-		close() {
-			this.$emit("cancel");
+			this.$emit("close");
 		}
 	}
 };

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -122,6 +122,10 @@ export default {
 		paste(e) {
 			this.$emit("paste", e);
 			this.close();
+			this.close();
+		},
+		close() {
+			this.$emit("cancel");
 		}
 	}
 };


### PR DESCRIPTION
Fixes #7087

* Call the correct `$emit("close")` function after pasting a block to then close the block selector