### PR TITLE
Use type hinting in A::get instead of is_array

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -255,21 +255,17 @@ class A
 	 * // result: ['cat' => 'miao', 'dog' => 'wuff'];
 	 * ```
 	 *
-	 * @param mixed $array The source array
+	 * @param array $array The source array
 	 * @param string|int|array|null $key The key to look for
 	 * @param mixed $default Optional default value, which
 	 *                       should be returned if no element
 	 *                       has been found
 	 */
 	public static function get(
-		$array,
+		array $array,
 		string|int|array|null $key,
 		mixed $default = null
 	) {
-		if (is_array($array) === false) {
-			return $array;
-		}
-
 		// return the entire array if the key is null
 		if ($key === null) {
 			return $array;

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -225,9 +225,6 @@ class ATest extends TestCase
 	{
 		$array = $this->_array();
 
-		// non-array
-		$this->assertSame('test', A::get('test', 'test'));
-
 		// single key
 		$this->assertSame('miao', A::get($array, 'cat'));
 


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Use type hinting in `A::get()` instead of the is_array check. Results in a 2% improvement of total execution time according to @bnomei https://github.com/getkirby/kirby/issues/7096

### Breaking changes

- `A::get()` no longer accepts a first argument that is not an array

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
