### PR TITLE
PageActions: fix parent's children after resporting

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -568,7 +568,10 @@ trait PageActions
 			// up the directory if it's empty
 			$page->versions()->delete();
 
-			if ($page->isListed() === true) {
+			if (
+				$page->isListed() === true &&
+				$page->blueprint()->num() === 'default'
+			) {
 				$page->resortSiblingsAfterUnlisting();
 			}
 
@@ -783,7 +786,7 @@ trait PageActions
 		}
 
 		// Update the parent's children collection with the new sorting
-		$parent->children = $siblings->sort('num', 'asc');
+		$parent->children = $siblings->sort('isListed', 'desc', 'num', 'asc');
 		$parent->childrenAndDrafts = null;
 
 		return true;
@@ -815,7 +818,7 @@ trait PageActions
 			}
 
 			// Update the parent's children collection with the new sorting
-			$parent->children = $siblings->sort('num', 'asc');
+			$parent->children = $siblings->sort('isListed', 'desc', 'num', 'asc');
 			$parent->childrenAndDrafts = null;
 		}
 

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -568,7 +568,7 @@ trait PageActions
 			// up the directory if it's empty
 			$page->versions()->delete();
 
-			if ($page->isDraft() === false) {
+			if ($page->isListed() === true) {
 				$page->resortSiblingsAfterUnlisting();
 			}
 
@@ -742,19 +742,20 @@ trait PageActions
 	 */
 	protected function resortSiblingsAfterListing(int|null $position = null): bool
 	{
-		// get all siblings including the current page
-		$siblings = $this
-			->parentModel()
-			->children()
+		$parent   = $this->parentModel();
+		$siblings = $parent->children();
+
+		// Get all listed siblings including the current page
+		$listed = $siblings
 			->listed()
 			->append($this)
 			->filter(fn ($page) => $page->blueprint()->num() === 'default');
 
-		// get a non-associative array of ids
-		$keys  = $siblings->keys();
+		// Get a non-associative array of ids
+		$keys  = $listed->keys();
 		$index = array_search($this->id(), $keys);
 
-		// if the page is not included in the siblings something went wrong
+		// If the page is not included in the siblings something went wrong
 		if ($index === false) {
 			throw new LogicException(
 				message: 'The page is not included in the sorting index'
@@ -765,8 +766,8 @@ trait PageActions
 			$position = count($keys);
 		}
 
-		// move the current page number in the array of keys
-		// subtract 1 from the num and the position, because of the
+		// Move the current page number in the array of keys.
+		// Subtract 1 from the num and the position, because of the
 		// zero-based array keys
 		$sorted = A::move($keys, $index, $position - 1);
 
@@ -775,11 +776,14 @@ trait PageActions
 				continue;
 			}
 
-			$siblings->get($id)?->changeNum($key + 1);
+			// Apply the new sorting number
+			// and update the new object in the siblings collection
+			$newSibling = $listed->get($id)?->changeNum($key + 1);
+			$siblings->update($newSibling);
 		}
 
-		$parent = $this->parentModel();
-		$parent->children = $parent->children()->sort('num', 'asc');
+		// Update the parent's children collection with the new sorting
+		$parent->children = $siblings->sort('num', 'asc');
 		$parent->childrenAndDrafts = null;
 
 		return true;
@@ -792,18 +796,25 @@ trait PageActions
 	{
 		$index    = 0;
 		$parent   = $this->parentModel();
-		$siblings = $parent
-			->children()
+		$siblings = $parent->children();
+
+		// Get all listed siblings excluding the current page
+		$listed = $siblings
 			->listed()
 			->not($this)
 			->filter(fn ($page) => $page->blueprint()->num() === 'default');
 
-		if ($siblings->count() > 0) {
-			foreach ($siblings as $sibling) {
+		if ($listed->count() > 0) {
+			foreach ($listed as $sibling) {
 				$index++;
-				$sibling->changeNum($index);
+
+				// Apply the new sorting number
+				// and update the new object in the siblings collection
+				$newSibling = $sibling->changeNum($index);
+				$siblings->update($newSibling);
 			}
 
+			// Update the parent's children collection with the new sorting
 			$parent->children = $siblings->sort('num', 'asc');
 			$parent->childrenAndDrafts = null;
 		}

--- a/tests/Cms/Page/PageDeleteTest.php
+++ b/tests/Cms/Page/PageDeleteTest.php
@@ -72,18 +72,30 @@ class PageDeleteTest extends ModelTestCase
 
 	public function testDeletePage(): void
 	{
-		$page = Page::create([
-			'slug' => 'test',
-			'num'  => 1
+		$parent = Page::create(['slug' => 'test']);
+		$listed = Page::create([
+			'slug'   => 'child-a',
+			'num'    => 1,
+			'parent' => $parent
 		]);
 
-		$this->assertTrue($page->exists());
-		$this->assertTrue($page->parentModel()->children()->has($page));
+		$unlisted = Page::create([
+			'slug'   => 'child-b',
+			'draft'  => false,
+			'parent' => $parent
+		]);
 
-		$page->delete();
+		$this->assertTrue($listed->exists());
+		$this->assertTrue($parent->children()->has($listed));
+		$this->assertTrue($unlisted->exists());
+		$this->assertTrue($parent->children()->has($unlisted));
 
-		$this->assertFalse($page->exists());
-		$this->assertFalse($page->parentModel()->children()->has($page));
+		$listed->delete();
+
+		$this->assertFalse($listed->exists());
+		$this->assertFalse($parent->children()->has($listed));
+		$this->assertTrue($unlisted->exists());
+		$this->assertTrue($parent->children()->has($unlisted));
 	}
 
 	public function testDeleteMultipleSortedPages(): void
@@ -118,12 +130,12 @@ class PageDeleteTest extends ModelTestCase
 			'num'  => 1
 		]);
 
-		$draft = $page->createChild([
+		$page->createChild([
 			'slug'  => 'child-a',
 			'draft' => true
 		]);
 
-		$child = $page->createChild([
+		$page->createChild([
 			'slug'  => 'child-b',
 			'draft' => false
 		]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Only resort when a listed page gets deleted (not when an unlisted page gets deleted)
- Ensure that after resorting the parent's children collection includes all pages, not just listed


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed cases where after resorting a page, the parent's children collection was incomplete


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
