### PR TITLE
Improve `F::read()` performance

### DIFF
--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -607,7 +607,11 @@ class F
 	 */
 	public static function read(string $file): string|false
 	{
-		return @file_get_contents($file);
+		try {
+			return @file_get_contents($file);
+		} catch (Throwable) {
+			return false;
+		}
 	}
 
 	/**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -607,15 +607,7 @@ class F
 	 */
 	public static function read(string $file): string|false
 	{
-		if (
-			is_readable($file) !== true &&
-			Str::startsWith($file, 'https://') !== true &&
-			Str::startsWith($file, 'http://') !== true
-		) {
-			return false;
-		}
-
-		return file_get_contents($file);
+		return @file_get_contents($file);
 	}
 
 	/**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -618,10 +618,10 @@ class F
 
 		// to increase performance, directly try to load the file without checking
 		// if it exists; fall back to a `false` return value if it doesn't exist
-		// or is not readable while letting other warnings through
+		// while letting other warnings through
 		return Helpers::handleErrors(
 			fn (): string|false => file_get_contents($file),
-			fn (int $errno, string $errstr): bool => str_contains($errstr, 'No such file') || str_contains($errstr, 'Permission denied'),
+			fn (int $errno, string $errstr): bool => str_contains($errstr, 'No such file'),
 			false
 		);
 	}

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -607,6 +607,10 @@ class F
 	 */
 	public static function read(string $file): string|false
 	{
+		if (str_contains($file, '://') === true) {
+			return false;
+		}
+
 		try {
 			return @file_get_contents($file);
 		} catch (Throwable) {

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -624,10 +624,33 @@ class FTest extends TestCase
 		file_put_contents($this->test, $content = 'my content is awesome');
 
 		$this->assertSame($content, F::read($this->test));
-		$this->assertFalse(F::read('invalid file'));
+	}
 
-		// TODO: This test is unreliable in CI (does not always get a response)
-		// $this->assertStringContainsString('Example Domain', F::read('https://example.com'));
+	/**
+	 * @covers ::read
+	 */
+	public function testReadFileWithoutReadPermissions()
+	{
+		file_put_contents($this->test, 'my content is awesome');
+		chmod($this->test, 0000);
+
+		$this->assertFalse(F::read($this->test));
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testReadInvalidFile()
+	{
+		$this->assertFalse(F::read('invalid file'));
+	}
+
+	/**
+	 * @covers ::read
+	 */
+	public function testReadRemoteFile()
+	{
+		$this->assertFalse(F::read('https://example.com/some-file.jpg'));
 	}
 
 	/**

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -629,17 +629,6 @@ class FTest extends TestCase
 	/**
 	 * @covers ::read
 	 */
-	public function testReadFileWithoutReadPermissions()
-	{
-		file_put_contents($this->test, 'my content is awesome');
-		chmod($this->test, 0000);
-
-		$this->assertFalse(F::read($this->test));
-	}
-
-	/**
-	 * @covers ::read
-	 */
 	public function testReadInvalidFile()
 	{
 		$this->assertFalse(F::read('invalid file'));

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -614,17 +614,6 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @covers ::read
-	 */
-	public function testReadUnreadble()
-	{
-		$file = new File(static::TMP . '/unreadable.txt');
-		$file->write('test');
-		chmod($file->root(), 0o000);
-		$this->assertFalse($file->read());
-	}
-
-	/**
 	 * @covers ::rename
 	 */
 	public function testRename()


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- `F::read()` now uses the @ error control operator instead of calling is_readable first. This should lead to a read function speed improvement of about 30-40% according to @bnomei https://github.com/getkirby/kirby/issues/7095

### Breaking changes

- `F::read()` no longer supports requesting URLs with protocols such as `http://` and `https://`. Please use the `Remote` class for this purpose.
- `F::read()` no longer silently returns `false` when the file exists but is not readable. Instead it triggers a PHP "Permission denied" warning.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
