### PR TITLE
Fix `App::$events` initialization

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -98,7 +98,8 @@ class App
 	 */
 	public function __construct(array $props = [], bool $setInstance = true)
 	{
-		$this->core = new Core($this);
+		$this->core   = new Core($this);
+		$this->events = new Events($this);
 
 		// start with a fresh version cache
 		VersionCache::$cache = [];
@@ -150,8 +151,6 @@ class App
 		$this->extensionsFromPlugins();
 		$this->extensionsFromOptions();
 		$this->extensionsFromFolders();
-
-		$this->events = new Events(bind: $this);
 
 		// must be set after the extensions are loaded.
 		// the default storage instance must be defined


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `App::$events` is initialized before error handler and extension, so that any error thrown e.g. by a plugin and handled by the error handler can actually deal with the `system.exception` event
- `Events` class doesn't accept a custom `$hooks` argument anymore
- `Events` class requires `$app` argument now
- `Events` class now loads hooks from extensions each time a hook runs. This could be a performance issue. However, caching the hooks array could lead to problems when the first event is already triggered/applied before all extensions (and thus all hooks have been registered).

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
