### PR TITLE
Avoid broken field component state after :fill() method call

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -283,7 +283,7 @@ class Field extends Component
 		$this->applyProp('value', $this->options['props']['value'] ?? $value);
 
 		// reevaluate the computed props
-		$this->applyComputed($this->options['computed']);
+		$this->applyComputed($this->options['computed'] ?? []);
 
 		// reset the errors cache
 		$this->errors = null;

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -270,6 +270,12 @@ class Field extends Component
 	 */
 	public function fill(mixed $value): static
 	{
+		// remember the current state to restore it afterwards
+		$attrs   = $this->attrs;
+		$methods = $this->methods;
+		$options = $this->options;
+		$type    = $this->type;
+
 		// overwrite the attribute value
 		$this->value = $this->attrs['value'] = $value;
 
@@ -281,6 +287,12 @@ class Field extends Component
 
 		// reset the errors cache
 		$this->errors = null;
+
+		// restore the original state
+		$this->attrs   = $attrs;
+		$this->methods = $methods;
+		$this->options = $options;
+		$this->type    = $type;
 
 		return $this;
 	}

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -394,6 +394,37 @@ class FieldTest extends TestCase
 		$this->assertSame('test2 computed', $field->computedValue());
 	}
 
+	public function testFillWithRestoredState()
+	{
+		Field::$types = [
+			'test' => $definition = [
+				'computed' => [
+					'options' => fn () => ['a', 'b', 'c']
+				],
+				'methods' => [
+					'optionsDebugger' => fn () => $this->options
+				]
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page,
+			'value' => 'test'
+		]);
+
+		$this->assertSame(['a', 'b', 'c'], $field->options());
+		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+
+		// filling a new value must not break the mandatory
+		// component definition properties
+		$field->fill('test2');
+
+		$this->assertSame(['a', 'b', 'c'], $field->options());
+		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+	}
+
 	public function testHelp()
 	{
 		Field::$types = [


### PR DESCRIPTION
## Summary of changes

The ::fill method in the Field class needs to reset the required component properties to make sure that they cannot be overwritten by a computed property for example. 

This is extracted from the big Field Improvements PR (https://github.com/getkirby/kirby/pull/7081)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Avoid broken field component state after :fill() method call
- Fixed notice issue in the `Field::fill()` method when no computed properties exist.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
