### PR TITLE
Finalize Form class refactoring

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -77,7 +77,7 @@ class Fieldset extends Item
 	protected function createFields(array $fields = []): array
 	{
 		$fields = Blueprint::fieldsProps($fields);
-		$fields = $this->form($fields)->fields()->toArray();
+		$fields = $this->form($fields)->toProps();
 
 		// collect all fields
 		$this->fields = [...$this->fields, ...$fields];

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -662,11 +662,11 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		string|null $languageCode = null,
 		bool $validate = false
 	): static {
-		$form = Form::for($this, [
-			'ignoreDisabled' => $validate === false,
-			'input'          => $input,
-			'language'       => $languageCode,
-		]);
+		$form = Form::for(
+			model: $this,
+			input: $input ?? [],
+			language: $languageCode,
+		);
 
 		if ($validate === true) {
 			$form->validate();
@@ -678,7 +678,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 				static::CLASS_ALIAS => $this,
 				'values'            => $form->data(),
 				'strings'           => $form->strings(),
-				'languageCode'      => $languageCode
+				'languageCode'      => $form->language()->code()
 			],
 			fn ($model, $values, $strings, $languageCode) =>
 				$model->save($strings, $languageCode, true)

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -237,7 +237,7 @@ class Fields extends Collection
 			if ($value instanceof Closure) {
 				$value = $value($this->passthrough[$key] ?? null);
 			}
-	
+
 			$this->passthrough[$key] = $value;
 		}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Closure;
+use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
@@ -27,18 +28,20 @@ use Kirby\Toolkit\Str;
 class Fields extends Collection
 {
 	protected Language $language;
+	protected ModelWithContent $model;
 	protected array $passthrough = [];
 
 	public function __construct(
 		array $fields = [],
-		protected ModelWithContent|null $model = null,
-		Language|null $language = null
+		ModelWithContent|null $model = null,
+		Language|string|null $language = null
 	) {
+		$this->model    = $model ?? App::instance()->site();
+		$this->language = Language::ensure($language ?? 'current');
+
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
 		}
-
-		$this->language = $language ?? Language::ensure('current');
 	}
 
 	/**
@@ -195,12 +198,12 @@ class Fields extends Collection
 	 */
 	public static function for(
 		ModelWithContent $model,
-		Language|string $language = 'default'
+		Language|string|null $language = null
 	): static {
 		return new static(
 			fields: $model->blueprint()->fields(),
 			model: $model,
-			language: Language::ensure($language),
+			language: $language,
 		);
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -224,13 +224,6 @@ class Fields extends Collection
 			return $this->passthrough;
 		}
 
-		// always start with a fresh set of passthrough values
-		// if the values array is empty
-		if ($values === []) {
-			$this->passthrough = [];
-			return $this;
-		}
-
 		foreach ($values as $key => $value) {
 			$key = strtolower($key);
 
@@ -240,6 +233,11 @@ class Fields extends Collection
 				continue;
 			}
 
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($this->passthrough[$key] ?? null);
+			}
+	
 			$this->passthrough[$key] = $value;
 		}
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -2,15 +2,12 @@
 
 namespace Kirby\Form;
 
-use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;
-use Kirby\Form\Field\ExceptionField;
 use Kirby\Toolkit\A;
