### PR TITLE
Add shortcuts for various Field class methods

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -34,15 +34,14 @@ class Fields extends Collection
 	public function __construct(
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|null $language = null
+		Language|string|null $language = null
 	) {
-		$this->model = $model ?? App::instance()->site();
+		$this->model    = $model ?? App::instance()->site();
+		$this->language = Language::ensure($language ?? 'current');
 
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
 		}
-
-		$this->language = $language ?? Language::ensure('current');
 	}
 
 	/**

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -65,6 +65,8 @@ class Fields extends Collection
 
 	/**
 	 * Returns an array with the default value of each field
+	 *
+	 * @since 5.0.0
 	 */
 	public function defaults(): array
 	{
@@ -96,6 +98,7 @@ class Fields extends Collection
 	 * Get the field object by name
 	 * and handle nested fields correctly
 	 *
+	 * @since 5.0.0
 	 * @throws \Kirby\Exception\NotFoundException
 	 */
 	public function field(string $name): Field|FieldClass
@@ -111,6 +114,8 @@ class Fields extends Collection
 
 	/**
 	 * Sets the value for each field with a matching key in the input array
+	 *
+	 * @since 5.0.0
 	 */
 	public function fill(
 		array $input,
@@ -195,6 +200,8 @@ class Fields extends Collection
 
 	/**
 	 * Creates a new Fields instance for the given model and language
+	 *
+	 * @since 5.0.0
 	 */
 	public static function for(
 		ModelWithContent $model,
@@ -209,6 +216,8 @@ class Fields extends Collection
 
 	/**
 	 * Returns the language of the fields
+	 *
+	 * @since 5.0.0
 	 */
 	public function language(): Language
 	{
@@ -219,6 +228,8 @@ class Fields extends Collection
 	 * Adds values to the passthrough array
 	 * which will be added to the form data
 	 * if the field does not exist
+	 *
+	 * @since 5.0.0
 	 */
 	public function passthrough(array|null $values = null): static|array
 	{
@@ -249,6 +260,8 @@ class Fields extends Collection
 
 	/**
 	 * Resets the value of each field
+	 *
+	 * @since 5.0.0
 	 */
 	public function reset(): static
 	{
@@ -316,6 +329,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the form value of each field
 	 * (e.g. used as data for Panel Vue components)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toFormValues(): array
 	{
@@ -328,6 +343,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the props of each field
 	 * for the frontend
+	 *
+	 * @since 5.0.0
 	 */
 	public function toProps(): array
 	{
@@ -367,6 +384,8 @@ class Fields extends Collection
 	/**
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toStoredValues(): array
 	{
@@ -398,6 +417,7 @@ class Fields extends Collection
 	 * Checks for errors in all fields and throws an
 	 * exception if there are any
 	 *
+	 * @since 5.0.0
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
 	public function validate(): void

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -236,6 +236,11 @@ class Fields extends Collection
 				continue;
 			}
 
+			// resolve closure values
+			if ($value instanceof Closure) {
+				$value = $value($this->passthrough[$key] ?? null);
+			}
+
 			$this->passthrough[$key] = $value;
 		}
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -148,6 +148,16 @@ class Form
 	}
 
 	/**
+	 * Returns an array with the default value of each field
+	 *
+	 * @since 5.0.0
+	 */
+	public function defaults(): array
+	{
+		return $this->fields->defaults();
+	}
+
+	/**
 	 * An array of all found errors
 	 */
 	public function errors(): array
@@ -174,6 +184,26 @@ class Form
 		return $this->fields;
 	}
 
+	/**
+	 * Sets the value for each field with a matching key in the input array
+	 *
+	 * @since 5.0.0
+	 */
+	public function fill(
+		array $input,
+		bool $passthrough = false
+	): static {
+		$this->fields->fill(
+			input: $input,
+			passthrough: $passthrough
+		);
+		return $this;
+	}
+
+	/**
+	 * Creates a new Form instance for the given model with the fields
+	 * from the blueprint and the values from the content
+	 */
 	public static function for(
 		ModelWithContent $model,
 		array $props = []
@@ -227,6 +257,37 @@ class Form
 	}
 
 	/**
+	 * Returns the language of the form
+	 *
+	 * @since 5.0.0
+	 */
+	public function language(): Language
+	{
+		return $this->fields->language();
+	}
+
+	/**
+	 * Adds values to the passthrough array
+	 * which will be added to the form data
+	 * if the field does not exist
+	 *
+	 * @since 5.0.0
+	 */
+	public function passthrough(
+		array|null $values = null
+	): static|array {
+		if ($values === null) {
+			return $this->fields->passthrough();
+		}
+
+		$this->fields->passthrough(
+			values: $values
+		);
+
+		return $this;
+	}
+
+	/**
 	 * Disables fields in secondary languages when
 	 * they are configured to be untranslatable
 	 */
@@ -250,6 +311,17 @@ class Form
 	}
 
 	/**
+	 * Resets the value of each field
+	 *
+	 * @since 5.0.0
+	 */
+	public function reset(): static
+	{
+		$this->fields->reset();
+		return $this;
+	}
+
+	/**
 	 * Converts the data of fields to strings
 	 */
 	public function strings($defaults = false): array
@@ -261,6 +333,23 @@ class Form
 				default		     => $value
 			}
 		);
+	}
+
+	/**
+	 * Sets the value for each field with a matching key in the input array
+	 * but only if the field is not disabled
+	 *
+	 * @since 5.0.0
+	 */
+	public function submit(
+		array $input,
+		bool $passthrough = false
+	): static {
+		$this->fields->submit(
+			input: $input,
+			passthrough: $passthrough
+		);
+		return $this;
 	}
 
 	/**
@@ -280,6 +369,8 @@ class Form
 	/**
 	 * Returns an array with the form value of each field
 	 * (e.g. used as data for Panel Vue components)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toFormValues(): array
 	{
@@ -287,8 +378,21 @@ class Form
 	}
 
 	/**
+	 * Returns an array with the props of each field
+	 * for the frontend
+	 *
+	 * @since 5.0.0
+	 */
+	public function toProps(): array
+	{
+		return $this->fields->toProps();
+	}
+
+	/**
 	 * Returns an array with the stored value of each field
 	 * (e.g. used for saving to content storage)
+	 *
+	 * @since 5.0.0
 	 */
 	public function toStoredValues(): array
 	{

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -363,6 +363,10 @@ class FieldsTest extends TestCase
 		$fields = new Fields(fields: [], language: $language);
 		$this->assertSame('de', $fields->language()->code());
 		$this->assertFalse($fields->language()->isDefault());
+
+		// language code passed
+		$fields = new Fields(fields: [], language: 'en');
+		$this->assertSame('en', $fields->language()->code());
 	}
 
 	public function testPassthrough(): void

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -430,6 +430,27 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testPassthroughWithClosureValues(): void
+	{
+		$fields = new Fields([], $this->model);
+
+		$fields->passthrough([
+			'test' => 'Test', // should be ignored
+		]);
+
+		$this->assertSame([
+			'test' => 'Test',
+		], $fields->toFormValues());
+
+
+		$fields->passthrough([
+			'test' => fn ($value) => $value . ' updated'
+		]);
+
+		$this->assertSame([
+			'test' => 'Test updated'
+		], $fields->toFormValues());
+	}
 
 	public function testPassthroughWithUpperAndLowerCases(): void
 	{

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -4,14 +4,14 @@ namespace Kirby\Form;
 
 use Kirby\Cms\App;
 use Kirby\Cms\File;
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Form\Field\ExceptionField;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Form\Form
- */
+#[CoversClass(Form::class)]
 class FormTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Form.Form';
@@ -38,9 +38,6 @@ class FormTest extends TestCase
 		$this->tearDownTmp();
 	}
 
-	/**
-	 * @covers ::content
-	 */
 	public function testContent()
 	{
 		$form = new Form([
@@ -54,10 +51,6 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->content());
 	}
 
-	/**
-	 * @covers ::content
-	 * @covers ::data
-	 */
 	public function testContentAndDataFromUnsaveableFields()
 	{
 		$form = new Form([
@@ -78,9 +71,6 @@ class FormTest extends TestCase
 		$this->assertArrayHasKey('info', $form->data());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithoutFields()
 	{
 		$form = new Form([
@@ -94,9 +84,6 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->data());
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataFromUnsaveableFields()
 	{
 		$form = new Form([
@@ -114,9 +101,6 @@ class FormTest extends TestCase
 		$this->assertNull($form->data()['info']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataFromNestedFields()
 	{
 		$form = new Form([
@@ -143,10 +127,6 @@ class FormTest extends TestCase
 		$this->assertSame('a, b', $form->data()['structure'][0]['tags']);
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithCorrectFieldOrder()
 	{
 		$form = new Form([
@@ -173,10 +153,6 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->values());
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithStrictMode()
 	{
 		$form = new Form([
@@ -203,10 +179,6 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->values());
 	}
 
-	/**
-	 * @covers ::data
-	 * @covers ::values
-	 */
 	public function testDataWithUntranslatedFields()
 	{
 		$this->setUpMultiLanguage();
@@ -258,11 +230,20 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->values());
 	}
 
-	/**
-	 * @covers ::errors
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
+	public function testDefaults()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'type' => 'text',
+					'default' => 'Test Value'
+				]
+			]
+		]);
+
+		$this->assertSame(['test' => 'Test Value'], $form->defaults());
+	}
+
 	public function testErrors()
 	{
 		$form = new Form([
@@ -307,9 +288,6 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->errors());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testExceptionField()
 	{
 		$form = new Form([
@@ -324,9 +302,24 @@ class FormTest extends TestCase
 		$this->assertInstanceOf(ExceptionField::class, $form->fields()->first());
 	}
 
-	/**
-	 * @covers ::for
-	 */
+	public function testFill()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'type' => 'text',
+				]
+			],
+		]);
+
+		$response = $form->fill([
+			'test' => 'Test Value'
+		]);
+
+		$this->assertSame($form, $response);
+		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
+	}
+
 	public function testForFileWithoutBlueprint()
 	{
 		$file = new File([
@@ -342,9 +335,6 @@ class FormTest extends TestCase
 		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->data());
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPage()
 	{
 		$page = new Page([
@@ -380,9 +370,6 @@ class FormTest extends TestCase
 		$this->assertSame('', $values['date']);
 	}
 
-	/**
-	 * @covers ::for
-	 */
 	public function testForPageWithClosureValues()
 	{
 		$page = new Page([
@@ -405,9 +392,56 @@ class FormTest extends TestCase
 		$this->assertSame('B', $values['b']);
 	}
 
-	/**
-	 * @covers ::strings
-	 */
+	public function testLanguage()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'type' => 'text',
+				]
+			],
+		]);
+
+		$this->assertInstanceOf(Language::class, $form->language());
+	}
+
+	public function testPassthrough()
+	{
+		$form = new Form([]);
+
+		$response = $form->passthrough([
+			'test' => 'Test Value'
+		]);
+
+		$this->assertSame($form, $response);
+		$this->assertSame(['test' => 'Test Value'], $response->passthrough());
+		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
+	}
+
+	public function testReset()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'type' => 'text',
+				]
+			],
+		]);
+
+		$this->assertSame(['test' => ''], $form->toFormValues());
+
+		$form->fill([
+			'test' => 'Test Value'
+		]);
+
+		$this->assertSame(['test' => 'Test Value'], $form->toFormValues());
+
+		$response = $form->reset();
+
+		$this->assertSame($form, $response);
+		$this->assertSame(['test' => ''], $form->toFormValues());
+	}
+
 	public function testStrings()
 	{
 		$form = new Form([
@@ -429,9 +463,24 @@ class FormTest extends TestCase
 		], $form->strings());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
+	public function testSubmit()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'type' => 'text',
+				]
+			],
+		]);
+
+		$response = $form->submit([
+			'test' => 'Test Value'
+		]);
+
+		$this->assertSame($form, $response);
+		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
+	}
+
 	public function testToArray()
 	{
 		$form = new Form([
@@ -459,9 +508,6 @@ class FormTest extends TestCase
 		$this->assertFalse($form->toArray()['invalid']);
 	}
 
-	/**
-	 * @covers ::toFormValues
-	 */
 	public function testToFormValues()
 	{
 		$form = new Form([
@@ -482,9 +528,20 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->toFormValues());
 	}
 
-	/**
-	 * @covers ::toStoredValues
-	 */
+	public function testToProps()
+	{
+		$form = new Form([
+			'fields' => [
+				'test' => [
+					'label' => 'Test',
+					'type'  => 'text',
+				],
+			]
+		]);
+
+		$this->assertSame($form->fields()->toProps(), $form->toProps());
+	}
+
 	public function testToStoredValues()
 	{
 		Field::$types['test'] = [
@@ -516,9 +573,6 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->toStoredValues());
 	}
 
-	/**
-	 * @covers ::values
-	 */
 	public function testValuesWithoutFields()
 	{
 		$form = new Form([


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7164

## Description

After this entire refactoring project, the Form class will be mostly a proxy for the methods of the Fields class, with some additional functionalities that are more related to the entire form and not just fields.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New Form class methods: 
  - `Form::defaults()`
  - `Form::fill()`
  - `Form::language()`
  - `Form::reset()`
  - `Form::passthrough()`
  - `Form::submit()`
  - `Form::toProps()`

### Enhancements from previous betas

- Added missing since tags to docblocks

### Refactoring

- Convert the FormTest class to PHPUnit attributes. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
