### PR TITLE
Load Vue via import map

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -29,7 +29,6 @@
 				"glob": "^11.0.1",
 				"jsdom": "^26.0.0",
 				"prettier": "^3.5.3",
-				"rollup-plugin-external-globals": "^0.13.0",
 				"terser": "^5.39.0",
 				"vite": "^6.2.2",
 				"vite-plugin-static-copy": "^2.3.0",
@@ -1038,36 +1037,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/@rollup/pluginutils": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-			"integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^2.0.2",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.34.5",
@@ -3093,16 +3062,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-reference": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
-			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.6"
-			}
-		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3689,19 +3648,6 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"license": "ISC"
 		},
-		"node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/portal-vue": {
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
@@ -4179,22 +4125,6 @@
 				"@rollup/rollup-win32-ia32-msvc": "4.34.5",
 				"@rollup/rollup-win32-x64-msvc": "4.34.5",
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/rollup-plugin-external-globals": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.13.0.tgz",
-			"integrity": "sha512-wBS3hmoF0OtEnA0lWsmTC6Nhnkk2zjZbfhaX2gLo8VnfNGFdGhiYKwMpIPQPrYbAw+mAYUYmoHYktAl1eZHgVw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/pluginutils": "^5.1.0",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.2",
-				"magic-string": "^0.30.10"
-			},
-			"peerDependencies": {
-				"rollup": "^2.25.0 || ^3.3.0 || ^4.1.4"
 			}
 		},
 		"node_modules/rope-sequence": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -34,7 +34,6 @@
 		"glob": "^11.0.1",
 		"jsdom": "^26.0.0",
 		"prettier": "^3.5.3",
-		"rollup-plugin-external-globals": "^0.13.0",
 		"terser": "^5.39.0",
 		"vite": "^6.2.2",
 		"vite-plugin-static-copy": "^2.3.0",

--- a/panel/src/index.js
+++ b/panel/src/index.js
@@ -9,6 +9,8 @@ import Legacy from "./panel/legacy.js";
 import Libraries from "./libraries/index.js";
 import Panel from "./panel/panel.js";
 
+window.Vue = Vue;
+
 Vue.config.productionTip = false;
 Vue.config.devtools = true;
 

--- a/panel/vite.config.mjs
+++ b/panel/vite.config.mjs
@@ -2,6 +2,7 @@
 import path from "path";
 
 import { defineConfig, loadEnv, splitVendorChunkPlugin } from "vite";
+import { minify } from "terser";
 import vue from "@vitejs/plugin-vue2";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import kirby from "./scripts/vite-kirby.mjs";
@@ -70,7 +71,18 @@ function createPlugins(mode) {
 					},
 					{
 						src: "node_modules/vue/dist/vue.runtime.esm.js",
-						dest: "js"
+						dest: "js",
+						rename: "vue.runtime.esm.min.js",
+						// TODO: we can simplify this in Vue 3 as a minified version
+						// is provided by Vue itself by default
+						transform: async (content) => {
+							content = content.replaceAll(
+								"process.env.NODE_ENV",
+								"'production'"
+							);
+							const minified = await minify(content);
+							return minified.code;
+						}
 					}
 				]
 			})

