### PR TITLE
New ::isStorable method for Field and FieldClass

### DIFF
--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -72,6 +72,29 @@ trait Value
 	}
 
 	/**
+	 * Checks if the field can be stored in the given language.
+	 */
+	public function isStorable(Language $language): bool
+	{
+		// the field cannot be stored at all if it has no value
+		if ($this->hasValue() === false) {
+			return false;
+		}
+
+		// the field cannot be translated into the given language
+		if ($this->isTranslatable($language) === false) {
+			return false;
+		}
+
+		// the field is hidden by a `when` rule
+		if ($this->isActive() === false) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * A field might have a value, but can still not be submitted
 	 * because it is disabled, not translatable into the given
 	 * language or not active due to a `when` rule.

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -91,6 +91,12 @@ trait Value
 			return false;
 		}
 
+		// We don't need to check if the field is disabled.
+		// A disabled field can still have a value and that value
+		// should still be stored. But that value must not be changed
+		// on submit. That's why we check for the disabled state
+		// in the isSubmittable method.
+
 		return true;
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -319,6 +319,75 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
+	public function testIsStorable()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField();
+		$this->assertTrue($field->isStorable($language));
+
+		$field = new NoValueField();
+		$this->assertFalse($field->isStorable($language));
+	}
+
+	public function testIsStorableWithDisabledField()
+	{
+		$language = Language::ensure('current');
+
+		$field = new TestField(['disabled' => true]);
+		$this->assertTrue($field->isStorable($language), 'The value of a storable field must not be changed on submit, but can still be stored.');
+	}
+
+	public function testIsStorableWithNonDefaultLanguage()
+	{
+		$language = new Language([
+			'code'    => 'de',
+			'default' => false
+		]);
+
+		$field = new TestField(['translate' => true]);
+		$this->assertTrue($field->isStorable($language));
+
+		$field = new TestField(['translate' => false]);
+		$this->assertFalse($field->isStorable($language));
+	}
+
+	public function testIsStorableWithWhenQueryAndMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'b']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertTrue($field->isStorable($language));
+	}
+
+	public function testIsStorableWithWhenQueryAndNonMatchingValue()
+	{
+		$language = Language::ensure('current');
+
+		$siblings = new Fields([
+			new TestField(['name' => 'a', 'value' => 'something-else']),
+		]);
+
+		$field = new TestField([
+			'siblings' => $siblings,
+			'when'     => [
+				'a' => 'b'
+			],
+		]);
+
+		$this->assertFalse($field->isStorable($language));
+	}
+
 	public function testIsSubmittable()
 	{
 		$language = Language::ensure('current');


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `::isStorable` method for Field and FieldClass

### Breaking changes

None

## Docs

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
