### PR TITLE
New Fields::submit and improved Fields::fill

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -188,6 +188,41 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Sets the value for each field with a matching key in the input array
+	 * but only if the field is not disabled
+	 * @since 5.0.0
+	 */
+	public function submit(
+		array $input
+	): static {
+		$language = $this->language();
+
+		foreach ($input as $name => $value) {
+			if (!$field = $this->get($name)) {
+				continue;
+			}
+
+			// don't change the value of non-submittable fields
+			if ($field->isSubmittable($language) === false) {
+				continue;
+			}
+
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($field->value());
+			}
+
+			// submit the value to the field
+			// the field class might override this method
+			// to handle submitted values differently
+			$field->submit($value);
+		}
+
+		// reset the errors cache
+		return $this;
+	}
+
+	/**
 	 * Converts the fields collection to an
 	 * array and also does that for every
 	 * included field.

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -94,7 +94,21 @@ class Fields extends Collection
 	public function fill(array $input): static
 	{
 		foreach ($input as $name => $value) {
-			$this->get($name)?->fill($value);
+			if (!$field = $this->get($name)) {
+				continue;
+			}
+
+			// don't change the value of non-value field
+			if ($field->hasValue() === false) {
+				continue;
+			}
+
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($field->toFormValue());
+			}
+
+			$field->fill($value);
 		}
 
 		return $this;

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -223,7 +223,7 @@ class Fields extends Collection
 
 			// resolve closure values
 			if ($value instanceof Closure) {
-				$value = $value($field->value());
+				$value = $value($field->toFormValue());
 			}
 
 			// submit the value to the field

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -252,7 +252,10 @@ class Fields extends Collection
 	 */
 	public function toFormValues(): array
 	{
-		return $this->toValues(fn ($field) => $field->toFormValue());
+		return $this->toValues(
+			fn ($field) => $field->toFormValue(),
+			fn ($field) => $field->hasValue()
+		);
 	}
 
 	/**
@@ -300,7 +303,10 @@ class Fields extends Collection
 	 */
 	public function toStoredValues(): array
 	{
-		return $this->toValues(fn ($field) => $field->toStoredValue());
+		return $this->toValues(
+			fn ($field) => $field->toStoredValue(),
+			fn ($field) => $field->isStorable($this->language())
+		);
 	}
 
 	/**
@@ -308,9 +314,9 @@ class Fields extends Collection
 	 * and adds passthrough values if they don't exist
 	 * @internal
 	 */
