### PR TITLE
Refactor language handling in the Form class

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -64,7 +64,8 @@ class Form
 		unset($inject['fields'], $inject['values'], $inject['input']);
 
 		$this->fields = new Fields(
-			model: $model
+			model: $model,
+			language: $language
 		);
 
 		$this->values = [];

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -3,8 +3,8 @@
 namespace Kirby\Form;
 
 use Closure;
-use Kirby\Cms\App;
 use Kirby\Cms\File;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;
 use Kirby\Exception\NotFoundException;
@@ -48,10 +48,13 @@ class Form
 		$strict = $props['strict'] ?? false;
 		$inject = $props;
 
+		// get the language for the form
+		$language = Language::ensure($props['language'] ?? 'current');
+
 		// prepare field properties for multilang setups
 		$fields = static::prepareFieldsForLanguage(
 			$fields,
-			$props['language'] ?? null
+			$language
 		);
 
 		// lowercase all value names
@@ -231,24 +234,17 @@ class Form
 	 */
 	protected static function prepareFieldsForLanguage(
 		array $fields,
-		string|null $language = null
+		Language $language
 	): array {
-		$kirby = App::instance(null, true);
-
-		// only modify the fields if we have a valid Kirby multilang instance
-		if ($kirby?->multilang() !== true) {
+		if ($language->isDefault() === true) {
 			return $fields;
 		}
 
-		$language ??= $kirby->language()->code();
-
-		if ($language !== $kirby->defaultLanguage()->code()) {
-			foreach ($fields as $fieldName => $fieldProps) {
-				// switch untranslatable fields to readonly
-				if (($fieldProps['translate'] ?? true) === false) {
-					$fields[$fieldName]['unset']    = true;
-					$fields[$fieldName]['disabled'] = true;
-				}
+		foreach ($fields as $fieldName => $fieldProps) {
+			// switch untranslatable fields to readonly
+			if (($fieldProps['translate'] ?? true) === false) {
+				$fields[$fieldName]['unset']    = true;
+				$fields[$fieldName]['disabled'] = true;
 			}
 		}
 


### PR DESCRIPTION
## Merge first 

- https://github.com/getkirby/kirby/pull/7129

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Refactor language handling in the Form class with the new Language::ensure method.

### Breaking changes

- The language argument in the protected internal Form::prepareForLanguage method is no longer optional and must be a Language object.

## Docs 

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
