### PR TITLE
Refactor createDefaultContent method with new Fields::for method

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -210,26 +210,24 @@ trait FileActions
 			...$props['content'],
 		];
 
+		// reuse the existing content if the uploaded file
+		// is identical to an existing file
+		if ($file->exists() === true) {
+			$existing = $file->parent()->file($file->filename());
+
+			if (
+				$file->sha1() === $upload->sha1() &&
+				$file->template() === $existing->template()
+			) {
+				// read the content of the existing file and use it
+				$props['content'] = $existing->content()->toArray();
+			}
+		}
+
 		// make sure that a UUID gets generated
 		// and added to content right away
-		if (
-			Uuids::enabled() === true &&
-			empty($props['content']['uuid']) === true
-		) {
-			// sets the current uuid if it is the exact same file
-			if ($file->exists() === true) {
-				$existing = $file->parent()->file($file->filename());
-
-				if (
-					$file->sha1() === $upload->sha1() &&
-					$file->template() === $existing->template()
-				) {
-					// use existing content data if it is the exact same file
-					$content = $existing->content()->toArray();
-				}
-			}
-
-			$props['content']['uuid'] = Uuid::generate();
+		if (Uuids::enabled() === true) {
+			$props['content']['uuid'] ??= Uuid::generate();
 		}
 
 		// keep the initial storage class

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -14,6 +14,7 @@ use Kirby\Content\Version;
 use Kirby\Content\VersionId;
 use Kirby\Content\Versions;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Fields;
 use Kirby\Form\Form;
 use Kirby\Panel\Model;
 use Kirby\Toolkit\Str;
@@ -260,12 +261,9 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function createDefaultContent(): array
 	{
-		// create the form to get the generate the defaults
-		$form = Form::for($this, [
-			'language' => Language::ensure('default')->code(),
-		]);
+		$fields = Fields::for($this, 'default');
 
-		return $form->strings(true);
+		return $fields->fill($fields->defaults())->toStoredValues();
 	}
 
 	/**


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7148

## Context

When using `Form::for()`, we always read the existing content for the model. This is quite weird here because the default content is created when the model does not exist yet. This could lead to quite some weird side-effects and my assumption is that some of our UUID issues for newly created pages could also come from that. By switching to `Fields::for()` we no longer read content unless we really want to.  

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Simplify `FileActions::create` when the same file is uploaded
- Use `Fields::for` method to simplify the `ModelWithContent::createDefaultContent` method and get rid of the Form class usage.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
