### PR TITLE
New Model::versions method

### DIFF
--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -36,7 +36,7 @@ abstract class Model
 	/**
 	 * Get the content values for the model
 	 *
-	 * @deprecated Use `versions()` instead
+	 * @deprecated 5.0.0 Use `self::versions()` instead
 	 */
 	public function content(): array
 	{

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -332,16 +332,6 @@ abstract class Model
 	}
 
 	/**
-	 * Get the original content values for the model
-	 *
-	 * @deprecated Use `versions()` instead
-	 */
-	public function originals(): array
-	{
-		return $this->versions()['latest'];
-	}
-
-	/**
 	 * Returns the full path without leading slash
 	 */
 	abstract public function path(): string;

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -4,9 +4,10 @@ namespace Kirby\Panel;
 
 use Closure;
 use Kirby\Cms\File as CmsFile;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
-use Kirby\Form\Form;
+use Kirby\Form\Fields;
 use Kirby\Http\Uri;
 use Kirby\Toolkit\A;
 
@@ -34,24 +35,12 @@ abstract class Model
 
 	/**
 	 * Get the content values for the model
+	 *
+	 * @deprecated Use `versions()` instead
 	 */
 	public function content(): array
 	{
-		$version = $this->model->version('changes');
-		$changes = [];
-
-		if ($version->exists('current') === true) {
-			$changes = $version->content('current')->toArray();
-		}
-
-		// create a form which will collect the latest values for the model,
-		// but also pass along unpublished changes as overwrites
-		return Form::for(
-			model: $this->model,
-			props: [
-				'values' => $changes
-			]
-		)->values();
+		return $this->versions()['changes'];
 	}
 
 	/**
@@ -344,10 +333,12 @@ abstract class Model
 
 	/**
 	 * Get the original content values for the model
+	 *
+	 * @deprecated Use `versions()` instead
 	 */
 	public function originals(): array
 	{
-		return Form::for(model: $this->model)->values();
+		return $this->versions()['latest'];
 	}
 
 	/**
@@ -387,15 +378,16 @@ abstract class Model
 		$request   = $this->model->kirby()->request();
 		$tabs      = $blueprint->tabs();
 		$tab       = $blueprint->tab($request->get('tab')) ?? $tabs[0] ?? null;
+		$versions  = $this->versions();
 
 		$props = [
 			'api'         => $link,
 			'buttons'     => fn () => $this->buttons(),
-			'content'     => (object)$this->content(),
+			'content'     => (object)$versions['changes'],
 			'id'          => $this->model->id(),
 			'link'        => $link,
 			'lock'        => $this->model->lock()->toArray(),
-			'originals'   => (object)$this->originals(),
+			'originals'   => (object)$versions['latest'],
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,
 			'uuid'        => fn () => $this->model->uuid()?->toString()
@@ -465,6 +457,36 @@ abstract class Model
 		}
 
 		return $this->model->kirby()->url('panel') . '/' . $this->path();
+	}
+
+	/**
+	 * Creates an array with two versions of the content:
+	 * `latest` and `changes`.
+	 *
+	 * The content is passed through the Fields class
+	 * to ensure that the content is in the correct format
+	 * for the Panel. If there's no `changes` version, the `latest`
+	 * version is used for both.
+	 */
+	public function versions(): array
+	{
+		$language = Language::ensure('current');
+		$fields   = Fields::for($this->model, $language);
+
+		$latestVersion  = $this->model->version('latest');
+		$changesVersion = $this->model->version('changes');
+
+		$latestContent  = $latestVersion->content($language)->toArray();
+		$changesContent = $latestContent;
+
+		if ($changesVersion->exists($language) === true) {
+			$changesContent = $changesVersion->content($language)->toArray();
+		}
+
+		return [
+			'latest'  => $fields->reset()->fill(input: $latestContent, passthrough: true)->toFormValues(),
+			'changes' => $fields->reset()->fill(input: $changesContent, passthrough: true)->toFormValues()
+		];
 	}
 
 	/**

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -96,17 +96,15 @@ class ModelTest extends TestCase
 		);
 
 		$panel->model()->version('latest')->save([
-			'foo'  => 'foo',
-			'uuid' => 'test'
+			'foo' => 'foo',
 		]);
 
 		$panel->model()->version('changes')->save([
-			'foo' => 'foobar'
+			'foo' => 'foobar',
 		]);
 
 		$this->assertSame([
-			'foo'  => 'foobar',
-			'uuid' => 'test'
+			'foo' => 'foobar',
 		], $panel->content());
 	}
 
@@ -545,5 +543,31 @@ class ModelTest extends TestCase
 	{
 		$this->assertSame('/panel/custom', $this->panel()->url());
 		$this->assertSame('/custom', $this->panel()->url(true));
+	}
+
+	/**
+	 * @covers ::versions
+	 */
+	public function testVersions()
+	{
+		$panel = $this->panel([]);
+
+		$panel->model()->version('latest')->save($latest = [
+			'foo' => 'bar'
+		]);
+
+		$versions = $panel->versions();
+
+		$this->assertSame($latest, $versions['latest']);
+		$this->assertSame($latest, $versions['changes']);
+
+		$panel->model()->version('changes')->save($changes = [
+			'foo' => 'baz'
+		]);
+
+		$versions = $panel->versions();
+
+		$this->assertSame($latest, $versions['latest']);
+		$this->assertSame($changes, $versions['changes']);
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7148
- [x] https://github.com/getkirby/kirby/pull/7149
- [x] https://github.com/getkirby/kirby/pull/7150

## Context

This is another big milestone, where we finally can use all the Fields improvements to only create a single Fields instance for both versions. This should eliminate any prior performance issues and also give us a better boilerplate to work with content consistently between versions. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancement

- New `Model::versions()` method, which returns an array with the two versions `latest` and `changes`. If there's no changes version, the `latest` will be used. 

### Deprecated 

- `Model::content()` and `Model::originals()` are deprecated. Use `Model::versions()` instead. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