-use Throwable;
 
 /**
  * The main form class, that is being
@@ -33,43 +30,65 @@ class Form
 
 	/**
 	 * Form constructor
+	 *
+	 * @param array $props @deprecated 5.0.0 Use following parameters instead
 	 */
 	public function __construct(
 		array $props = [],
+		array $fields = [],
+		ModelWithContent|null $model = null,
+		Language|null $language = null
 	) {
-		$this->legacyConstructor($props);
-	}
-
-	protected function legacyConstructor(array $props): void
-	{
-		$passthrough = ($props['strict'] ?? false) === false;
-		$language    = Language::ensure($props['language'] ?? 'current');
+		if ($props !== []) {
+			$this->__constructLegacy(...$props);
+			return;
+		}
 
 		$this->fields = new Fields(
-			fields: $props['fields'] ?? [],
-			model: $props['model'] ?? App::instance()->site(),
+			fields: $fields,
+			model: $model,
+			language: $language
+		);
+	}
+
+	/**	
+	 * Legacy constructor to support the old props array
+	 * @deprecated 5.0.0 Use the new constructor with named parameters instead
+	 */
+	protected function __constructLegacy(
+		array $props = [],
+		array $fields = [],
+		ModelWithContent|null $model = null,
+		Language|string|null $language = 'current',
+		array $values = [],
+		array $input = [],
+		bool $strict = false
+	): void {
+		$model ??= App::instance()->site();
+		$language    = Language::ensure($language ?? 'current');
+		$passthrough = $strict === false;
+
+		$this->fields = new Fields(
+			fields: $fields,
+			model: $model,
 			language: $language
 		);
 
-		if (isset($props['values']) === true) {
-			$this->fill(
-				input: $props['values'],
-				passthrough: $passthrough
-			);
-		}
+		$this->fill(
+			input: $values,
+			passthrough: $passthrough
+		);
 
-		if (isset($props['input']) === true) {
-			$this->submit(
-				input: $props['input'],
-				passthrough: $passthrough
-			);
-		}
+		$this->submit(
+			input: $input,
+			passthrough: $passthrough
+		);
 	}
 
 	/**
 	 * Returns the data required to write to the content file
 	 * Doesn't include default and null values
-	 * 
+	 *
 	 * @deprecated 5.0.0 Use `::toStoredValues()` instead
 	 */
 	public function content(): array
