### PR TITLE
Mixin improvements

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -337,14 +337,6 @@ class Field extends Component
 	}
 
 	/**
-	 * Checks if the field is required
-	 */
-	public function isRequired(): bool
-	{
-		return $this->required ?? false;
-	}
-
-	/**
 	 * Checks if the field is saveable
 	 */
 	public function isSaveable(): bool

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -368,15 +368,6 @@ class Field extends Component
 	}
 
 	/**
-	 * Checks if the field is saveable
-	 * @deprecated 5.0.0 Use `::isSaveable()` instead
-	 */
-	public function save(): bool
-	{
-		return $this->isSaveable();
-	}
-
-	/**
 	 * Parent collection with all fields of the current form
 	 */
 	public function siblings(): Fields

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -105,7 +105,10 @@ class BlocksField extends FieldClass
 		return $groups === [] ? null : $groups;
 	}
 
-	public function fill(mixed $value = null): static
+	/**	
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
+	public function fill(mixed $value): static
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -107,6 +107,7 @@ class BlocksField extends FieldClass
 
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
 	 */
 	public function fill(mixed $value): static
 	{

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -105,7 +105,7 @@ class BlocksField extends FieldClass
 		return $groups === [] ? null : $groups;
 	}
 
-	/**	
+	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 */
 	public function fill(mixed $value): static

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -51,7 +51,7 @@ class EntriesField extends FieldClass
 		return $this->form()->fields()->first()->toArray();
 	}
 
-	/**	
+	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 */
 	public function fill(mixed $value): static

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -51,7 +51,10 @@ class EntriesField extends FieldClass
 		return $this->form()->fields()->first()->toArray();
 	}
 
-	public function fill(mixed $value = null): static
+	/**	
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
+	public function fill(mixed $value): static
 	{
 		$value = Data::decode($value ?? '', 'yaml');
 		parent::fill($value);

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -53,6 +53,7 @@ class EntriesField extends FieldClass
 
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
 	 */
 	public function fill(mixed $value): static
 	{

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -32,6 +32,7 @@ class LayoutField extends BlocksField
 
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
 	 */
 	public function fill(mixed $value): static
 	{

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,7 +30,10 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	public function fill(mixed $value = null): static
+	/**	
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
+	public function fill(mixed $value): static
 	{
 		$value   = Data::decode($value, type: 'json', fail: false);
 		$layouts = Layouts::factory($value, ['parent' => $this->model])->toArray();

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,7 +30,7 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	/**	
+	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 */
 	public function fill(mixed $value): static

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -33,7 +33,6 @@ abstract class FieldClass
 	protected string|null $after;
 	protected bool $autofocus;
 	protected string|null $before;
-	protected mixed $default;
 	protected bool $disabled;
 	protected string|null $help;
 	protected string|null $icon;
@@ -42,7 +41,6 @@ abstract class FieldClass
 	protected string|null $placeholder;
 	protected bool $required;
 	protected Fields $siblings;
-	protected mixed $value = null;
 	protected string|null $width;
 
 	public function __construct(
@@ -119,17 +117,6 @@ abstract class FieldClass
 	}
 
 	/**
-	 * Sets a new value for the field
-	 */
-	public function fill(mixed $value): static
-	{
-		$this->value = $value;
-		$this->errors = null;
-
-		return $this;
-	}
-
-	/**
 	 * Optional help text below the field
 	 */
 	public function help(): string|null
@@ -174,11 +161,6 @@ abstract class FieldClass
 	public function isRequired(): bool
 	{
 		return $this->required;
-	}
-
-	public function isSaveable(): bool
-	{
-		return true;
 	}
 
 	/**
@@ -250,15 +232,6 @@ abstract class FieldClass
 		return $this->required;
 	}
 
-	/**
-	 * Checks if the field is saveable
-	 * @deprecated 5.0.0 Use `::isSaveable()` instead
-	 */
-	public function save(): bool
-	{
-		return $this->isSaveable();
-	}
-
 	protected function setAfter(array|string|null $after = null): void
 	{
 		$this->after = $this->i18n($after);
@@ -272,11 +245,6 @@ abstract class FieldClass
 	protected function setBefore(array|string|null $before = null): void
 	{
 		$this->before = $this->i18n($before);
-	}
-
-	protected function setDefault(mixed $default = null): void
-	{
-		$this->default = $default;
 	}
 
 	protected function setDisabled(bool $disabled = false): void

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -39,7 +39,6 @@ abstract class FieldClass
 	protected string|null $label;
 	protected string|null $name;
 	protected string|null $placeholder;
-	protected bool $required;
 	protected Fields $siblings;
 	protected string|null $width;
 
@@ -158,11 +157,6 @@ abstract class FieldClass
 		return false;
 	}
 
-	public function isRequired(): bool
-	{
-		return $this->required;
-	}
-
 	/**
 	 * The field label can be set as string or associative array with translations
 	 */
@@ -224,14 +218,6 @@ abstract class FieldClass
 		];
 	}
 
