### PR TITLE
Skip `dump()` PHPUnit tests in local Herd environment

### DIFF
--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -197,6 +197,10 @@ class HelperFunctionsTest extends HelpersTestCase
 
 	public function testDumpOnCli()
 	{
+		if (KIRBY_DUMP_OVERRIDDEN === true) {
+			$this->markTestSkipped('The dump() helper was externally overridden.');
+		}
+
 		$this->assertSame("test\n", dump('test', false));
 
 		$this->expectOutputString("test1\ntest2\n");
@@ -206,6 +210,10 @@ class HelperFunctionsTest extends HelpersTestCase
 
 	public function testDumpOnServer()
 	{
+		if (KIRBY_DUMP_OVERRIDDEN === true) {
+			$this->markTestSkipped('The dump() helper was externally overridden.');
+		}
+
 		$this->kirby = $this->kirby->clone([
 			'cli' => false
 		]);

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -11,6 +11,7 @@ use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
+use ReflectionFunction;
 
 /**
  * PHPUnit extension to bootstrap the tests and
@@ -54,6 +55,10 @@ final class PhpUnitExtension implements Extension
 
 		// prevent PHPUnit tests from accessing files outside the repo
 		Core::$indexRoot = '/dev/null';
+
+		// check if the `dump()` helper was overridden, e.g. by Herd
+		$dump = new ReflectionFunction('dump');
+		define('KIRBY_DUMP_OVERRIDDEN', str_starts_with($dump->getFileName(), dirname(__DIR__)) === false);
 	}
 }
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

The `dump()` unit tests are no longer executed when the `dump()` helper is overridden externally.

### Reasoning

Herd Pro overrides `dump()`, which made the tests fail. It is not possible to test the helper when it was overridden.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Housekeeping

- Fix local unit tests when run in a Herd setup

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
