### PR TITLE
Remove $defaults argument from form methods wherever possible

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -395,9 +395,9 @@ class Field extends Component
 	/**
 	 * Returns the value of the field in a format to be stored by our storage classes
 	 */
-	public function toStoredValue(bool $default = false): mixed
+	public function toStoredValue(): mixed
 	{
-		$value = $this->value($default);
+		$value = $this->toFormValue();
 		$store = $this->options['save'] ?? true;
 
 		if ($store === false) {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -167,8 +167,10 @@ class Fields extends Collection
 	 */
 	public function passthrough(array $values = []): static
 	{
+		// always start with a fresh set of passthrough values
+		$this->passthrough = [];
+
 		if ($values === []) {
-			$this->passthrough = [];
 			return $this;
 		}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -173,9 +173,9 @@ class Fields extends Collection
 	 * Returns an array with the form value of each field
 	 * (e.g. used as data for Panel Vue components)
 	 */
-	public function toFormValues(bool $defaults = false): array
+	public function toFormValues(): array
 	{
-		return $this->toArray(fn ($field) => $field->toFormValue($defaults));
+		return $this->toArray(fn ($field) => $field->toFormValue());
 	}
 
 	/**
@@ -221,9 +221,9 @@ class Fields extends Collection
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
 	 */
-	public function toStoredValues(bool $defaults = false): array
+	public function toStoredValues(): array
 	{
-		return $this->toArray(fn ($field) => $field->toStoredValue($defaults));
+		return $this->toArray(fn ($field) => $field->toStoredValue());
 	}
 
 	/**

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -26,7 +26,7 @@ use Kirby\Toolkit\Str;
 class Fields extends Collection
 {
 	protected Language $language;
-	protected array $passthrough = []; 
+	protected array $passthrough = [];
 
 	public function __construct(
 		array $fields = [],
@@ -178,8 +178,8 @@ class Fields extends Collection
 			if ($this->get(strtolower($key)) !== null) {
 				continue;
 			}
-			
-			$this->passthrough[$key] = $value;			
+
+			$this->passthrough[$key] = $value;
 		}
 
 		return $this;
@@ -252,7 +252,7 @@ class Fields extends Collection
 		return $this->toValues('toStoredValue');
 	}
 
-	/** 
+	/**
 	 * Returns an array with the values of each field
 	 * and adds passthrough values if they don't exist
 	 * @internal
@@ -262,7 +262,7 @@ class Fields extends Collection
 		$values = $this->toArray(fn ($field) => $field->{$method}());
 
 		foreach ($this->passthrough as $key => $value) {
-			if (isset($values[$key]) === false) {	
+			if (isset($values[$key]) === false) {
 				$values[$key] = $value;
 			}
 		}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -26,6 +26,7 @@ use Kirby\Toolkit\Str;
 class Fields extends Collection
 {
 	protected Language $language;
+	protected array $passthrough = []; 
 
 	public function __construct(
 		array $fields = [],
@@ -160,6 +161,31 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Adds values to the passthrough array
+	 * which will be added to the form data
+	 * if the field does not exist
+	 */
+	public function passthrough(array $values = []): static
+	{
+		if ($values === []) {
+			$this->passthrough = [];
+			return $this;
+		}
+
+		foreach ($values as $key => $value) {
+			// check if the field exists and don't passthrough
+			// values for existing fields
+			if ($this->get(strtolower($key)) !== null) {
+				continue;
+			}
+			
+			$this->passthrough[$key] = $value;			
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Converts the fields collection to an
 	 * array and also does that for every
 	 * included field.
@@ -175,7 +201,7 @@ class Fields extends Collection
 	 */
 	public function toFormValues(): array
 	{
-		return $this->toArray(fn ($field) => $field->toFormValue());
+		return $this->toValues('toFormValue');
 	}
 
 	/**
@@ -223,7 +249,25 @@ class Fields extends Collection
 	 */
 	public function toStoredValues(): array
 	{
-		return $this->toArray(fn ($field) => $field->toStoredValue());
+		return $this->toValues('toStoredValue');
+	}
+
+	/** 
+	 * Returns an array with the values of each field
+	 * and adds passthrough values if they don't exist
+	 * @internal
+	 */
+	protected function toValues(string $method): array
+	{
+		$values = $this->toArray(fn ($field) => $field->{$method}());
+
+		foreach ($this->passthrough as $key => $value) {
+			if (isset($values[$key]) === false) {	
+				$values[$key] = $value;
+			}
+		}
+
+		return $values;
 	}
 
 	/**

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -203,7 +203,7 @@ class Fields extends Collection
 	 */
 	public function toFormValues(): array
 	{
-		return $this->toValues('toFormValue');
+		return $this->toValues(fn ($field) => $field->toFormValue());
 	}
 
 	/**
@@ -251,7 +251,7 @@ class Fields extends Collection
 	 */
 	public function toStoredValues(): array
 	{
-		return $this->toValues('toStoredValue');
+		return $this->toValues(fn ($field) => $field->toStoredValue());
 	}
 
 	/**
@@ -259,9 +259,9 @@ class Fields extends Collection
 	 * and adds passthrough values if they don't exist
 	 * @internal
 	 */
-	protected function toValues(string $method): array
+	protected function toValues(Closure $method): array
 	{
-		$values = $this->toArray(fn ($field) => $field->{$method}());
+		$values = $this->toArray($method);
 
 		foreach ($this->passthrough as $key => $value) {
 			if (isset($values[$key]) === false) {

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -137,7 +137,7 @@ class Form
 					unset($data[$field->name()]);
 				}
 			} else {
-				$data[$field->name()] = $field->toStoredValue($defaults);
+				$data[$field->name()] = $field->data($defaults);
 			}
 		}
 
@@ -284,18 +284,18 @@ class Form
 	 * Returns an array with the form value of each field
 	 * (e.g. used as data for Panel Vue components)
 	 */
-	public function toFormValues(bool $defaults = false): array
+	public function toFormValues(): array
 	{
-		return $this->fields->toFormValues($defaults);
+		return $this->fields->toFormValues();
 	}
 
 	/**
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
 	 */
-	public function toStoredValues(bool $defaults = false): array
+	public function toStoredValues(): array
 	{
-		return $this->fields->toStoredValues($defaults);
+		return $this->fields->toStoredValues();
 	}
 
 	/**

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -137,7 +137,11 @@ class Form
 					unset($data[$field->name()]);
 				}
 			} else {
-				$data[$field->name()] = $field->data($defaults);
+				if ($defaults === true && $field->isEmpty() === true) {
+					$field->fill($field->default());
+				}
+
+				$data[$field->name()] = $field->toStoredValue();
 			}
 		}
 

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -17,7 +17,11 @@ trait Value
 	protected mixed $value = null;
 
 	/**
-	 * @deprecated 5.0.0 Use `::toStoredValue()` instead
+	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
+	 * the value in the format that will be needed for content files.
+	 *
+	 * If you need to get the value with the default as fallback, you should use
+	 * the fill method first `$field->fill($field->default())->toStoredValue()`
 	 */
 	public function data(bool $default = false): mixed
 	{
@@ -209,6 +213,9 @@ trait Value
 	 *
 	 * @see `self::toFormValue()`
 	 * @todo might get deprecated or reused later. Use `self::toFormValue()` instead.
+	 *
+	 * If you need the form value with the default as fallback, you should use
+	 * the fill method first `$field->fill($field->default())->toFormValue()`
 	 */
 	public function value(bool $default = false): mixed
 	{

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -21,7 +21,11 @@ trait Value
 	 */
 	public function data(bool $default = false): mixed
 	{
-		return $this->toStoredValue($default);
+		if ($default === true && $this->isEmpty() === true) {
+			$this->fill($this->default());
+		}
+
+		return $this->toStoredValue();
 	}
 
 	/**
@@ -181,14 +185,10 @@ trait Value
 	 * Returns the value of the field in a format to be used in forms
 	 * (e.g. used as data for Panel Vue components)
 	 */
-	public function toFormValue(bool $default = false): mixed
+	public function toFormValue(): mixed
 	{
 		if ($this->hasValue() === false) {
 			return null;
-		}
-
-		if ($default === true && $this->isEmpty() === true) {
-			return $this->default();
 		}
 
 		return $this->value;
@@ -198,9 +198,9 @@ trait Value
 	 * Returns the value of the field in a format
 	 * to be stored by our storage classes
 	 */
-	public function toStoredValue(bool $default = false): mixed
+	public function toStoredValue(): mixed
 	{
-		return $this->toFormValue($default);
+		return $this->toFormValue();
 	}
 
 	/**
@@ -208,10 +208,14 @@ trait Value
 	 * otherwise it returns null
 	 *
 	 * @see `self::toFormValue()`
-	 * @todo might get deprecated or reused later
+	 * @todo might get deprecated or reused later. Use `self::toFormValue()` instead.
 	 */
 	public function value(bool $default = false): mixed
 	{
-		return $this->toFormValue($default);
+		if ($default === true && $this->isEmpty() === true) {
+			$this->fill($this->default());
+		}
+
+		return $this->toFormValue();
 	}
 }

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -1126,7 +1126,6 @@ class FieldTest extends TestCase
 		$this->assertNull($field->value());
 
 		$field = new Field('test', ['default' => 'Default value']);
-		$this->assertSame('Default value', $field->toFormValue(true));
 		$this->assertSame('Default value', $field->value(true));
 
 		Field::$types['test'] = [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -259,6 +259,31 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testPassthroughWithExistingPassthroughValues(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'a'
+			],
+		], $this->model);
+
+		// add passthrough values
+		$fields->passthrough([
+			'b' => 'B',
+		]);
+
+		// replace passthrough values
+		$fields->passthrough([
+			'c' => 'C'
+		]);
+
+		$this->assertSame([
+			'a' => 'a',
+			'c' => 'C'
+		], $fields->toFormValues());
+	}
+
 	public function testPassthroughWithEmptyArray(): void
 	{
 		$fields = new Fields([

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -11,10 +11,10 @@ use Kirby\Cms\Site;
 use Kirby\Cms\TestCase;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Form\Fields
- */
+#[CoversClass(Fields::class)]
 class FieldsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Form.Fields';
@@ -32,9 +32,6 @@ class FieldsTest extends TestCase
 		$this->model = new Page(['slug' => 'test']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct()
 	{
 		$fields = new Fields([
@@ -52,9 +49,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructWithModel()
 	{
 		$fields = new Fields([
@@ -72,9 +66,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
 	public function testDefaults()
 	{
 		$fields = new Fields([
@@ -91,9 +82,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->defaults());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
 	public function testErrors()
 	{
 		$fields = new Fields([
@@ -139,9 +127,6 @@ class FieldsTest extends TestCase
 		], $fields->errors());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
 	public function testErrorsWithoutErrors()
 	{
 		$fields = new Fields([
@@ -156,9 +141,6 @@ class FieldsTest extends TestCase
 		$this->assertSame([], $fields->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
 	public function testFill()
 	{
 		$fields = new Fields([
@@ -185,10 +167,6 @@ class FieldsTest extends TestCase
 		$this->assertSame($input, $fields->toArray(fn ($field) => $field->value()));
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByKeyRecursive
-	 */
 	public function testFind()
 	{
 		Field::$types['test'] = [
@@ -217,10 +195,6 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+missing-child'));
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByKeyRecursive
-	 */
 	public function testFindWhenFieldHasNoForm()
 	{
 		$fields = new Fields([
@@ -232,9 +206,6 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+child'));
 	}
 
-	/**
-	 * @covers ::language
-	 */
 	public function testLanguage(): void
 	{
 		// no language passed = current language
@@ -249,9 +220,67 @@ class FieldsTest extends TestCase
 		$this->assertFalse($fields->language()->isDefault());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
+	public function testPassthrough(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'a'
+			],
+		], $this->model);
+
+		$fields->passthrough([
+			'b' => 'B',
+		]);
+
+		$this->assertSame([
+			'a' => 'a',
+			'b' => 'B'
+		], $fields->toFormValues());
+	}
+
+	public function testPassthroughWithExistingField(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'a'
+			],
+		], $this->model);
+
+		$fields->passthrough([
+			'a' => 'A', // should be ignored
+			'b' => 'B',
+		]);
+
+		$this->assertSame([
+			'a' => 'a',
+			'b' => 'B'
+		], $fields->toFormValues());
+	}
+
+	public function testPassthroughWithEmptyArray(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'a'
+			],
+		], $this->model);
+
+		// add passthrough values
+		$fields->passthrough([
+			'b' => 'B',
+		]);
+
+		// remove passthrough values
+		$fields->passthrough();
+
+		$this->assertSame([
+			'a' => 'a',
+		], $fields->toFormValues());
+	}
+
 	public function testToArray()
 	{
 		$fields = new Fields([
@@ -266,9 +295,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn ($field) => $field->name()));
 	}
 
-	/**
-	 * @covers ::toFormValues
-	 */
 	public function testToFormValues()
 	{
 		$fields = new Fields([
@@ -285,9 +311,6 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'Value a', 'b' => 'Value b'], $fields->toFormValues());
 	}
 
-	/**
-	 * @covers ::toProps
-	 */
 	public function testToProps(): void
 	{
 		$this->setUpSingleLanguage();
@@ -331,10 +354,7 @@ class FieldsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::toProps
-	 * @dataProvider modelProvider
-	 */
+	#[DataProvider('modelProvider')]
 	public function testToPropsWithSkippedTitleFieldForPage(ModelWithContent $model, bool $skip): void
 	{
 		$this->setUpSingleLanguage();
@@ -363,9 +383,6 @@ class FieldsTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::toProps
-	 */
 	public function testToPropsWithoutUpdatePermission(): void
 	{
 		$this->setUpSingleLanguage();
@@ -383,9 +400,6 @@ class FieldsTest extends TestCase
 		$this->assertTrue($fields->toProps()['a']['disabled']);
 	}
 
-	/**
-	 * @covers ::toProps
-	 */
 	public function testToPropsForNonTranslatableField(): void
 	{
 		$this->setUpMultiLanguage();
@@ -416,9 +430,6 @@ class FieldsTest extends TestCase
 		$this->assertTrue($props['b']['translate']);
 	}
 
-	/**
-	 * @covers ::toStoredValues
-	 */
 	public function testToStoredValues()
 	{
 		Field::$types['test'] = [


### PR DESCRIPTION
## Changelog

### Refactoring from previous betas

- Remove `$defaults` argument from form and field methods wherever possible, to clean up default value handling
  - Removed from `Field::toFormValue`
  - Removed from `Field::toStoredValue`
  - Removed from `FieldClass::toFormValue`
  - Removed from `FieldClass::toStoredValue`
  - Removed from `Fields::toFormValues`  
  - Removed from `Fields::toStoredValues`  
  - Removed from `Form::toFormValues`  
  - Removed from `Form::toStoredValues`  

### Breaking changes

None. The `toForm...` and `toStored...` methods didn't exist in v4.

## Reasoning

Removing the $defaults argument significantly simplifies the methods and makes them a lot easier to extend. Especially for custom fields. They can now focus on how values need to be transformed on fill or submit. It's also clearer to use the `$fields->defaults()` method in form setups and removes some of the magic behind filling in defaults. 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Filling fields with defaults

```php
$fields = new Fields(
  fields: [
    'a' => [
      'default' => 'Some default value',
      'type'    => 'text'
    ], 
    'b' => [
	    'type' => 'text',
    ]
  ],
  model: $page  
);

$fields->fill($fields->defaults());

// fill in additional values afterwards to overwrite defaults
$fields->fill([
  'b' => 'A value for the field without default'
]);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