-	protected function toValues(Closure $method): array
+	protected function toValues(Closure $method, Closure $filter): array
 	{
-		$values = $this->toArray($method);
+		$values = $this->filter($filter)->toArray($method);
 
 		foreach ($this->passthrough as $key => $value) {
 			if (isset($values[$key]) === false) {

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -167,6 +167,82 @@ class FieldsTest extends TestCase
 		$this->assertSame($input, $fields->toArray(fn ($field) => $field->value()));
 	}
 
+	public function testFillWithClosureValues(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A'
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->fill([
+			'a' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated'
+		], $fields->toFormValues());
+	}
+
+	public function testFillWithNoValueField(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'info',
+				],
+				'b' => [
+					'type' => 'text',
+				]
+			],
+			model: $this->model
+		);
+
+		$fields->fill([
+			'a' => 'A',
+			'b' => 'B'
+		]);
+
+		$this->assertSame([
+			'a' => null,
+			'b' => 'B',
+		], $fields->toFormValues());
+	}
+
+	public function testFillWithUnknownFields(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				],
+			],
+			model: $this->model
+		);
+
+		$input = [
+			'a' => 'A',
+			'b' => 'B',
+		];
+
+		$fields->fill($input);
+
+		$this->assertSame([
+			'a' => 'A',
+		], $fields->toFormValues(), 'Unknown fields are not included');
+
+		$fields->passthrough($input)->fill($input);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B'
+		], $fields->toFormValues(), 'Unknown fields are included');
+	}
+
 	public function testFind()
 	{
 		Field::$types['test'] = [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -306,6 +306,111 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testSubmit(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A',
+				],
+				'b' => [
+					'type'  => 'text',
+					'value' => 'B',
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->submit([
+			'a' => 'A updated',
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated',
+			'b' => 'B',
+		], $fields->toStoredValues());
+	}
+
+	public function testSubmitWithClosureValues(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A',
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->submit([
+			'a' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated'
+		], $fields->toStoredValues());
+	}
+
+	public function testSubmitWithDisabledField(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A',
+				],
+				'b' => [
+					'type'     => 'text',
+					'disabled' => true,
+					'value'    => 'B',
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->submit([
+			'a' => 'A updated',
+			'b' => 'B updated',
+		]);
+
+		$this->assertSame([
+			'a' => 'A updated',
+			'b' => 'B'
+		], $fields->toStoredValues());
+	}
+
+	public function testSubmitWithPassthrough(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				],
+			],
+			model: $this->model
+		);
+
+		$input = [
+			'a' => 'A',
+			'b' => 'B',
+		];
+
+		$fields->submit($input);
+
+		$this->assertSame([
+			'a' => 'A',
+		], $fields->toStoredValues(), 'Unknown fields are not included');
+
+		$fields->passthrough($input)->submit($input);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B'
+		], $fields->toStoredValues(), 'Unknown fields are included');
+	}
+
 	public function testToArray()
 	{
 		$fields = new Fields([

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -208,7 +208,6 @@ class FieldsTest extends TestCase
 		]);
 
 		$this->assertSame([
-			'a' => null,
 			'b' => 'B',
 		], $fields->toFormValues());
 	}
@@ -517,6 +516,27 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'Value a', 'b' => 'Value b'], $fields->toFormValues());
 	}
 
+	public function testToFormValuesWithNonValueField(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type' => 'info',
+			],
+			'b' => [
+				'type' => 'text',
+			],
+		], $this->model);
+
+		$fields->fill([
+			'a' => 'Value a',
+			'b' => 'Value b',
+		]);
+
+		$this->assertSame([
+			'b' => 'Value b',
+		], $fields->toFormValues());
+	}
+
 	public function testToProps(): void
 	{
 		$this->setUpSingleLanguage();
@@ -657,6 +677,27 @@ class FieldsTest extends TestCase
 
 		$this->assertSame(['a' => 'Value a', 'b' => 'Value b'], $fields->toFormValues());
 		$this->assertSame(['a' => 'Value a stored', 'b' => 'Value b stored'], $fields->toStoredValues());
+	}
+
+	public function testToStoredValuesWithNonValueField(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type' => 'info',
+			],
+			'b' => [
+				'type' => 'text',
+			],
+		], $this->model);
+
+		$fields->fill([
+			'a' => 'Value a',
+			'b' => 'Value b',
+		]);
+
+		$this->assertSame([
+			'b' => 'Value b',
+		], $fields->toStoredValues());
 	}
 
 	public function testValidate(): void


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7134
- [x]  https://github.com/getkirby/kirby/pull/7135

## Changelog

### Enhancements

- New `Fields::submit($input)` method
- `Fields::toStoredValues()` and `Fields::toFormValues()` skip non-storable (toStoredValues) fields and fields without value (toFormValues)
- `Fields::fill()` and `Fields::submit()` can now handle closure values. 

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Submitting values

```php
$fields = new Fields(
  fields: [
    'text' => [
      'type' => 'text'
    ]
  ],
  model: $page  
);

$fields->submit([
  'text' => 'Some text',
]);
```

### Submitting closure values

```php
$fields = new Fields(
  fields: [
    'text' => [
      'type'  => 'text', 
      'value' => 'Text'
    ]
  ],
  model: $page  
);

$fields->submit([
  'text' => function ($value) {
    return 'Modified ' . $value;
  },
]);

dump($fields->get('text')->toStoredValue());
// Result: 'Modified Text'
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
