### PR TITLE
New Fields::$language property

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Closure;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
@@ -22,13 +23,18 @@ use Kirby\Toolkit\Str;
  */
 class Fields extends Collection
 {
+	protected Language $language;
+
 	public function __construct(
 		array $fields = [],
-		protected ModelWithContent|null $model = null
+		protected ModelWithContent|null $model = null,
+		Language|null $language = null
 	) {
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
 		}
+
+		$this->language = $language ?? Language::ensure('current');
 	}
 
 	/**
@@ -141,6 +147,14 @@ class Fields extends Collection
 		}
 
 		return $field;
+	}
+
+	/**
+	 * Returns the language of the fields
+	 */
+	public function language(): Language
+	{
+		return $this->language;
 	}
 
 	/**

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
@@ -223,6 +224,23 @@ class FieldsTest extends TestCase
 		], $this->model);
 
 		$this->assertNull($fields->find('mother+child'));
+	}
+
+	/**
+	 * @covers ::language
+	 */
+	public function testLanguage(): void
+	{
+		// no language passed = current language
+		$fields = new Fields();
+		$this->assertSame('en', $fields->language()->code());
+		$this->assertTrue($fields->language()->isDefault());
+
+		// language passed
+		$language = new Language(['code' => 'de']);
+		$fields = new Fields(fields: [], language: $language);
+		$this->assertSame('de', $fields->language()->code());
+		$this->assertFalse($fields->language()->isDefault());
 	}
 
 	/**


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Fields::$language` property, which is needed to render and submit fields correctly.

### Breaking changes

None

## Docs

```php
$fields = new Fields(
  fields: [...],
  model: $page,
  language: $kirby->language('de')
);
```

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
