### PR TITLE
Delete children and drafts

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -559,7 +559,7 @@ trait PageActions
 			}
 
 			// delete all children individually
-			foreach ($page->children() as $child) {
+			foreach ($page->childrenAndDrafts() as $child) {
 				$child->delete(true);
 			}
 

--- a/tests/Cms/Page/PageDeleteTest.php
+++ b/tests/Cms/Page/PageDeleteTest.php
@@ -111,4 +111,26 @@ class PageDeleteTest extends ModelTestCase
 		$this->assertCount(0, $site->children());
 	}
 
+	public function testDeletePageWithChildrenAndDrafts(): void
+	{
+		$page = Page::create([
+			'slug' => 'test',
+			'num'  => 1
+		]);
+
+		$draft = $page->createChild([
+			'slug'  => 'child-a',
+			'draft' => true
+		]);
+
+		$child = $page->createChild([
+			'slug'  => 'child-b',
+			'draft' => false
+		]);
+
+		$page->delete(force: true);
+
+		$this->assertFalse($page->exists());
+	}
+
 }


### PR DESCRIPTION
## Description

When force-deleting a page, we ignored deleting drafts so far in v5.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Pages with drafts can now be deleted properly again (might be related: https://github.com/getkirby/kirby/issues/7086) 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
