### PR TITLE
New Fields::for method

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -185,6 +185,20 @@ class Fields extends Collection
 	}
 
 	/**
+	 * Creates a new Fields instance for the given model and language
+	 */
+	public static function for(
+		ModelWithContent $model,
+		Language|string $language = 'default'
+	): static {
+		return new static(
+			fields: $model->blueprint()->fields(),
+			model: $model,
+			language: Language::ensure($language),
+		);
+	}
+
+	/**
 	 * Returns the language of the fields
 	 */
 	public function language(): Language

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -308,6 +308,43 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+child'));
 	}
 
+	public function testFor(): void
+	{
+		$this->model = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'fields' => [
+					'a' => [
+						'type' => 'text',
+					],
+					'b' => [
+						'type' => 'text',
+					]
+				]
+			]
+		]);
+
+		$fields = Fields::for($this->model);
+
+		$this->assertTrue($fields->language()->isDefault());
+		$this->assertCount(2, $fields);
+
+		$this->assertSame('a', $fields->first()->name());
+		$this->assertSame('b', $fields->last()->name());
+
+		$this->assertSame($this->model, $fields->first()->model());
+		$this->assertSame($this->model, $fields->last()->model());
+	}
+
+	public function testForWithLanguage(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$fields = Fields::for($this->model, 'de');
+
+		$this->assertSame('de', $fields->language()->code());
+	}
+
 	public function testLanguage(): void
 	{
 		// no language passed = current language


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7147

## Context

The `Fields:for()` method can be used in multiple places later to load the field objects for a model and work with them. We don't need the full Form class with its content magic for a lot of cases (API, dialogs, versions). This method will also help to get rid of `Form::for()` in general. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Fields::for()` method, which can be used to get a collection of all field objects for a model

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

```php
$fields = Fields::for($page);

$fields->submit([
  'text' => 'Some nice text'
]);

$fields->toStoredValues();
```

### Get field definitions in a different language

```php
$fields = Fields::for($page, 'de')->toProps();
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
