### PR TITLE
New Form::validate and Fields::validate methods

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -670,12 +670,8 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			'language'       => $languageCode,
 		]);
 
-		// validate the input
-		if ($validate === true && $form->isInvalid() === true) {
-			throw new InvalidArgumentException(
-				fallback: 'Invalid form with errors',
-				details: $form->errors()
-			);
+		if ($validate === true) {
+			$form->validate();
 		}
 
 		return $this->commit(

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -4,6 +4,7 @@ namespace Kirby\Form;
 
 use Closure;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Str;
@@ -183,5 +184,23 @@ class Fields extends Collection
 	public function toStoredValues(bool $defaults = false): array
 	{
 		return $this->toArray(fn ($field) => $field->toStoredValue($defaults));
+	}
+
+	/**
+	 * Checks for errors in all fields and throws an
+	 * exception if there are any
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
+	 */
+	public function validate(): void
+	{
+		$errors = $this->errors();
+
+		if ($errors !==	[]) {
+			throw new InvalidArgumentException(
+				fallback: 'Invalid form with errors',
+				details: $errors
+			);
+		}
 	}
 }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -300,6 +300,16 @@ class Form
 	}
 
 	/**
+	 * Validates the form and throws an exception if there are any errors
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException
+	 */
+	public function validate(): void
+	{
+		$this->fields->validate();
+	}
+
+	/**
 	 * Returns form values
 	 */
 	public function values(): array

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Form;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use Kirby\Exception\InvalidArgumentException;
 
 /**
  * @coversDefaultClass \Kirby\Form\Fields
@@ -284,5 +285,37 @@ class FieldsTest extends TestCase
 
 		$this->assertSame(['a' => 'Value a', 'b' => 'Value b'], $fields->toFormValues());
 		$this->assertSame(['a' => 'Value a stored', 'b' => 'Value b stored'], $fields->toStoredValues());
+	}
+
+	public function testValidate(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'     => 'text',
+					'required' => true,
+				]
+			],
+			model: $this->model
+		);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid form with errors');
+
+		$fields->validate();
+	}
+
+	public function testValidateWithoutErrors(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				]
+			],
+			model: $this->model
+		);
+
+		$this->assertNull($fields->validate());
 	}
 }


### PR DESCRIPTION
## Description

This PR extracts improvements from https://github.com/getkirby/kirby/pull/7081

## Changelog

### Enhancements

- New `Fields::validate()` method
- New `Form::validate()` method, which is a proxy for `Fields::validate()` 
- Use `Form::validate()` in `ModelWithContent::update()`

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion