### PR TITLE
Fix unsetting field values in changes 

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -250,8 +250,6 @@ class Version
 			]
 		)->values();
 
-		dump($a, $b);
-
 		ksort($a);
 		ksort($b);
 
@@ -508,8 +506,6 @@ class Version
 		foreach (array_diff_key($latest, $changes) as $key => $value) {
 			$changes[$key] = null;
 		}
-
-		dump($changes);
 
 		// update the latest version
 		$this->model = $this->model->update(

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -495,7 +495,7 @@ class Version
 		$changes = $this->read($language);
 		$latest  = $this->model->version(VersionId::latest())->read($language);
 
-		// Find all fields that were removed from the changeds version
+		// Find all fields that were removed from the changed version
 		// and need to be explicitly set to null when merging with the
 		// latest version.
 		//

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -175,7 +175,8 @@ class Form
 
 	public static function for(
 		ModelWithContent $model,
-		array $props = []
+		array $props = [],
+		bool $merge = true
 	): static {
 		// get the original model data
 		$original = $model->content($props['language'] ?? null)->toArray();
@@ -188,8 +189,13 @@ class Form
 			}
 		}
 
+		if ($merge === true) {
+			$props['values'] = [...$original, ...$values];
+		} else {
+			$props['values'] = $values;
+		}
+
 		// set a few defaults
-		$props['values']   = [...$original, ...$values];
 		$props['fields'] ??= [];
 		$props['model']    = $model;
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -1046,6 +1046,40 @@ class VersionTest extends TestCase
 	}
 
 	/**
+	 * @covers ::publish
+	 */
+	public function testPublishWithRemovedField()
+	{
+		$this->setUpSingleLanguage();
+		$this->app->impersonate('kirby');
+
+		$model = new File([
+			'parent'   => $this->model,
+			'filename' => 'test.jpg',
+		]);
+
+		$latest = $model->version('latest');
+		$latest->save([
+			'title' => 'Title',
+			'focus' => '50% 50%'
+		]);
+
+		$changes = $model->version('changes');
+		$changes->save([
+			'title' => 'Updated title',
+			'focus' => null,
+		]);
+
+		$changes->publish();
+
+		// get the updated model through the changes version
+		$latest = $changes->model()->version('latest')->read();
+
+		$this->assertArrayNotHasKey('focus', $latest);
+		$this->assertSame('Updated title', $latest['title']);
+	}
+
+	/**
 	 * @covers ::read
 	 * @covers ::convertFieldNamesToLowerCase
 	 * @covers ::prepareFieldsAfterRead

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -406,6 +406,37 @@ class FormTest extends TestCase
 	}
 
 	/**
+	 * @covers ::for
+	 */
+	public function testForPageWithoutMerge()
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'content' => [
+				'title' => 'Test',
+				'date'  => '2012-12-12'
+			],
+		]);
+
+		$form = Form::for(
+			model: $page,
+			props: [
+				'values' => [
+					'title' => 'Updated Title',
+				],
+			],
+			merge: false
+		);
+
+		$values   = $form->values();
+		$expected = [
+			'title' => 'Updated Title'
+		];
+
+		$this->assertSame($expected, $values, 'The date field should not be present');
+	}
+
+	/**
 	 * @covers ::strings
 	 */
 	public function testStrings()


### PR DESCRIPTION
## Description

When passing null as field value when saving changes, the value from the latest version would be magically merged back in. This PR fixes this regression. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- The focus point can be removed again, once set. https://github.com/getkirby/kirby/issues/7022
- Passing `null` as field value will remove the field correctly from the latest version, when publishing changes.
- `Version::isIdentical()` is now comparing two versions more reliably, by not merging original values.

### Enhancements

- New `merge: true` argument for `Kirby\Form\Form::for()` which will disable merging original values. Merging is activated by default. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
