### PR TITLE
New Fields::toProps method

### DIFF
--- a/config/sections/fields.php
+++ b/config/sections/fields.php
@@ -1,7 +1,5 @@
 <?php
 
-use Kirby\Cms\Page;
-use Kirby\Cms\Site;
 use Kirby\Form\Form;
 
 return [
@@ -12,41 +10,16 @@ return [
 	],
 	'computed' => [
 		'form' => function () {
-			$fields   = $this->fields;
-			$disabled = $this->model->permissions()->cannot('update');
-			$lang     = $this->model->kirby()->languageCode();
-			$content  = $this->model->content($lang)->toArray();
-
-			if ($disabled === true) {
-				foreach ($fields as $key => $props) {
-					$fields[$key]['disabled'] = true;
-				}
-			}
-
 			return new Form([
-				'fields' => $fields,
-				'values' => $content,
-				'model'  => $this->model,
-				'strict' => true
+				'fields'   => $this->fields,
+				'values'   => $this->model->content('current')->toArray(),
+				'model'    => $this->model,
+				'language' => 'current',
+				'strict'   => true
 			]);
 		},
 		'fields' => function () {
-			$fields = $this->form->fields()->toArray();
-
-			if (
-				$this->model instanceof Page ||
-				$this->model instanceof Site
-			) {
-				// the title should never be updated directly via
-				// fields section to avoid conflicts with the rename dialog
-				unset($fields['title']);
-			}
-
-			foreach ($fields as $index => $props) {
-				unset($fields[$index]['value']);
-			}
-
-			return $fields;
+			return $this->form->fields()->toProps();
 		}
 	],
 	'methods' => [

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -201,10 +201,16 @@ class Fields extends Collection
 		foreach ($fields as $name => $field) {
 			$props[$name] = $field->toArray();
 
+			// the field should be disabled in the form if the user
+			// has no update permissions for the model or if the field
+			// is not translatable into the current language
 			if ($permissions === false || $field->isTranslatable($language) === false) {
 				$props[$name]['disabled'] = true;
 			}
 
+			// the value should not be included in the props
+			// we pass on the values to the frontend via the model
+			// view props to make them globally available for the view.
 			unset($props[$name]['value']);
 		}
 


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7129
- [x] https://github.com/getkirby/kirby/pull/7132

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Fields::toProps()` method, which will deliver all the required properties for the Panel forms. The permission and language title skipping logic from the fields section has been moved into this method and the fields section has been refactored. 

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

To get the props for the frontend components, we can use the `toProps` method. The set language in the Fields constructor is used to disable fields that cannot be translated into the current language. The method also checks update permissions to disable all fields if the current user does not have permissions. 

```php
$fields = new Fields(
  fields: [
    'text' => [
      'type' => 'text'
    ]
  ],
  model: $page,
  language: $kirby->language('de')
);

$fields->toProps();
```

Full docs for all Form changes: https://www.notion.so/getkirby/Fields-docs-1c359ef0a5cb805189b5ffdc7fa54e0b

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
