### PR TITLE
New Fields::reset method

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -202,6 +202,18 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Resets the value of each field
+	 */
+	public function reset(): static
+	{
+		foreach ($this->data as $field) {
+			$field->fill(null);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Sets the value for each field with a matching key in the input array
 	 * but only if the field is not disabled
 	 * @since 5.0.0

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -206,6 +206,10 @@ class Fields extends Collection
 	 */
 	public function reset(): static
 	{
+		// reset the passthrough values
+		$this->passthrough = [];
+
+		// reset the values of each field
 		foreach ($this->data as $field) {
 			$field->fill(null);
 		}

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -381,6 +381,70 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testReset(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+			],
+			'b' => [
+				'type'  => 'text',
+			],
+		], $this->model);
+
+		$fields->fill([
+			'a' => 'A',
+			'b' => 'B',
+		]);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B',
+		], $fields->toFormValues());
+
+		$fields->reset();
+
+		$this->assertSame([
+			'a' => '',
+			'b' => '',
+		], $fields->toFormValues());
+	}
+
+	public function testResetStructureFields(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type' => 'structure',
+				'fields' => [
+					'text' => [
+						'type'  => 'text',
+					],
+				],
+			],
+		], $this->model);
+
+		$fields->fill([
+			'a' => $input = [
+				[
+					'text' => 'A',
+				],
+				[
+					'text' => 'B',
+				]
+			],
+		]);
+
+		$this->assertSame([
+			'a' => $input
+		], $fields->toFormValues());
+
+		$fields->reset();
+
+		$this->assertSame([
+			'a' => []
+		], $fields->toFormValues());
+	}
+
 	public function testSubmit(): void
 	{
 		$fields = new Fields(

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -445,6 +445,28 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testResetWithPassthroughValues(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type' => 'text',
+			],
+		], $this->model);
+
+		$fields->passthrough(['b' => 'B'])->fill(['a' => 'A']);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B'
+		], $fields->toFormValues());
+
+		$fields->reset();
+
+		$this->assertSame([
+			'a' => ''
+		], $fields->toFormValues());
+	}
+
 	public function testSubmit(): void
 	{
 		$fields = new Fields(


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7134
- [x]  https://github.com/getkirby/kirby/pull/7135
- [x] https://github.com/getkirby/kirby/pull/7136

## Context

We need to be able to reset/clear the values of all fields later when we want to use the same Field instance multiple times. E.g. when comparing versions. 

Let's have a look at this code: 

```php
$fields = new Fields(
  fields: $page->blueprint()->fields()
  model: $page
);

$latest = $page->version('latest')->content()->toArray();
$changes = $page->version('latest')->content()->toArray();

$a = $fields->reset()->fill($latest)->toFormValues();
$b = $fields->reset()->fiil($changes)->toFormValues();
```

If the reset method would not exist, some fields could already contain values from previous fill calls and we would have to create two independent instances of the Fields object to make a valid comparison. When we call reset first, we can make sure that we reuse the same fields, but we always start from scratch with fresh values.  

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Fields::reset()` method, which will set the value of each field to null. 

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Resetting field values

```php
$fields = new Fields(
  fields: [
    'text' => [
      'type' => 'text'
    ]
  ],
  model: $page  
);

$fields->fill([
  'text' => 'Some text',
]);

$fields->get('text')->toFormValue()
// will return 'Some text'

$fields->reset();

$fields->get('text')->toFormValue()
// will return ''
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
