### PR TITLE
Fields Class Improvements

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -65,6 +65,8 @@ class Fields extends Collection
 
 	/**
 	 * Returns an array with the default value of each field
+	 *
+	 * @since 5.0.0
 	 */
 	public function defaults(): array
 	{
@@ -96,6 +98,7 @@ class Fields extends Collection
 	 * Get the field object by name
 	 * and handle nested fields correctly
 	 *
+	 * @since 5.0.0
 	 * @throws \Kirby\Exception\NotFoundException
 	 */
 	public function field(string $name): Field|FieldClass
@@ -111,6 +114,8 @@ class Fields extends Collection
 
 	/**
 	 * Sets the value for each field with a matching key in the input array
+	 *
+	 * @since 5.0.0
 	 */
 	public function fill(
 		array $input,
@@ -195,6 +200,8 @@ class Fields extends Collection
 
 	/**
 	 * Creates a new Fields instance for the given model and language
+	 *
+	 * @since 5.0.0
 	 */
 	public static function for(
 		ModelWithContent $model,
@@ -209,6 +216,8 @@ class Fields extends Collection
 
 	/**
 	 * Returns the language of the fields
+	 *
+	 * @since 5.0.0
 	 */
 	public function language(): Language
 	{
@@ -219,6 +228,8 @@ class Fields extends Collection
 	 * Adds values to the passthrough array
 	 * which will be added to the form data
 	 * if the field does not exist
+	 *
+	 * @since 5.0.0
 	 */
 	public function passthrough(array|null $values = null): static|array
 	{
@@ -249,6 +260,8 @@ class Fields extends Collection
 
 	/**
 	 * Resets the value of each field
+	 *
+	 * @since 5.0.0
 	 */
 	public function reset(): static
 	{
@@ -316,6 +329,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the form value of each field
 	 * (e.g. used as data for Panel Vue components)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toFormValues(): array
 	{
@@ -328,6 +343,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the props of each field
 	 * for the frontend
+	 *
+	 * @since 5.0.0
 	 */
 	public function toProps(): array
 	{
@@ -367,6 +384,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toStoredValues(): array
 	{
@@ -398,6 +417,7 @@ class Fields extends Collection
 	 * Checks for errors in all fields and throws an
 	 * exception if there are any
 	 *
+	 * @since 5.0.0
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public function validate(): void

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form;
 
 use Closure;
+use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
@@ -27,13 +28,16 @@ use Kirby\Toolkit\Str;
 class Fields extends Collection
 {
 	protected Language $language;
+	protected ModelWithContent $model;
 	protected array $passthrough = [];
 
 	public function __construct(
 		array $fields = [],
-		protected ModelWithContent|null $model = null,
+		ModelWithContent|null $model = null,
 		Language|null $language = null
 	) {
+		$this->model = $model ?? App::instance()->site();
+
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
 		}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -34,15 +34,14 @@ class Fields extends Collection
 	public function __construct(
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|null $language = null
+		Language|string|null $language = null
 	) {
-		$this->model = $model ?? App::instance()->site();
+		$this->model    = $model ?? App::instance()->site();
+		$this->language = Language::ensure($language ?? 'current');
 
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
 		}
-
-		$this->language = $language ?? Language::ensure('current');
 	}
 
 	/**
@@ -199,12 +198,12 @@ class Fields extends Collection
 	 */
 	public static function for(
 		ModelWithContent $model,
-		Language|string $language = 'default'
+		Language|string|null $language = null
 	): static {
 		return new static(
 			fields: $model->blueprint()->fields(),
 			model: $model,
-			language: Language::ensure($language),
+			language: $language,
 		);
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -224,13 +224,6 @@ class Fields extends Collection
 			return $this->passthrough;
 		}
 
-		// always start with a fresh set of passthrough values
-		// if the values array is empty
-		if ($values === []) {
-			$this->passthrough = [];
-			return $this;
-		}
-
 		foreach ($values as $key => $value) {
 			$key = strtolower($key);
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -236,6 +236,11 @@ class Fields extends Collection
 				continue;
 			}
 
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($this->passthrough[$key] ?? null);
+			}
+
 			$this->passthrough[$key] = $value;
 		}
 

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -474,28 +474,6 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
-	public function testPassthroughWithEmptyArray(): void
-	{
-		$fields = new Fields([
-			'a' => [
-				'type'  => 'text',
-				'value' => 'A'
-			],
-		], $this->model);
-
-		// add passthrough values
-		$fields->passthrough([
-			'b' => 'B',
-		]);
-
-		// remove passthrough values
-		$fields->passthrough([]);
-
-		$this->assertSame([
-			'a' => 'A',
-		], $fields->toFormValues());
-	}
-
 	public function testPassthroughWithFillAndSubmit(): void
 	{
 		$fields = new Fields([

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -35,14 +35,17 @@ class FieldsTest extends TestCase
 
 	public function testConstruct()
 	{
-		$fields = new Fields([
-			'a' => [
-				'type'  => 'text',
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+				],
+				'b' => [
+					'type'  => 'text',
+				],
 			],
-			'b' => [
-				'type'  => 'text',
-			],
-		], $this->model);
+			model: $this->model
+		);
 
 		$this->assertSame('a', $fields->first()->name());
 		$this->assertSame($this->model, $fields->first()->model());
@@ -50,21 +53,21 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	public function testConstructWithModel()
+	public function testConstructWithoutModel()
 	{
-		$fields = new Fields([
-			'a' => [
-				'type'  => 'text',
-			],
-			'b' => [
-				'type'  => 'text',
-			],
-		], $this->model);
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+				],
+				'b' => [
+					'type'  => 'text',
+				],
+			]
+		);
 
-		$this->assertSame('a', $fields->first()->name());
-		$this->assertSame($this->model, $fields->first()->model());
-		$this->assertSame('b', $fields->last()->name());
-		$this->assertSame($this->model, $fields->last()->model());
+		$this->assertSame($this->app->site(), $fields->first()->model());
+		$this->assertSame($this->app->site(), $fields->last()->model());
 	}
 
 	public function testDefaults()

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -363,6 +363,10 @@ class FieldsTest extends TestCase
 		$fields = new Fields(fields: [], language: $language);
 		$this->assertSame('de', $fields->language()->code());
 		$this->assertFalse($fields->language()->isDefault());
+
+		// language code passed
+		$fields = new Fields(fields: [], language: 'en');
+		$this->assertSame('en', $fields->language()->code());
 	}
 
 	public function testPassthrough(): void

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -430,6 +430,27 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testPassthroughWithClosureValues(): void
+	{
+		$fields = new Fields([], $this->model);
+
+		$fields->passthrough([
+			'test' => 'Test', // should be ignored
+		]);
+
+		$this->assertSame([
+			'test' => 'Test',
+		], $fields->toFormValues());
+
+
+		$fields->passthrough([
+			'test' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'test' => 'Test updated'
+		], $fields->toFormValues());
+	}
 
 	public function testPassthroughWithUpperAndLowerCases(): void
 	{


### PR DESCRIPTION
## Description

The next form steps brought up some more Fields class improvements, which can be extracted into their own PR. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements from previous betas

- The Fields class constructor now accepts a string value for the language parameter
- The Fields class will fall back to the site if no model is given.
- `Fields::passthrough()` will resolve closure values (just like fill and submit)
- Add missing since tags to methods. 

### Fixes from previous betas

- The `Fields::passthrough()` method supported passing an empty array to reset all passthrough values. This seemed like a good idea, but can lead to quite unexpected results, especially when using the fill and submit methods and the input to those is potentially empty (e.g. an empty post request). This could erase passthrough values even if not wanted. This PR removes the option to pass an empty array to reset passthrough values. We can still use the `::reset` method to achieve the same.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
