### PR TITLE
New `::isSubmittable` method for `Field` and `FieldClass`

### DIFF
--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Cms\Language;
+
 /**
  * @package   Kirby Form
  * @author    Bastian Allgeier <bastian@getkirby.com>
@@ -67,6 +69,32 @@ trait Value
 	public function isEmptyValue(mixed $value = null): bool
 	{
 		return in_array($value, [null, '', []], true);
+	}
+
+	/**
+	 * A field might have a value, but can still not be submitted
+	 * because it is disabled, not translatable into the given
+	 * language or not active due to a `when` rule.
+	 */
+	public function isSubmittable(Language $language): bool
+	{
+		if ($this->hasValue() === false) {
+			return false;
+		}
+
+		if ($this->isDisabled() === true) {
+			return false;
+		}
+
+		if ($this->isTranslatable($language) === false) {
+			return false;
+		}
+
+		if ($this->isActive() === false) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -319,6 +319,75 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
+	public function testIsSubmittable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isSubmittable($language));
+
+		$field = new NoValueField();
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithDisabledField()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField(['disabled' => true]);
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithNonDefaultLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isSubmittable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithWhenQueryAndMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'b']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertTrue($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithWhenQueryAndNonMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'something-else']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertFalse($field->isSubmittable($language));
+	}
+
 	/**
 	 * @covers ::hasValue
 	 */


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7125

## Description

Extracts improvements from https://github.com/getkirby/kirby/pull/7081

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `::isSubmittable` method for `Field` and `FieldClass`

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
