### PR TITLE
`Media::thumb()`: Fix passing `File $model` and test logic

### DIFF
--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -128,6 +128,8 @@ class Media
 			$source = match (true) {
 				is_string($model) === true
 					=> $kirby->root('index') . '/' . $model . '/' . $options['filename'],
+				$model instanceof File
+					=> $model->root(),
 				default
 				=> $model->file($options['filename'])->root()
 			};

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -282,23 +282,20 @@ class MediaTest extends TestCase
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
-		Dir::make(static::TMP . '/media/assets/site/' . $file->mediaHash());
+		Dir::make(static::TMP . '/media/assets/content/' . $file->mediaHash());
 		$this->assertIsFile($file);
 
 		// create job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write(static::TMP . '/media/assets/site/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write(static::TMP . '/media/assets/content/' . $file->mediaHash() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
-		// copy to media folder
-		$file->asset()->copy($mediaPath = static::TMP . '/media/assets/site/' . $file->mediaHash() . '/' . $file->filename());
-
-		$thumb = Media::thumb('site', $file->mediaHash(), $file->filename());
+		$thumb = Media::thumb('content', $file->mediaHash(), $file->filename());
 		$this->assertInstanceOf(Response::class, $thumb);
 		$this->assertNotFalse($thumb->body());
 		$this->assertSame(200, $thumb->code());
 		$this->assertSame('image/jpeg', $thumb->type());
 
-		$thumbInfo = getimagesize($mediaPath);
+		$thumbInfo = getimagesize(static::TMP . '/media/assets/content/' . $file->mediaHash() . '/' . $file->filename());
 		$this->assertSame(64, $thumbInfo[0]);
 		$this->assertSame(64, $thumbInfo[1]);
 	}

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -257,7 +257,11 @@ class MediaTest extends TestCase
 		F::copy(static::FIXTURES . '/files/test.jpg', static::TMP . '/content/test.jpg');
 
 		// get file object
-		$file = $this->app->file('test.jpg');
+		$site = $this->app->site();
+		$file = $site->file('test.jpg');
+
+		// make the image mysteriously disappear again
+		F::remove(static::TMP . '/content/test.jpg');
 
 		// create a valid job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
@@ -266,8 +270,7 @@ class MediaTest extends TestCase
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('File not found');
 
-		// but the file cannot be found in the media folder
-		Media::thumb($file, $file->mediaHash(), $file->filename());
+		Media::thumb($site, $file->mediaHash(), $file->filename());
 	}
 
 	public function testThumbStringModel()


### PR DESCRIPTION
## Description

<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

See individual commit descriptions for explanations of the changes.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Passing a `File` model object to `Media::thumb()` now works as expected.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
