### PR TITLE
Reset Vite dev mode after PHPUnit tests

### DIFF
--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -14,9 +14,11 @@ use Kirby\Toolkit\Str;
  */
 class AssetsTest extends TestCase
 {
-	public const TMP = KIRBY_TMP_DIR . '/Panel.Assets';
+	public const TMP               = KIRBY_TMP_DIR . '/Panel.Assets';
+	public const VITE_RUNNING_PATH = KIRBY_DIR . '/panel/.vite-running';
 
-	protected $app;
+	protected App $app;
+	protected bool $hadViteRunning;
 
 	public function setUp(): void
 	{
@@ -26,6 +28,10 @@ class AssetsTest extends TestCase
 			]
 		]);
 
+		// initialize development mode to a known state
+		$this->hadViteRunning = is_file(static::VITE_RUNNING_PATH);
+		F::remove(static::VITE_RUNNING_PATH);
+
 		Dir::make(static::TMP);
 	}
 
@@ -33,6 +39,13 @@ class AssetsTest extends TestCase
 	{
 		// clear session file first
 		$this->app->session()->destroy();
+
+		// reset development mode
+		if ($this->hadViteRunning === true) {
+			touch(static::VITE_RUNNING_PATH);
+		} else {
+			F::remove(static::VITE_RUNNING_PATH);
+		}
 
 		Dir::remove(static::TMP);
 
@@ -73,7 +86,7 @@ class AssetsTest extends TestCase
 		]);
 
 		// add vite file
-		F::write($app->roots()->panel() . '/.vite-running', '');
+		F::write(static::VITE_RUNNING_PATH, '');
 	}
 
 	/**

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -178,6 +178,7 @@ class AssetsTest extends TestCase
 	 */
 	public function testCssWithCustomUrl(): void
 	{
+		$this->setDevMode();
 		$this->setCustomUrl();
 
 		// default asset setup
@@ -337,6 +338,7 @@ class AssetsTest extends TestCase
 	 */
 	public function testFaviconsWithCustomUrl(): void
 	{
+		$this->setDevMode();
 		$this->setCustomUrl();
 
 		// default asset setup
@@ -536,6 +538,7 @@ class AssetsTest extends TestCase
 	 */
 	public function testJsWithCustomUrl(): void
 	{
+		$this->setDevMode();
 		$this->setCustomUrl();
 
 		// default asset setup

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -86,7 +86,7 @@ class AssetsTest extends TestCase
 		]);
 
 		// add vite file
-		F::write(static::VITE_RUNNING_PATH, '');
+		touch(static::VITE_RUNNING_PATH);
 	}
 
 	/**
@@ -124,8 +124,8 @@ class AssetsTest extends TestCase
 	 */
 	public function testCssWithCustomFile(): void
 	{
-		F::write(static::TMP . '/panel.css', '');
-		F::write(static::TMP . '/foo.css', '');
+		touch(static::TMP . '/panel.css');
+		touch(static::TMP . '/foo.css');
 
 		// single
 		$this->app->clone([
@@ -483,8 +483,8 @@ class AssetsTest extends TestCase
 	 */
 	public function testJsWithCustomFile(): void
 	{
-		F::write(static::TMP . '/panel.js', '');
-		F::write(static::TMP . '/foo.js', '');
+		touch(static::TMP . '/panel.js');
+		touch(static::TMP . '/foo.js');
 
 		// single
 		$this->app->clone([

--- a/tests/PhpUnitExtension.php
+++ b/tests/PhpUnitExtension.php
@@ -45,6 +45,7 @@ final class PhpUnitExtension implements Extension
 			$tmpDir .= '/' . getenv('UNIQUE_TEST_TOKEN');
 		}
 
+		define('KIRBY_DIR', dirname(__DIR__));
 		define('KIRBY_TMP_DIR', $tmpDir);
 		define('KIRBY_TESTING', true);
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Clean up `.vite-running` file that is created during PHPUnit tests

### Reasoning

I often do my backend work with production assets and kept wondering why a `.vite-running` file was appearing out of nowhere.