### PR TITLE
Reactive blocks drawer hidden icon

### DIFF
--- a/panel/src/components/Drawers/BlockDrawer.vue
+++ b/panel/src/components/Drawers/BlockDrawer.vue
@@ -14,7 +14,7 @@
 				v-if="hidden"
 				class="k-drawer-option"
 				icon="hidden"
-				@click="$emit('show')"
+				@click="show"
 			/>
 			<k-button
 				:disabled="!prev"
@@ -63,6 +63,12 @@ export default {
 		"show",
 		"submit",
 		"tab"
-	]
+	],
+	methods: {
+		show() {
+			this.hidden = false;
+			this.$emit("show");
+		}
+	}
 };
 </script>

--- a/panel/src/components/Drawers/BlockDrawer.vue
+++ b/panel/src/components/Drawers/BlockDrawer.vue
@@ -11,7 +11,7 @@
 	>
 		<template #options>
 			<k-button
-				v-if="hidden"
+				v-if="isHidden"
 				class="k-drawer-option"
 				icon="hidden"
 				@click="show"
@@ -64,9 +64,14 @@ export default {
 		"submit",
 		"tab"
 	],
+	data() {
+		return {
+			isHidden: this.hidden
+		};
+	},
 	methods: {
 		show() {
-			this.hidden = false;
+			this.isHidden = false;
 			this.$emit("show");
 		}
 	}


### PR DESCRIPTION
### Fixes
- Blocks drawer: hidden icon in drawer options not reactive #7105


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
