### PR TITLE
Use Fields class in Changes controller

### DIFF
--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -118,7 +118,10 @@ class Changes
 		);
 
 		// submit the new values from the request input
-		$fields->submit($input);
+		$fields->submit(
+			input: $input,
+			passthrough: true
+		);
 
 		// save the changes
 		$changes->save(

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -217,19 +217,26 @@ class Fields extends Collection
 	 * which will be added to the form data
 	 * if the field does not exist
 	 */
-	public function passthrough(array $values = []): static
+	public function passthrough(array|null $values = null): static|array
 	{
-		// always start with a fresh set of passthrough values
-		$this->passthrough = [];
+		// use passthrough method as getter if the value is null
+		if ($values === null) {
+			return $this->passthrough;
+		}
 
+		// always start with a fresh set of passthrough values
+		// if the values array is empty
 		if ($values === []) {
+			$this->passthrough = [];
 			return $this;
 		}
 
 		foreach ($values as $key => $value) {
+			$key = strtolower($key);
+
 			// check if the field exists and don't passthrough
 			// values for existing fields
-			if ($this->get(strtolower($key)) !== null) {
+			if ($this->get($key) !== null) {
 				continue;
 			}
 

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -141,6 +141,10 @@ class ChangesTest extends TestCase
 		$this->assertFileDoesNotExist($this->page->root() . '/_changes/article.txt');
 	}
 
+	/**
+	 * @todo We want to ignore undefined fields later in v6. This needs to be
+	 * refactored at that point to make sure that undefined fields are not saved.
+	 */
 	public function testSaveWithUndefinedField()
 	{
 		Data::write($this->page->root() . '/article.txt', [
@@ -151,16 +155,17 @@ class ChangesTest extends TestCase
 
 		$response = Changes::save($this->page, [
 			'text'      => 'Test',
-			'undefined' => 'This should not be saved'
+			'undefined' => 'This should be passed through'
 		]);
 
 		// the changes file should have the changes
 		$changes = Data::read($this->page->root() . '/_changes/article.txt');
 
 		$this->assertSame([
-			'title' => 'Test',
-			'text'  => 'Test',
-			'uuid'  => 'test'
+			'title'     => 'Test',
+			'text'      => 'Test',
+			'uuid'      => 'test',
+			'undefined' => 'This should be passed through'
 		], $changes);
 	}
 }

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -381,6 +381,28 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testPassthroughAsGetter(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'A'
+			],
+		], $this->model);
+
+		$this->assertSame([], $fields->passthrough());
+
+		$fields->passthrough([
+			'a' => 'A', // should be ignored
+			'b' => 'B',
+		]);
+
+		$this->assertSame([
+			'b' => 'B'
+		], $fields->passthrough());
+	}
+
+
 	public function testPassthroughWithExistingField(): void
 	{
 		$fields = new Fields([
@@ -401,12 +423,37 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
-	public function testPassthroughWithExistingPassthroughValues(): void
+
+	public function testPassthroughWithUpperAndLowerCases(): void
 	{
 		$fields = new Fields([
 			'a' => [
 				'type'  => 'text',
 				'value' => 'a'
+			],
+		], $this->model);
+
+		$fields->passthrough([
+			'A' => 'A', // should be ignored even with the wrong case
+			'b' => 'B',
+		]);
+
+		$fields->passthrough([
+			'B' => 'B changed' // should be stored with the lower case 'b' key
+		]);
+
+		$this->assertSame([
+			'a' => 'a',
+			'b' => 'B changed'
+		], $fields->toFormValues());
+	}
+
+	public function testPassthroughWithExistingPassthroughValues(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+				'value' => 'A'
 			],
 		], $this->model);
 
@@ -421,7 +468,8 @@ class FieldsTest extends TestCase
 		]);
 
 		$this->assertSame([
-			'a' => 'a',
+			'a' => 'A',
+			'b' => 'B',
 			'c' => 'C'
 		], $fields->toFormValues());
 	}
@@ -431,7 +479,7 @@ class FieldsTest extends TestCase
 		$fields = new Fields([
 			'a' => [
 				'type'  => 'text',
-				'value' => 'a'
+				'value' => 'A'
 			],
 		], $this->model);
 
@@ -441,10 +489,40 @@ class FieldsTest extends TestCase
 		]);
 
 		// remove passthrough values
-		$fields->passthrough();
+		$fields->passthrough([]);
 
 		$this->assertSame([
-			'a' => 'a',
+			'a' => 'A',
+		], $fields->toFormValues());
+	}
+
+	public function testPassthroughWithFillAndSubmit(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'  => 'text',
+			],
+		], $this->model);
+
+		$fields->fill(
+			input: [
+				'a' => 'A',
+				'b' => 'B'
+			],
+			passthrough: true
+		);
+
+		$fields->submit(
+			input: [
+				'c' => 'C',
+			],
+			passthrough: true
+		);
+
+		$this->assertSame([
+			'a' => 'A',
+			'b' => 'B',
+			'c' => 'C',
 		], $fields->toFormValues());
 	}
 


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7155

## Context

This is another big milestone. We can finally get rid of content merges in the Changes controller and remove the Form class there. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring from previous betas

- The Fields class is now used instead of Form in the Changes controller to save changes. 

### Breaking changes

- None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