--- a/panel/vite.config.mjs
+++ b/panel/vite.config.mjs
@@ -12,11 +12,17 @@ import postcssLightDarkFunction from "@csstools/postcss-light-dark-function";
  * Returns all aliases used in the project
  */
 function createAliases(proxy) {
-	return {
-		"@": path.resolve(__dirname, "src"),
-		// use absolute proxied url to avoid Vue being loaded twice
-		vue: proxy.target + ":3000/node_modules/vue/dist/vue.esm.browser.js"
+	const aliases = {
+		"@": path.resolve(__dirname, "src")
 	};
+
+	if (!process.env.VITEST) {
+		// use absolute proxied url to avoid Vue being loaded twice
+		aliases.vue =
+			proxy.target + ":3000/node_modules/vue/dist/vue.esm.browser.js";
+	}
+
+	return aliases;
 }
 
 /**
@@ -62,14 +68,6 @@ function createPlugins(mode) {
 			viteStaticCopy({
 				targets: [
 					{
-						src: "node_modules/vue/dist/vue.esm.browser.js",
-						dest: "js"
-					},
-					{
-						src: "node_modules/vue/dist/vue.esm.browser.min.js",
-						dest: "js"
-					},
-					{
 						src: "node_modules/vue/dist/vue.runtime.esm.js",
 						dest: "js",
 						rename: "vue.runtime.esm.min.js",
@@ -83,6 +81,16 @@ function createPlugins(mode) {
 							const minified = await minify(content);
 							return minified.code;
 						}
+					},
+					{
+						src: "node_modules/vue/dist/vue.esm.browser.min.js",
+						dest: "js"
+					},
+					// Also copy the non-minified version to the dist folder as
+					// we will expose this for plugins in dev mode with Vue 3
+					{
+						src: "node_modules/vue/dist/vue.esm.browser.js",
+						dest: "js"
 					}
 				]
 			})

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -27,7 +27,7 @@ use Kirby\Toolkit\A;
  */
 class Assets
 {
-	protected bool $dev;
+	protected bool $isDev;
 	protected App $kirby;
 	protected string $nonce;
 	protected Plugins $plugins;
@@ -43,12 +43,14 @@ class Assets
 		$vite       = $this->kirby->roots()->panel() . '/.vite-running';
 		$this->vite = is_file($vite) === true;
 
-		// get the assets from the Vite dev server in dev mode;
+		// Check if Panel is running in dev mode to
+		// get the assets from the Vite dev server;
 		// dev mode = explicitly enabled in the config AND Vite is running
-		$dev       = $this->kirby->option('panel.dev', false);
-		$this->dev = $dev !== false && $this->vite === true;
+		$this->isDev =
+			$this->kirby->option('panel.dev', false) !== false &&
+			$this->vite === true;
 
-		// get the base URL
+		// Get the base URL
 		$this->url = $this->url();
 	}
 
@@ -65,7 +67,7 @@ class Assets
 
 		// during dev mode we do not need to load
 		// the general stylesheet (as styling will be inlined)
-		if ($this->dev === true) {
+		if ($this->isDev === true) {
 			$css['index'] = null;
 		}
 
@@ -109,10 +111,11 @@ class Assets
 		return [
 			'css'            => $this->css(),
 			'icons'          => $this->favicons(),
+			'import-maps'    => $this->importMaps(),
+			'js'             => $this->js(),
 			// loader for plugins' index.dev.mjs files – inlined,
 			// so we provide the code instead of the asset URL
 			'plugin-imports' => $this->plugins->read('mjs'),
-			'js'             => $this->js()
 		];
 	}
 
@@ -203,10 +206,20 @@ class Assets
 	public function icons(): string
 	{
 		$dir   = $this->kirby->root('panel') . '/';
-		$dir  .= $this->dev ? 'public' : 'dist';
+		$dir  .= $this->isDev ? 'public' : 'dist';
 		$icons = F::read($dir . '/img/icons.svg');
 		$icons = preg_replace('/<!--(.|\s)*?-->/', '', $icons);
 		return $icons;
+	}
+
+	/**
+	 * Get all import maps
+	 */
+	public function importMaps(): array
+	{
+		return array_filter([
+			'vue' => $this->vue()
+		]);
 	}
 
 	/**
@@ -215,49 +228,41 @@ class Assets
 	public function js(): array
 	{
 		$js = [
-			'vue' => [
-				'nonce' => $this->nonce,
-				'src'   => $this->vue(),
-			],
 			'vendor' => [
-				'nonce' => $this->nonce,
-				'src'   => $this->url . '/js/vendor.min.js',
-				'type'  => 'module'
+				'src'  => $this->url . '/js/vendor.min.js',
+				'type' => 'module'
 			],
-			'pluginloader' => [
-				'nonce' => $this->nonce,
-				'src'   => $this->url . '/js/plugins.js',
-				'type'  => 'module'
+			'plugin-registry' => [
+				'src'  => $this->url . '/js/plugins.js',
+				'type' => 'module'
 			],
 			'plugins' => [
 				'nonce' => $this->nonce,
 				'src'   => $this->plugins->url('js'),
-				'defer' => true
+				'defer' => true,
 			],
 			...A::map($this->custom('panel.js'), fn ($src) => [
-				'nonce' => $this->nonce,
 				'src'   => $src,
-				'type'  => 'module'
+				'type'  => 'module',
+				'defer' => true
 			]),
 			'index' => [
-				'nonce' => $this->nonce,
 				'src'   => $this->url . '/js/index.min.js',
-				'type'  => 'module'
+				'type'  => 'module',
+				'defer' => true
 			],
 		];
 
 
-		// during dev mode, add vite client and adapt
+		// During dev mode, add vite client and adapt
 		// path to `index.js` - vendor does not need
 		// to be loaded in dev mode
-		if ($this->dev === true) {
-			// load the non-minified index.js, remove vendor script and
-			//  development version of Vue
+		if ($this->isDev === true) {
+			// Load the non-minified index.js, remove vendor script
 			$js['vendor']['src'] = null;
 			$js['index']['src']  = $this->url . '/src/index.js';
-			$js['vue']['src']    = $this->vue(production: false);
 
-			// add vite dev client
+			// Add vite dev client
 			$js['vite'] = [
 				'nonce' => $this->nonce,
 				'src'   => $this->url . '/@vite/client',
@@ -308,12 +313,13 @@ class Assets
 	public function url(): string
 	{
 		// vite is not running, use production assets
-		if ($this->dev === false) {
+		if ($this->isDev === false) {
 			return $this->kirby->url('media') . '/panel/' . $this->kirby->versionHash();
 		}
 
 		// explicitly configured base URL
 		$dev = $this->kirby->option('panel.dev');
+
 		if (is_string($dev) === true) {
 			return $dev;
 		}
@@ -331,14 +337,17 @@ class Assets
 	 * Get the correct Vue script URL depending on dev mode
 	 * and the enabled/disabled template compiler
 	 */
-	public function vue(bool $production = true): string
+	public function vue(): string
 	{
-		$script = $this->kirby->option('panel.vue.compiler', true) === true ? 'vue' : 'vue.runtime';
-
-		if ($production === false) {
-			return $this->url . '/node_modules/vue/dist/' . $script . '.js';
+		// During dev mode, load the dev version of Vue
+		if ($this->isDev === true) {
+			return $this->url . '/node_modules/vue/dist/vue.esm.browser.js';
 		}
 
-		return $this->url . '/js/' . $script . '.min.js';
+		if ($this->kirby->option('panel.vue.compiler', true) === true) {
+			return $this->url . '/js/vue.esm.browser.min.js';
+		}
+
+		return $this->url . '/js/vue.runtime.esm.js';
 	}
 }

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -348,6 +348,6 @@ class Assets
 			return $this->url . '/js/vue.esm.browser.min.js';
 		}
 
