### PR TITLE
Use the new Form methods in the structure field

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -172,19 +172,12 @@ return [
 
 			return $value;
 		},
-		'form' => function (array $values = []) {
-			$form = new Form(
+		'form' => function () {
+			return new Form(
 				fields: $this->attrs['fields'] ?? [],
 				model: $this->model,
 				language: 'current'
 			);
-
-			$form->fill(
-				input: $values,
-				passthrough: true
-			);
-
-			return $form;
 		},
 	],
 	'save' => function ($value) {

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -159,6 +159,7 @@ return [
 	'methods' => [
 		'rows' => function ($value) {
 			$rows  = Data::decode($value, 'yaml');
+			$form  = $this->form();
 			$value = [];
 
 			foreach ($rows as $index => $row) {
@@ -166,24 +167,32 @@ return [
 					continue;
 				}
 
-				$value[] = $this->form($row)->values();
+				$value[] = $form->reset()->fill(input: $row, passthrough: true)->toFormValues();
 			}
 
 			return $value;
 		},
 		'form' => function (array $values = []) {
-			return new Form([
-				'fields' => $this->attrs['fields'] ?? [],
-				'values' => $values,
-				'model'  => $this->model
-			]);
+			$form = new Form(
+				fields: $this->attrs['fields'] ?? [],
+				model: $this->model,
+				language: 'current'
+			);
+
+			$form->fill(
+				input: $values,
+				passthrough: true
+			);
+
+			return $form;
 		},
 	],
 	'save' => function ($value) {
 		$data = [];
+		$form = $this->form();
 
 		foreach ($value as $row) {
-			$row = $this->form($row)->content();
+			$row = $form->reset()->submit(input: $row, passthrough: true)->toStoredValues();
 
 			// remove frontend helper id
 			unset($row['_id']);
@@ -202,9 +211,10 @@ return [
 			}
 
 			$values = A::wrap($value);
+			$form   = $this->form();
 
 			foreach ($values as $index => $value) {
-				$form = $this->form($value);
+				$form->reset()->submit(input: $value, passthrough: true);
 
 				foreach ($form->fields() as $field) {
 					$errors = $field->errors();

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -255,7 +255,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame($expected, $data);
 
 		// filled mother form
-		$motherForm = $field->form($value[0]);
+		$motherForm = $field->form()->fill(input: $value[0], passthrough: true);
 		$expected   = $value[0];
 
 		$this->assertEquals($expected, $motherForm->data()); // cannot use strict assertion (array order)
@@ -271,9 +271,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('', $childrenForm->data()['name']);
 
 		// filled children form
-		$childrenForm = $childrenField->form([
-			'name' => 'Test'
-		]);
+		$childrenForm = $childrenField->form()->fill(input: ['name' => 'Test'], passthrough: true);
 
 		$this->assertSame('Test', $childrenForm->data()['name']);
 


### PR DESCRIPTION
## Description

We can use our new form methods to finally fix the performance issues in the structure field. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- Use new Form methods to improve the structure field and fix performance issues. Related https://github.com/getkirby/kirby/issues/4554

### Breaking changes

The structure field `::form` method does no longer have a `$values` parameter. Use `$field->form()->fill()` or `$field->form()->submit()` instead if you want to add values to the form. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
