### PR TITLE
[v5] Form buttons: larger save btn on mobile

### DIFF
--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -4,7 +4,6 @@
 			<k-button
 				v-for="button in buttons"
 				:key="button.text"
-				:responsive="true"
 				v-bind="button"
 				size="sm"
 				variant="filled"
@@ -76,6 +75,7 @@ export default {
 						dropdown: true,
 						text: this.editor,
 						icon: "lock",
+						responsive: true,
 						click: () => this.$refs.dropdown.toggle()
 					}
 				];
@@ -87,6 +87,7 @@ export default {
 						theme: "notice",
 						text: this.$t("discard"),
 						icon: "undo",
+						responsive: true,
 						click: () => this.discard()
 					},
 					{


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Save button is non-responsive (full size) on mobile


### Reasoning
https://github.com/getkirby/kirby/issues/7157

### Additional context
https://github.com/getkirby/kirby/pull/7159 won't work for v5 as we have removed the form buttons component. This PR allows us to simply keep the deleted form buttons commit when resolving the merge conflict, and still having this changed behavior in v5 as well.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Panel: larger save button on mobile


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