-		return $this->url . '/js/vue.runtime.esm.js';
+		return $this->url . '/js/vue.runtime.esm.min.js';
 	}
 }

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -229,27 +229,29 @@ class Assets
 	{
 		$js = [
 			'vendor' => [
-				'src'  => $this->url . '/js/vendor.min.js',
-				'type' => 'module'
+				'nonce' => $this->nonce,
+				'src'   => $this->url . '/js/vendor.min.js',
+				'type'  => 'module'
 			],
 			'plugin-registry' => [
-				'src'  => $this->url . '/js/plugins.js',
-				'type' => 'module'
+				'nonce' => $this->nonce,
+				'src'   => $this->url . '/js/plugins.js',
+				'type'  => 'module'
 			],
 			'plugins' => [
 				'nonce' => $this->nonce,
 				'src'   => $this->plugins->url('js'),
-				'defer' => true,
+				'defer' => true
 			],
 			...A::map($this->custom('panel.js'), fn ($src) => [
+				'nonce' => $this->nonce,
 				'src'   => $src,
 				'type'  => 'module',
 				'defer' => true
 			]),
 			'index' => [
-				'src'   => $this->url . '/js/index.min.js',
-				'type'  => 'module',
-				'defer' => true
+				'src'  => $this->url . '/js/index.min.js',
+				'type' => 'module'
 			],
 		];
 
@@ -259,8 +261,8 @@ class Assets
 		// to be loaded in dev mode
 		if ($this->isDev === true) {
 			// Load the non-minified index.js, remove vendor script
-			$js['vendor']['src'] = null;
 			$js['index']['src']  = $this->url . '/src/index.js';
+			$js['vendor'] = null;
 
 			// Add vite dev client
 			$js['vite'] = [
@@ -270,7 +272,7 @@ class Assets
 			];
 		}
 
-		return array_filter($js, fn ($js) => empty($js['src']) === false);
+		return array_filter($js);
 	}
 
 	/**

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -8,10 +8,9 @@ use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Assets
- */
+#[CoversClass(Assets::class)]
 class AssetsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Assets';