@@ -143,7 +162,7 @@ class Form
 	 * Shortcut for `::fields()->fill()`
 	 */
 	public function fill(
-		array $input, 
+		array $input,
 		bool $passthrough = false
 	): static {
 		$this->fields->fill(
@@ -204,7 +223,7 @@ class Form
 		return $this->fields->errors() === [];
 	}
 
-	/**	
+	/**
 	 * Returns the language of the form
 	 */
 	public function language(): Language
@@ -214,7 +233,7 @@ class Form
 
 	/**
 	 * Converts the data of fields to strings
-	 * 
+	 *
 	 * @deprecated 5.0.0 Use `::toStoredValues()` instead
 	 */
 	public function strings($defaults = false): array
@@ -232,7 +251,7 @@ class Form
 	 * Shortcut for `::fields()->submit()`
 	 */
 	public function submit(
-		array $input, 
+		array $input,
 		bool $passthrough = false
 	): static {
 		$this->fields->submit(
@@ -295,7 +314,7 @@ class Form
 
 	/**
 	 * Returns form values
-	 * 
+	 *
 	 * @deprecated 5.0.0 Use `::toFormValues()` instead
 	 */
 	public function values(): array

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -256,6 +256,15 @@ class Form
 	}
 
 	/**
+	 * Shortcut for `::fields()->reset()`
+	 */
+	public function reset(): static
+	{
+		$this->fields->reset();
+		return $this;
+	}
+
+	/**
 	 * Converts the data of fields to strings
 	 *
 	 * @deprecated 5.0.0 Use `::toStoredValues()` instead

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Form;
 
-use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
@@ -37,7 +36,7 @@ class Form
 		array $props = [],
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|null $language = null
+		Language|string|null $language = null
 	) {
 		if ($props !== []) {
 			$this->__constructLegacy(...$props);
@@ -51,7 +50,7 @@ class Form
 		);
 	}
 
-	/**	
+	/**
 	 * Legacy constructor to support the old props array
 	 * @deprecated 5.0.0 Use the new constructor with named parameters instead
 	 */
@@ -59,15 +58,11 @@ class Form
 		array $props = [],
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|string|null $language = 'current',
+		Language|string|null $language = null,
 		array $values = [],
 		array $input = [],
 		bool $strict = false
 	): void {
-		$model ??= App::instance()->site();
-		$language    = Language::ensure($language ?? 'current');
-		$passthrough = $strict === false;
-
 		$this->fields = new Fields(
 			fields: $fields,
 			model: $model,
@@ -76,12 +71,12 @@ class Form
 
 		$this->fill(
 			input: $values,
-			passthrough: $passthrough
+			passthrough: $strict === false
 		);
 
 		$this->submit(
 			input: $input,
-			passthrough: $passthrough
+			passthrough: $strict === false
 		);
 	}
 
@@ -177,11 +172,11 @@ class Form
 		ModelWithContent $model,
 		array $props = []
 	): static {
-		$form = new static([
-			'language' => $props['language'] ?? 'current',
-			'fields'   => $model->blueprint()->fields(),
-			'model'    => $model,
-		]);
+		$form = new static(
+			fields: $model->blueprint()->fields(),
+			model: $model,
+			language: $props['language'] ?? 'current'
+		);
 
 		$passthrough = ($props['strict'] ?? false) !== true;
 		$language    = $form->language();

--- a/tests/Cms/File/FileBlueprintsTest.php
+++ b/tests/Cms/File/FileBlueprintsTest.php
@@ -17,11 +17,11 @@ class FileBlueprintsTest extends ModelTestCase
 					'sections' => [
 						[
 							'type' => 'files',
-							'template' => 'for-section/a'
+							'template' => 'for-section-a'
 						],
 						[
 							'type' => 'files',
-							'template' => 'for-section/b'
+							'template' => 'for-section-b'
 						],
 						[
 							'type' => 'files',
@@ -38,42 +38,42 @@ class FileBlueprintsTest extends ModelTestCase
 								],
 								'c' => [
 									'type'    => 'files',
-									'uploads' => 'for-fields/a'
+									'uploads' => 'for-fields-a'
 								],
 								'd' => [
 									'type'    => 'files',
 									'uploads' => [
-										'template' => 'for-fields/b'
+										'template' => 'for-fields-b'
 									]
 								],
 								'e' => [
 									'type'    => 'files',
 									'uploads' => [
-										'parent'   => 'foo',
-										'template' => 'for-fields/c'
+										'parent'   => 'site',
+										'template' => 'for-fields-c'
 									]
 								],
 								'f' => [
 									'type'    => 'files',
-									'uploads' => 'for-fields/c'
+									'uploads' => 'for-fields-c'
 								],
 								'g' => [
 									'type'    => 'textarea',
-									'uploads' => 'for-fields/d'
+									'uploads' => 'for-fields-d'
 								],
 								'h' => [
 									'type'    => 'structure',
 									'fields'  => [
 										[
 											'type'    => 'files',
-											'uploads' => 'for-fields/e'
+											'uploads' => 'for-fields-e'
 										],
 										[
 											'type'    => 'structure',
 											'fields'  => [
 												[
 													'type'    => 'files',
-													'uploads' => 'for-fields/f'
+													'uploads' => 'for-fields-f'
 												]
 											]
 										]
@@ -83,29 +83,29 @@ class FileBlueprintsTest extends ModelTestCase
 						]
 					]
 				],
-				'files/for-section/a' => [
+				'files/for-section-a' => [
 					'title' => 'Type A'
 				],
-				'files/for-section/b' => [
+				'files/for-section-b' => [
 					'title' => 'Type B'
 				],
-				'files/for-fields/a' => [
+				'files/for-fields-a' => [
 					'title' => 'Field Type A'
 				],
-				'files/for-fields/b' => [
+				'files/for-fields-b' => [
 					'title' => 'Field Type B'
 				],
-				'files/for-fields/c' => [
+				'files/for-fields-c' => [
 					'title' => 'Field Type C',
 					'accept' => 'image'
 				],
-				'files/for-fields/d' => [
+				'files/for-fields-d' => [
 					'title' => 'Field Type D'
 				],
-				'files/for-fields/e' => [
+				'files/for-fields-e' => [
 					'title' => 'Field Type E'
 				],
-				'files/for-fields/f' => [
+				'files/for-fields-f' => [
 					'title' => 'Field Type F'
 				],
 				'files/current' => [
@@ -128,14 +128,14 @@ class FileBlueprintsTest extends ModelTestCase
 		$blueprints = $file->blueprints();
 		$this->assertCount(9, $blueprints);
 		$this->assertSame('default', $blueprints[0]['name']);
-		$this->assertSame('for-fields/a', $blueprints[1]['name']);
-		$this->assertSame('for-fields/b', $blueprints[2]['name']);
-		$this->assertSame('for-fields/d', $blueprints[3]['name']);
-		$this->assertSame('for-fields/e', $blueprints[4]['name']);
-		$this->assertSame('for-fields/f', $blueprints[5]['name']);
+		$this->assertSame('for-fields-a', $blueprints[1]['name']);
+		$this->assertSame('for-fields-b', $blueprints[2]['name']);
+		$this->assertSame('for-fields-d', $blueprints[3]['name']);
+		$this->assertSame('for-fields-e', $blueprints[4]['name']);
+		$this->assertSame('for-fields-f', $blueprints[5]['name']);
 		$this->assertSame('current', $blueprints[6]['name']);
-		$this->assertSame('for-section/a', $blueprints[7]['name']);
-		$this->assertSame('for-section/b', $blueprints[8]['name']);
+		$this->assertSame('for-section-a', $blueprints[7]['name']);
+		$this->assertSame('for-section-b', $blueprints[8]['name']);
 	}
 
 	public function testBlueprintsInSection(): void
@@ -146,11 +146,11 @@ class FileBlueprintsTest extends ModelTestCase
 					'sections' => [
 						'section-a' => [
 							'type' => 'files',
-							'template' => 'for-section/a'
+							'template' => 'for-section-a'
 						],
 						'section-b' => [
 							'type' => 'files',
-							'template' => 'for-section/b'
+							'template' => 'for-section-b'
 						],
 						'section-c' => [
 							'type' => 'fields',
@@ -160,42 +160,42 @@ class FileBlueprintsTest extends ModelTestCase
 								],
 								[
 									'type'    => 'files',
-									'uploads' => 'for-fields/a'
+									'uploads' => 'for-fields-a'
 								],
 								[
 									'type'    => 'files',
 									'uploads' => [
-										'template' => 'for-fields/b'
+										'template' => 'for-fields-b'
 									]
 								],
 								[
 									'type'    => 'files',
 									'uploads' => [
-										'parent'   => 'foo',
-										'template' => 'for-fields/c'
+										'parent'   => 'site',
+										'template' => 'for-fields-c'
 									]
 								],
 								[
 									'type'    => 'files',
-									'uploads' => 'for-fields/c'
+									'uploads' => 'for-fields-c'
 								]
 							]
 						]
 					]
 				],
-				'files/for-section/a' => [
+				'files/for-section-a' => [
 					'title' => 'Type A'
 				],
-				'files/for-section/b' => [
+				'files/for-section-b' => [
 					'title' => 'Type B'
 				],
-				'files/for-fields/a' => [
+				'files/for-fields-a' => [
 					'title' => 'Field Type A'
 				],
-				'files/for-fields/b' => [
+				'files/for-fields-b' => [
 					'title' => 'Field Type B'
 				],
-				'files/for-fields/c' => [
+				'files/for-fields-c' => [
 					'title' => 'Field Type C',
 					'accept' => 'image'
 				],
@@ -218,15 +218,16 @@ class FileBlueprintsTest extends ModelTestCase
 
 
 		$blueprints = $file->blueprints('section-a');
+
 		$this->assertCount(2, $blueprints);
 		$this->assertSame('current', $blueprints[0]['name']);
-		$this->assertSame('for-section/a', $blueprints[1]['name']);
+		$this->assertSame('for-section-a', $blueprints[1]['name']);
 
 		$blueprints = $file->blueprints('section-c');
 		$this->assertCount(4, $blueprints);
 		$this->assertSame('default', $blueprints[0]['name']);
-		$this->assertSame('for-fields/a', $blueprints[1]['name']);
-		$this->assertSame('for-fields/b', $blueprints[2]['name']);
+		$this->assertSame('for-fields-a', $blueprints[1]['name']);
+		$this->assertSame('for-fields-b', $blueprints[2]['name']);
 		$this->assertSame('current', $blueprints[3]['name']);
 	}
 }

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -341,6 +341,8 @@ class BlocksFieldTest extends TestCase
 			]
 		]);
 
+		$app->impersonate('kirby');
+
 		$props = [
 			'fieldsets' => [
 				'heading' => [

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -351,6 +351,8 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
+		$app->impersonate('kirby');
+
 		$field = $this->field('structure', [
 			'fields' => [
 				'a' => [
@@ -365,13 +367,17 @@ class StructureFieldTest extends TestCase
 
 		$app->setCurrentLanguage('en');
 
-		$this->assertFalse($field->form()->fields()->a()->disabled());
-		$this->assertFalse($field->form()->fields()->b()->disabled());
+		$props = $field->form()->toProps();
+
+		$this->assertFalse($props['a']['disabled']);
+		$this->assertFalse($props['b']['disabled']);
 
 		$app->setCurrentLanguage('de');
 
-		$this->assertFalse($field->form()->fields()->a()->disabled());
-		$this->assertTrue($field->form()->fields()->b()->disabled());
+		$props = $field->form()->toProps();
+
+		$this->assertFalse($props['a']['disabled']);
+		$this->assertTrue($props['b']['disabled']);
 	}
 
 	public function testDefault()

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -474,28 +474,6 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
-	public function testPassthroughWithEmptyArray(): void
-	{
-		$fields = new Fields([
-			'a' => [
-				'type'  => 'text',
-				'value' => 'A'
-			],
-		], $this->model);
-
-		// add passthrough values
-		$fields->passthrough([
-			'b' => 'B',
-		]);
-
-		// remove passthrough values
-		$fields->passthrough([]);
-
-		$this->assertSame([
-			'a' => 'A',
-		], $fields->toFormValues());
-	}
-
 	public function testPassthroughWithFillAndSubmit(): void
 	{
 		$fields = new Fields([

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -6,7 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
-use Kirby\Form\Field\ExceptionField;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 
 /**
@@ -310,8 +310,11 @@ class FormTest extends TestCase
 	/**
 	 * @covers ::__construct
 	 */
-	public function testExceptionField()
+	public function testFieldException()
 	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Field "test": The field type "does-not-exist" does not exist');
+
 		$form = new Form([
 			'fields' => [
 				'test' => [
@@ -320,8 +323,6 @@ class FormTest extends TestCase
 				]
 			]
 		]);
-
-		$this->assertInstanceOf(ExceptionField::class, $form->fields()->first());
 	}
 
 	/**


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Support for named parameters in Form constructor. Passing the $props array is still supported but deprecated.
- Support for named parameters in `Form::for()`. Passing the $props array is still supported here as well, but also deprecated.
- New Form class methods `::submit()`, `::fill()`, `::language()`, `::reset()` as shortcuts for the matching fields methods.

### Refactoring

- Use named parameters in the Form constructor in `ModelWithContent::update()`

### Refactoring from previous betas

- The Fields constructor now also accepts a string value for the given language. 
- The Fields constructor now also accepts null as value for the model and will fall back to the site in that case.
- `Fields::passthrough()` with empty array does no longer reset the passthrough values. This leads to unwanted side effects if you are not careful with the input you pass. 

### Fixes

- Fixed faulty file blueprint test in `Kirby\Cms\FileBlueprintsTest`

### Fixes from previous betas (or commits)

- Passthrough values can now also be Closures that will be resolved. 
- `Form::values()` now uses `Form::toFormValues()`

### Breaking changes

- When using the Form class, the disabled state of fields will no longer be overwritten on construction for secondary languages. Use `Form::toProps()` instead, to get the correct disabled state for each field. When using `Form::toProps()`, permissions will also be honored when the model cannot be updated by the user role. 
- `Form::$values` has been removed
- `Form::prepareFieldsForLanguage()` has been removed

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Using the Form class with named parameters

```php
$form = new Form(
  model: $page,
  fields: [...],
  language: 'current'
);
```

### Using Form::for with named parameters.

```php
$form = Form::for(
  model: $page,
  language: 'current',
  input: [...],
  passthrough: true
);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
