### PR TITLE
New ::isTranslatable method for Field and FieldClass

### DIFF
--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -17,6 +17,8 @@ trait Translatable
 
 	/**
 	 * Should the field be translatable into the given language?
+	 *
+	 * @since 5.0.0
 	 */
 	public function isTranslatable(Language $language): bool
 	{

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Cms\Language;
+
 /**
  * @package   Kirby Form
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -12,6 +14,18 @@ namespace Kirby\Form\Mixin;
 trait Translatable
 {
 	protected bool $translate = true;
+
+	/**
+	 * Should the field be translatable into the given language?
+	 */
+	public function isTranslatable(Language $language): bool
+	{
+		if ($this->translate() === false && $language->isDefault() === false) {
+			return false;
+		}
+
+		return true;
+	}
 
 	/**
 	 * Set the translatable status

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Exception;
+use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
 
@@ -263,6 +264,28 @@ class FieldClassTest extends TestCase
 
 		$field = new HiddenField();
 		$this->assertTrue($field->isHidden());
+	}
+
+	public function testIsTranslatable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isTranslatable($language));
+	}
+
+	public function testIsTranslatableWithNonDefaultLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isTranslatable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isTranslatable($language));
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR extracts improvements from https://github.com/getkirby/kirby/pull/7081

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `::isTranslatable($language)` method for `Field` and `FieldClass` 

### Breaking changes

- None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
