### PR TITLE
New `::submit` method for fields

### DIFF
--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -137,6 +137,20 @@ trait Value
 	}
 
 	/**
+	 * Submits a new value for the field.
+	 * Fields can overwrite this method to provide custom
+	 * submit logic. This is useful if the field component
+	 * sends data that needs to be processed before being
+	 * stored.
+	 *
+	 * @since 5.0.0
+	 */
+	public function submit(mixed $value): static
+	{
+		return $this->fill($value);
+	}
+
+	/**
 	 * Returns the value of the field in a format to be used in forms
 	 * (e.g. used as data for Panel Vue components)
 	 */

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -622,6 +622,17 @@ class FieldClassTest extends TestCase
 	}
 
 	/**
+	 * @covers ::submit
+	 */
+	public function testSubmit(): void
+	{
+		$field = new TestField();
+		$this->assertNull($field->value());
+		$field->submit('Test value');
+		$this->assertSame('Test value', $field->value());
+	}
+
+	/**
 	 * @covers ::toStoredValue
 	 */
 	public function testToStoredValue()

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -1058,6 +1058,26 @@ class FieldTest extends TestCase
 	}
 
 	/**
+	 * @covers ::submit
+	 */
+	public function testSubmit(): void
+	{
+		Field::$types = [
+			'test' => []
+		];
+
+		$field = new Field('test', [
+			'model' => new Page(['slug' => 'test']),
+			'value' => 'test'
+		]);
+
+		$this->assertSame('test', $field->value());
+
+		$field->submit('test2');
+		$this->assertSame('test2', $field->value());
+	}
+
+	/**
 	 * @covers ::toArray
 	 */
 	public function testToArray()


### PR DESCRIPTION
## Changelog

### Enhancements

- New `::submit` for fields to be used when a form is submitted in a request. `::fill()` is now only responsible for providing the values that the form should have on render.

### Breaking changes

None

## Docs

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