-	/**
-	 * If `true`, the field has to be filled in correctly to be saved.
-	 */
-	public function required(): bool
-	{
-		return $this->required;
-	}
-
 	protected function setAfter(array|string|null $after = null): void
 	{
 		$this->after = $this->i18n($after);
@@ -275,11 +261,6 @@ abstract class FieldClass
 	protected function setPlaceholder(array|string|null $placeholder = null): void
 	{
 		$this->placeholder = $this->i18n($placeholder);
-	}
-
-	protected function setRequired(bool $required = false): void
-	{
-		$this->required = $required;
 	}
 
 	protected function setSiblings(Fields|null $siblings = null): void

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -66,6 +66,9 @@ trait Validation
 		return $this->required;
 	}
 
+	/**
+	 * @internal
+	 */
 	protected function setRequired(bool $required = false): void
 	{
 		$this->required = $required;

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -18,6 +18,8 @@ use Kirby\Toolkit\V;
  */
 trait Validation
 {
+	protected bool $required;
+
 	/**
 	 * An array of all found errors
 	 */
@@ -30,6 +32,14 @@ trait Validation
 	public function errors(): array
 	{
 		return $this->errors ??= $this->validate();
+	}
+
+	/**
+	 * Checks if the field is required
+	 */
+	public function isRequired(): bool
+	{
+		return $this->required;
 	}
 
 	/**
@@ -46,6 +56,19 @@ trait Validation
 	public function isValid(): bool
 	{
 		return $this->errors() === [];
+	}
+
+	/**
+	 * Getter for the required property
+	 */
+	public function required(): bool
+	{
+		return $this->required;
+	}
+
+	protected function setRequired(bool $required = false): void
+	{
+		$this->required = $required;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -100,6 +100,9 @@ trait Value
 		return $this->isSaveable();
 	}
 
+	/**
+	 * @internal
+	 */
 	protected function setDefault(mixed $default = null): void
 	{
 		$this->default = $default;

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -11,6 +11,9 @@ namespace Kirby\Form\Mixin;
  */
 trait Value
 {
+	protected mixed $default = null;
+	protected mixed $value = null;
+
 	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead
 	 */
@@ -32,6 +35,17 @@ trait Value
 	}
 
 	/**
+	 * Sets a new value for the field
+	 */
+	public function fill(mixed $value): static
+	{
+		$this->value = $value;
+		$this->errors = null;
+
+		return $this;
+	}
+
+	/**
 	 * Checks if the field is empty
 	 */
 	public function isEmpty(): bool
@@ -45,6 +59,14 @@ trait Value
 	public function isEmptyValue(mixed $value = null): bool
 	{
 		return in_array($value, [null, '', []], true);
+	}
+
+	/**
+	 * Checks if the field is saveable
+	 */
+	public function isSaveable(): bool
+	{
+		return true;
 	}
 
 	/**
@@ -67,6 +89,20 @@ trait Value
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if the field is saveable
+	 * @deprecated 5.0.0 Use `::isSaveable()` instead
+	 */
+	public function save(): bool
+	{
+		return $this->isSaveable();
+	}
+
+	protected function setDefault(mixed $default = null): void
+	{
+		$this->default = $default;
 	}
 
 	/**

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -220,7 +220,6 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertSame('test', $field->default());
-		$this->assertSame('test', $field->default);
 		$this->assertSame('test', $field->data(true));
 
 		// don't overwrite existing values
@@ -231,9 +230,7 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertSame('test', $field->default());
-		$this->assertSame('test', $field->default);
 		$this->assertSame('something', $field->value());
-		$this->assertSame('something', $field->value);
 		$this->assertSame('something', $field->data(true));
 
 		// with query
@@ -243,7 +240,6 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertSame('blog', $field->default());
-		$this->assertSame('blog', $field->default);
 		$this->assertSame('blog', $field->data(true));
 	}
 
@@ -384,13 +380,11 @@ class FieldTest extends TestCase
 		]);
 
 		$this->assertSame('test', $field->value());
-		$this->assertSame('test', $field->value);
 		$this->assertSame('test computed', $field->computedValue());
 
 		$field->fill('test2');
 
 		$this->assertSame('test2', $field->value());
-		$this->assertSame('test2', $field->value);
 		$this->assertSame('test2 computed', $field->computedValue());
 	}
 


### PR DESCRIPTION
## Description

Extracts improvements from https://github.com/getkirby/kirby/pull/7081

## Changelog

### Enhancements from previous betas

- Value-related methods and properties are now all moved to the Value mixin
- `Required` methods and properties are now moved to the Validation mixin
- `::fill()` is no longer setting a `null` default value, which makes no sense. 

### Breaking changes

The old Field class exposed all its properties publicly. This is leads to redundant options like: 
```php
$field->value  
$field->value()
```
We don't do this in other places and especially don't do it in the new `FieldClass`. By defining protected properties for $value and $default, they are no longer accessible publicly. It's technically a breaking change, but we've not documented this option at all anywhere. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
