### PR TITLE
`k-panel-menu`: simplify gap

### DIFF
--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -154,13 +154,8 @@ export default {
 }
 /* Keep the remaining space between 2nd last and last button group */
 .k-panel-menu-buttons[data-second-last="true"] {
-	flex-grow: 1;
+	margin-bottom: auto;
 }
-/* Move the last menu to the end */
-.k-panel-menu-buttons:last-child {
-	justify-content: flex-end;
-}
-
 /* Menu buttons incl. search */
 .k-panel-menu-button {
 	--button-align: flex-start;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `margin: auto` is a good way in a flex context to create a space, instead of growing an item.
- `.k-panel-menu-buttons:last-child` had no effect because of the activation button menu