### PR TITLE
Remove the error property cache for fields

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -285,9 +285,6 @@ class Field extends Component
 		// reevaluate the computed props
 		$this->applyComputed($this->options['computed'] ?? []);
 
-		// reset the errors cache
-		$this->errors = null;
-
 		// restore the original state
 		$this->attrs   = $attrs;
 		$this->methods = $methods;

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -113,8 +113,7 @@ class BlocksField extends FieldClass
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();
-		$this->value  = $this->blocksToValues($blocks);
-		$this->errors = null;
+		$this->value = $this->blocksToValues($blocks);
 
 		return $this;
 	}

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -49,8 +49,7 @@ class LayoutField extends BlocksField
 			}
 		}
 
-		$this->value  = $layouts;
-		$this->errors = null;
+		$this->value = $layouts;
 
 		return $this;
 	}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -22,13 +22,6 @@ use Kirby\Toolkit\Str;
  */
 class Fields extends Collection
 {
-	/**
-	 * Cache for the errors array
-	 *
-	 * @var array<string, array<string, string>>|null
-	 */
-	protected array|null $errors = null;
-
 	public function __construct(
 		array $fields = [],
 		protected ModelWithContent|null $model = null
@@ -55,9 +48,6 @@ class Fields extends Collection
 		}
 
 		parent::__set($field->name(), $field);
-
-		// reset the errors cache if new fields are added
-		$this->errors = null;
 	}
 
 	/**
@@ -73,24 +63,20 @@ class Fields extends Collection
 	 */
 	public function errors(): array
 	{
-		if ($this->errors !== null) {
-			return $this->errors; // @codeCoverageIgnore
-		}
-
-		$this->errors = [];
+		$errors = [];
 
 		foreach ($this->data as $name => $field) {
-			$errors = $field->errors();
+			$fieldErrors = $field->errors();
 
-			if ($errors !== []) {
-				$this->errors[$name] = [
+			if ($fieldErrors !== []) {
+				$errors[$name] = [
 					'label'   => $field->label(),
-					'message' => $errors
+					'message' => $fieldErrors
 				];
 			}
 		}
 
-		return $this->errors;
+		return $errors;
 	}
 
 	/**
@@ -101,9 +87,6 @@ class Fields extends Collection
 		foreach ($input as $name => $value) {
 			$this->get($name)?->fill($value);
 		}
-
-		// reset the errors cache
-		$this->errors = null;
 
 		return $this;
 	}

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -21,63 +21,10 @@ trait Validation
 	protected bool $required;
 
 	/**
-	 * An array of all found errors
-	 */
-	protected array|null $errors = null;
-
-	/**
 	 * Runs all validations and returns an array of
 	 * error messages
 	 */
 	public function errors(): array
-	{
-		return $this->errors ??= $this->validate();
-	}
-
-	/**
-	 * Checks if the field is required
-	 */
-	public function isRequired(): bool
-	{
-		return $this->required;
-	}
-
-	/**
-	 * Checks if the field is invalid
-	 */
-	public function isInvalid(): bool
-	{
-		return $this->isValid() === false;
-	}
-
-	/**
-	 * Checks if the field is valid
-	 */
-	public function isValid(): bool
-	{
-		return $this->errors() === [];
-	}
-
-	/**
-	 * Getter for the required property
-	 */
-	public function required(): bool
-	{
-		return $this->required;
-	}
-
-	/**
-	 * @internal
-	 */
-	protected function setRequired(bool $required = false): void
-	{
-		$this->required = $required;
-	}
-
-	/**
-	 * Runs the validations defined for the field
-	 */
-	protected function validate(): array
 	{
 		$validations = $this->validations();
 		$value       = $this->value();
@@ -121,6 +68,46 @@ trait Validation
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * Checks if the field is required
+	 */
+	public function isRequired(): bool
+	{
+		return $this->required;
+	}
+
+	/**
+	 * Checks if the field is invalid
+	 */
+	public function isInvalid(): bool
+	{
+		return $this->errors() !== [];
+	}
+
+	/**
+	 * Checks if the field is valid
+	 */
+	public function isValid(): bool
+	{
+		return $this->errors() === [];
+	}
+
+	/**
+	 * Getter for the required property
+	 */
+	public function required(): bool
+	{
+		return $this->required;
+	}
+
+	/**
+	 * @internal
+	 */
+	protected function setRequired(bool $required = false): void
+	{
+		$this->required = $required;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -42,8 +42,6 @@ trait Value
 	public function fill(mixed $value): static
 	{
 		$this->value = $value;
-		$this->errors = null;
-
 		return $this;
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -192,7 +192,6 @@ class FieldClassTest extends TestCase
 
 	/**
 	 * @covers ::errors
-	 * @covers ::validate
 	 * @covers ::validations
 	 */
 	public function testErrors()

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -1168,7 +1168,6 @@ class FieldTest extends TestCase
 	}
 
 	/**
-	 * @covers ::validate
 	 * @covers ::validations
 	 * @covers ::errors
 	 */
@@ -1223,7 +1222,6 @@ class FieldTest extends TestCase
 	}
 
 	/**
-	 * @covers ::validate
 	 * @covers ::validations
 	 * @covers ::isValid
 	 */
@@ -1283,7 +1281,6 @@ class FieldTest extends TestCase
 	}
 
 	/**
-	 * @covers ::validate
 	 * @covers ::validations
 	 * @covers ::errors
 	 * @covers ::isValid


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring 

- Removed the error property cache in the fields and field classes. This simplifies the `:fill` methods and will make them easier to extend without creating unintended issues - when forgetting to unset the error cache. The refactored form code will lead to less situations where we need to cache errors at all. Validation happens when the form is submitted and we can only run it once there and get all the errors in a single call without additional caching. This will also prevent issues with an outdated error cache in general. Removing the protected `::validate` method will also make it possbible to introduce a new public `::validate` method later, which will have the same behavior as the `Fields::validate()` method and throw an exception if there are any field errors. This will clean up the code even more and bring Fields and Field classes closer together. 

### Breaking changes

- Removed `Fields::$errors`, `Field::$errors` and `FieldClass::$errors`

## Docs

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