@@ -74,9 +73,6 @@ class AssetsTest extends TestCase
 		F::write($app->roots()->panel() . '/.vite-running', '');
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCss(): void
 	{
 		// default asset setup
@@ -89,9 +85,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/media/plugins/index.css?0', $css['plugins']);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssInDevMode(): void
 	{
 		$this->setDevMode();
@@ -103,10 +96,6 @@ class AssetsTest extends TestCase
 		$this->assertSame(['plugins' => '/media/plugins/index.css?0'], $css);
 	}
 
-	/**
-	 * @covers ::css
-	 * @covers ::custom
-	 */
 	public function testCssWithCustomFile(): void
 	{
 		F::write(static::TMP . '/panel.css', '');
@@ -141,9 +130,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($url, $assets['custom-2']);
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithCustomFileMissing(): void
 	{
 		$this->app->clone([
@@ -158,9 +144,6 @@ class AssetsTest extends TestCase
 		$this->assertEmpty($assets->custom('panel.css'));
 	}
 
-	/**
-	 * @covers ::css
-	 */
 	public function testCssWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -174,10 +157,6 @@ class AssetsTest extends TestCase
 		$this->assertSame(['plugins' => '/media/plugins/index.css?0'], $css);
 	}
 
-	/**
-	 * @covers ::external
-	 * @covers ::custom
-	 */
 	public function testExternalWithCustomCssJs(): void
 	{
 		// custom panel css and js
@@ -201,9 +180,6 @@ class AssetsTest extends TestCase
 		$this->assertTrue(Str::contains($external['js']['custom-0']['src'], 'assets/panel.js'));
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFavicons(): void
 	{
 		// default asset setup
@@ -219,9 +195,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon-dark.png', $favicons[4]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsInDevMode(): void
 	{
 		$this->setDevMode();
@@ -237,9 +210,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon-dark.png', $favicons[4]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomArraySetup(): void
 	{
 		// array
@@ -271,9 +241,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/assets/my-favicon.png', $favicons[1]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomStringSetup(): void
 	{
 		// array
@@ -295,9 +262,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('/assets/favicon.ico', $favicons[0]['href']);
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomInvalidSetup(): void
 	{
 		// array
@@ -317,9 +281,6 @@ class AssetsTest extends TestCase
 		$assets->favicons();
 	}
 
-	/**
-	 * @covers ::favicons
-	 */
 	public function testFaviconsWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -335,9 +296,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($base . '/favicon.svg', $favicons[2]['href']);
 	}
 
-	/**
-	 * @covers ::icons
-	 */
 	public function testIcons(): void
 	{
 		$assets = new Assets();
@@ -347,9 +305,14 @@ class AssetsTest extends TestCase
 		$this->assertTrue(str_contains($icons, '<svg'));
 	}
 
-	/**
-	 * @covers ::js
-	 */
+	public function testImportMaps(): void
+	{
+		$assets = new Assets();
+		$importMaps = $assets->importMaps();
+
+		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.esm.browser.min.js', $importMaps['vue']);
+	}
+
 	public function testJs(): void
 	{
 		// default asset setup
@@ -358,12 +321,11 @@ class AssetsTest extends TestCase
 		$js     = $assets->js();
 
 		// js
-		$this->assertSame($base . '/js/vue.min.js', $js['vue']['src']);
 		$this->assertSame($base . '/js/vendor.min.js', $js['vendor']['src']);
 		$this->assertSame('module', $js['vendor']['type']);
 
-		$this->assertSame($base . '/js/plugins.js', $js['pluginloader']['src']);
-		$this->assertSame('module', $js['pluginloader']['type']);
+		$this->assertSame($base . '/js/plugins.js', $js['plugin-registry']['src']);
+		$this->assertSame('module', $js['plugin-registry']['type']);
 
 		$this->assertSame('/media/plugins/index.js?0', $js['plugins']['src']);
 		$this->assertTrue($js['plugins']['defer']);
@@ -373,9 +335,6 @@ class AssetsTest extends TestCase
 		$this->assertSame('module', $js['index']['type']);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsInDevMode(): void
 	{
 		$this->setDevMode();
@@ -385,17 +344,13 @@ class AssetsTest extends TestCase
 		$js     = $assets->js();
 
 		$this->assertSame([
-			'vue' => $base . '/node_modules/vue/dist/vue.js',
-			'pluginloader' => $base . '/js/plugins.js',
-			'plugins' => '/media/plugins/index.js?0',
-			'index' => $base . '/src/index.js',
-			'vite' => $base . '/@vite/client'
+			'plugin-registry' => $base . '/js/plugins.js',
+			'plugins'         => '/media/plugins/index.js?0',
+			'index'           => $base . '/src/index.js',
+			'vite'            => $base . '/@vite/client'
 		], array_map(fn ($js) => $js['src'], $js));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomFile(): void
 	{
 		F::write(static::TMP . '/panel.js', '');
@@ -431,9 +386,6 @@ class AssetsTest extends TestCase
 		$this->assertSame($url, $assets['custom-2']);
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomFileMissing(): void
 	{
 		$this->app->clone([
@@ -448,9 +400,6 @@ class AssetsTest extends TestCase
 		$this->assertEmpty($assets->custom('panel.js'));
 	}
 
-	/**
-	 * @covers ::js
-	 */
 	public function testJsWithCustomUrl(): void
 	{
 		$this->setCustomUrl();
@@ -462,17 +411,13 @@ class AssetsTest extends TestCase
 
 		// js
 		$this->assertSame([
-			'vue' => $base . '/node_modules/vue/dist/vue.js',
-			'pluginloader' => $base . '/js/plugins.js',
-			'plugins' => '/media/plugins/index.js?0',
-			'index' => $base . '/src/index.js',
-			'vite' => $base . '/@vite/client'
+			'plugin-registry' => $base . '/js/plugins.js',
+			'plugins'         => '/media/plugins/index.js?0',
+			'index'           => $base . '/src/index.js',
+			'vite'            => $base . '/@vite/client'
 		], array_map(fn ($js) => $js['src'], $js));
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$assets = new Assets();
@@ -491,15 +436,17 @@ class AssetsTest extends TestCase
 		$assets = new Assets();
 		$vue    = $assets->vue();
 
-		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.min.js', $vue);
+		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.esm.browser.min.js', $vue);
 	}
 
 	public function testVueInDevMode()
 	{
-		$assets = new Assets();
-		$vue    = $assets->vue(production: false);
+		$this->setDevMode();
 
-		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/node_modules/vue/dist/vue.js', $vue);
+		$assets = new Assets();
+		$vue    = $assets->vue();
+
+		$this->assertSame('http://sandbox.test:3000/node_modules/vue/dist/vue.esm.browser.js', $vue);
 	}
 
 	public function testVueWithDisabledTemplateCompiler()
@@ -517,24 +464,6 @@ class AssetsTest extends TestCase
 		$assets = new Assets();
 		$vue    = $assets->vue();
 
-		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.runtime.min.js', $vue);
-	}
-
-	public function testVueWithDisabledTemplateCompilerInDevMode()
-	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'vue' => [
-						'compiler' => false
-					]
-				]
-			]
-		]);
-
-		$assets = new Assets();
-		$vue    = $assets->vue(production: false);
-
-		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/node_modules/vue/dist/vue.runtime.js', $vue);
+		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.runtime.esm.min.js', $vue);
 	}
 }

--- a/views/panel.php
+++ b/views/panel.php
@@ -20,6 +20,12 @@ use Kirby\Toolkit\Html;
 
   <title>Kirby Panel</title>
 
+	<script type="importmap">
+	{
+	  "imports": <?= json_encode($assets['import-maps'] ?? []) ?>
+	}
+	</script>
+
   <script nonce="<?= $nonce ?>">
     if (
         !window.CSS ||
@@ -39,7 +45,7 @@ use Kirby\Toolkit\Html;
   <?php endforeach ?>
 
   <?php foreach ($assets['js'] as $js): ?>
-  <?php if (($js['type'] ?? null) === 'module'): ?>
+  <?php if (($js['defer'] ?? null) !== true): ?>
   <link rel="modulepreload" href="<?= $js['src'] ?>">
   <?php endif ?>
   <?php endforeach ?>
@@ -60,16 +66,16 @@ use Kirby\Toolkit\Html;
     window.fiber = <?= json_encode($fiber) ?>;
   </script>
 
-  <?php foreach ($assets['js'] as $key => $js): ?>
-  <?php if ($key === 'index'): ?>
-  <script type="module" nonce="<?= $nonce ?>">
-    <?= $assets['plugin-imports'] ?>
-    import('<?= $js['src'] ?>')
-  </script>
-  <?php else: ?>
-  <?= Html::tag('script', '', $js) . PHP_EOL ?>
-  <?php endif ?>
-  <?php endforeach ?>
+	<?php foreach ($assets['js'] as $key => $js): ?>
+		<?php if ($key === 'index'): ?>
+			<script type="module" nonce="<?= $nonce ?>" defer>
+				<?= $assets['plugin-imports'] ?>
+    		import('<?= $js['src'] ?>')
+			</script>
+		<?php else: ?>
+			<?= Html::tag('script', '', $js) . PHP_EOL ?>
+		<?php endif ?>
+	<?php endforeach ?>
 
 </body>
 </html>

--- a/views/panel.php
+++ b/views/panel.php
@@ -45,7 +45,7 @@ use Kirby\Toolkit\Html;
   <?php endforeach ?>
 
   <?php foreach ($assets['js'] as $js): ?>
-  <?php if (($js['defer'] ?? null) !== true): ?>
+  <?php if (($js['type'] ?? null) === 'module'): ?>
   <link rel="modulepreload" href="<?= $js['src'] ?>">
   <?php endif ?>
   <?php endforeach ?>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Make `Vue` bundle accessible as JS Import map


### Reasoning
Prepares for Vue 3 usage.


### Additional context
As we have to build a minified ESM runtime version of Vue ourselves, the file grows from 76 to 99 KB.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
