### PR TITLE
New Version::sibling and fixed Version::publish

### DIFF
--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -41,6 +41,14 @@ export default (panel) => {
 				}
 			}
 
+			// find all fields that have been present in the original content
+			// but have been removed from the current content
+			for (const field in panel.view.props.originals) {
+				if (panel.view.props.content[field] === undefined) {
+					changes[field] = null;
+				}
+			}
+
 			return changes;
 		},
 
@@ -186,7 +194,6 @@ export default (panel) => {
 			}
 
 			panel.view.props.content = {
-				...panel.view.props.originals,
 				...panel.view.props.content,
 				...values
 			};

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -62,9 +62,12 @@ class ChangesTest extends TestCase
 			'uuid'  => 'test'
 		]);
 
-		// create an empty changes file to be able to check if it
+		// create a changes file to be able to check if it
 		// is being cleaned up correctly after publishing
-		Data::write($file = $this->page->root() . '/_changes/article.txt', []);
+		Data::write($file = $this->page->root() . '/_changes/article.txt', [
+			'title' => 'Title modified',
+			'uuid'  => 'test',
+		]);
 
 		$response = Changes::publish($this->page, [
 			'text' => 'Test'
@@ -79,7 +82,7 @@ class ChangesTest extends TestCase
 		$published = Data::read($this->page->root() . '/article.txt');
 
 		$this->assertSame([
-			'title' => 'Test',
+			'title' => 'Title modified',
 			'text'  => 'Test',
 			'uuid'  => 'test'
 		], $published);


### PR DESCRIPTION
## Description

Next big milestone: We can finally solve the issue that we started with in the first place :) 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements from previous betas

- New `Version::sibling()` method to fetch a different version for the same model

### Fixes from previous betas

- Fields with null values will be removed again when saving changes. This will also fix the removal of the focus point for images. https://github.com/getkirby/kirby/issues/7022
- The content.js module no longer merges changes with the originals. 
- The content.js module now also recognizes removed fields when finding changes to show the form controls. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
