### PR TITLE
Tags field preview: render non-selectable

### DIFF
--- a/panel/src/components/Forms/Previews/TagsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TagsFieldPreview.vue
@@ -12,8 +12,8 @@
 				:image="tag.image"
 				:link="tag.link"
 				:text="tag.text"
+				element="div"
 				theme="light"
-				@click.native.stop
 			/>
 		</li>
 	</ul>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Tags field preview: tags cannot be selected anymore


### Reasoning
Since field previews are non-intractable (wouldn't store changed values) for now, better they fully behave like this.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
