### PR TITLE
Return static in FieldClass::fill

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -105,12 +105,14 @@ class BlocksField extends FieldClass
 		return $groups === [] ? null : $groups;
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();
 		$this->value  = $this->blocksToValues($blocks);
 		$this->errors = null;
+
+		return $this;
 	}
 
 	public function form(array $fields, array $input = []): Form

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -51,10 +51,12 @@ class EntriesField extends FieldClass
 		return $this->form()->fields()->first()->toArray();
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value = Data::decode($value ?? '', 'yaml');
 		parent::fill($value);
+
+		return $this;
 	}
 
 	public function form(array $values = []): Form

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,7 +30,7 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$value   = Data::decode($value, type: 'json', fail: false);
 		$layouts = Layouts::factory($value, ['parent' => $this->model])->toArray();
@@ -47,6 +47,8 @@ class LayoutField extends BlocksField
 
 		$this->value  = $layouts;
 		$this->errors = null;
+
+		return $this;
 	}
 
 	public function attrsForm(array $input = []): Form

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -121,10 +121,12 @@ abstract class FieldClass
 	/**
 	 * Sets a new value for the field
 	 */
-	public function fill(mixed $value = null): void
+	public function fill(mixed $value = null): static
 	{
 		$this->value = $value;
 		$this->errors = null;
+
+		return $this;
 	}
 
 	/**

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -121,7 +121,7 @@ abstract class FieldClass
 	/**
 	 * Sets a new value for the field
 	 */
-	public function fill(mixed $value = null): static
+	public function fill(mixed $value): static
 	{
 		$this->value = $value;
 		$this->errors = null;


### PR DESCRIPTION
## Description

This PR extracts improvements from https://github.com/getkirby/kirby/pull/7081

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements from previous betas

- `FieldClass::fill()` now returns static instead of void. This no longer introduces a difference to the Field class and also makes `::fill()` chainable, which can be handy. 

### Breaking changes

- None (`::fill()` is new in v5)

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
